### PR TITLE
Fix isArgument handling for zapTypeToClusterObjectType for structs.

### DIFF
--- a/src/app/zap-templates/templates/app/helper.js
+++ b/src/app/zap-templates/templates/app/helper.js
@@ -367,7 +367,7 @@ async function zapTypeToClusterObjectType(type, isDecodable, options)
     return zclHelper.asUnderlyingZclType.call({ global : this.global }, type, options);
   }
 
-  let promise = templateUtil.ensureZclPackageId(this).then(fn.bind(this));
+  let typeStr = await templateUtil.ensureZclPackageId(this).then(fn.bind(this));
   if ((this.isList || this.isArray || this.entryType) && !options.hash.forceNotList) {
     passByReference = true;
     // If we did not have a namespace provided, we can assume we're inside
@@ -375,13 +375,13 @@ async function zapTypeToClusterObjectType(type, isDecodable, options)
     let listNamespace = options.hash.ns ? "chip::app::" : ""
     if (isDecodable)
     {
-      promise = promise.then(typeStr => `${listNamespace}DataModel::DecodableList<${typeStr}>`);
+      typeStr = `${listNamespace}DataModel::DecodableList<${typeStr}>`;
     }
     else
     {
       // Use const ${typeStr} so that consumers don't have to create non-const
       // data to encode.
-      promise = promise.then(typeStr => `${listNamespace}DataModel::List<const ${typeStr}>`);
+      typeStr = `${listNamespace}DataModel::List<const ${typeStr}>`;
     }
   }
   if (this.isNullable && !options.hash.forceNotNullable) {
@@ -389,19 +389,19 @@ async function zapTypeToClusterObjectType(type, isDecodable, options)
     // If we did not have a namespace provided, we can assume we're inside
     // chip::app::.
     let ns  = options.hash.ns ? "chip::app::" : ""
-    promise = promise.then(typeStr => `${ns}DataModel::Nullable<${typeStr}>`);
+    typeStr = `${ns}DataModel::Nullable<${typeStr}>`;
   }
   if (this.isOptional && !options.hash.forceNotOptional) {
     passByReference = true;
     // If we did not have a namespace provided, we can assume we're inside
     // chip::.
     let ns  = options.hash.ns ? "chip::" : ""
-    promise = promise.then(typeStr => `${ns}Optional<${typeStr}>`);
+    typeStr = `${ns}Optional<${typeStr}>`;
   }
   if (options.hash.isArgument && passByReference) {
-    promise = promise.then(typeStr => `const ${typeStr} &`);
+    typeStr = `const ${typeStr} &`;
   }
-  return templateUtil.templatePromise(this.global, promise)
+  return templateUtil.templatePromise(this.global, Promise.resolve(typeStr))
 }
 
 function zapTypeToEncodableClusterObjectType(type, options)


### PR DESCRIPTION
We were setting the passByReference boolean in an async function but
examining it sync in some cases, so could get the wrong answer.  The
fix is to await the async function before we examine the boolean.

#### Problem
Some uses of `zapTypeToClusterObjectType` that I was adding were missing the `const ... &` decorators.

#### Change overview
See above.

#### Testing
No codegen changes so far, because nothing actually uses this function on struct types with isArgument true yet.   Checked what happens if I do, and it now behaved correctly.