### PR TITLE
Enforce interface match for unauthenticated session, temporary fix #11120

### DIFF
--- a/src/transport/UnauthenticatedSessionTable.h
+++ b/src/transport/UnauthenticatedSessionTable.h
@@ -185,7 +185,7 @@ private:
         }
         else
         {
-            // One of the interface is null
+            // One of the interfaces is null.
             return true;
         }
     }

--- a/src/transport/UnauthenticatedSessionTable.h
+++ b/src/transport/UnauthenticatedSessionTable.h
@@ -175,6 +175,21 @@ private:
         return result;
     }
 
+    // A temporary solution for #11120
+    // Enforce interface match if not null
+    static bool MatchInterface(Inet::InterfaceId i1, Inet::InterfaceId i2)
+    {
+        if (i1.IsPresent() && i2.IsPresent())
+        {
+            return i1 == i2;
+        }
+        else
+        {
+            // One of the interface is null
+            return true;
+        }
+    }
+
     static bool MatchPeerAddress(const PeerAddress & a1, const PeerAddress & a2)
     {
         if (a1.GetTransportType() != a2.GetTransportType())
@@ -188,7 +203,9 @@ private:
         case Transport::Type::kTcp:
             return a1.GetIPAddress() == a2.GetIPAddress() && a1.GetPort() == a2.GetPort() &&
                 // Enforce interface equal-ness if the address is link-local, otherwise ignore interface
-                (a1.GetIPAddress().IsIPv6LinkLocal() ? a1.GetInterface() == a2.GetInterface() : true);
+                // Use MatchInterface for a temporary solution for #11120
+                (a1.GetIPAddress().IsIPv6LinkLocal() ? a1.GetInterface() == a2.GetInterface()
+                                                     : MatchInterface(a1.GetInterface(), a2.GetInterface()));
         case Transport::Type::kBle:
             // TODO: complete BLE address comparation
             return true;


### PR DESCRIPTION
#### Problem
#11120 

#### Change overview
Ensure that interface should match when matching unauthenticated session, if the interface is not null

#### Testing
Verified by unit-tests
Verified by scripts/tests/test_suites.sh

Haven't observed error in #11120, but have observed several mDNS discovery timeout error. It is probably unrelated to this PR.

```
[1635792380.261110][1098785:1098785] CHIP:DL: MDNS failed to join multicast group on enp0s31f6 for address type IPv4: ../../src/inet/UDPEndPoint.cpp:1453: Inet Error 0x00000110: Address not found
[1635792380.261804][1098785:1098785] CHIP:ZCL: Using ZAP configuration...
[1635792380.262466][1098785:1098785] CHIP:DIS: Verifying the received credentials
[1635792380.263859][1098785:1098785] CHIP:IN: Generating compressed fabric ID using uncompressed fabric ID 0x0000000000000000 and root pubkey
[1635792380.263889][1098785:1098785] CHIP:IN: 0x04, 0x31, 0xcd, 0x87, 0xde, 0xa9, 0xa8, 0x69, 
[1635792380.263907][1098785:1098785] CHIP:IN: 0x15, 0xe0, 0xf2, 0x6d, 0x39, 0x28, 0x02, 0x4e, 
[1635792380.263924][1098785:1098785] CHIP:IN: 0x77, 0x94, 0xd1, 0x77, 0x02, 0x3f, 0x22, 0xd6, 
[1635792380.263944][1098785:1098785] CHIP:IN: 0x78, 0xcd, 0x85, 0x90, 0x4c, 0x97, 0x2e, 0x28, 
[1635792380.263963][1098785:1098785] CHIP:IN: 0x59, 0x32, 0x1a, 0x05, 0x2a, 0xeb, 0x08, 0x2f, 
[1635792380.263983][1098785:1098785] CHIP:IN: 0xd3, 0x9c, 0x72, 0xa6, 0x2f, 0xe1, 0x9a, 0x70, 
[1635792380.264001][1098785:1098785] CHIP:IN: 0x39, 0xf5, 0xec, 0x10, 0xd5, 0x12, 0xcf, 0x77, 
[1635792380.264020][1098785:1098785] CHIP:IN: 0xe7, 0x44, 0x2b, 0xbe, 0x8a, 0x46, 0xcd, 0x9f, 
[1635792380.264036][1098785:1098785] CHIP:IN: 0xac, 
[1635792380.264101][1098785:1098785] CHIP:IN: Generated compressed fabric ID
[1635792380.264121][1098785:1098785] CHIP:IN: 0xee, 0x03, 0xe1, 0xb6, 0x06, 0x26, 0xb1, 0x06, 
[1635792380.264146][1098785:1098785] CHIP:DIS: Added new fabric at index: 1, Initialized: 1
[1635792380.264164][1098785:1098785] CHIP:DIS: Assigned compressed fabric ID: 0xEE03E1B60626B106, node ID: 0x000000000001B669
[1635792380.264183][1098785:1098785] CHIP:CTL: Joined the fabric at index 1. Compressed fabric ID is: 0xEE03E1B60626B106
[1635792380.264406][1098785:1098799] CHIP:DL: CHIP task running
[1635792380.264609][1098785:1098799] CHIP:DIS: Attempt to mDNS broadcast failed:  ../../src/inet/UDPEndPoint.cpp:1085: OS Error 0x02000065: Network is unreachable
        [1635792384.922267][1098752:1098752] CHIP:DIS: Broadcasting mDns reply for query from 192.168.90.193
        [1635792390.042901][1098752:1098752] CHIP:DIS: Broadcasting mDns reply for query from 192.168.90.193
[1635792500.264921][1098785:1098785] CHIP:-: ../../examples/chip-tool/commands/common/CHIPCommand.cpp:125: CHIP Error 0x00000032: Timeout at ../../examples/chip-tool/commands/common/CHIPCommand.cpp:84
[1635792500.265029][1098785:1098785] CHIP:TOO: Run command failure: ../../examples/chip-tool/commands/common/CHIPCommand.cpp:125: CHIP Error 0x00000032: Timeout
[1635792500.320322][1098785:1098785] CHIP:CTL: Shutting down the System State, this will teardown the CHIP Stack
[1635792500.320444][1098785:1098785] CHIP:DL: writing settings to file (/tmp/chip_counters.ini-orqMga)
[1635792500.320660][1098785:1098785] CHIP:DL: renamed tmp file to file (/tmp/chip_counters.ini)
[1635792500.320679][1098785:1098785] CHIP:DL: NVS set: chip-counters/total-operational-hours = 0 (0x0)
[1635792500.320696][1098785:1098785] CHIP:DL: Inet Layer shutdown
[1635792500.320756][1098785:1098785] CHIP:DL: BLE layer shutdown
[1635792500.320767][1098785:1098785] CHIP:DL: System Layer shutdown
```