### PR TITLE
[python] Fix incorrect wheel suffix on ARM64 MacOS

### DIFF
--- a/src/controller/python/BUILD.gn
+++ b/src/controller/python/BUILD.gn
@@ -172,7 +172,7 @@ pw_python_action("python") {
 
   if (current_cpu == "x64") {
     cpu_tag = "x86_64"
-  } else if (current_cpu == "arm64") {
+  } else if (current_cpu == "arm64" && current_os == "linux") {
     cpu_tag = "aarch64"
   } else {
     cpu_tag = current_cpu


### PR DESCRIPTION
#### Problem
* Fixes #11250 

#### Change overview
When setting the wheel arch suffix, check both CPU architecture **and** operating system before switching from `arm64` to `aarch64`.

#### Testing
* Tested manually on an M1 MacBook pro, @erjiaqing I would appreciate if you could kindly test on RPi as well 🥺🙏 
