### PR TITLE
[IM] Add refcount to CommandHandler for async commands

### DIFF
--- a/src/app/CommandHandler.cpp
+++ b/src/app/CommandHandler.cpp
@@ -74,8 +74,8 @@ CHIP_ERROR CommandHandler::OnInvokeCommandRequest(Messaging::ExchangeContext * e
 
     // Use the RAII feature, if this is the only Handle when this function returns, DecrementHoldOff will trigger sending response.
     Handle workHandle(this);
-    ReturnErrorOnFailure(ProcessInvokeRequest(std::move(payload)));
     mpExchangeCtx->WillSendMessage();
+    ReturnErrorOnFailure(ProcessInvokeRequest(std::move(payload)));
 
     return CHIP_NO_ERROR;
 }
@@ -149,7 +149,7 @@ void CommandHandler::DecrementHoldOff()
     CHIP_ERROR err = SendCommandResponse();
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DataManagement, "Failed to send command response: %s", err.AsString());
+        ChipLogError(DataManagement, "Failed to send command response: %" CHIP_ERROR_FORMAT, err.Format());
         // We marked the exchange as "WillSendMessage", need to shutdown the exchange manually to avoid leaking exchanges.
         if (mpExchangeCtx != nullptr)
         {

--- a/src/app/CommandHandler.h
+++ b/src/app/CommandHandler.h
@@ -103,6 +103,10 @@ public:
             return *this;
         }
 
+        /**
+         * Get the CommandHandler object it holds. Get() may return a nullptr if the CommandHandler object is holds is no longer
+         * valid.
+         */
         CommandHandler * Get();
 
         void Release();

--- a/src/app/CommandHandler.h
+++ b/src/app/CommandHandler.h
@@ -79,21 +79,21 @@ public:
         Handle(Handle && handle)
         {
             mpHandler        = handle.mpHandler;
+            mMagic           = handle.mMagic;
             handle.mpHandler = nullptr;
+            handle.mMagic    = 0;
         }
         Handle(decltype(nullptr)) {}
-        Handle(CommandHandler * handle)
-        {
-            handle->IncRef();
-            mpHandler = handle;
-        }
+        Handle(CommandHandler * handle);
         ~Handle() { Release(); }
 
         Handle & operator=(Handle && handle)
         {
             Release();
             mpHandler        = handle.mpHandler;
+            mMagic           = handle.mMagic;
             handle.mpHandler = nullptr;
+            handle.mMagic    = 0;
             return *this;
         }
 
@@ -103,19 +103,13 @@ public:
             return *this;
         }
 
-        CommandHandler * operator->() { return mpHandler; }
+        CommandHandler * Get();
 
-        void Release()
-        {
-            if (mpHandler != nullptr)
-            {
-                mpHandler->DecRef();
-                mpHandler = nullptr;
-            }
-        }
+        void Release();
 
     private:
         CommandHandler * mpHandler = nullptr;
+        uint32_t mMagic            = 0;
     };
 
     /*
@@ -195,11 +189,11 @@ private:
      */
     CHIP_ERROR AllocateBuffer();
 
-    //
-    // Called internally to signal the completion of all work on this object, gracefully close the
-    // exchange (by calling into the base class) and finally, signal to a registerd callback that it's
-    // safe to release this object.
-    //
+    /**
+     * Called internally to signal the completion of all work on this object, gracefully close the
+     * exchange (by calling into the base class) and finally, signal to a registerd callback that it's
+     * safe to release this object.
+     */
     void Close();
 
     CHIP_ERROR ProcessCommandDataIB(CommandDataIB::Parser & aCommandElement);

--- a/src/app/CommandHandler.h
+++ b/src/app/CommandHandler.h
@@ -133,8 +133,6 @@ public:
 
     CHIP_ERROR AddClusterSpecificFailure(const ConcreteCommandPath & aCommandPath, ClusterStatus aClusterStatus) override;
 
