### PR TITLE
Address request from #10771 - add timeouts to thread join in test

### DIFF
--- a/src/controller/python/test/test_scripts/base.py
+++ b/src/controller/python/test/test_scripts/base.py
@@ -370,10 +370,21 @@ class BaseTestHelper:
             changeThread.start()
             with handler.cv:
                 while handler.subscriptionReceived < 5:
-                    # We should observe 10 attribute changes
-                    handler.cv.wait()
-            changeThread.join()
-            return True
+                    # We should observe 5 attribute changes
+                    # The changing thread will change the value after 3 seconds. If we're waiting more than 10, assume something
+                    # is really wrong and bail out here with some information.
+                    if not handler.cv.wait(10.0):
+                        self.logger.error(f"Failed to receive subscription update")
+                        break
+
+            # thread changes 5 times, and sleeps for 3 seconds in between. Add an additional 3 seconds of slack. Timeout is in seconds.
+            changeThread.join(18.0)
+            if changeThread.is_alive():
+                # Thread join timed out
+                self.logger.error(f"Failed to join change thread")
+                return False
+            return True if handler.subscriptionReceived == 5 else False
+
         except Exception as ex:
             self.logger.exception(f"Failed to finish API test: {ex}")
             return False

--- a/src/controller/python/test/test_scripts/base.py
+++ b/src/controller/python/test/test_scripts/base.py
@@ -374,7 +374,8 @@ class BaseTestHelper:
                     # The changing thread will change the value after 3 seconds. If we're waiting more than 10, assume something
                     # is really wrong and bail out here with some information.
                     if not handler.cv.wait(10.0):
-                        self.logger.error(f"Failed to receive subscription update")
+                        self.logger.error(
+                            f"Failed to receive subscription update")
                         break
 
             # thread changes 5 times, and sleeps for 3 seconds in between. Add an additional 3 seconds of slack. Timeout is in seconds.


### PR DESCRIPTION


#### Problem
There was a request to add a timeout to the join in #10771.
The thread itself is unlikely to hang - more likely situation here
is the subscription failing to cause updates, causing the main
thread to hang forever on the condition variable.

#### Change overview

Add timeouts to to both thread join and waiting threadso we can have a bit more information about what actually
happened when the test completes.

#### Testing
This only affects the cirque tests.
