### PR TITLE
Fix chip-tool logging to work for various interesting data types.

### DIFF
--- a/examples/chip-tool/templates/commands.zapt
+++ b/examples/chip-tool/templates/commands.zapt
@@ -3,14 +3,155 @@
 #pragma once
 
 #include <cstdint>
+#include <string>
+#include <type_traits>
 
 #include <app-common/zap-generated/cluster-objects.h>
 #include <app/data-model/DecodableList.h>
+#include <app/data-model/Nullable.h>
 #include <commands/clusters/ModelCommand.h>
 #include <lib/core/CHIPSafeCasts.h>
 #include <lib/support/BytesToHex.h>
+#include <lib/support/Span.h>
+#include <lib/support/TypeTraits.h>
 #include <zap-generated/CHIPClientCallbacks.h>
 #include <zap-generated/CHIPClusters.h>
+
+// Value logging functions.  The non-generated ones depend on the
+// generated ones, so are placed here.
+namespace {
+
+{{#zcl_clusters}}
+{{#zcl_structs}}
+CHIP_ERROR LogValue(const char * label, size_t indent, {{zapTypeToDecodableClusterObjectType name ns=parent.name isArgument=true}} value);
+{{/zcl_structs}}
+{{/zcl_clusters}}
+
+#if CHIP_PROGRESS_LOGGING
+std::string IndentStr(size_t indent)
+{
+  std::string str;
+  for (size_t i = 0; i < indent; ++i) {
+    str.append("  ");
+  }
+  return str;
+}
+#endif // CHIP_PROGRESS_LOGGING
+
+template <typename X, typename std::enable_if_t<std::is_integral<X>::value && !std::is_same<std::remove_cv_t<std::remove_reference_t<X>>, bool>::value, int> = 0>
+CHIP_ERROR LogValue(const char * label, size_t indent, X value)
+{
+    ChipLogProgress(chipTool, "%s%s: %s", IndentStr(indent).c_str(), label, std::to_string(value).c_str());
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR LogValue(const char * label, size_t indent, bool value)
+{
+    ChipLogProgress(chipTool, "%s%s: %s", IndentStr(indent).c_str(), label, value ? "TRUE" : "FALSE");
+    return CHIP_NO_ERROR;
+}
+
+template <typename X, typename std::enable_if_t<std::is_enum<X>::value, int> = 0>
+CHIP_ERROR LogValue(const char * label, size_t indent, X value)
+{
+    return LogValue(label, indent, chip::to_underlying(value));
+}
+
+
+CHIP_ERROR LogValue(const char * label, size_t indent, chip::CharSpan value)
+{
+    ChipLogProgress(chipTool, "%s%s: %.*s", IndentStr(indent).c_str(), label, static_cast<int>(value.size()), value.data());
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR LogValue(const char * label, size_t indent, chip::ByteSpan value)
+{
+    ChipLogProgress(chipTool, "%s%s: %zu", IndentStr(indent).c_str(), label, value.size());
+    return CHIP_NO_ERROR;
+}
+
+template <typename X>
+CHIP_ERROR LogValue(const char * label, size_t indent, chip::BitFlags<X> value)
+{
+    return LogValue(label, indent, value.Raw());
+}
+
+template <typename T>
+CHIP_ERROR LogValue(const char * label, size_t indent, const chip::app::DataModel::DecodableList<T> & value)
+{
+    size_t count = 0;
+    CHIP_ERROR err = value.ComputeSize(&count);
+    if (err != CHIP_NO_ERROR)
+    {
+        return err;
+    }
+    ChipLogProgress(chipTool, "%s%s: %zu entries", IndentStr(indent).c_str(), label, count);
+
+    auto iter = value.begin();
+    size_t i = 0;
+    while (iter.Next())
+    {
+      ++i;
+      std::string itemLabel = std::string("[") + std::to_string(i) + "]";
+      ReturnErrorOnFailure(LogValue(itemLabel.c_str(), indent + 1, iter.GetValue()));
+    }
+    if (iter.GetStatus() != CHIP_NO_ERROR)
+    {
+      ChipLogProgress(chipTool, "%sList truncated due to invalid value", IndentStr(indent+1).c_str());
+    }
+    return iter.GetStatus();
+}
+
+
+template <typename T>
+CHIP_ERROR LogValue(const char * label, size_t indent, const chip::app::DataModel::Nullable<T> & value)
+{
+    if (!value.IsNull())
+    {
+        return LogValue(label, indent, value.Value());
+    }
+    ChipLogProgress(chipTool, "%s%s: null", IndentStr(indent).c_str(), label);
+    return CHIP_NO_ERROR;
+}
+
+template <typename T>
+CHIP_ERROR LogValue(const char * label, size_t indent, const chip::Optional<T> & value)
+{
+    if (value.HasValue())
+    {
+        return LogValue(label, indent, value.Value());
+    }
+
+    return CHIP_NO_ERROR;
+}
+
+// We output helpers for all structs here, including ones we might not actually
+// be logging.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-function"
+{{#zcl_clusters}}
+{{#zcl_structs}}
+CHIP_ERROR LogValue(const char * label, size_t indent, {{zapTypeToDecodableClusterObjectType name ns=parent.name isArgument=true}} value)
+{
+  ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+{{#zcl_struct_items}}
+  {
+      CHIP_ERROR err = LogValue("{{asUpperCamelCase label}}", indent + 1, value.{{asLowerCamelCase label}});
+      if (err != CHIP_NO_ERROR)
+      {
+          ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for '{{asUpperCamelCase label}}'", IndentStr(indent + 1).c_str());
+          return err;
+      }
+  }
+{{/zcl_struct_items}}
+  ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+  return CHIP_NO_ERROR;
+}
+{{/zcl_structs}}
+{{/zcl_clusters}}
+#pragma GCC diagnostic pop
+
+} // anonymous namespace
 
 static void OnDefaultSuccessResponse(void * context)
 {
@@ -136,69 +277,10 @@ static void OnCharStringAttributeResponse(void * context, const chip::CharSpan v
 {{#if isList}}
 static void On{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}ListAttributeResponse(void * context, {{zapTypeToDecodableClusterObjectType type ns=parent.name isArgument=true}} list)
 {
+    CHIP_ERROR err = LogValue("On{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}ListAttributeResponse", 0, list);
+
     ModelCommand * command = static_cast<ModelCommand *>(context);
-
-    size_t count = 0;
-    CHIP_ERROR err = list.ComputeSize(&count);
-    if (err != CHIP_NO_ERROR) {
-      command->SetCommandExitStatus(err);
-      return;
-    }
-
-    ChipLogProgress(chipTool, "On{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}ListAttributeResponse: %zu entries", count);
-
-    auto iter = list.begin();
-    uint16_t i = 0;
-    while (iter.Next())
-    {
-        ++i;
-#if CHIP_PROGRESS_LOGGING
-        auto & entry = iter.GetValue();
-        {{#if isStruct}}
-        ChipLogProgress(chipTool, "{{type}}[%" PRIu16 "]:", i);
-        {{#chip_attribute_list_entryTypes}}
-        {{~#*inline "field"}}entry.{{asLowerCamelCase name}}{{#if isOptional}}.Value(){{/if}}{{/inline~}}
-        {{~#*inline "fieldValue"}}{{>field}}{{#if isNullable}}.Value(){{/if}}{{/inline~}}
-        {{#if isOptional}}
-        if (entry.{{asLowerCamelCase name}}.HasValue()) {
-        {{/if}}
-        {{#if isNullable}}
-        if ({{>field}}.IsNull()) {
-          ChipLogProgress(chipTool, "  {{asSymbol label}}: null");
-        } else {
-        {{/if}}
-        {{#if isArray}}
-        {{! TODO: Add support for printing list member of struct element of list attribute }}
-        ChipLogProgress(chipTool, "  {{asSymbol label}}: list member of struct element of list attribute printing not supported yet");
-        {{else if (isOctetString type)}}
-        ChipLogProgress(Zcl, "  {{asSymbol label}}: %zu", {{>fieldValue}}.size());
-        {{else if (isCharString type)}}
-        ChipLogProgress(Zcl, "  {{asSymbol label}}: %.*s", static_cast<int>({{>fieldValue}}.size()), {{>fieldValue}}.data());
-        {{else if isStruct}}
-        {{! TODO: Add support for printing struct member of struct element of list attribute }}
-        ChipLogProgress(chipTool, "  {{asSymbol label}}: struct member of struct element of list attribute printing not supported yet");
-        {{else}}
-        ChipLogProgress(chipTool, "  {{asSymbol label}}: {{asPrintFormat type}}", {{>fieldValue}});
-        {{/if}}
-        {{#if isNullable}}
-        }
-        {{/if}}
-        {{#if isOptional}}
-        }
-        {{/if}}
-        {{/chip_attribute_list_entryTypes}}
-        {{else}}
-        {{#if (isOctetString type)}}
-        ChipLogProgress(Zcl, "  {{asSymbol label}}: %zu", entry.size());
-        {{else if (isCharString type)}}
-        ChipLogProgress(Zcl, "  {{asSymbol label}}: %.*s", static_cast<int>(entry.size()), entry.data());
-        {{else}}
-        ChipLogProgress(chipTool, "{{type}}[%" PRIu16 "]: {{asPrintFormat type}}", i, entry);
-        {{/if}}
-        {{/if}}
-#endif // CHIP_PROGRESS_LOGGING
-    }
-    command->SetCommandExitStatus(iter.GetStatus());
+    command->SetCommandExitStatus(err);
 }
 
 {{/if}}
@@ -210,23 +292,15 @@ static void On{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}ListAttri
 static void On{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}Success(void * context, const chip::app::Clusters::{{asUpperCamelCase parent.name}}::Commands::{{asUpperCamelCase name}}::DecodableType & data)
 {
     ChipLogProgress(Zcl, "Received {{asUpperCamelCase name}}:");
+    CHIP_ERROR err = CHIP_NO_ERROR;
     {{#chip_cluster_response_arguments}}
-    {{~#*inline "field"}}data.{{asLowerCamelCase label}}{{/inline~}}
-    {{#if isArray}}
-    ChipLogProgress(Zcl, "  {{label}}: Array printing is not implemented yet.");
-    {{else if isOptional}}
-    ChipLogProgress(Zcl, "  {{label}}: Optional printing is not implemented yet.");
-    {{else if (isOctetString type)}}
-    ChipLogProgress(Zcl, "  {{label}}: %zu", {{>field}}.size());
-    {{else if (isCharString type)}}
-    ChipLogProgress(Zcl, "  {{label}}: %.*s", static_cast<int>({{>field}}.size()), {{>field}}.data());
-    {{else}}
-    ChipLogProgress(Zcl, "  {{label}}: {{asPrintFormat type}}", {{>field}});
-    {{/if}}
+    if (err == CHIP_NO_ERROR) {
+       err = LogValue("{{asLowerCamelCase label}}", 1, data.{{asLowerCamelCase label}});
+    }
     {{/chip_cluster_response_arguments}}
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
+    command->SetCommandExitStatus(err);
 };
 
 {{/chip_cluster_responses}}

--- a/zzz_generated/chip-tool/zap-generated/cluster/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/cluster/Commands.h
@@ -20,14 +20,1983 @@
 #pragma once
 
 #include <cstdint>
+#include <string>
+#include <type_traits>
 
 #include <app-common/zap-generated/cluster-objects.h>
 #include <app/data-model/DecodableList.h>
+#include <app/data-model/Nullable.h>
 #include <commands/clusters/ModelCommand.h>
 #include <lib/core/CHIPSafeCasts.h>
 #include <lib/support/BytesToHex.h>
+#include <lib/support/Span.h>
+#include <lib/support/TypeTraits.h>
 #include <zap-generated/CHIPClientCallbacks.h>
 #include <zap-generated/CHIPClusters.h>
+
+// Value logging functions.  The non-generated ones depend on the
+// generated ones, so are placed here.
+namespace {
+
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    const chip::app::Clusters::Scenes::Structs::SceneExtensionFieldSet::DecodableType & value);
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    const chip::app::Clusters::PowerProfile::Structs::PowerProfileRecord::DecodableType & value);
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    const chip::app::Clusters::PowerProfile::Structs::ScheduledPhase::DecodableType & value);
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    const chip::app::Clusters::PowerProfile::Structs::TransferredPhase::DecodableType & value);
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    const chip::app::Clusters::Descriptor::Structs::DeviceType::DecodableType & value);
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    const chip::app::Clusters::BridgedActions::Structs::ActionStruct::DecodableType & value);
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    const chip::app::Clusters::BridgedActions::Structs::EndpointListStruct::DecodableType & value);
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    const chip::app::Clusters::GeneralCommissioning::Structs::BasicCommissioningInfoType::DecodableType & value);
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    const chip::app::Clusters::NetworkCommissioning::Structs::ThreadInterfaceScanResult::DecodableType & value);
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    const chip::app::Clusters::NetworkCommissioning::Structs::WiFiInterfaceScanResult::DecodableType & value);
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    const chip::app::Clusters::GeneralDiagnostics::Structs::NetworkInterfaceType::DecodableType & value);
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    const chip::app::Clusters::SoftwareDiagnostics::Structs::ThreadMetrics::DecodableType & value);
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    const chip::app::Clusters::ThreadNetworkDiagnostics::Structs::NeighborTable::DecodableType & value);
+CHIP_ERROR
+LogValue(const char * label, size_t indent,
+         const chip::app::Clusters::ThreadNetworkDiagnostics::Structs::OperationalDatasetComponents::DecodableType & value);
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    const chip::app::Clusters::ThreadNetworkDiagnostics::Structs::RouteTable::DecodableType & value);
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    const chip::app::Clusters::ThreadNetworkDiagnostics::Structs::SecurityPolicy::DecodableType & value);
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    const chip::app::Clusters::OperationalCredentials::Structs::FabricDescriptor::DecodableType & value);
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    const chip::app::Clusters::OperationalCredentials::Structs::NOCStruct::DecodableType & value);
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    const chip::app::Clusters::FixedLabel::Structs::LabelStruct::DecodableType & value);
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    const chip::app::Clusters::ModeSelect::Structs::ModeOptionStruct::DecodableType & value);
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    const chip::app::Clusters::ModeSelect::Structs::SemanticTag::DecodableType & value);
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    const chip::app::Clusters::IasAce::Structs::IasAceZoneStatusResult::DecodableType & value);
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    const chip::app::Clusters::TvChannel::Structs::TvChannelInfo::DecodableType & value);
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    const chip::app::Clusters::TvChannel::Structs::TvChannelLineupInfo::DecodableType & value);
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    const chip::app::Clusters::TargetNavigator::Structs::NavigateTargetTargetInfo::DecodableType & value);
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    const chip::app::Clusters::MediaPlayback::Structs::MediaPlaybackPosition::DecodableType & value);
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    const chip::app::Clusters::MediaInput::Structs::MediaInputInfo::DecodableType & value);
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    const chip::app::Clusters::ContentLauncher::Structs::ContentLaunchAdditionalInfo::DecodableType & value);
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    const chip::app::Clusters::ContentLauncher::Structs::ContentLaunchParamater::DecodableType & value);
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    const chip::app::Clusters::ContentLauncher::Structs::ContentLaunchBrandingInformation::DecodableType & value);
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    const chip::app::Clusters::ContentLauncher::Structs::ContentLaunchDimension::DecodableType & value);
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    const chip::app::Clusters::ContentLauncher::Structs::ContentLaunchStyleInformation::DecodableType & value);
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    const chip::app::Clusters::AudioOutput::Structs::AudioOutputInfo::DecodableType & value);
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    const chip::app::Clusters::ApplicationLauncher::Structs::ApplicationLauncherApp::DecodableType & value);
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    const chip::app::Clusters::TestCluster::Structs::SimpleStruct::DecodableType & value);
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    const chip::app::Clusters::TestCluster::Structs::NullablesAndOptionalsStruct::DecodableType & value);
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    const chip::app::Clusters::TestCluster::Structs::NestedStruct::DecodableType & value);
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    const chip::app::Clusters::TestCluster::Structs::NestedStructList::DecodableType & value);
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    const chip::app::Clusters::TestCluster::Structs::DoubleNestedStructList::DecodableType & value);
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    const chip::app::Clusters::TestCluster::Structs::TestListStructOctet::DecodableType & value);
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    const chip::app::Clusters::GroupKeyManagement::Structs::GroupKey::DecodableType & value);
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    const chip::app::Clusters::GroupKeyManagement::Structs::GroupState::DecodableType & value);
+
+#if CHIP_PROGRESS_LOGGING
+std::string IndentStr(size_t indent)
+{
+    std::string str;
+    for (size_t i = 0; i < indent; ++i)
+    {
+        str.append("  ");
+    }
+    return str;
+}
+#endif // CHIP_PROGRESS_LOGGING
+
+template <typename X,
+          typename std::enable_if_t<
+              std::is_integral<X>::value && !std::is_same<std::remove_cv_t<std::remove_reference_t<X>>, bool>::value, int> = 0>
+CHIP_ERROR LogValue(const char * label, size_t indent, X value)
+{
+    ChipLogProgress(chipTool, "%s%s: %s", IndentStr(indent).c_str(), label, std::to_string(value).c_str());
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR LogValue(const char * label, size_t indent, bool value)
+{
+    ChipLogProgress(chipTool, "%s%s: %s", IndentStr(indent).c_str(), label, value ? "TRUE" : "FALSE");
+    return CHIP_NO_ERROR;
+}
+
+template <typename X, typename std::enable_if_t<std::is_enum<X>::value, int> = 0>
+CHIP_ERROR LogValue(const char * label, size_t indent, X value)
+{
+    return LogValue(label, indent, chip::to_underlying(value));
+}
+
+CHIP_ERROR LogValue(const char * label, size_t indent, chip::CharSpan value)
+{
+    ChipLogProgress(chipTool, "%s%s: %.*s", IndentStr(indent).c_str(), label, static_cast<int>(value.size()), value.data());
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR LogValue(const char * label, size_t indent, chip::ByteSpan value)
+{
+    ChipLogProgress(chipTool, "%s%s: %zu", IndentStr(indent).c_str(), label, value.size());
+    return CHIP_NO_ERROR;
+}
+
+template <typename X>
+CHIP_ERROR LogValue(const char * label, size_t indent, chip::BitFlags<X> value)
+{
+    return LogValue(label, indent, value.Raw());
+}
+
+template <typename T>
+CHIP_ERROR LogValue(const char * label, size_t indent, const chip::app::DataModel::DecodableList<T> & value)
+{
+    size_t count   = 0;
+    CHIP_ERROR err = value.ComputeSize(&count);
+    if (err != CHIP_NO_ERROR)
+    {
+        return err;
+    }
+    ChipLogProgress(chipTool, "%s%s: %zu entries", IndentStr(indent).c_str(), label, count);
+
+    auto iter = value.begin();
+    size_t i  = 0;
+    while (iter.Next())
+    {
+        ++i;
+        std::string itemLabel = std::string("[") + std::to_string(i) + "]";
+        ReturnErrorOnFailure(LogValue(itemLabel.c_str(), indent + 1, iter.GetValue()));
+    }
+    if (iter.GetStatus() != CHIP_NO_ERROR)
+    {
+        ChipLogProgress(chipTool, "%sList truncated due to invalid value", IndentStr(indent + 1).c_str());
+    }
+    return iter.GetStatus();
+}
+
+template <typename T>
+CHIP_ERROR LogValue(const char * label, size_t indent, const chip::app::DataModel::Nullable<T> & value)
+{
+    if (!value.IsNull())
+    {
+        return LogValue(label, indent, value.Value());
+    }
+    ChipLogProgress(chipTool, "%s%s: null", IndentStr(indent).c_str(), label);
+    return CHIP_NO_ERROR;
+}
+
+template <typename T>
+CHIP_ERROR LogValue(const char * label, size_t indent, const chip::Optional<T> & value)
+{
+    if (value.HasValue())
+    {
+        return LogValue(label, indent, value.Value());
+    }
+
+    return CHIP_NO_ERROR;
+}
+
+// We output helpers for all structs here, including ones we might not actually
+// be logging.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-function"
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    const chip::app::Clusters::Scenes::Structs::SceneExtensionFieldSet::DecodableType & value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    {
+        CHIP_ERROR err = LogValue("ClusterId", indent + 1, value.clusterId);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'ClusterId'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("Length", indent + 1, value.length);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'Length'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("Value", indent + 1, value.value);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'Value'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    const chip::app::Clusters::PowerProfile::Structs::PowerProfileRecord::DecodableType & value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    {
+        CHIP_ERROR err = LogValue("PowerProfileId", indent + 1, value.powerProfileId);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'PowerProfileId'",
+                            IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("EnergyPhaseId", indent + 1, value.energyPhaseId);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'EnergyPhaseId'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("PowerProfileRemoteControl", indent + 1, value.powerProfileRemoteControl);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'PowerProfileRemoteControl'",
+                            IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("PowerProfileState", indent + 1, value.powerProfileState);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'PowerProfileState'",
+                            IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    const chip::app::Clusters::PowerProfile::Structs::ScheduledPhase::DecodableType & value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    {
+        CHIP_ERROR err = LogValue("EnergyPhaseId", indent + 1, value.energyPhaseId);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'EnergyPhaseId'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("ScheduledTime", indent + 1, value.scheduledTime);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'ScheduledTime'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    const chip::app::Clusters::PowerProfile::Structs::TransferredPhase::DecodableType & value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    {
+        CHIP_ERROR err = LogValue("EnergyPhaseId", indent + 1, value.energyPhaseId);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'EnergyPhaseId'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("MacroPhaseId", indent + 1, value.macroPhaseId);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'MacroPhaseId'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("ExpectedDuration", indent + 1, value.expectedDuration);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'ExpectedDuration'",
+                            IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("PeakPower", indent + 1, value.peakPower);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'PeakPower'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("Energy", indent + 1, value.energy);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'Energy'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("MaxActivationDelay", indent + 1, value.maxActivationDelay);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'MaxActivationDelay'",
+                            IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    const chip::app::Clusters::Descriptor::Structs::DeviceType::DecodableType & value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    {
+        CHIP_ERROR err = LogValue("Type", indent + 1, value.type);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'Type'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("Revision", indent + 1, value.revision);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'Revision'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    const chip::app::Clusters::BridgedActions::Structs::ActionStruct::DecodableType & value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    {
+        CHIP_ERROR err = LogValue("ActionID", indent + 1, value.actionID);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'ActionID'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("Name", indent + 1, value.name);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'Name'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("Type", indent + 1, value.type);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'Type'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("EndpointListID", indent + 1, value.endpointListID);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'EndpointListID'",
+                            IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("SupportedCommands", indent + 1, value.supportedCommands);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'SupportedCommands'",
+                            IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("Status", indent + 1, value.status);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'Status'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    const chip::app::Clusters::BridgedActions::Structs::EndpointListStruct::DecodableType & value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    {
+        CHIP_ERROR err = LogValue("EndpointListID", indent + 1, value.endpointListID);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'EndpointListID'",
+                            IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("Name", indent + 1, value.name);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'Name'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("Type", indent + 1, value.type);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'Type'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("Endpoints", indent + 1, value.endpoints);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'Endpoints'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    const chip::app::Clusters::GeneralCommissioning::Structs::BasicCommissioningInfoType::DecodableType & value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    {
+        CHIP_ERROR err = LogValue("FailSafeExpiryLengthMs", indent + 1, value.failSafeExpiryLengthMs);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'FailSafeExpiryLengthMs'",
+                            IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    const chip::app::Clusters::NetworkCommissioning::Structs::ThreadInterfaceScanResult::DecodableType & value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    {
+        CHIP_ERROR err = LogValue("DiscoveryResponse", indent + 1, value.discoveryResponse);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'DiscoveryResponse'",
+                            IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    const chip::app::Clusters::NetworkCommissioning::Structs::WiFiInterfaceScanResult::DecodableType & value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    {
+        CHIP_ERROR err = LogValue("Security", indent + 1, value.security);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'Security'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("Ssid", indent + 1, value.ssid);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'Ssid'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("Bssid", indent + 1, value.bssid);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'Bssid'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("Channel", indent + 1, value.channel);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'Channel'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("FrequencyBand", indent + 1, value.frequencyBand);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'FrequencyBand'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    const chip::app::Clusters::GeneralDiagnostics::Structs::NetworkInterfaceType::DecodableType & value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    {
+        CHIP_ERROR err = LogValue("Name", indent + 1, value.name);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'Name'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("FabricConnected", indent + 1, value.fabricConnected);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'FabricConnected'",
+                            IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("OffPremiseServicesReachableIPv4", indent + 1, value.offPremiseServicesReachableIPv4);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'OffPremiseServicesReachableIPv4'",
+                            IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("OffPremiseServicesReachableIPv6", indent + 1, value.offPremiseServicesReachableIPv6);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'OffPremiseServicesReachableIPv6'",
+                            IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("HardwareAddress", indent + 1, value.hardwareAddress);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'HardwareAddress'",
+                            IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("Type", indent + 1, value.type);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'Type'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    const chip::app::Clusters::SoftwareDiagnostics::Structs::ThreadMetrics::DecodableType & value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    {
+        CHIP_ERROR err = LogValue("Id", indent + 1, value.id);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'Id'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("Name", indent + 1, value.name);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'Name'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("StackFreeCurrent", indent + 1, value.stackFreeCurrent);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'StackFreeCurrent'",
+                            IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("StackFreeMinimum", indent + 1, value.stackFreeMinimum);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'StackFreeMinimum'",
+                            IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("StackSize", indent + 1, value.stackSize);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'StackSize'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    const chip::app::Clusters::ThreadNetworkDiagnostics::Structs::NeighborTable::DecodableType & value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    {
+        CHIP_ERROR err = LogValue("ExtAddress", indent + 1, value.extAddress);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'ExtAddress'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("Age", indent + 1, value.age);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'Age'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("Rloc16", indent + 1, value.rloc16);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'Rloc16'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("LinkFrameCounter", indent + 1, value.linkFrameCounter);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'LinkFrameCounter'",
+                            IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("MleFrameCounter", indent + 1, value.mleFrameCounter);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'MleFrameCounter'",
+                            IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("Lqi", indent + 1, value.lqi);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'Lqi'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("AverageRssi", indent + 1, value.averageRssi);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'AverageRssi'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("LastRssi", indent + 1, value.lastRssi);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'LastRssi'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("FrameErrorRate", indent + 1, value.frameErrorRate);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'FrameErrorRate'",
+                            IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("MessageErrorRate", indent + 1, value.messageErrorRate);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'MessageErrorRate'",
+                            IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("RxOnWhenIdle", indent + 1, value.rxOnWhenIdle);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'RxOnWhenIdle'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("FullThreadDevice", indent + 1, value.fullThreadDevice);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'FullThreadDevice'",
+                            IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("FullNetworkData", indent + 1, value.fullNetworkData);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'FullNetworkData'",
+                            IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("IsChild", indent + 1, value.isChild);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'IsChild'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR
+LogValue(const char * label, size_t indent,
+         const chip::app::Clusters::ThreadNetworkDiagnostics::Structs::OperationalDatasetComponents::DecodableType & value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    {
+        CHIP_ERROR err = LogValue("ActiveTimestampPresent", indent + 1, value.activeTimestampPresent);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'ActiveTimestampPresent'",
+                            IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("PendingTimestampPresent", indent + 1, value.pendingTimestampPresent);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'PendingTimestampPresent'",
+                            IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("MasterKeyPresent", indent + 1, value.masterKeyPresent);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'MasterKeyPresent'",
+                            IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("NetworkNamePresent", indent + 1, value.networkNamePresent);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'NetworkNamePresent'",
+                            IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("ExtendedPanIdPresent", indent + 1, value.extendedPanIdPresent);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'ExtendedPanIdPresent'",
+                            IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("MeshLocalPrefixPresent", indent + 1, value.meshLocalPrefixPresent);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'MeshLocalPrefixPresent'",
+                            IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("DelayPresent", indent + 1, value.delayPresent);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'DelayPresent'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("PanIdPresent", indent + 1, value.panIdPresent);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'PanIdPresent'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("ChannelPresent", indent + 1, value.channelPresent);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'ChannelPresent'",
+                            IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("PskcPresent", indent + 1, value.pskcPresent);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'PskcPresent'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("SecurityPolicyPresent", indent + 1, value.securityPolicyPresent);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'SecurityPolicyPresent'",
+                            IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("ChannelMaskPresent", indent + 1, value.channelMaskPresent);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'ChannelMaskPresent'",
+                            IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    const chip::app::Clusters::ThreadNetworkDiagnostics::Structs::RouteTable::DecodableType & value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    {
+        CHIP_ERROR err = LogValue("ExtAddress", indent + 1, value.extAddress);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'ExtAddress'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("Rloc16", indent + 1, value.rloc16);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'Rloc16'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("RouterId", indent + 1, value.routerId);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'RouterId'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("NextHop", indent + 1, value.nextHop);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'NextHop'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("PathCost", indent + 1, value.pathCost);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'PathCost'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("LQIIn", indent + 1, value.LQIIn);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'LQIIn'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("LQIOut", indent + 1, value.LQIOut);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'LQIOut'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("Age", indent + 1, value.age);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'Age'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("Allocated", indent + 1, value.allocated);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'Allocated'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("LinkEstablished", indent + 1, value.linkEstablished);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'LinkEstablished'",
+                            IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    const chip::app::Clusters::ThreadNetworkDiagnostics::Structs::SecurityPolicy::DecodableType & value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    {
+        CHIP_ERROR err = LogValue("RotationTime", indent + 1, value.rotationTime);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'RotationTime'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("Flags", indent + 1, value.flags);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'Flags'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    const chip::app::Clusters::OperationalCredentials::Structs::FabricDescriptor::DecodableType & value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    {
+        CHIP_ERROR err = LogValue("FabricIndex", indent + 1, value.fabricIndex);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'FabricIndex'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("RootPublicKey", indent + 1, value.rootPublicKey);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'RootPublicKey'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("VendorId", indent + 1, value.vendorId);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'VendorId'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("FabricId", indent + 1, value.fabricId);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'FabricId'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("NodeId", indent + 1, value.nodeId);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'NodeId'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("Label", indent + 1, value.label);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'Label'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    const chip::app::Clusters::OperationalCredentials::Structs::NOCStruct::DecodableType & value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    {
+        CHIP_ERROR err = LogValue("FabricIndex", indent + 1, value.fabricIndex);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'FabricIndex'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("Noc", indent + 1, value.noc);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'Noc'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    const chip::app::Clusters::FixedLabel::Structs::LabelStruct::DecodableType & value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    {
+        CHIP_ERROR err = LogValue("Label", indent + 1, value.label);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'Label'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("Value", indent + 1, value.value);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'Value'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    const chip::app::Clusters::ModeSelect::Structs::ModeOptionStruct::DecodableType & value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    {
+        CHIP_ERROR err = LogValue("Label", indent + 1, value.label);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'Label'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("Mode", indent + 1, value.mode);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'Mode'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("SemanticTag", indent + 1, value.semanticTag);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'SemanticTag'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    const chip::app::Clusters::ModeSelect::Structs::SemanticTag::DecodableType & value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    {
+        CHIP_ERROR err = LogValue("MfgCode", indent + 1, value.mfgCode);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'MfgCode'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("Value", indent + 1, value.value);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'Value'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    const chip::app::Clusters::IasAce::Structs::IasAceZoneStatusResult::DecodableType & value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    {
+        CHIP_ERROR err = LogValue("ZoneId", indent + 1, value.zoneId);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'ZoneId'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("ZoneStatus", indent + 1, value.zoneStatus);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'ZoneStatus'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    const chip::app::Clusters::TvChannel::Structs::TvChannelInfo::DecodableType & value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    {
+        CHIP_ERROR err = LogValue("MajorNumber", indent + 1, value.majorNumber);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'MajorNumber'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("MinorNumber", indent + 1, value.minorNumber);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'MinorNumber'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("Name", indent + 1, value.name);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'Name'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("CallSign", indent + 1, value.callSign);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'CallSign'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("AffiliateCallSign", indent + 1, value.affiliateCallSign);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'AffiliateCallSign'",
+                            IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    const chip::app::Clusters::TvChannel::Structs::TvChannelLineupInfo::DecodableType & value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    {
+        CHIP_ERROR err = LogValue("OperatorName", indent + 1, value.operatorName);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'OperatorName'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("LineupName", indent + 1, value.lineupName);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'LineupName'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("PostalCode", indent + 1, value.postalCode);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'PostalCode'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("LineupInfoType", indent + 1, value.lineupInfoType);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'LineupInfoType'",
+                            IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    const chip::app::Clusters::TargetNavigator::Structs::NavigateTargetTargetInfo::DecodableType & value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    {
+        CHIP_ERROR err = LogValue("Identifier", indent + 1, value.identifier);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'Identifier'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("Name", indent + 1, value.name);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'Name'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    const chip::app::Clusters::MediaPlayback::Structs::MediaPlaybackPosition::DecodableType & value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    {
+        CHIP_ERROR err = LogValue("UpdatedAt", indent + 1, value.updatedAt);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'UpdatedAt'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("Position", indent + 1, value.position);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'Position'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    const chip::app::Clusters::MediaInput::Structs::MediaInputInfo::DecodableType & value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    {
+        CHIP_ERROR err = LogValue("Index", indent + 1, value.index);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'Index'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("InputType", indent + 1, value.inputType);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'InputType'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("Name", indent + 1, value.name);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'Name'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("Description", indent + 1, value.description);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'Description'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    const chip::app::Clusters::ContentLauncher::Structs::ContentLaunchAdditionalInfo::DecodableType & value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    {
+        CHIP_ERROR err = LogValue("Name", indent + 1, value.name);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'Name'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("Value", indent + 1, value.value);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'Value'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    const chip::app::Clusters::ContentLauncher::Structs::ContentLaunchParamater::DecodableType & value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    {
+        CHIP_ERROR err = LogValue("Type", indent + 1, value.type);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'Type'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("Value", indent + 1, value.value);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'Value'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("ExternalIDList", indent + 1, value.externalIDList);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'ExternalIDList'",
+                            IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    const chip::app::Clusters::ContentLauncher::Structs::ContentLaunchBrandingInformation::DecodableType & value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    {
+        CHIP_ERROR err = LogValue("ProviderName", indent + 1, value.providerName);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'ProviderName'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("Background", indent + 1, value.background);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'Background'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("Logo", indent + 1, value.logo);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'Logo'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("ProgressBar", indent + 1, value.progressBar);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'ProgressBar'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("Splash", indent + 1, value.splash);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'Splash'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("WaterMark", indent + 1, value.waterMark);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'WaterMark'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    const chip::app::Clusters::ContentLauncher::Structs::ContentLaunchDimension::DecodableType & value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    {
+        CHIP_ERROR err = LogValue("Width", indent + 1, value.width);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'Width'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("Height", indent + 1, value.height);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'Height'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("Metric", indent + 1, value.metric);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'Metric'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    const chip::app::Clusters::ContentLauncher::Structs::ContentLaunchStyleInformation::DecodableType & value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    {
+        CHIP_ERROR err = LogValue("ImageUrl", indent + 1, value.imageUrl);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'ImageUrl'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("Color", indent + 1, value.color);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'Color'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("Size", indent + 1, value.size);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'Size'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    const chip::app::Clusters::AudioOutput::Structs::AudioOutputInfo::DecodableType & value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    {
+        CHIP_ERROR err = LogValue("Index", indent + 1, value.index);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'Index'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("OutputType", indent + 1, value.outputType);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'OutputType'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("Name", indent + 1, value.name);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'Name'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    const chip::app::Clusters::ApplicationLauncher::Structs::ApplicationLauncherApp::DecodableType & value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    {
+        CHIP_ERROR err = LogValue("CatalogVendorId", indent + 1, value.catalogVendorId);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'CatalogVendorId'",
+                            IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("ApplicationId", indent + 1, value.applicationId);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'ApplicationId'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    const chip::app::Clusters::TestCluster::Structs::SimpleStruct::DecodableType & value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    {
+        CHIP_ERROR err = LogValue("A", indent + 1, value.a);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'A'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("B", indent + 1, value.b);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'B'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("C", indent + 1, value.c);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'C'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("D", indent + 1, value.d);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'D'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("E", indent + 1, value.e);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'E'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("F", indent + 1, value.f);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'F'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    const chip::app::Clusters::TestCluster::Structs::NullablesAndOptionalsStruct::DecodableType & value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    {
+        CHIP_ERROR err = LogValue("NullableInt", indent + 1, value.nullableInt);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'NullableInt'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("OptionalInt", indent + 1, value.optionalInt);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'OptionalInt'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("NullableOptionalInt", indent + 1, value.nullableOptionalInt);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'NullableOptionalInt'",
+                            IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("NullableString", indent + 1, value.nullableString);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'NullableString'",
+                            IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("OptionalString", indent + 1, value.optionalString);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'OptionalString'",
+                            IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("NullableOptionalString", indent + 1, value.nullableOptionalString);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'NullableOptionalString'",
+                            IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("NullableStruct", indent + 1, value.nullableStruct);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'NullableStruct'",
+                            IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("OptionalStruct", indent + 1, value.optionalStruct);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'OptionalStruct'",
+                            IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("NullableOptionalStruct", indent + 1, value.nullableOptionalStruct);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'NullableOptionalStruct'",
+                            IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("NullableList", indent + 1, value.nullableList);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'NullableList'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("OptionalList", indent + 1, value.optionalList);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'OptionalList'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("NullableOptionalList", indent + 1, value.nullableOptionalList);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'NullableOptionalList'",
+                            IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    const chip::app::Clusters::TestCluster::Structs::NestedStruct::DecodableType & value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    {
+        CHIP_ERROR err = LogValue("A", indent + 1, value.a);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'A'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("B", indent + 1, value.b);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'B'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("C", indent + 1, value.c);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'C'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    const chip::app::Clusters::TestCluster::Structs::NestedStructList::DecodableType & value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    {
+        CHIP_ERROR err = LogValue("A", indent + 1, value.a);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'A'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("B", indent + 1, value.b);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'B'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("C", indent + 1, value.c);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'C'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("D", indent + 1, value.d);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'D'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("E", indent + 1, value.e);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'E'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("F", indent + 1, value.f);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'F'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("G", indent + 1, value.g);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'G'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    const chip::app::Clusters::TestCluster::Structs::DoubleNestedStructList::DecodableType & value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    {
+        CHIP_ERROR err = LogValue("A", indent + 1, value.a);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'A'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    const chip::app::Clusters::TestCluster::Structs::TestListStructOctet::DecodableType & value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    {
+        CHIP_ERROR err = LogValue("FabricIndex", indent + 1, value.fabricIndex);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'FabricIndex'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("OperationalCert", indent + 1, value.operationalCert);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'OperationalCert'",
+                            IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    const chip::app::Clusters::GroupKeyManagement::Structs::GroupKey::DecodableType & value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    {
+        CHIP_ERROR err = LogValue("VendorId", indent + 1, value.vendorId);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'VendorId'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("GroupKeyIndex", indent + 1, value.groupKeyIndex);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'GroupKeyIndex'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("GroupKeyRoot", indent + 1, value.groupKeyRoot);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'GroupKeyRoot'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("GroupKeyEpochStartTime", indent + 1, value.groupKeyEpochStartTime);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'GroupKeyEpochStartTime'",
+                            IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("GroupKeySecurityPolicy", indent + 1, value.groupKeySecurityPolicy);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'GroupKeySecurityPolicy'",
+                            IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR LogValue(const char * label, size_t indent,
+                    const chip::app::Clusters::GroupKeyManagement::Structs::GroupState::DecodableType & value)
+{
+    ChipLogProgress(chipTool, "%s%s: {", IndentStr(indent).c_str(), label);
+    {
+        CHIP_ERROR err = LogValue("VendorId", indent + 1, value.vendorId);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'VendorId'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("VendorGroupId", indent + 1, value.vendorGroupId);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'VendorGroupId'", IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = LogValue("GroupKeySetIndex", indent + 1, value.groupKeySetIndex);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(chipTool, "%sStruct truncated due to invalid value for 'GroupKeySetIndex'",
+                            IndentStr(indent + 1).c_str());
+            return err;
+        }
+    }
+    ChipLogProgress(chipTool, "%s}", IndentStr(indent).c_str());
+    return CHIP_NO_ERROR;
+}
+#pragma GCC diagnostic pop
+
+} // anonymous namespace
 
 static void OnDefaultSuccessResponse(void * context)
 {
@@ -156,96 +2125,30 @@ static void
 OnApplicationLauncherApplicationLauncherListListAttributeResponse(void * context,
                                                                   const chip::app::DataModel::DecodableList<uint16_t> & list)
 {
+    CHIP_ERROR err = LogValue("OnApplicationLauncherApplicationLauncherListListAttributeResponse", 0, list);
+
     ModelCommand * command = static_cast<ModelCommand *>(context);
-
-    size_t count   = 0;
-    CHIP_ERROR err = list.ComputeSize(&count);
-    if (err != CHIP_NO_ERROR)
-    {
-        command->SetCommandExitStatus(err);
-        return;
-    }
-
-    ChipLogProgress(chipTool, "OnApplicationLauncherApplicationLauncherListListAttributeResponse: %zu entries", count);
-
-    auto iter  = list.begin();
-    uint16_t i = 0;
-    while (iter.Next())
-    {
-        ++i;
-#if CHIP_PROGRESS_LOGGING
-        auto & entry = iter.GetValue();
-        ChipLogProgress(chipTool, "INT16U[%" PRIu16 "]: %" PRIu16 "", i, entry);
-#endif // CHIP_PROGRESS_LOGGING
-    }
-    command->SetCommandExitStatus(iter.GetStatus());
+    command->SetCommandExitStatus(err);
 }
 
 static void OnAudioOutputAudioOutputListListAttributeResponse(
     void * context,
     const chip::app::DataModel::DecodableList<chip::app::Clusters::AudioOutput::Structs::AudioOutputInfo::DecodableType> & list)
 {
+    CHIP_ERROR err = LogValue("OnAudioOutputAudioOutputListListAttributeResponse", 0, list);
+
     ModelCommand * command = static_cast<ModelCommand *>(context);
-
-    size_t count   = 0;
-    CHIP_ERROR err = list.ComputeSize(&count);
-    if (err != CHIP_NO_ERROR)
-    {
-        command->SetCommandExitStatus(err);
-        return;
-    }
-
-    ChipLogProgress(chipTool, "OnAudioOutputAudioOutputListListAttributeResponse: %zu entries", count);
-
-    auto iter  = list.begin();
-    uint16_t i = 0;
-    while (iter.Next())
-    {
-        ++i;
-#if CHIP_PROGRESS_LOGGING
-        auto & entry = iter.GetValue();
-        ChipLogProgress(chipTool, "AudioOutputInfo[%" PRIu16 "]:", i);
-        ChipLogProgress(chipTool, "  index: %" PRIu8 "", entry.index);
-        ChipLogProgress(chipTool, "  outputType: %" PRIu8 "", entry.outputType);
-        ChipLogProgress(Zcl, "  name: %.*s", static_cast<int>(entry.name.size()), entry.name.data());
-#endif // CHIP_PROGRESS_LOGGING
-    }
-    command->SetCommandExitStatus(iter.GetStatus());
+    command->SetCommandExitStatus(err);
 }
 
 static void OnBridgedActionsActionListListAttributeResponse(
     void * context,
     const chip::app::DataModel::DecodableList<chip::app::Clusters::BridgedActions::Structs::ActionStruct::DecodableType> & list)
 {
+    CHIP_ERROR err = LogValue("OnBridgedActionsActionListListAttributeResponse", 0, list);
+
     ModelCommand * command = static_cast<ModelCommand *>(context);
-
-    size_t count   = 0;
-    CHIP_ERROR err = list.ComputeSize(&count);
-    if (err != CHIP_NO_ERROR)
-    {
-        command->SetCommandExitStatus(err);
-        return;
-    }
-
-    ChipLogProgress(chipTool, "OnBridgedActionsActionListListAttributeResponse: %zu entries", count);
-
-    auto iter  = list.begin();
-    uint16_t i = 0;
-    while (iter.Next())
-    {
-        ++i;
-#if CHIP_PROGRESS_LOGGING
-        auto & entry = iter.GetValue();
-        ChipLogProgress(chipTool, "ActionStruct[%" PRIu16 "]:", i);
-        ChipLogProgress(chipTool, "  ActionID: %" PRIu16 "", entry.actionID);
-        ChipLogProgress(Zcl, "  Name: %.*s", static_cast<int>(entry.name.size()), entry.name.data());
-        ChipLogProgress(chipTool, "  Type: %" PRIu8 "", entry.type);
-        ChipLogProgress(chipTool, "  EndpointListID: %" PRIu16 "", entry.endpointListID);
-        ChipLogProgress(chipTool, "  SupportedCommands: %" PRIu16 "", entry.supportedCommands);
-        ChipLogProgress(chipTool, "  Status: %" PRIu8 "", entry.status);
-#endif // CHIP_PROGRESS_LOGGING
-    }
-    command->SetCommandExitStatus(iter.GetStatus());
+    command->SetCommandExitStatus(err);
 }
 
 static void OnBridgedActionsEndpointListListAttributeResponse(
@@ -253,237 +2156,77 @@ static void OnBridgedActionsEndpointListListAttributeResponse(
     const chip::app::DataModel::DecodableList<chip::app::Clusters::BridgedActions::Structs::EndpointListStruct::DecodableType> &
         list)
 {
+    CHIP_ERROR err = LogValue("OnBridgedActionsEndpointListListAttributeResponse", 0, list);
+
     ModelCommand * command = static_cast<ModelCommand *>(context);
-
-    size_t count   = 0;
-    CHIP_ERROR err = list.ComputeSize(&count);
-    if (err != CHIP_NO_ERROR)
-    {
-        command->SetCommandExitStatus(err);
-        return;
-    }
-
-    ChipLogProgress(chipTool, "OnBridgedActionsEndpointListListAttributeResponse: %zu entries", count);
-
-    auto iter  = list.begin();
-    uint16_t i = 0;
-    while (iter.Next())
-    {
-        ++i;
-#if CHIP_PROGRESS_LOGGING
-        auto & entry = iter.GetValue();
-        ChipLogProgress(chipTool, "EndpointListStruct[%" PRIu16 "]:", i);
-        ChipLogProgress(chipTool, "  EndpointListID: %" PRIu16 "", entry.endpointListID);
-        ChipLogProgress(Zcl, "  Name: %.*s", static_cast<int>(entry.name.size()), entry.name.data());
-        ChipLogProgress(chipTool, "  Type: %" PRIu8 "", entry.type);
-        ChipLogProgress(Zcl, "  Endpoints: %zu", entry.endpoints.size());
-#endif // CHIP_PROGRESS_LOGGING
-    }
-    command->SetCommandExitStatus(iter.GetStatus());
+    command->SetCommandExitStatus(err);
 }
 
 static void
 OnContentLauncherAcceptsHeaderListListAttributeResponse(void * context,
                                                         const chip::app::DataModel::DecodableList<chip::ByteSpan> & list)
 {
+    CHIP_ERROR err = LogValue("OnContentLauncherAcceptsHeaderListListAttributeResponse", 0, list);
+
     ModelCommand * command = static_cast<ModelCommand *>(context);
-
-    size_t count   = 0;
-    CHIP_ERROR err = list.ComputeSize(&count);
-    if (err != CHIP_NO_ERROR)
-    {
-        command->SetCommandExitStatus(err);
-        return;
-    }
-
-    ChipLogProgress(chipTool, "OnContentLauncherAcceptsHeaderListListAttributeResponse: %zu entries", count);
-
-    auto iter  = list.begin();
-    uint16_t i = 0;
-    while (iter.Next())
-    {
-        ++i;
-#if CHIP_PROGRESS_LOGGING
-        auto & entry = iter.GetValue();
-        ChipLogProgress(Zcl, "  : %zu", entry.size());
-#endif // CHIP_PROGRESS_LOGGING
-    }
-    command->SetCommandExitStatus(iter.GetStatus());
+    command->SetCommandExitStatus(err);
 }
 
 static void OnContentLauncherSupportedStreamingTypesListAttributeResponse(
     void * context,
     const chip::app::DataModel::DecodableList<chip::app::Clusters::ContentLauncher::ContentLaunchStreamingType> & list)
 {
+    CHIP_ERROR err = LogValue("OnContentLauncherSupportedStreamingTypesListAttributeResponse", 0, list);
+
     ModelCommand * command = static_cast<ModelCommand *>(context);
-
-    size_t count   = 0;
-    CHIP_ERROR err = list.ComputeSize(&count);
-    if (err != CHIP_NO_ERROR)
-    {
-        command->SetCommandExitStatus(err);
-        return;
-    }
-
-    ChipLogProgress(chipTool, "OnContentLauncherSupportedStreamingTypesListAttributeResponse: %zu entries", count);
-
-    auto iter  = list.begin();
-    uint16_t i = 0;
-    while (iter.Next())
-    {
-        ++i;
-#if CHIP_PROGRESS_LOGGING
-        auto & entry = iter.GetValue();
-        ChipLogProgress(chipTool, "ContentLaunchStreamingType[%" PRIu16 "]: %" PRIu8 "", i, entry);
-#endif // CHIP_PROGRESS_LOGGING
-    }
-    command->SetCommandExitStatus(iter.GetStatus());
+    command->SetCommandExitStatus(err);
 }
 
 static void OnDescriptorDeviceListListAttributeResponse(
     void * context,
     const chip::app::DataModel::DecodableList<chip::app::Clusters::Descriptor::Structs::DeviceType::DecodableType> & list)
 {
+    CHIP_ERROR err = LogValue("OnDescriptorDeviceListListAttributeResponse", 0, list);
+
     ModelCommand * command = static_cast<ModelCommand *>(context);
-
-    size_t count   = 0;
-    CHIP_ERROR err = list.ComputeSize(&count);
-    if (err != CHIP_NO_ERROR)
-    {
-        command->SetCommandExitStatus(err);
-        return;
-    }
-
-    ChipLogProgress(chipTool, "OnDescriptorDeviceListListAttributeResponse: %zu entries", count);
-
-    auto iter  = list.begin();
-    uint16_t i = 0;
-    while (iter.Next())
-    {
-        ++i;
-#if CHIP_PROGRESS_LOGGING
-        auto & entry = iter.GetValue();
-        ChipLogProgress(chipTool, "DeviceType[%" PRIu16 "]:", i);
-        ChipLogProgress(chipTool, "  type: %" PRIu32 "", entry.type);
-        ChipLogProgress(chipTool, "  revision: %" PRIu16 "", entry.revision);
-#endif // CHIP_PROGRESS_LOGGING
-    }
-    command->SetCommandExitStatus(iter.GetStatus());
+    command->SetCommandExitStatus(err);
 }
 
 static void OnDescriptorServerListListAttributeResponse(void * context,
                                                         const chip::app::DataModel::DecodableList<chip::ClusterId> & list)
 {
+    CHIP_ERROR err = LogValue("OnDescriptorServerListListAttributeResponse", 0, list);
+
     ModelCommand * command = static_cast<ModelCommand *>(context);
-
-    size_t count   = 0;
-    CHIP_ERROR err = list.ComputeSize(&count);
-    if (err != CHIP_NO_ERROR)
-    {
-        command->SetCommandExitStatus(err);
-        return;
-    }
-
-    ChipLogProgress(chipTool, "OnDescriptorServerListListAttributeResponse: %zu entries", count);
-
-    auto iter  = list.begin();
-    uint16_t i = 0;
-    while (iter.Next())
-    {
-        ++i;
-#if CHIP_PROGRESS_LOGGING
-        auto & entry = iter.GetValue();
-        ChipLogProgress(chipTool, "CLUSTER_ID[%" PRIu16 "]: %" PRIu32 "", i, entry);
-#endif // CHIP_PROGRESS_LOGGING
-    }
-    command->SetCommandExitStatus(iter.GetStatus());
+    command->SetCommandExitStatus(err);
 }
 
 static void OnDescriptorClientListListAttributeResponse(void * context,
                                                         const chip::app::DataModel::DecodableList<chip::ClusterId> & list)
 {
+    CHIP_ERROR err = LogValue("OnDescriptorClientListListAttributeResponse", 0, list);
+
     ModelCommand * command = static_cast<ModelCommand *>(context);
-
-    size_t count   = 0;
-    CHIP_ERROR err = list.ComputeSize(&count);
-    if (err != CHIP_NO_ERROR)
-    {
-        command->SetCommandExitStatus(err);
-        return;
-    }
-
-    ChipLogProgress(chipTool, "OnDescriptorClientListListAttributeResponse: %zu entries", count);
-
-    auto iter  = list.begin();
-    uint16_t i = 0;
-    while (iter.Next())
-    {
-        ++i;
-#if CHIP_PROGRESS_LOGGING
-        auto & entry = iter.GetValue();
-        ChipLogProgress(chipTool, "CLUSTER_ID[%" PRIu16 "]: %" PRIu32 "", i, entry);
-#endif // CHIP_PROGRESS_LOGGING
-    }
-    command->SetCommandExitStatus(iter.GetStatus());
+    command->SetCommandExitStatus(err);
 }
 
 static void OnDescriptorPartsListListAttributeResponse(void * context,
                                                        const chip::app::DataModel::DecodableList<chip::EndpointId> & list)
 {
+    CHIP_ERROR err = LogValue("OnDescriptorPartsListListAttributeResponse", 0, list);
+
     ModelCommand * command = static_cast<ModelCommand *>(context);
-
-    size_t count   = 0;
-    CHIP_ERROR err = list.ComputeSize(&count);
-    if (err != CHIP_NO_ERROR)
-    {
-        command->SetCommandExitStatus(err);
-        return;
-    }
-
-    ChipLogProgress(chipTool, "OnDescriptorPartsListListAttributeResponse: %zu entries", count);
-
-    auto iter  = list.begin();
-    uint16_t i = 0;
-    while (iter.Next())
-    {
-        ++i;
-#if CHIP_PROGRESS_LOGGING
-        auto & entry = iter.GetValue();
-        ChipLogProgress(chipTool, "ENDPOINT_NO[%" PRIu16 "]: %" PRIu16 "", i, entry);
-#endif // CHIP_PROGRESS_LOGGING
-    }
-    command->SetCommandExitStatus(iter.GetStatus());
+    command->SetCommandExitStatus(err);
 }
 
 static void OnFixedLabelLabelListListAttributeResponse(
     void * context,
     const chip::app::DataModel::DecodableList<chip::app::Clusters::FixedLabel::Structs::LabelStruct::DecodableType> & list)
 {
+    CHIP_ERROR err = LogValue("OnFixedLabelLabelListListAttributeResponse", 0, list);
+
     ModelCommand * command = static_cast<ModelCommand *>(context);
-
-    size_t count   = 0;
-    CHIP_ERROR err = list.ComputeSize(&count);
-    if (err != CHIP_NO_ERROR)
-    {
-        command->SetCommandExitStatus(err);
-        return;
-    }
-
-    ChipLogProgress(chipTool, "OnFixedLabelLabelListListAttributeResponse: %zu entries", count);
-
-    auto iter  = list.begin();
-    uint16_t i = 0;
-    while (iter.Next())
-    {
-        ++i;
-#if CHIP_PROGRESS_LOGGING
-        auto & entry = iter.GetValue();
-        ChipLogProgress(chipTool, "LabelStruct[%" PRIu16 "]:", i);
-        ChipLogProgress(Zcl, "  label: %.*s", static_cast<int>(entry.label.size()), entry.label.data());
-        ChipLogProgress(Zcl, "  value: %.*s", static_cast<int>(entry.value.size()), entry.value.data());
-#endif // CHIP_PROGRESS_LOGGING
-    }
-    command->SetCommandExitStatus(iter.GetStatus());
+    command->SetCommandExitStatus(err);
 }
 
 static void OnGeneralCommissioningBasicCommissioningInfoListListAttributeResponse(
@@ -491,30 +2234,10 @@ static void OnGeneralCommissioningBasicCommissioningInfoListListAttributeRespons
     const chip::app::DataModel::DecodableList<
         chip::app::Clusters::GeneralCommissioning::Structs::BasicCommissioningInfoType::DecodableType> & list)
 {
+    CHIP_ERROR err = LogValue("OnGeneralCommissioningBasicCommissioningInfoListListAttributeResponse", 0, list);
+
     ModelCommand * command = static_cast<ModelCommand *>(context);
-
-    size_t count   = 0;
-    CHIP_ERROR err = list.ComputeSize(&count);
-    if (err != CHIP_NO_ERROR)
-    {
-        command->SetCommandExitStatus(err);
-        return;
-    }
-
-    ChipLogProgress(chipTool, "OnGeneralCommissioningBasicCommissioningInfoListListAttributeResponse: %zu entries", count);
-
-    auto iter  = list.begin();
-    uint16_t i = 0;
-    while (iter.Next())
-    {
-        ++i;
-#if CHIP_PROGRESS_LOGGING
-        auto & entry = iter.GetValue();
-        ChipLogProgress(chipTool, "BasicCommissioningInfoType[%" PRIu16 "]:", i);
-        ChipLogProgress(chipTool, "  FailSafeExpiryLengthMs: %" PRIu32 "", entry.failSafeExpiryLengthMs);
-#endif // CHIP_PROGRESS_LOGGING
-    }
-    command->SetCommandExitStatus(iter.GetStatus());
+    command->SetCommandExitStatus(err);
 }
 
 static void OnGeneralDiagnosticsNetworkInterfacesListAttributeResponse(
@@ -522,166 +2245,50 @@ static void OnGeneralDiagnosticsNetworkInterfacesListAttributeResponse(
     const chip::app::DataModel::DecodableList<
         chip::app::Clusters::GeneralDiagnostics::Structs::NetworkInterfaceType::DecodableType> & list)
 {
+    CHIP_ERROR err = LogValue("OnGeneralDiagnosticsNetworkInterfacesListAttributeResponse", 0, list);
+
     ModelCommand * command = static_cast<ModelCommand *>(context);
-
-    size_t count   = 0;
-    CHIP_ERROR err = list.ComputeSize(&count);
-    if (err != CHIP_NO_ERROR)
-    {
-        command->SetCommandExitStatus(err);
-        return;
-    }
-
-    ChipLogProgress(chipTool, "OnGeneralDiagnosticsNetworkInterfacesListAttributeResponse: %zu entries", count);
-
-    auto iter  = list.begin();
-    uint16_t i = 0;
-    while (iter.Next())
-    {
-        ++i;
-#if CHIP_PROGRESS_LOGGING
-        auto & entry = iter.GetValue();
-        ChipLogProgress(chipTool, "NetworkInterfaceType[%" PRIu16 "]:", i);
-        ChipLogProgress(Zcl, "  Name: %.*s", static_cast<int>(entry.name.size()), entry.name.data());
-        ChipLogProgress(chipTool, "  FabricConnected: %d", entry.fabricConnected);
-        ChipLogProgress(chipTool, "  OffPremiseServicesReachableIPv4: %d", entry.offPremiseServicesReachableIPv4);
-        ChipLogProgress(chipTool, "  OffPremiseServicesReachableIPv6: %d", entry.offPremiseServicesReachableIPv6);
-        ChipLogProgress(Zcl, "  HardwareAddress: %zu", entry.hardwareAddress.size());
-        ChipLogProgress(chipTool, "  Type: %" PRIu8 "", entry.type);
-#endif // CHIP_PROGRESS_LOGGING
-    }
-    command->SetCommandExitStatus(iter.GetStatus());
+    command->SetCommandExitStatus(err);
 }
 
 static void OnGroupKeyManagementGroupsListAttributeResponse(
     void * context,
     const chip::app::DataModel::DecodableList<chip::app::Clusters::GroupKeyManagement::Structs::GroupState::DecodableType> & list)
 {
+    CHIP_ERROR err = LogValue("OnGroupKeyManagementGroupsListAttributeResponse", 0, list);
+
     ModelCommand * command = static_cast<ModelCommand *>(context);
-
-    size_t count   = 0;
-    CHIP_ERROR err = list.ComputeSize(&count);
-    if (err != CHIP_NO_ERROR)
-    {
-        command->SetCommandExitStatus(err);
-        return;
-    }
-
-    ChipLogProgress(chipTool, "OnGroupKeyManagementGroupsListAttributeResponse: %zu entries", count);
-
-    auto iter  = list.begin();
-    uint16_t i = 0;
-    while (iter.Next())
-    {
-        ++i;
-#if CHIP_PROGRESS_LOGGING
-        auto & entry = iter.GetValue();
-        ChipLogProgress(chipTool, "GroupState[%" PRIu16 "]:", i);
-        ChipLogProgress(chipTool, "  VendorId: %" PRIu16 "", entry.vendorId);
-        ChipLogProgress(chipTool, "  VendorGroupId: %" PRIu16 "", entry.vendorGroupId);
-        ChipLogProgress(chipTool, "  GroupKeySetIndex: %" PRIu16 "", entry.groupKeySetIndex);
-#endif // CHIP_PROGRESS_LOGGING
-    }
-    command->SetCommandExitStatus(iter.GetStatus());
+    command->SetCommandExitStatus(err);
 }
 
 static void OnGroupKeyManagementGroupKeysListAttributeResponse(
     void * context,
     const chip::app::DataModel::DecodableList<chip::app::Clusters::GroupKeyManagement::Structs::GroupKey::DecodableType> & list)
 {
+    CHIP_ERROR err = LogValue("OnGroupKeyManagementGroupKeysListAttributeResponse", 0, list);
+
     ModelCommand * command = static_cast<ModelCommand *>(context);
-
-    size_t count   = 0;
-    CHIP_ERROR err = list.ComputeSize(&count);
-    if (err != CHIP_NO_ERROR)
-    {
-        command->SetCommandExitStatus(err);
-        return;
-    }
-
-    ChipLogProgress(chipTool, "OnGroupKeyManagementGroupKeysListAttributeResponse: %zu entries", count);
-
-    auto iter  = list.begin();
-    uint16_t i = 0;
-    while (iter.Next())
-    {
-        ++i;
-#if CHIP_PROGRESS_LOGGING
-        auto & entry = iter.GetValue();
-        ChipLogProgress(chipTool, "GroupKey[%" PRIu16 "]:", i);
-        ChipLogProgress(chipTool, "  VendorId: %" PRIu16 "", entry.vendorId);
-        ChipLogProgress(chipTool, "  GroupKeyIndex: %" PRIu16 "", entry.groupKeyIndex);
-        ChipLogProgress(Zcl, "  GroupKeyRoot: %zu", entry.groupKeyRoot.size());
-        ChipLogProgress(chipTool, "  GroupKeyEpochStartTime: %" PRIu64 "", entry.groupKeyEpochStartTime);
-        ChipLogProgress(chipTool, "  GroupKeySecurityPolicy: %" PRIu8 "", entry.groupKeySecurityPolicy);
-#endif // CHIP_PROGRESS_LOGGING
-    }
-    command->SetCommandExitStatus(iter.GetStatus());
+    command->SetCommandExitStatus(err);
 }
 
 static void OnMediaInputMediaInputListListAttributeResponse(
     void * context,
     const chip::app::DataModel::DecodableList<chip::app::Clusters::MediaInput::Structs::MediaInputInfo::DecodableType> & list)
 {
+    CHIP_ERROR err = LogValue("OnMediaInputMediaInputListListAttributeResponse", 0, list);
+
     ModelCommand * command = static_cast<ModelCommand *>(context);
-
-    size_t count   = 0;
-    CHIP_ERROR err = list.ComputeSize(&count);
-    if (err != CHIP_NO_ERROR)
-    {
-        command->SetCommandExitStatus(err);
-        return;
-    }
-
-    ChipLogProgress(chipTool, "OnMediaInputMediaInputListListAttributeResponse: %zu entries", count);
-
-    auto iter  = list.begin();
-    uint16_t i = 0;
-    while (iter.Next())
-    {
-        ++i;
-#if CHIP_PROGRESS_LOGGING
-        auto & entry = iter.GetValue();
-        ChipLogProgress(chipTool, "MediaInputInfo[%" PRIu16 "]:", i);
-        ChipLogProgress(chipTool, "  index: %" PRIu8 "", entry.index);
-        ChipLogProgress(chipTool, "  inputType: %" PRIu8 "", entry.inputType);
-        ChipLogProgress(Zcl, "  name: %.*s", static_cast<int>(entry.name.size()), entry.name.data());
-        ChipLogProgress(Zcl, "  description: %.*s", static_cast<int>(entry.description.size()), entry.description.data());
-#endif // CHIP_PROGRESS_LOGGING
-    }
-    command->SetCommandExitStatus(iter.GetStatus());
+    command->SetCommandExitStatus(err);
 }
 
 static void OnModeSelectSupportedModesListAttributeResponse(
     void * context,
     const chip::app::DataModel::DecodableList<chip::app::Clusters::ModeSelect::Structs::ModeOptionStruct::DecodableType> & list)
 {
+    CHIP_ERROR err = LogValue("OnModeSelectSupportedModesListAttributeResponse", 0, list);
+
     ModelCommand * command = static_cast<ModelCommand *>(context);
-
-    size_t count   = 0;
-    CHIP_ERROR err = list.ComputeSize(&count);
-    if (err != CHIP_NO_ERROR)
-    {
-        command->SetCommandExitStatus(err);
-        return;
-    }
-
-    ChipLogProgress(chipTool, "OnModeSelectSupportedModesListAttributeResponse: %zu entries", count);
-
-    auto iter  = list.begin();
-    uint16_t i = 0;
-    while (iter.Next())
-    {
-        ++i;
-#if CHIP_PROGRESS_LOGGING
-        auto & entry = iter.GetValue();
-        ChipLogProgress(chipTool, "ModeOptionStruct[%" PRIu16 "]:", i);
-        ChipLogProgress(Zcl, "  Label: %.*s", static_cast<int>(entry.label.size()), entry.label.data());
-        ChipLogProgress(chipTool, "  Mode: %" PRIu8 "", entry.mode);
-        ChipLogProgress(chipTool, "  SemanticTag: %" PRIu32 "", entry.semanticTag);
-#endif // CHIP_PROGRESS_LOGGING
-    }
-    command->SetCommandExitStatus(iter.GetStatus());
+    command->SetCommandExitStatus(err);
 }
 
 static void OnOperationalCredentialsFabricsListListAttributeResponse(
@@ -689,126 +2296,38 @@ static void OnOperationalCredentialsFabricsListListAttributeResponse(
     const chip::app::DataModel::DecodableList<
         chip::app::Clusters::OperationalCredentials::Structs::FabricDescriptor::DecodableType> & list)
 {
+    CHIP_ERROR err = LogValue("OnOperationalCredentialsFabricsListListAttributeResponse", 0, list);
+
     ModelCommand * command = static_cast<ModelCommand *>(context);
-
-    size_t count   = 0;
-    CHIP_ERROR err = list.ComputeSize(&count);
-    if (err != CHIP_NO_ERROR)
-    {
-        command->SetCommandExitStatus(err);
-        return;
-    }
-
-    ChipLogProgress(chipTool, "OnOperationalCredentialsFabricsListListAttributeResponse: %zu entries", count);
-
-    auto iter  = list.begin();
-    uint16_t i = 0;
-    while (iter.Next())
-    {
-        ++i;
-#if CHIP_PROGRESS_LOGGING
-        auto & entry = iter.GetValue();
-        ChipLogProgress(chipTool, "FabricDescriptor[%" PRIu16 "]:", i);
-        ChipLogProgress(chipTool, "  FabricIndex: %" PRIu8 "", entry.fabricIndex);
-        ChipLogProgress(Zcl, "  RootPublicKey: %zu", entry.rootPublicKey.size());
-        ChipLogProgress(chipTool, "  VendorId: %" PRIu16 "", entry.vendorId);
-        ChipLogProgress(chipTool, "  FabricId: %" PRIu64 "", entry.fabricId);
-        ChipLogProgress(chipTool, "  NodeId: %" PRIu64 "", entry.nodeId);
-        ChipLogProgress(Zcl, "  Label: %.*s", static_cast<int>(entry.label.size()), entry.label.data());
-#endif // CHIP_PROGRESS_LOGGING
-    }
-    command->SetCommandExitStatus(iter.GetStatus());
+    command->SetCommandExitStatus(err);
 }
 
 static void OnOperationalCredentialsTrustedRootCertificatesListAttributeResponse(
     void * context, const chip::app::DataModel::DecodableList<chip::ByteSpan> & list)
 {
+    CHIP_ERROR err = LogValue("OnOperationalCredentialsTrustedRootCertificatesListAttributeResponse", 0, list);
+
     ModelCommand * command = static_cast<ModelCommand *>(context);
-
-    size_t count   = 0;
-    CHIP_ERROR err = list.ComputeSize(&count);
-    if (err != CHIP_NO_ERROR)
-    {
-        command->SetCommandExitStatus(err);
-        return;
-    }
-
-    ChipLogProgress(chipTool, "OnOperationalCredentialsTrustedRootCertificatesListAttributeResponse: %zu entries", count);
-
-    auto iter  = list.begin();
-    uint16_t i = 0;
-    while (iter.Next())
-    {
-        ++i;
-#if CHIP_PROGRESS_LOGGING
-        auto & entry = iter.GetValue();
-        ChipLogProgress(Zcl, "  : %zu", entry.size());
-#endif // CHIP_PROGRESS_LOGGING
-    }
-    command->SetCommandExitStatus(iter.GetStatus());
+    command->SetCommandExitStatus(err);
 }
 
 static void OnPowerSourceActiveBatteryFaultsListAttributeResponse(void * context,
                                                                   const chip::app::DataModel::DecodableList<uint8_t> & list)
 {
+    CHIP_ERROR err = LogValue("OnPowerSourceActiveBatteryFaultsListAttributeResponse", 0, list);
+
     ModelCommand * command = static_cast<ModelCommand *>(context);
-
-    size_t count   = 0;
-    CHIP_ERROR err = list.ComputeSize(&count);
-    if (err != CHIP_NO_ERROR)
-    {
-        command->SetCommandExitStatus(err);
-        return;
-    }
-
-    ChipLogProgress(chipTool, "OnPowerSourceActiveBatteryFaultsListAttributeResponse: %zu entries", count);
-
-    auto iter  = list.begin();
-    uint16_t i = 0;
-    while (iter.Next())
-    {
-        ++i;
-#if CHIP_PROGRESS_LOGGING
-        auto & entry = iter.GetValue();
-        ChipLogProgress(chipTool, "ENUM8[%" PRIu16 "]: %" PRIu8 "", i, entry);
-#endif // CHIP_PROGRESS_LOGGING
-    }
-    command->SetCommandExitStatus(iter.GetStatus());
+    command->SetCommandExitStatus(err);
 }
 
 static void OnTvChannelTvChannelListListAttributeResponse(
     void * context,
     const chip::app::DataModel::DecodableList<chip::app::Clusters::TvChannel::Structs::TvChannelInfo::DecodableType> & list)
 {
+    CHIP_ERROR err = LogValue("OnTvChannelTvChannelListListAttributeResponse", 0, list);
+
     ModelCommand * command = static_cast<ModelCommand *>(context);
-
-    size_t count   = 0;
-    CHIP_ERROR err = list.ComputeSize(&count);
-    if (err != CHIP_NO_ERROR)
-    {
-        command->SetCommandExitStatus(err);
-        return;
-    }
-
-    ChipLogProgress(chipTool, "OnTvChannelTvChannelListListAttributeResponse: %zu entries", count);
-
-    auto iter  = list.begin();
-    uint16_t i = 0;
-    while (iter.Next())
-    {
-        ++i;
-#if CHIP_PROGRESS_LOGGING
-        auto & entry = iter.GetValue();
-        ChipLogProgress(chipTool, "TvChannelInfo[%" PRIu16 "]:", i);
-        ChipLogProgress(chipTool, "  majorNumber: %" PRIu16 "", entry.majorNumber);
-        ChipLogProgress(chipTool, "  minorNumber: %" PRIu16 "", entry.minorNumber);
-        ChipLogProgress(Zcl, "  name: %.*s", static_cast<int>(entry.name.size()), entry.name.data());
-        ChipLogProgress(Zcl, "  callSign: %.*s", static_cast<int>(entry.callSign.size()), entry.callSign.data());
-        ChipLogProgress(Zcl, "  affiliateCallSign: %.*s", static_cast<int>(entry.affiliateCallSign.size()),
-                        entry.affiliateCallSign.data());
-#endif // CHIP_PROGRESS_LOGGING
-    }
-    command->SetCommandExitStatus(iter.GetStatus());
+    command->SetCommandExitStatus(err);
 }
 
 static void OnTargetNavigatorTargetNavigatorListListAttributeResponse(
@@ -816,117 +2335,37 @@ static void OnTargetNavigatorTargetNavigatorListListAttributeResponse(
     const chip::app::DataModel::DecodableList<
         chip::app::Clusters::TargetNavigator::Structs::NavigateTargetTargetInfo::DecodableType> & list)
 {
+    CHIP_ERROR err = LogValue("OnTargetNavigatorTargetNavigatorListListAttributeResponse", 0, list);
+
     ModelCommand * command = static_cast<ModelCommand *>(context);
-
-    size_t count   = 0;
-    CHIP_ERROR err = list.ComputeSize(&count);
-    if (err != CHIP_NO_ERROR)
-    {
-        command->SetCommandExitStatus(err);
-        return;
-    }
-
-    ChipLogProgress(chipTool, "OnTargetNavigatorTargetNavigatorListListAttributeResponse: %zu entries", count);
-
-    auto iter  = list.begin();
-    uint16_t i = 0;
-    while (iter.Next())
-    {
-        ++i;
-#if CHIP_PROGRESS_LOGGING
-        auto & entry = iter.GetValue();
-        ChipLogProgress(chipTool, "NavigateTargetTargetInfo[%" PRIu16 "]:", i);
-        ChipLogProgress(chipTool, "  identifier: %" PRIu8 "", entry.identifier);
-        ChipLogProgress(Zcl, "  name: %.*s", static_cast<int>(entry.name.size()), entry.name.data());
-#endif // CHIP_PROGRESS_LOGGING
-    }
-    command->SetCommandExitStatus(iter.GetStatus());
+    command->SetCommandExitStatus(err);
 }
 
 static void OnTestClusterListInt8uListAttributeResponse(void * context, const chip::app::DataModel::DecodableList<uint8_t> & list)
 {
+    CHIP_ERROR err = LogValue("OnTestClusterListInt8uListAttributeResponse", 0, list);
+
     ModelCommand * command = static_cast<ModelCommand *>(context);
-
-    size_t count   = 0;
-    CHIP_ERROR err = list.ComputeSize(&count);
-    if (err != CHIP_NO_ERROR)
-    {
-        command->SetCommandExitStatus(err);
-        return;
-    }
-
-    ChipLogProgress(chipTool, "OnTestClusterListInt8uListAttributeResponse: %zu entries", count);
-
-    auto iter  = list.begin();
-    uint16_t i = 0;
-    while (iter.Next())
-    {
-        ++i;
-#if CHIP_PROGRESS_LOGGING
-        auto & entry = iter.GetValue();
-        ChipLogProgress(chipTool, "INT8U[%" PRIu16 "]: %" PRIu8 "", i, entry);
-#endif // CHIP_PROGRESS_LOGGING
-    }
-    command->SetCommandExitStatus(iter.GetStatus());
+    command->SetCommandExitStatus(err);
 }
 
 static void OnTestClusterListOctetStringListAttributeResponse(void * context,
                                                               const chip::app::DataModel::DecodableList<chip::ByteSpan> & list)
 {
+    CHIP_ERROR err = LogValue("OnTestClusterListOctetStringListAttributeResponse", 0, list);
+
     ModelCommand * command = static_cast<ModelCommand *>(context);
-
-    size_t count   = 0;
-    CHIP_ERROR err = list.ComputeSize(&count);
-    if (err != CHIP_NO_ERROR)
-    {
-        command->SetCommandExitStatus(err);
-        return;
-    }
-
-    ChipLogProgress(chipTool, "OnTestClusterListOctetStringListAttributeResponse: %zu entries", count);
-
-    auto iter  = list.begin();
-    uint16_t i = 0;
-    while (iter.Next())
-    {
-        ++i;
-#if CHIP_PROGRESS_LOGGING
-        auto & entry = iter.GetValue();
-        ChipLogProgress(Zcl, "  : %zu", entry.size());
-#endif // CHIP_PROGRESS_LOGGING
-    }
-    command->SetCommandExitStatus(iter.GetStatus());
+    command->SetCommandExitStatus(err);
 }
 
 static void OnTestClusterListStructOctetStringListAttributeResponse(
     void * context,
     const chip::app::DataModel::DecodableList<chip::app::Clusters::TestCluster::Structs::TestListStructOctet::DecodableType> & list)
 {
+    CHIP_ERROR err = LogValue("OnTestClusterListStructOctetStringListAttributeResponse", 0, list);
+
     ModelCommand * command = static_cast<ModelCommand *>(context);
-
-    size_t count   = 0;
-    CHIP_ERROR err = list.ComputeSize(&count);
-    if (err != CHIP_NO_ERROR)
-    {
-        command->SetCommandExitStatus(err);
-        return;
-    }
-
-    ChipLogProgress(chipTool, "OnTestClusterListStructOctetStringListAttributeResponse: %zu entries", count);
-
-    auto iter  = list.begin();
-    uint16_t i = 0;
-    while (iter.Next())
-    {
-        ++i;
-#if CHIP_PROGRESS_LOGGING
-        auto & entry = iter.GetValue();
-        ChipLogProgress(chipTool, "TestListStructOctet[%" PRIu16 "]:", i);
-        ChipLogProgress(chipTool, "  fabricIndex: %" PRIu64 "", entry.fabricIndex);
-        ChipLogProgress(Zcl, "  operationalCert: %zu", entry.operationalCert.size());
-#endif // CHIP_PROGRESS_LOGGING
-    }
-    command->SetCommandExitStatus(iter.GetStatus());
+    command->SetCommandExitStatus(err);
 }
 
 static void OnTestClusterListNullablesAndOptionalsStructListAttributeResponse(
@@ -934,130 +2373,10 @@ static void OnTestClusterListNullablesAndOptionalsStructListAttributeResponse(
     const chip::app::DataModel::DecodableList<
         chip::app::Clusters::TestCluster::Structs::NullablesAndOptionalsStruct::DecodableType> & list)
 {
+    CHIP_ERROR err = LogValue("OnTestClusterListNullablesAndOptionalsStructListAttributeResponse", 0, list);
+
     ModelCommand * command = static_cast<ModelCommand *>(context);
-
-    size_t count   = 0;
-    CHIP_ERROR err = list.ComputeSize(&count);
-    if (err != CHIP_NO_ERROR)
-    {
-        command->SetCommandExitStatus(err);
-        return;
-    }
-
-    ChipLogProgress(chipTool, "OnTestClusterListNullablesAndOptionalsStructListAttributeResponse: %zu entries", count);
-
-    auto iter  = list.begin();
-    uint16_t i = 0;
-    while (iter.Next())
-    {
-        ++i;
-#if CHIP_PROGRESS_LOGGING
-        auto & entry = iter.GetValue();
-        ChipLogProgress(chipTool, "NullablesAndOptionalsStruct[%" PRIu16 "]:", i);
-        if (entry.nullableInt.IsNull())
-        {
-            ChipLogProgress(chipTool, "  NullableInt: null");
-        }
-        else
-        {
-            ChipLogProgress(chipTool, "  NullableInt: %" PRIu16 "", entry.nullableInt.Value());
-        }
-        if (entry.optionalInt.HasValue())
-        {
-            ChipLogProgress(chipTool, "  OptionalInt: %" PRIu16 "", entry.optionalInt.Value());
-        }
-        if (entry.nullableOptionalInt.HasValue())
-        {
-            if (entry.nullableOptionalInt.Value().IsNull())
-            {
-                ChipLogProgress(chipTool, "  NullableOptionalInt: null");
-            }
-            else
-            {
-                ChipLogProgress(chipTool, "  NullableOptionalInt: %" PRIu16 "", entry.nullableOptionalInt.Value().Value());
-            }
-        }
-        if (entry.nullableString.IsNull())
-        {
-            ChipLogProgress(chipTool, "  NullableString: null");
-        }
-        else
-        {
-            ChipLogProgress(Zcl, "  NullableString: %.*s", static_cast<int>(entry.nullableString.Value().size()),
-                            entry.nullableString.Value().data());
-        }
-        if (entry.optionalString.HasValue())
-        {
-            ChipLogProgress(Zcl, "  OptionalString: %.*s", static_cast<int>(entry.optionalString.Value().size()),
-                            entry.optionalString.Value().data());
-        }
-        if (entry.nullableOptionalString.HasValue())
-        {
-            if (entry.nullableOptionalString.Value().IsNull())
-            {
-                ChipLogProgress(chipTool, "  NullableOptionalString: null");
-            }
-            else
-            {
-                ChipLogProgress(Zcl, "  NullableOptionalString: %.*s",
-                                static_cast<int>(entry.nullableOptionalString.Value().Value().size()),
-                                entry.nullableOptionalString.Value().Value().data());
-            }
-        }
-        if (entry.nullableStruct.IsNull())
-        {
-            ChipLogProgress(chipTool, "  NullableStruct: null");
-        }
-        else
-        {
-            ChipLogProgress(chipTool,
-                            "  NullableStruct: struct member of struct element of list attribute printing not supported yet");
-        }
-        if (entry.optionalStruct.HasValue())
-        {
-            ChipLogProgress(chipTool,
-                            "  OptionalStruct: struct member of struct element of list attribute printing not supported yet");
-        }
-        if (entry.nullableOptionalStruct.HasValue())
-        {
-            if (entry.nullableOptionalStruct.Value().IsNull())
-            {
-                ChipLogProgress(chipTool, "  NullableOptionalStruct: null");
-            }
-            else
-            {
-                ChipLogProgress(
-                    chipTool,
-                    "  NullableOptionalStruct: struct member of struct element of list attribute printing not supported yet");
-            }
-        }
-        if (entry.nullableList.IsNull())
-        {
-            ChipLogProgress(chipTool, "  NullableList: null");
-        }
-        else
-        {
-            ChipLogProgress(chipTool, "  NullableList: list member of struct element of list attribute printing not supported yet");
-        }
-        if (entry.optionalList.HasValue())
-        {
-            ChipLogProgress(chipTool, "  OptionalList: list member of struct element of list attribute printing not supported yet");
-        }
-        if (entry.nullableOptionalList.HasValue())
-        {
-            if (entry.nullableOptionalList.Value().IsNull())
-            {
-                ChipLogProgress(chipTool, "  NullableOptionalList: null");
-            }
-            else
-            {
-                ChipLogProgress(
-                    chipTool, "  NullableOptionalList: list member of struct element of list attribute printing not supported yet");
-            }
-        }
-#endif // CHIP_PROGRESS_LOGGING
-    }
-    command->SetCommandExitStatus(iter.GetStatus());
+    command->SetCommandExitStatus(err);
 }
 
 static void OnThreadNetworkDiagnosticsNeighborTableListListAttributeResponse(
@@ -1065,43 +2384,10 @@ static void OnThreadNetworkDiagnosticsNeighborTableListListAttributeResponse(
     const chip::app::DataModel::DecodableList<
         chip::app::Clusters::ThreadNetworkDiagnostics::Structs::NeighborTable::DecodableType> & list)
 {
+    CHIP_ERROR err = LogValue("OnThreadNetworkDiagnosticsNeighborTableListListAttributeResponse", 0, list);
+
     ModelCommand * command = static_cast<ModelCommand *>(context);
-
-    size_t count   = 0;
-    CHIP_ERROR err = list.ComputeSize(&count);
-    if (err != CHIP_NO_ERROR)
-    {
-        command->SetCommandExitStatus(err);
-        return;
-    }
-
-    ChipLogProgress(chipTool, "OnThreadNetworkDiagnosticsNeighborTableListListAttributeResponse: %zu entries", count);
-
-    auto iter  = list.begin();
-    uint16_t i = 0;
-    while (iter.Next())
-    {
-        ++i;
-#if CHIP_PROGRESS_LOGGING
-        auto & entry = iter.GetValue();
-        ChipLogProgress(chipTool, "NeighborTable[%" PRIu16 "]:", i);
-        ChipLogProgress(chipTool, "  ExtAddress: %" PRIu64 "", entry.extAddress);
-        ChipLogProgress(chipTool, "  Age: %" PRIu32 "", entry.age);
-        ChipLogProgress(chipTool, "  Rloc16: %" PRIu16 "", entry.rloc16);
-        ChipLogProgress(chipTool, "  LinkFrameCounter: %" PRIu32 "", entry.linkFrameCounter);
-        ChipLogProgress(chipTool, "  MleFrameCounter: %" PRIu32 "", entry.mleFrameCounter);
-        ChipLogProgress(chipTool, "  LQI: %" PRIu8 "", entry.lqi);
-        ChipLogProgress(chipTool, "  AverageRssi: %" PRId8 "", entry.averageRssi);
-        ChipLogProgress(chipTool, "  LastRssi: %" PRId8 "", entry.lastRssi);
-        ChipLogProgress(chipTool, "  FrameErrorRate: %" PRIu8 "", entry.frameErrorRate);
-        ChipLogProgress(chipTool, "  MessageErrorRate: %" PRIu8 "", entry.messageErrorRate);
-        ChipLogProgress(chipTool, "  RxOnWhenIdle: %d", entry.rxOnWhenIdle);
-        ChipLogProgress(chipTool, "  FullThreadDevice: %d", entry.fullThreadDevice);
-        ChipLogProgress(chipTool, "  FullNetworkData: %d", entry.fullNetworkData);
-        ChipLogProgress(chipTool, "  IsChild: %d", entry.isChild);
-#endif // CHIP_PROGRESS_LOGGING
-    }
-    command->SetCommandExitStatus(iter.GetStatus());
+    command->SetCommandExitStatus(err);
 }
 
 static void OnThreadNetworkDiagnosticsRouteTableListListAttributeResponse(
@@ -1109,39 +2395,10 @@ static void OnThreadNetworkDiagnosticsRouteTableListListAttributeResponse(
     const chip::app::DataModel::DecodableList<chip::app::Clusters::ThreadNetworkDiagnostics::Structs::RouteTable::DecodableType> &
         list)
 {
+    CHIP_ERROR err = LogValue("OnThreadNetworkDiagnosticsRouteTableListListAttributeResponse", 0, list);
+
     ModelCommand * command = static_cast<ModelCommand *>(context);
-
-    size_t count   = 0;
-    CHIP_ERROR err = list.ComputeSize(&count);
-    if (err != CHIP_NO_ERROR)
-    {
-        command->SetCommandExitStatus(err);
-        return;
-    }
-
-    ChipLogProgress(chipTool, "OnThreadNetworkDiagnosticsRouteTableListListAttributeResponse: %zu entries", count);
-
-    auto iter  = list.begin();
-    uint16_t i = 0;
-    while (iter.Next())
-    {
-        ++i;
-#if CHIP_PROGRESS_LOGGING
-        auto & entry = iter.GetValue();
-        ChipLogProgress(chipTool, "RouteTable[%" PRIu16 "]:", i);
-        ChipLogProgress(chipTool, "  ExtAddress: %" PRIu64 "", entry.extAddress);
-        ChipLogProgress(chipTool, "  Rloc16: %" PRIu16 "", entry.rloc16);
-        ChipLogProgress(chipTool, "  RouterId: %" PRIu8 "", entry.routerId);
-        ChipLogProgress(chipTool, "  NextHop: %" PRIu8 "", entry.nextHop);
-        ChipLogProgress(chipTool, "  PathCost: %" PRIu8 "", entry.pathCost);
-        ChipLogProgress(chipTool, "  LQIIn: %" PRIu8 "", entry.LQIIn);
-        ChipLogProgress(chipTool, "  LQIOut: %" PRIu8 "", entry.LQIOut);
-        ChipLogProgress(chipTool, "  Age: %" PRIu8 "", entry.age);
-        ChipLogProgress(chipTool, "  Allocated: %d", entry.allocated);
-        ChipLogProgress(chipTool, "  LinkEstablished: %d", entry.linkEstablished);
-#endif // CHIP_PROGRESS_LOGGING
-    }
-    command->SetCommandExitStatus(iter.GetStatus());
+    command->SetCommandExitStatus(err);
 }
 
 static void OnThreadNetworkDiagnosticsSecurityPolicyListAttributeResponse(
@@ -1149,31 +2406,10 @@ static void OnThreadNetworkDiagnosticsSecurityPolicyListAttributeResponse(
     const chip::app::DataModel::DecodableList<
         chip::app::Clusters::ThreadNetworkDiagnostics::Structs::SecurityPolicy::DecodableType> & list)
 {
+    CHIP_ERROR err = LogValue("OnThreadNetworkDiagnosticsSecurityPolicyListAttributeResponse", 0, list);
+
     ModelCommand * command = static_cast<ModelCommand *>(context);
-
-    size_t count   = 0;
-    CHIP_ERROR err = list.ComputeSize(&count);
-    if (err != CHIP_NO_ERROR)
-    {
-        command->SetCommandExitStatus(err);
-        return;
-    }
-
-    ChipLogProgress(chipTool, "OnThreadNetworkDiagnosticsSecurityPolicyListAttributeResponse: %zu entries", count);
-
-    auto iter  = list.begin();
-    uint16_t i = 0;
-    while (iter.Next())
-    {
-        ++i;
-#if CHIP_PROGRESS_LOGGING
-        auto & entry = iter.GetValue();
-        ChipLogProgress(chipTool, "SecurityPolicy[%" PRIu16 "]:", i);
-        ChipLogProgress(chipTool, "  RotationTime: %" PRIu16 "", entry.rotationTime);
-        ChipLogProgress(chipTool, "  Flags: %" PRIu16 "", entry.flags);
-#endif // CHIP_PROGRESS_LOGGING
-    }
-    command->SetCommandExitStatus(iter.GetStatus());
+    command->SetCommandExitStatus(err);
 }
 
 static void OnThreadNetworkDiagnosticsOperationalDatasetComponentsListAttributeResponse(
@@ -1181,125 +2417,113 @@ static void OnThreadNetworkDiagnosticsOperationalDatasetComponentsListAttributeR
     const chip::app::DataModel::DecodableList<
         chip::app::Clusters::ThreadNetworkDiagnostics::Structs::OperationalDatasetComponents::DecodableType> & list)
 {
+    CHIP_ERROR err = LogValue("OnThreadNetworkDiagnosticsOperationalDatasetComponentsListAttributeResponse", 0, list);
+
     ModelCommand * command = static_cast<ModelCommand *>(context);
-
-    size_t count   = 0;
-    CHIP_ERROR err = list.ComputeSize(&count);
-    if (err != CHIP_NO_ERROR)
-    {
-        command->SetCommandExitStatus(err);
-        return;
-    }
-
-    ChipLogProgress(chipTool, "OnThreadNetworkDiagnosticsOperationalDatasetComponentsListAttributeResponse: %zu entries", count);
-
-    auto iter  = list.begin();
-    uint16_t i = 0;
-    while (iter.Next())
-    {
-        ++i;
-#if CHIP_PROGRESS_LOGGING
-        auto & entry = iter.GetValue();
-        ChipLogProgress(chipTool, "OperationalDatasetComponents[%" PRIu16 "]:", i);
-        ChipLogProgress(chipTool, "  ActiveTimestampPresent: %d", entry.activeTimestampPresent);
-        ChipLogProgress(chipTool, "  PendingTimestampPresent: %d", entry.pendingTimestampPresent);
-        ChipLogProgress(chipTool, "  MasterKeyPresent: %d", entry.masterKeyPresent);
-        ChipLogProgress(chipTool, "  NetworkNamePresent: %d", entry.networkNamePresent);
-        ChipLogProgress(chipTool, "  ExtendedPanIdPresent: %d", entry.extendedPanIdPresent);
-        ChipLogProgress(chipTool, "  MeshLocalPrefixPresent: %d", entry.meshLocalPrefixPresent);
-        ChipLogProgress(chipTool, "  DelayPresent: %d", entry.delayPresent);
-        ChipLogProgress(chipTool, "  PanIdPresent: %d", entry.panIdPresent);
-        ChipLogProgress(chipTool, "  ChannelPresent: %d", entry.channelPresent);
-        ChipLogProgress(chipTool, "  PskcPresent: %d", entry.pskcPresent);
-        ChipLogProgress(chipTool, "  SecurityPolicyPresent: %d", entry.securityPolicyPresent);
-        ChipLogProgress(chipTool, "  ChannelMaskPresent: %d", entry.channelMaskPresent);
-#endif // CHIP_PROGRESS_LOGGING
-    }
-    command->SetCommandExitStatus(iter.GetStatus());
+    command->SetCommandExitStatus(err);
 }
 
 static void OnThreadNetworkDiagnosticsActiveNetworkFaultsListListAttributeResponse(
     void * context, const chip::app::DataModel::DecodableList<chip::app::Clusters::ThreadNetworkDiagnostics::NetworkFault> & list)
 {
+    CHIP_ERROR err = LogValue("OnThreadNetworkDiagnosticsActiveNetworkFaultsListListAttributeResponse", 0, list);
+
     ModelCommand * command = static_cast<ModelCommand *>(context);
-
-    size_t count   = 0;
-    CHIP_ERROR err = list.ComputeSize(&count);
-    if (err != CHIP_NO_ERROR)
-    {
-        command->SetCommandExitStatus(err);
-        return;
-    }
-
-    ChipLogProgress(chipTool, "OnThreadNetworkDiagnosticsActiveNetworkFaultsListListAttributeResponse: %zu entries", count);
-
-    auto iter  = list.begin();
-    uint16_t i = 0;
-    while (iter.Next())
-    {
-        ++i;
-#if CHIP_PROGRESS_LOGGING
-        auto & entry = iter.GetValue();
-        ChipLogProgress(chipTool, "NetworkFault[%" PRIu16 "]: %" PRIu8 "", i, entry);
-#endif // CHIP_PROGRESS_LOGGING
-    }
-    command->SetCommandExitStatus(iter.GetStatus());
+    command->SetCommandExitStatus(err);
 }
 
 static void OnAccountLoginGetSetupPINResponseSuccess(
     void * context, const chip::app::Clusters::AccountLogin::Commands::GetSetupPINResponse::DecodableType & data)
 {
     ChipLogProgress(Zcl, "Received GetSetupPINResponse:");
-    ChipLogProgress(Zcl, "  setupPIN: %.*s", static_cast<int>(data.setupPIN.size()), data.setupPIN.data());
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("setupPIN", 1, data.setupPIN);
+    }
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
+    command->SetCommandExitStatus(err);
 };
 
 static void OnApplicationLauncherLaunchAppResponseSuccess(
     void * context, const chip::app::Clusters::ApplicationLauncher::Commands::LaunchAppResponse::DecodableType & data)
 {
     ChipLogProgress(Zcl, "Received LaunchAppResponse:");
-    ChipLogProgress(Zcl, "  status: %" PRIu8 "", data.status);
-    ChipLogProgress(Zcl, "  data: %.*s", static_cast<int>(data.data.size()), data.data.data());
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("status", 1, data.status);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("data", 1, data.data);
+    }
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
+    command->SetCommandExitStatus(err);
 };
 
 static void OnContentLauncherLaunchContentResponseSuccess(
     void * context, const chip::app::Clusters::ContentLauncher::Commands::LaunchContentResponse::DecodableType & data)
 {
     ChipLogProgress(Zcl, "Received LaunchContentResponse:");
-    ChipLogProgress(Zcl, "  data: %.*s", static_cast<int>(data.data.size()), data.data.data());
-    ChipLogProgress(Zcl, "  contentLaunchStatus: %" PRIu8 "", data.contentLaunchStatus);
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("data", 1, data.data);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("contentLaunchStatus", 1, data.contentLaunchStatus);
+    }
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
+    command->SetCommandExitStatus(err);
 };
 
 static void OnContentLauncherLaunchURLResponseSuccess(
     void * context, const chip::app::Clusters::ContentLauncher::Commands::LaunchURLResponse::DecodableType & data)
 {
     ChipLogProgress(Zcl, "Received LaunchURLResponse:");
-    ChipLogProgress(Zcl, "  data: %.*s", static_cast<int>(data.data.size()), data.data.data());
-    ChipLogProgress(Zcl, "  contentLaunchStatus: %" PRIu8 "", data.contentLaunchStatus);
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("data", 1, data.data);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("contentLaunchStatus", 1, data.contentLaunchStatus);
+    }
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
+    command->SetCommandExitStatus(err);
 };
 
 static void OnDiagnosticLogsRetrieveLogsResponseSuccess(
     void * context, const chip::app::Clusters::DiagnosticLogs::Commands::RetrieveLogsResponse::DecodableType & data)
 {
     ChipLogProgress(Zcl, "Received RetrieveLogsResponse:");
-    ChipLogProgress(Zcl, "  status: %" PRIu8 "", data.status);
-    ChipLogProgress(Zcl, "  content: %zu", data.content.size());
-    ChipLogProgress(Zcl, "  timeStamp: %" PRIu32 "", data.timeStamp);
-    ChipLogProgress(Zcl, "  timeSinceBoot: %" PRIu32 "", data.timeSinceBoot);
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("status", 1, data.status);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("content", 1, data.content);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("timeStamp", 1, data.timeStamp);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("timeSinceBoot", 1, data.timeSinceBoot);
+    }
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
+    command->SetCommandExitStatus(err);
 };
 
 static void
@@ -1307,10 +2531,14 @@ OnDoorLockClearAllPinsResponseSuccess(void * context,
                                       const chip::app::Clusters::DoorLock::Commands::ClearAllPinsResponse::DecodableType & data)
 {
     ChipLogProgress(Zcl, "Received ClearAllPinsResponse:");
-    ChipLogProgress(Zcl, "  status: %" PRIu8 "", data.status);
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("status", 1, data.status);
+    }
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
+    command->SetCommandExitStatus(err);
 };
 
 static void
@@ -1318,30 +2546,42 @@ OnDoorLockClearAllRfidsResponseSuccess(void * context,
                                        const chip::app::Clusters::DoorLock::Commands::ClearAllRfidsResponse::DecodableType & data)
 {
     ChipLogProgress(Zcl, "Received ClearAllRfidsResponse:");
-    ChipLogProgress(Zcl, "  status: %" PRIu8 "", data.status);
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("status", 1, data.status);
+    }
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
+    command->SetCommandExitStatus(err);
 };
 
 static void OnDoorLockClearHolidayScheduleResponseSuccess(
     void * context, const chip::app::Clusters::DoorLock::Commands::ClearHolidayScheduleResponse::DecodableType & data)
 {
     ChipLogProgress(Zcl, "Received ClearHolidayScheduleResponse:");
-    ChipLogProgress(Zcl, "  status: %" PRIu8 "", data.status);
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("status", 1, data.status);
+    }
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
+    command->SetCommandExitStatus(err);
 };
 
 static void OnDoorLockClearPinResponseSuccess(void * context,
                                               const chip::app::Clusters::DoorLock::Commands::ClearPinResponse::DecodableType & data)
 {
     ChipLogProgress(Zcl, "Received ClearPinResponse:");
-    ChipLogProgress(Zcl, "  status: %" PRIu8 "", data.status);
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("status", 1, data.status);
+    }
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
+    command->SetCommandExitStatus(err);
 };
 
 static void
@@ -1349,44 +2589,72 @@ OnDoorLockClearRfidResponseSuccess(void * context,
                                    const chip::app::Clusters::DoorLock::Commands::ClearRfidResponse::DecodableType & data)
 {
     ChipLogProgress(Zcl, "Received ClearRfidResponse:");
-    ChipLogProgress(Zcl, "  status: %" PRIu8 "", data.status);
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("status", 1, data.status);
+    }
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
+    command->SetCommandExitStatus(err);
 };
 
 static void OnDoorLockClearWeekdayScheduleResponseSuccess(
     void * context, const chip::app::Clusters::DoorLock::Commands::ClearWeekdayScheduleResponse::DecodableType & data)
 {
     ChipLogProgress(Zcl, "Received ClearWeekdayScheduleResponse:");
-    ChipLogProgress(Zcl, "  status: %" PRIu8 "", data.status);
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("status", 1, data.status);
+    }
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
+    command->SetCommandExitStatus(err);
 };
 
 static void OnDoorLockClearYeardayScheduleResponseSuccess(
     void * context, const chip::app::Clusters::DoorLock::Commands::ClearYeardayScheduleResponse::DecodableType & data)
 {
     ChipLogProgress(Zcl, "Received ClearYeardayScheduleResponse:");
-    ChipLogProgress(Zcl, "  status: %" PRIu8 "", data.status);
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("status", 1, data.status);
+    }
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
+    command->SetCommandExitStatus(err);
 };
 
 static void OnDoorLockGetHolidayScheduleResponseSuccess(
     void * context, const chip::app::Clusters::DoorLock::Commands::GetHolidayScheduleResponse::DecodableType & data)
 {
     ChipLogProgress(Zcl, "Received GetHolidayScheduleResponse:");
-    ChipLogProgress(Zcl, "  scheduleId: %" PRIu8 "", data.scheduleId);
-    ChipLogProgress(Zcl, "  status: %" PRIu8 "", data.status);
-    ChipLogProgress(Zcl, "  localStartTime: %" PRIu32 "", data.localStartTime);
-    ChipLogProgress(Zcl, "  localEndTime: %" PRIu32 "", data.localEndTime);
-    ChipLogProgress(Zcl, "  operatingModeDuringHoliday: %" PRIu8 "", data.operatingModeDuringHoliday);
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("scheduleId", 1, data.scheduleId);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("status", 1, data.status);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("localStartTime", 1, data.localStartTime);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("localEndTime", 1, data.localEndTime);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("operatingModeDuringHoliday", 1, data.operatingModeDuringHoliday);
+    }
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
+    command->SetCommandExitStatus(err);
 };
 
 static void
@@ -1394,42 +2662,90 @@ OnDoorLockGetLogRecordResponseSuccess(void * context,
                                       const chip::app::Clusters::DoorLock::Commands::GetLogRecordResponse::DecodableType & data)
 {
     ChipLogProgress(Zcl, "Received GetLogRecordResponse:");
-    ChipLogProgress(Zcl, "  logEntryId: %" PRIu16 "", data.logEntryId);
-    ChipLogProgress(Zcl, "  timestamp: %" PRIu32 "", data.timestamp);
-    ChipLogProgress(Zcl, "  eventType: %" PRIu8 "", data.eventType);
-    ChipLogProgress(Zcl, "  source: %" PRIu8 "", data.source);
-    ChipLogProgress(Zcl, "  eventIdOrAlarmCode: %" PRIu8 "", data.eventIdOrAlarmCode);
-    ChipLogProgress(Zcl, "  userId: %" PRIu16 "", data.userId);
-    ChipLogProgress(Zcl, "  pin: %zu", data.pin.size());
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("logEntryId", 1, data.logEntryId);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("timestamp", 1, data.timestamp);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("eventType", 1, data.eventType);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("source", 1, data.source);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("eventIdOrAlarmCode", 1, data.eventIdOrAlarmCode);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("userId", 1, data.userId);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("pin", 1, data.pin);
+    }
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
+    command->SetCommandExitStatus(err);
 };
 
 static void OnDoorLockGetPinResponseSuccess(void * context,
                                             const chip::app::Clusters::DoorLock::Commands::GetPinResponse::DecodableType & data)
 {
     ChipLogProgress(Zcl, "Received GetPinResponse:");
-    ChipLogProgress(Zcl, "  userId: %" PRIu16 "", data.userId);
-    ChipLogProgress(Zcl, "  userStatus: %" PRIu8 "", data.userStatus);
-    ChipLogProgress(Zcl, "  userType: %" PRIu8 "", data.userType);
-    ChipLogProgress(Zcl, "  pin: %zu", data.pin.size());
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("userId", 1, data.userId);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("userStatus", 1, data.userStatus);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("userType", 1, data.userType);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("pin", 1, data.pin);
+    }
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
+    command->SetCommandExitStatus(err);
 };
 
 static void OnDoorLockGetRfidResponseSuccess(void * context,
                                              const chip::app::Clusters::DoorLock::Commands::GetRfidResponse::DecodableType & data)
 {
     ChipLogProgress(Zcl, "Received GetRfidResponse:");
-    ChipLogProgress(Zcl, "  userId: %" PRIu16 "", data.userId);
-    ChipLogProgress(Zcl, "  userStatus: %" PRIu8 "", data.userStatus);
-    ChipLogProgress(Zcl, "  userType: %" PRIu8 "", data.userType);
-    ChipLogProgress(Zcl, "  rfid: %zu", data.rfid.size());
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("userId", 1, data.userId);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("userStatus", 1, data.userStatus);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("userType", 1, data.userType);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("rfid", 1, data.rfid);
+    }
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
+    command->SetCommandExitStatus(err);
 };
 
 static void
@@ -1437,82 +2753,146 @@ OnDoorLockGetUserTypeResponseSuccess(void * context,
                                      const chip::app::Clusters::DoorLock::Commands::GetUserTypeResponse::DecodableType & data)
 {
     ChipLogProgress(Zcl, "Received GetUserTypeResponse:");
-    ChipLogProgress(Zcl, "  userId: %" PRIu16 "", data.userId);
-    ChipLogProgress(Zcl, "  userType: %" PRIu8 "", data.userType);
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("userId", 1, data.userId);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("userType", 1, data.userType);
+    }
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
+    command->SetCommandExitStatus(err);
 };
 
 static void OnDoorLockGetWeekdayScheduleResponseSuccess(
     void * context, const chip::app::Clusters::DoorLock::Commands::GetWeekdayScheduleResponse::DecodableType & data)
 {
     ChipLogProgress(Zcl, "Received GetWeekdayScheduleResponse:");
-    ChipLogProgress(Zcl, "  scheduleId: %" PRIu8 "", data.scheduleId);
-    ChipLogProgress(Zcl, "  userId: %" PRIu16 "", data.userId);
-    ChipLogProgress(Zcl, "  status: %" PRIu8 "", data.status);
-    ChipLogProgress(Zcl, "  daysMask: %" PRIu8 "", data.daysMask);
-    ChipLogProgress(Zcl, "  startHour: %" PRIu8 "", data.startHour);
-    ChipLogProgress(Zcl, "  startMinute: %" PRIu8 "", data.startMinute);
-    ChipLogProgress(Zcl, "  endHour: %" PRIu8 "", data.endHour);
-    ChipLogProgress(Zcl, "  endMinute: %" PRIu8 "", data.endMinute);
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("scheduleId", 1, data.scheduleId);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("userId", 1, data.userId);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("status", 1, data.status);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("daysMask", 1, data.daysMask);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("startHour", 1, data.startHour);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("startMinute", 1, data.startMinute);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("endHour", 1, data.endHour);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("endMinute", 1, data.endMinute);
+    }
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
+    command->SetCommandExitStatus(err);
 };
 
 static void OnDoorLockGetYeardayScheduleResponseSuccess(
     void * context, const chip::app::Clusters::DoorLock::Commands::GetYeardayScheduleResponse::DecodableType & data)
 {
     ChipLogProgress(Zcl, "Received GetYeardayScheduleResponse:");
-    ChipLogProgress(Zcl, "  scheduleId: %" PRIu8 "", data.scheduleId);
-    ChipLogProgress(Zcl, "  userId: %" PRIu16 "", data.userId);
-    ChipLogProgress(Zcl, "  status: %" PRIu8 "", data.status);
-    ChipLogProgress(Zcl, "  localStartTime: %" PRIu32 "", data.localStartTime);
-    ChipLogProgress(Zcl, "  localEndTime: %" PRIu32 "", data.localEndTime);
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("scheduleId", 1, data.scheduleId);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("userId", 1, data.userId);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("status", 1, data.status);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("localStartTime", 1, data.localStartTime);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("localEndTime", 1, data.localEndTime);
+    }
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
+    command->SetCommandExitStatus(err);
 };
 
 static void OnDoorLockLockDoorResponseSuccess(void * context,
                                               const chip::app::Clusters::DoorLock::Commands::LockDoorResponse::DecodableType & data)
 {
     ChipLogProgress(Zcl, "Received LockDoorResponse:");
-    ChipLogProgress(Zcl, "  status: %" PRIu8 "", data.status);
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("status", 1, data.status);
+    }
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
+    command->SetCommandExitStatus(err);
 };
 
 static void OnDoorLockSetHolidayScheduleResponseSuccess(
     void * context, const chip::app::Clusters::DoorLock::Commands::SetHolidayScheduleResponse::DecodableType & data)
 {
     ChipLogProgress(Zcl, "Received SetHolidayScheduleResponse:");
-    ChipLogProgress(Zcl, "  status: %" PRIu8 "", data.status);
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("status", 1, data.status);
+    }
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
+    command->SetCommandExitStatus(err);
 };
 
 static void OnDoorLockSetPinResponseSuccess(void * context,
                                             const chip::app::Clusters::DoorLock::Commands::SetPinResponse::DecodableType & data)
 {
     ChipLogProgress(Zcl, "Received SetPinResponse:");
-    ChipLogProgress(Zcl, "  status: %" PRIu8 "", data.status);
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("status", 1, data.status);
+    }
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
+    command->SetCommandExitStatus(err);
 };
 
 static void OnDoorLockSetRfidResponseSuccess(void * context,
                                              const chip::app::Clusters::DoorLock::Commands::SetRfidResponse::DecodableType & data)
 {
     ChipLogProgress(Zcl, "Received SetRfidResponse:");
-    ChipLogProgress(Zcl, "  status: %" PRIu8 "", data.status);
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("status", 1, data.status);
+    }
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
+    command->SetCommandExitStatus(err);
 };
 
 static void
@@ -1520,30 +2900,42 @@ OnDoorLockSetUserTypeResponseSuccess(void * context,
                                      const chip::app::Clusters::DoorLock::Commands::SetUserTypeResponse::DecodableType & data)
 {
     ChipLogProgress(Zcl, "Received SetUserTypeResponse:");
-    ChipLogProgress(Zcl, "  status: %" PRIu8 "", data.status);
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("status", 1, data.status);
+    }
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
+    command->SetCommandExitStatus(err);
 };
 
 static void OnDoorLockSetWeekdayScheduleResponseSuccess(
     void * context, const chip::app::Clusters::DoorLock::Commands::SetWeekdayScheduleResponse::DecodableType & data)
 {
     ChipLogProgress(Zcl, "Received SetWeekdayScheduleResponse:");
-    ChipLogProgress(Zcl, "  status: %" PRIu8 "", data.status);
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("status", 1, data.status);
+    }
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
+    command->SetCommandExitStatus(err);
 };
 
 static void OnDoorLockSetYeardayScheduleResponseSuccess(
     void * context, const chip::app::Clusters::DoorLock::Commands::SetYeardayScheduleResponse::DecodableType & data)
 {
     ChipLogProgress(Zcl, "Received SetYeardayScheduleResponse:");
-    ChipLogProgress(Zcl, "  status: %" PRIu8 "", data.status);
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("status", 1, data.status);
+    }
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
+    command->SetCommandExitStatus(err);
 };
 
 static void
@@ -1551,76 +2943,122 @@ OnDoorLockUnlockDoorResponseSuccess(void * context,
                                     const chip::app::Clusters::DoorLock::Commands::UnlockDoorResponse::DecodableType & data)
 {
     ChipLogProgress(Zcl, "Received UnlockDoorResponse:");
-    ChipLogProgress(Zcl, "  status: %" PRIu8 "", data.status);
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("status", 1, data.status);
+    }
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
+    command->SetCommandExitStatus(err);
 };
 
 static void OnDoorLockUnlockWithTimeoutResponseSuccess(
     void * context, const chip::app::Clusters::DoorLock::Commands::UnlockWithTimeoutResponse::DecodableType & data)
 {
     ChipLogProgress(Zcl, "Received UnlockWithTimeoutResponse:");
-    ChipLogProgress(Zcl, "  status: %" PRIu8 "", data.status);
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("status", 1, data.status);
+    }
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
+    command->SetCommandExitStatus(err);
 };
 
 static void OnGeneralCommissioningArmFailSafeResponseSuccess(
     void * context, const chip::app::Clusters::GeneralCommissioning::Commands::ArmFailSafeResponse::DecodableType & data)
 {
     ChipLogProgress(Zcl, "Received ArmFailSafeResponse:");
-    ChipLogProgress(Zcl, "  errorCode: %" PRIu8 "", data.errorCode);
-    ChipLogProgress(Zcl, "  debugText: %.*s", static_cast<int>(data.debugText.size()), data.debugText.data());
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("errorCode", 1, data.errorCode);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("debugText", 1, data.debugText);
+    }
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
+    command->SetCommandExitStatus(err);
 };
 
 static void OnGeneralCommissioningCommissioningCompleteResponseSuccess(
     void * context, const chip::app::Clusters::GeneralCommissioning::Commands::CommissioningCompleteResponse::DecodableType & data)
 {
     ChipLogProgress(Zcl, "Received CommissioningCompleteResponse:");
-    ChipLogProgress(Zcl, "  errorCode: %" PRIu8 "", data.errorCode);
-    ChipLogProgress(Zcl, "  debugText: %.*s", static_cast<int>(data.debugText.size()), data.debugText.data());
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("errorCode", 1, data.errorCode);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("debugText", 1, data.debugText);
+    }
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
+    command->SetCommandExitStatus(err);
 };
 
 static void OnGeneralCommissioningSetRegulatoryConfigResponseSuccess(
     void * context, const chip::app::Clusters::GeneralCommissioning::Commands::SetRegulatoryConfigResponse::DecodableType & data)
 {
     ChipLogProgress(Zcl, "Received SetRegulatoryConfigResponse:");
-    ChipLogProgress(Zcl, "  errorCode: %" PRIu8 "", data.errorCode);
-    ChipLogProgress(Zcl, "  debugText: %.*s", static_cast<int>(data.debugText.size()), data.debugText.data());
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("errorCode", 1, data.errorCode);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("debugText", 1, data.debugText);
+    }
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
+    command->SetCommandExitStatus(err);
 };
 
 static void OnGroupsAddGroupResponseSuccess(void * context,
                                             const chip::app::Clusters::Groups::Commands::AddGroupResponse::DecodableType & data)
 {
     ChipLogProgress(Zcl, "Received AddGroupResponse:");
-    ChipLogProgress(Zcl, "  status: %" PRIu8 "", data.status);
-    ChipLogProgress(Zcl, "  groupId: %" PRIu16 "", data.groupId);
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("status", 1, data.status);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("groupId", 1, data.groupId);
+    }
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
+    command->SetCommandExitStatus(err);
 };
 
 static void OnGroupsGetGroupMembershipResponseSuccess(
     void * context, const chip::app::Clusters::Groups::Commands::GetGroupMembershipResponse::DecodableType & data)
 {
     ChipLogProgress(Zcl, "Received GetGroupMembershipResponse:");
-    ChipLogProgress(Zcl, "  capacity: %" PRIu8 "", data.capacity);
-    ChipLogProgress(Zcl, "  groupCount: %" PRIu8 "", data.groupCount);
-    ChipLogProgress(Zcl, "  groupList: Array printing is not implemented yet.");
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("capacity", 1, data.capacity);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("groupCount", 1, data.groupCount);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("groupList", 1, data.groupList);
+    }
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
+    command->SetCommandExitStatus(err);
 };
 
 static void
@@ -1628,23 +3066,40 @@ OnGroupsRemoveGroupResponseSuccess(void * context,
                                    const chip::app::Clusters::Groups::Commands::RemoveGroupResponse::DecodableType & data)
 {
     ChipLogProgress(Zcl, "Received RemoveGroupResponse:");
-    ChipLogProgress(Zcl, "  status: %" PRIu8 "", data.status);
-    ChipLogProgress(Zcl, "  groupId: %" PRIu16 "", data.groupId);
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("status", 1, data.status);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("groupId", 1, data.groupId);
+    }
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
+    command->SetCommandExitStatus(err);
 };
 
 static void OnGroupsViewGroupResponseSuccess(void * context,
                                              const chip::app::Clusters::Groups::Commands::ViewGroupResponse::DecodableType & data)
 {
     ChipLogProgress(Zcl, "Received ViewGroupResponse:");
-    ChipLogProgress(Zcl, "  status: %" PRIu8 "", data.status);
-    ChipLogProgress(Zcl, "  groupId: %" PRIu16 "", data.groupId);
-    ChipLogProgress(Zcl, "  groupName: %.*s", static_cast<int>(data.groupName.size()), data.groupName.data());
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("status", 1, data.status);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("groupId", 1, data.groupId);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("groupName", 1, data.groupName);
+    }
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
+    command->SetCommandExitStatus(err);
 };
 
 static void
@@ -1652,10 +3107,14 @@ OnIdentifyIdentifyQueryResponseSuccess(void * context,
                                        const chip::app::Clusters::Identify::Commands::IdentifyQueryResponse::DecodableType & data)
 {
     ChipLogProgress(Zcl, "Received IdentifyQueryResponse:");
-    ChipLogProgress(Zcl, "  timeout: %" PRIu16 "", data.timeout);
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("timeout", 1, data.timeout);
+    }
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
+    command->SetCommandExitStatus(err);
 };
 
 static void
@@ -1663,20 +3122,28 @@ OnKeypadInputSendKeyResponseSuccess(void * context,
                                     const chip::app::Clusters::KeypadInput::Commands::SendKeyResponse::DecodableType & data)
 {
     ChipLogProgress(Zcl, "Received SendKeyResponse:");
-    ChipLogProgress(Zcl, "  status: %" PRIu8 "", data.status);
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("status", 1, data.status);
+    }
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
+    command->SetCommandExitStatus(err);
 };
 
 static void OnMediaPlaybackMediaFastForwardResponseSuccess(
     void * context, const chip::app::Clusters::MediaPlayback::Commands::MediaFastForwardResponse::DecodableType & data)
 {
     ChipLogProgress(Zcl, "Received MediaFastForwardResponse:");
-    ChipLogProgress(Zcl, "  mediaPlaybackStatus: %" PRIu8 "", data.mediaPlaybackStatus);
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("mediaPlaybackStatus", 1, data.mediaPlaybackStatus);
+    }
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
+    command->SetCommandExitStatus(err);
 };
 
 static void
@@ -1684,20 +3151,28 @@ OnMediaPlaybackMediaNextResponseSuccess(void * context,
                                         const chip::app::Clusters::MediaPlayback::Commands::MediaNextResponse::DecodableType & data)
 {
     ChipLogProgress(Zcl, "Received MediaNextResponse:");
-    ChipLogProgress(Zcl, "  mediaPlaybackStatus: %" PRIu8 "", data.mediaPlaybackStatus);
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("mediaPlaybackStatus", 1, data.mediaPlaybackStatus);
+    }
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
+    command->SetCommandExitStatus(err);
 };
 
 static void OnMediaPlaybackMediaPauseResponseSuccess(
     void * context, const chip::app::Clusters::MediaPlayback::Commands::MediaPauseResponse::DecodableType & data)
 {
     ChipLogProgress(Zcl, "Received MediaPauseResponse:");
-    ChipLogProgress(Zcl, "  mediaPlaybackStatus: %" PRIu8 "", data.mediaPlaybackStatus);
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("mediaPlaybackStatus", 1, data.mediaPlaybackStatus);
+    }
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
+    command->SetCommandExitStatus(err);
 };
 
 static void
@@ -1705,30 +3180,42 @@ OnMediaPlaybackMediaPlayResponseSuccess(void * context,
                                         const chip::app::Clusters::MediaPlayback::Commands::MediaPlayResponse::DecodableType & data)
 {
     ChipLogProgress(Zcl, "Received MediaPlayResponse:");
-    ChipLogProgress(Zcl, "  mediaPlaybackStatus: %" PRIu8 "", data.mediaPlaybackStatus);
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("mediaPlaybackStatus", 1, data.mediaPlaybackStatus);
+    }
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
+    command->SetCommandExitStatus(err);
 };
 
 static void OnMediaPlaybackMediaPreviousResponseSuccess(
     void * context, const chip::app::Clusters::MediaPlayback::Commands::MediaPreviousResponse::DecodableType & data)
 {
     ChipLogProgress(Zcl, "Received MediaPreviousResponse:");
-    ChipLogProgress(Zcl, "  mediaPlaybackStatus: %" PRIu8 "", data.mediaPlaybackStatus);
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("mediaPlaybackStatus", 1, data.mediaPlaybackStatus);
+    }
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
+    command->SetCommandExitStatus(err);
 };
 
 static void OnMediaPlaybackMediaRewindResponseSuccess(
     void * context, const chip::app::Clusters::MediaPlayback::Commands::MediaRewindResponse::DecodableType & data)
 {
     ChipLogProgress(Zcl, "Received MediaRewindResponse:");
-    ChipLogProgress(Zcl, "  mediaPlaybackStatus: %" PRIu8 "", data.mediaPlaybackStatus);
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("mediaPlaybackStatus", 1, data.mediaPlaybackStatus);
+    }
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
+    command->SetCommandExitStatus(err);
 };
 
 static void
@@ -1736,40 +3223,56 @@ OnMediaPlaybackMediaSeekResponseSuccess(void * context,
                                         const chip::app::Clusters::MediaPlayback::Commands::MediaSeekResponse::DecodableType & data)
 {
     ChipLogProgress(Zcl, "Received MediaSeekResponse:");
-    ChipLogProgress(Zcl, "  mediaPlaybackStatus: %" PRIu8 "", data.mediaPlaybackStatus);
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("mediaPlaybackStatus", 1, data.mediaPlaybackStatus);
+    }
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
+    command->SetCommandExitStatus(err);
 };
 
 static void OnMediaPlaybackMediaSkipBackwardResponseSuccess(
     void * context, const chip::app::Clusters::MediaPlayback::Commands::MediaSkipBackwardResponse::DecodableType & data)
 {
     ChipLogProgress(Zcl, "Received MediaSkipBackwardResponse:");
-    ChipLogProgress(Zcl, "  mediaPlaybackStatus: %" PRIu8 "", data.mediaPlaybackStatus);
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("mediaPlaybackStatus", 1, data.mediaPlaybackStatus);
+    }
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
+    command->SetCommandExitStatus(err);
 };
 
 static void OnMediaPlaybackMediaSkipForwardResponseSuccess(
     void * context, const chip::app::Clusters::MediaPlayback::Commands::MediaSkipForwardResponse::DecodableType & data)
 {
     ChipLogProgress(Zcl, "Received MediaSkipForwardResponse:");
-    ChipLogProgress(Zcl, "  mediaPlaybackStatus: %" PRIu8 "", data.mediaPlaybackStatus);
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("mediaPlaybackStatus", 1, data.mediaPlaybackStatus);
+    }
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
+    command->SetCommandExitStatus(err);
 };
 
 static void OnMediaPlaybackMediaStartOverResponseSuccess(
     void * context, const chip::app::Clusters::MediaPlayback::Commands::MediaStartOverResponse::DecodableType & data)
 {
     ChipLogProgress(Zcl, "Received MediaStartOverResponse:");
-    ChipLogProgress(Zcl, "  mediaPlaybackStatus: %" PRIu8 "", data.mediaPlaybackStatus);
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("mediaPlaybackStatus", 1, data.mediaPlaybackStatus);
+    }
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
+    command->SetCommandExitStatus(err);
 };
 
 static void
@@ -1777,198 +3280,350 @@ OnMediaPlaybackMediaStopResponseSuccess(void * context,
                                         const chip::app::Clusters::MediaPlayback::Commands::MediaStopResponse::DecodableType & data)
 {
     ChipLogProgress(Zcl, "Received MediaStopResponse:");
-    ChipLogProgress(Zcl, "  mediaPlaybackStatus: %" PRIu8 "", data.mediaPlaybackStatus);
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("mediaPlaybackStatus", 1, data.mediaPlaybackStatus);
+    }
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
+    command->SetCommandExitStatus(err);
 };
 
 static void OnNetworkCommissioningAddThreadNetworkResponseSuccess(
     void * context, const chip::app::Clusters::NetworkCommissioning::Commands::AddThreadNetworkResponse::DecodableType & data)
 {
     ChipLogProgress(Zcl, "Received AddThreadNetworkResponse:");
-    ChipLogProgress(Zcl, "  errorCode: %" PRIu8 "", data.errorCode);
-    ChipLogProgress(Zcl, "  debugText: %.*s", static_cast<int>(data.debugText.size()), data.debugText.data());
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("errorCode", 1, data.errorCode);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("debugText", 1, data.debugText);
+    }
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
+    command->SetCommandExitStatus(err);
 };
 
 static void OnNetworkCommissioningAddWiFiNetworkResponseSuccess(
     void * context, const chip::app::Clusters::NetworkCommissioning::Commands::AddWiFiNetworkResponse::DecodableType & data)
 {
     ChipLogProgress(Zcl, "Received AddWiFiNetworkResponse:");
-    ChipLogProgress(Zcl, "  errorCode: %" PRIu8 "", data.errorCode);
-    ChipLogProgress(Zcl, "  debugText: %.*s", static_cast<int>(data.debugText.size()), data.debugText.data());
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("errorCode", 1, data.errorCode);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("debugText", 1, data.debugText);
+    }
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
+    command->SetCommandExitStatus(err);
 };
 
 static void OnNetworkCommissioningDisableNetworkResponseSuccess(
     void * context, const chip::app::Clusters::NetworkCommissioning::Commands::DisableNetworkResponse::DecodableType & data)
 {
     ChipLogProgress(Zcl, "Received DisableNetworkResponse:");
-    ChipLogProgress(Zcl, "  errorCode: %" PRIu8 "", data.errorCode);
-    ChipLogProgress(Zcl, "  debugText: %.*s", static_cast<int>(data.debugText.size()), data.debugText.data());
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("errorCode", 1, data.errorCode);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("debugText", 1, data.debugText);
+    }
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
+    command->SetCommandExitStatus(err);
 };
 
 static void OnNetworkCommissioningEnableNetworkResponseSuccess(
     void * context, const chip::app::Clusters::NetworkCommissioning::Commands::EnableNetworkResponse::DecodableType & data)
 {
     ChipLogProgress(Zcl, "Received EnableNetworkResponse:");
-    ChipLogProgress(Zcl, "  errorCode: %" PRIu8 "", data.errorCode);
-    ChipLogProgress(Zcl, "  debugText: %.*s", static_cast<int>(data.debugText.size()), data.debugText.data());
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("errorCode", 1, data.errorCode);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("debugText", 1, data.debugText);
+    }
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
+    command->SetCommandExitStatus(err);
 };
 
 static void OnNetworkCommissioningRemoveNetworkResponseSuccess(
     void * context, const chip::app::Clusters::NetworkCommissioning::Commands::RemoveNetworkResponse::DecodableType & data)
 {
     ChipLogProgress(Zcl, "Received RemoveNetworkResponse:");
-    ChipLogProgress(Zcl, "  errorCode: %" PRIu8 "", data.errorCode);
-    ChipLogProgress(Zcl, "  debugText: %.*s", static_cast<int>(data.debugText.size()), data.debugText.data());
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("errorCode", 1, data.errorCode);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("debugText", 1, data.debugText);
+    }
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
+    command->SetCommandExitStatus(err);
 };
 
 static void OnNetworkCommissioningScanNetworksResponseSuccess(
     void * context, const chip::app::Clusters::NetworkCommissioning::Commands::ScanNetworksResponse::DecodableType & data)
 {
     ChipLogProgress(Zcl, "Received ScanNetworksResponse:");
-    ChipLogProgress(Zcl, "  errorCode: %" PRIu8 "", data.errorCode);
-    ChipLogProgress(Zcl, "  debugText: %.*s", static_cast<int>(data.debugText.size()), data.debugText.data());
-    ChipLogProgress(Zcl, "  wifiScanResults: Array printing is not implemented yet.");
-    ChipLogProgress(Zcl, "  threadScanResults: Array printing is not implemented yet.");
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("errorCode", 1, data.errorCode);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("debugText", 1, data.debugText);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("wifiScanResults", 1, data.wifiScanResults);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("threadScanResults", 1, data.threadScanResults);
+    }
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
+    command->SetCommandExitStatus(err);
 };
 
 static void OnNetworkCommissioningUpdateThreadNetworkResponseSuccess(
     void * context, const chip::app::Clusters::NetworkCommissioning::Commands::UpdateThreadNetworkResponse::DecodableType & data)
 {
     ChipLogProgress(Zcl, "Received UpdateThreadNetworkResponse:");
-    ChipLogProgress(Zcl, "  errorCode: %" PRIu8 "", data.errorCode);
-    ChipLogProgress(Zcl, "  debugText: %.*s", static_cast<int>(data.debugText.size()), data.debugText.data());
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("errorCode", 1, data.errorCode);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("debugText", 1, data.debugText);
+    }
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
+    command->SetCommandExitStatus(err);
 };
 
 static void OnNetworkCommissioningUpdateWiFiNetworkResponseSuccess(
     void * context, const chip::app::Clusters::NetworkCommissioning::Commands::UpdateWiFiNetworkResponse::DecodableType & data)
 {
     ChipLogProgress(Zcl, "Received UpdateWiFiNetworkResponse:");
-    ChipLogProgress(Zcl, "  errorCode: %" PRIu8 "", data.errorCode);
-    ChipLogProgress(Zcl, "  debugText: %.*s", static_cast<int>(data.debugText.size()), data.debugText.data());
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("errorCode", 1, data.errorCode);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("debugText", 1, data.debugText);
+    }
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
+    command->SetCommandExitStatus(err);
 };
 
 static void OnOtaSoftwareUpdateProviderApplyUpdateResponseSuccess(
     void * context, const chip::app::Clusters::OtaSoftwareUpdateProvider::Commands::ApplyUpdateResponse::DecodableType & data)
 {
     ChipLogProgress(Zcl, "Received ApplyUpdateResponse:");
-    ChipLogProgress(Zcl, "  action: %" PRIu8 "", data.action);
-    ChipLogProgress(Zcl, "  delayedActionTime: %" PRIu32 "", data.delayedActionTime);
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("action", 1, data.action);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("delayedActionTime", 1, data.delayedActionTime);
+    }
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
+    command->SetCommandExitStatus(err);
 };
 
 static void OnOtaSoftwareUpdateProviderQueryImageResponseSuccess(
     void * context, const chip::app::Clusters::OtaSoftwareUpdateProvider::Commands::QueryImageResponse::DecodableType & data)
 {
     ChipLogProgress(Zcl, "Received QueryImageResponse:");
-    ChipLogProgress(Zcl, "  status: %" PRIu8 "", data.status);
-    ChipLogProgress(Zcl, "  delayedActionTime: Optional printing is not implemented yet.");
-    ChipLogProgress(Zcl, "  imageURI: Optional printing is not implemented yet.");
-    ChipLogProgress(Zcl, "  softwareVersion: Optional printing is not implemented yet.");
-    ChipLogProgress(Zcl, "  softwareVersionString: Optional printing is not implemented yet.");
-    ChipLogProgress(Zcl, "  updateToken: Optional printing is not implemented yet.");
-    ChipLogProgress(Zcl, "  userConsentNeeded: Optional printing is not implemented yet.");
-    ChipLogProgress(Zcl, "  metadataForRequestor: Optional printing is not implemented yet.");
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("status", 1, data.status);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("delayedActionTime", 1, data.delayedActionTime);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("imageURI", 1, data.imageURI);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("softwareVersion", 1, data.softwareVersion);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("softwareVersionString", 1, data.softwareVersionString);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("updateToken", 1, data.updateToken);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("userConsentNeeded", 1, data.userConsentNeeded);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("metadataForRequestor", 1, data.metadataForRequestor);
+    }
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
+    command->SetCommandExitStatus(err);
 };
 
 static void OnOperationalCredentialsAttestationResponseSuccess(
     void * context, const chip::app::Clusters::OperationalCredentials::Commands::AttestationResponse::DecodableType & data)
 {
     ChipLogProgress(Zcl, "Received AttestationResponse:");
-    ChipLogProgress(Zcl, "  AttestationElements: %zu", data.attestationElements.size());
-    ChipLogProgress(Zcl, "  Signature: %zu", data.signature.size());
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("attestationElements", 1, data.attestationElements);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("signature", 1, data.signature);
+    }
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
+    command->SetCommandExitStatus(err);
 };
 
 static void OnOperationalCredentialsCertificateChainResponseSuccess(
     void * context, const chip::app::Clusters::OperationalCredentials::Commands::CertificateChainResponse::DecodableType & data)
 {
     ChipLogProgress(Zcl, "Received CertificateChainResponse:");
-    ChipLogProgress(Zcl, "  Certificate: %zu", data.certificate.size());
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("certificate", 1, data.certificate);
+    }
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
+    command->SetCommandExitStatus(err);
 };
 
 static void OnOperationalCredentialsNOCResponseSuccess(
     void * context, const chip::app::Clusters::OperationalCredentials::Commands::NOCResponse::DecodableType & data)
 {
     ChipLogProgress(Zcl, "Received NOCResponse:");
-    ChipLogProgress(Zcl, "  StatusCode: %" PRIu8 "", data.statusCode);
-    ChipLogProgress(Zcl, "  FabricIndex: %" PRIu8 "", data.fabricIndex);
-    ChipLogProgress(Zcl, "  DebugText: %.*s", static_cast<int>(data.debugText.size()), data.debugText.data());
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("statusCode", 1, data.statusCode);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("fabricIndex", 1, data.fabricIndex);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("debugText", 1, data.debugText);
+    }
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
+    command->SetCommandExitStatus(err);
 };
 
 static void OnOperationalCredentialsOpCSRResponseSuccess(
     void * context, const chip::app::Clusters::OperationalCredentials::Commands::OpCSRResponse::DecodableType & data)
 {
     ChipLogProgress(Zcl, "Received OpCSRResponse:");
-    ChipLogProgress(Zcl, "  NOCSRElements: %zu", data.NOCSRElements.size());
-    ChipLogProgress(Zcl, "  AttestationSignature: %zu", data.attestationSignature.size());
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("NOCSRElements", 1, data.NOCSRElements);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("attestationSignature", 1, data.attestationSignature);
+    }
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
+    command->SetCommandExitStatus(err);
 };
 
 static void OnScenesAddSceneResponseSuccess(void * context,
                                             const chip::app::Clusters::Scenes::Commands::AddSceneResponse::DecodableType & data)
 {
     ChipLogProgress(Zcl, "Received AddSceneResponse:");
-    ChipLogProgress(Zcl, "  status: %" PRIu8 "", data.status);
-    ChipLogProgress(Zcl, "  groupId: %" PRIu16 "", data.groupId);
-    ChipLogProgress(Zcl, "  sceneId: %" PRIu8 "", data.sceneId);
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("status", 1, data.status);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("groupId", 1, data.groupId);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("sceneId", 1, data.sceneId);
+    }
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
+    command->SetCommandExitStatus(err);
 };
 
 static void OnScenesGetSceneMembershipResponseSuccess(
     void * context, const chip::app::Clusters::Scenes::Commands::GetSceneMembershipResponse::DecodableType & data)
 {
     ChipLogProgress(Zcl, "Received GetSceneMembershipResponse:");
-    ChipLogProgress(Zcl, "  status: %" PRIu8 "", data.status);
-    ChipLogProgress(Zcl, "  capacity: %" PRIu8 "", data.capacity);
-    ChipLogProgress(Zcl, "  groupId: %" PRIu16 "", data.groupId);
-    ChipLogProgress(Zcl, "  sceneCount: %" PRIu8 "", data.sceneCount);
-    ChipLogProgress(Zcl, "  sceneList: Array printing is not implemented yet.");
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("status", 1, data.status);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("capacity", 1, data.capacity);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("groupId", 1, data.groupId);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("sceneCount", 1, data.sceneCount);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("sceneList", 1, data.sceneList);
+    }
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
+    command->SetCommandExitStatus(err);
 };
 
 static void
