### PR TITLE
[darwin] Fix build failure for ios simulator (#9559).

### DIFF
--- a/build/toolchain/ios/BUILD.gn
+++ b/build/toolchain/ios/BUILD.gn
@@ -33,7 +33,7 @@ gcc_toolchain("ios_arm64") {
   }
 }
 
-gcc_toolchain("ios_x86_64") {
+gcc_toolchain("ios_x64") {
   toolchain_args = {
     current_os = "ios"
     current_cpu = "x86_64"


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* Fix build failure for ios simulator (#9559).

Currently, when build src/darwin/Framework, build will fail when target is ios simulator (x64). The reason being build/toolchain/ios/BUILD.gn only defined `ios_x86_64`. 

#### Change overview
* Fix build issue described previously

#### Testing
How was this tested? (at least one bullet point required)
* ios simulator build succeeded with this patch.
* target mac os works
* target ios arm64 works
