### PR TITLE
Pull up LayerLwIP::ScheduleLambda to SystemLayer

### DIFF
--- a/src/include/platform/CHIPDeviceEvent.h
+++ b/src/include/platform/CHIPDeviceEvent.h
@@ -314,10 +314,7 @@ typedef void (*AsyncWorkFunct)(intptr_t arg);
 
 #include <ble/BleConfig.h>
 #include <inet/InetLayer.h>
-#include <system/SystemEvent.h>
-#include <system/SystemLayer.h>
-#include <system/SystemObject.h>
-#include <system/SystemPacketBuffer.h>
+#include <lib/support/LambdaBridge.h>
 
 namespace chip {
 namespace DeviceLayer {
@@ -332,7 +329,7 @@ struct ChipDeviceEvent final
     union
     {
         ChipDevicePlatformEvent Platform;
-        System::LambdaBridge LambdaEvent;
+        LambdaBridge LambdaEvent;
         struct
         {
             ::chip::System::EventType Type;

--- a/src/include/platform/PlatformManager.h
+++ b/src/include/platform/PlatformManager.h
@@ -25,11 +25,8 @@
 
 #include <platform/CHIPDeviceBuildConfig.h>
 #include <platform/CHIPDeviceEvent.h>
+#include <system/PlatformEventSupport.h>
 #include <system/SystemLayer.h>
-
-#if CHIP_SYSTEM_CONFIG_USE_LWIP
-#include <system/LwIPEventSupport.h>
-#endif // CHIP_SYSTEM_CONFIG_USE_LWIP
 
 namespace chip {
 

--- a/src/include/platform/PlatformManager.h
+++ b/src/include/platform/PlatformManager.h
@@ -222,9 +222,7 @@ private:
     friend class Internal::GenericThreadStackManagerImpl_OpenThread_LwIP;
     template <class>
     friend class Internal::GenericConfigurationManagerImpl;
-#if CHIP_SYSTEM_CONFIG_USE_LWIP
     friend class System::PlatformEventing;
-#endif // CHIP_SYSTEM_CONFIG_USE_LWIP
 
     /*
      * PostEvent can be called safely on any thread without locking the stack.

--- a/src/include/platform/internal/GenericPlatformManagerImpl.cpp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl.cpp
@@ -227,7 +227,7 @@ void GenericPlatformManagerImpl<ImplClass>::_DispatchEvent(const ChipDeviceEvent
         break;
 
     case DeviceEventType::kChipLambdaEvent:
-        event->LambdaEvent.LambdaProxy(static_cast<const void *>(event->LambdaEvent.LambdaBody));
+        event->LambdaEvent();
         break;
 
     case DeviceEventType::kCallWorkFunct:

--- a/src/include/platform/internal/GenericPlatformManagerImpl_FreeRTOS.cpp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl_FreeRTOS.cpp
@@ -71,6 +71,8 @@ CHIP_ERROR GenericPlatformManagerImpl_FreeRTOS<ImplClass>::_InitChipStack(void)
         ExitNow(err = CHIP_ERROR_NO_MEMORY);
     }
 
+    mShouldRunEventLoop.store(false);
+
     // Call up to the base class _InitChipStack() to perform the bulk of the initialization.
     err = GenericPlatformManagerImpl<ImplClass>::_InitChipStack();
     SuccessOrExit(err);
@@ -119,12 +121,17 @@ void GenericPlatformManagerImpl_FreeRTOS<ImplClass>::_RunEventLoop(void)
     CHIP_ERROR err;
     ChipDeviceEvent event;
 
-    VerifyOrDie(mEventLoopTask != NULL);
-
     // Lock the CHIP stack.
     Impl()->LockChipStack();
 
-    while (true)
+    bool oldShouldRunEventLoop = false;
+    if (!mShouldRunEventLoop.compare_exchange_strong(oldShouldRunEventLoop /* expected */, true /* desired */))
+    {
+        ChipLogError(DeviceLayer, "Error trying to run the event loop while it is already running");
+        return;
+    }
+
+    while (mShouldRunEventLoop.load())
     {
         TickType_t waitTime;
 
@@ -251,8 +258,8 @@ CHIP_ERROR GenericPlatformManagerImpl_FreeRTOS<ImplClass>::_Shutdown(void)
 template <class ImplClass>
 CHIP_ERROR GenericPlatformManagerImpl_FreeRTOS<ImplClass>::_StopEventLoopTask(void)
 {
-    VerifyOrDieWithMsg(false, DeviceLayer, "StopEventLoopTask is not implemented");
-    return CHIP_ERROR_NOT_IMPLEMENTED;
+    mShouldRunEventLoop.store(false);
+    return CHIP_NO_ERROR;
 }
 
 } // namespace Internal

--- a/src/include/platform/internal/GenericPlatformManagerImpl_FreeRTOS.h
+++ b/src/include/platform/internal/GenericPlatformManagerImpl_FreeRTOS.h
@@ -39,6 +39,8 @@
 #include "task.h"
 #endif
 
+#include <atomic>
+
 namespace chip {
 namespace DeviceLayer {
 namespace Internal {
@@ -92,6 +94,7 @@ private:
     StaticQueue_t mEventQueueStruct;
 #endif
 
+    std::atomic<bool> mShouldRunEventLoop;
 #if defined(CHIP_CONFIG_FREERTOS_USE_STATIC_TASK) && CHIP_CONFIG_FREERTOS_USE_STATIC_TASK
     StackType_t mEventLoopStack[CHIP_DEVICE_CONFIG_CHIP_TASK_STACK_SIZE / sizeof(StackType_t)];
     StaticTask_t mventLoopTaskStruct;

--- a/src/include/platform/internal/GenericPlatformManagerImpl_Zephyr.h
+++ b/src/include/platform/internal/GenericPlatformManagerImpl_Zephyr.h
@@ -91,6 +91,7 @@ private:
     void SysProcess();
     void ProcessDeviceEvents();
 
+    volatile bool mShouldRunEventLoop;
     static void EventLoopTaskMain(void * thisPtr, void *, void *);
 };
 

--- a/src/lib/support/LambdaBridge.h
+++ b/src/lib/support/LambdaBridge.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <string.h>
+#include <type_traits>
 
 #include <lib/core/CHIPConfig.h>
 
@@ -35,17 +36,16 @@ public:
         static_assert(CHIP_CONFIG_LAMBDA_EVENT_ALIGN % alignof(Lambda) == 0, "lambda align too large");
 
         // Implicit cast a capture-less lambda into a raw function pointer.
-        mLambdaProxy = [](const std::aligned_storage<CHIP_CONFIG_LAMBDA_EVENT_SIZE, CHIP_CONFIG_LAMBDA_EVENT_ALIGN> & body) {
-            (*reinterpret_cast<const Lambda *>(&body))();
-        };
-        memcpy(&mLambdaBody, &lambda, sizeof(Lambda));
+        mLambdaProxy = [](const LambdaStorage & body) { (*reinterpret_cast<const Lambda *>(&body))(); };
+        ::memcpy(&mLambdaBody, &lambda, sizeof(Lambda));
     }
 
     void operator()() const { mLambdaProxy(mLambdaBody); }
 
 private:
-    void (*mLambdaProxy)(const std::aligned_storage<CHIP_CONFIG_LAMBDA_EVENT_SIZE, CHIP_CONFIG_LAMBDA_EVENT_ALIGN> & body);
-    std::aligned_storage<CHIP_CONFIG_LAMBDA_EVENT_SIZE, CHIP_CONFIG_LAMBDA_EVENT_ALIGN> mLambdaBody;
+    using LambdaStorage = std::aligned_storage_t<CHIP_CONFIG_LAMBDA_EVENT_SIZE, CHIP_CONFIG_LAMBDA_EVENT_ALIGN>;
+    void (*mLambdaProxy)(const LambdaStorage & body);
+    LambdaStorage mLambdaBody;
 };
 
 static_assert(std::is_trivial<LambdaBridge>::value, "LambdaBridge is not trivial");

--- a/src/lib/support/LambdaBridge.h
+++ b/src/lib/support/LambdaBridge.h
@@ -1,0 +1,53 @@
+/*
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <string.h>
+
+#include <lib/core/CHIPConfig.h>
+
+namespace chip {
+
+class LambdaBridge
+{
+public:
+    // Use initialize instead of constructor because this class has to be trivial
+    template <typename Lambda>
+    void Initialize(const Lambda & lambda)
+    {
+        // memcpy is used to move the lambda into the event queue, so it must be trivially copyable
+        static_assert(std::is_trivially_copyable<Lambda>::value, "lambda must be trivially copyable");
+        static_assert(sizeof(Lambda) <= CHIP_CONFIG_LAMBDA_EVENT_SIZE, "lambda too large");
+        static_assert(CHIP_CONFIG_LAMBDA_EVENT_ALIGN % alignof(Lambda) == 0, "lambda align too large");
+
+        // Implicit cast a capture-less lambda into a raw function pointer.
+        mLambdaProxy = [](const std::aligned_storage<CHIP_CONFIG_LAMBDA_EVENT_SIZE, CHIP_CONFIG_LAMBDA_EVENT_ALIGN> & body) {
+            (*reinterpret_cast<const Lambda *>(&body))();
+        };
+        memcpy(&mLambdaBody, &lambda, sizeof(Lambda));
+    }
+
+    void operator()() const { mLambdaProxy(mLambdaBody); }
+
+private:
+    void (*mLambdaProxy)(const std::aligned_storage<CHIP_CONFIG_LAMBDA_EVENT_SIZE, CHIP_CONFIG_LAMBDA_EVENT_ALIGN> & body);
+    std::aligned_storage<CHIP_CONFIG_LAMBDA_EVENT_SIZE, CHIP_CONFIG_LAMBDA_EVENT_ALIGN> mLambdaBody;
+};
+
+static_assert(std::is_trivial<LambdaBridge>::value, "LambdaBridge is not trivial");
+
+} // namespace chip

--- a/src/platform/BUILD.gn
+++ b/src/platform/BUILD.gn
@@ -284,8 +284,8 @@ if (chip_device_platform != "none") {
       "GeneralUtils.cpp",
       "Globals.cpp",
       "LockTracker.cpp",
-      "LwIPEventSupport.cpp",
       "PersistedStorage.cpp",
+      "PlatformEventSupport.cpp",
       "TestIdentity.cpp",
     ]
 

--- a/src/platform/PlatformEventSupport.cpp
+++ b/src/platform/PlatformEventSupport.cpp
@@ -27,8 +27,6 @@
 
 #include <platform/PlatformManager.h>
 
-#if CHIP_SYSTEM_CONFIG_USE_LWIP
-
 namespace chip {
 namespace System {
 
@@ -62,5 +60,3 @@ CHIP_ERROR PlatformEventing::StartTimer(System::Layer & aLayer, System::Clock::T
 
 } // namespace System
 } // namespace chip
-
-#endif // CHIP_SYSTEM_CONFIG_USE_LWIP

--- a/src/platform/PlatformEventSupport.cpp
+++ b/src/platform/PlatformEventSupport.cpp
@@ -34,11 +34,11 @@ namespace System {
 
 using namespace ::chip::DeviceLayer;
 
-CHIP_ERROR PlatformEventing::ScheduleLambdaBridge(System::Layer & aLayer, const LambdaBridge & bridge)
+CHIP_ERROR PlatformEventing::ScheduleLambdaBridge(System::Layer & aLayer, LambdaBridge && bridge)
 {
     ChipDeviceEvent event;
     event.Type        = DeviceEventType::kChipLambdaEvent;
-    event.LambdaEvent = bridge;
+    event.LambdaEvent = std::move(bridge);
 
     return PlatformMgr().PostEvent(&event);
 }

--- a/src/platform/fake/PlatformManagerImpl.h
+++ b/src/platform/fake/PlatformManagerImpl.h
@@ -24,6 +24,8 @@
 
 #include <platform/PlatformManager.h>
 
+#include <queue>
+
 namespace chip {
 namespace DeviceLayer {
 
@@ -43,21 +45,62 @@ private:
     // ===== Methods that implement the PlatformManager abstract interface.
 
     CHIP_ERROR _InitChipStack() { return CHIP_NO_ERROR; }
+    CHIP_ERROR _Shutdown() { return CHIP_NO_ERROR; }
 
     CHIP_ERROR _AddEventHandler(EventHandlerFunct handler, intptr_t arg = 0) { return CHIP_ERROR_NOT_IMPLEMENTED; }
     void _RemoveEventHandler(EventHandlerFunct handler, intptr_t arg = 0) {}
     void _ScheduleWork(AsyncWorkFunct workFunct, intptr_t arg = 0) {}
-    void _RunEventLoop() {}
+
+    void _RunEventLoop()
+    {
+        do
+        {
+            ProcessDeviceEvents();
+        } while (mShouldRunEventLoop);
+    }
+
+    void ProcessDeviceEvents()
+    {
+        while (!mQueue.empty())
+        {
+            const ChipDeviceEvent & event = mQueue.front();
+            _DispatchEvent(&event);
+            mQueue.pop();
+        }
+    }
+
     CHIP_ERROR _StartEventLoopTask() { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    CHIP_ERROR _StopEventLoopTask() { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    CHIP_ERROR _PostEvent(const ChipDeviceEvent * event) { return CHIP_NO_ERROR; }
-    void _DispatchEvent(const ChipDeviceEvent * event) {}
+
+    CHIP_ERROR _StopEventLoopTask()
+    {
+        mShouldRunEventLoop = false;
+        return CHIP_NO_ERROR;
+    }
+
+    CHIP_ERROR _PostEvent(const ChipDeviceEvent * event)
+    {
+        mQueue.emplace(*event);
+        return CHIP_NO_ERROR;
+    }
+
+    void _DispatchEvent(const ChipDeviceEvent * event)
+    {
+        switch (event->Type)
+        {
+        case DeviceEventType::kChipLambdaEvent:
+            event->LambdaEvent();
+            break;
+
+        default:
+            break;
+        }
+    }
+
     CHIP_ERROR _StartChipTimer(System::Clock::Timeout duration) { return CHIP_ERROR_NOT_IMPLEMENTED; }
 
     void _LockChipStack() {}
     bool _TryLockChipStack() { return true; }
     void _UnlockChipStack() {}
-    CHIP_ERROR _Shutdown() { return CHIP_ERROR_NOT_IMPLEMENTED; }
 
     CHIP_ERROR _GetCurrentHeapFree(uint64_t & currentHeapFree);
     CHIP_ERROR _GetCurrentHeapUsed(uint64_t & currentHeapUsed);
@@ -75,6 +118,9 @@ private:
     friend class Internal::BLEManagerImpl;
 
     static PlatformManagerImpl sInstance;
+
+    bool mShouldRunEventLoop = true;
+    std::queue<ChipDeviceEvent> mQueue;
 };
 
 /**

--- a/src/system/BUILD.gn
+++ b/src/system/BUILD.gn
@@ -123,6 +123,7 @@ static_library("system") {
   output_name = "libSystemLayer"
 
   sources = [
+    "PlatformEventSupport.h",
     "SystemAlignSize.h",
     "SystemClock.cpp",
     "SystemClock.h",
@@ -168,10 +169,6 @@ static_library("system") {
     if (chip_system_config_event_loop == "Libevent") {
       libs = [ "event" ]
     }
-  }
-
-  if (chip_system_config_use_lwip) {
-    sources += [ "PlatformEventSupport.h" ]
   }
 
   if (chip_with_nlfaultinjection) {

--- a/src/system/BUILD.gn
+++ b/src/system/BUILD.gn
@@ -131,6 +131,7 @@ static_library("system") {
     "SystemError.h",
     "SystemEvent.h",
     "SystemFaultInjection.h",
+    "SystemLayer.cpp",
     "SystemLayer.h",
     "SystemLayerImpl${chip_system_config_event_loop}.cpp",
     "SystemLayerImpl${chip_system_config_event_loop}.h",
@@ -170,7 +171,7 @@ static_library("system") {
   }
 
   if (chip_system_config_use_lwip) {
-    sources += [ "LwIPEventSupport.h" ]
+    sources += [ "PlatformEventSupport.h" ]
   }
 
   if (chip_with_nlfaultinjection) {

--- a/src/system/PlatformEventSupport.h
+++ b/src/system/PlatformEventSupport.h
@@ -1,0 +1,38 @@
+/*
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <lib/core/CHIPError.h>
+#include <system/SystemEvent.h>
+#include <system/SystemLayer.h>
+
+namespace chip {
+namespace System {
+
+class Layer;
+class Object;
+
+class PlatformEventing
+{
+public:
+    static CHIP_ERROR ScheduleLambdaBridge(System::Layer & aLayer, LambdaBridge && bridge);
+    static CHIP_ERROR PostEvent(System::Layer & aLayer, Object & aTarget, EventType aType, uintptr_t aArgument);
+    static CHIP_ERROR StartTimer(System::Layer & aLayer, System::Clock::Timeout aTimeout);
+};
+
+} // namespace System
+} // namespace chip

--- a/src/system/SystemLayer.cpp
+++ b/src/system/SystemLayer.cpp
@@ -14,25 +14,22 @@
  *    limitations under the License.
  */
 
-#pragma once
-
-#include <lib/core/CHIPError.h>
-#include <system/SystemEvent.h>
+#include <lib/support/CodeUtils.h>
+#include <system/PlatformEventSupport.h>
 #include <system/SystemLayer.h>
 
 namespace chip {
 namespace System {
 
-class Layer;
-class Object;
-
-class PlatformEventing
+CHIP_ERROR Layer::ScheduleLambdaBridge(LambdaBridge && bridge)
 {
-public:
-    static CHIP_ERROR ScheduleLambdaBridge(System::Layer & aLayer, const LambdaBridge & bridge);
-    static CHIP_ERROR PostEvent(System::Layer & aLayer, Object & aTarget, EventType aType, uintptr_t aArgument);
-    static CHIP_ERROR StartTimer(System::Layer & aLayer, System::Clock::Timeout aTimeout);
-};
+    CHIP_ERROR lReturn = PlatformEventing::ScheduleLambdaBridge(*this, std::move(bridge));
+    if (lReturn != CHIP_NO_ERROR)
+    {
+        ChipLogError(chipSystemLayer, "Failed to queue CHIP System Layer lambda event: %s", ErrorStr(lReturn));
+    }
+    return lReturn;
+}
 
 } // namespace System
 } // namespace chip

--- a/src/system/SystemLayer.h
+++ b/src/system/SystemLayer.h
@@ -25,8 +25,6 @@
 
 #pragma once
 
-#include <type_traits>
-
 // Include configuration headers
 #include <system/SystemConfig.h>
 

--- a/src/system/SystemLayer.h
+++ b/src/system/SystemLayer.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <type_traits>
+
 // Include configuration headers
 #include <system/SystemConfig.h>
 
@@ -32,6 +34,7 @@
 
 #include <lib/support/CodeUtils.h>
 #include <lib/support/DLLUtil.h>
+#include <lib/support/LambdaBridge.h>
 #include <lib/support/ObjectLifeCycle.h>
 #include <system/SystemClock.h>
 #include <system/SystemError.h>
@@ -49,12 +52,6 @@
 
 namespace chip {
 namespace System {
-
-struct LambdaBridge
-{
-    void (*LambdaProxy)(const void * context);
-    alignas(CHIP_CONFIG_LAMBDA_EVENT_ALIGN) char LambdaBody[CHIP_CONFIG_LAMBDA_EVENT_SIZE];
-};
 
 class Layer;
 using TimerCompleteCallback = void (*)(Layer * aLayer, void * appState);
@@ -148,6 +145,31 @@ public:
      */
     virtual CHIP_ERROR ScheduleWork(TimerCompleteCallback aComplete, void * aAppState) = 0;
 
+    /**
+     * @brief
+     *   Schedules a lambda even to be run as soon as possible in the CHIP context. This function is not thread-safe,
+     *   it must be called with in the CHIP context
+     *
+     *  @param[in] event   A object encapsulate the context of a lambda
+     *
+     *  @retval    CHIP_NO_ERROR                  On success.
+     *  @retval    other Platform-specific errors generated indicating the reason for failure.
+     */
+    CHIP_ERROR ScheduleLambdaBridge(LambdaBridge && event);
+
+    /**
+     * @brief
+     *   Schedules a lambda object to be run as soon as possible in the CHIP context. This function is not thread-safe,
+     *   it must be called with in the CHIP context
+     */
+    template <typename Lambda>
+    CHIP_ERROR ScheduleLambda(const Lambda & lambda)
+    {
+        LambdaBridge bridge;
+        bridge.Initialize(lambda);
+        return ScheduleLambdaBridge(std::move(bridge));
+    }
+
 private:
     // Copy and assignment NOT DEFINED
     Layer(const Layer &) = delete;
@@ -201,36 +223,6 @@ public:
      *  @retval    other Platform-specific errors generated indicating the reason for failure.
      */
     virtual CHIP_ERROR PostEvent(Object & aTarget, EventType aEventType, uintptr_t aArgument) = 0;
-
-    /**
-     * This posts an event / message of the specified type with the provided argument to this instance's platform-specific event
-     * queue.
-     *
-     *  @param[in] event   A object encapsulate the context of a lambda
-     *
-     *  @retval    CHIP_NO_ERROR                  On success.
-     *  @retval    CHIP_ERROR_INCORRECT_STATE     If the state of the Layer object is incorrect.
-     *  @retval    CHIP_ERROR_NO_MEMORY           If the event queue is already full.
-     *  @retval    other Platform-specific errors generated indicating the reason for failure.
-     */
-    virtual CHIP_ERROR ScheduleLambdaBridge(const LambdaBridge & event) = 0;
-
-    template <typename Lambda>
-    CHIP_ERROR ScheduleLambda(const Lambda & lambda)
-    {
-        LambdaBridge event;
-
-        // memcpy is used to move the lambda into the event queue, so it must be trivially copyable
-        static_assert(std::is_trivially_copyable<Lambda>::value);
-        static_assert(sizeof(Lambda) <= CHIP_CONFIG_LAMBDA_EVENT_SIZE);
-        static_assert(alignof(Lambda) <= CHIP_CONFIG_LAMBDA_EVENT_ALIGN);
-
-        // Implicit cast a capture-less lambda into a raw function pointer.
-        event.LambdaProxy = [](const void * body) { (*static_cast<const Lambda *>(body))(); };
-        memcpy(event.LambdaBody, &lambda, sizeof(Lambda));
-
-        return ScheduleLambdaBridge(event);
-    }
 
 protected:
     // Provide access to private members of EventHandlerDelegate.

--- a/src/system/SystemLayerImplLwIP.cpp
+++ b/src/system/SystemLayerImplLwIP.cpp
@@ -22,7 +22,7 @@
  */
 
 #include <lib/support/CodeUtils.h>
-#include <system/LwIPEventSupport.h>
+#include <system/PlatformEventSupport.h>
 #include <system/SystemFaultInjection.h>
 #include <system/SystemLayer.h>
 #include <system/SystemLayerImplLwIP.h>
@@ -120,18 +120,6 @@ CHIP_ERROR LayerImplLwIP::AddEventHandlerDelegate(EventHandlerDelegate & aDelega
     VerifyOrReturnError(lDelegate.GetFunction() != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     lDelegate.Prepend(mEventDelegateList);
     return CHIP_NO_ERROR;
-}
-
-CHIP_ERROR LayerImplLwIP::ScheduleLambdaBridge(const LambdaBridge & bridge)
-{
-    VerifyOrReturnError(IsInitialized(), CHIP_ERROR_INCORRECT_STATE);
-
-    CHIP_ERROR lReturn = PlatformEventing::ScheduleLambdaBridge(*this, bridge);
-    if (lReturn != CHIP_NO_ERROR)
-    {
-        ChipLogError(chipSystemLayer, "Failed to queue CHIP System Layer lambda event: %s", ErrorStr(lReturn));
-    }
-    return lReturn;
 }
 
 CHIP_ERROR LayerImplLwIP::PostEvent(Object & aTarget, EventType aEventType, uintptr_t aArgument)

--- a/src/system/SystemLayerImplLwIP.h
+++ b/src/system/SystemLayerImplLwIP.h
@@ -44,7 +44,6 @@ public:
 
     // LayerLwIP overrides.
     CHIP_ERROR AddEventHandlerDelegate(EventHandlerDelegate & aDelegate);
-    CHIP_ERROR ScheduleLambdaBridge(const LambdaBridge & bridge) override;
     CHIP_ERROR PostEvent(Object & aTarget, EventType aEventType, uintptr_t aArgument);
 
 public:

--- a/src/system/tests/BUILD.gn
+++ b/src/system/tests/BUILD.gn
@@ -26,6 +26,7 @@ chip_test_suite("tests") {
     "TestSystemErrorStr.cpp",
     "TestSystemObject.cpp",
     "TestSystemPacketBuffer.cpp",
+    "TestSystemScheduleLambda.cpp",
     "TestSystemTimer.cpp",
     "TestSystemWakeEvent.cpp",
     "TestTimeSource.cpp",

--- a/src/system/tests/TestSystemScheduleLambda.cpp
+++ b/src/system/tests/TestSystemScheduleLambda.cpp
@@ -1,0 +1,98 @@
+/*
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <system/SystemConfig.h>
+
+#include <lib/support/CodeUtils.h>
+#include <lib/support/ErrorStr.h>
+#include <lib/support/UnitTestRegistration.h>
+#include <nlunit-test.h>
+#include <platform/CHIPDeviceLayer.h>
+
+// Test input data.
+
+static void CheckScheduleLambda(nlTestSuite * inSuite, void * aContext)
+{
+    bool * called = new bool(false);
+    chip::DeviceLayer::SystemLayer().ScheduleLambda([called] {
+        *called = true;
+        chip::DeviceLayer::PlatformMgr().StopEventLoopTask();
+    });
+    chip::DeviceLayer::PlatformMgr().RunEventLoop();
+    NL_TEST_ASSERT(inSuite, *called);
+    delete called;
+}
+
+// Test Suite
+
+/**
+ *   Test Suite. It lists all the test functions.
+ */
+// clang-format off
+static const nlTest sTests[] =
+{
+    NL_TEST_DEF("System::TestScheduleLambda", CheckScheduleLambda),
+    NL_TEST_SENTINEL()
+};
+// clang-format on
+
+static int TestSetup(void * aContext);
+static int TestTeardown(void * aContext);
+
+// clang-format off
+static nlTestSuite kTheSuite =
+{
+    "chip-system-schedule-lambda",
+    &sTests[0],
+    TestSetup,
+    TestTeardown
+};
+// clang-format on
+
+/**
+ *  Set up the test suite.
+ */
+static int TestSetup(void * aContext)
+{
+    if (chip::DeviceLayer::PlatformMgr().InitChipStack() != CHIP_NO_ERROR)
+        return FAILURE;
+
+    return (SUCCESS);
+}
+
+/**
+ *  Tear down the test suite.
+ *  Free memory reserved at TestSetup.
+ */
+static int TestTeardown(void * aContext)
+{
+    CHIP_ERROR err = chip::DeviceLayer::PlatformMgr().Shutdown();
+    // RTOS shutdown is not implemented, ignore CHIP_ERROR_NOT_IMPLEMENTED
+    if (err != CHIP_NO_ERROR && err != CHIP_ERROR_NOT_IMPLEMENTED)
+        return FAILURE;
+
+    return (SUCCESS);
+}
+
+int TestSystemScheduleLambda(void)
+{
+    // Run test suit againt one lContext.
+    nlTestRunner(&kTheSuite, nullptr);
+
+    return nlTestRunnerStats(&kTheSuite);
+}
+
+CHIP_REGISTER_TEST_SUITE(TestSystemScheduleLambda)


### PR DESCRIPTION
#### Problem
Re-post of #11187

#### Change overview
Pull up `LayerLwIP::ScheduleLambda` to `SystemLayer`
Implement `ScheduleLambdaBridge` for `LayerImplLibevent` and `LayerImplSelect`


#11187 fails because `std::aligned_storage` is being used as a container, but it is actually a type traits.
Fixed by using `std::aligned_storage<...>::type` instead of `std::aligned_storage<...>`

Add unit-tests to test `ScheduleLambda`

#### Testing
Verified by unit-tests