### PR TITLE
Remove UnauthenticatedSession::mLocalMessageCounter

### DIFF
--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -134,7 +134,7 @@ CHIP_ERROR SessionManager::PrepareMessage(SessionHandle sessionHandle, PayloadHe
     {
         ReturnErrorOnFailure(payloadHeader.EncodeBeforeData(message));
 
-        MessageCounter & counter = sessionHandle.GetUnauthenticatedSession()->GetLocalMessageCounter();
+        MessageCounter & counter = mGlobalUnencryptedMessageCounter;
         uint32_t messageCounter  = counter.Value();
         ReturnErrorOnFailure(counter.Advance());
 

--- a/src/transport/UnauthenticatedSessionTable.h
+++ b/src/transport/UnauthenticatedSessionTable.h
@@ -47,7 +47,7 @@ public:
 class UnauthenticatedSession : public ReferenceCounted<UnauthenticatedSession, UnauthenticatedSessionDeleter, 0>
 {
 public:
-    UnauthenticatedSession(const PeerAddress & address) : mPeerAddress(address) { mLocalMessageCounter.Init(); }
+    UnauthenticatedSession(const PeerAddress & address) : mPeerAddress(address) {}
 
     UnauthenticatedSession(const UnauthenticatedSession &) = delete;
     UnauthenticatedSession & operator=(const UnauthenticatedSession &) = delete;
@@ -59,14 +59,12 @@ public:
 
     const PeerAddress & GetPeerAddress() const { return mPeerAddress; }
 
-    MessageCounter & GetLocalMessageCounter() { return mLocalMessageCounter; }
     PeerMessageCounter & GetPeerMessageCounter() { return mPeerMessageCounter; }
 
 private:
     uint64_t mLastActivityTimeMs = 0;
 
     const PeerAddress mPeerAddress;
-    GlobalUnencryptedMessageCounter mLocalMessageCounter;
     PeerMessageCounter mPeerMessageCounter;
 };
 


### PR DESCRIPTION
#### Problem
Unauthenticated session counter is no longer defined in specs.

#### Change overview
Remove `UnauthenticatedSession::mLocalMessageCounter`, use the global counter instead.

#### Testing
Verified by unit-tests