### PR TITLE
Align QueryImage and QueryImageResponse XML with the spec

### DIFF
--- a/examples/ota-provider-app/ota-provider-common/OTAProviderExample.cpp
+++ b/examples/ota-provider-app/ota-provider-common/OTAProviderExample.cpp
@@ -33,6 +33,7 @@ using chip::CharSpan;
 using chip::Optional;
 using chip::Span;
 using chip::app::Clusters::OTAProviderDelegate;
+using namespace chip::app::Clusters::OtaSoftwareUpdateProvider::Commands;
 
 constexpr uint8_t kUpdateTokenLen    = 32;                      // must be between 8 and 32
 constexpr uint8_t kUpdateTokenStrLen = kUpdateTokenLen * 2 + 1; // Hex string needs 2 hex chars for every byte
@@ -94,17 +95,14 @@ void OTAProviderExample::SetOTAFilePath(const char * path)
 }
 
 EmberAfStatus OTAProviderExample::HandleQueryImage(chip::app::CommandHandler * commandObj,
-                                                   const chip::app::ConcreteCommandPath & commandPath, uint16_t vendorId,
-                                                   uint16_t productId, uint32_t softwareVersion, uint8_t protocolsSupported,
-                                                   const Optional<uint16_t> & hardwareVersion, const Optional<CharSpan> & location,
-                                                   const Optional<bool> & requestorCanConsent,
-                                                   const Optional<ByteSpan> & metadataForProvider)
+                                                   const chip::app::ConcreteCommandPath & commandPath,
+                                                   const QueryImage::DecodableType & commandData)
 {
     // TODO: add confiuration for returning BUSY status
 
     EmberAfOTAQueryStatus queryStatus = EMBER_ZCL_OTA_QUERY_STATUS_NOT_AVAILABLE;
-    uint32_t newSoftwareVersion       = softwareVersion + 1; // This implementation will always indicate that an update is available
-                                                             // (if the user provides a file).
+    uint32_t newSoftwareVersion = commandData.softwareVersion + 1; // This implementation will always indicate that an update is
+                                                                   // available (if the user provides a file).
     constexpr char kExampleSoftwareString[] = "Example-Image-V0.1";
     bool userConsentNeeded                  = false;
     uint8_t updateToken[kUpdateTokenLen]    = { 0 };
@@ -149,19 +147,16 @@ EmberAfStatus OTAProviderExample::HandleQueryImage(chip::app::CommandHandler * c
         queryStatus = EMBER_ZCL_OTA_QUERY_STATUS_NOT_AVAILABLE;
     }
 
-    chip::app::Clusters::OtaSoftwareUpdateProvider::Commands::QueryImageResponse::Type response;
-    response.status                = queryStatus;
-    response.delayedActionTime     = mDelayedActionTimeSec;
-    response.imageURI              = chip::CharSpan(uriBuf, strlen(uriBuf));
-    response.softwareVersion       = newSoftwareVersion;
-    response.softwareVersionString = chip::CharSpan(kExampleSoftwareString, strlen(kExampleSoftwareString));
-    response.updateToken           = chip::ByteSpan(updateToken);
-    response.userConsentNeeded     = userConsentNeeded;
-    // TODO: Once our client is using APIs that handle optional arguments
-    // correctly, update QueryImageResponse to have the right things optional.
-    // At that point we can decide whether to send metadataForRequestor as an
-    // empty ByteSpan or whether to not send it at all.
-    response.metadataForRequestor = chip::ByteSpan();
+    QueryImageResponse::Type response;
+    response.status = queryStatus;
+    response.delayedActionTime.Emplace(mDelayedActionTimeSec);
+    response.imageURI.Emplace(chip::CharSpan(uriBuf, strlen(uriBuf)));
+    response.softwareVersion.Emplace(newSoftwareVersion);
+    response.softwareVersionString.Emplace(chip::CharSpan(kExampleSoftwareString, strlen(kExampleSoftwareString)));
+    response.updateToken.Emplace(chip::ByteSpan(updateToken));
+    response.userConsentNeeded.Emplace(userConsentNeeded);
+    // Could also just not send metadataForRequestor at all.
+    response.metadataForRequestor.Emplace(chip::ByteSpan());
 
     VerifyOrReturnError(commandObj->AddResponseData(commandPath, response) == CHIP_NO_ERROR, EMBER_ZCL_STATUS_FAILURE);
     return EMBER_ZCL_STATUS_SUCCESS;
@@ -169,19 +164,19 @@ EmberAfStatus OTAProviderExample::HandleQueryImage(chip::app::CommandHandler * c
 
 EmberAfStatus OTAProviderExample::HandleApplyUpdateRequest(chip::app::CommandHandler * commandObj,
                                                            const chip::app::ConcreteCommandPath & commandPath,
-                                                           const ByteSpan & updateToken, uint32_t newVersion)
+                                                           const ApplyUpdateRequest::DecodableType & commandData)
 {
     // TODO: handle multiple transfers by tracking updateTokens
 
     EmberAfOTAApplyUpdateAction updateAction = EMBER_ZCL_OTA_APPLY_UPDATE_ACTION_PROCEED; // For now, just allow any update request
     char tokenBuf[kUpdateTokenStrLen]        = { 0 };
 
-    GetUpdateTokenString(updateToken, tokenBuf, kUpdateTokenStrLen);
-    ChipLogDetail(SoftwareUpdate, "%s: token: %s, version: %" PRIu32, __FUNCTION__, tokenBuf, newVersion);
+    GetUpdateTokenString(commandData.updateToken, tokenBuf, kUpdateTokenStrLen);
+    ChipLogDetail(SoftwareUpdate, "%s: token: %s, version: %" PRIu32, __FUNCTION__, tokenBuf, commandData.newVersion);
 
     VerifyOrReturnError(commandObj != nullptr, EMBER_ZCL_STATUS_INVALID_VALUE);
 
-    chip::app::Clusters::OtaSoftwareUpdateProvider::Commands::ApplyUpdateResponse::Type response;
+    ApplyUpdateResponse::Type response;
     response.action            = updateAction;
     response.delayedActionTime = mDelayedActionTimeSec;
     VerifyOrReturnError(commandObj->AddResponseData(commandPath, response) == CHIP_NO_ERROR, EMBER_ZCL_STATUS_FAILURE);
@@ -189,12 +184,14 @@ EmberAfStatus OTAProviderExample::HandleApplyUpdateRequest(chip::app::CommandHan
     return EMBER_ZCL_STATUS_SUCCESS;
 }
 
-EmberAfStatus OTAProviderExample::HandleNotifyUpdateApplied(const chip::ByteSpan & updateToken, uint32_t softwareVersion)
+EmberAfStatus OTAProviderExample::HandleNotifyUpdateApplied(chip::app::CommandHandler * commandObj,
+                                                            const chip::app::ConcreteCommandPath & commandPath,
+                                                            const NotifyUpdateApplied::DecodableType & commandData)
 {
     char tokenBuf[kUpdateTokenStrLen] = { 0 };
 
-    GetUpdateTokenString(updateToken, tokenBuf, kUpdateTokenStrLen);
-    ChipLogDetail(SoftwareUpdate, "%s: token: %s, version: %" PRIu32, __FUNCTION__, tokenBuf, softwareVersion);
+    GetUpdateTokenString(commandData.updateToken, tokenBuf, kUpdateTokenStrLen);
+    ChipLogDetail(SoftwareUpdate, "%s: token: %s, version: %" PRIu32, __FUNCTION__, tokenBuf, commandData.softwareVersion);
 
     emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
 

--- a/examples/ota-provider-app/ota-provider-common/OTAProviderExample.h
+++ b/examples/ota-provider-app/ota-provider-common/OTAProviderExample.h
@@ -32,16 +32,15 @@ public:
     void SetOTAFilePath(const char * path);
 
     // Inherited from OTAProviderDelegate
-    EmberAfStatus HandleQueryImage(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
-                                   uint16_t vendorId, uint16_t productId, uint32_t softwareVersion, uint8_t protocolsSupported,
-                                   const chip::Optional<uint16_t> & hardwareVersion,
-                                   const chip::Optional<chip::CharSpan> & location,
-                                   const chip::Optional<bool> & requestorCanConsent,
-                                   const chip::Optional<chip::ByteSpan> & metadataForServer) override;
-    EmberAfStatus HandleApplyUpdateRequest(chip::app::CommandHandler * commandObj,
-                                           const chip::app::ConcreteCommandPath & commandPath, const chip::ByteSpan & updateToken,
-                                           uint32_t newVersion) override;
-    EmberAfStatus HandleNotifyUpdateApplied(const chip::ByteSpan & updateToken, uint32_t softwareVersion) override;
+    EmberAfStatus HandleQueryImage(
+        chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
+        const chip::app::Clusters::OtaSoftwareUpdateProvider::Commands::QueryImage::DecodableType & commandData) override;
+    EmberAfStatus HandleApplyUpdateRequest(
+        chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
+        const chip::app::Clusters::OtaSoftwareUpdateProvider::Commands::ApplyUpdateRequest::DecodableType & commandData) override;
+    EmberAfStatus HandleNotifyUpdateApplied(
+        chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
+        const chip::app::Clusters::OtaSoftwareUpdateProvider::Commands::NotifyUpdateApplied::DecodableType & commandData) override;
 
     enum queryImageBehaviorType
     {

--- a/examples/ota-requestor-app/linux/main.cpp
+++ b/examples/ota-requestor-app/linux/main.cpp
@@ -151,13 +151,12 @@ void OnConnected(void * context, OperationalDeviceProxy * operationalDeviceProxy
     constexpr EndpointId kOtaProviderEndpoint = 0;
 
     // These QueryImage params have been chosen arbitrarily
-    constexpr VendorId kExampleVendorId        = VendorId::Common;
-    constexpr uint16_t kExampleProductId       = 77;
-    constexpr uint16_t kExampleHWVersion       = 3;
-    constexpr uint16_t kExampleSoftwareVersion = 0;
-    constexpr EmberAfOTADownloadProtocol kExampleProtocolsSupported =
-        EMBER_ZCL_OTA_DOWNLOAD_PROTOCOL_BDX_SYNCHRONOUS; // TODO: support this as a list once ember adds list support
-    const char locationBuf[] = { 'U', 'S' };
+    constexpr VendorId kExampleVendorId                               = VendorId::Common;
+    constexpr uint16_t kExampleProductId                              = 77;
+    constexpr uint16_t kExampleHWVersion                              = 3;
+    constexpr uint16_t kExampleSoftwareVersion                        = 0;
+    constexpr EmberAfOTADownloadProtocol kExampleProtocolsSupported[] = { EMBER_ZCL_OTA_DOWNLOAD_PROTOCOL_BDX_SYNCHRONOUS };
+    const char locationBuf[]                                          = { 'U', 'S' };
     CharSpan exampleLocation(locationBuf);
     constexpr bool kExampleClientCanConsent = false;
     ByteSpan metadata;

--- a/examples/ota-requestor-app/linux/main.cpp
+++ b/examples/ota-requestor-app/linux/main.cpp
@@ -17,6 +17,7 @@
  */
 
 #include <app-common/zap-generated/callback.h>
+#include <app-common/zap-generated/cluster-objects.h>
 #include <app/device/OperationalDeviceProxy.h>
 #include <app/server/Server.h>
 #include <credentials/examples/DeviceAttestationCredsExample.h>
@@ -43,11 +44,10 @@ using chip::Transport::PeerAddress;
 using namespace chip::ArgParser;
 using namespace chip::Messaging;
 using namespace chip::app::device;
+using namespace chip::app::Clusters::OtaSoftwareUpdateProvider::Commands;
 
-void OnQueryImageResponse(void * context, uint8_t status, uint32_t delayedActionTime, CharSpan imageURI, uint32_t softwareVersion,
-                          CharSpan softwareVersionString, ByteSpan updateToken, bool userConsentNeeded,
-                          ByteSpan metadataForRequestor);
-void OnQueryImageFailure(void * context, uint8_t status);
+void OnQueryImageResponse(void * context, const QueryImageResponse::DecodableType & response);
+void OnQueryImageFailure(void * context, EmberAfStatus status);
 void OnConnected(void * context, OperationalDeviceProxy * operationalDeviceProxy);
 void OnConnectionFailure(void * context, OperationalDeviceProxy * operationalDeviceProxy, CHIP_ERROR error);
 bool HandleOptions(const char * aProgram, OptionSet * aOptions, int aIdentifier, const char * aName, const char * aValue);
@@ -56,8 +56,6 @@ bool HandleOptions(const char * aProgram, OptionSet * aOptions, int aIdentifier,
 OperationalDeviceProxy gOperationalDeviceProxy;
 ExchangeContext * exchangeCtx = nullptr;
 BdxDownloader bdxDownloader;
-Callback<OtaSoftwareUpdateProviderClusterQueryImageResponseCallback> mQueryImageResponseCallback(OnQueryImageResponse, nullptr);
-Callback<DefaultFailureCallback> mOnQueryFailureCallback(OnQueryImageFailure, nullptr);
 Callback<OnOperationalDeviceConnected> mOnConnectedCallback(OnConnected, nullptr);
 Callback<OnOperationalDeviceConnectionFailure> mOnConnectionFailureCallback(OnConnectionFailure, nullptr);
 
@@ -108,11 +106,9 @@ HelpOptions helpOptions("ota-requestor-app", "Usage: ota-requestor-app [options]
 
 OptionSet * allOptions[] = { &cmdLineOptions, &helpOptions, nullptr };
 
-void OnQueryImageResponse(void * context, uint8_t status, uint32_t delayedActionTime, CharSpan imageURI, uint32_t softwareVersion,
-                          CharSpan softwareVersionString, ByteSpan updateToken, bool userConsentNeeded,
-                          ByteSpan metadataForRequestor)
+void OnQueryImageResponse(void * context, const QueryImageResponse::DecodableType & response)
 {
-    ChipLogDetail(SoftwareUpdate, "QueryImageResponse responded with action %" PRIu8, status);
+    ChipLogDetail(SoftwareUpdate, "QueryImageResponse responded with action %" PRIu8, response.status);
 
     TransferSession::TransferInitData initOptions;
     initOptions.TransferCtlFlags = chip::bdx::TransferControlFlags::kReceiverDrive;
@@ -143,7 +139,7 @@ void OnQueryImageResponse(void * context, uint8_t status, uint32_t delayedAction
                                    chip::System::Clock::Seconds16(20));
 }
 
-void OnQueryImageFailure(void * context, uint8_t status)
+void OnQueryImageFailure(void * context, EmberAfStatus status)
 {
     ChipLogDetail(SoftwareUpdate, "QueryImage failure response %" PRIu8, status);
 }
@@ -154,15 +150,12 @@ void OnConnected(void * context, OperationalDeviceProxy * operationalDeviceProxy
     chip::Controller::OtaSoftwareUpdateProviderCluster cluster;
     constexpr EndpointId kOtaProviderEndpoint = 0;
 
-    chip::Callback::Cancelable * successCallback = mQueryImageResponseCallback.Cancel();
-    chip::Callback::Cancelable * failureCallback = mOnQueryFailureCallback.Cancel();
-
     // These QueryImage params have been chosen arbitrarily
     constexpr VendorId kExampleVendorId        = VendorId::Common;
     constexpr uint16_t kExampleProductId       = 77;
     constexpr uint16_t kExampleHWVersion       = 3;
     constexpr uint16_t kExampleSoftwareVersion = 0;
-    constexpr uint8_t kExampleProtocolsSupported =
+    constexpr EmberAfOTADownloadProtocol kExampleProtocolsSupported =
         EMBER_ZCL_OTA_DOWNLOAD_PROTOCOL_BDX_SYNCHRONOUS; // TODO: support this as a list once ember adds list support
     const char locationBuf[] = { 'U', 'S' };
     CharSpan exampleLocation(locationBuf);
@@ -175,8 +168,16 @@ void OnConnected(void * context, OperationalDeviceProxy * operationalDeviceProxy
         ChipLogError(SoftwareUpdate, "Associate() failed: %" CHIP_ERROR_FORMAT, err.Format());
         return;
     }
-    err = cluster.QueryImage(successCallback, failureCallback, kExampleVendorId, kExampleProductId, kExampleSoftwareVersion,
-                             kExampleProtocolsSupported, kExampleHWVersion, exampleLocation, kExampleClientCanConsent, metadata);
+    QueryImage::Type args;
+    args.vendorId           = kExampleVendorId;
+    args.productId          = kExampleProductId;
+    args.softwareVersion    = kExampleSoftwareVersion;
+    args.protocolsSupported = kExampleProtocolsSupported;
+    args.hardwareVersion.Emplace(kExampleHWVersion);
+    args.location.Emplace(exampleLocation);
+    args.requestorCanConsent.Emplace(kExampleClientCanConsent);
+    args.metadataForProvider.Emplace(metadata);
+    err = cluster.InvokeCommand(args, /* context = */ nullptr, OnQueryImageResponse, OnQueryImageFailure);
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(SoftwareUpdate, "QueryImage() failed: %" CHIP_ERROR_FORMAT, err.Format());

--- a/src/app/clusters/ota-provider/ota-provider-delegate.h
+++ b/src/app/clusters/ota-provider/ota-provider-delegate.h
@@ -18,9 +18,11 @@
 
 #pragma once
 
+#include <app-common/zap-generated/cluster-objects.h>
 #include <app-common/zap-generated/enums.h>
 #include <app/CommandHandler.h>
 #include <app/ConcreteCommandPath.h>
+#include <app/data-model/DecodableList.h>
 #include <app/util/af.h>
 #include <lib/core/Optional.h>
 
@@ -35,17 +37,16 @@ namespace Clusters {
 class OTAProviderDelegate
 {
 public:
-    // TODO(#8605): protocolsSupported should be list of OTADownloadProtocol enums, not uint8_t
-    virtual EmberAfStatus HandleQueryImage(CommandHandler * commandObj, const ConcreteCommandPath & commandPath, uint16_t vendorId,
-                                           uint16_t productId, uint32_t softwareVersion, uint8_t protocolsSupported,
-                                           const Optional<uint16_t> & hardwareVersion, const Optional<CharSpan> & location,
-                                           const Optional<bool> & requestorCanConsent,
-                                           const Optional<ByteSpan> & metadataForProvider) = 0;
+    virtual EmberAfStatus HandleQueryImage(CommandHandler * commandObj, const ConcreteCommandPath & commandPath,
+                                           const OtaSoftwareUpdateProvider::Commands::QueryImage::DecodableType & commandData) = 0;
 
-    virtual EmberAfStatus HandleApplyUpdateRequest(CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
-                                                   const chip::ByteSpan & updateToken, uint32_t newVersion) = 0;
+    virtual EmberAfStatus
+    HandleApplyUpdateRequest(CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
+                             const OtaSoftwareUpdateProvider::Commands::ApplyUpdateRequest::DecodableType & commandData) = 0;
 
-    virtual EmberAfStatus HandleNotifyUpdateApplied(const chip::ByteSpan & updateToken, uint32_t softwareVersion) = 0;
+    virtual EmberAfStatus
+    HandleNotifyUpdateApplied(CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
+                              const OtaSoftwareUpdateProvider::Commands::NotifyUpdateApplied::DecodableType & commandData) = 0;
 
     virtual ~OTAProviderDelegate() = default;
 };

--- a/src/app/clusters/ota-provider/ota-provider.cpp
+++ b/src/app/clusters/ota-provider/ota-provider.cpp
@@ -72,7 +72,6 @@ bool emberAfOtaSoftwareUpdateProviderClusterApplyUpdateRequestCallback(
     const Commands::ApplyUpdateRequest::DecodableType & commandData)
 {
     auto & updateToken = commandData.updateToken;
-    auto & newVersion  = commandData.newVersion;
 
     EndpointId endpoint = commandPath.mEndpointId;
 
@@ -90,9 +89,10 @@ bool emberAfOtaSoftwareUpdateProviderClusterApplyUpdateRequestCallback(
     {
         ChipLogError(Zcl, "expected size %zu for UpdateToken, got %zu", kUpdateTokenMaxLength, updateToken.size());
         emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+        return true;
     }
 
-    status = delegate->HandleApplyUpdateRequest(commandObj, commandPath, updateToken, newVersion);
+    status = delegate->HandleApplyUpdateRequest(commandObj, commandPath, commandData);
     if (status != EMBER_ZCL_STATUS_SUCCESS)
     {
         emberAfSendImmediateDefaultResponse(status);
@@ -114,8 +114,7 @@ bool emberAfOtaSoftwareUpdateProviderClusterNotifyUpdateAppliedCallback(
     app::CommandHandler * commandObj, const app::ConcreteCommandPath & commandPath,
     const Commands::NotifyUpdateApplied::DecodableType & commandData)
 {
-    auto & updateToken     = commandData.updateToken;
-    auto & softwareVersion = commandData.softwareVersion;
+    auto & updateToken = commandData.updateToken;
 
     EndpointId endpoint = commandPath.mEndpointId;
 
@@ -133,9 +132,10 @@ bool emberAfOtaSoftwareUpdateProviderClusterNotifyUpdateAppliedCallback(
     {
         ChipLogError(Zcl, "expected size %zu for UpdateToken, got %zu", kUpdateTokenMaxLength, updateToken.size());
         emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_INVALID_ARGUMENT);
+        return true;
     }
 
-    status = delegate->HandleNotifyUpdateApplied(updateToken, softwareVersion);
+    status = delegate->HandleNotifyUpdateApplied(commandObj, commandPath, commandData);
     if (status != EMBER_ZCL_STATUS_SUCCESS)
     {
         emberAfSendImmediateDefaultResponse(status);
@@ -188,7 +188,13 @@ bool emberAfOtaSoftwareUpdateProviderClusterQueryImageCallback(app::CommandHandl
     ChipLogDetail(Zcl, "  VendorID: 0x%" PRIx16, vendorId);
     ChipLogDetail(Zcl, "  ProductID: %" PRIu16, productId);
     ChipLogDetail(Zcl, "  SoftwareVersion: %" PRIu32, softwareVersion);
-    ChipLogDetail(Zcl, "  ProtocolsSupported: %" PRIu8, protocolsSupported);
+    ChipLogDetail(Zcl, "  ProtocolsSupported: [");
+    auto protocolIter = protocolsSupported.begin();
+    while (protocolIter.Next())
+    {
+        ChipLogDetail(Zcl, "    %" PRIu8, protocolIter.GetValue());
+    }
+    ChipLogDetail(Zcl, "  ]");
     if (hardwareVersion.HasValue())
     {
         ChipLogDetail(Zcl, "  HardwareVersion: %" PRIu16, hardwareVersion.Value());
@@ -220,8 +226,7 @@ bool emberAfOtaSoftwareUpdateProviderClusterQueryImageCallback(app::CommandHandl
         return true;
     }
 
-    status = delegate->HandleQueryImage(commandObj, commandPath, vendorId, productId, softwareVersion, protocolsSupported,
-                                        hardwareVersion, location, requestorCanConsent, metadataForProvider);
+    status = delegate->HandleQueryImage(commandObj, commandPath, commandData);
     if (status != EMBER_ZCL_STATUS_SUCCESS)
     {
         emberAfSendImmediateDefaultResponse(status);

--- a/src/app/zap-templates/zcl/data-model/chip/chip-ota.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/chip-ota.xml
@@ -48,7 +48,7 @@ limitations under the License.
             <arg name="vendorId" type="vendor_id"/>
             <arg name="productId" type="INT16U"/>
             <arg name="softwareVersion" type="INT32U"/>
-            <arg name="protocolsSupported" type="OTADownloadProtocol"/> <!-- TODO(#8605): add array="true" when lists are supported -->
+            <arg name="protocolsSupported" type="OTADownloadProtocol" array="true"/>
             <arg name="hardwareVersion" type="INT16U" optional="true"/>
             <arg name="location" type="CHAR_STRING" length="2" optional="true"/>
             <arg name="requestorCanConsent" type="BOOLEAN" optional="true"/>
@@ -67,13 +67,13 @@ limitations under the License.
         <command source="server" code="0x03" name="QueryImageResponse" optional="false" cli="chip ota queryimageresponse">
             <description>Response to QueryImage command</description>
             <arg name="status" type="OTAQueryStatus"/>
-            <arg name="delayedActionTime" type="INT32U"/>
-            <arg name="imageURI" type="CHAR_STRING"/>
-            <arg name="softwareVersion" type="INT32U"/>
-            <arg name="softwareVersionString" type="CHAR_STRING"/>
-            <arg name="updateToken" type="OCTET_STRING" length="32"/>
-            <arg name="userConsentNeeded" type="BOOLEAN" default="false"/>
-            <arg name="metadataForRequestor" type="OCTET_STRING" length="512"/>
+            <arg name="delayedActionTime" type="INT32U" optional="true"/>
+            <arg name="imageURI" type="CHAR_STRING" optional="true"/>
+            <arg name="softwareVersion" type="INT32U" optional="true"/>
+            <arg name="softwareVersionString" type="CHAR_STRING" optional="true"/>
+            <arg name="updateToken" type="OCTET_STRING" length="32" optional="true"/>
+            <arg name="userConsentNeeded" type="BOOLEAN" default="false" optional="true"/>
+            <arg name="metadataForRequestor" type="OCTET_STRING" length="512" optional="true"/>
         </command>
         <command source="server" code="0x04" name="ApplyUpdateResponse" optional="false" cli="chip ota applyupdateresponse">
             <description>Reponse to ApplyUpdateRequest command</description>

--- a/src/controller/python/chip/clusters/Objects.py
+++ b/src/controller/python/chip/clusters/Objects.py
@@ -4973,7 +4973,7 @@ class OtaSoftwareUpdateProvider:
                         ClusterObjectFieldDescriptor(
                             Label="softwareVersion", Tag=2, Type=uint),
                         ClusterObjectFieldDescriptor(
-                            Label="protocolsSupported", Tag=3, Type=OtaSoftwareUpdateProvider.Enums.OTADownloadProtocol),
+                            Label="protocolsSupported", Tag=3, Type=OtaSoftwareUpdateProvider.Enums.OTADownloadProtocol, IsArray=True),
                         ClusterObjectFieldDescriptor(
                             Label="hardwareVersion", Tag=4, Type=uint),
                         ClusterObjectFieldDescriptor(
@@ -4987,7 +4987,7 @@ class OtaSoftwareUpdateProvider:
             vendorId: 'uint' = None
             productId: 'uint' = None
             softwareVersion: 'uint' = None
-            protocolsSupported: 'OtaSoftwareUpdateProvider.Enums.OTADownloadProtocol' = None
+            protocolsSupported: typing.List['OtaSoftwareUpdateProvider.Enums.OTADownloadProtocol'] = None
             hardwareVersion: 'uint' = None
             location: 'str' = None
             requestorCanConsent: 'bool' = None

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
@@ -5904,7 +5904,7 @@ public:
     chip::VendorId vendorId;
     uint16_t productId;
     uint32_t softwareVersion;
-    OTADownloadProtocol protocolsSupported;
+    DataModel::List<const OTADownloadProtocol> protocolsSupported;
     Optional<uint16_t> hardwareVersion;
     Optional<chip::CharSpan> location;
     Optional<bool> requestorCanConsent;
@@ -5922,7 +5922,7 @@ public:
     chip::VendorId vendorId;
     uint16_t productId;
     uint32_t softwareVersion;
-    OTADownloadProtocol protocolsSupported;
+    DataModel::DecodableList<OTADownloadProtocol> protocolsSupported;
     Optional<uint16_t> hardwareVersion;
     Optional<chip::CharSpan> location;
     Optional<bool> requestorCanConsent;
@@ -6013,13 +6013,13 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::OtaSoftwareUpdateProvider::Id; }
 
     OTAQueryStatus status;
-    uint32_t delayedActionTime;
-    chip::CharSpan imageURI;
-    uint32_t softwareVersion;
-    chip::CharSpan softwareVersionString;
-    chip::ByteSpan updateToken;
-    bool userConsentNeeded;
-    chip::ByteSpan metadataForRequestor;
+    Optional<uint32_t> delayedActionTime;
+    Optional<chip::CharSpan> imageURI;
+    Optional<uint32_t> softwareVersion;
+    Optional<chip::CharSpan> softwareVersionString;
+    Optional<chip::ByteSpan> updateToken;
+    Optional<bool> userConsentNeeded;
+    Optional<chip::ByteSpan> metadataForRequestor;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -6031,13 +6031,13 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::OtaSoftwareUpdateProvider::Id; }
 
     OTAQueryStatus status;
-    uint32_t delayedActionTime;
-    chip::CharSpan imageURI;
-    uint32_t softwareVersion;
-    chip::CharSpan softwareVersionString;
-    chip::ByteSpan updateToken;
-    bool userConsentNeeded;
-    chip::ByteSpan metadataForRequestor;
+    Optional<uint32_t> delayedActionTime;
+    Optional<chip::CharSpan> imageURI;
+    Optional<uint32_t> softwareVersion;
+    Optional<chip::CharSpan> softwareVersionString;
+    Optional<chip::ByteSpan> updateToken;
+    Optional<bool> userConsentNeeded;
+    Optional<chip::ByteSpan> metadataForRequestor;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace QueryImageResponse

--- a/zzz_generated/chip-tool/zap-generated/cluster/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/cluster/Commands.h
@@ -1889,14 +1889,13 @@ static void OnOtaSoftwareUpdateProviderQueryImageResponseSuccess(
 {
     ChipLogProgress(Zcl, "Received QueryImageResponse:");
     ChipLogProgress(Zcl, "  status: %" PRIu8 "", data.status);
-    ChipLogProgress(Zcl, "  delayedActionTime: %" PRIu32 "", data.delayedActionTime);
-    ChipLogProgress(Zcl, "  imageURI: %.*s", static_cast<int>(data.imageURI.size()), data.imageURI.data());
-    ChipLogProgress(Zcl, "  softwareVersion: %" PRIu32 "", data.softwareVersion);
-    ChipLogProgress(Zcl, "  softwareVersionString: %.*s", static_cast<int>(data.softwareVersionString.size()),
-                    data.softwareVersionString.data());
-    ChipLogProgress(Zcl, "  updateToken: %zu", data.updateToken.size());
-    ChipLogProgress(Zcl, "  userConsentNeeded: %d", data.userConsentNeeded);
-    ChipLogProgress(Zcl, "  metadataForRequestor: %zu", data.metadataForRequestor.size());
+    ChipLogProgress(Zcl, "  delayedActionTime: Optional printing is not implemented yet.");
+    ChipLogProgress(Zcl, "  imageURI: Optional printing is not implemented yet.");
+    ChipLogProgress(Zcl, "  softwareVersion: Optional printing is not implemented yet.");
+    ChipLogProgress(Zcl, "  softwareVersionString: Optional printing is not implemented yet.");
+    ChipLogProgress(Zcl, "  updateToken: Optional printing is not implemented yet.");
+    ChipLogProgress(Zcl, "  userConsentNeeded: Optional printing is not implemented yet.");
+    ChipLogProgress(Zcl, "  metadataForRequestor: Optional printing is not implemented yet.");
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
     command->SetCommandExitStatus(CHIP_NO_ERROR);
@@ -14959,9 +14958,7 @@ public:
         AddArgument("VendorId", 0, UINT16_MAX, &mRequest.vendorId);
         AddArgument("ProductId", 0, UINT16_MAX, &mRequest.productId);
         AddArgument("SoftwareVersion", 0, UINT32_MAX, &mRequest.softwareVersion);
-        AddArgument(
-            "ProtocolsSupported", 0, UINT8_MAX,
-            reinterpret_cast<std::underlying_type_t<decltype(mRequest.protocolsSupported)> *>(&mRequest.protocolsSupported));
+        // protocolsSupported Array parsing is not supported yet
         AddArgument("HardwareVersion", 0, UINT16_MAX, &mRequest.hardwareVersion);
         AddArgument("Location", &mRequest.location);
         AddArgument("RequestorCanConsent", 0, 1, &mRequest.requestorCanConsent);


### PR DESCRIPTION
#### Problem
QueryImage is not using a list where it should and QueryImageResponse does not have various fields marked as optional.

#### Change overview
Fix those issues.

#### Testing
Ran manual test of ota-requestor and ota-provider.

@carol-apple @holbrookt Would it make sense to change `HandleQueryImage` to just take the response struct as an arg instead of the individual args?