### PR TITLE
Convert TimeSource to safer Clock types

### DIFF
--- a/src/app/server/Dnssd.h
+++ b/src/app/server/Dnssd.h
@@ -26,10 +26,11 @@
 namespace chip {
 namespace app {
 
-#define TIMEOUT_CLEARED 0
 class DLL_EXPORT DnssdServer
 {
 public:
+    static constexpr System::Clock::Timestamp kTimeoutCleared = System::Clock::kZero;
+
     /// Provides the system-wide implementation of the service advertiser
     static DnssdServer & Instance()
     {
@@ -104,9 +105,9 @@ private:
 
     void ClearTimeouts()
     {
-        mDiscoveryExpirationMs = TIMEOUT_CLEARED;
+        mDiscoveryExpiration = kTimeoutCleared;
 #if CHIP_DEVICE_CONFIG_ENABLE_EXTENDED_DISCOVERY
-        mExtendedDiscoveryExpirationMs = TIMEOUT_CLEARED;
+        mExtendedDiscoveryExpiration = kTimeoutCleared;
 #endif // CHIP_DEVICE_CONFIG_ENABLE_EXTENDED_DISCOVERY
     }
 
@@ -115,11 +116,11 @@ private:
 
     /// schedule next discovery expiration
     CHIP_ERROR ScheduleDiscoveryExpiration();
-    int16_t mDiscoveryTimeoutSecs   = CHIP_DEVICE_CONFIG_DISCOVERY_TIMEOUT_SECS;
-    uint64_t mDiscoveryExpirationMs = TIMEOUT_CLEARED;
+    int16_t mDiscoveryTimeoutSecs                 = CHIP_DEVICE_CONFIG_DISCOVERY_TIMEOUT_SECS;
+    System::Clock::Timestamp mDiscoveryExpiration = kTimeoutCleared;
 
     /// return true if expirationMs is valid (not cleared and not in the future)
-    bool OnExpiration(uint64_t expirationMs);
+    bool OnExpiration(System::Clock::Timestamp expiration);
 
 #if CHIP_DEVICE_CONFIG_ENABLE_EXTENDED_DISCOVERY
     /// get the current extended discovery timeout (from persistent storage)
@@ -128,7 +129,7 @@ private:
     /// schedule next extended discovery expiration
     CHIP_ERROR ScheduleExtendedDiscoveryExpiration();
 
-    uint64_t mExtendedDiscoveryExpirationMs = TIMEOUT_CLEARED;
+    System::Clock::Timestamp mExtendedDiscoveryExpiration = kTimeoutCleared;
 #endif // CHIP_DEVICE_CONFIG_ENABLE_EXTENDED_DISCOVERY
 };
 

--- a/src/lib/dnssd/Discovery_ImplPlatform.cpp
+++ b/src/lib/dnssd/Discovery_ImplPlatform.cpp
@@ -589,7 +589,8 @@ void DiscoveryImplPlatform::HandleNodeIdResolve(void * context, DnssdService * r
 #if CHIP_CONFIG_MDNS_CACHE_SIZE > 0
     // TODO --  define appropriate TTL, for now use 2000 msec (rfc default)
     // figure out way to use TTL value from mDNS packet in  future update
-    error = mgr->sDnssdCache.Insert(nodeData.mPeerId, result->mAddress.Value(), result->mPort, result->mInterface, 2 * 1000);
+    error = mgr->sDnssdCache.Insert(nodeData.mPeerId, result->mAddress.Value(), result->mPort, result->mInterface,
+                                    System::Clock::Seconds16(2));
 
     if (CHIP_NO_ERROR != error)
     {

--- a/src/lib/dnssd/tests/TestDnssdCache.cpp
+++ b/src/lib/dnssd/tests/TestDnssdCache.cpp
@@ -55,7 +55,7 @@ void TestInsert(nlTestSuite * inSuite, void * inContext)
 
     Inet::IPAddress addr;
     Inet::IPAddress addrV6;
-    const int ttl = 2; /* seconds */
+    const System::Clock::Timestamp ttl = System::Clock::Seconds16(2);
     Inet::InterfaceId iface_out;
     Inet::IPAddress addr_out;
     uint16_t port_out;
@@ -71,7 +71,7 @@ void TestInsert(nlTestSuite * inSuite, void * inContext)
 
         // ml -- why doesn't adding 2 uint16_t give a uint16_t?
         peerId.SetNodeId((NodeId) id + i);
-        result = tDnssdCache.Insert(peerId, addr, (uint16_t)(port + i), iface, 1000 * ttl);
+        result = tDnssdCache.Insert(peerId, addr, (uint16_t)(port + i), iface, ttl);
         if (i < sizeOfCache)
         {
             NL_TEST_ASSERT(inSuite, result == CHIP_NO_ERROR);
@@ -83,7 +83,7 @@ void TestInsert(nlTestSuite * inSuite, void * inContext)
     }
 
     tDnssdCache.DumpCache();
-    usleep(static_cast<useconds_t>((ttl + 1) * 1000 * 1000));
+    usleep(static_cast<useconds_t>(std::chrono::microseconds(ttl + System::Clock::Seconds16(1)).count()));
     id   = 0x200;
     port = 3000;
     for (uint16_t i = 0; i < sizeOfCache; i++)
@@ -91,7 +91,7 @@ void TestInsert(nlTestSuite * inSuite, void * inContext)
         CHIP_ERROR result;
 
         peerId.SetNodeId((NodeId) id + i);
-        result = tDnssdCache.Insert(peerId, addr, (uint16_t)(port + i), iface, 1000 * ttl);
+        result = tDnssdCache.Insert(peerId, addr, (uint16_t)(port + i), iface, ttl);
         NL_TEST_ASSERT(inSuite, result == CHIP_NO_ERROR);
     }
     tDnssdCache.DumpCache();
@@ -115,7 +115,7 @@ void TestInsert(nlTestSuite * inSuite, void * inContext)
         CHIP_ERROR result;
 
         peerId.SetNodeId((NodeId) id + i);
-        result = tDnssdCache.Insert(peerId, addrV6, (uint16_t)(port + i), iface, 1000 * ttl);
+        result = tDnssdCache.Insert(peerId, addrV6, (uint16_t)(port + i), iface, ttl);
         NL_TEST_ASSERT(inSuite, result == CHIP_NO_ERROR);
     }
 

--- a/src/protocols/user_directed_commissioning/UDCClientState.h
+++ b/src/protocols/user_directed_commissioning/UDCClientState.h
@@ -78,13 +78,13 @@ public:
     UDCClientProcessingState GetUDCClientProcessingState() const { return mUDCClientProcessingState; }
     void SetUDCClientProcessingState(UDCClientProcessingState state) { mUDCClientProcessingState = state; }
 
-    uint64_t GetExpirationTimeMs() const { return mExpirationTimeMs; }
-    void SetExpirationTimeMs(uint64_t value) { mExpirationTimeMs = value; }
+    System::Clock::Timestamp GetExpirationTime() const { return mExpirationTime; }
+    void SetExpirationTime(System::Clock::Timestamp value) { mExpirationTime = value; }
 
-    bool IsInitialized(uint64_t currentTime)
+    bool IsInitialized(System::Clock::Timestamp currentTime)
     {
         // if state is not the "not-initialized" and it has not expired
-        return (mUDCClientProcessingState != UDCClientProcessingState::kNotInitialized && mExpirationTimeMs > currentTime);
+        return (mUDCClientProcessingState != UDCClientProcessingState::kNotInitialized && mExpirationTime > currentTime);
     }
 
     /**
@@ -93,7 +93,7 @@ public:
     void Reset()
     {
         mPeerAddress              = PeerAddress::Uninitialized();
-        mExpirationTimeMs         = 0;
+        mExpirationTime           = System::Clock::kZero;
         mUDCClientProcessingState = UDCClientProcessingState::kNotInitialized;
     }
 
@@ -103,7 +103,7 @@ private:
     char mDeviceName[Dnssd::kMaxDeviceNameLen + 1];
     uint16_t mLongDiscriminator = 0;
     UDCClientProcessingState mUDCClientProcessingState;
-    uint64_t mExpirationTimeMs = 0;
+    System::Clock::Timestamp mExpirationTime = System::Clock::kZero;
 };
 
 } // namespace UserDirectedCommissioning

--- a/src/protocols/user_directed_commissioning/UDCClients.h
+++ b/src/protocols/user_directed_commissioning/UDCClients.h
@@ -26,7 +26,7 @@ namespace Protocols {
 namespace UserDirectedCommissioning {
 
 // UDC client state times out after 1 hour. This may need to be tweaked.
-constexpr const uint64_t kUDCClientTimeoutMs = 60 * 60 * 1000;
+constexpr const System::Clock::Timestamp kUDCClientTimeout = System::Clock::Milliseconds64(60 * 60 * 1000);
 
 /**
  * Handles a set of UDC Client Processing States.
@@ -54,7 +54,7 @@ public:
     CHECK_RETURN_VALUE
     CHIP_ERROR CreateNewUDCClientState(const char * instanceName, UDCClientState ** state)
     {
-        const uint64_t currentTime = mTimeSource.GetCurrentMonotonicTimeMs();
+        const System::Clock::Timestamp currentTime = mTimeSource.GetMonotonicTimestamp();
 
         CHIP_ERROR err = CHIP_ERROR_NO_MEMORY;
 
@@ -68,7 +68,7 @@ public:
             if (!stateiter.IsInitialized(currentTime))
             {
                 stateiter.SetInstanceName(instanceName);
-                stateiter.SetExpirationTimeMs(currentTime + kUDCClientTimeoutMs);
+                stateiter.SetExpirationTime(currentTime + kUDCClientTimeout);
                 stateiter.SetUDCClientProcessingState(UDCClientProcessingState::kDiscoveringNode);
 
                 if (state)
@@ -99,8 +99,8 @@ public:
             return nullptr;
         }
 
-        const uint64_t currentTime = mTimeSource.GetCurrentMonotonicTimeMs();
-        UDCClientState state       = mStates[index];
+        const System::Clock::Timestamp currentTime = mTimeSource.GetMonotonicTimestamp();
+        UDCClientState state                       = mStates[index];
         if (!state.IsInitialized(currentTime))
         {
             return nullptr;
@@ -118,7 +118,7 @@ public:
     CHECK_RETURN_VALUE
     UDCClientState * FindUDCClientState(const PeerAddress & address)
     {
-        const uint64_t currentTime = mTimeSource.GetCurrentMonotonicTimeMs();
+        const System::Clock::Timestamp currentTime = mTimeSource.GetMonotonicTimestamp();
 
         UDCClientState * state = nullptr;
 
@@ -147,7 +147,7 @@ public:
     CHECK_RETURN_VALUE
     UDCClientState * FindUDCClientState(const char * instanceName)
     {
-        const uint64_t currentTime = mTimeSource.GetCurrentMonotonicTimeMs();
+        const System::Clock::Timestamp currentTime = mTimeSource.GetMonotonicTimestamp();
 
         UDCClientState * state = nullptr;
 
@@ -180,7 +180,7 @@ public:
     /// Convenience method to mark a UDC Client state as active (non-expired)
     void MarkUDCClientActive(UDCClientState * state)
     {
-        state->SetExpirationTimeMs(mTimeSource.GetCurrentMonotonicTimeMs() + kUDCClientTimeoutMs);
+        state->SetExpirationTime(mTimeSource.GetMonotonicTimestamp() + kUDCClientTimeout);
     }
 
 private:

--- a/src/protocols/user_directed_commissioning/tests/TestUdcMessages.cpp
+++ b/src/protocols/user_directed_commissioning/tests/TestUdcMessages.cpp
@@ -256,11 +256,11 @@ void TestUDCClients(nlTestSuite * inSuite, void * inContext)
 
     // test re-activation
     NL_TEST_ASSERT(inSuite, CHIP_NO_ERROR == mUdcClients.CreateNewUDCClientState(instanceName4, &state));
-    uint64_t expirationTime = state->GetExpirationTimeMs();
-    state->SetExpirationTimeMs(expirationTime - 1);
-    NL_TEST_ASSERT(inSuite, (expirationTime - 1) == state->GetExpirationTimeMs());
+    System::Clock::Timestamp expirationTime = state->GetExpirationTime();
+    state->SetExpirationTime(expirationTime - System::Clock::Milliseconds64(1));
+    NL_TEST_ASSERT(inSuite, (expirationTime - System::Clock::Milliseconds64(1)) == state->GetExpirationTime());
     mUdcClients.MarkUDCClientActive(state);
-    NL_TEST_ASSERT(inSuite, (expirationTime - 1) < state->GetExpirationTimeMs());
+    NL_TEST_ASSERT(inSuite, (expirationTime - System::Clock::Milliseconds64(1)) < state->GetExpirationTime());
 }
 
 // Test Suite

--- a/src/system/TimeSource.h
+++ b/src/system/TimeSource.h
@@ -53,7 +53,7 @@ public:
      *    such that the values do not entail a restart upon wake.
      *  - This function is expected to be thread-safe on any platform that employs threading.
      */
-    uint64_t GetCurrentMonotonicTimeMs();
+    System::Clock::Timestamp GetMonotonicTimestamp();
 };
 
 /**
@@ -63,7 +63,7 @@ template <>
 class TimeSource<Source::kSystem>
 {
 public:
-    uint64_t GetCurrentMonotonicTimeMs() { return System::SystemClock().GetMonotonicMilliseconds64().count(); }
+    System::Clock::Timestamp GetMonotonicTimestamp() { return System::SystemClock().GetMonotonicTimestamp(); }
 };
 
 /**
@@ -73,19 +73,19 @@ template <>
 class TimeSource<Source::kTest>
 {
 public:
-    uint64_t GetCurrentMonotonicTimeMs() { return mCurrentTimeMs; }
+    System::Clock::Timestamp GetMonotonicTimestamp() { return mCurrentTime; }
 
-    void SetCurrentMonotonicTimeMs(uint64_t value)
+    void SetMonotonicTimestamp(System::Clock::Timestamp value)
     {
-        if (value < mCurrentTimeMs)
+        if (value < mCurrentTime)
         {
             abort();
         }
-        mCurrentTimeMs = value;
+        mCurrentTime = value;
     }
 
 private:
-    uint64_t mCurrentTimeMs = 0;
+    System::Clock::Timestamp mCurrentTime = System::Clock::kZero;
 };
 
 } // namespace Time

--- a/src/system/tests/TestTimeSource.cpp
+++ b/src/system/tests/TestTimeSource.cpp
@@ -40,10 +40,11 @@ void TestTimeSourceSetAndGet(nlTestSuite * inSuite, void * inContext)
 
     chip::Time::TimeSource<chip::Time::Source::kTest> source;
 
-    NL_TEST_ASSERT(inSuite, source.GetCurrentMonotonicTimeMs() == 0);
+    NL_TEST_ASSERT(inSuite, source.GetMonotonicTimestamp() == chip::System::Clock::kZero);
 
-    source.SetCurrentMonotonicTimeMs(1234);
-    NL_TEST_ASSERT(inSuite, source.GetCurrentMonotonicTimeMs() == 1234);
+    constexpr chip::System::Clock::Milliseconds64 k1234 = chip::System::Clock::Milliseconds64(1234);
+    source.SetMonotonicTimestamp(k1234);
+    NL_TEST_ASSERT(inSuite, source.GetMonotonicTimestamp() == k1234);
 }
 
 void SystemTimeSourceGet(nlTestSuite * inSuite, void * inContext)
@@ -51,13 +52,13 @@ void SystemTimeSourceGet(nlTestSuite * inSuite, void * inContext)
 
     chip::Time::TimeSource<chip::Time::Source::kSystem> source;
 
-    uint64_t oldValue = source.GetCurrentMonotonicTimeMs();
+    chip::System::Clock::Timestamp oldValue = source.GetMonotonicTimestamp();
 
     // a basic monotonic test. This is likely to take less than 1ms, so the
     // actual test value lies mostly in ensuring things compile.
     for (int i = 0; i < 100; i++)
     {
-        uint64_t newValue = source.GetCurrentMonotonicTimeMs();
+        chip::System::Clock::Timestamp newValue = source.GetMonotonicTimestamp();
         NL_TEST_ASSERT(inSuite, newValue >= oldValue);
         oldValue = newValue;
     }

--- a/src/transport/SecureSession.h
+++ b/src/transport/SecureSession.h
@@ -40,7 +40,7 @@ static constexpr uint32_t kUndefinedMessageIndex = UINT32_MAX;
  *   - PeerAddress represents how to talk to the peer
  *   - PeerNodeId is the unique ID of the peer
  *   - SendMessageIndex is an ever increasing index for sending messages
- *   - LastActivityTimeMs is a monotonic timestamp of when this connection was
+ *   - LastActivityTime is a monotonic timestamp of when this connection was
  *     last used. Inactive connections can expire.
  *   - CryptoContext contains the encryption context of a connection
  *
@@ -49,10 +49,12 @@ static constexpr uint32_t kUndefinedMessageIndex = UINT32_MAX;
 class SecureSession
 {
 public:
-    SecureSession(uint16_t localSessionId, NodeId peerNodeId, uint16_t peerSessionId, FabricIndex fabric, uint64_t currentTime) :
-        mPeerNodeId(peerNodeId), mLocalSessionId(localSessionId), mPeerSessionId(peerSessionId), mFabric(fabric)
+    SecureSession(uint16_t localSessionId, NodeId peerNodeId, uint16_t peerSessionId, FabricIndex fabric,
+                  System::Clock::Timestamp currentTime) :
+        mPeerNodeId(peerNodeId),
+        mLocalSessionId(localSessionId), mPeerSessionId(peerSessionId), mFabric(fabric)
     {
-        SetLastActivityTimeMs(currentTime);
+        SetLastActivityTime(currentTime);
     }
 
     SecureSession(SecureSession &&)      = delete;
@@ -69,8 +71,8 @@ public:
     uint16_t GetPeerSessionId() const { return mPeerSessionId; }
     FabricIndex GetFabricIndex() const { return mFabric; }
 
-    uint64_t GetLastActivityTimeMs() const { return mLastActivityTimeMs; }
-    void SetLastActivityTimeMs(uint64_t value) { mLastActivityTimeMs = value; }
+    System::Clock::Timestamp GetLastActivityTime() const { return mLastActivityTime; }
+    void SetLastActivityTime(System::Clock::Timestamp value) { mLastActivityTime = value; }
 
     CryptoContext & GetCryptoContext() { return mCryptoContext; }
 
@@ -95,7 +97,7 @@ private:
     const FabricIndex mFabric;
 
     PeerAddress mPeerAddress;
-    uint64_t mLastActivityTimeMs = 0;
+    System::Clock::Timestamp mLastActivityTime = System::Clock::kZero;
     CryptoContext mCryptoContext;
     SessionMessageCounter mSessionMessageCounter;
 };

--- a/src/transport/UnauthenticatedSessionTable.h
+++ b/src/transport/UnauthenticatedSessionTable.h
@@ -54,15 +54,15 @@ public:
     UnauthenticatedSession(UnauthenticatedSession &&)                  = delete;
     UnauthenticatedSession & operator=(UnauthenticatedSession &&) = delete;
 
-    uint64_t GetLastActivityTimeMs() const { return mLastActivityTimeMs; }
-    void SetLastActivityTimeMs(uint64_t value) { mLastActivityTimeMs = value; }
+    System::Clock::Timestamp GetLastActivityTime() const { return mLastActivityTime; }
+    void SetLastActivityTime(System::Clock::Timestamp value) { mLastActivityTime = value; }
 
     const PeerAddress & GetPeerAddress() const { return mPeerAddress; }
 
     PeerMessageCounter & GetPeerMessageCounter() { return mPeerMessageCounter; }
 
 private:
-    uint64_t mLastActivityTimeMs = 0;
+    System::Clock::Timestamp mLastActivityTime = System::Clock::kZero;
 
     const PeerAddress mPeerAddress;
     PeerMessageCounter mPeerMessageCounter;
@@ -106,7 +106,7 @@ public:
     /// Mark a session as active
     void MarkSessionActive(UnauthenticatedSessionHandle session)
     {
-        session->SetLastActivityTimeMs(mTimeSource.GetCurrentMonotonicTimeMs());
+        session->SetLastActivityTime(mTimeSource.GetMonotonicTimestamp());
     }
 
     /// Allows access to the underlying time source used for keeping track of session active time
@@ -158,14 +158,14 @@ private:
 
     UnauthenticatedSession * FindLeastRecentUsedEntry()
     {
-        UnauthenticatedSession * result = nullptr;
-        uint64_t oldestTimeMs           = std::numeric_limits<uint64_t>::max();
+        UnauthenticatedSession * result     = nullptr;
+        System::Clock::Timestamp oldestTime = System::Clock::Timestamp(std::numeric_limits<System::Clock::Timestamp::rep>::max());
 
         mEntries.ForEachActiveObject([&](UnauthenticatedSession * entry) {
-            if (entry->GetReferenceCount() == 0 && entry->GetLastActivityTimeMs() < oldestTimeMs)
+            if (entry->GetReferenceCount() == 0 && entry->GetLastActivityTime() < oldestTime)
             {
-                result       = entry;
-                oldestTimeMs = entry->GetLastActivityTimeMs();
+                result     = entry;
+                oldestTime = entry->GetLastActivityTime();
             }
             return true;
         });


### PR DESCRIPTION
#### Problem

`System::TimeSource` still uses raw integer times rather than
the safer `Syste::Clock` types based on `std::chrono::duration`.

Followup to #10062 _Some operations on System::Clock types are not safe_

#### Change overview

Convert `TimeSource` and its uses.

#### Testing

CI; no changes to functionality.
Converted `TestTimeSource`.
