### PR TITLE
Add BLE shutdown, make linux free up scanning upon shutdown

### DIFF
--- a/scripts/build/builders/gn.py
+++ b/scripts/build/builders/gn.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 Project CHIP Authors
+# Copyright (c) 2021 Project CHIP Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/build/builders/gn.py
+++ b/scripts/build/builders/gn.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 Project CHIP Authors
+# Copyright (c) 2020 Project CHIP Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/include/platform/internal/BLEManager.h
+++ b/src/include/platform/internal/BLEManager.h
@@ -54,6 +54,7 @@ public:
     using BLEAdvertisingMode  = ConnectivityManager::BLEAdvertisingMode;
 
     CHIP_ERROR Init();
+    CHIP_ERROR Shutdown();
     CHIPoBLEServiceMode GetCHIPoBLEServiceMode();
     CHIP_ERROR SetCHIPoBLEServiceMode(CHIPoBLEServiceMode val);
     bool IsAdvertisingEnabled();
@@ -114,6 +115,12 @@ namespace Internal {
 inline CHIP_ERROR BLEManager::Init()
 {
     return static_cast<ImplClass *>(this)->_Init();
+}
+
+inline CHIP_ERROR BLEManager::Shutdown()
+{
+    ReturnErrorOnFailure(GetBleLayer()->Shutdown());
+    return static_cast<ImplClass *>(this)->_Shutdown();
 }
 
 inline BLEManager::CHIPoBLEServiceMode BLEManager::GetCHIPoBLEServiceMode()

--- a/src/include/platform/internal/GenericPlatformManagerImpl.cpp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl.cpp
@@ -134,8 +134,8 @@ CHIP_ERROR GenericPlatformManagerImpl<ImplClass>::_Shutdown()
     err = InetLayer().Shutdown();
 
 #if CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
-    ChipLogError(DeviceLayer, "BLE layer shutdown");
-    err = BLEMgr().GetBleLayer()->Shutdown();
+    ChipLogError(DeviceLayer, "BLE shutdown");
+    err = BLEMgr().Shutdown();
 #endif
 
     ChipLogError(DeviceLayer, "System Layer shutdown");

--- a/src/platform/Ameba/BLEManagerImpl.h
+++ b/src/platform/Ameba/BLEManagerImpl.h
@@ -46,6 +46,7 @@ private:
     // ===== Members that implement the BLEManager internal interface.
 
     CHIP_ERROR _Init(void);
+    CHIP_ERROR _Shutdown() { return CHIP_NO_ERROR; }
     CHIPoBLEServiceMode _GetCHIPoBLEServiceMode(void);
     CHIP_ERROR _SetCHIPoBLEServiceMode(CHIPoBLEServiceMode val);
     bool _IsAdvertisingEnabled(void);

--- a/src/platform/Darwin/BLEManagerImpl.h
+++ b/src/platform/Darwin/BLEManagerImpl.h
@@ -47,6 +47,7 @@ private:
     // ===== Members that implement the BLEManager internal interface.
 
     CHIP_ERROR _Init(void);
+    CHIP_ERROR _Shutdown() { return CHIP_NO_ERROR; }
     CHIPoBLEServiceMode _GetCHIPoBLEServiceMode(void);
     CHIP_ERROR _SetCHIPoBLEServiceMode(CHIPoBLEServiceMode val);
     bool _IsAdvertisingEnabled(void);

--- a/src/platform/EFR32/BLEManagerImpl.h
+++ b/src/platform/EFR32/BLEManagerImpl.h
@@ -49,6 +49,7 @@ class BLEManagerImpl final : public BLEManager, private BleLayer, private BlePla
     // ===== Members that implement the BLEManager internal interface.
 
     CHIP_ERROR _Init(void);
+    CHIP_ERROR _Shutdown() { return CHIP_NO_ERROR; }
     CHIPoBLEServiceMode _GetCHIPoBLEServiceMode(void);
     CHIP_ERROR _SetCHIPoBLEServiceMode(CHIPoBLEServiceMode val);
     bool _IsAdvertisingEnabled(void);

--- a/src/platform/ESP32/BLEManagerImpl.h
+++ b/src/platform/ESP32/BLEManagerImpl.h
@@ -81,6 +81,7 @@ private:
     // ===== Members that implement the BLEManager internal interface.
 
     CHIP_ERROR _Init(void);
+    CHIP_ERROR _Shutdown() { return CHIP_NO_ERROR; }
     CHIPoBLEServiceMode _GetCHIPoBLEServiceMode(void);
     CHIP_ERROR _SetCHIPoBLEServiceMode(CHIPoBLEServiceMode val);
     bool _IsAdvertisingEnabled(void);

--- a/src/platform/Linux/BLEManagerImpl.cpp
+++ b/src/platform/Linux/BLEManagerImpl.cpp
@@ -92,6 +92,14 @@ exit:
     return err;
 }
 
