### PR TITLE
Increase CASE timeout to fix CI failures

### DIFF
--- a/src/protocols/secure_channel/CASESession.cpp
+++ b/src/protocols/secure_channel/CASESession.cpp
@@ -84,10 +84,10 @@ using HKDF_sha_crypto = HKDF_shaHSM;
 using HKDF_sha_crypto = HKDF_sha;
 #endif
 
-// Wait at most 10 seconds for the response from the peer.
+// Wait at most 30 seconds for the response from the peer.
 // This timeout value assumes the underlying transport is reliable.
 // The session establishment fails if the response is not received within timeout window.
-static constexpr ExchangeContext::Timeout kSigma_Response_Timeout = System::Clock::Seconds16(10);
+static constexpr ExchangeContext::Timeout kSigma_Response_Timeout = System::Clock::Seconds16(30);
 
 CASESession::CASESession()
 {


### PR DESCRIPTION
#### Problem
Darwin CI is failing sporadically in CASE establishment. The sender timeouts after sending the message (Sigma1) while it's waiting for response (Sigma2).

#### Change overview
The CASE message timeout is 10 seconds, which may be a bit low for CI and virtualization. Increasing it to 30 seconds for time being.

#### Testing
TestCASESession runs the existing unit tests related to this change.