@@ -1976,11 +3631,18 @@ OnScenesRemoveAllScenesResponseSuccess(void * context,
                                        const chip::app::Clusters::Scenes::Commands::RemoveAllScenesResponse::DecodableType & data)
 {
     ChipLogProgress(Zcl, "Received RemoveAllScenesResponse:");
-    ChipLogProgress(Zcl, "  status: %" PRIu8 "", data.status);
-    ChipLogProgress(Zcl, "  groupId: %" PRIu16 "", data.groupId);
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("status", 1, data.status);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("groupId", 1, data.groupId);
+    }
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
+    command->SetCommandExitStatus(err);
 };
 
 static void
@@ -1988,39 +3650,78 @@ OnScenesRemoveSceneResponseSuccess(void * context,
                                    const chip::app::Clusters::Scenes::Commands::RemoveSceneResponse::DecodableType & data)
 {
     ChipLogProgress(Zcl, "Received RemoveSceneResponse:");
-    ChipLogProgress(Zcl, "  status: %" PRIu8 "", data.status);
-    ChipLogProgress(Zcl, "  groupId: %" PRIu16 "", data.groupId);
-    ChipLogProgress(Zcl, "  sceneId: %" PRIu8 "", data.sceneId);
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("status", 1, data.status);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("groupId", 1, data.groupId);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("sceneId", 1, data.sceneId);
+    }
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
+    command->SetCommandExitStatus(err);
 };
 
 static void OnScenesStoreSceneResponseSuccess(void * context,
                                               const chip::app::Clusters::Scenes::Commands::StoreSceneResponse::DecodableType & data)
 {
     ChipLogProgress(Zcl, "Received StoreSceneResponse:");
-    ChipLogProgress(Zcl, "  status: %" PRIu8 "", data.status);
-    ChipLogProgress(Zcl, "  groupId: %" PRIu16 "", data.groupId);
-    ChipLogProgress(Zcl, "  sceneId: %" PRIu8 "", data.sceneId);
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("status", 1, data.status);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("groupId", 1, data.groupId);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("sceneId", 1, data.sceneId);
+    }
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
+    command->SetCommandExitStatus(err);
 };
 
 static void OnScenesViewSceneResponseSuccess(void * context,
                                              const chip::app::Clusters::Scenes::Commands::ViewSceneResponse::DecodableType & data)
 {
     ChipLogProgress(Zcl, "Received ViewSceneResponse:");
-    ChipLogProgress(Zcl, "  status: %" PRIu8 "", data.status);
-    ChipLogProgress(Zcl, "  groupId: %" PRIu16 "", data.groupId);
-    ChipLogProgress(Zcl, "  sceneId: %" PRIu8 "", data.sceneId);
-    ChipLogProgress(Zcl, "  transitionTime: %" PRIu16 "", data.transitionTime);
-    ChipLogProgress(Zcl, "  sceneName: %.*s", static_cast<int>(data.sceneName.size()), data.sceneName.data());
-    ChipLogProgress(Zcl, "  extensionFieldSets: Array printing is not implemented yet.");
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("status", 1, data.status);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("groupId", 1, data.groupId);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("sceneId", 1, data.sceneId);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("transitionTime", 1, data.transitionTime);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("sceneName", 1, data.sceneName);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("extensionFieldSets", 1, data.extensionFieldSets);
+    }
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
+    command->SetCommandExitStatus(err);
 };
 
 static void
