### PR TITLE
Save Darwin framework test logs in artifacts

### DIFF
--- a/.github/workflows/darwin.yaml
+++ b/.github/workflows/darwin.yaml
@@ -112,6 +112,14 @@ jobs:
             - name: Run Framework Tests
               timeout-minutes: 10
               run: |
-                ../../../out/debug/chip-all-clusters-app &
-                xcodebuild test -target "CHIP" -scheme "CHIP Framework Tests" -sdk macosx
+                mkdir -p /tmp/darwin/framework-tests
+                ../../../out/debug/chip-all-clusters-app > >(tee /tmp/darwin/framework-tests/all-cluster-app.log) 2> >(tee /tmp/darwin/framework-tests/all-cluster-app-err.log >&2) &
+                xcodebuild test -target "CHIP" -scheme "CHIP Framework Tests" -sdk macosx > >(tee /tmp/darwin/framework-tests/darwin-tests.log) 2> >(tee /tmp/darwin/framework-tests/darwin-tests-err.log >&2)
               working-directory: src/darwin/Framework
+            - name: Uploading log files
+              uses: actions/upload-artifact@v2
+              if: ${{ always() }} && ${{ !env.ACT }}
+              with:
+                  name: darwin-framework-test-logs
+                  path: /tmp/darwin/framework-tests
+                  retention-days: 5

--- a/.github/workflows/darwin.yaml
+++ b/.github/workflows/darwin.yaml
@@ -118,7 +118,7 @@ jobs:
               working-directory: src/darwin/Framework
             - name: Uploading log files
               uses: actions/upload-artifact@v2
-              if: ${{ always() }} && ${{ !env.ACT }}
+              if: ${{ failure() }} && ${{ !env.ACT }}
               with:
                   name: darwin-framework-test-logs
                   path: /tmp/darwin/framework-tests


### PR DESCRIPTION
#### Problem
* Fixes #11146 

#### Change overview
Save logs from Darwin framework CI test runs in build artifacts.

#### Testing
This PR should upload the logs as part of the CI run.