-    size_t RefCount() const { return mRefCount; }
-
     CHIP_ERROR ProcessInvokeRequest(System::PacketBufferHandle && payload);
     CHIP_ERROR PrepareCommand(const CommandPathParams & aCommandPathParams, bool aStartDataStruct = true);
     CHIP_ERROR FinishCommand(bool aStartDataStruct = true);
@@ -168,18 +166,18 @@ private:
     friend class CommandHandler::Handle;
 
     /**
-     * IncRef will increase the inner refcount of the CommandHandler.
+     * IncrementHoldOff will increase the inner refcount of the CommandHandler.
      *
      * Users should use CommandHandler::Handle for management the lifespan of the CommandHandler.
      * DefRef should be released in reasonable time, and Close() should only be called when the refcount reached 0.
      */
-    void IncRef();
+    void IncrementHoldOff();
 
     /**
-     * DefRef is used by CommandHandler::Handle for decreasing the refcount of the CommandHandler.
+     * DecrementHoldOff is used by CommandHandler::Handle for decreasing the refcount of the CommandHandler.
      * When refcount reached 0, CommandHandler will send the response to the peer and shutdown.
      */
-    void DecRef();
+    void DecrementHoldOff();
 
     /*
      * Allocates a packet buffer used for encoding an invoke response payload.
@@ -205,7 +203,7 @@ private:
     Callback * mpCallback = nullptr;
     InvokeResponseMessage::Builder mInvokeResponseBuilder;
     TLV::TLVType mDataElementContainerType = TLV::kTLVType_NotSpecified;
-    size_t mRefCount                       = 0;
+    size_t mPendingWork                    = 0;
     bool mSuppressResponse                 = false;
     bool mTimedRequest                     = false;
 };

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -78,13 +78,16 @@ void InteractionModelEngine::Shutdown()
 
     mCommandHandlerList = nullptr;
 
-    // Increase magic number to invalid all Handle-s.
+    // Increase magic number to invalidate all Handle-s.
     mMagic++;
 
     mCommandHandlerObjs.ForEachActiveObject([this](CommandHandler * obj) -> bool {
         // Modifying the pool during iteration is generally frowned upon.
         // This is almost safe since mCommandHandlerObjs is a BitMapObjectPool which won't malfunction when modifying the inner
         // record while during traversal. But this behavior is not guranteed, so we should fix this by implementing DeallocateAll.
+        //
+        // Deallocate an CommandHandler will call its destructor (and abort the exchange context it holds) without calling
+        // Shutdown().
         //
         // TODO(@kghost, #10332) Implement DeallocateAll and replace this.
 

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -82,8 +82,9 @@ void InteractionModelEngine::Shutdown()
     mMagic++;
 
     mCommandHandlerObjs.ForEachActiveObject([this](CommandHandler * obj) -> bool {
-        // Modifying the pool during iteration is generally frowned upon, this should not be a issue since we are running in the
-        // main loop.
+        // Modifying the pool during iteration is generally frowned upon.
+        // This is almost safe since mCommandHandlerObjs is a BitMapObjectPool which won't malfunction when modifying the inner
+        // record while during traversal. But this behavior is not guranteed, so we should fix this by implementing DeallocateAll.
         //
         // TODO(@kghost, #10332) Implement DeallocateAll and replace this.
 

--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -179,6 +179,11 @@ public:
 
     uint16_t GetWriteClientArrayIndex(const WriteClient * const apWriteClient) const;
 
+    /**
+     * The Magic number of this InteractionModelEngine, the magic number is set during Init()
+     */
+    uint32_t GetMagicNumber() { return mMagic; }
+
     reporting::Engine & GetReportingEngine() { return mReportingEngine; }
 
     void ReleaseClusterInfoList(ClusterInfo *& aClusterInfo);
@@ -247,6 +252,10 @@ private:
     reporting::Engine mReportingEngine;
     ClusterInfo mClusterInfoPool[CHIP_IM_SERVER_MAX_NUM_PATH_GROUPS];
     ClusterInfo * mpNextAvailableClusterInfo = nullptr;