@@ -2028,22 +3729,36 @@ OnTvChannelChangeChannelResponseSuccess(void * context,
                                         const chip::app::Clusters::TvChannel::Commands::ChangeChannelResponse::DecodableType & data)
 {
     ChipLogProgress(Zcl, "Received ChangeChannelResponse:");
-    ChipLogProgress(Zcl, "  ChannelMatch: Array printing is not implemented yet.");
-    ChipLogProgress(Zcl, "  ErrorType: %" PRIu8 "", data.errorType);
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("channelMatch", 1, data.channelMatch);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("errorType", 1, data.errorType);
+    }
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
+    command->SetCommandExitStatus(err);
 };
 
 static void OnTargetNavigatorNavigateTargetResponseSuccess(
     void * context, const chip::app::Clusters::TargetNavigator::Commands::NavigateTargetResponse::DecodableType & data)
 {
     ChipLogProgress(Zcl, "Received NavigateTargetResponse:");
-    ChipLogProgress(Zcl, "  status: %" PRIu8 "", data.status);
-    ChipLogProgress(Zcl, "  data: %.*s", static_cast<int>(data.data.size()), data.data.data());
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("status", 1, data.status);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("data", 1, data.data);
+    }
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
+    command->SetCommandExitStatus(err);
 };
 
 static void
