### PR TITLE
ci: Update ESP-IDF version to v4.4 in docker

### DIFF
--- a/integrations/docker/images/chip-build-esp32/Dockerfile
+++ b/integrations/docker/images/chip-build-esp32/Dockerfile
@@ -10,16 +10,8 @@ RUN set -x \
     && : # last line
 
 RUN set -x \
-    && git clone --depth 1 --recursive -b v4.3 https://github.com/espressif/esp-idf.git /tmp/esp-idf \
-    && : # last line
-
-# TODO: Remove this patch once https://github.com/espressif/esp-idf/pull/7632 is available
-COPY 0001-esp_crt_bundle-remove-EC-ACC-certificate.patch /tmp/esp-idf/0001-esp_crt_bundle-remove-EC-ACC-certificate.patch
-
-WORKDIR /tmp/esp-idf
-RUN set -x \
-    && git apply /tmp/esp-idf/0001-esp_crt_bundle-remove-EC-ACC-certificate.patch \
-    && rm -f /tmp/esp-idf/0001-esp_crt_bundle-remove-EC-ACC-certificate.patch \
+    && git clone --depth 1 --recursive -b release/v4.4 https://github.com/espressif/esp-idf.git /tmp/esp-idf \
+    && git -C /tmp/esp-idf checkout 6a7d83af1984b93ebaefa7ca9be36304806c3dc8 \
     && : # last line
 
 FROM connectedhomeip/chip-build:${VERSION}

--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.5.26 Version bump reason: [nRF Connect] Implement Docker best practices
+0.5.27 Version bump reason: [ESP32] Update ESP-IDF to v4.4 release


### PR DESCRIPTION
#### Problem

After https://github.com/project-chip/connectedhomeip/pull/11412, ESP-IDF v4.4 release is required.

#### Change overview

Update ESP-IDF release and docker version.

#### Testing

* Not applicable, CI updates.
