### PR TITLE
Fix _InitChipStack() initialization order.

### DIFF
--- a/src/include/platform/internal/GenericPlatformManagerImpl.cpp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl.cpp
@@ -64,18 +64,19 @@ CHIP_ERROR GenericPlatformManagerImpl<ImplClass>::_InitChipStack()
     }
     SuccessOrExit(err);
 
-    err = ConfigurationMgr().Init();
-    if (err != CHIP_NO_ERROR)
-    {
-        ChipLogError(DeviceLayer, "Configuration Manager initialization failed: %s", ErrorStr(err));
-    }
-    SuccessOrExit(err);
-
     // Initialize the CHIP system layer.
     err = SystemLayer().Init();
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(DeviceLayer, "SystemLayer initialization failed: %s", ErrorStr(err));
+    }
+    SuccessOrExit(err);
+
+    // Initialize the Configuration Manager.
+    err = ConfigurationMgr().Init();
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(DeviceLayer, "Configuration Manager initialization failed: %s", ErrorStr(err));
     }
     SuccessOrExit(err);
 


### PR DESCRIPTION
#### Problem

`ConfigurationMgr().Init()` indirectly uses the System layer,
which has not yet been initialized, in its ‘fail-safe armed’ case.

Fixes #5336 TestPlatformMgr occasionally crashes on Linux

#### Change overview

Initialize Configuration Manager after the System layer.

#### Testing

Confirmed on Linux that adding `fail-safe-armed=1` to
`/tmp/chip_config.ini` reliably triggers the `TestPlatformMgr`
crash on master, but not after this change.

Relying on CI to confirm that there are no unexpected side effects
of changing the initialization order. (There should be none, since
System::Layer does not depend on ConfigurationMgr.)
