### PR TITLE
[GeneralDiagnostics]: Reporting change for the attributes not managed by the attribute store

### DIFF
--- a/src/app/clusters/general_diagnostics_server/general_diagnostics_server.cpp
+++ b/src/app/clusters/general_diagnostics_server/general_diagnostics_server.cpp
@@ -20,6 +20,7 @@
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app/AttributeAccessInterface.h>
+#include <app/reporting/reporting.h>
 #include <app/util/attribute-storage.h>
 #include <platform/ConnectivityManager.h>
 #include <platform/PlatformManager.h>
@@ -29,7 +30,7 @@ using namespace chip::app;
 using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::GeneralDiagnostics::Attributes;
 using chip::DeviceLayer::ConnectivityMgr;
-using chip::DeviceLayer::PlatformManager;
+using chip::DeviceLayer::PlatformMgr;
 
 namespace {
 
@@ -43,12 +44,12 @@ public:
 
 private:
     template <typename T>
-    CHIP_ERROR ReadIfSupported(CHIP_ERROR (PlatformManager::*getter)(T &), AttributeValueEncoder & aEncoder);
+    CHIP_ERROR ReadIfSupported(CHIP_ERROR (DeviceLayer::PlatformManager::*getter)(T &), AttributeValueEncoder & aEncoder);
     CHIP_ERROR ReadNetworkInterfaces(AttributeValueEncoder & aEncoder);
 };
 
 template <typename T>
-CHIP_ERROR GeneralDiagosticsAttrAccess::ReadIfSupported(CHIP_ERROR (PlatformManager::*getter)(T &),
+CHIP_ERROR GeneralDiagosticsAttrAccess::ReadIfSupported(CHIP_ERROR (DeviceLayer::PlatformManager::*getter)(T &),
                                                         AttributeValueEncoder & aEncoder)
 {
     T data;
@@ -107,16 +108,16 @@ CHIP_ERROR GeneralDiagosticsAttrAccess::Read(const ConcreteAttributePath & aPath
         return ReadNetworkInterfaces(aEncoder);
     }
     case RebootCount::Id: {
-        return ReadIfSupported(&PlatformManager::GetRebootCount, aEncoder);
+        return ReadIfSupported(&DeviceLayer::PlatformManager::GetRebootCount, aEncoder);
     }
     case UpTime::Id: {
-        return ReadIfSupported(&PlatformManager::GetUpTime, aEncoder);
+        return ReadIfSupported(&DeviceLayer::PlatformManager::GetUpTime, aEncoder);
     }
     case TotalOperationalHours::Id: {
-        return ReadIfSupported(&PlatformManager::GetTotalOperationalHours, aEncoder);
+        return ReadIfSupported(&DeviceLayer::PlatformManager::GetTotalOperationalHours, aEncoder);
     }
     case BootReasons::Id: {
-        return ReadIfSupported(&PlatformManager::GetBootReasons, aEncoder);
+        return ReadIfSupported(&DeviceLayer::PlatformManager::GetBootReasons, aEncoder);
     }
     default: {
         break;
@@ -124,9 +125,65 @@ CHIP_ERROR GeneralDiagosticsAttrAccess::Read(const ConcreteAttributePath & aPath
     }
     return CHIP_NO_ERROR;
 }
+
+class GeneralDiagnosticDelegate : public DeviceLayer::ConnectivityManagerDelegate, public DeviceLayer::PlatformManagerDelegate
+{
+
+    // Gets called when any network interface on the Node is updated.
+    void OnNetworkInfoChanged() override
+    {
+        ChipLogProgress(Zcl, "GeneralDiagnosticDelegate: OnNetworkInfoChanged");
+
+        for (uint16_t index = 0; index < emberAfEndpointCount(); index++)
+        {
+            if (emberAfEndpointIndexIsEnabled(index))
+            {
+                EndpointId endpointId = emberAfEndpointFromIndex(index);
+                if (endpointId == 0)
+                    continue;
+
+                if (emberAfContainsServer(endpointId, GeneralDiagnostics::Id))
+                {
+                    // If General Diagnostics cluster is implemented on this endpoint
+                    MatterReportingAttributeChangeCallback(endpointId, GeneralDiagnostics::Id,
+                                                           GeneralDiagnostics::Attributes::NetworkInterfaces::Id);
+                }
+            }
+        }
+    }
+
+    // Gets called when the device has been rebooted.
+    void OnDeviceRebooted() override
+    {
+        ChipLogProgress(Zcl, "GeneralDiagnosticDelegate: OnDeviceRebooted");
+
+        for (uint16_t index = 0; index < emberAfEndpointCount(); index++)
+        {
+            if (emberAfEndpointIndexIsEnabled(index))
+            {
+                EndpointId endpointId = emberAfEndpointFromIndex(index);
+
+                if (emberAfContainsServer(endpointId, GeneralDiagnostics::Id))
+                {
+                    // If General Diagnostics cluster is implemented on this endpoint
+                    MatterReportingAttributeChangeCallback(endpointId, GeneralDiagnostics::Id,
+                                                           GeneralDiagnostics::Attributes::RebootCount::Id);
+                    MatterReportingAttributeChangeCallback(endpointId, GeneralDiagnostics::Id,
+                                                           GeneralDiagnostics::Attributes::BootReasons::Id);
+                }
+            }
+        }
+    }
+};
+
+GeneralDiagnosticDelegate gDiagnosticDelegate;
+
 } // anonymous namespace
 
 void MatterGeneralDiagnosticsPluginServerInitCallback()
 {
     registerAttributeAccessOverride(&gAttrAccess);
+
+    PlatformMgr().SetDelegate(&gDiagnosticDelegate);
+    ConnectivityMgr().SetDelegate(&gDiagnosticDelegate);
 }

--- a/src/include/platform/ConnectivityManager.h
+++ b/src/include/platform/ConnectivityManager.h
@@ -60,7 +60,24 @@ struct NetworkInterface : public app::Clusters::GeneralDiagnostics::Structs::Net
     NetworkInterface * Next; /* Pointer to the next structure.  */
 };
 
