### PR TITLE
Increase commissioning session establishment timeout

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -104,7 +104,7 @@ using namespace chip::Encoding;
 using namespace chip::Protocols::UserDirectedCommissioning;
 #endif // CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY
 
-constexpr uint32_t kSessionEstablishmentTimeout = 30 * kMillisecondsPerSecond;
+constexpr uint32_t kSessionEstablishmentTimeout = 40 * kMillisecondsPerSecond;
 
 DeviceController::DeviceController()
 {


### PR DESCRIPTION
Signed-off-by: Doru Gucea <doru-cristian.gucea@nxp.com>

#### Problem
Second admin commissioning was failing on K32W platform due to timeout - see the logs

[second_admin_logs.txt](https://github.com/project-chip/connectedhomeip/files/7486277/second_admin_logs.txt)
[device_logs.txt](https://github.com/project-chip/connectedhomeip/files/7486279/device_logs.txt)


#### Change overview
Increase the commissioning timeout. This is just a temporary solution until optimizations are being applied.

#### Testing
Manual testing
