### PR TITLE
Add logging for OTA QueryImage, AnnounceOTAProvider, and BDX Output Event Type

### DIFF
--- a/examples/ota-provider-app/ota-provider-common/BdxOtaSender.cpp
+++ b/examples/ota-provider-app/ota-provider-common/BdxOtaSender.cpp
@@ -53,7 +53,7 @@ void BdxOtaSender::HandleTransferSessionOutput(TransferSession::OutputEvent & ev
 
     if (event.EventType != TransferSession::OutputEventType::kNone)
     {
-        ChipLogDetail(BDX, "OutputEvent type: %d", static_cast<uint16_t>(event.EventType));
+        ChipLogDetail(BDX, "OutputEvent type: %s", event.ToString(event.EventType));
     }
 
     switch (event.EventType)

--- a/examples/ota-requestor-app/ota-requestor-common/BDXDownloader.cpp
+++ b/examples/ota-requestor-app/ota-requestor-common/BDXDownloader.cpp
@@ -40,7 +40,7 @@ void BdxDownloader::HandleTransferSessionOutput(TransferSession::OutputEvent & e
 
     if (event.EventType != TransferSession::OutputEventType::kNone)
     {
-        ChipLogDetail(BDX, "OutputEvent type: %d", static_cast<uint16_t>(event.EventType));
+        ChipLogDetail(BDX, "OutputEvent type: %s", event.ToString(event.EventType));
     }
 
     switch (event.EventType)

--- a/examples/ota-requestor-app/ota-requestor-common/ExampleOTARequestor.cpp
+++ b/examples/ota-requestor-app/ota-requestor-common/ExampleOTARequestor.cpp
@@ -98,8 +98,7 @@ EmberAfStatus ExampleOTARequestor::HandleAnnounceOTAProvider(
     ChipLogDetail(SoftwareUpdate, "  AnnouncementReason: %" PRIu8, announcementReason);
     if (commandData.metadataForNode.HasValue())
     {
-        ChipLogDetail(SoftwareUpdate, "  MetadataForNode: %.*s", static_cast<int>(commandData.metadataForNode.Value().size()),
-                      commandData.metadataForNode.Value().data());
+        ChipLogDetail(SoftwareUpdate, "  MetadataForNode: %zu", commandData.metadataForNode.Value().size());
     }
 
     // If reason is URGENT_UPDATE_AVAILABLE, we start OTA immediately. Otherwise, respect the timer value set in mOtaStartDelayMs.

--- a/examples/ota-requestor-app/ota-requestor-common/ExampleOTARequestor.cpp
+++ b/examples/ota-requestor-app/ota-requestor-common/ExampleOTARequestor.cpp
@@ -91,8 +91,16 @@ EmberAfStatus ExampleOTARequestor::HandleAnnounceOTAProvider(
     mProviderNodeId      = providerLocation;
     mProviderFabricIndex = commandObj->GetExchangeContext()->GetSessionHandle().GetFabricIndex();
 
-    ChipLogProgress(SoftwareUpdate, "Notified of Provider at NodeID: 0x" ChipLogFormatX64 " on FabricIndex 0x%" PRIu8,
-                    ChipLogValueX64(mProviderNodeId), mProviderFabricIndex);
+    ChipLogProgress(SoftwareUpdate, "OTA Requestor received AnnounceOTAProvider");
+    ChipLogDetail(SoftwareUpdate, "  FabricIndex: %" PRIu8, mProviderFabricIndex);
+    ChipLogDetail(SoftwareUpdate, "  ProviderNodeID: %" PRIu64, mProviderNodeId);
+    ChipLogDetail(SoftwareUpdate, "  VendorID: %" PRIu16, commandData.vendorId);
+    ChipLogDetail(SoftwareUpdate, "  AnnouncementReason: %" PRIu8, announcementReason);
+    if (commandData.metadataForNode.HasValue())
+    {
+        ChipLogDetail(SoftwareUpdate, "  MetadataForNode: %.*s", static_cast<int>(commandData.metadataForNode.Value().size()),
+                      commandData.metadataForNode.Value().data());
+    }
 
     // If reason is URGENT_UPDATE_AVAILABLE, we start OTA immediately. Otherwise, respect the timer value set in mOtaStartDelayMs.
     // This is done to exemplify what a real-world OTA Requestor might do while also being configurable enough to use as a test app.

--- a/examples/ota-requestor-app/ota-requestor-common/ExampleOTARequestor.cpp
+++ b/examples/ota-requestor-app/ota-requestor-common/ExampleOTARequestor.cpp
@@ -93,8 +93,8 @@ EmberAfStatus ExampleOTARequestor::HandleAnnounceOTAProvider(
 
     ChipLogProgress(SoftwareUpdate, "OTA Requestor received AnnounceOTAProvider");
     ChipLogDetail(SoftwareUpdate, "  FabricIndex: %" PRIu8, mProviderFabricIndex);
-    ChipLogDetail(SoftwareUpdate, "  ProviderNodeID: %" PRIu64, mProviderNodeId);
-    ChipLogDetail(SoftwareUpdate, "  VendorID: %" PRIu16, commandData.vendorId);
+    ChipLogDetail(SoftwareUpdate, "  ProviderNodeID: 0x" ChipLogFormatX64, ChipLogValueX64(mProviderNodeId));
+    ChipLogDetail(SoftwareUpdate, "  VendorID: 0x%" PRIx16, commandData.vendorId);
     ChipLogDetail(SoftwareUpdate, "  AnnouncementReason: %" PRIu8, announcementReason);
     if (commandData.metadataForNode.HasValue())
     {

--- a/src/app/clusters/ota-provider/ota-provider.cpp
+++ b/src/app/clusters/ota-provider/ota-provider.cpp
@@ -185,7 +185,7 @@ bool emberAfOtaSoftwareUpdateProviderClusterQueryImageCallback(app::CommandHandl
     };
 
     ChipLogProgress(Zcl, "OTA Provider received QueryImage");
-    ChipLogDetail(Zcl, "  VendorID: %" PRIu16, vendorId);
+    ChipLogDetail(Zcl, "  VendorID: 0x%" PRIx16, vendorId);
     ChipLogDetail(Zcl, "  ProductID: %" PRIu16, productId);
     ChipLogDetail(Zcl, "  SoftwareVersion: %" PRIu32, softwareVersion);
     ChipLogDetail(Zcl, "  ProtocolsSupported: %" PRIu8, protocolsSupported);

--- a/src/app/clusters/ota-provider/ota-provider.cpp
+++ b/src/app/clusters/ota-provider/ota-provider.cpp
@@ -192,7 +192,7 @@ bool emberAfOtaSoftwareUpdateProviderClusterQueryImageCallback(app::CommandHandl
     ChipLogDetail(Zcl, "  HardwareVersion: %" PRIu16, hardwareVersion);
     ChipLogDetail(Zcl, "  Location: %.*s", static_cast<int>(location.size()), location.data());
     ChipLogDetail(Zcl, "  RequestorCanConsent: %" PRIu8, requestorCanConsent);
-    ChipLogDetail(Zcl, "  MetadataForProvider: %.*s", static_cast<int>(metadataForProvider.size()), metadataForProvider.data());
+    ChipLogDetail(Zcl, "  MetadataForProvider: %zu", metadataForProvider.size());
 
     if (location.size() != kLocationLen)
     {

--- a/src/app/clusters/ota-provider/ota-provider.cpp
+++ b/src/app/clusters/ota-provider/ota-provider.cpp
@@ -184,7 +184,15 @@ bool emberAfOtaSoftwareUpdateProviderClusterQueryImageCallback(app::CommandHandl
         return true;
     };
 
-    ChipLogDetail(Zcl, "OTA Provider received QueryImage");
+    ChipLogProgress(Zcl, "OTA Provider received QueryImage");
+    ChipLogDetail(Zcl, "  VendorID: %" PRIu16, vendorId);
+    ChipLogDetail(Zcl, "  ProductID: %" PRIu16, productId);
+    ChipLogDetail(Zcl, "  SoftwareVersion: %" PRIu32, softwareVersion);
+    ChipLogDetail(Zcl, "  ProtocolsSupported: %" PRIu8, protocolsSupported);
+    ChipLogDetail(Zcl, "  HardwareVersion: %" PRIu16, hardwareVersion);
+    ChipLogDetail(Zcl, "  Location: %.*s", static_cast<int>(location.size()), location.data());
+    ChipLogDetail(Zcl, "  RequestorCanConsent: %" PRIu8, requestorCanConsent);
+    ChipLogDetail(Zcl, "  MetadataForProvider: %.*s", static_cast<int>(metadataForProvider.size()), metadataForProvider.data());
 
     if (location.size() != kLocationLen)
     {

--- a/src/protocols/bdx/BdxTransferSession.cpp
+++ b/src/protocols/bdx/BdxTransferSession.cpp
@@ -774,6 +774,37 @@ bool TransferSession::IsTransferLengthDefinite()
     return (mTransferLength > 0);
 }
 
+const char * TransferSession::OutputEvent::ToString(OutputEventType outputEventType)
+{
+    switch (outputEventType)
+    {
+    case OutputEventType::kNone:
+        return "None";
+    case OutputEventType::kMsgToSend:
+        return "MsgToSend";
+    case OutputEventType::kInitReceived:
+        return "InitReceived";
+    case OutputEventType::kAcceptReceived:
+        return "AcceptReceived";
+    case OutputEventType::kBlockReceived:
+        return "BlockReceived";
+    case OutputEventType::kQueryReceived:
+        return "QueryReceived";
+    case OutputEventType::kAckReceived:
+        return "AckReceived";
+    case OutputEventType::kAckEOFReceived:
+        return "AckEOFReceived";
+    case OutputEventType::kStatusReceived:
+        return "StatusReceived";
+    case OutputEventType::kInternalError:
+        return "InternalError";
+    case OutputEventType::kTransferTimeout:
+        return "TransferTimeout";
+    default:
+        return "Unknown";
+    }
+}
+
 TransferSession::OutputEvent TransferSession::OutputEvent::TransferInitEvent(TransferInitData data, System::PacketBufferHandle msg)
 {
     OutputEvent event(OutputEventType::kInitReceived);

--- a/src/protocols/bdx/BdxTransferSession.h
+++ b/src/protocols/bdx/BdxTransferSession.h
@@ -125,6 +125,8 @@ public:
         OutputEvent() : EventType(OutputEventType::kNone) { statusData = { StatusCode::kNone }; }
         OutputEvent(OutputEventType type) : EventType(type) { statusData = { StatusCode::kNone }; }
 
+        const char * ToString(OutputEventType outputEventType);
+
         static OutputEvent TransferInitEvent(TransferInitData data, System::PacketBufferHandle msg);
         static OutputEvent TransferAcceptEvent(TransferAcceptData data);
         static OutputEvent TransferAcceptEvent(TransferAcceptData data, System::PacketBufferHandle msg);


### PR DESCRIPTION
#### Problem
Fixes: https://github.com/project-chip/connectedhomeip/issues/11074 
The above issue requires certain OTA logs to be printed in order to to be parsed and to validate test cases. Current logging does not exist.

#### Change overview
This PR adds the parameters to QueryImage and AnnounceOTAProvider commands. In addition, it also logs the type of BDX output event rather than printing its numerical value. 

#### Testing
Launch the ota-provider app and ota-requestor-app and initiate a BDX transfer between the two apps
- Verify that the parameters to QueryImage is logged
- Verify that the parameters to AnnounceOTAProvider is logged
- Verify that the BDX output event type is logged