+
+    // A magic number for tracking values between stack Shutdown()-s and Init()-s.
+    // An ObjectHandle is valid iff. its magic equals to this one.
+    uint32_t mMagic = 0;
 };
 
 void DispatchSingleClusterCommand(const ConcreteCommandPath & aCommandPath, chip::TLV::TLVReader & aReader,

--- a/src/controller/tests/data_model/TestCommands.cpp
+++ b/src/controller/tests/data_model/TestCommands.cpp
@@ -39,6 +39,7 @@
 using TestContext = chip::Test::AppContext;
 
 using namespace chip;
+using namespace chip::app;
 using namespace chip::app::Clusters;
 
 namespace {
@@ -54,9 +55,11 @@ enum ResponseDirective
     kSendError,
     kSendSuccessStatusCodeWithClusterStatus,
     kSendErrorWithClusterStatus,
+    kAsync,
 };
 
 ResponseDirective responseDirective;
+CommandHandler::Handle asyncHandle;
 
 } // namespace
 
@@ -118,6 +121,10 @@ void DispatchSingleClusterCommand(const ConcreteCommandPath & aCommandPath, chip
         {
             apCommandObj->AddClusterSpecificFailure(aCommandPath, kTestFailureClusterStatus);
         }
+        else if (responseDirective == kAsync)
+        {
+            asyncHandle = apCommandObj;
+        }
     }
 }
 
@@ -149,6 +156,7 @@ public:
     TestCommandInteraction() {}
     static void TestDataResponse(nlTestSuite * apSuite, void * apContext);
     static void TestSuccessNoDataResponse(nlTestSuite * apSuite, void * apContext);
+    static void TestAsyncResponse(nlTestSuite * apSuite, void * apContext);
     static void TestFailure(nlTestSuite * apSuite, void * apContext);
     static void TestSuccessNoDataResponseWithClusterStatus(nlTestSuite * apSuite, void * apContext);
     static void TestFailureWithClusterStatus(nlTestSuite * apSuite, void * apContext);
@@ -234,6 +242,53 @@ void TestCommandInteraction::TestSuccessNoDataResponse(nlTestSuite * apSuite, vo
                                            onFailureCb);
 
     ctx.DrainAndServiceIO();