+CHIP_ERROR BLEManagerImpl::_Shutdown()
+{
+    // ensure scan resources are cleared (e.g. timeout timers)
+    mDeviceScanner.reset();
+
+    return CHIP_NO_ERROR;
+}
+
 CHIP_ERROR BLEManagerImpl::_SetCHIPoBLEServiceMode(CHIPoBLEServiceMode val)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;

--- a/src/platform/Linux/BLEManagerImpl.h
+++ b/src/platform/Linux/BLEManagerImpl.h
@@ -112,6 +112,7 @@ private:
     // ===== Members that implement the BLEManager internal interface.
 
     CHIP_ERROR _Init();
+    CHIP_ERROR _Shutdown();
     CHIPoBLEServiceMode _GetCHIPoBLEServiceMode();
     CHIP_ERROR _SetCHIPoBLEServiceMode(CHIPoBLEServiceMode val);
     bool _IsAdvertisingEnabled();

--- a/src/platform/P6/BLEManagerImpl.h
+++ b/src/platform/P6/BLEManagerImpl.h
@@ -51,6 +51,7 @@ class BLEManagerImpl final : public BLEManager,
     // ===== Members that implement the BLEManager internal interface.
 
     CHIP_ERROR _Init(void);
+    CHIP_ERROR _Shutdown() { return CHIP_NO_ERROR; }
     CHIPoBLEServiceMode _GetCHIPoBLEServiceMode(void);
     CHIP_ERROR _SetCHIPoBLEServiceMode(CHIPoBLEServiceMode val);
     bool _IsAdvertisingEnabled(void);

--- a/src/platform/Tizen/BLEManagerImpl.h
+++ b/src/platform/Tizen/BLEManagerImpl.h
@@ -55,6 +55,7 @@ private:
     // ===== Members that implement the BLEManager internal interface.
 
     CHIP_ERROR _Init(void);
+    CHIP_ERROR _Shutdown() { return CHIP_NO_ERROR; }
     CHIPoBLEServiceMode _GetCHIPoBLEServiceMode(void);
     CHIP_ERROR _SetCHIPoBLEServiceMode(CHIPoBLEServiceMode val);
     bool _IsAdvertisingEnabled(void);

--- a/src/platform/Zephyr/BLEManagerImpl.h
+++ b/src/platform/Zephyr/BLEManagerImpl.h
@@ -50,6 +50,7 @@ private:
     // ===== Members that implement the BLEManager internal interface.
 
     CHIP_ERROR _Init(void);
+    CHIP_ERROR _Shutdown() { return CHIP_NO_ERROR; }
     CHIPoBLEServiceMode _GetCHIPoBLEServiceMode(void);
     CHIP_ERROR _SetCHIPoBLEServiceMode(CHIPoBLEServiceMode val);
     bool _IsAdvertisingEnabled(void);

