### PR TITLE
[IM] AttributePathExpandIterator for iterating over list of ClusterInfo-s with wildcard

### DIFF
--- a/src/app/AttributePathExpandIterator.cpp
+++ b/src/app/AttributePathExpandIterator.cpp
@@ -1,0 +1,193 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *     This file defines read handler for a CHIP Interaction Data model
+ *
+ */
+
+#include <app/AttributePathExpandIterator.h>
+
+#include <app-common/zap-generated/att-storage.h>
+#include <app/ClusterInfo.h>
+#include <app/ConcreteAttributePath.h>
+#include <app/EventManagement.h>
+#include <app/InteractionModelDelegate.h>
+#include <lib/core/CHIPCore.h>
+#include <lib/core/CHIPTLVDebug.hpp>
+#include <lib/support/CodeUtils.h>
+#include <lib/support/DLLUtil.h>
+#include <lib/support/logging/CHIPLogging.h>
+
+using namespace chip;
+
+// TODO: Here we use forward declaration for these symbols used, there should be some reorganize for code in app/util so they can be
+// used with generated files or some mock files.
+typedef uint8_t EmberAfClusterMask;
+#define CLUSTER_MASK_SERVER (0x40)
+
+extern uint16_t emberAfEndpointCount(void);
+extern uint16_t emberAfIndexFromEndpoint(EndpointId endpoint);
+extern uint8_t emberAfClusterCount(EndpointId endpoint, bool server);
+extern uint16_t emberAfGetServerAttributeCount(chip::EndpointId endpoint, chip::ClusterId cluster);
+extern uint16_t emberAfGetServerAttributeIndexByAttributeId(chip::EndpointId endpoint, chip::ClusterId cluster,
+                                                            chip::AttributeId attributeId);
+extern chip::EndpointId emberAfEndpointFromIndex(uint16_t index);
+extern Optional<ClusterId> emberAfGetNthClusterId(chip::EndpointId endpoint, uint8_t n, bool server);
+extern Optional<AttributeId> emberAfGetServerAttributeIdByIndex(chip::EndpointId endpoint, chip::ClusterId cluster,
+                                                                uint16_t attributeIndex);
+extern uint8_t emberAfClusterIndex(EndpointId endpoint, ClusterId clusterId, EmberAfClusterMask mask);
+
+namespace chip {
+namespace app {
+
+void AttributePathExpandIterator::Reset(ClusterInfo * aClusterInfo)
+{
+    mpClusterInfo = aClusterInfo;
+
+    // Reset iterator state
+    mEndpointIndex  = UINT16_MAX;
+    mClusterIndex   = UINT8_MAX;
+    mAttributeIndex = UINT16_MAX;
+
+    Proceed();
+}
+
+void AttributePathExpandIterator::PrepareEndpointIndexRange(const ClusterInfo & aClusterInfo)
+{
+    if (aClusterInfo.HasWildcardEndpointId())
+    {
+        mBeginEndpointIndex = 0;
+        mEndEndpointIndex   = emberAfEndpointCount();
+    }
+    else
+    {
+        mBeginEndpointIndex = emberAfIndexFromEndpoint(aClusterInfo.mEndpointId);
+        // If the given cluster id does not exist on the given endpoint, it will return uint16(0xFFFF), then endEndpointIndex
+        // will be 0, means we should iterate a null endppint set (skip it).
+        mEndEndpointIndex = static_cast<uint16_t>(mBeginEndpointIndex + 1);
+    }
+}
+
+void AttributePathExpandIterator::PrepareClusterIndexRange(const ClusterInfo & aClusterInfo, EndpointId aEndpointId)
+{
+    if (aClusterInfo.HasWildcardClusterId())
+    {
+        mBeginClusterIndex = 0;
+        mEndClusterIndex   = emberAfClusterCount(aEndpointId, true /* server */);
+    }
+    else
+    {
+        mBeginClusterIndex = emberAfClusterIndex(aEndpointId, aClusterInfo.mClusterId, CLUSTER_MASK_SERVER);
+        // If the given cluster id does not exist on the given endpoint, it will return uint8(0xFF), then endClusterIndex
+        // will be 0, means we should i
+        mEndClusterIndex = static_cast<uint8_t>(mBeginClusterIndex + 1);
+    }
+}
+
+void AttributePathExpandIterator::PrepareAttributeIndexRange(const ClusterInfo & aClusterInfo, EndpointId aEndpointId,
+                                                             ClusterId aClusterId)
+{
+    if (aClusterInfo.HasWildcardAttributeId())
+    {
+        mBeginAttributeIndex = 0;
+        mEndAttributeIndex   = emberAfGetServerAttributeCount(aEndpointId, aClusterId);
+    }
+    else
+    {
+        mBeginAttributeIndex = emberAfGetServerAttributeIndexByAttributeId(aEndpointId, aClusterId, aClusterInfo.mFieldId);
+        // If the given attribute id does not exist on the given endpoint, it will return uint16(0xFFFF), then endAttributeIndex
+        // will be 0
+        mEndAttributeIndex = static_cast<uint16_t>(mBeginAttributeIndex + 1);
+    }
+}
+
+bool AttributePathExpandIterator::Proceed()
+{
+    for (; mpClusterInfo != nullptr; (mpClusterInfo = mpClusterInfo->mpNext, mEndpointIndex = UINT16_MAX))
+    {
+        // Special case: If this is a concrete path, we just return its value as-is.
+        if (!mpClusterInfo->HasWildcard())
+        {
+            mOutputPath.mEndpointId  = mpClusterInfo->mEndpointId;
+            mOutputPath.mClusterId   = mpClusterInfo->mClusterId;
+            mOutputPath.mAttributeId = mpClusterInfo->mFieldId;
+
+            // Prepare for next iteration
+            (mpClusterInfo = mpClusterInfo->mpNext, mEndpointIndex = UINT16_MAX);
+            return true;
+        }
+
+        if (mEndpointIndex == UINT16_MAX)
+        {
+            PrepareEndpointIndexRange(*mpClusterInfo);
+            // If we have not started iterating over the endpoints yet.
+            mEndpointIndex = mBeginEndpointIndex;
+            mClusterIndex  = UINT8_MAX;
+        }
+
+        for (; mEndpointIndex < mEndEndpointIndex; (mEndpointIndex++, mClusterIndex = UINT8_MAX, mAttributeIndex = UINT16_MAX))
+        {
+            EndpointId endpointId = emberAfEndpointFromIndex(mEndpointIndex);
+
+            if (mClusterIndex == UINT8_MAX)
+            {
+                PrepareClusterIndexRange(*mpClusterInfo, endpointId);
+                // If we have not started iterating over the clusters yet.
+                mClusterIndex   = mBeginClusterIndex;
+                mAttributeIndex = UINT16_MAX;
+            }
+
+            for (; mClusterIndex < mEndClusterIndex; (mClusterIndex++, mAttributeIndex = UINT16_MAX))
+            {
+                // emberAfGetNthClusterId must return a valid cluster id here since we have verified the mClusterIndex does
+                // not exceed the endAttributeIndex.
+                ClusterId clusterId = emberAfGetNthClusterId(endpointId, mClusterIndex, true /* server */).Value();
+                if (mAttributeIndex == UINT16_MAX)
+                {
+                    PrepareAttributeIndexRange(*mpClusterInfo, endpointId, clusterId);
+                    // If we have not started iterating over the attributes yet.
+                    mAttributeIndex = mBeginAttributeIndex;
+                }
+
+                if (mAttributeIndex < mEndAttributeIndex)
+                {
+                    // GetServerAttributeIdByIdex must return a valid attribute here since we have verified the mAttributeindex does
+                    // not exceed the endAttributeIndex.
+                    mOutputPath.mAttributeId = emberAfGetServerAttributeIdByIndex(endpointId, clusterId, mAttributeIndex).Value();
+                    mOutputPath.mClusterId   = clusterId;
+                    mOutputPath.mEndpointId  = endpointId;
+                    mAttributeIndex++;
+                    // We found a valid attribute path, now return and increase the attribute index for next iteration.
+                    // Return true will skip the increment of mClusterIndex, mEndpointIndex and mpClusterInfo.
+                    return true;
+                }
+                // We have exhausted all attributes of this cluster, continue iterating over attributes of next cluster.
+            }
+            // We have exhausted all clusters of this endpoint, continue iterating over clusters of next endpoint.
+        }
+        // We have exhausted all endpoints in this cluster info, continue iterating over next cluster info item.
+    }
+
+    // Reset to default, invalid value.
+    mOutputPath = ConcreteAttributePath();
+    return false;
+}
+} // namespace app
+} // namespace chip

