### PR TITLE
[Tests Suites] Add build time configurable PICS

### DIFF
--- a/src/app/tests/suites/certification/PICS.yaml
+++ b/src/app/tests/suites/certification/PICS.yaml
@@ -1,0 +1,24 @@
+# Copyright (c) 2021 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: PICS Items
+
+PICS:
+    - label: "Does the device support discovery over Bluetooth Low Power (BLE)"
+      id: BLE
+      value: false
+
+    - label: "Does the device support discovery over WiFi?"
+      id: WIFI
+      value: true

--- a/src/app/zap-templates/common/ClusterTestGeneration.js
+++ b/src/app/zap-templates/common/ClusterTestGeneration.js
@@ -41,6 +41,7 @@ const kArgumentsName     = 'arguments';
 const kResponseName      = 'response';
 const kDisabledName      = 'disabled';
 const kResponseErrorName = 'error';
+const kPICSName          = 'PICS';
 
 class NullObject {
   toString()
@@ -100,6 +101,21 @@ function setDefaultType(test)
     test.commandName = test.command;
     test.isCommand   = true;
     break;
+  }
+}
+
+function setDefaultPICS(test)
+{
+  const defaultPICS = '';
+  setDefault(test, kPICSName, defaultPICS);
+
+  if (test[kPICSName] == '') {
+    return;
+  }
+
+  if (!PICS.has(test[kPICSName])) {
+    const errorStr = 'PICS database does not contains any defined value for: ' + test[kPICSName];
+    throwError(test, errorStr);
   }
 }
 
@@ -196,6 +212,7 @@ function setDefaults(test, defaultConfig)
   setDefault(test, kClusterName, defaultClusterName);
   setDefault(test, kEndpointName, defaultEndpointId);
   setDefault(test, kDisabledName, defaultDisabled);
+  setDefaultPICS(test);
   setDefaultArguments(test);
   setDefaultResponse(test);
 }
@@ -250,6 +267,10 @@ function parse(filename)
 
   // Filter disabled tests
   yaml.tests = yaml.tests.filter(test => !test.disabled);
+
+  // Filter tests based on PICS
+  yaml.tests = yaml.tests.filter(test => test[kPICSName] == '' || PICS.get(test[kPICSName]).value == true);
+
   yaml.tests.forEach((test, index) => {
     setDefault(test, kIndexName, index);
   });
@@ -344,9 +365,31 @@ function assertCommandOrAttribute(context)
   });
 }
 
+const PICS = (() => {
+  let filepath = path.resolve(__dirname, basePath + certificationPath + 'PICS.yaml');
+  const data   = fs.readFileSync(filepath, { encoding : 'utf8', flag : 'r' });
+  const yaml   = YAML.parse(data);
+
+  const getAll = () => yaml.PICS;
+  const get = (id) => has(id) ? yaml.PICS.filter(pics => pics.id == id)[0] : null;
+  const has = (id) => !!(yaml.PICS.filter(pics => pics.id == id)).length;
+
+  const PICS = {
+    getAll : getAll,
+    get : get,
+    has : has,
+  };
+  return PICS;
+})();
+
 //
 // Templates
 //
+function chip_tests_pics(options)
+{
+  return templateUtil.collectBlocks(PICS.getAll(), options, this);
+}
+
 function chip_tests(list, options)
 {
   const items = Array.isArray(list) ? list : list.split(',');
@@ -511,5 +554,6 @@ exports.chip_tests_items                    = chip_tests_items;
 exports.chip_tests_item_parameters          = chip_tests_item_parameters;
 exports.chip_tests_item_response_type       = chip_tests_item_response_type;
 exports.chip_tests_item_response_parameters = chip_tests_item_response_parameters;
+exports.chip_tests_pics                     = chip_tests_pics;
 exports.isTestOnlyCluster                   = isTestOnlyCluster;
 exports.isLiteralNull                       = isLiteralNull;


### PR DESCRIPTION
#### Problem

Certification tests should run conditionally based on a declared configuration.
One example of such configuration is `PICS_A_ONOFF`  which means `Does the device implement the OnOff attribute?`

At the moment there is no mechanism to characterise a test step based on this. 

#### Change overview
 * Add a build time mechanism  to configure PICS. Tests are filtered based on that

A followup could be to use `libyaml` to dynamically configure those values instead of them beeing hardcoded.

#### Testing
It was tested locally by adding `PICS: "A_ONOFF"` to one of the test test of `TEST_TC_OO_1_1.yaml`. I expect others to add more values to `src/app/test/suites/certification/PICS.yaml` and use it for tests.
