### PR TITLE
Fix name of mbed shell example.

### DIFF
--- a/scripts/build/builders/mbed.py
+++ b/scripts/build/builders/mbed.py
@@ -56,7 +56,7 @@ class MbedApp(Enum):
         elif self == MbedApp.PIGWEED:
             return 'chip-mbed-pigweed-app-example'
         elif self == MbedApp.SHELL:
-            return 'shell'
+            return 'chip-mbed-shell-example'
         else:
             raise Exception('Unknown app type: %r' % self)
 


### PR DESCRIPTION
This makes the following work:

```
./scripts/build/build_examples.py --target-glob 'mbed*' build
--copy-artifacts-to out/artifacts
```

#### Problem
Mbed example name is off, making copy artifacts not work

#### Change overview
Fix name 

#### Testing
manually tested with the provided command