--- a/src/app/AttributePathExpandIterator.cpp
+++ b/src/app/AttributePathExpandIterator.cpp
@@ -106,7 +106,7 @@ void AttributePathExpandIterator::PrepareAttributeIndexRange(const ClusterInfo &
     }
     else
     {
-        mBeginAttributeIndex = emberAfGetServerAttributeIndexByAttributeId(aEndpointId, aClusterId, aClusterInfo.mFieldId);
+        mBeginAttributeIndex = emberAfGetServerAttributeIndexByAttributeId(aEndpointId, aClusterId, aClusterInfo.mAttributeId);
         // If the given attribute id does not exist on the given endpoint, it will return uint16(0xFFFF), then endAttributeIndex
         // will be 0, means we should iterate a null attribute set (skip it).
         mEndAttributeIndex = static_cast<uint16_t>(mBeginAttributeIndex + 1);
@@ -122,7 +122,7 @@ bool AttributePathExpandIterator::Next()
         {
             mOutputPath.mEndpointId  = mpClusterInfo->mEndpointId;
             mOutputPath.mClusterId   = mpClusterInfo->mClusterId;
-            mOutputPath.mAttributeId = mpClusterInfo->mFieldId;
+            mOutputPath.mAttributeId = mpClusterInfo->mAttributeId;
 
             // Prepare for next iteration
             (mpClusterInfo = mpClusterInfo->mpNext, mEndpointIndex = UINT16_MAX);

--- a/src/app/AttributePathExpandIterator.h
+++ b/src/app/AttributePathExpandIterator.h
@@ -16,6 +16,12 @@
  *    limitations under the License.
  */
 
+/**
+ * @file
+ *   Defines an iterator for iterating all possible paths from a list of ClusterInfo-s according to spec section 8.9.2.2 (Valid
+ * Attribute Paths)
+ */
+
 #pragma once
 
 #include <app/ClusterInfo.h>
@@ -37,8 +43,8 @@ namespace chip {
 namespace app {
 
 /**
- * AttributePathExpandIterator is used for iterate over a linked list of ClusterInfo-s.
- * The AttributePathExpandIterator is copiable, however, the given cluster info must be valid when calling proceed.
+ * AttributePathExpandIterator is used to iterate over a linked list of ClusterInfo-s.
+ * The AttributePathExpandIterator is copiable, however, the given cluster info must be valid when calling Next().
  *
  * AttributePathExpandIterator will expand attribute paths with wildcards, and only emit exist paths for ClusterInfo with
  * wildcards. For ClusterInfo with a concrete path (i.e. does not contain wildcards), AttributePathExpandIterator will emit them
@@ -46,52 +52,73 @@ namespace app {
  *
  * The typical use of AttributePathExpandIterator may look like:
  * ConcreteAttributePath path;
- * for (AttributePathExpandIterator iterator(clusterInfo); iterator.Get(path); iterator.Proceed()) {...}
+ * for (AttributePathExpandIterator iterator(clusterInfo); iterator.Get(path); iterator.Next()) {...}
  *
- * If AttributePathExpandIterator is called with a invalid ClusterInfo (e.g. a freed ClusterInfo), the program may misbehave.
- * If there are new endpoints, clusters or attributes adds, AttributePathExpandIterator must be reseted or it may emit unexpected
- * value.
+ * The iterator does not copy the given ClusterInfo, The given ClusterInfo must be valid when using the iterator.
+ * If there are new endpoints, clusters or attributes adds, AttributePathExpandIterator must be reinitialized.
+ *
+ * A initialized iterator will return the first valid path, no need to call Next() before calling Get() for the first time.
+ *
+ * Note: The Next() and Get() are two separate operations by design since a possible call of this iterator might be:
+ * - Get()
+ * - Chunk full, return
+ * - In a new chunk, Get()
+ *
+ * TODO: The ClusterInfo may support a group id, the iterator should be able to call group data provider to expand the group id.
  */
 class AttributePathExpandIterator
 {
 public:
-    AttributePathExpandIterator(ClusterInfo * aClusterInfo) { Reset(aClusterInfo); }
-
-    /**
-     * Initialize / reset the state of the path iterator.
-     * Get() will return the first valid path in the first ClusterInfo.
-     * Passing a nullptr to Reset will clear the state of the AttributePathExpandIterator.
-     */
-    void Reset(ClusterInfo * aClusterInfo);
+    AttributePathExpandIterator(ClusterInfo * aClusterInfo);
 
     /**
      * Proceed the iterator to the next attribute path in the given cluster info.
      *
      * Feturns false if AttributePathExpandIterator has exhausted all paths in the given ClusterInfo list.
      */
-    bool Proceed();
+    bool Next();
 
     /**
-     * Fills the aPath with the path the iterator current points to.
-     * Return false if the iterator is not pointing a valid path (i.e. it has exhausted the cluster info).
+     * Fills the aPath with the path the iterator currently points to.
+     * Returns false if the iterator is not pointing to a valid path (i.e. it has exhausted the cluster info).
      */
     bool Get(ConcreteAttributePath & aPath)
     {
         aPath = mOutputPath;
-        return mOutputPath.mEndpointId != ConcreteAttributePath::kInvalidEndpointId;
+        return Valid();
     }
 
-    bool Valid() { return mpClusterInfo != nullptr; }
+    /**
+     * Returns if the iterator is valid (not exhausted). An iterator is exhausted if and only if:
+     * - Next() is called after iterating last path.
+     * - Iterator is initialized wirh a null ClusterInfo.
+     */
+    inline bool Valid() const
+    {
+        // Check if we can emitting a valid path, we are not checking mpClusterInfo since we may just visited a ClusterInfo with
+        // concrete attribute path, and it is the last one in the linked list.
+        return mOutputPath.mEndpointId != kInvalidEndpointId;
+    }
 
 private:
     ClusterInfo * mpClusterInfo;
 
     uint16_t mEndpointIndex, mBeginEndpointIndex, mEndEndpointIndex;
+    // Note: should use decltype(EmberAfEndpointType::clusterCount) here, but af-types is including app specific generated files.
     uint8_t mClusterIndex, mBeginClusterIndex, mEndClusterIndex;
     uint16_t mAttributeIndex, mBeginAttributeIndex, mEndAttributeIndex;
 
-    ConcreteAttributePath mOutputPath = ConcreteAttributePath();
+    ConcreteAttributePath mOutputPath;
 
+    /**
+     * Prepare*IndexRange will update mBegin*Index and mEnd*Index variables.
+     * If ClusterInfo contains a wildcard field, it will set mBegin*Index to 0 and mEnd*Index to count.
+     * Or it will set mBegin*Index to the index of the Endpoint/Cluster/Attribute, and mEnd*Index to mBegin*Index + 1.
+     *
+     * If the Endpoint/Cluster/Attribute does not exist, mBegin*Index will be UINT*_MAX, and mEnd*Inde will be 0.
+     *
+     * The index can be used with emberAfEndpointFromIndex, emberAfGetNthClusterId and emberAfGetServerAttributeIdByIndex.
+     */
     void PrepareEndpointIndexRange(const ClusterInfo & aClusterInfo);
     void PrepareClusterIndexRange(const ClusterInfo & aClusterInfo, EndpointId aEndpointId);
     void PrepareAttributeIndexRange(const ClusterInfo & aClusterInfo, EndpointId aEndpointId, ClusterId aClusterId);

--- a/src/app/AttributePathExpandIterator.h
+++ b/src/app/AttributePathExpandIterator.h
@@ -46,7 +46,7 @@ namespace app {
  * AttributePathExpandIterator is used to iterate over a linked list of ClusterInfo-s.
  * The AttributePathExpandIterator is copiable, however, the given cluster info must be valid when calling Next().
  *
- * AttributePathExpandIterator will expand attribute paths with wildcards, and only emit exist paths for ClusterInfo with
+ * AttributePathExpandIterator will expand attribute paths with wildcards, and only emit existing paths for ClusterInfo with
  * wildcards. For ClusterInfo with a concrete path (i.e. does not contain wildcards), AttributePathExpandIterator will emit them
  * as-is.
  *
@@ -55,7 +55,7 @@ namespace app {
  * for (AttributePathExpandIterator iterator(clusterInfo); iterator.Get(path); iterator.Next()) {...}
  *
  * The iterator does not copy the given ClusterInfo, The given ClusterInfo must be valid when using the iterator.
- * If there are new endpoints, clusters or attributes adds, AttributePathExpandIterator must be reinitialized.
+ * If the set of endpoints, clusters, or attributes that are supported changes, AttributePathExpandIterator must be reinitialized.
  *
  * A initialized iterator will return the first valid path, no need to call Next() before calling Get() for the first time.
  *
@@ -74,7 +74,7 @@ public:
     /**
      * Proceed the iterator to the next attribute path in the given cluster info.
      *
-     * Feturns false if AttributePathExpandIterator has exhausted all paths in the given ClusterInfo list.
+     * Returns false if AttributePathExpandIterator has exhausted all paths in the given ClusterInfo list.
      */
     bool Next();
 
@@ -93,20 +93,15 @@ public:
      * - Next() is called after iterating last path.
      * - Iterator is initialized wirh a null ClusterInfo.
      */
-    inline bool Valid() const
-    {
-        // Check if we can emitting a valid path, we are not checking mpClusterInfo since we may just visited a ClusterInfo with
-        // concrete attribute path, and it is the last one in the linked list.
-        return mOutputPath.mEndpointId != kInvalidEndpointId;
-    }
+    inline bool Valid() const { return mpClusterInfo != nullptr; }
 
 private:
     ClusterInfo * mpClusterInfo;
 
-    uint16_t mEndpointIndex, mBeginEndpointIndex, mEndEndpointIndex;
+    uint16_t mEndpointIndex, mEndEndpointIndex;
     // Note: should use decltype(EmberAfEndpointType::clusterCount) here, but af-types is including app specific generated files.
-    uint8_t mClusterIndex, mBeginClusterIndex, mEndClusterIndex;
-    uint16_t mAttributeIndex, mBeginAttributeIndex, mEndAttributeIndex;
+    uint8_t mClusterIndex, mEndClusterIndex;
+    uint16_t mAttributeIndex, mEndAttributeIndex;
 
     ConcreteAttributePath mOutputPath;
 

--- a/src/app/AttributePathExpandIterator.h
+++ b/src/app/AttributePathExpandIterator.h
@@ -91,7 +91,7 @@ public:
     /**
      * Returns if the iterator is valid (not exhausted). An iterator is exhausted if and only if:
      * - Next() is called after iterating last path.
-     * - Iterator is initialized wirh a null ClusterInfo.
+     * - Iterator is initialized with a null ClusterInfo.
      */
     inline bool Valid() const { return mpClusterInfo != nullptr; }
 

--- a/src/app/AttributePathExpandIterator.h
+++ b/src/app/AttributePathExpandIterator.h
@@ -1,0 +1,100 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <app/ClusterInfo.h>
+#include <app/ConcreteAttributePath.h>
+#include <app/EventManagement.h>
+#include <app/InteractionModelDelegate.h>
+#include <lib/core/CHIPCore.h>
+#include <lib/core/CHIPTLVDebug.hpp>
+#include <lib/support/CodeUtils.h>
+#include <lib/support/DLLUtil.h>
+#include <lib/support/logging/CHIPLogging.h>
+#include <messaging/ExchangeContext.h>
+#include <messaging/ExchangeMgr.h>
+#include <messaging/Flags.h>
+#include <protocols/Protocols.h>
+#include <system/SystemPacketBuffer.h>
+
+namespace chip {
+namespace app {
+
+/**
+ * AttributePathExpandIterator is used for iterate over a linked list of ClusterInfo-s.
+ * The AttributePathExpandIterator is copiable, however, the given cluster info must be valid when calling proceed.
+ *
+ * AttributePathExpandIterator will expand attribute paths with wildcards, and only emit exist paths for ClusterInfo with
+ * wildcards. For ClusterInfo with a concrete path (i.e. does not contain wildcards), AttributePathExpandIterator will emit them
+ * as-is.
+ *
+ * The typical use of AttributePathExpandIterator may look like:
+ * ConcreteAttributePath path;
+ * for (AttributePathExpandIterator iterator(clusterInfo); iterator.Get(path); iterator.Proceed()) {...}
+ *
+ * If AttributePathExpandIterator is called with a invalid ClusterInfo (e.g. a freed ClusterInfo), the program may misbehave.
+ * If there are new endpoints, clusters or attributes adds, AttributePathExpandIterator must be reseted or it may emit unexpected
+ * value.
+ */
+class AttributePathExpandIterator
+{
+public:
+    AttributePathExpandIterator(ClusterInfo * aClusterInfo) { Reset(aClusterInfo); }
+
+    /**
+     * Initialize / reset the state of the path iterator.
+     * Get() will return the first valid path in the first ClusterInfo.
+     * Passing a nullptr to Reset will clear the state of the AttributePathExpandIterator.
+     */
+    void Reset(ClusterInfo * aClusterInfo);
+
+    /**
+     * Proceed the iterator to the next attribute path in the given cluster info.
+     *
+     * Feturns false if AttributePathExpandIterator has exhausted all paths in the given ClusterInfo list.
+     */
+    bool Proceed();
+
+    /**
+     * Fills the aPath with the path the iterator current points to.
+     * Return false if the iterator is not pointing a valid path (i.e. it has exhausted the cluster info).
+     */
+    bool Get(ConcreteAttributePath & aPath)
+    {
+        aPath = mOutputPath;
+        return mOutputPath.mEndpointId != ConcreteAttributePath::kInvalidEndpointId;
+    }
+
+    bool Valid() { return mpClusterInfo != nullptr; }
+
+private:
+    ClusterInfo * mpClusterInfo;
+
+    uint16_t mEndpointIndex, mBeginEndpointIndex, mEndEndpointIndex;
+    uint8_t mClusterIndex, mBeginClusterIndex, mEndClusterIndex;
+    uint16_t mAttributeIndex, mBeginAttributeIndex, mEndAttributeIndex;
+
+    ConcreteAttributePath mOutputPath = ConcreteAttributePath();
+
+    void PrepareEndpointIndexRange(const ClusterInfo & aClusterInfo);
+    void PrepareClusterIndexRange(const ClusterInfo & aClusterInfo, EndpointId aEndpointId);
+    void PrepareAttributeIndexRange(const ClusterInfo & aClusterInfo, EndpointId aEndpointId, ClusterId aClusterId);
+};
+} // namespace app
+} // namespace chip

--- a/src/app/AttributePathParams.h
+++ b/src/app/AttributePathParams.h
@@ -58,12 +58,12 @@ struct AttributePathParams
      */
     bool IsValidAttributePath() const { return HasWildcardListIndex() || !HasWildcardAttributeId(); }
 
-    inline bool HasWildcardEndpointId() const { return mEndpointId == ClusterInfo::kInvalidEndpointId; }
+    inline bool HasWildcardEndpointId() const { return mEndpointId == kInvalidEndpointId; }
     inline bool HasWildcardClusterId() const { return mClusterId == ClusterInfo::kInvalidClusterId; }
     inline bool HasWildcardAttributeId() const { return mAttributeId == ClusterInfo::kInvalidAttributeId; }
     inline bool HasWildcardListIndex() const { return mListIndex == ClusterInfo::kInvalidListIndex; }
 
-    EndpointId mEndpointId   = ClusterInfo::kInvalidEndpointId;
+    EndpointId mEndpointId   = kInvalidEndpointId;
     ClusterId mClusterId     = ClusterInfo::kInvalidClusterId;
     AttributeId mAttributeId = ClusterInfo::kInvalidAttributeId;
     ListIndex mListIndex     = ClusterInfo::kInvalidListIndex;

--- a/src/app/BUILD.gn
+++ b/src/app/BUILD.gn
@@ -35,7 +35,10 @@ static_library("app") {
   output_name = "libCHIPDataModel"
 
   sources = [
+    "AttributePathExpandIterator.cpp",
+    "AttributePathExpandIterator.h",
     "AttributePathParams.cpp",
+    "AttributePathParams.h",
     "Command.cpp",
     "Command.h",
     "CommandHandler.cpp",

--- a/src/app/ClusterInfo.h
+++ b/src/app/ClusterInfo.h
@@ -37,8 +37,6 @@ struct ClusterInfo
 private:
     // Allow AttributePathParams access these constants.
     friend struct AttributePathParams;
-    // Allow ConcreteAttributePath access these constants.
-    friend struct ConcreteAttributePath;
 
     // The ClusterId, AttributeId and EventId are MEIs,
     // 0xFFFF is not a valid manufacturer code, thus 0xFFFF'FFFF is not a valid MEI

--- a/src/app/ClusterInfo.h
+++ b/src/app/ClusterInfo.h
@@ -37,8 +37,9 @@ struct ClusterInfo
 private:
     // Allow AttributePathParams access these constants.
     friend struct AttributePathParams;
-    // Endpoint Id is a uint16 number, and should between 0 and 0xFFFE
-    static constexpr EndpointId kInvalidEndpointId = 0xFFFF;
+    // Allow ConcreteAttributePath access these constants.
+    friend struct ConcreteAttributePath;
+
     // The ClusterId, AttributeId and EventId are MEIs,
     // 0xFFFF is not a valid manufacturer code, thus 0xFFFF'FFFF is not a valid MEI
     static constexpr ClusterId kInvalidClusterId     = 0xFFFF'FFFF;

--- a/src/app/ConcreteAttributePath.h
+++ b/src/app/ConcreteAttributePath.h
@@ -28,6 +28,11 @@ namespace app {
  */
 struct ConcreteAttributePath
 {
+    static constexpr EndpointId kInvalidEndpointId   = 0xFFFF;
+    static constexpr ClusterId kInvalidClusterId     = 0xFFFF'FFFF;
+    static constexpr AttributeId kInvalidAttributeId = 0xFFFF'FFFF;
+
+    ConcreteAttributePath() {}
     ConcreteAttributePath(EndpointId aEndpointId, ClusterId aClusterId, AttributeId aAttributeId) :
         mEndpointId(aEndpointId), mClusterId(aClusterId), mAttributeId(aAttributeId)
     {}
@@ -37,9 +42,9 @@ struct ConcreteAttributePath
         return mEndpointId == other.mEndpointId && mClusterId == other.mClusterId && mAttributeId == other.mAttributeId;
     }
 
-    EndpointId mEndpointId   = 0;
-    ClusterId mClusterId     = 0;
-    AttributeId mAttributeId = 0;
+    EndpointId mEndpointId   = kInvalidEndpointId;
+    ClusterId mClusterId     = kInvalidClusterId;
+    AttributeId mAttributeId = kInvalidAttributeId;
 };
 } // namespace app
 } // namespace chip

--- a/src/app/ConcreteAttributePath.h
+++ b/src/app/ConcreteAttributePath.h
@@ -18,8 +18,8 @@
 
 #pragma once
 
+#include <app/ClusterInfo.h>
 #include <app/util/basic-types.h>
-
 namespace chip {
 namespace app {
 
@@ -28,10 +28,6 @@ namespace app {
  */
 struct ConcreteAttributePath
 {
-    static constexpr EndpointId kInvalidEndpointId   = 0xFFFF;
-    static constexpr ClusterId kInvalidClusterId     = 0xFFFF'FFFF;
-    static constexpr AttributeId kInvalidAttributeId = 0xFFFF'FFFF;
-
     ConcreteAttributePath() {}
     ConcreteAttributePath(EndpointId aEndpointId, ClusterId aClusterId, AttributeId aAttributeId) :
         mEndpointId(aEndpointId), mClusterId(aClusterId), mAttributeId(aAttributeId)
@@ -43,8 +39,8 @@ struct ConcreteAttributePath
     }
 
     EndpointId mEndpointId   = kInvalidEndpointId;
-    ClusterId mClusterId     = kInvalidClusterId;
-    AttributeId mAttributeId = kInvalidAttributeId;
+    ClusterId mClusterId     = ClusterInfo::kInvalidClusterId;
+    AttributeId mAttributeId = ClusterInfo::kInvalidAttributeId;
 };
 } // namespace app
 } // namespace chip

--- a/src/app/ConcreteAttributePath.h
+++ b/src/app/ConcreteAttributePath.h
@@ -18,7 +18,6 @@
 
 #pragma once
 
-#include <app/ClusterInfo.h>
 #include <app/util/basic-types.h>
 namespace chip {
 namespace app {
@@ -38,9 +37,9 @@ struct ConcreteAttributePath
         return mEndpointId == other.mEndpointId && mClusterId == other.mClusterId && mAttributeId == other.mAttributeId;
     }
 
-    EndpointId mEndpointId   = kInvalidEndpointId;
-    ClusterId mClusterId     = ClusterInfo::kInvalidClusterId;
-    AttributeId mAttributeId = ClusterInfo::kInvalidAttributeId;
+    EndpointId mEndpointId   = 0;
+    ClusterId mClusterId     = 0;
+    AttributeId mAttributeId = 0;
 };
 } // namespace app
 } // namespace chip

--- a/src/app/ConcreteAttributePath.h
+++ b/src/app/ConcreteAttributePath.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include <app/util/basic-types.h>
+
 namespace chip {
 namespace app {
 

--- a/src/app/tests/BUILD.gn
+++ b/src/app/tests/BUILD.gn
@@ -41,6 +41,7 @@ chip_test_suite("tests") {
   output_name = "libAppTests"
 
   test_sources = [
+    "TestAttributePathExpandIterator.cpp",
     "TestAttributeValueEncoder.cpp",
     "TestBuilderParser.cpp",
     "TestCHIPDeviceCallbacksMgr.cpp",
@@ -65,6 +66,7 @@ chip_test_suite("tests") {
     "${chip_root}/src/app/common:cluster-objects",
     "${chip_root}/src/app/tests:helpers",
     "${chip_root}/src/app/util:device_callbacks_manager",
+    "${chip_root}/src/app/util/mock:mock_ember",
     "${chip_root}/src/lib/core",
     "${nlunit_test_root}:nlunit-test",
   ]

--- a/src/app/tests/TestAttributePathExpandIterator.cpp
+++ b/src/app/tests/TestAttributePathExpandIterator.cpp
@@ -33,6 +33,8 @@
 #include <nlunit-test.h>
 
 using namespace chip;
+using namespace chip::Test;
+using namespace chip::app;
 
 namespace {
 
@@ -44,16 +46,35 @@ void TestAllWildcard(nlTestSuite * apSuite, void * apContext)
 
     app::ConcreteAttributePath path;
     P paths[] = {
-        { 0xFFFE, 0xFFF1'0001, 0x0000'FFFD }, { 0xFFFE, 0xFFF1'0001, 0x0000'FFFC }, { 0xFFFE, 0xFFF1'0002, 0x0000'FFFD },
-        { 0xFFFE, 0xFFF1'0002, 0x0000'FFFC }, { 0xFFFE, 0xFFF1'0002, 0xFFF1'0001 }, { 0xFFFD, 0xFFF1'0001, 0x0000'FFFD },
-        { 0xFFFD, 0xFFF1'0001, 0x0000'FFFC }, { 0xFFFD, 0xFFF1'0002, 0x0000'FFFD }, { 0xFFFD, 0xFFF1'0002, 0x0000'FFFC },
-        { 0xFFFD, 0xFFF1'0002, 0xFFF1'0001 }, { 0xFFFD, 0xFFF1'0002, 0xFFF1'0002 }, { 0xFFFD, 0xFFF1'0003, 0x0000'FFFD },
-        { 0xFFFD, 0xFFF1'0003, 0x0000'FFFC }, { 0xFFFD, 0xFFF1'0003, 0xFFF1'0001 }, { 0xFFFD, 0xFFF1'0003, 0xFFF1'0002 },
-        { 0xFFFD, 0xFFF1'0003, 0xFFF1'0003 }, { 0xFFFC, 0xFFF1'0001, 0x0000'FFFD }, { 0xFFFC, 0xFFF1'0001, 0x0000'FFFC },
-        { 0xFFFC, 0xFFF1'0001, 0xFFF1'0001 }, { 0xFFFC, 0xFFF1'0002, 0x0000'FFFD }, { 0xFFFC, 0xFFF1'0002, 0x0000'FFFC },
-        { 0xFFFC, 0xFFF1'0002, 0xFFF1'0001 }, { 0xFFFC, 0xFFF1'0002, 0xFFF1'0002 }, { 0xFFFC, 0xFFF1'0002, 0xFFF1'0003 },
-        { 0xFFFC, 0xFFF1'0002, 0xFFF1'0004 }, { 0xFFFC, 0xFFF1'0003, 0x0000'FFFD }, { 0xFFFC, 0xFFF1'0003, 0x0000'FFFC },
-        { 0xFFFC, 0xFFF1'0004, 0x0000'FFFD }, { 0xFFFC, 0xFFF1'0004, 0x0000'FFFC },
+        { kMockEndpoint1, MockClusterId(1), Clusters::Globals::Attributes::ClusterRevision::Id },
+        { kMockEndpoint1, MockClusterId(1), Clusters::Globals::Attributes::FeatureMap::Id },
+        { kMockEndpoint1, MockClusterId(2), Clusters::Globals::Attributes::ClusterRevision::Id },
+        { kMockEndpoint1, MockClusterId(2), Clusters::Globals::Attributes::FeatureMap::Id },
+        { kMockEndpoint1, MockClusterId(2), MockAttributeId(1) },
+        { kMockEndpoint2, MockClusterId(1), Clusters::Globals::Attributes::ClusterRevision::Id },
+        { kMockEndpoint2, MockClusterId(1), Clusters::Globals::Attributes::FeatureMap::Id },
+        { kMockEndpoint2, MockClusterId(2), Clusters::Globals::Attributes::ClusterRevision::Id },
+        { kMockEndpoint2, MockClusterId(2), Clusters::Globals::Attributes::FeatureMap::Id },
+        { kMockEndpoint2, MockClusterId(2), MockAttributeId(1) },
+        { kMockEndpoint2, MockClusterId(2), MockAttributeId(2) },
+        { kMockEndpoint2, MockClusterId(3), Clusters::Globals::Attributes::ClusterRevision::Id },
+        { kMockEndpoint2, MockClusterId(3), Clusters::Globals::Attributes::FeatureMap::Id },
+        { kMockEndpoint2, MockClusterId(3), MockAttributeId(1) },
+        { kMockEndpoint2, MockClusterId(3), MockAttributeId(2) },
+        { kMockEndpoint2, MockClusterId(3), MockAttributeId(3) },
+        { kMockEndpoint3, MockClusterId(1), Clusters::Globals::Attributes::ClusterRevision::Id },
+        { kMockEndpoint3, MockClusterId(1), Clusters::Globals::Attributes::FeatureMap::Id },
+        { kMockEndpoint3, MockClusterId(1), MockAttributeId(1) },
+        { kMockEndpoint3, MockClusterId(2), Clusters::Globals::Attributes::ClusterRevision::Id },
+        { kMockEndpoint3, MockClusterId(2), Clusters::Globals::Attributes::FeatureMap::Id },
+        { kMockEndpoint3, MockClusterId(2), MockAttributeId(1) },
+        { kMockEndpoint3, MockClusterId(2), MockAttributeId(2) },
+        { kMockEndpoint3, MockClusterId(2), MockAttributeId(3) },
+        { kMockEndpoint3, MockClusterId(2), MockAttributeId(4) },
+        { kMockEndpoint3, MockClusterId(3), Clusters::Globals::Attributes::ClusterRevision::Id },
+        { kMockEndpoint3, MockClusterId(3), Clusters::Globals::Attributes::FeatureMap::Id },
+        { kMockEndpoint3, MockClusterId(4), Clusters::Globals::Attributes::ClusterRevision::Id },
+        { kMockEndpoint3, MockClusterId(4), Clusters::Globals::Attributes::FeatureMap::Id },
     };
 
     size_t index = 0;
@@ -71,12 +92,12 @@ void TestAllWildcard(nlTestSuite * apSuite, void * apContext)
 void TestWildcardEndpoint(nlTestSuite * apSuite, void * apContext)
 {
     app::ClusterInfo clusInfo;
-    clusInfo.mClusterId = Test::MockClusterId(3);
-    clusInfo.mFieldId   = Test::MockAttributeId(3);
+    clusInfo.mClusterId   = Test::MockClusterId(3);
+    clusInfo.mAttributeId = Test::MockAttributeId(3);
 
     app::ConcreteAttributePath path;
     P paths[] = {
-        { 0xFFFD, 0xFFF1'0003, 0xFFF1'0003 },
+        { kMockEndpoint2, MockClusterId(3), MockAttributeId(3) },
     };
 
     size_t index = 0;
@@ -94,15 +115,15 @@ void TestWildcardEndpoint(nlTestSuite * apSuite, void * apContext)
 void TestWildcardCluster(nlTestSuite * apSuite, void * apContext)
 {
     app::ClusterInfo clusInfo;
-    clusInfo.mEndpointId = Test::kMockEndpoint3;
-    clusInfo.mFieldId    = app::Clusters::Globals::Attributes::ClusterRevision::Id;
+    clusInfo.mEndpointId  = Test::kMockEndpoint3;
+    clusInfo.mAttributeId = app::Clusters::Globals::Attributes::ClusterRevision::Id;
 
     app::ConcreteAttributePath path;
     P paths[] = {
-        { 0xFFFC, 0xFFF1'0001, 0x0000'FFFD },
-        { 0xFFFC, 0xFFF1'0002, 0x0000'FFFD },
-        { 0xFFFC, 0xFFF1'0003, 0x0000'FFFD },
-        { 0xFFFC, 0xFFF1'0004, 0x0000'FFFD },
+        { kMockEndpoint3, MockClusterId(1), Clusters::Globals::Attributes::ClusterRevision::Id },
+        { kMockEndpoint3, MockClusterId(2), Clusters::Globals::Attributes::ClusterRevision::Id },
+        { kMockEndpoint3, MockClusterId(3), Clusters::Globals::Attributes::ClusterRevision::Id },
+        { kMockEndpoint3, MockClusterId(4), Clusters::Globals::Attributes::ClusterRevision::Id },
     };
 
     size_t index = 0;
@@ -125,8 +146,11 @@ void TestWildcardAttribute(nlTestSuite * apSuite, void * apContext)
 
     app::ConcreteAttributePath path;
     P paths[] = {
-        { 0xFFFD, 0xFFF1'0003, 0x0000'FFFD }, { 0xFFFD, 0xFFF1'0003, 0x0000'FFFC }, { 0xFFFD, 0xFFF1'0003, 0xFFF1'0001 },
-        { 0xFFFD, 0xFFF1'0003, 0xFFF1'0002 }, { 0xFFFD, 0xFFF1'0003, 0xFFF1'0003 },
+        { kMockEndpoint2, MockClusterId(3), Clusters::Globals::Attributes::ClusterRevision::Id },
+        { kMockEndpoint2, MockClusterId(3), Clusters::Globals::Attributes::FeatureMap::Id },
+        { kMockEndpoint2, MockClusterId(3), MockAttributeId(1) },
+        { kMockEndpoint2, MockClusterId(3), MockAttributeId(2) },
+        { kMockEndpoint2, MockClusterId(3), MockAttributeId(3) },
     };
 
     size_t index = 0;
@@ -144,13 +168,13 @@ void TestWildcardAttribute(nlTestSuite * apSuite, void * apContext)
 void TestNoWildcard(nlTestSuite * apSuite, void * apContext)
 {
     app::ClusterInfo clusInfo;
-    clusInfo.mEndpointId = Test::kMockEndpoint2;
-    clusInfo.mClusterId  = Test::MockClusterId(3);
-    clusInfo.mFieldId    = Test::MockAttributeId(3);
+    clusInfo.mEndpointId  = Test::kMockEndpoint2;
+    clusInfo.mClusterId   = Test::MockClusterId(3);
+    clusInfo.mAttributeId = Test::MockAttributeId(3);
 
     app::ConcreteAttributePath path;
     P paths[] = {
-        { 0xFFFD, 0xFFF1'0003, 0xFFF1'0003 },
+        { kMockEndpoint2, MockClusterId(3), MockAttributeId(3) },
     };
 
     size_t index = 0;
@@ -171,21 +195,21 @@ void TestMultipleClusInfo(nlTestSuite * apSuite, void * apContext)
     app::ClusterInfo clusInfo1;
 
     app::ClusterInfo clusInfo2;
-    clusInfo2.mClusterId = Test::MockClusterId(3);
-    clusInfo2.mFieldId   = Test::MockAttributeId(3);
+    clusInfo2.mClusterId   = Test::MockClusterId(3);
+    clusInfo2.mAttributeId = Test::MockAttributeId(3);
 
     app::ClusterInfo clusInfo3;
-    clusInfo3.mEndpointId = Test::kMockEndpoint3;
-    clusInfo3.mFieldId    = app::Clusters::Globals::Attributes::ClusterRevision::Id;
+    clusInfo3.mEndpointId  = Test::kMockEndpoint3;
+    clusInfo3.mAttributeId = app::Clusters::Globals::Attributes::ClusterRevision::Id;
 
     app::ClusterInfo clusInfo4;
     clusInfo4.mEndpointId = Test::kMockEndpoint2;
     clusInfo4.mClusterId  = Test::MockClusterId(3);
 
     app::ClusterInfo clusInfo5;
-    clusInfo5.mEndpointId = Test::kMockEndpoint2;
-    clusInfo5.mClusterId  = Test::MockClusterId(3);
-    clusInfo5.mFieldId    = Test::MockAttributeId(3);
+    clusInfo5.mEndpointId  = Test::kMockEndpoint2;
+    clusInfo5.mClusterId   = Test::MockClusterId(3);
+    clusInfo5.mAttributeId = Test::MockAttributeId(3);
 
     clusInfo1.mpNext = &clusInfo2;
     clusInfo2.mpNext = &clusInfo3;
@@ -194,20 +218,46 @@ void TestMultipleClusInfo(nlTestSuite * apSuite, void * apContext)
 
     app::ConcreteAttributePath path;
     P paths[] = {
-        { 0xFFFE, 0xFFF1'0001, 0x0000'FFFD }, { 0xFFFE, 0xFFF1'0001, 0x0000'FFFC }, { 0xFFFE, 0xFFF1'0002, 0x0000'FFFD },
-        { 0xFFFE, 0xFFF1'0002, 0x0000'FFFC }, { 0xFFFE, 0xFFF1'0002, 0xFFF1'0001 }, { 0xFFFD, 0xFFF1'0001, 0x0000'FFFD },
-        { 0xFFFD, 0xFFF1'0001, 0x0000'FFFC }, { 0xFFFD, 0xFFF1'0002, 0x0000'FFFD }, { 0xFFFD, 0xFFF1'0002, 0x0000'FFFC },
-        { 0xFFFD, 0xFFF1'0002, 0xFFF1'0001 }, { 0xFFFD, 0xFFF1'0002, 0xFFF1'0002 }, { 0xFFFD, 0xFFF1'0003, 0x0000'FFFD },
-        { 0xFFFD, 0xFFF1'0003, 0x0000'FFFC }, { 0xFFFD, 0xFFF1'0003, 0xFFF1'0001 }, { 0xFFFD, 0xFFF1'0003, 0xFFF1'0002 },
-        { 0xFFFD, 0xFFF1'0003, 0xFFF1'0003 }, { 0xFFFC, 0xFFF1'0001, 0x0000'FFFD }, { 0xFFFC, 0xFFF1'0001, 0x0000'FFFC },
-        { 0xFFFC, 0xFFF1'0001, 0xFFF1'0001 }, { 0xFFFC, 0xFFF1'0002, 0x0000'FFFD }, { 0xFFFC, 0xFFF1'0002, 0x0000'FFFC },
-        { 0xFFFC, 0xFFF1'0002, 0xFFF1'0001 }, { 0xFFFC, 0xFFF1'0002, 0xFFF1'0002 }, { 0xFFFC, 0xFFF1'0002, 0xFFF1'0003 },
-        { 0xFFFC, 0xFFF1'0002, 0xFFF1'0004 }, { 0xFFFC, 0xFFF1'0003, 0x0000'FFFD }, { 0xFFFC, 0xFFF1'0003, 0x0000'FFFC },
-        { 0xFFFC, 0xFFF1'0004, 0x0000'FFFD }, { 0xFFFC, 0xFFF1'0004, 0x0000'FFFC }, { 0xFFFD, 0xFFF1'0003, 0xFFF1'0003 },
-        { 0xFFFC, 0xFFF1'0001, 0x0000'FFFD }, { 0xFFFC, 0xFFF1'0002, 0x0000'FFFD }, { 0xFFFC, 0xFFF1'0003, 0x0000'FFFD },
-        { 0xFFFC, 0xFFF1'0004, 0x0000'FFFD }, { 0xFFFD, 0xFFF1'0003, 0x0000'FFFD }, { 0xFFFD, 0xFFF1'0003, 0x0000'FFFC },
-        { 0xFFFD, 0xFFF1'0003, 0xFFF1'0001 }, { 0xFFFD, 0xFFF1'0003, 0xFFF1'0002 }, { 0xFFFD, 0xFFF1'0003, 0xFFF1'0003 },
-        { 0xFFFD, 0xFFF1'0003, 0xFFF1'0003 },
+        { kMockEndpoint1, MockClusterId(1), Clusters::Globals::Attributes::ClusterRevision::Id },
+        { kMockEndpoint1, MockClusterId(1), Clusters::Globals::Attributes::FeatureMap::Id },
+        { kMockEndpoint1, MockClusterId(2), Clusters::Globals::Attributes::ClusterRevision::Id },
+        { kMockEndpoint1, MockClusterId(2), Clusters::Globals::Attributes::FeatureMap::Id },
+        { kMockEndpoint1, MockClusterId(2), MockAttributeId(1) },
+        { kMockEndpoint2, MockClusterId(1), Clusters::Globals::Attributes::ClusterRevision::Id },
+        { kMockEndpoint2, MockClusterId(1), Clusters::Globals::Attributes::FeatureMap::Id },
+        { kMockEndpoint2, MockClusterId(2), Clusters::Globals::Attributes::ClusterRevision::Id },
+        { kMockEndpoint2, MockClusterId(2), Clusters::Globals::Attributes::FeatureMap::Id },
+        { kMockEndpoint2, MockClusterId(2), MockAttributeId(1) },
+        { kMockEndpoint2, MockClusterId(2), MockAttributeId(2) },
+        { kMockEndpoint2, MockClusterId(3), Clusters::Globals::Attributes::ClusterRevision::Id },
+        { kMockEndpoint2, MockClusterId(3), Clusters::Globals::Attributes::FeatureMap::Id },
+        { kMockEndpoint2, MockClusterId(3), MockAttributeId(1) },
+        { kMockEndpoint2, MockClusterId(3), MockAttributeId(2) },
+        { kMockEndpoint2, MockClusterId(3), MockAttributeId(3) },
+        { kMockEndpoint3, MockClusterId(1), Clusters::Globals::Attributes::ClusterRevision::Id },
+        { kMockEndpoint3, MockClusterId(1), Clusters::Globals::Attributes::FeatureMap::Id },
+        { kMockEndpoint3, MockClusterId(1), MockAttributeId(1) },
+        { kMockEndpoint3, MockClusterId(2), Clusters::Globals::Attributes::ClusterRevision::Id },
+        { kMockEndpoint3, MockClusterId(2), Clusters::Globals::Attributes::FeatureMap::Id },
+        { kMockEndpoint3, MockClusterId(2), MockAttributeId(1) },
+        { kMockEndpoint3, MockClusterId(2), MockAttributeId(2) },
+        { kMockEndpoint3, MockClusterId(2), MockAttributeId(3) },
+        { kMockEndpoint3, MockClusterId(2), MockAttributeId(4) },
+        { kMockEndpoint3, MockClusterId(3), Clusters::Globals::Attributes::ClusterRevision::Id },
+        { kMockEndpoint3, MockClusterId(3), Clusters::Globals::Attributes::FeatureMap::Id },
+        { kMockEndpoint3, MockClusterId(4), Clusters::Globals::Attributes::ClusterRevision::Id },
+        { kMockEndpoint3, MockClusterId(4), Clusters::Globals::Attributes::FeatureMap::Id },
+        { kMockEndpoint2, MockClusterId(3), MockAttributeId(3) },
+        { kMockEndpoint3, MockClusterId(1), Clusters::Globals::Attributes::ClusterRevision::Id },
+        { kMockEndpoint3, MockClusterId(2), Clusters::Globals::Attributes::ClusterRevision::Id },
+        { kMockEndpoint3, MockClusterId(3), Clusters::Globals::Attributes::ClusterRevision::Id },
+        { kMockEndpoint3, MockClusterId(4), Clusters::Globals::Attributes::ClusterRevision::Id },
+        { kMockEndpoint2, MockClusterId(3), Clusters::Globals::Attributes::ClusterRevision::Id },
+        { kMockEndpoint2, MockClusterId(3), Clusters::Globals::Attributes::FeatureMap::Id },
+        { kMockEndpoint2, MockClusterId(3), MockAttributeId(1) },
+        { kMockEndpoint2, MockClusterId(3), MockAttributeId(2) },
+        { kMockEndpoint2, MockClusterId(3), MockAttributeId(3) },
+        { kMockEndpoint2, MockClusterId(3), MockAttributeId(3) },
     };
 
     size_t index = 0;

--- a/src/app/tests/TestAttributePathExpandIterator.cpp
+++ b/src/app/tests/TestAttributePathExpandIterator.cpp
@@ -16,12 +16,6 @@
  *    limitations under the License.
  */
 
-/**
- *    @file
- *     This file defines read handler for a CHIP Interaction Data model
- *
- */
-
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app/AttributePathExpandIterator.h>
 #include <app/ClusterInfo.h>
@@ -50,21 +44,21 @@ void TestAllWildcard(nlTestSuite * apSuite, void * apContext)
 
     app::ConcreteAttributePath path;
     P paths[] = {
-        P(0xFFFE, 0xFFF1'0001, 0x0000'FFFD), P(0xFFFE, 0xFFF1'0001, 0x0000'FFFC), P(0xFFFE, 0xFFF1'0002, 0x0000'FFFD),
-        P(0xFFFE, 0xFFF1'0002, 0x0000'FFFC), P(0xFFFE, 0xFFF1'0002, 0xFFF1'0001), P(0xFFFD, 0xFFF1'0001, 0x0000'FFFD),
-        P(0xFFFD, 0xFFF1'0001, 0x0000'FFFC), P(0xFFFD, 0xFFF1'0002, 0x0000'FFFD), P(0xFFFD, 0xFFF1'0002, 0x0000'FFFC),
-        P(0xFFFD, 0xFFF1'0002, 0xFFF1'0001), P(0xFFFD, 0xFFF1'0002, 0xFFF1'0002), P(0xFFFD, 0xFFF1'0003, 0x0000'FFFD),
-        P(0xFFFD, 0xFFF1'0003, 0x0000'FFFC), P(0xFFFD, 0xFFF1'0003, 0xFFF1'0001), P(0xFFFD, 0xFFF1'0003, 0xFFF1'0002),
-        P(0xFFFD, 0xFFF1'0003, 0xFFF1'0003), P(0xFFFC, 0xFFF1'0001, 0x0000'FFFD), P(0xFFFC, 0xFFF1'0001, 0x0000'FFFC),
-        P(0xFFFC, 0xFFF1'0001, 0xFFF1'0001), P(0xFFFC, 0xFFF1'0002, 0x0000'FFFD), P(0xFFFC, 0xFFF1'0002, 0x0000'FFFC),
-        P(0xFFFC, 0xFFF1'0002, 0xFFF1'0001), P(0xFFFC, 0xFFF1'0002, 0xFFF1'0002), P(0xFFFC, 0xFFF1'0002, 0xFFF1'0003),
-        P(0xFFFC, 0xFFF1'0002, 0xFFF1'0004), P(0xFFFC, 0xFFF1'0003, 0x0000'FFFD), P(0xFFFC, 0xFFF1'0003, 0x0000'FFFC),
-        P(0xFFFC, 0xFFF1'0004, 0x0000'FFFD), P(0xFFFC, 0xFFF1'0004, 0x0000'FFFC),
+        { 0xFFFE, 0xFFF1'0001, 0x0000'FFFD }, { 0xFFFE, 0xFFF1'0001, 0x0000'FFFC }, { 0xFFFE, 0xFFF1'0002, 0x0000'FFFD },
+        { 0xFFFE, 0xFFF1'0002, 0x0000'FFFC }, { 0xFFFE, 0xFFF1'0002, 0xFFF1'0001 }, { 0xFFFD, 0xFFF1'0001, 0x0000'FFFD },
+        { 0xFFFD, 0xFFF1'0001, 0x0000'FFFC }, { 0xFFFD, 0xFFF1'0002, 0x0000'FFFD }, { 0xFFFD, 0xFFF1'0002, 0x0000'FFFC },
+        { 0xFFFD, 0xFFF1'0002, 0xFFF1'0001 }, { 0xFFFD, 0xFFF1'0002, 0xFFF1'0002 }, { 0xFFFD, 0xFFF1'0003, 0x0000'FFFD },
+        { 0xFFFD, 0xFFF1'0003, 0x0000'FFFC }, { 0xFFFD, 0xFFF1'0003, 0xFFF1'0001 }, { 0xFFFD, 0xFFF1'0003, 0xFFF1'0002 },
+        { 0xFFFD, 0xFFF1'0003, 0xFFF1'0003 }, { 0xFFFC, 0xFFF1'0001, 0x0000'FFFD }, { 0xFFFC, 0xFFF1'0001, 0x0000'FFFC },
+        { 0xFFFC, 0xFFF1'0001, 0xFFF1'0001 }, { 0xFFFC, 0xFFF1'0002, 0x0000'FFFD }, { 0xFFFC, 0xFFF1'0002, 0x0000'FFFC },
+        { 0xFFFC, 0xFFF1'0002, 0xFFF1'0001 }, { 0xFFFC, 0xFFF1'0002, 0xFFF1'0002 }, { 0xFFFC, 0xFFF1'0002, 0xFFF1'0003 },
+        { 0xFFFC, 0xFFF1'0002, 0xFFF1'0004 }, { 0xFFFC, 0xFFF1'0003, 0x0000'FFFD }, { 0xFFFC, 0xFFF1'0003, 0x0000'FFFC },
+        { 0xFFFC, 0xFFF1'0004, 0x0000'FFFD }, { 0xFFFC, 0xFFF1'0004, 0x0000'FFFC },
     };
 
     size_t index = 0;
 
-    for (app::AttributePathExpandIterator iter(&clusInfo); iter.Get(path); iter.Proceed())
+    for (app::AttributePathExpandIterator iter(&clusInfo); iter.Get(path); iter.Next())
     {
         ChipLogDetail(AppServer, "Visited Attribute: 0x%04" PRIX16 " / " ChipLogFormatMEI " / " ChipLogFormatMEI, path.mEndpointId,
                       ChipLogValueMEI(path.mClusterId), ChipLogValueMEI(path.mAttributeId));
@@ -82,12 +76,12 @@ void TestWildcardEndpoint(nlTestSuite * apSuite, void * apContext)
 
     app::ConcreteAttributePath path;
     P paths[] = {
-        P(0xFFFD, 0xFFF1'0003, 0xFFF1'0003),
+        { 0xFFFD, 0xFFF1'0003, 0xFFF1'0003 },
     };
 
     size_t index = 0;
 
-    for (app::AttributePathExpandIterator iter(&clusInfo); iter.Get(path); iter.Proceed())
+    for (app::AttributePathExpandIterator iter(&clusInfo); iter.Get(path); iter.Next())
     {
         ChipLogDetail(AppServer, "Visited Attribute: 0x%04" PRIX16 " / " ChipLogFormatMEI " / " ChipLogFormatMEI, path.mEndpointId,
                       ChipLogValueMEI(path.mClusterId), ChipLogValueMEI(path.mAttributeId));
@@ -105,15 +99,15 @@ void TestWildcardCluster(nlTestSuite * apSuite, void * apContext)
 
     app::ConcreteAttributePath path;
     P paths[] = {
-        P(0xFFFC, 0xFFF1'0001, 0x0000'FFFD),
-        P(0xFFFC, 0xFFF1'0002, 0x0000'FFFD),
-        P(0xFFFC, 0xFFF1'0003, 0x0000'FFFD),
-        P(0xFFFC, 0xFFF1'0004, 0x0000'FFFD),
+        { 0xFFFC, 0xFFF1'0001, 0x0000'FFFD },
+        { 0xFFFC, 0xFFF1'0002, 0x0000'FFFD },
+        { 0xFFFC, 0xFFF1'0003, 0x0000'FFFD },
+        { 0xFFFC, 0xFFF1'0004, 0x0000'FFFD },
     };
 
     size_t index = 0;
 
-    for (app::AttributePathExpandIterator iter(&clusInfo); iter.Get(path); iter.Proceed())
+    for (app::AttributePathExpandIterator iter(&clusInfo); iter.Get(path); iter.Next())
     {
         ChipLogDetail(AppServer, "Visited Attribute: 0x%04" PRIX16 " / " ChipLogFormatMEI " / " ChipLogFormatMEI, path.mEndpointId,
                       ChipLogValueMEI(path.mClusterId), ChipLogValueMEI(path.mAttributeId));
@@ -131,13 +125,13 @@ void TestWildcardAttribute(nlTestSuite * apSuite, void * apContext)
 
     app::ConcreteAttributePath path;
     P paths[] = {
-        P(0xFFFD, 0xFFF1'0003, 0x0000'FFFD), P(0xFFFD, 0xFFF1'0003, 0x0000'FFFC), P(0xFFFD, 0xFFF1'0003, 0xFFF1'0001),
-        P(0xFFFD, 0xFFF1'0003, 0xFFF1'0002), P(0xFFFD, 0xFFF1'0003, 0xFFF1'0003),
+        { 0xFFFD, 0xFFF1'0003, 0x0000'FFFD }, { 0xFFFD, 0xFFF1'0003, 0x0000'FFFC }, { 0xFFFD, 0xFFF1'0003, 0xFFF1'0001 },
+        { 0xFFFD, 0xFFF1'0003, 0xFFF1'0002 }, { 0xFFFD, 0xFFF1'0003, 0xFFF1'0003 },
     };
 
     size_t index = 0;
 
-    for (app::AttributePathExpandIterator iter(&clusInfo); iter.Get(path); iter.Proceed())
+    for (app::AttributePathExpandIterator iter(&clusInfo); iter.Get(path); iter.Next())
     {
         ChipLogDetail(AppServer, "Visited Attribute: 0x%04" PRIX16 " / " ChipLogFormatMEI " / " ChipLogFormatMEI, path.mEndpointId,
                       ChipLogValueMEI(path.mClusterId), ChipLogValueMEI(path.mAttributeId));
@@ -156,12 +150,12 @@ void TestNoWildcard(nlTestSuite * apSuite, void * apContext)
 
     app::ConcreteAttributePath path;
     P paths[] = {
-        P(0xFFFD, 0xFFF1'0003, 0xFFF1'0003),
+        { 0xFFFD, 0xFFF1'0003, 0xFFF1'0003 },
     };
 
     size_t index = 0;
 
-    for (app::AttributePathExpandIterator iter(&clusInfo); iter.Get(path); iter.Proceed())
+    for (app::AttributePathExpandIterator iter(&clusInfo); iter.Get(path); iter.Next())
     {
         ChipLogDetail(AppServer, "Visited Attribute: 0x%04" PRIX16 " / " ChipLogFormatMEI " / " ChipLogFormatMEI, path.mEndpointId,
                       ChipLogValueMEI(path.mClusterId), ChipLogValueMEI(path.mAttributeId));
@@ -200,25 +194,25 @@ void TestMultipleClusInfo(nlTestSuite * apSuite, void * apContext)
 
     app::ConcreteAttributePath path;
     P paths[] = {
-        P(0xFFFE, 0xFFF1'0001, 0x0000'FFFD), P(0xFFFE, 0xFFF1'0001, 0x0000'FFFC), P(0xFFFE, 0xFFF1'0002, 0x0000'FFFD),
-        P(0xFFFE, 0xFFF1'0002, 0x0000'FFFC), P(0xFFFE, 0xFFF1'0002, 0xFFF1'0001), P(0xFFFD, 0xFFF1'0001, 0x0000'FFFD),
-        P(0xFFFD, 0xFFF1'0001, 0x0000'FFFC), P(0xFFFD, 0xFFF1'0002, 0x0000'FFFD), P(0xFFFD, 0xFFF1'0002, 0x0000'FFFC),
-        P(0xFFFD, 0xFFF1'0002, 0xFFF1'0001), P(0xFFFD, 0xFFF1'0002, 0xFFF1'0002), P(0xFFFD, 0xFFF1'0003, 0x0000'FFFD),
-        P(0xFFFD, 0xFFF1'0003, 0x0000'FFFC), P(0xFFFD, 0xFFF1'0003, 0xFFF1'0001), P(0xFFFD, 0xFFF1'0003, 0xFFF1'0002),
-        P(0xFFFD, 0xFFF1'0003, 0xFFF1'0003), P(0xFFFC, 0xFFF1'0001, 0x0000'FFFD), P(0xFFFC, 0xFFF1'0001, 0x0000'FFFC),
-        P(0xFFFC, 0xFFF1'0001, 0xFFF1'0001), P(0xFFFC, 0xFFF1'0002, 0x0000'FFFD), P(0xFFFC, 0xFFF1'0002, 0x0000'FFFC),
-        P(0xFFFC, 0xFFF1'0002, 0xFFF1'0001), P(0xFFFC, 0xFFF1'0002, 0xFFF1'0002), P(0xFFFC, 0xFFF1'0002, 0xFFF1'0003),
-        P(0xFFFC, 0xFFF1'0002, 0xFFF1'0004), P(0xFFFC, 0xFFF1'0003, 0x0000'FFFD), P(0xFFFC, 0xFFF1'0003, 0x0000'FFFC),
-        P(0xFFFC, 0xFFF1'0004, 0x0000'FFFD), P(0xFFFC, 0xFFF1'0004, 0x0000'FFFC), P(0xFFFD, 0xFFF1'0003, 0xFFF1'0003),
-        P(0xFFFC, 0xFFF1'0001, 0x0000'FFFD), P(0xFFFC, 0xFFF1'0002, 0x0000'FFFD), P(0xFFFC, 0xFFF1'0003, 0x0000'FFFD),
-        P(0xFFFC, 0xFFF1'0004, 0x0000'FFFD), P(0xFFFD, 0xFFF1'0003, 0x0000'FFFD), P(0xFFFD, 0xFFF1'0003, 0x0000'FFFC),
-        P(0xFFFD, 0xFFF1'0003, 0xFFF1'0001), P(0xFFFD, 0xFFF1'0003, 0xFFF1'0002), P(0xFFFD, 0xFFF1'0003, 0xFFF1'0003),
-        P(0xFFFD, 0xFFF1'0003, 0xFFF1'0003),
+        { 0xFFFE, 0xFFF1'0001, 0x0000'FFFD }, { 0xFFFE, 0xFFF1'0001, 0x0000'FFFC }, { 0xFFFE, 0xFFF1'0002, 0x0000'FFFD },
+        { 0xFFFE, 0xFFF1'0002, 0x0000'FFFC }, { 0xFFFE, 0xFFF1'0002, 0xFFF1'0001 }, { 0xFFFD, 0xFFF1'0001, 0x0000'FFFD },
+        { 0xFFFD, 0xFFF1'0001, 0x0000'FFFC }, { 0xFFFD, 0xFFF1'0002, 0x0000'FFFD }, { 0xFFFD, 0xFFF1'0002, 0x0000'FFFC },
+        { 0xFFFD, 0xFFF1'0002, 0xFFF1'0001 }, { 0xFFFD, 0xFFF1'0002, 0xFFF1'0002 }, { 0xFFFD, 0xFFF1'0003, 0x0000'FFFD },
+        { 0xFFFD, 0xFFF1'0003, 0x0000'FFFC }, { 0xFFFD, 0xFFF1'0003, 0xFFF1'0001 }, { 0xFFFD, 0xFFF1'0003, 0xFFF1'0002 },
+        { 0xFFFD, 0xFFF1'0003, 0xFFF1'0003 }, { 0xFFFC, 0xFFF1'0001, 0x0000'FFFD }, { 0xFFFC, 0xFFF1'0001, 0x0000'FFFC },
+        { 0xFFFC, 0xFFF1'0001, 0xFFF1'0001 }, { 0xFFFC, 0xFFF1'0002, 0x0000'FFFD }, { 0xFFFC, 0xFFF1'0002, 0x0000'FFFC },
+        { 0xFFFC, 0xFFF1'0002, 0xFFF1'0001 }, { 0xFFFC, 0xFFF1'0002, 0xFFF1'0002 }, { 0xFFFC, 0xFFF1'0002, 0xFFF1'0003 },
+        { 0xFFFC, 0xFFF1'0002, 0xFFF1'0004 }, { 0xFFFC, 0xFFF1'0003, 0x0000'FFFD }, { 0xFFFC, 0xFFF1'0003, 0x0000'FFFC },
+        { 0xFFFC, 0xFFF1'0004, 0x0000'FFFD }, { 0xFFFC, 0xFFF1'0004, 0x0000'FFFC }, { 0xFFFD, 0xFFF1'0003, 0xFFF1'0003 },
+        { 0xFFFC, 0xFFF1'0001, 0x0000'FFFD }, { 0xFFFC, 0xFFF1'0002, 0x0000'FFFD }, { 0xFFFC, 0xFFF1'0003, 0x0000'FFFD },
+        { 0xFFFC, 0xFFF1'0004, 0x0000'FFFD }, { 0xFFFD, 0xFFF1'0003, 0x0000'FFFD }, { 0xFFFD, 0xFFF1'0003, 0x0000'FFFC },
+        { 0xFFFD, 0xFFF1'0003, 0xFFF1'0001 }, { 0xFFFD, 0xFFF1'0003, 0xFFF1'0002 }, { 0xFFFD, 0xFFF1'0003, 0xFFF1'0003 },
+        { 0xFFFD, 0xFFF1'0003, 0xFFF1'0003 },
     };
 
     size_t index = 0;
 
-    for (app::AttributePathExpandIterator iter(&clusInfo1); iter.Get(path); iter.Proceed())
+    for (app::AttributePathExpandIterator iter(&clusInfo1); iter.Get(path); iter.Next())
     {
         ChipLogDetail(AppServer, "Visited Attribute: 0x%04" PRIX16 " / " ChipLogFormatMEI " / " ChipLogFormatMEI, path.mEndpointId,
                       ChipLogValueMEI(path.mClusterId), ChipLogValueMEI(path.mAttributeId));

--- a/src/app/tests/TestAttributePathExpandIterator.cpp
+++ b/src/app/tests/TestAttributePathExpandIterator.cpp
@@ -1,0 +1,279 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *     This file defines read handler for a CHIP Interaction Data model
+ *
+ */
+
+#include <app-common/zap-generated/ids/Attributes.h>
+#include <app/AttributePathExpandIterator.h>
+#include <app/ClusterInfo.h>
+#include <app/ConcreteAttributePath.h>
+#include <app/EventManagement.h>
+#include <app/InteractionModelDelegate.h>
+#include <app/util/mock/Constants.h>
+#include <lib/core/CHIPCore.h>
+#include <lib/core/CHIPTLVDebug.hpp>
+#include <lib/support/CodeUtils.h>
+#include <lib/support/DLLUtil.h>
+#include <lib/support/UnitTestRegistration.h>
+#include <lib/support/logging/CHIPLogging.h>
+
+#include <nlunit-test.h>
+
+using namespace chip;
+
+namespace {
+
+using P = app::ConcreteAttributePath;
+
+void TestAllWildcard(nlTestSuite * apSuite, void * apContext)
+{
+    app::ClusterInfo clusInfo;
+
+    app::ConcreteAttributePath path;
+    P paths[] = {
+        P(0xFFFE, 0xFFF1'0001, 0x0000'FFFD), P(0xFFFE, 0xFFF1'0001, 0x0000'FFFC), P(0xFFFE, 0xFFF1'0002, 0x0000'FFFD),
+        P(0xFFFE, 0xFFF1'0002, 0x0000'FFFC), P(0xFFFE, 0xFFF1'0002, 0xFFF1'0001), P(0xFFFD, 0xFFF1'0001, 0x0000'FFFD),
+        P(0xFFFD, 0xFFF1'0001, 0x0000'FFFC), P(0xFFFD, 0xFFF1'0002, 0x0000'FFFD), P(0xFFFD, 0xFFF1'0002, 0x0000'FFFC),
+        P(0xFFFD, 0xFFF1'0002, 0xFFF1'0001), P(0xFFFD, 0xFFF1'0002, 0xFFF1'0002), P(0xFFFD, 0xFFF1'0003, 0x0000'FFFD),
+        P(0xFFFD, 0xFFF1'0003, 0x0000'FFFC), P(0xFFFD, 0xFFF1'0003, 0xFFF1'0001), P(0xFFFD, 0xFFF1'0003, 0xFFF1'0002),
+        P(0xFFFD, 0xFFF1'0003, 0xFFF1'0003), P(0xFFFC, 0xFFF1'0001, 0x0000'FFFD), P(0xFFFC, 0xFFF1'0001, 0x0000'FFFC),
+        P(0xFFFC, 0xFFF1'0001, 0xFFF1'0001), P(0xFFFC, 0xFFF1'0002, 0x0000'FFFD), P(0xFFFC, 0xFFF1'0002, 0x0000'FFFC),
+        P(0xFFFC, 0xFFF1'0002, 0xFFF1'0001), P(0xFFFC, 0xFFF1'0002, 0xFFF1'0002), P(0xFFFC, 0xFFF1'0002, 0xFFF1'0003),
+        P(0xFFFC, 0xFFF1'0002, 0xFFF1'0004), P(0xFFFC, 0xFFF1'0003, 0x0000'FFFD), P(0xFFFC, 0xFFF1'0003, 0x0000'FFFC),
+        P(0xFFFC, 0xFFF1'0004, 0x0000'FFFD), P(0xFFFC, 0xFFF1'0004, 0x0000'FFFC),
+    };
+
+    size_t index = 0;
+
+    for (app::AttributePathExpandIterator iter(&clusInfo); iter.Get(path); iter.Proceed())
+    {
+        ChipLogDetail(AppServer, "Visited Attribute: 0x%04" PRIX16 " / " ChipLogFormatMEI " / " ChipLogFormatMEI, path.mEndpointId,
+                      ChipLogValueMEI(path.mClusterId), ChipLogValueMEI(path.mAttributeId));
+        // NL_TEST_ASSERT(apSuite, index < ArraySize(paths) && paths[index] == path);
+        index++;
+    }
+    NL_TEST_ASSERT(apSuite, index == ArraySize(paths));
+}
+
+void TestWildcardEndpoint(nlTestSuite * apSuite, void * apContext)
+{
+    app::ClusterInfo clusInfo;
+    clusInfo.mClusterId = Test::MockClusterId(3);
+    clusInfo.mFieldId   = Test::MockAttributeId(3);
+
+    app::ConcreteAttributePath path;
+    P paths[] = {
+        P(0xFFFD, 0xFFF1'0003, 0xFFF1'0003),
+    };
+
+    size_t index = 0;
+
+    for (app::AttributePathExpandIterator iter(&clusInfo); iter.Get(path); iter.Proceed())
+    {
+        ChipLogDetail(AppServer, "Visited Attribute: 0x%04" PRIX16 " / " ChipLogFormatMEI " / " ChipLogFormatMEI, path.mEndpointId,
+                      ChipLogValueMEI(path.mClusterId), ChipLogValueMEI(path.mAttributeId));
+        // NL_TEST_ASSERT(apSuite, index < ArraySize(paths) && paths[index] == path);
+        index++;
+    }
+    NL_TEST_ASSERT(apSuite, index == ArraySize(paths));
+}
+
+void TestWildcardCluster(nlTestSuite * apSuite, void * apContext)
+{
+    app::ClusterInfo clusInfo;
+    clusInfo.mEndpointId = Test::kMockEndpoint3;
+    clusInfo.mFieldId    = app::Clusters::Globals::Attributes::ClusterRevision::Id;
+
+    app::ConcreteAttributePath path;
+    P paths[] = {
+        P(0xFFFC, 0xFFF1'0001, 0x0000'FFFD),
+        P(0xFFFC, 0xFFF1'0002, 0x0000'FFFD),
+        P(0xFFFC, 0xFFF1'0003, 0x0000'FFFD),
+        P(0xFFFC, 0xFFF1'0004, 0x0000'FFFD),
+    };
+
+    size_t index = 0;
+
+    for (app::AttributePathExpandIterator iter(&clusInfo); iter.Get(path); iter.Proceed())
+    {
+        ChipLogDetail(AppServer, "Visited Attribute: 0x%04" PRIX16 " / " ChipLogFormatMEI " / " ChipLogFormatMEI, path.mEndpointId,
+                      ChipLogValueMEI(path.mClusterId), ChipLogValueMEI(path.mAttributeId));
+        // NL_TEST_ASSERT(apSuite, index < ArraySize(paths) && paths[index] == path);
+        index++;
+    }
+    NL_TEST_ASSERT(apSuite, index == ArraySize(paths));
+}
+
+void TestWildcardAttribute(nlTestSuite * apSuite, void * apContext)
+{
+    app::ClusterInfo clusInfo;
+    clusInfo.mEndpointId = Test::kMockEndpoint2;
+    clusInfo.mClusterId  = Test::MockClusterId(3);
+
+    app::ConcreteAttributePath path;
+    P paths[] = {
+        P(0xFFFD, 0xFFF1'0003, 0x0000'FFFD), P(0xFFFD, 0xFFF1'0003, 0x0000'FFFC), P(0xFFFD, 0xFFF1'0003, 0xFFF1'0001),
+        P(0xFFFD, 0xFFF1'0003, 0xFFF1'0002), P(0xFFFD, 0xFFF1'0003, 0xFFF1'0003),
+    };
+
+    size_t index = 0;
+
+    for (app::AttributePathExpandIterator iter(&clusInfo); iter.Get(path); iter.Proceed())
+    {
+        ChipLogDetail(AppServer, "Visited Attribute: 0x%04" PRIX16 " / " ChipLogFormatMEI " / " ChipLogFormatMEI, path.mEndpointId,
+                      ChipLogValueMEI(path.mClusterId), ChipLogValueMEI(path.mAttributeId));
+        // NL_TEST_ASSERT(apSuite, index < ArraySize(paths) && paths[index] == path);
+        index++;
+    }
+    NL_TEST_ASSERT(apSuite, index == ArraySize(paths));
+}
+
+void TestNoWildcard(nlTestSuite * apSuite, void * apContext)
+{
+    app::ClusterInfo clusInfo;
+    clusInfo.mEndpointId = Test::kMockEndpoint2;
+    clusInfo.mClusterId  = Test::MockClusterId(3);
+    clusInfo.mFieldId    = Test::MockAttributeId(3);
+
+    app::ConcreteAttributePath path;
+    P paths[] = {
+        P(0xFFFD, 0xFFF1'0003, 0xFFF1'0003),
+    };
+
+    size_t index = 0;
+
+    for (app::AttributePathExpandIterator iter(&clusInfo); iter.Get(path); iter.Proceed())
+    {
+        ChipLogDetail(AppServer, "Visited Attribute: 0x%04" PRIX16 " / " ChipLogFormatMEI " / " ChipLogFormatMEI, path.mEndpointId,
+                      ChipLogValueMEI(path.mClusterId), ChipLogValueMEI(path.mAttributeId));
+        // NL_TEST_ASSERT(apSuite, index < ArraySize(paths) && paths[index] == path);
+        index++;
+    }
+    NL_TEST_ASSERT(apSuite, index == ArraySize(paths));
+}
+
+void TestMultipleClusInfo(nlTestSuite * apSuite, void * apContext)
+{
+
+    app::ClusterInfo clusInfo1;
+
+    app::ClusterInfo clusInfo2;
+    clusInfo2.mClusterId = Test::MockClusterId(3);
+    clusInfo2.mFieldId   = Test::MockAttributeId(3);
+
+    app::ClusterInfo clusInfo3;
+    clusInfo3.mEndpointId = Test::kMockEndpoint3;
+    clusInfo3.mFieldId    = app::Clusters::Globals::Attributes::ClusterRevision::Id;
+
+    app::ClusterInfo clusInfo4;
+    clusInfo4.mEndpointId = Test::kMockEndpoint2;
+    clusInfo4.mClusterId  = Test::MockClusterId(3);
+
+    app::ClusterInfo clusInfo5;
+    clusInfo5.mEndpointId = Test::kMockEndpoint2;
+    clusInfo5.mClusterId  = Test::MockClusterId(3);
+    clusInfo5.mFieldId    = Test::MockAttributeId(3);
+
+    clusInfo1.mpNext = &clusInfo2;
+    clusInfo2.mpNext = &clusInfo3;
+    clusInfo3.mpNext = &clusInfo4;
+    clusInfo4.mpNext = &clusInfo5;
+
+    app::ConcreteAttributePath path;
+    P paths[] = {
+        P(0xFFFE, 0xFFF1'0001, 0x0000'FFFD), P(0xFFFE, 0xFFF1'0001, 0x0000'FFFC), P(0xFFFE, 0xFFF1'0002, 0x0000'FFFD),
+        P(0xFFFE, 0xFFF1'0002, 0x0000'FFFC), P(0xFFFE, 0xFFF1'0002, 0xFFF1'0001), P(0xFFFD, 0xFFF1'0001, 0x0000'FFFD),
+        P(0xFFFD, 0xFFF1'0001, 0x0000'FFFC), P(0xFFFD, 0xFFF1'0002, 0x0000'FFFD), P(0xFFFD, 0xFFF1'0002, 0x0000'FFFC),
+        P(0xFFFD, 0xFFF1'0002, 0xFFF1'0001), P(0xFFFD, 0xFFF1'0002, 0xFFF1'0002), P(0xFFFD, 0xFFF1'0003, 0x0000'FFFD),
+        P(0xFFFD, 0xFFF1'0003, 0x0000'FFFC), P(0xFFFD, 0xFFF1'0003, 0xFFF1'0001), P(0xFFFD, 0xFFF1'0003, 0xFFF1'0002),
+        P(0xFFFD, 0xFFF1'0003, 0xFFF1'0003), P(0xFFFC, 0xFFF1'0001, 0x0000'FFFD), P(0xFFFC, 0xFFF1'0001, 0x0000'FFFC),
+        P(0xFFFC, 0xFFF1'0001, 0xFFF1'0001), P(0xFFFC, 0xFFF1'0002, 0x0000'FFFD), P(0xFFFC, 0xFFF1'0002, 0x0000'FFFC),
+        P(0xFFFC, 0xFFF1'0002, 0xFFF1'0001), P(0xFFFC, 0xFFF1'0002, 0xFFF1'0002), P(0xFFFC, 0xFFF1'0002, 0xFFF1'0003),
+        P(0xFFFC, 0xFFF1'0002, 0xFFF1'0004), P(0xFFFC, 0xFFF1'0003, 0x0000'FFFD), P(0xFFFC, 0xFFF1'0003, 0x0000'FFFC),
+        P(0xFFFC, 0xFFF1'0004, 0x0000'FFFD), P(0xFFFC, 0xFFF1'0004, 0x0000'FFFC), P(0xFFFD, 0xFFF1'0003, 0xFFF1'0003),
+        P(0xFFFC, 0xFFF1'0001, 0x0000'FFFD), P(0xFFFC, 0xFFF1'0002, 0x0000'FFFD), P(0xFFFC, 0xFFF1'0003, 0x0000'FFFD),
+        P(0xFFFC, 0xFFF1'0004, 0x0000'FFFD), P(0xFFFD, 0xFFF1'0003, 0x0000'FFFD), P(0xFFFD, 0xFFF1'0003, 0x0000'FFFC),
+        P(0xFFFD, 0xFFF1'0003, 0xFFF1'0001), P(0xFFFD, 0xFFF1'0003, 0xFFF1'0002), P(0xFFFD, 0xFFF1'0003, 0xFFF1'0003),
+        P(0xFFFD, 0xFFF1'0003, 0xFFF1'0003),
+    };
+
+    size_t index = 0;
+
+    for (app::AttributePathExpandIterator iter(&clusInfo1); iter.Get(path); iter.Proceed())
+    {
+        ChipLogDetail(AppServer, "Visited Attribute: 0x%04" PRIX16 " / " ChipLogFormatMEI " / " ChipLogFormatMEI, path.mEndpointId,
+                      ChipLogValueMEI(path.mClusterId), ChipLogValueMEI(path.mAttributeId));
+        // NL_TEST_ASSERT(apSuite, index < ArraySize(paths) && paths[index] == path);
+        index++;
+    }
+    NL_TEST_ASSERT(apSuite, index == ArraySize(paths));
+}
+
+static int TestSetup(void * inContext)
+{
+    return SUCCESS;
+}
+
+/**
+ *  Tear down the test suite.
+ */
+static int TestTeardown(void * inContext)
+{
+    return SUCCESS;
+}
+
+/**
+ *   Test Suite. It lists all the test functions.
+ */
+
+// clang-format off
+const nlTest sTests[] =
+{
+        NL_TEST_DEF("TestAllWildcard", TestAllWildcard),
+        NL_TEST_DEF("TestWildcardEndpoint", TestWildcardEndpoint),
+        NL_TEST_DEF("TestWildcardCluster", TestWildcardCluster),
+        NL_TEST_DEF("TestWildcardAttribute", TestWildcardAttribute),
+        NL_TEST_DEF("TestNoWildcard", TestNoWildcard),
+        NL_TEST_DEF("TestMultipleClusInfo", TestMultipleClusInfo),
+        NL_TEST_SENTINEL()
+};
+// clang-format on
+
+// clang-format off
+nlTestSuite sSuite =
+{
+    "TestAttributePathExpandIterator",
+    &sTests[0],
+    TestSetup,
+    TestTeardown,
+};
+// clang-format on
+
+} // namespace
+
+int TestAttributePathExpandIterator()
+{
+    nlTestRunner(&sSuite, nullptr);
+    return (nlTestRunnerStats(&sSuite));
+}
+
+CHIP_REGISTER_TEST_SUITE(TestAttributePathExpandIterator)

--- a/src/app/tests/TestAttributePathExpandIterator.cpp
+++ b/src/app/tests/TestAttributePathExpandIterator.cpp
@@ -183,7 +183,7 @@ void TestNoWildcard(nlTestSuite * apSuite, void * apContext)
     {
         ChipLogDetail(AppServer, "Visited Attribute: 0x%04" PRIX16 " / " ChipLogFormatMEI " / " ChipLogFormatMEI, path.mEndpointId,
                       ChipLogValueMEI(path.mClusterId), ChipLogValueMEI(path.mAttributeId));
-        // NL_TEST_ASSERT(apSuite, index < ArraySize(paths) && paths[index] == path);
+        NL_TEST_ASSERT(apSuite, index < ArraySize(paths) && paths[index] == path);
         index++;
     }
     NL_TEST_ASSERT(apSuite, index == ArraySize(paths));
@@ -266,7 +266,7 @@ void TestMultipleClusInfo(nlTestSuite * apSuite, void * apContext)
     {
         ChipLogDetail(AppServer, "Visited Attribute: 0x%04" PRIX16 " / " ChipLogFormatMEI " / " ChipLogFormatMEI, path.mEndpointId,
                       ChipLogValueMEI(path.mClusterId), ChipLogValueMEI(path.mAttributeId));
-        // NL_TEST_ASSERT(apSuite, index < ArraySize(paths) && paths[index] == path);
+        NL_TEST_ASSERT(apSuite, index < ArraySize(paths) && paths[index] == path);
         index++;
     }
     NL_TEST_ASSERT(apSuite, index == ArraySize(paths));

--- a/src/app/tests/TestAttributePathExpandIterator.cpp
+++ b/src/app/tests/TestAttributePathExpandIterator.cpp
@@ -83,7 +83,7 @@ void TestAllWildcard(nlTestSuite * apSuite, void * apContext)
     {
         ChipLogDetail(AppServer, "Visited Attribute: 0x%04" PRIX16 " / " ChipLogFormatMEI " / " ChipLogFormatMEI, path.mEndpointId,
                       ChipLogValueMEI(path.mClusterId), ChipLogValueMEI(path.mAttributeId));
-        // NL_TEST_ASSERT(apSuite, index < ArraySize(paths) && paths[index] == path);
+        NL_TEST_ASSERT(apSuite, index < ArraySize(paths) && paths[index] == path);
         index++;
     }
     NL_TEST_ASSERT(apSuite, index == ArraySize(paths));
@@ -106,7 +106,7 @@ void TestWildcardEndpoint(nlTestSuite * apSuite, void * apContext)
     {
         ChipLogDetail(AppServer, "Visited Attribute: 0x%04" PRIX16 " / " ChipLogFormatMEI " / " ChipLogFormatMEI, path.mEndpointId,
                       ChipLogValueMEI(path.mClusterId), ChipLogValueMEI(path.mAttributeId));
-        // NL_TEST_ASSERT(apSuite, index < ArraySize(paths) && paths[index] == path);
+        NL_TEST_ASSERT(apSuite, index < ArraySize(paths) && paths[index] == path);
         index++;
     }
     NL_TEST_ASSERT(apSuite, index == ArraySize(paths));
@@ -132,7 +132,7 @@ void TestWildcardCluster(nlTestSuite * apSuite, void * apContext)
     {
         ChipLogDetail(AppServer, "Visited Attribute: 0x%04" PRIX16 " / " ChipLogFormatMEI " / " ChipLogFormatMEI, path.mEndpointId,
                       ChipLogValueMEI(path.mClusterId), ChipLogValueMEI(path.mAttributeId));
-        // NL_TEST_ASSERT(apSuite, index < ArraySize(paths) && paths[index] == path);
+        NL_TEST_ASSERT(apSuite, index < ArraySize(paths) && paths[index] == path);
         index++;
     }
     NL_TEST_ASSERT(apSuite, index == ArraySize(paths));
@@ -159,7 +159,7 @@ void TestWildcardAttribute(nlTestSuite * apSuite, void * apContext)
     {
         ChipLogDetail(AppServer, "Visited Attribute: 0x%04" PRIX16 " / " ChipLogFormatMEI " / " ChipLogFormatMEI, path.mEndpointId,
                       ChipLogValueMEI(path.mClusterId), ChipLogValueMEI(path.mAttributeId));
-        // NL_TEST_ASSERT(apSuite, index < ArraySize(paths) && paths[index] == path);
+        NL_TEST_ASSERT(apSuite, index < ArraySize(paths) && paths[index] == path);
         index++;
     }
     NL_TEST_ASSERT(apSuite, index == ArraySize(paths));

--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -44,6 +44,7 @@
 #include <app/reporting/reporting.h>
 #include <app/util/af.h>
 #include <app/util/attribute-storage.h>
+#include <lib/support/CodeUtils.h>
 #include <lib/support/logging/CHIPLogging.h>
 
 #include <app-common/zap-generated/attribute-type.h>
@@ -1150,6 +1151,19 @@ EmberAfCluster * emberAfGetNthCluster(EndpointId endpoint, uint8_t n, bool serve
     return NULL;
 }
 
+// Returns the cluster id of Nth server or client cluster,
+// depending on server toggle.
+// Returns EMBER_AF_INVALID_CLUSTER_ID if cluster does not exist.
+Optional<ClusterId> emberAfGetNthClusterId(EndpointId endpoint, uint8_t n, bool server)
+{
+    EmberAfCluster * cluster = emberAfGetNthCluster(endpoint, n, server);
+    if (cluster == nullptr)
+    {
+        return Optional<ClusterId>::Missing();
+    }
+    return Optional<ClusterId>(cluster->clusterId);
+}
+
 // Returns number of clusters put into the passed cluster list
 // for the given endpoint and client/server polarity
 uint8_t emberAfGetClustersFromEndpoint(EndpointId endpoint, ClusterId * clusterList, uint8_t listLen, bool server)
@@ -1363,4 +1377,37 @@ app::AttributeAccessInterface * findAttributeAccessOverride(EndpointId endpointI
     }
 
     return nullptr;
+}
+
+uint16_t emberAfGetServerAttributeCount(chip::EndpointId endpoint, chip::ClusterId cluster)
+{
+    EmberAfCluster * clusterObj = emberAfFindCluster(endpoint, cluster, CLUSTER_MASK_SERVER);
+    VerifyOrReturnError(clusterObj != nullptr, 0);
+    return clusterObj->attributeCount;
+}
+
+uint16_t emberAfGetServerAttributeIndexByAttributeId(chip::EndpointId endpoint, chip::ClusterId cluster,
+                                                     chip::AttributeId attributeId)
+{
+    EmberAfCluster * clusterObj = emberAfFindCluster(endpoint, cluster, CLUSTER_MASK_SERVER);
+    VerifyOrReturnError(clusterObj != nullptr, UINT16_MAX);
+
+    for (uint16_t i = 0; i < clusterObj->attributeCount; i++)
+    {
+        if (clusterObj->attributes[i].attributeId == attributeId)
+        {
+            return i;
+        }
+    }
+    return UINT16_MAX;
+}
+
+Optional<AttributeId> emberAfGetServerAttributeIdByIndex(EndpointId endpoint, ClusterId cluster, uint16_t attributeIndex)
+{
+    EmberAfCluster * clusterObj = emberAfFindCluster(endpoint, cluster, CLUSTER_MASK_SERVER);
+    if (clusterObj == nullptr || clusterObj->attributeCount <= attributeIndex)
+    {
+        return Optional<AttributeId>::Missing();
+    }
+    return Optional<AttributeId>(clusterObj->attributes[attributeIndex].attributeId);
 }

--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -1153,7 +1153,7 @@ EmberAfCluster * emberAfGetNthCluster(EndpointId endpoint, uint8_t n, bool serve
 
 // Returns the cluster id of Nth server or client cluster,
 // depending on server toggle.
-// Returns EMBER_AF_INVALID_CLUSTER_ID if cluster does not exist.
+// Returns Optional<ClusterId>::Missing() if cluster does not exist.
 Optional<ClusterId> emberAfGetNthClusterId(EndpointId endpoint, uint8_t n, bool server)
 {
     EmberAfCluster * cluster = emberAfGetNthCluster(endpoint, n, server);

--- a/src/app/util/attribute-storage.h
+++ b/src/app/util/attribute-storage.h
@@ -151,9 +151,14 @@ uint8_t emberAfClusterIndex(chip::EndpointId endpoint, chip::ClusterId clusterId
 // otherwise number of client clusters on this endpoint
 uint8_t emberAfClusterCount(chip::EndpointId endpoint, bool server);
 
-// Returns the clusterId of Nth server or client cluster,
+// Returns the cluster of Nth server or client cluster,
 // depending on server toggle.
 EmberAfCluster * emberAfGetNthCluster(chip::EndpointId endpoint, uint8_t n, bool server);
+
+// Returns the clusterId of Nth server or client cluster,
+// depending on server toggle.
+// Returns Optional<ClusterId>::Missing if cluster does not exist.
+chip::Optional<chip::ClusterId> emberAfGetNthClusterId(chip::EndpointId endpoint, uint8_t n, bool server);
 
 // Returns number of clusters put into the passed cluster list
 // for the given endpoint and client/server polarity
@@ -242,7 +247,7 @@ bool emberAfEndpointIsEnabled(chip::EndpointId endpoint);
 // and those indexes may be DIFFERENT than the indexes returned from
 // emberAfGetNthCluster().  In other words:
 //
-//  - Use emberAfGetClustersFromEndpoint()  with emberAfGetNthCluster()
+//  - Use emberAfGetClustersFromEndpoint()  with emberAfGetNthCluster() amberAfGetNthClusterId()
 //  - Use emberAfGetClusterCountForEndpoint() with emberAfGetClusterByIndex()
 //
 // Don't mix them.
@@ -254,6 +259,23 @@ EmberAfStatus emberAfSetDynamicEndpoint(uint16_t index, chip::EndpointId id, Emb
                                         uint8_t deviceVersion);
 chip::EndpointId emberAfClearDynamicEndpoint(uint16_t index);
 uint16_t emberAfGetDynamicIndexFromEndpoint(chip::EndpointId id);
+
+// Get the number of attributs of the specific cluster under the endpoint. Is useful for the application to get the basic infomation
+// of or iterate over the attributes.
+// Returns 0 if the cluster does not exist.
+uint16_t emberAfGetServerAttributeCount(chip::EndpointId endpoint, chip::ClusterId cluster);
+
+// Get the index of attribut of the specific cluster under the endpoint. Is useful for the application to get the basic infomation
+// of or iterate over the attributes.
+// Returns UINT16_MAX if the attribute does not exist.
+uint16_t emberAfGetServerAttributeIndexByAttributeId(chip::EndpointId endpoint, chip::ClusterId cluster,
+                                                     chip::AttributeId attributeId);
+
+// Get the attribute id at the attributeIndex of the cluster under the endpoint. This function is useful for iterating over the
+// attributes.
+// Returns Optional<chip::AttributeId>::Missing() if the attribute does not exist.
+chip::Optional<chip::AttributeId> emberAfGetServerAttributeIdByIndex(chip::EndpointId endpoint, chip::ClusterId cluster,
+                                                                     uint16_t attributeIndex);
 
 /**
  * Register an attribute access override.  It will remain registered until

--- a/src/app/util/attribute-storage.h
+++ b/src/app/util/attribute-storage.h
@@ -247,7 +247,7 @@ bool emberAfEndpointIsEnabled(chip::EndpointId endpoint);
 // and those indexes may be DIFFERENT than the indexes returned from
 // emberAfGetNthCluster().  In other words:
 //
-//  - Use emberAfGetClustersFromEndpoint()  with emberAfGetNthCluster() amberAfGetNthClusterId()
+//  - Use emberAfGetClustersFromEndpoint()  with emberAfGetNthCluster() emberAfGetNthClusterId()
 //  - Use emberAfGetClusterCountForEndpoint() with emberAfGetClusterByIndex()
 //
 // Don't mix them.
@@ -260,13 +260,11 @@ EmberAfStatus emberAfSetDynamicEndpoint(uint16_t index, chip::EndpointId id, Emb
 chip::EndpointId emberAfClearDynamicEndpoint(uint16_t index);
 uint16_t emberAfGetDynamicIndexFromEndpoint(chip::EndpointId id);
 
-// Get the number of attributs of the specific cluster under the endpoint. Is useful for the application to get the basic infomation
-// of or iterate over the attributes.
+// Get the number of attributes of the specific cluster under the endpoint.
 // Returns 0 if the cluster does not exist.
 uint16_t emberAfGetServerAttributeCount(chip::EndpointId endpoint, chip::ClusterId cluster);
 
-// Get the index of attribut of the specific cluster under the endpoint. Is useful for the application to get the basic infomation
-// of or iterate over the attributes.
+// Get the index of the given attribute of the specific cluster under the endpoint.
 // Returns UINT16_MAX if the attribute does not exist.
 uint16_t emberAfGetServerAttributeIndexByAttributeId(chip::EndpointId endpoint, chip::ClusterId cluster,
                                                      chip::AttributeId attributeId);

--- a/src/app/util/mock/BUILD.gn
+++ b/src/app/util/mock/BUILD.gn
@@ -1,0 +1,27 @@
+# Copyright (c) 2021 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build_overrides/chip.gni")
+
+source_set("mock_ember") {
+  sources = [ "attribute-storage.cpp" ]
+
+  public_deps = [
+    "${chip_root}/src/app",
+    "${chip_root}/src/lib/core",
+    "${chip_root}/src/lib/support",
+  ]
+
+  cflags = [ "-Wconversion" ]
+}

--- a/src/app/util/mock/Constants.h
+++ b/src/app/util/mock/Constants.h
@@ -1,0 +1,45 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *     This file contains the constants for the mocked attribute-storage.cpp
+ */
+
+#pragma once
+
+#include <lib/core/DataModelTypes.h>
+
+namespace chip {
+namespace Test {
+constexpr EndpointId kMockEndpoint1 = 0xFFFE;
+constexpr EndpointId kMockEndpoint2 = 0xFFFD;
+constexpr EndpointId kMockEndpoint3 = 0xFFFC;
+
+constexpr AttributeId MockAttributeId(const uint16_t & id)
+{
+    return (0xFFF1'0000 | id);
+}
+
+constexpr AttributeId MockClusterId(const uint16_t & id)
+{
+    return (0xFFF1'0000 | id);
+}
+
+} // namespace Test
+} // namespace chip

--- a/src/app/util/mock/attribute-storage.cpp
+++ b/src/app/util/mock/attribute-storage.cpp
@@ -1,0 +1,187 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *     This file contains the mock implementation for the generated attribute-storage.cpp
+ *     - It contains three endpoints, 0xFFFE, 0xFFFD, 0xFFFC
+ *     - It contains four clusters: 0xFFF1'0001 to 0xFFF1'0004
+ *     - All cluster has two global attribute (0x0000'FFFC, 0x0000'FFFD)
+ *     - Some clusters has some cluster-specific attributes, with 0xFFF1 prefix.
+ */
+
+#include <app-common/zap-generated/ids/Attributes.h>
+#include <app/util/mock/Constants.h>
+
+#include <app/ClusterInfo.h>
+#include <app/ConcreteAttributePath.h>
+#include <app/EventManagement.h>
+#include <app/InteractionModelDelegate.h>
+#include <lib/core/CHIPCore.h>
+#include <lib/core/CHIPTLVDebug.hpp>
+#include <lib/support/CodeUtils.h>
+#include <lib/support/DLLUtil.h>
+#include <lib/support/UnitTestRegistration.h>
+#include <lib/support/logging/CHIPLogging.h>
+
+// Mock Functions
+typedef uint8_t EmberAfClusterMask;
+#define CLUSTER_MASK_SERVER (0x40)
+
+using namespace chip;
+using namespace chip::Test;
+using namespace chip::app;
+
+namespace {
+
+EndpointId endpoints[]    = { kMockEndpoint1, kMockEndpoint2, kMockEndpoint3 };
+uint16_t clusterIndex[]   = { 0, 2, 5 };
+uint8_t clusterCount[]    = { 2, 3, 4 };
+ClusterId clusters[]      = { MockClusterId(1), MockClusterId(2), MockClusterId(1), MockClusterId(2), MockClusterId(3),
+                         MockClusterId(1), MockClusterId(2), MockClusterId(3), MockClusterId(4) };
+uint16_t attributeIndex[] = { 0, 2, 5, 7, 11, 16, 19, 25, 27 };
+uint16_t attributeCount[] = { 2, 3, 2, 4, 5, 3, 6, 2, 2 };
+AttributeId attributes[]  = {
+    // clang-format off
+    Clusters::Globals::Attributes::ClusterRevision::Id, Clusters::Globals::Attributes::FeatureMap::Id,
+    Clusters::Globals::Attributes::ClusterRevision::Id, Clusters::Globals::Attributes::FeatureMap::Id, MockAttributeId(1),
+    Clusters::Globals::Attributes::ClusterRevision::Id, Clusters::Globals::Attributes::FeatureMap::Id,
+    Clusters::Globals::Attributes::ClusterRevision::Id, Clusters::Globals::Attributes::FeatureMap::Id, MockAttributeId(1), MockAttributeId(2),
+    Clusters::Globals::Attributes::ClusterRevision::Id, Clusters::Globals::Attributes::FeatureMap::Id, MockAttributeId(1), MockAttributeId(2), MockAttributeId(3),
+    Clusters::Globals::Attributes::ClusterRevision::Id, Clusters::Globals::Attributes::FeatureMap::Id, MockAttributeId(1),
+    Clusters::Globals::Attributes::ClusterRevision::Id, Clusters::Globals::Attributes::FeatureMap::Id, MockAttributeId(1), MockAttributeId(2), MockAttributeId(3), MockAttributeId(4),
+    Clusters::Globals::Attributes::ClusterRevision::Id, Clusters::Globals::Attributes::FeatureMap::Id,
+    Clusters::Globals::Attributes::ClusterRevision::Id, Clusters::Globals::Attributes::FeatureMap::Id
+    // clang-format on
+};
+
+} // namespace
+
+uint16_t emberAfEndpointCount(void)
+{
+    return ArraySize(endpoints);
+}
+
+uint16_t emberAfIndexFromEndpoint(chip::EndpointId endpoint)
+{
+    for (uint16_t i = 0; i < ArraySize(endpoints); i++)
+    {
+        if (endpoints[i] == endpoint)
+        {
+            return i;
+        }
+    }
+    return UINT16_MAX;
+}
+
+uint8_t emberAfClusterCount(chip::EndpointId endpoint, bool server)
+{
+    for (uint16_t i = 0; i < ArraySize(endpoints); i++)
+    {
+        if (endpoints[i] == endpoint)
+        {
+            return clusterCount[i];
+        }
+    }
+    return 0;
+}
+
+uint16_t emberAfGetServerAttributeCount(chip::EndpointId endpoint, chip::ClusterId cluster)
+{
+    uint16_t endpointIndex          = emberAfIndexFromEndpoint(endpoint);
+    uint16_t clusterCountOnEndpoint = emberAfClusterCount(endpoint, true);
+    for (uint16_t i = 0; i < clusterCountOnEndpoint; i++)
+    {
+        if (clusters[i + clusterIndex[endpointIndex]] == cluster)
+        {
+            return attributeCount[i + clusterIndex[endpointIndex]];
+        }
+    }
+    return UINT16_MAX;
+}
+
+uint16_t emberAfGetServerAttributeIndexByAttributeId(chip::EndpointId endpoint, chip::ClusterId cluster,
+                                                     chip::AttributeId attributeId)
+{
+    uint16_t endpointIndex          = emberAfIndexFromEndpoint(endpoint);
+    uint16_t clusterCountOnEndpoint = emberAfClusterCount(endpoint, true);
+    for (uint16_t i = 0; i < clusterCountOnEndpoint; i++)
+    {
+        if (clusters[i + clusterIndex[endpointIndex]] == cluster)
+        {
+            uint16_t clusterAttributeOffset = attributeIndex[i + clusterIndex[endpointIndex]];
+            for (uint16_t j = 0; j < emberAfGetServerAttributeCount(endpoint, cluster); j++)
+            {
+                if (attributes[clusterAttributeOffset + j] == attributeId)
+                {
+                    return j;
+                }
+            }
+            break;
+        }
+    }
+    return UINT16_MAX;
+}
+
+chip::EndpointId emberAfEndpointFromIndex(uint16_t index)
+{
+    return index < ArraySize(endpoints) ? endpoints[index] : app::ConcreteAttributePath::kInvalidEndpointId;
+}
+
+chip::Optional<chip::ClusterId> emberAfGetNthClusterId(chip::EndpointId endpoint, uint8_t n, bool server)
+{
+    if (n >= emberAfClusterCount(endpoint, server))
+    {
+        return chip::Optional<chip::ClusterId>::Missing();
+    }
+    return chip::Optional<chip::ClusterId>(clusters[clusterIndex[emberAfIndexFromEndpoint(endpoint)] + n]);
+}
+
+chip::Optional<chip::AttributeId> emberAfGetServerAttributeIdByIndex(chip::EndpointId endpoint, chip::ClusterId cluster,
+                                                                     uint16_t index)
+{
+    uint16_t endpointIndex          = emberAfIndexFromEndpoint(endpoint);
+    uint16_t clusterCountOnEndpoint = emberAfClusterCount(endpoint, true);
+    for (uint16_t i = 0; i < clusterCountOnEndpoint; i++)
+    {
+        if (clusters[i + clusterIndex[endpointIndex]] == cluster)
+        {
+            uint16_t clusterAttributeOffset = attributeIndex[i + clusterIndex[endpointIndex]];
+            if (index < emberAfGetServerAttributeCount(endpoint, cluster))
+            {
+                return Optional<AttributeId>(attributes[clusterAttributeOffset + index]);
+            }
+            break;
+        }
+    }
+    return Optional<AttributeId>::Missing();
+}
+
+uint8_t emberAfClusterIndex(chip::EndpointId endpoint, chip::ClusterId cluster, EmberAfClusterMask mask)
+{
+    uint16_t endpointIndex          = emberAfIndexFromEndpoint(endpoint);
+    uint16_t clusterCountOnEndpoint = emberAfClusterCount(endpoint, true);
+    for (uint8_t i = 0; i < clusterCountOnEndpoint; i++)
+    {
+        if (clusters[i + clusterIndex[endpointIndex]] == cluster)
+        {
+            return i;
+        }
+    }
+    return UINT8_MAX;
+}

--- a/src/app/util/mock/attribute-storage.cpp
+++ b/src/app/util/mock/attribute-storage.cpp
@@ -23,8 +23,12 @@
  *     - It contains four clusters: 0xFFF1'0001 to 0xFFF1'0004
  *     - All cluster has two global attribute (0x0000'FFFC, 0x0000'FFFD)
  *     - Some clusters has some cluster-specific attributes, with 0xFFF1 prefix.
+ *
+ *    Note: The ember's attribute-storage.cpp will include some app specific generated files. So we cannot use it directly. This
+ *    might be fixed with a mock endpoint-config.h
  */
 
+#include <app-common/zap-generated/att-storage.h>
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app/util/mock/Constants.h>
 
@@ -39,9 +43,7 @@
 #include <lib/support/UnitTestRegistration.h>
 #include <lib/support/logging/CHIPLogging.h>
 
-// Mock Functions
 typedef uint8_t EmberAfClusterMask;
-#define CLUSTER_MASK_SERVER (0x40)
 
 using namespace chip;
 using namespace chip::Test;
@@ -112,7 +114,7 @@ uint16_t emberAfGetServerAttributeCount(chip::EndpointId endpoint, chip::Cluster
             return attributeCount[i + clusterIndex[endpointIndex]];
         }
     }
-    return UINT16_MAX;
+    return 0;
 }
 
 uint16_t emberAfGetServerAttributeIndexByAttributeId(chip::EndpointId endpoint, chip::ClusterId cluster,
@@ -140,7 +142,8 @@ uint16_t emberAfGetServerAttributeIndexByAttributeId(chip::EndpointId endpoint, 
 
 chip::EndpointId emberAfEndpointFromIndex(uint16_t index)
 {
-    return index < ArraySize(endpoints) ? endpoints[index] : app::ConcreteAttributePath::kInvalidEndpointId;
+    VerifyOrDie(index < ArraySize(endpoints));
+    return endpoints[index];
 }
 
 chip::Optional<chip::ClusterId> emberAfGetNthClusterId(chip::EndpointId endpoint, uint8_t n, bool server)

--- a/src/lib/core/DataModelTypes.h
+++ b/src/lib/core/DataModelTypes.h
@@ -43,5 +43,6 @@ typedef uint16_t ListIndex;
 typedef uint32_t TransactionId;
 
 static constexpr FabricIndex kUndefinedFabricIndex = 0;
+static constexpr EndpointId kInvalidEndpointId     = 0xFFFF;
 
 } // namespace chip


### PR DESCRIPTION
#### Problem

- We need to support wildcard read

#### Change overview

- Implement PathIterator
- The usage of this class can be found at https://github.com/project-chip/connectedhomeip/pull/11304

#### Testing
- Adds unit test for PathIterator
- Introduce some mocked ember attribute storage api.
