### PR TITLE
0.5.24 Version bump reason: [Cirque] Bump version for virtual android chip-tool test

### DIFF
--- a/integrations/docker/images/chip-build-cirque/Dockerfile
+++ b/integrations/docker/images/chip-build-cirque/Dockerfile
@@ -32,7 +32,7 @@ RUN set -x \
 RUN set -x \
     && apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -fy \
-       sudo socat psmisc tigervnc-standalone-server tigervnc-viewer \
+       sudo socat psmisc tigervnc-standalone-server xorg xauth \
        python3-pip python3-venv python3-setuptools libdbus-glib-1-dev \
        uuid-runtime libgirepository1.0-dev \
     && : # aids diffs
@@ -41,4 +41,5 @@ COPY requirements_nogrpc.txt /requirements.txt
 
 RUN set -x \
     && pip3 install -r requirements.txt \
+    && xinit -- /usr/bin/Xvnc \
     && : # aids diffs

--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.5.23 Version bump reason: [Ameba] Support BLE & IP commissioning function
+0.5.24 Version bump reason: [Cirque] Bump version for virtual android chip-tool test


### PR DESCRIPTION
#### Problem
Bump cirque build version to 0.5.24 and prepare to enable android chip-tool test.

#### Change overview
See above

#### Testing
Local run