--- a/src/platform/android/BLEManagerImpl.h
+++ b/src/platform/android/BLEManagerImpl.h
@@ -56,6 +56,7 @@ private:
     // ===== Members that implement the BLEManager internal interface.
 
     CHIP_ERROR _Init();
+    CHIP_ERROR _Shutdown() { return CHIP_NO_ERROR; }
     CHIPoBLEServiceMode _GetCHIPoBLEServiceMode();
     CHIP_ERROR _SetCHIPoBLEServiceMode(CHIPoBLEServiceMode val);
     bool _IsAdvertisingEnabled();

--- a/src/platform/cc13x2_26x2/BLEManagerImpl.h
+++ b/src/platform/cc13x2_26x2/BLEManagerImpl.h
@@ -205,6 +205,7 @@ private:
     // ===== Members that implement the BLEManager internal interface.
 
     CHIP_ERROR _Init(void);
+    CHIP_ERROR _Shutdown() { return CHIP_NO_ERROR; }
     CHIPoBLEServiceMode _GetCHIPoBLEServiceMode(void);
     CHIP_ERROR _SetCHIPoBLEServiceMode(CHIPoBLEServiceMode val);
     bool _IsAdvertisingEnabled(void);

--- a/src/platform/mbed/BLEManagerImpl.h
+++ b/src/platform/mbed/BLEManagerImpl.h
@@ -46,6 +46,7 @@ class BLEManagerImpl final : public BLEManager, private BleLayer, private BlePla
     // ===== Members that implement the BLEManager internal interface.
 
     CHIP_ERROR _Init(void);
+    CHIP_ERROR _Shutdown() { return CHIP_NO_ERROR; }
     CHIPoBLEServiceMode _GetCHIPoBLEServiceMode(void);
     CHIP_ERROR _SetCHIPoBLEServiceMode(CHIPoBLEServiceMode val);
     bool _IsAdvertisingEnabled(void);

--- a/src/platform/nxp/k32w/k32w0/BLEManagerImpl.h
+++ b/src/platform/nxp/k32w/k32w0/BLEManagerImpl.h
@@ -64,6 +64,7 @@ private:
     // ===== Members that implement the BLEManager internal interface.
 
     CHIP_ERROR _Init(void);
+    CHIP_ERROR _Shutdown() { return CHIP_NO_ERROR; }
     CHIPoBLEServiceMode _GetCHIPoBLEServiceMode(void);
     CHIP_ERROR _SetCHIPoBLEServiceMode(CHIPoBLEServiceMode val);
     bool _IsAdvertisingEnabled(void);

--- a/src/platform/qpg/BLEManagerImpl.h
+++ b/src/platform/qpg/BLEManagerImpl.h
@@ -48,6 +48,7 @@ private:
     // ===== Members that implement the BLEManager internal interface.
 
     CHIP_ERROR _Init(void);
+    CHIP_ERROR _Shutdown() { return CHIP_NO_ERROR; }
     CHIPoBLEServiceMode _GetCHIPoBLEServiceMode(void);
     CHIP_ERROR _SetCHIPoBLEServiceMode(CHIPoBLEServiceMode val);
     bool _IsAdvertisingEnabled(void);


### PR DESCRIPTION
#### Problem
Crash on succesful wifi pairing:

