### PR TITLE
[Android] Switch fragment coroutine scopes to use lifecycleScope

### DIFF
--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/BasicClientFragment.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/BasicClientFragment.kt
@@ -8,32 +8,30 @@ import android.view.ViewGroup
 import android.view.inputmethod.EditorInfo
 import android.widget.ArrayAdapter
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
 import chip.devicecontroller.ChipClusters
 import chip.devicecontroller.ChipClusters.BasicCluster
 import chip.devicecontroller.ChipDeviceController
 import com.google.chip.chiptool.ChipClient
 import com.google.chip.chiptool.GenericChipDeviceListener
 import com.google.chip.chiptool.R
-import kotlinx.android.synthetic.main.basic_client_fragment.basicClusterCommandStatus
-import kotlinx.android.synthetic.main.basic_client_fragment.userLabelEd
-import kotlinx.android.synthetic.main.basic_client_fragment.locationEd
 import kotlinx.android.synthetic.main.basic_client_fragment.attributeNameSpinner
-import kotlinx.android.synthetic.main.basic_client_fragment.view.writeUserLabelBtn
-import kotlinx.android.synthetic.main.basic_client_fragment.view.writeLocationBtn
-import kotlinx.android.synthetic.main.basic_client_fragment.view.writeLocalConfigDisabledSwitch
+import kotlinx.android.synthetic.main.basic_client_fragment.basicClusterCommandStatus
+import kotlinx.android.synthetic.main.basic_client_fragment.locationEd
+import kotlinx.android.synthetic.main.basic_client_fragment.userLabelEd
 import kotlinx.android.synthetic.main.basic_client_fragment.view.attributeNameSpinner
 import kotlinx.android.synthetic.main.basic_client_fragment.view.readAttributeBtn
