### PR TITLE
Fix ZAP bustage from merge conflict.

### DIFF
--- a/src/controller/java/zap-generated/chip/devicecontroller/ClusterInfoMapping.java
+++ b/src/controller/java/zap-generated/chip/devicecontroller/ClusterInfoMapping.java
@@ -5332,7 +5332,6 @@ public class ClusterInfoMapping {
     Map<String, CommandInfo> modeSelectClusterCommandInfoMap = new LinkedHashMap<>();
     Map<String, CommandParameterInfo> modeSelectchangeToModeCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
-    // PLEASE UPDATE LATER: fill out parameter types
     CommandParameterInfo modeSelectchangeToModeCommandParameterInfo =
         new CommandParameterInfo("ModeSelect", ChipClusters.DefaultClusterCallback.class);
     CommandParameterInfo modeSelectchangeToModenewModeCommandParameterInfo =


### PR DESCRIPTION
https://github.com/project-chip/connectedhomeip/pull/10752 added a generated line
based on a template that https://github.com/project-chip/connectedhomeip/pull/10942
had removed.

#### Problem
ZAP job fails on master.

#### Change overview
Regenerate.

#### Testing
Looked at the output.