+class ConnectivityManager;
 class ConnectivityManagerImpl;
+
+/**
+ * Defines the delegate class of Connectivity Manager to notify connectivity updates.
+ */
+class ConnectivityManagerDelegate
+{
+public:
+    virtual ~ConnectivityManagerDelegate() {}
+
+    /**
+     * @brief
+     *   Called when any network interface on the Node is changed
+     *
+     */
+    virtual void OnNetworkInfoChanged() {}
+};
 
 /**
  * Provides control of network connectivity for a chip device.
@@ -139,6 +156,9 @@ public:
     };
 
     struct ThreadPollingConfig;
+
+    void SetDelegate(ConnectivityManagerDelegate * delegate) { mDelegate = delegate; }
+    ConnectivityManagerDelegate * GetDelegate() const { return mDelegate; }
 
     // WiFi station methods
     WiFiStationMode GetWiFiStationMode();
@@ -241,6 +261,8 @@ public:
     static const char * CHIPoBLEServiceModeToStr(CHIPoBLEServiceMode mode);
 
 private:
+    ConnectivityManagerDelegate * mDelegate = nullptr;
+
     // ===== Members for internal use by the following friends.
 
     friend class PlatformManagerImpl;

--- a/src/include/platform/PlatformManager.h
+++ b/src/include/platform/PlatformManager.h
@@ -69,6 +69,23 @@ template <class>
 class GenericThreadStackManagerImpl_OpenThread_LwIP;
 } // namespace Internal
 
+class PlatformManager;
+
+/**
+ * Defines the delegate class of Platform Manager to notify platform updates.
+ */
+class PlatformManagerDelegate
+{
+public:
+    virtual ~PlatformManagerDelegate() {}
+
+    /**
+     * @brief
+     *   Called after the current device is rebooted
+     */
+    virtual void OnDeviceRebooted() {}
+};
+
 /**
  * Provides features for initializing and interacting with the chip network
  * stack on a chip-enabled device.
@@ -91,6 +108,8 @@ public:
     CHIP_ERROR InitChipStack();
     CHIP_ERROR AddEventHandler(EventHandlerFunct handler, intptr_t arg = 0);
     void RemoveEventHandler(EventHandlerFunct handler, intptr_t arg = 0);
+    void SetDelegate(PlatformManagerDelegate * delegate) { mDelegate = delegate; }
+    PlatformManagerDelegate * GetDelegate() const { return mDelegate; }
 
     /**
      * ScheduleWork can be called after InitChipStack has been called.  Calls
@@ -174,7 +193,9 @@ public:
 #endif
 
 private:
-    bool mInitialized = false;
+    bool mInitialized                   = false;
+    PlatformManagerDelegate * mDelegate = nullptr;
+
     // ===== Members for internal use by the following friends.
 
     friend class PlatformManagerImpl;

--- a/src/platform/Linux/PlatformManagerImpl.cpp
+++ b/src/platform/Linux/PlatformManagerImpl.cpp
@@ -216,6 +216,8 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack()
 
     mStartTimeMilliseconds = System::SystemClock().GetMonotonicMilliseconds();
 
+    ScheduleWork(HandleDeviceRebooted, 0);
+
 exit:
     return err;
 }
@@ -341,6 +343,16 @@ CHIP_ERROR PlatformManagerImpl::_GetBootReasons(uint8_t & bootReasons)
     }
 
     return err;
+}
+
+void PlatformManagerImpl::HandleDeviceRebooted(intptr_t arg)
+{
+    PlatformManagerDelegate * delegate = PlatformMgr().GetDelegate();
+
+    if (delegate != nullptr)
+    {
+        delegate->OnDeviceRebooted();
+    }
 }
 
 #if CHIP_WITH_GIO

--- a/src/platform/Linux/PlatformManagerImpl.h
+++ b/src/platform/Linux/PlatformManagerImpl.h
@@ -83,6 +83,7 @@ private:
     // The temporary hack for getting IP address change on linux for network provisioning in the rendezvous session.
     // This should be removed or find a better place once we depercate the rendezvous session.
     static void WiFIIPChangeListener();
+    static void HandleDeviceRebooted(intptr_t arg);
 
 #if CHIP_WITH_GIO
     struct GDBusConnectionDeleter


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* For the attribute not managed by the attribute store, there is no logic to mark them dirty and notify the report engine when those attributes change. We need to call notify the report engine in such case with the affected paths.

#### Change overview
Reporting change for the attributes not managed by the attribute store in general diagnostic cluster.

The platform delegate callback for NetworkInfo update will be done in a separate PR.

#### Testing
How was this tested? (at least one bullet point required)
* Restart program "chip-lighting-app" and confirm the reboot count and reason attributes are reported 
```
yufengw@yufengw-SEi:~/connectedhomeip/out/debug/standalone$ ./chip-lighting-app
[1635825616.790022][295517:295517] CHIP:DL:  PlatformManagerImpl::_InitChipStack
[1635825616.790126][295517:295517] CHIP:DL: MatterGeneralDiagnosticsPluginServerInitCallback->
[1635825616.815775][295517:295517] CHIP:DL: PlatformManagerImpl::HandleDeviceRebooted
[1635825616.815788][295517:295517] CHIP:ZCL: GeneralDiagnostics: OnDeviceRebooted
[1635825616.815834][295517:295517] CHIP:ZCL: MatterReportingAttributeChangeCallback
.....
```