+
+    NL_TEST_ASSERT(apSuite, onSuccessWasCalled && !onFailureWasCalled && statusCheck);
+    NL_TEST_ASSERT(apSuite, ctx.GetExchangeManager().GetNumActiveExchanges() == 0);
+}
+
+void TestCommandInteraction::TestAsyncResponse(nlTestSuite * apSuite, void * apContext)
+{
+    TestContext & ctx = *static_cast<TestContext *>(apContext);
+    TestCluster::Commands::TestSimpleArgumentRequest::Type request;
+    auto sessionHandle = ctx.GetSessionBobToAlice();
+
+    bool onSuccessWasCalled = false;
+    bool onFailureWasCalled = false;
+    bool statusCheck        = false;
+    request.arg1            = true;
+
+    // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
+    // not safe to do so.
+    auto onSuccessCb = [&onSuccessWasCalled, &statusCheck](const app::ConcreteCommandPath & commandPath,
+                                                           const app::StatusIB & aStatus, const auto & dataResponse) {
+        statusCheck        = (aStatus.mStatus == Protocols::InteractionModel::Status::Success);
+        onSuccessWasCalled = true;
+    };
+
+    // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
+    // not safe to do so.
+    auto onFailureCb = [&onFailureWasCalled](const app::StatusIB & aStatus, CHIP_ERROR aError) { onFailureWasCalled = true; };
+
+    responseDirective = kAsync;
+
+    chip::Controller::InvokeCommandRequest(&ctx.GetExchangeManager(), sessionHandle, kTestEndpointId, request, onSuccessCb,
+                                           onFailureCb);
+
+    NL_TEST_ASSERT(apSuite, !onSuccessWasCalled && !onFailureWasCalled && !statusCheck);
+    NL_TEST_ASSERT(apSuite, ctx.GetExchangeManager().GetNumActiveExchanges() == 1);
+
+    CommandHandler * commandHandle = asyncHandle.Get();
+    NL_TEST_ASSERT(apSuite, commandHandle != nullptr);
+
+    if (commandHandle == nullptr)
+    {
+        return;
+    }
+
+    commandHandle->AddStatus(ConcreteCommandPath(kTestEndpointId, request.GetClusterId(), request.GetCommandId()),
+                             Protocols::InteractionModel::Status::Success);
+    asyncHandle.Release();
 
     NL_TEST_ASSERT(apSuite, onSuccessWasCalled && !onFailureWasCalled && statusCheck);
     NL_TEST_ASSERT(apSuite, ctx.GetExchangeManager().GetNumActiveExchanges() == 0);
@@ -348,6 +403,7 @@ const nlTest sTests[] =
 {
     NL_TEST_DEF("TestDataResponse", TestCommandInteraction::TestDataResponse),
     NL_TEST_DEF("TestSuccessNoDataResponse", TestCommandInteraction::TestSuccessNoDataResponse),
+    NL_TEST_DEF("TestAsyncResponse", TestCommandInteraction::TestAsyncResponse),
     NL_TEST_DEF("TestFailure", TestCommandInteraction::TestFailure),
     NL_TEST_DEF("TestSuccessNoDataResponseWithClusterStatus", TestCommandInteraction::TestSuccessNoDataResponseWithClusterStatus),
     NL_TEST_DEF("TestFailureWithClusterStatus", TestCommandInteraction::TestFailureWithClusterStatus),

--- a/src/controller/tests/data_model/TestCommands.cpp
+++ b/src/controller/tests/data_model/TestCommands.cpp
@@ -275,8 +275,10 @@ void TestCommandInteraction::TestAsyncResponse(nlTestSuite * apSuite, void * apC
     chip::Controller::InvokeCommandRequest(&ctx.GetExchangeManager(), sessionHandle, kTestEndpointId, request, onSuccessCb,
                                            onFailureCb);
 
+    ctx.DrainAndServiceIO();
+
     NL_TEST_ASSERT(apSuite, !onSuccessWasCalled && !onFailureWasCalled && !statusCheck);
-    NL_TEST_ASSERT(apSuite, ctx.GetExchangeManager().GetNumActiveExchanges() == 1);
+    NL_TEST_ASSERT(apSuite, ctx.GetExchangeManager().GetNumActiveExchanges() == 2);
 
     CommandHandler * commandHandle = asyncHandle.Get();
     NL_TEST_ASSERT(apSuite, commandHandle != nullptr);
@@ -289,6 +291,8 @@ void TestCommandInteraction::TestAsyncResponse(nlTestSuite * apSuite, void * apC
     commandHandle->AddStatus(ConcreteCommandPath(kTestEndpointId, request.GetClusterId(), request.GetCommandId()),
                              Protocols::InteractionModel::Status::Success);
     asyncHandle.Release();
+
+    ctx.DrainAndServiceIO();
 
     NL_TEST_ASSERT(apSuite, onSuccessWasCalled && !onFailureWasCalled && statusCheck);
     NL_TEST_ASSERT(apSuite, ctx.GetExchangeManager().GetNumActiveExchanges() == 0);


### PR DESCRIPTION
#### Problem
Some cluster commands requires async works (i.e. several commands in NetworkCommissioningCluster)

#### Change overview
- Adds `AddRef` and `DecRef`
- When DecRef reached 0, it will send the response message.
- Users are not expected to use AddRef and DecRef directly, added `CommandHandler::Handle` class for RAII management.
- Calling CommandHandle() with active Handle-s should not happen, program will crash in this case.
    - TODO: Add real graceful period in shutdown functions.
        - It should look like: Reject all new commands, wait for a while, and call shutdown.

#### Testing
- Adds unit test `TestCommandSenderCommandAsyncSuccessResponseFlow`
