### PR TITLE
Bump timeout on the "Build example lighting app with RPCs" test.

### DIFF
--- a/.github/workflows/examples-linux-standalone.yaml
+++ b/.github/workflows/examples-linux-standalone.yaml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
     linux_standalone:
         name: Linux Standalone
-        timeout-minutes: 60
+        timeout-minutes: 70
 
         env:
             BUILD_TYPE: gn_linux
@@ -91,7 +91,7 @@ jobs:
                     out/tv_app_debug/chip-tv-app \
                     /tmp/bloat_reports/
             - name: Build example lighting app with RPCs
-              timeout-minutes: 5
+              timeout-minutes: 10
               run: |
                   scripts/examples/gn_build_example.sh examples/lighting-app/linux out/lighting_app_debug_rpc \
                     'import("//with_pw_rpc.gni")'


### PR DESCRIPTION
It hits the 5 minute timeout pretty regularly.

#### Problem
Test times out often.

#### Change overview
Give it more time.

#### Testing
Assuming it will just work.