### PR TITLE
Pigweed Console default timeout

### DIFF
--- a/examples/common/pigweed/rpc_console/py/chip_rpc/console.py
+++ b/examples/common/pigweed/rpc_console/py/chip_rpc/console.py
@@ -46,9 +46,12 @@ from inspect import cleandoc
 import serial  # type: ignore
 import re
 import pw_cli.log
-from pw_console.console_app import embed
+from pw_console import PwConsoleEmbed
 from pw_console.__main__ import create_temp_log_file
 from pw_hdlc.rpc import HdlcRpcClient, default_channels
+from pw_rpc import callback_client
+from pw_rpc.console_tools.console import ClientInfo, flattened_rpc_completions
+
 
 # Protos
 from attributes_service import attributes_service_pb2
@@ -111,6 +114,10 @@ def _start_ipython_terminal(client: HdlcRpcClient) -> None:
         LOG=_DEVICE_LOG,
     )
 
+    client_info = ClientInfo('channel_client',
+                             client.client.channel(1).rpcs, client.client)
+    completions = flattened_rpc_completions([client_info])
+
     welcome_message = cleandoc("""
         Welcome to the CHIP RPC Console!
 
@@ -122,12 +129,25 @@ def _start_ipython_terminal(client: HdlcRpcClient) -> None:
           LOG.warning('Message appears console log window.')
     """)
 
-    embed(global_vars=local_variables,
-          local_vars=None,
-          loggers=[_DEVICE_LOG],
-          repl_startup_message=welcome_message,
-          help_text=__doc__,
-          app_title="CHIP Console")
+    interactive_console = PwConsoleEmbed(
+        global_vars=local_variables,
+        local_vars=None,
+        loggers={
+            'Device Logs': [_DEVICE_LOG],
+            'Host Logs': [logging.getLogger()],
+        },
+        repl_startup_message=welcome_message,
+        help_text=__doc__,
+        app_title="CHIP Console",
+    )
+    interactive_console.hide_windows('Host Logs')
+    interactive_console.add_sentence_completer(completions)
+
+    # Setup Python logger propagation
+    interactive_console.setup_python_logging()
+    # Don't send device logs to the root logger.
+    _DEVICE_LOG.propagate = False
+    interactive_console.embed()
 
 
 class SocketClientImpl:
@@ -200,9 +220,16 @@ def console(device: str, baudrate: int,
             _LOG.exception('Failed to initialize socket at %s', socket_addr)
             return 1
 
+    callback_client_impl = callback_client.Impl(
+        default_unary_timeout_s=5.0,
+        default_stream_timeout_s=None,
+    )
+
     _start_ipython_terminal(
         HdlcRpcClient(read, PROTOS, default_channels(write),
-                      lambda data: write_to_output(data, output)))
+                      lambda data: write_to_output(data, output),
+                      client_impl=callback_client_impl)
+    )
     return 0
 
 


### PR DESCRIPTION
#### Problem
- Set a default timeout for unary RPCs of 5 seconds. This prevents python scripts from hanging indefinitely. The existing timeout of None meant wait indefinitely for a response.


#### Additional RPC Console Improvements
- Add all RPCs to the console sentence completer, under the existing
  channel_client variable.
- Add a hidden by default host log window (useful for Python debugging).

#### Testing
Flash all-clusters-app and run the rpc_console. Test `channel_client.rpcs.pw.rpc.EchoService.Echo(msg='hi')` which should fail and observe a failure after 5 seconds.