+import kotlinx.android.synthetic.main.basic_client_fragment.view.writeLocalConfigDisabledSwitch
+import kotlinx.android.synthetic.main.basic_client_fragment.view.writeLocationBtn
+import kotlinx.android.synthetic.main.basic_client_fragment.view.writeUserLabelBtn
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 
 class BasicClientFragment : Fragment() {
   private val deviceController: ChipDeviceController
     get() = ChipClient.getDeviceController(requireContext())
 
-  private val scope = CoroutineScope(Dispatchers.Main + Job())
+  private lateinit var scope: CoroutineScope
 
   private lateinit var addressUpdateFragment: AddressUpdateFragment
 
@@ -42,6 +40,8 @@ class BasicClientFragment : Fragment() {
     container: ViewGroup?,
     savedInstanceState: Bundle?
   ): View {
+    scope = viewLifecycleOwner.lifecycleScope
+
     return inflater.inflate(R.layout.basic_client_fragment, container, false).apply {
       deviceController.setCompletionListener(ChipControllerCallback())
 
@@ -85,10 +85,6 @@ class BasicClientFragment : Fragment() {
     }
   }
 
-  override fun onStop() {
-    super.onStop()
-    scope.cancel()
-  }
 
   private fun makeAttributeNamesAdapter(): ArrayAdapter<String> {
     return ArrayAdapter(

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/MultiAdminClientFragment.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/MultiAdminClientFragment.kt
@@ -6,6 +6,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
 import chip.devicecontroller.ChipClusters
 import chip.devicecontroller.ChipDeviceController
 import com.google.chip.chiptool.ChipClient
@@ -24,7 +25,7 @@ class MultiAdminClientFragment : Fragment() {
   private val deviceController: ChipDeviceController
     get() = ChipClient.getDeviceController(requireContext())
 
-  private val scope = CoroutineScope(Dispatchers.Main + Job())
+  private lateinit var scope: CoroutineScope
 
   private lateinit var addressUpdateFragment: AddressUpdateFragment
 
@@ -33,6 +34,8 @@ class MultiAdminClientFragment : Fragment() {
     container: ViewGroup?,
     savedInstanceState: Bundle?
   ): View {
+    scope = viewLifecycleOwner.lifecycleScope
+
     return inflater.inflate(R.layout.multi_admin_client_fragment, container, false).apply {
       deviceController.setCompletionListener(ChipControllerCallback())
 
@@ -72,11 +75,6 @@ class MultiAdminClientFragment : Fragment() {
     override fun onError(error: Throwable?) {
       Log.d(TAG, "onError: $error")
     }
-  }
-
-  override fun onStop() {
-    super.onStop()
-    scope.cancel()
   }
 
   private suspend fun sendBasicCommissioningCommandClick() {

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/OnOffClientFragment.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/OnOffClientFragment.kt
@@ -11,6 +11,7 @@ import android.widget.EditText
 import android.widget.SeekBar
 import android.widget.Toast
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
 import chip.devicecontroller.ChipClusters
 import chip.devicecontroller.ChipClusters.OnOffCluster
 import chip.devicecontroller.ChipDeviceController
@@ -30,16 +31,14 @@ import kotlinx.android.synthetic.main.on_off_client_fragment.view.readBtn
 import kotlinx.android.synthetic.main.on_off_client_fragment.view.showSubscribeDialogBtn
 import kotlinx.android.synthetic.main.on_off_client_fragment.view.toggleBtn
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.cancel
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 
 class OnOffClientFragment : Fragment() {
   private val deviceController: ChipDeviceController
     get() = ChipClient.getDeviceController(requireContext())
 
-  private val scope = CoroutineScope(Dispatchers.Main + Job())
+  private lateinit var scope: CoroutineScope
 
   private lateinit var addressUpdateFragment: AddressUpdateFragment
 
@@ -48,6 +47,8 @@ class OnOffClientFragment : Fragment() {
     container: ViewGroup?,
     savedInstanceState: Bundle?
   ): View {
+    scope = viewLifecycleOwner.lifecycleScope
+
     return inflater.inflate(R.layout.on_off_client_fragment, container, false).apply {
       deviceController.setCompletionListener(ChipControllerCallback())
 
@@ -164,11 +165,6 @@ class OnOffClientFragment : Fragment() {
     override fun onError(error: Throwable?) {
       Log.d(TAG, "onError: $error")
     }
-  }
-
-  override fun onStop() {
-    super.onStop()
-    scope.cancel()
   }
 
   private suspend fun sendLevelCommandClick() {

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/OpCredClientFragment.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/OpCredClientFragment.kt
@@ -6,6 +6,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
 import chip.devicecontroller.ChipClusters
 import chip.devicecontroller.ChipDeviceController
 import com.google.chip.chiptool.ChipClient
@@ -15,16 +16,13 @@ import kotlinx.android.synthetic.main.op_cred_client_fragment.opCredClusterComma
 import kotlinx.android.synthetic.main.op_cred_client_fragment.view.readCommissionedFabricBtn
 import kotlinx.android.synthetic.main.op_cred_client_fragment.view.readSupportedFabricBtn
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 
 class OpCredClientFragment : Fragment() {
   private val deviceController: ChipDeviceController
     get() = ChipClient.getDeviceController(requireContext())
 
-  private val scope = CoroutineScope(Dispatchers.Main + Job())
+  private lateinit var scope: CoroutineScope
 
   private lateinit var addressUpdateFragment: AddressUpdateFragment
 
@@ -33,6 +31,8 @@ class OpCredClientFragment : Fragment() {
     container: ViewGroup?,
     savedInstanceState: Bundle?
   ): View {
+    scope = viewLifecycleOwner.lifecycleScope
+
     return inflater.inflate(R.layout.op_cred_client_fragment, container, false).apply {
       deviceController.setCompletionListener(ChipControllerCallback())
 
@@ -62,11 +62,6 @@ class OpCredClientFragment : Fragment() {
     override fun onError(error: Throwable?) {
       Log.d(TAG, "onError: $error")
     }
-  }
-
-  override fun onStop() {
-    super.onStop()
-    scope.cancel()
   }
 
   private suspend fun sendReadOpCredSupportedFabricAttrClick() {

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/SensorClientFragment.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/SensorClientFragment.kt
@@ -10,6 +10,7 @@ import android.widget.AdapterView
 import android.widget.ArrayAdapter
 import android.widget.Toast
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
 import chip.devicecontroller.ChipClusters
 import com.google.chip.chiptool.ChipClient
 import com.google.chip.chiptool.R
@@ -18,16 +19,26 @@ import com.jjoe64.graphview.LabelFormatter
 import com.jjoe64.graphview.Viewport
 import com.jjoe64.graphview.series.DataPoint
 import com.jjoe64.graphview.series.LineGraphSeries
-import kotlinx.android.synthetic.main.sensor_client_fragment.*
-import kotlinx.android.synthetic.main.sensor_client_fragment.view.*
-import kotlinx.coroutines.*
 import java.text.SimpleDateFormat
-import java.util.*
+import java.util.Calendar
+import java.util.Date
+import kotlinx.android.synthetic.main.sensor_client_fragment.clusterNameSpinner
+import kotlinx.android.synthetic.main.sensor_client_fragment.deviceIdEd
+import kotlinx.android.synthetic.main.sensor_client_fragment.endpointIdEd
+import kotlinx.android.synthetic.main.sensor_client_fragment.lastValueTv
+import kotlinx.android.synthetic.main.sensor_client_fragment.sensorGraph
+import kotlinx.android.synthetic.main.sensor_client_fragment.view.clusterNameSpinner
+import kotlinx.android.synthetic.main.sensor_client_fragment.view.readSensorBtn
+import kotlinx.android.synthetic.main.sensor_client_fragment.view.sensorGraph
+import kotlinx.android.synthetic.main.sensor_client_fragment.view.watchSensorBtn
+import kotlinx.android.synthetic.main.sensor_client_fragment.watchSensorBtn
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 
 private typealias ReadCallback = ChipClusters.IntegerAttributeCallback
 
 class SensorClientFragment : Fragment() {
-  private val scope = CoroutineScope(Dispatchers.Main + Job())
+  private lateinit var scope: CoroutineScope
 
   // History of sensor values
   private val sensorData = LineGraphSeries<DataPoint>()
@@ -40,6 +51,8 @@ class SensorClientFragment : Fragment() {
       container: ViewGroup?,
       savedInstanceState: Bundle?
   ): View {
+    scope = viewLifecycleOwner.lifecycleScope
+
     return inflater.inflate(R.layout.sensor_client_fragment, container, false).apply {
       ChipClient.getDeviceController(requireContext()).setCompletionListener(null)
       deviceIdEd.setOnEditorActionListener { textView, actionId, _ ->
@@ -97,7 +110,6 @@ class SensorClientFragment : Fragment() {
   }
 
   override fun onStop() {
-    scope.cancel()
     resetSensorGraph() // reset the graph on fragment exit
     super.onStop()
   }

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/clusterinteraction/ClusterDetailFragment.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/clusterinteraction/ClusterDetailFragment.kt
@@ -6,14 +6,12 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
 import chip.devicecontroller.ChipDeviceController
 import com.google.chip.chiptool.ChipClient
 import com.google.chip.chiptool.GenericChipDeviceListener
 import com.google.chip.chiptool.R
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.cancel
 
 /**
  * ClusterDetailFragment allows user to pick cluster, command, specify parameters and see
@@ -23,13 +21,15 @@ class ClusterDetailFragment : Fragment(){
   private val deviceController: ChipDeviceController
     get() = ChipClient.getDeviceController(requireContext())
 
-  private val scope = CoroutineScope(Dispatchers.Main + Job())
+  private lateinit var scope: CoroutineScope
 
   override fun onCreateView(
     inflater: LayoutInflater,
     container: ViewGroup?,
     savedInstanceState: Bundle?
   ): View {
+    scope = viewLifecycleOwner.lifecycleScope
+
     return inflater.inflate(R.layout.cluster_detail_fragment, container, false).apply {
       deviceController.setCompletionListener(GenericChipDeviceListener())
     }
@@ -39,11 +39,6 @@ class ClusterDetailFragment : Fragment(){
     requireActivity().runOnUiThread {
       Toast.makeText(requireContext(), msg, Toast.LENGTH_SHORT).show()
     }
-  }
-
-  override fun onStop() {
-    super.onStop()
-    scope.cancel()
   }
 
   companion object {

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/clusterinteraction/ClusterInteractionFragment.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/clusterinteraction/ClusterInteractionFragment.kt
@@ -7,27 +7,25 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import chip.clusterinfo.ClusterInfo
 import chip.devicecontroller.ChipDeviceController
+import chip.devicecontroller.ClusterInfoMapping
 import com.google.chip.chiptool.ChipClient
 import com.google.chip.chiptool.GenericChipDeviceListener
 import com.google.chip.chiptool.R
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.cancel
-import chip.devicecontroller.ClusterInfoMapping
 import com.google.chip.chiptool.clusterclient.AddressUpdateFragment
 import kotlinx.android.synthetic.main.cluster_interaction_fragment.view.endpointList
 import kotlinx.android.synthetic.main.cluster_interaction_fragment.view.getEndpointListBtn
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
 class ClusterInteractionFragment : Fragment() {
   private val deviceController: ChipDeviceController
     get() = ChipClient.getDeviceController(requireContext())
 
-  private val scope = CoroutineScope(Dispatchers.Main + Job())
+  private lateinit var scope: CoroutineScope
   private lateinit var addressUpdateFragment: AddressUpdateFragment
   private lateinit var clusterMap: Map<String, ClusterInfo>
 
@@ -36,6 +34,8 @@ class ClusterInteractionFragment : Fragment() {
     container: ViewGroup?,
     savedInstanceState: Bundle?
   ): View {
+    scope = viewLifecycleOwner.lifecycleScope
+
     return inflater.inflate(R.layout.cluster_interaction_fragment, container, false).apply {
       deviceController.setCompletionListener(ChipControllerCallback())
       getEndpointListBtn.setOnClickListener {
@@ -82,11 +82,6 @@ class ClusterInteractionFragment : Fragment() {
     override fun onError(error: Throwable?) {
       Log.d(TAG, "onError: $error")
     }
-  }
-
-  override fun onStop() {
-    super.onStop()
-    scope.cancel()
   }
 
   companion object {

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/provisioning/DeviceProvisioningFragment.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/provisioning/DeviceProvisioningFragment.kt
@@ -26,6 +26,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
 import com.google.chip.chiptool.ChipClient
 import com.google.chip.chiptool.GenericChipDeviceListener
 import com.google.chip.chiptool.R
@@ -34,10 +35,7 @@ import com.google.chip.chiptool.setuppayloadscanner.CHIPDeviceInfo
 import com.google.chip.chiptool.util.DeviceIdUtil
 import com.google.chip.chiptool.util.FragmentUtil
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 
 @ExperimentalCoroutinesApi
@@ -52,13 +50,14 @@ class DeviceProvisioningFragment : Fragment() {
       ProvisionNetworkType.fromName(arguments?.getString(ARG_PROVISION_NETWORK_TYPE))
     )
 
-  private val scope = CoroutineScope(Dispatchers.Main + Job())
+  private lateinit var scope: CoroutineScope
 
   override fun onCreateView(
     inflater: LayoutInflater,
     container: ViewGroup?,
     savedInstanceState: Bundle?
   ): View {
+    scope = viewLifecycleOwner.lifecycleScope
     deviceInfo = checkNotNull(requireArguments().getParcelable(ARG_DEVICE_INFO))
     return inflater.inflate(R.layout.single_fragment_container, container, false).apply {
       if (savedInstanceState == null) {
@@ -74,7 +73,6 @@ class DeviceProvisioningFragment : Fragment() {
   override fun onStop() {
     super.onStop()
     gatt = null
-    scope.cancel()
   }
 
   private fun pairDeviceWithAddress() {

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/provisioning/EnterNetworkFragment.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/provisioning/EnterNetworkFragment.kt
@@ -24,6 +24,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
 import chip.devicecontroller.ChipClusters.NetworkCommissioningCluster
 import com.google.chip.chiptool.ChipClient
 import com.google.chip.chiptool.R
@@ -37,8 +38,6 @@ import kotlinx.android.synthetic.main.enter_wifi_network_fragment.pwdEd
 import kotlinx.android.synthetic.main.enter_wifi_network_fragment.ssidEd
 import kotlinx.android.synthetic.main.enter_wifi_network_fragment.view.saveNetworkBtn
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 
 /**
@@ -46,7 +45,7 @@ import kotlinx.coroutines.launch
  */
 class EnterNetworkFragment : Fragment() {
 
-  private val scope = CoroutineScope(Dispatchers.Main + Job())
+  private lateinit var scope: CoroutineScope
 
   private val networkType: ProvisionNetworkType
     get() = requireNotNull(
@@ -58,6 +57,8 @@ class EnterNetworkFragment : Fragment() {
     container: ViewGroup?,
     savedInstanceState: Bundle?
   ): View? {
+    scope = viewLifecycleOwner.lifecycleScope
+
     val layoutRes = when (networkType) {
       ProvisionNetworkType.WIFI -> R.layout.enter_wifi_network_fragment
       ProvisionNetworkType.THREAD -> R.layout.enter_thread_network_fragment


### PR DESCRIPTION
#### Problem
* Fixes #11310
* Root cause is that `CoroutineScope` is not re-created after being canceled in `onStop()`.

#### Change overview
* Switch all fragments to `viewLifecycleOwner.lifecycleScope`, a `CoroutineScope` with a lifecycle tied to the fragment. No more manual management of `CoroutineScope` lifecycle required.

#### Testing
* Manual commission and control, after hitting the recents button, leaving the app, and returning to it.