```
[1636041758.162650][1867993:1868024] CHIP:DL: BluezDisconnect peer=98:F4:AB:6B:1A:FE                                                                                                                                                 
pure virtual method called                              
terminate called without an active exception                                                                                                                                                                                         
                                                                                                                                                                                                                                     
Thread 1 "chip-tool" received signal SIGABRT, Aborted.                                                                                                                                                                               
__GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:49
49      ../sysdeps/unix/sysv/linux/raise.c: No such file or directory.                                                                                                                                                               
(gdb) bt                                                                                                                                                                                                                             
        #0  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:49                                                                                                                                                    
#1  0x00007ffff7573536 in __GI_abort () at abort.c:79                                                             
#2  0x00007ffff77b189a in  () at /lib/x86_64-linux-gnu/libstdc++.so.6                                                                                                                                                                
#3  0x00007ffff77bd0ba in  () at /lib/x86_64-linux-gnu/libstdc++.so.6
#4  0x00007ffff77bd125 in  () at /lib/x86_64-linux-gnu/libstdc++.so.6                                                                                                                                                                
#5  0x00007ffff77bde93 in  () at /lib/x86_64-linux-gnu/libstdc++.so.6                                        
#6  0x00005555558d6795 in chip::DeviceLayer::Internal::ChipDeviceScanner::~ChipDeviceScanner() (this=0x7fffe000fa30, __in_chrg=<optimized out>)
    at ../../examples/chip-tool/third_party/connectedhomeip/src/platform/Linux/bluez/ChipDeviceScanner.cpp:81     
#7  0x00005555558ca5ee in std::default_delete<chip::DeviceLayer::Internal::ChipDeviceScanner>::operator()(chip::DeviceLayer::Internal::ChipDeviceScanner*) const
    (this=0x5555559ae308 <chip::DeviceLayer::Internal::BLEManagerImpl::sInstance+264>, __ptr=0x7fffe000fa30) at /usr/include/c++/9/bits/unique_ptr.h:81
#8  0x00005555558ca484 in std::unique_ptr<chip::DeviceLayer::Internal::ChipDeviceScanner, std::default_delete<chip::DeviceLayer::Internal::ChipDeviceScanner> >::~unique_ptr()
    (this=0x5555559ae308 <chip::DeviceLayer::Internal::BLEManagerImpl::sInstance+264>, __in_chrg=<optimized out>) at /usr/include/c++/9/bits/unique_ptr.h:292
#9  0x00005555558ca99a in chip::DeviceLayer::Internal::BLEManagerImpl::~BLEManagerImpl() (this=0x5555559ae200 <chip::DeviceLayer::Internal::BLEManagerImpl::sInstance>, __in_chrg=<optimized out>)
    at ../../examples/chip-tool/third_party/connectedhomeip/src/platform/Linux/BLEManagerImpl.h:81
#10 0x00007ffff758c537 in __run_exit_handlers (status=0, listp=0x7ffff770b738 <__exit_funcs>, run_list_atexit=run_list_atexit@entry=true, run_dtors=run_dtors@entry=true) at exit.c:108
#11 0x00007ffff758c6da in __GI_exit (status=<optimized out>) at exit.c:139                                                                                                                                                           
#12 0x00007ffff7574e51 in __libc_start_main (main=0x5555556a7167 <main(int, char**)>, argc=9, argv=0x7fffffffd258, init=<optimized out>, fini=<optimized out>, rtld_fini=<optimized out>, stack_end=0x7fffffffd248)                  
    at ../csu/libc-start.c:348                                                                                    
#13 0x00005555555961fe in _start ()                                                                                                                                                                                                  
(gdb) frame 6                                                                                                     
#6  0x00005555558d6795 in chip::DeviceLayer::Internal::ChipDeviceScanner::~ChipDeviceScanner (this=0x7fffe000fa30, __in_chrg=<optimized out>)
    at ../../examples/chip-tool/third_party/connectedhomeip/src/platform/Linux/bluez/ChipDeviceScanner.cpp:81
```
    
From what I can tell, the order of operations is:
- BLEManager has a 'device scanner' object which contains a timer in it
- App shutdown does a BLE**Layer** (! not manager) shutdown followed by a system layer
- libc runs global object destructors, which destroys BLEManager, which tries to free the scanner, which calls SystemLayer()->CancelTimer, however System layer was destroyed in the step above (either as shutdown or because global destructor order is not well defined, so system global object is already gone)

#### Change overview
add a BLE layer shutdown, that allows for device scanner to be freed properly

#### Testing
Paired via BLE, no crash