@@ -2051,20 +3766,28 @@ OnTestClusterBooleanResponseSuccess(void * context,
                                     const chip::app::Clusters::TestCluster::Commands::BooleanResponse::DecodableType & data)
 {
     ChipLogProgress(Zcl, "Received BooleanResponse:");
-    ChipLogProgress(Zcl, "  value: %d", data.value);
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("value", 1, data.value);
+    }
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
+    command->SetCommandExitStatus(err);
 };
 
 static void OnTestClusterTestAddArgumentsResponseSuccess(
     void * context, const chip::app::Clusters::TestCluster::Commands::TestAddArgumentsResponse::DecodableType & data)
 {
     ChipLogProgress(Zcl, "Received TestAddArgumentsResponse:");
-    ChipLogProgress(Zcl, "  returnValue: %" PRIu8 "", data.returnValue);
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("returnValue", 1, data.returnValue);
+    }
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
+    command->SetCommandExitStatus(err);
 };
 
 static void
@@ -2072,44 +3795,72 @@ OnTestClusterTestEnumsResponseSuccess(void * context,
                                       const chip::app::Clusters::TestCluster::Commands::TestEnumsResponse::DecodableType & data)
 {
     ChipLogProgress(Zcl, "Received TestEnumsResponse:");
-    ChipLogProgress(Zcl, "  arg1: %" PRIu16 "", data.arg1);
-    ChipLogProgress(Zcl, "  arg2: %" PRIu8 "", data.arg2);
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("arg1", 1, data.arg1);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("arg2", 1, data.arg2);
+    }
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
+    command->SetCommandExitStatus(err);
 };
 
 static void OnTestClusterTestListInt8UReverseResponseSuccess(
     void * context, const chip::app::Clusters::TestCluster::Commands::TestListInt8UReverseResponse::DecodableType & data)
 {
     ChipLogProgress(Zcl, "Received TestListInt8UReverseResponse:");
-    ChipLogProgress(Zcl, "  arg1: Array printing is not implemented yet.");
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("arg1", 1, data.arg1);
+    }
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
+    command->SetCommandExitStatus(err);
 };
 
 static void OnTestClusterTestNullableOptionalResponseSuccess(
     void * context, const chip::app::Clusters::TestCluster::Commands::TestNullableOptionalResponse::DecodableType & data)
 {
     ChipLogProgress(Zcl, "Received TestNullableOptionalResponse:");
-    ChipLogProgress(Zcl, "  wasPresent: %d", data.wasPresent);
-    ChipLogProgress(Zcl, "  wasNull: Optional printing is not implemented yet.");
-    ChipLogProgress(Zcl, "  value: Optional printing is not implemented yet.");
-    ChipLogProgress(Zcl, "  originalValue: Optional printing is not implemented yet.");
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("wasPresent", 1, data.wasPresent);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("wasNull", 1, data.wasNull);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("value", 1, data.value);
+    }
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("originalValue", 1, data.originalValue);
+    }
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
+    command->SetCommandExitStatus(err);
 };
 
 static void OnTestClusterTestSpecificResponseSuccess(
     void * context, const chip::app::Clusters::TestCluster::Commands::TestSpecificResponse::DecodableType & data)
 {
     ChipLogProgress(Zcl, "Received TestSpecificResponse:");
-    ChipLogProgress(Zcl, "  returnValue: %" PRIu8 "", data.returnValue);
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if (err == CHIP_NO_ERROR)
+    {
+        err = LogValue("returnValue", 1, data.returnValue);
+    }
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(CHIP_NO_ERROR);
+    command->SetCommandExitStatus(err);
 };
 
 /*----------------------------------------------------------------------------*\


### PR DESCRIPTION
Optional values, nullable types, etc, etc.

Fixes https://github.com/project-chip/connectedhomeip/issues/11214
Fixes https://github.com/project-chip/connectedhomeip/issues/11215

#### Problem
Command-line chip-tool received value logging can't handle all values: has trouble with structs and lists when they're nested deeply..

#### Change overview
Use helper functions to implement logging of arbitrary-nesting data structures.

#### Testing
Manually ran some chip-tool commands and observed the output.