### PR TITLE
Rename System::Clock::Zero to System::Clock::kZero

### DIFF
--- a/examples/lock-app/esp32/main/AppTask.cpp
+++ b/examples/lock-app/esp32/main/AppTask.cpp
@@ -114,7 +114,7 @@ CHIP_ERROR AppTask::Init()
 void AppTask::AppTaskMain(void * pvParameter)
 {
     AppEvent event;
-    Clock::Timestamp lastChangeTime = Clock::Zero;
+    Clock::Timestamp lastChangeTime = Clock::kZero;
 
     CHIP_ERROR err = sAppTask.Init();
     if (err != CHIP_NO_ERROR)

--- a/examples/shell/shell_common/cmd_ping.cpp
+++ b/examples/shell/shell_common/cmd_ping.cpp
@@ -50,7 +50,7 @@ public:
     {
         mMaxEchoCount       = 3;
         mEchoInterval       = 1000;
-        mLastEchoTime       = System::Clock::Zero;
+        mLastEchoTime       = System::Clock::kZero;
         mEchoCount          = 0;
         mEchoRespCount      = 0;
         mPayloadSize        = 32;

--- a/examples/shell/shell_common/cmd_send.cpp
+++ b/examples/shell/shell_common/cmd_send.cpp
@@ -47,7 +47,7 @@ public:
     {
         mProtocolId   = 0x0002;
         mMessageType  = 1;
-        mLastSendTime = System::Clock::Zero;
+        mLastSendTime = System::Clock::kZero;
         mPayloadSize  = 32;
 #if INET_CONFIG_ENABLE_TCP_ENDPOINT
         mUsingTCP = false;

--- a/src/app/EventManagement.cpp
+++ b/src/app/EventManagement.cpp
@@ -87,7 +87,7 @@ struct EventEnvelopeContext
 
     uint16_t mFieldsToRead = 0;
     /* PriorityLevel and DeltaSystemTimestamp are there if that is not first event when putting events in report*/
-    Timestamp mDeltaSystemTime = Timestamp::System(System::Clock::Zero);
+    Timestamp mDeltaSystemTime = Timestamp::System(System::Clock::kZero);
     Timestamp mDeltaUtc        = Timestamp::UTC(0);
     PriorityLevel mPriority    = PriorityLevel::First;
     NodeId mNodeId             = 0;
@@ -854,8 +854,8 @@ void CircularEventBuffer::Init(uint8_t * apBuffer, uint32_t aBufferLength, Circu
     mPriority                  = aPriorityLevel;
     mFirstEventNumber          = 1;
     mLastEventNumber           = 0;
-    mFirstEventSystemTimestamp = Timestamp::System(System::Clock::Zero);
-    mLastEventSystemTimestamp  = Timestamp::System(System::Clock::Zero);
+    mFirstEventSystemTimestamp = Timestamp::System(System::Clock::kZero);
+    mLastEventSystemTimestamp  = Timestamp::System(System::Clock::kZero);
     mpEventNumberCounter       = nullptr;
 }
 

--- a/src/app/tests/integration/MockEvents.cpp
+++ b/src/app/tests/integration/MockEvents.cpp
@@ -188,7 +188,7 @@ void MockEventGeneratorImpl::SetEventGeneratorStop()
     // This helps quit the standalone app in an orderly way without
     // spurious leaked timers.
     if (mTimeBetweenEvents != 0)
-        mpExchangeMgr->GetSessionManager()->SystemLayer()->StartTimer(chip::System::Clock::Zero, HandleNextEvent, this);
+        mpExchangeMgr->GetSessionManager()->SystemLayer()->StartTimer(chip::System::Clock::kZero, HandleNextEvent, this);
 }
 
 bool MockEventGeneratorImpl::IsEventGeneratorStopped()

--- a/src/app/tests/integration/chip_im_initiator.cpp
+++ b/src/app/tests/integration/chip_im_initiator.cpp
@@ -63,7 +63,7 @@ chip::TransportMgr<chip::Transport::UDP> gTransportManager;
 chip::Inet::IPAddress gDestAddr;
 
 // The last time a CHIP Command was attempted to be sent.
-chip::System::Clock::Timestamp gLastMessageTime = chip::System::Clock::Zero;
+chip::System::Clock::Timestamp gLastMessageTime = chip::System::Clock::kZero;
 
 // Count of the number of CommandRequests sent.
 uint64_t gCommandCount = 0;
@@ -703,7 +703,7 @@ int main(int argc, char * argv[])
     err = EstablishSecureSession();
     SuccessOrExit(err);
 
-    err = chip::DeviceLayer::SystemLayer().StartTimer(chip::System::Clock::Zero, CommandRequestTimerHandler, NULL);
+    err = chip::DeviceLayer::SystemLayer().StartTimer(chip::System::Clock::kZero, CommandRequestTimerHandler, NULL);
     SuccessOrExit(err);
 
     chip::DeviceLayer::PlatformMgr().RunEventLoop();

--- a/src/include/platform/internal/GenericConnectivityManagerImpl_NoWiFi.h
+++ b/src/include/platform/internal/GenericConnectivityManagerImpl_NoWiFi.h
@@ -123,7 +123,7 @@ inline bool GenericConnectivityManagerImpl_NoWiFi<ImplClass>::_IsWiFiStationConn
 template <class ImplClass>
 inline System::Clock::Timeout GenericConnectivityManagerImpl_NoWiFi<ImplClass>::_GetWiFiStationReconnectInterval(void)
 {
-    return System::Clock::Zero;
+    return System::Clock::kZero;
 }
 
 template <class ImplClass>
@@ -181,7 +181,7 @@ inline void GenericConnectivityManagerImpl_NoWiFi<ImplClass>::_MaintainOnDemandW
 template <class ImplClass>
 inline System::Clock::Timeout GenericConnectivityManagerImpl_NoWiFi<ImplClass>::_GetWiFiAPIdleTimeout(void)
 {
-    return System::Clock::Zero;
+    return System::Clock::kZero;
 }
 
 template <class ImplClass>

--- a/src/include/platform/internal/GenericConnectivityManagerImpl_WiFi.h
+++ b/src/include/platform/internal/GenericConnectivityManagerImpl_WiFi.h
@@ -109,7 +109,7 @@ private:
 template <class ImplClass>
 inline System::Clock::Timeout GenericConnectivityManagerImpl_WiFi<ImplClass>::_GetWiFiStationReconnectInterval()
 {
-    return System::Clock::Zero;
+    return System::Clock::kZero;
 }
 
 template <class ImplClass>
@@ -167,7 +167,7 @@ inline void GenericConnectivityManagerImpl_WiFi<ImplClass>::_MaintainOnDemandWiF
 template <class ImplClass>
 inline System::Clock::Timeout GenericConnectivityManagerImpl_WiFi<ImplClass>::_GetWiFiAPIdleTimeout()
 {
-    return System::Clock::Zero;
+    return System::Clock::kZero;
 }
 
 template <class ImplClass>

--- a/src/lib/dnssd/minimal_mdns/responders/QueryResponder.cpp
+++ b/src/lib/dnssd/minimal_mdns/responders/QueryResponder.cpp
@@ -160,7 +160,7 @@ void QueryResponderBase::ClearBroadcastThrottle()
 {
     for (size_t i = 0; i < mResponderInfoSize; i++)
     {
-        mResponderInfos[i].lastMulticastTime = chip::System::Clock::Zero;
+        mResponderInfos[i].lastMulticastTime = chip::System::Clock::kZero;
     }
 }
 

--- a/src/lib/dnssd/minimal_mdns/responders/QueryResponder.h
+++ b/src/lib/dnssd/minimal_mdns/responders/QueryResponder.h
@@ -29,9 +29,9 @@ namespace Minimal {
 /// Represents available data (replies) for mDNS queries.
 struct QueryResponderRecord
 {
-    Responder * responder                            = nullptr;                   // what response/data is available
-    bool reportService                               = false;                     // report as a service when listing dnssd services
-    chip::System::Clock::Timestamp lastMulticastTime = chip::System::Clock::Zero; // last time this record was multicast
+    Responder * responder                            = nullptr; // what response/data is available
+    bool reportService                               = false;   // report as a service when listing dnssd services
+    chip::System::Clock::Timestamp lastMulticastTime = chip::System::Clock::kZero; // last time this record was multicast
 };
 
 namespace Internal {
@@ -140,7 +140,8 @@ public:
             return false;
         }
 
-        if ((mIncludeOnlyMulticastBefore > chip::System::Clock::Zero) && (record->lastMulticastTime >= mIncludeOnlyMulticastBefore))
+        if ((mIncludeOnlyMulticastBefore > chip::System::Clock::kZero) &&
+            (record->lastMulticastTime >= mIncludeOnlyMulticastBefore))
         {
             return false;
         }
@@ -156,7 +157,7 @@ public:
 private:
     bool mIncludeAdditionalRepliesOnly                         = false;
     ReplyFilter * mReplyFilter                                 = nullptr;
-    chip::System::Clock::Timestamp mIncludeOnlyMulticastBefore = chip::System::Clock::Zero;
+    chip::System::Clock::Timestamp mIncludeOnlyMulticastBefore = chip::System::Clock::kZero;
 };
 
 /// Iterates over an array of QueryResponderRecord items, providing only 'valid' ones, where

--- a/src/messaging/ExchangeContext.cpp
+++ b/src/messaging/ExchangeContext.cpp
@@ -124,7 +124,7 @@ CHIP_ERROR ExchangeContext::SendMessage(Protocols::Id protocolId, uint8_t msgTyp
         SetResponseExpected(true);
 
         // Arm the response timer if a timeout has been specified.
-        if (mResponseTimeout > System::Clock::Zero)
+        if (mResponseTimeout > System::Clock::kZero)
         {
             CHIP_ERROR err = StartResponseTimer();
             if (err != CHIP_NO_ERROR)

--- a/src/messaging/ReliableMessageMgr.cpp
+++ b/src/messaging/ReliableMessageMgr.cpp
@@ -59,7 +59,7 @@ void ReliableMessageMgr::Init(chip::System::Layer * systemLayer, SessionManager 
 {
     mSystemLayer        = systemLayer;
     mTimeStampBase      = System::SystemClock().GetMonotonicTimestamp();
-    mCurrentTimerExpiry = System::Clock::Zero;
+    mCurrentTimerExpiry = System::Clock::kZero;
 }
 
 void ReliableMessageMgr::Shutdown()
@@ -448,7 +448,7 @@ void ReliableMessageMgr::StartTimer()
             // If the tick boundary has expired in the past (delayed processing of event due to other system activity),
             // expire the timer immediately
             System::Clock::Timestamp now         = System::SystemClock().GetMonotonicTimestamp();
-            System::Clock::Timeout timerArmValue = (timerExpiry > now) ? timerExpiry - now : System::Clock::Zero;
+            System::Clock::Timeout timerArmValue = (timerExpiry > now) ? timerExpiry - now : System::Clock::kZero;
 
 #if defined(RMP_TICKLESS_DEBUG)
             ChipLogDetail(ExchangeManager, "ReliableMessageMgr::StartTimer set timer for %" PRIu32 " ms",

--- a/src/messaging/tests/echo/echo_requester.cpp
+++ b/src/messaging/tests/echo/echo_requester.cpp
@@ -62,7 +62,7 @@ chip::TransportMgr<chip::Transport::TCP<kMaxTcpActiveConnectionCount, kMaxTcpPen
 chip::Inet::IPAddress gDestAddr;
 
 // The last time a CHIP Echo was attempted to be sent.
-chip::System::Clock::Timestamp gLastEchoTime = chip::System::Clock::Zero;
+chip::System::Clock::Timestamp gLastEchoTime = chip::System::Clock::kZero;
 
 // Count of the number of EchoRequests sent.
 uint64_t gEchoCount = 0;
@@ -263,7 +263,7 @@ int main(int argc, char * argv[])
     // Arrange to get a callback whenever an Echo Response is received.
     gEchoClient.SetEchoResponseReceived(HandleEchoResponseReceived);
 
-    err = chip::DeviceLayer::SystemLayer().StartTimer(chip::System::Clock::Zero, EchoTimerHandler, NULL);
+    err = chip::DeviceLayer::SystemLayer().StartTimer(chip::System::Clock::kZero, EchoTimerHandler, NULL);
     SuccessOrExit(err);
 
     chip::DeviceLayer::PlatformMgr().RunEventLoop();

--- a/src/platform/Ameba/ConnectivityManagerImpl.cpp
+++ b/src/platform/Ameba/ConnectivityManagerImpl.cpp
@@ -129,7 +129,7 @@ void ConnectivityManagerImpl::_StopOnDemandWiFiAP(void)
 {
     if (mWiFiAPMode == kWiFiAPMode_OnDemand || mWiFiAPMode == kWiFiAPMode_OnDemand_NoStationProvision)
     {
-        mLastAPDemandTime = System::Clock::Zero;
+        mLastAPDemandTime = System::Clock::kZero;
         DeviceLayer::SystemLayer().ScheduleWork(DriveAPState, NULL);
     }
 }
@@ -334,8 +334,8 @@ CHIP_ERROR ConnectivityManagerImpl::_GetAndLogWifiStatsCounters(void)
 
 CHIP_ERROR ConnectivityManagerImpl::_Init()
 {
-    mLastStationConnectFailTime   = System::Clock::Zero;
-    mLastAPDemandTime             = System::Clock::Zero;
+    mLastStationConnectFailTime   = System::Clock::kZero;
+    mLastAPDemandTime             = System::Clock::kZero;
     mWiFiStationMode              = kWiFiStationMode_Disabled;
     mWiFiStationState             = kWiFiStationState_NotConnected;
     mWiFiAPMode                   = kWiFiAPMode_Disabled;
@@ -462,7 +462,7 @@ void ConnectivityManagerImpl::DriveStationState()
         {
             ChangeWiFiStationState(kWiFiStationState_Connected);
             ChipLogProgress(DeviceLayer, "WiFi station interface connected");
-            mLastStationConnectFailTime = System::Clock::Zero;
+            mLastStationConnectFailTime = System::Clock::kZero;
             OnStationConnected();
         }
 
@@ -499,7 +499,7 @@ void ConnectivityManagerImpl::DriveStationState()
             if (prevState != kWiFiStationState_Connecting_Failed)
             {
                 ChipLogProgress(DeviceLayer, "WiFi station interface disconnected");
-                mLastStationConnectFailTime = System::Clock::Zero;
+                mLastStationConnectFailTime = System::Clock::kZero;
                 OnStationDisconnected();
             }
             else
@@ -514,7 +514,7 @@ void ConnectivityManagerImpl::DriveStationState()
         {
             // Initiate a connection to the AP if we haven't done so before, or if enough
             // time has passed since the last attempt.
-            if (mLastStationConnectFailTime == System::Clock::Zero ||
+            if (mLastStationConnectFailTime == System::Clock::kZero ||
                 now >= mLastStationConnectFailTime + mWiFiStationReconnectInterval)
             {
                 ChipLogProgress(DeviceLayer, "Attempting to connect WiFi station interface");

--- a/src/platform/ESP32/ConnectivityManagerImpl_WiFi.cpp
+++ b/src/platform/ESP32/ConnectivityManagerImpl_WiFi.cpp
@@ -142,7 +142,7 @@ void ConnectivityManagerImpl::_StopOnDemandWiFiAP(void)
 {
     if (mWiFiAPMode == kWiFiAPMode_OnDemand || mWiFiAPMode == kWiFiAPMode_OnDemand_NoStationProvision)
     {
-        mLastAPDemandTime = System::Clock::Zero;
+        mLastAPDemandTime = System::Clock::kZero;
         DeviceLayer::SystemLayer().ScheduleWork(DriveAPState, NULL);
     }
 }
@@ -375,8 +375,8 @@ CHIP_ERROR ConnectivityManagerImpl::_GetAndLogWifiStatsCounters(void)
 
 CHIP_ERROR ConnectivityManagerImpl::InitWiFi()
 {
-    mLastStationConnectFailTime   = System::Clock::Zero;
-    mLastAPDemandTime             = System::Clock::Zero;
+    mLastStationConnectFailTime   = System::Clock::kZero;
+    mLastAPDemandTime             = System::Clock::kZero;
     mWiFiStationMode              = kWiFiStationMode_Disabled;
     mWiFiStationState             = kWiFiStationState_NotConnected;
     mWiFiAPMode                   = kWiFiAPMode_Disabled;
@@ -551,7 +551,7 @@ void ConnectivityManagerImpl::DriveStationState()
         {
             ChangeWiFiStationState(kWiFiStationState_Connected);
             ChipLogProgress(DeviceLayer, "WiFi station interface connected");
-            mLastStationConnectFailTime = System::Clock::Zero;
+            mLastStationConnectFailTime = System::Clock::kZero;
             OnStationConnected();
         }
 
@@ -588,7 +588,7 @@ void ConnectivityManagerImpl::DriveStationState()
             if (prevState != kWiFiStationState_Connecting_Failed)
             {
                 ChipLogProgress(DeviceLayer, "WiFi station interface disconnected");
-                mLastStationConnectFailTime = System::Clock::Zero;
+                mLastStationConnectFailTime = System::Clock::kZero;
                 OnStationDisconnected();
             }
             else
@@ -604,7 +604,7 @@ void ConnectivityManagerImpl::DriveStationState()
         {
             // Initiate a connection to the AP if we haven't done so before, or if enough
             // time has passed since the last attempt.
-            if (mLastStationConnectFailTime == System::Clock::Zero ||
+            if (mLastStationConnectFailTime == System::Clock::kZero ||
                 now >= mLastStationConnectFailTime + mWiFiStationReconnectInterval)
             {
                 ChipLogProgress(DeviceLayer, "Attempting to connect WiFi station interface");
@@ -740,7 +740,7 @@ void ConnectivityManagerImpl::DriveAPState()
         {
             System::Clock::Timestamp now = System::SystemClock().GetMonotonicTimestamp();
 
-            if (mLastAPDemandTime != System::Clock::Zero && now < (mLastAPDemandTime + mWiFiAPIdleTimeout))
+            if (mLastAPDemandTime != System::Clock::kZero && now < (mLastAPDemandTime + mWiFiAPIdleTimeout))
             {
                 targetState = kWiFiAPState_Active;
 

--- a/src/platform/ESP32/PlatformManagerImpl.h
+++ b/src/platform/ESP32/PlatformManagerImpl.h
@@ -70,7 +70,7 @@ private:
     friend PlatformManager & PlatformMgr(void);
     friend PlatformManagerImpl & PlatformMgrImpl(void);
 
-    chip::System::Clock::Timestamp mStartTime = System::Clock::Zero;
+    chip::System::Clock::Timestamp mStartTime = System::Clock::kZero;
 
     static PlatformManagerImpl sInstance;
 };

--- a/src/platform/Linux/ConnectivityManagerImpl.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl.cpp
@@ -452,7 +452,7 @@ void ConnectivityManagerImpl::_StopOnDemandWiFiAP()
     if (mWiFiAPMode == kWiFiAPMode_OnDemand || mWiFiAPMode == kWiFiAPMode_OnDemand_NoStationProvision)
     {
         ChipLogProgress(DeviceLayer, "wpa_supplicant: Demand stop WiFi AP");
-        mLastAPDemandTime = System::Clock::Zero;
+        mLastAPDemandTime = System::Clock::kZero;
         DeviceLayer::SystemLayer().ScheduleWork(DriveAPState, NULL);
     }
     else
@@ -769,7 +769,7 @@ void ConnectivityManagerImpl::DriveAPState()
         {
             System::Clock::Timestamp now = System::SystemClock().GetMonotonicTimestamp();
 
-            if (mLastAPDemandTime != System::Clock::Zero && now < (mLastAPDemandTime + mWiFiAPIdleTimeout))
+            if (mLastAPDemandTime != System::Clock::kZero && now < (mLastAPDemandTime + mWiFiAPIdleTimeout))
             {
                 targetState = kWiFiAPState_Active;
 

--- a/src/platform/Linux/PlatformManagerImpl.h
+++ b/src/platform/Linux/PlatformManagerImpl.h
@@ -76,7 +76,7 @@ private:
     friend PlatformManagerImpl & PlatformMgrImpl();
     friend class Internal::BLEManagerImpl;
 
-    System::Clock::Timestamp mStartTime = System::Clock::Zero;
+    System::Clock::Timestamp mStartTime = System::Clock::kZero;
 
     static PlatformManagerImpl sInstance;
 

--- a/src/platform/P6/ConnectivityManagerImpl.cpp
+++ b/src/platform/P6/ConnectivityManagerImpl.cpp
@@ -131,7 +131,7 @@ void ConnectivityManagerImpl::_StopOnDemandWiFiAP(void)
 {
     if (mWiFiAPMode == kWiFiAPMode_OnDemand || mWiFiAPMode == kWiFiAPMode_OnDemand_NoStationProvision)
     {
-        mLastAPDemandTime = System::Clock::Zero;
+        mLastAPDemandTime = System::Clock::kZero;
         DeviceLayer::SystemLayer().ScheduleWork(DriveAPState, NULL);
     }
 }
@@ -182,8 +182,8 @@ CHIP_ERROR ConnectivityManagerImpl::_Init()
 {
     CHIP_ERROR err                = CHIP_NO_ERROR;
     cy_rslt_t result              = CY_RSLT_SUCCESS;
-    mLastStationConnectFailTime   = System::Clock::Zero;
-    mLastAPDemandTime             = System::Clock::Zero;
+    mLastStationConnectFailTime   = System::Clock::kZero;
+    mLastAPDemandTime             = System::Clock::kZero;
     mWiFiStationMode              = kWiFiStationMode_Disabled;
     mWiFiStationState             = kWiFiStationState_NotConnected;
     mWiFiAPMode                   = kWiFiAPMode_Disabled;
@@ -404,7 +404,7 @@ void ConnectivityManagerImpl::DriveAPState()
         {
             System::Clock::Timestamp now = System::SystemClock().GetMonotonicTimestamp();
 
-            if (mLastAPDemandTime != System::Clock::Zero && now < (mLastAPDemandTime + mWiFiAPIdleTimeout))
+            if (mLastAPDemandTime != System::Clock::kZero && now < (mLastAPDemandTime + mWiFiAPIdleTimeout))
             {
                 targetState = kWiFiAPState_Active;
 
@@ -502,7 +502,7 @@ void ConnectivityManagerImpl::DriveStationState()
         {
             ChangeWiFiStationState(kWiFiStationState_Connected);
             ChipLogProgress(DeviceLayer, "WiFi station interface connected");
-            mLastStationConnectFailTime = System::Clock::Zero;
+            mLastStationConnectFailTime = System::Clock::kZero;
         }
 
         // If the WiFi station interface is no longer enabled, or no longer provisioned,
@@ -537,7 +537,7 @@ void ConnectivityManagerImpl::DriveStationState()
             if (prevState != kWiFiStationState_Connecting_Failed)
             {
                 ChipLogProgress(DeviceLayer, "WiFi station interface disconnected");
-                mLastStationConnectFailTime = System::Clock::Zero;
+                mLastStationConnectFailTime = System::Clock::kZero;
             }
             else
             {
@@ -551,7 +551,7 @@ void ConnectivityManagerImpl::DriveStationState()
         {
             // Initiate a connection to the AP if we haven't done so before, or if enough
             // time has passed since the last attempt.
-            if (mLastStationConnectFailTime == System::Clock::Zero ||
+            if (mLastStationConnectFailTime == System::Clock::kZero ||
                 now >= mLastStationConnectFailTime + mWiFiStationReconnectInterval)
             {
                 ChangeWiFiStationState(kWiFiStationState_Connecting);

--- a/src/platform/Tizen/ConnectivityManagerImpl.cpp
+++ b/src/platform/Tizen/ConnectivityManagerImpl.cpp
@@ -55,7 +55,7 @@ CHIP_ERROR ConnectivityManagerImpl::_Init(void)
     mWiFiStationMode              = kWiFiStationMode_Disabled;
     mWiFiAPMode                   = kWiFiAPMode_Disabled;
     mWiFiAPState                  = kWiFiAPState_NotActive;
-    mLastAPDemandTime             = System::Clock::Zero;
+    mLastAPDemandTime             = System::Clock::kZero;
     mWiFiStationReconnectInterval = System::Clock::Milliseconds32(CHIP_DEVICE_CONFIG_WIFI_STATION_RECONNECT_INTERVAL);
     mWiFiAPIdleTimeout            = System::Clock::Milliseconds32(CHIP_DEVICE_CONFIG_WIFI_AP_IDLE_TIMEOUT);
 

--- a/src/platform/Tizen/ConnectivityManagerImpl.h
+++ b/src/platform/Tizen/ConnectivityManagerImpl.h
@@ -145,7 +145,7 @@ inline bool ConnectivityManagerImpl::_IsWiFiAPApplicationControlled()
 
 inline System::Clock::Timeout ConnectivityManagerImpl::_GetWiFiAPIdleTimeout()
 {
-    return System::Clock::Zero;
+    return System::Clock::kZero;
 }
 
 #endif

--- a/src/platform/android/ConnectivityManagerImpl.cpp
+++ b/src/platform/android/ConnectivityManagerImpl.cpp
@@ -158,7 +158,7 @@ void ConnectivityManagerImpl::_StopOnDemandWiFiAP()
     if (mWiFiAPMode == kWiFiAPMode_OnDemand || mWiFiAPMode == kWiFiAPMode_OnDemand_NoStationProvision)
     {
         ChipLogProgress(DeviceLayer, "wpa_supplicant: Demand stop WiFi AP");
-        mLastAPDemandTime = System::Clock::Zero;
+        mLastAPDemandTime = System::Clock::kZero;
         DeviceLayer::SystemLayer().ScheduleWork(DriveAPState, NULL);
     }
     else

--- a/src/platform/tests/TestPlatformMgr.cpp
+++ b/src/platform/tests/TestPlatformMgr.cpp
@@ -202,8 +202,8 @@ static void TestPlatformMgr_MockSystemLayer(nlTestSuite * inSuite, void * inCont
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, &DeviceLayer::SystemLayer() == static_cast<chip::System::Layer *>(&systemLayer));
 
-    NL_TEST_ASSERT(inSuite,
-                   DeviceLayer::SystemLayer().StartTimer(chip::System::Clock::Zero, nullptr, nullptr) == CHIP_APPLICATION_ERROR(1));
+    NL_TEST_ASSERT(
+        inSuite, DeviceLayer::SystemLayer().StartTimer(chip::System::Clock::kZero, nullptr, nullptr) == CHIP_APPLICATION_ERROR(1));
     NL_TEST_ASSERT(inSuite, DeviceLayer::SystemLayer().ScheduleWork(nullptr, nullptr) == CHIP_APPLICATION_ERROR(2));
 
     err = PlatformMgr().Shutdown();

--- a/src/protocols/bdx/BdxTransferSession.cpp
+++ b/src/protocols/bdx/BdxTransferSession.cpp
@@ -361,8 +361,8 @@ void TransferSession::Reset()
     mLastQueryNum      = 0;
     mNextQueryNum      = 0;
 
-    mTimeout                = System::Clock::Zero;
-    mTimeoutStartTime       = System::Clock::Zero;
+    mTimeout                = System::Clock::kZero;
+    mTimeoutStartTime       = System::Clock::kZero;
     mShouldInitTimeoutStart = true;
     mAwaitingResponse       = false;
 }

--- a/src/protocols/bdx/BdxTransferSession.h
+++ b/src/protocols/bdx/BdxTransferSession.h
@@ -352,8 +352,8 @@ private:
     uint32_t mLastQueryNum = 0;
     uint32_t mNextQueryNum = 0;
 
-    System::Clock::Timeout mTimeout            = System::Clock::Zero;
-    System::Clock::Timestamp mTimeoutStartTime = System::Clock::Zero;
+    System::Clock::Timeout mTimeout            = System::Clock::kZero;
+    System::Clock::Timestamp mTimeoutStartTime = System::Clock::kZero;
     bool mShouldInitTimeoutStart               = true;
     bool mAwaitingResponse                     = false;
 };

--- a/src/protocols/bdx/tests/TestBdxTransferSession.cpp
+++ b/src/protocols/bdx/tests/TestBdxTransferSession.cpp
@@ -21,7 +21,7 @@ using namespace ::chip::Protocols;
 
 namespace {
 // Use this as a timestamp if not needing to test BDX timeouts.
-constexpr System::Clock::Timestamp kNoAdvanceTime = System::Clock::Zero;
+constexpr System::Clock::Timestamp kNoAdvanceTime = System::Clock::kZero;
 
 const TLV::Tag tlvStrTag  = TLV::ContextTag(4);
 const TLV::Tag tlvListTag = TLV::ProfileTag(7777, 8888);

--- a/src/system/SystemClock.h
+++ b/src/system/SystemClock.h
@@ -63,7 +63,7 @@ using Seconds64 = std::chrono::duration<uint64_t>;
 using Seconds32 = std::chrono::duration<uint32_t>;
 using Seconds16 = std::chrono::duration<uint16_t>;
 
-constexpr Seconds16 Zero{ 0 };
+constexpr Seconds16 kZero{ 0 };
 
 namespace Literals {
 

--- a/src/system/SystemLayerImplLibevent.cpp
+++ b/src/system/SystemLayerImplLibevent.cpp
@@ -210,7 +210,7 @@ CHIP_ERROR LayerImplLibevent::ScheduleWork(TimerCompleteCallback onComplete, voi
     assertChipStackLockedByCurrentThread();
     VerifyOrReturnError(mLayerState.IsInitialized(), CHIP_ERROR_INCORRECT_STATE);
 
-    return StartTimer(Clock::Zero, onComplete, appState);
+    return StartTimer(Clock::kZero, onComplete, appState);
 }
 
 // static

--- a/src/system/SystemLayerImplLwIP.cpp
+++ b/src/system/SystemLayerImplLwIP.cpp
@@ -56,7 +56,7 @@ CHIP_ERROR LayerImplLwIP::StartTimer(Clock::Timeout delay, TimerCompleteCallback
 {
     VerifyOrReturnError(mLayerState.IsInitialized(), CHIP_ERROR_INCORRECT_STATE);
 
-    CHIP_SYSTEM_FAULT_INJECT(FaultInjection::kFault_TimeoutImmediate, delay = Clock::Zero);
+    CHIP_SYSTEM_FAULT_INJECT(FaultInjection::kFault_TimeoutImmediate, delay = Clock::kZero);
 
     CancelTimer(onComplete, appState);
 
@@ -91,7 +91,7 @@ CHIP_ERROR LayerImplLwIP::ScheduleWork(TimerCompleteCallback onComplete, void * 
 {
     VerifyOrReturnError(mLayerState.IsInitialized(), CHIP_ERROR_INCORRECT_STATE);
 
-    Timer * timer = Timer::New(*this, System::Clock::Zero, onComplete, appState);
+    Timer * timer = Timer::New(*this, System::Clock::kZero, onComplete, appState);
     VerifyOrReturnError(timer != nullptr, CHIP_ERROR_NO_MEMORY);
 
     return ScheduleLambda([timer] { timer->HandleComplete(); });
@@ -236,7 +236,7 @@ CHIP_ERROR LayerImplLwIP::HandlePlatformTimer()
     if (!mTimerList.Empty())
     {
         // timers still exist so restart the platform timer.
-        Clock::Timeout delay = System::Clock::Zero;
+        Clock::Timeout delay = System::Clock::kZero;
 
         Clock::Timestamp currentTime = SystemClock().GetMonotonicTimestamp();
 

--- a/src/system/SystemLayerImplSelect.cpp
+++ b/src/system/SystemLayerImplSelect.cpp
@@ -120,7 +120,7 @@ CHIP_ERROR LayerImplSelect::StartTimer(Clock::Timeout delay, TimerCompleteCallba
 {
     VerifyOrReturnError(mLayerState.IsInitialized(), CHIP_ERROR_INCORRECT_STATE);
 
-    CHIP_SYSTEM_FAULT_INJECT(FaultInjection::kFault_TimeoutImmediate, delay = System::Clock::Zero);
+    CHIP_SYSTEM_FAULT_INJECT(FaultInjection::kFault_TimeoutImmediate, delay = System::Clock::kZero);
 
     CancelTimer(onComplete, appState);
 
@@ -188,7 +188,7 @@ CHIP_ERROR LayerImplSelect::ScheduleWork(TimerCompleteCallback onComplete, void 
 
     CancelTimer(onComplete, appState);
 
-    Timer * timer = Timer::New(*this, Clock::Zero, onComplete, appState);
+    Timer * timer = Timer::New(*this, Clock::kZero, onComplete, appState);
     VerifyOrReturnError(timer != nullptr, CHIP_ERROR_NO_MEMORY);
 
 #if CHIP_SYSTEM_CONFIG_USE_DISPATCH
@@ -339,7 +339,7 @@ void LayerImplSelect::PrepareEvents()
         awakenTime = timer->AwakenTime();
     }
 
-    const Clock::Timestamp sleepTime = (awakenTime > currentTime) ? (awakenTime - currentTime) : Clock::Zero;
+    const Clock::Timestamp sleepTime = (awakenTime > currentTime) ? (awakenTime - currentTime) : Clock::kZero;
     Clock::ToTimeval(sleepTime, mNextTimeout);
 
     mMaxFd = -1;

--- a/src/system/tests/TestSystemClock.cpp
+++ b/src/system/tests/TestSystemClock.cpp
@@ -90,15 +90,15 @@ void TestMockClock(nlTestSuite * inSuite, void * inContext)
     public:
         Clock::Microseconds64 GetMonotonicMicroseconds64() override { return mTime; }
         Clock::Milliseconds64 GetMonotonicMilliseconds64() override { return mTime; }
-        Clock::Milliseconds64 mTime = Clock::Zero;
+        Clock::Milliseconds64 mTime = Clock::kZero;
     };
     MockClock clock;
 
     Clock::ClockBase * savedRealClock = &SystemClock();
     Clock::Internal::SetSystemClockForTesting(&clock);
 
-    NL_TEST_ASSERT(inSuite, SystemClock().GetMonotonicMilliseconds64() == Clock::Zero);
-    NL_TEST_ASSERT(inSuite, SystemClock().GetMonotonicMicroseconds64() == Clock::Zero);
+    NL_TEST_ASSERT(inSuite, SystemClock().GetMonotonicMilliseconds64() == Clock::kZero);
+    NL_TEST_ASSERT(inSuite, SystemClock().GetMonotonicMicroseconds64() == Clock::kZero);
 
     constexpr Clock::Milliseconds64 k1234 = Clock::Milliseconds64(1234);
     clock.mTime                           = k1234;

--- a/src/system/tests/TestSystemTimer.cpp
+++ b/src/system/tests/TestSystemTimer.cpp
@@ -154,7 +154,7 @@ void HandleGreedyTimer(Layer * aLayer, void * aState)
         return;
     }
 
-    aLayer->StartTimer(chip::System::Clock::Zero, HandleGreedyTimer, aState);
+    aLayer->StartTimer(chip::System::Clock::kZero, HandleGreedyTimer, aState);
     sNumTimersHandled++;
 }
 
@@ -163,7 +163,7 @@ static void CheckStarvation(nlTestSuite * inSuite, void * aContext)
     TestContext & lContext = *static_cast<TestContext *>(aContext);
     Layer & lSys           = *lContext.mLayer;
 
-    lSys.StartTimer(chip::System::Clock::Zero, HandleGreedyTimer, aContext);
+    lSys.StartTimer(chip::System::Clock::kZero, HandleGreedyTimer, aContext);
 
     ServiceEvents(lSys);
 }


### PR DESCRIPTION
#### Problem

`System::Clock::Zero` is a constants that doesn't follow the usual
convention of being named with a leading `k`.

Requested in PR #11238 review.

#### Change overview

Rename `System::Clock::Zero` to `System::Clock::kZero`.

#### Testing

CI; no changes to functionality.
