### PR TITLE
Added using CRA/CRI values in the controller for MRP intervals

### DIFF
--- a/src/app/server/Dnssd.cpp
+++ b/src/app/server/Dnssd.cpp
@@ -263,7 +263,7 @@ CHIP_ERROR DnssdServer::AdvertiseOperational()
                     .SetPeerId(fabricInfo.GetPeerId())
                     .SetMac(mac)
                     .SetPort(GetSecuredPort())
-                    .SetMRPRetryIntervals(Optional<uint32_t>(CHIP_CONFIG_MRP_DEFAULT_INITIAL_RETRY_INTERVAL),
+                    .SetMRPRetryIntervals(Optional<uint32_t>(CHIP_CONFIG_MRP_DEFAULT_IDLE_RETRY_INTERVAL),
                                           Optional<uint32_t>(CHIP_CONFIG_MRP_DEFAULT_ACTIVE_RETRY_INTERVAL))
                     .SetTcpSupported(Optional<bool>(INET_CONFIG_ENABLE_TCP_ENDPOINT))
                     .EnableIpV4(true);
@@ -344,7 +344,7 @@ CHIP_ERROR DnssdServer::Advertise(bool commissionableNode, chip::Dnssd::Commissi
 #endif
 
     advertiseParameters
-        .SetMRPRetryIntervals(Optional<uint32_t>(CHIP_CONFIG_MRP_DEFAULT_INITIAL_RETRY_INTERVAL),
+        .SetMRPRetryIntervals(Optional<uint32_t>(CHIP_CONFIG_MRP_DEFAULT_IDLE_RETRY_INTERVAL),
                               Optional<uint32_t>(CHIP_CONFIG_MRP_DEFAULT_ACTIVE_RETRY_INTERVAL))
         .SetTcpSupported(Optional<bool>(INET_CONFIG_ENABLE_TCP_ENDPOINT));
 

--- a/src/channel/ChannelContext.cpp
+++ b/src/channel/ChannelContext.cpp
@@ -271,6 +271,8 @@ void ChannelContext::EnterCasePairingState()
         EnterFailedState(CHIP_ERROR_NO_MEMORY);
         return;
     }
+    session.Value().GetUnauthenticatedSession()->SetMRPIntervals(CHIP_CONFIG_MRP_DEFAULT_IDLE_RETRY_INTERVAL,
+                                                                 CHIP_CONFIG_MRP_DEFAULT_ACTIVE_RETRY_INTERVAL);
 
     ExchangeContext * ctxt = mExchangeManager->NewContext(session.Value(), prepare.mCasePairingSession);
     VerifyOrReturn(ctxt != nullptr);

--- a/src/controller/CHIPDevice.h
+++ b/src/controller/CHIPDevice.h
@@ -348,17 +348,19 @@ public:
 
     /**
      * @brief
-     *   Update address of the device.
+     *   Update data of the device.
      *
-     *   This function will set new IP address and port of the device. Since the device settings might
-     *   have been moved from RAM to the persistent storage, the function will load the device settings
-     *   first, before making the changes.
+     *   This function will set new IP address, port and MRP retransmission intervals of the device.
+     *   Since the device settings might have been moved from RAM to the persistent storage, the function
+     *   will load the device settings first, before making the changes.
      *
-     * @param[in] addr   Address of the device to be set.
+     * @param[in] addr                Address of the device to be set.
+     * @param[in] mrpIdleInterval     MRP idle retransmission interval of the device to be set.
+     * @param[in] mrpActiveInterval   MRP active retransmision interval of the device to be set.
      *
-     * @return CHIP_NO_ERROR if the address has been updated, an error code otherwise.
+     * @return CHIP_NO_ERROR if the data has been updated, an error code otherwise.
      */
-    CHIP_ERROR UpdateAddress(const Transport::PeerAddress & addr);
+    CHIP_ERROR UpdateDeviceData(const Transport::PeerAddress & addr, uint32_t mrpIdleInterval, uint32_t mrpActiveInterval);
     /**
      * @brief
      *   Return whether the current device object is actively associated with a paired CHIP
@@ -383,6 +385,12 @@ public:
     Messaging::ExchangeManager * GetExchangeManager() const { return mExchangeMgr; }
 
     void SetAddress(const Inet::IPAddress & deviceAddr) { mDeviceAddress.SetIPAddress(deviceAddr); }
+
+    void GetMRPIntervals(uint32_t & idleInterval, uint32_t & activeInterval) const
+    {
+        idleInterval   = mMrpIdleInterval;
+        activeInterval = mMrpActiveInterval;
+    }
 
     PASESessionSerializable & GetPairing() { return mPairing; }
 
@@ -485,6 +493,9 @@ private:
     /** Address used to communicate with the device.
      */
     Transport::PeerAddress mDeviceAddress = Transport::PeerAddress::UDP(Inet::IPAddress::Any);
+
+    uint32_t mMrpIdleInterval   = CHIP_CONFIG_MRP_DEFAULT_IDLE_RETRY_INTERVAL;
+    uint32_t mMrpActiveInterval = CHIP_CONFIG_MRP_DEFAULT_ACTIVE_RETRY_INTERVAL;
 
     Inet::InetLayer * mInetLayer = nullptr;
 

--- a/src/messaging/ReliableMessageContext.cpp
+++ b/src/messaging/ReliableMessageContext.cpp
@@ -131,9 +131,9 @@ bool ReliableMessageContext::HasPiggybackAckPending() const
     return mFlags.Has(Flags::kFlagAckMessageCounterIsValid);
 }
 
-uint64_t ReliableMessageContext::GetInitialRetransmitTimeoutTick()
+uint64_t ReliableMessageContext::GetIdleRetransmitTimeoutTick()
 {
-    return mConfig.mInitialRetransTimeoutTick;
+    return mConfig.mIdleRetransTimeoutTick;
 }
 
 uint64_t ReliableMessageContext::GetActiveRetransmitTimeoutTick()

--- a/src/messaging/ReliableMessageContext.h
+++ b/src/messaging/ReliableMessageContext.h
@@ -76,12 +76,12 @@ public:
     bool HasPiggybackAckPending() const;
 
     /**
-     *  Get the initial retransmission interval. It would be the time to wait before
+     *  Get the idle retransmission interval. It would be the time to wait before
      *  retransmission after first failure.
      *
-     *  @return the initial retransmission interval.
+     *  @return the idle retransmission interval.
      */
-    uint64_t GetInitialRetransmitTimeoutTick();
+    uint64_t GetIdleRetransmitTimeoutTick();
 
     /**
      *  Get the active retransmit interval. It would be the time to wait before

--- a/src/messaging/ReliableMessageMgr.cpp
+++ b/src/messaging/ReliableMessageMgr.cpp
@@ -278,7 +278,7 @@ CHIP_ERROR ReliableMessageMgr::AddToRetransTable(ReliableMessageContext * rc, Re
 
 void ReliableMessageMgr::StartRetransmision(RetransTableEntry * entry)
 {
-    entry->nextRetransTimeTick = static_cast<uint16_t>(entry->ec->GetInitialRetransmitTimeoutTick() +
+    entry->nextRetransTimeTick = static_cast<uint16_t>(entry->ec->GetIdleRetransmitTimeoutTick() +
                                                        GetTickCounterFromTimeDelta(System::SystemClock().GetMonotonicTimestamp()));
 
     // Check if the timer needs to be started and start it.

--- a/src/messaging/ReliableMessageProtocolConfig.h
+++ b/src/messaging/ReliableMessageProtocolConfig.h
@@ -58,18 +58,18 @@ namespace Messaging {
 #endif // CHIP_CONFIG_MRP_DEFAULT_ACTIVE_RETRY_INTERVAL
 
 /**
- *  @def CHIP_CONFIG_MRP_DEFAULT_INITIAL_RETRY_INTERVAL
+ *  @def CHIP_CONFIG_MRP_DEFAULT_IDLE_RETRY_INTERVAL
  *
  *  @brief
- *    Initial retransmission interval, or time to wait before retransmission after first
+ *    Initial base retransmission interval, or time to wait before retransmission after first
  *    failure in milliseconds.
  *
  * This is the default value, that might be adjusted by end device depending on its
  * needs (e.g. sleeping period) using Service Discovery TXT record CRI key.
  */
-#ifndef CHIP_CONFIG_MRP_DEFAULT_INITIAL_RETRY_INTERVAL
-#define CHIP_CONFIG_MRP_DEFAULT_INITIAL_RETRY_INTERVAL (5000)
-#endif // CHIP_CONFIG_MRP_DEFAULT_INITIAL_RETRY_INTERVAL
+#ifndef CHIP_CONFIG_MRP_DEFAULT_IDLE_RETRY_INTERVAL
+#define CHIP_CONFIG_MRP_DEFAULT_IDLE_RETRY_INTERVAL (5000)
+#endif // CHIP_CONFIG_MRP_DEFAULT_IDLE_RETRY_INTERVAL
 
 /**
  *  @def CHIP_CONFIG_RMP_DEFAULT_ACK_TIMEOUT_TICK
@@ -118,12 +118,12 @@ namespace Messaging {
  */
 struct ReliableMessageProtocolConfig
 {
-    uint32_t mInitialRetransTimeoutTick; /**< Configurable timeout in msec for retransmission of the first sent message. */
-    uint32_t mActiveRetransTimeoutTick;  /**< Configurable timeout in msec for retransmission of all subsequent messages. */
+    uint32_t mIdleRetransTimeoutTick;   /**< Configurable timeout in msec for retransmission of the first sent message. */
+    uint32_t mActiveRetransTimeoutTick; /**< Configurable timeout in msec for retransmission of all subsequent messages. */
 };
 
 const ReliableMessageProtocolConfig gDefaultReliableMessageProtocolConfig = {
-    CHIP_CONFIG_MRP_DEFAULT_INITIAL_RETRY_INTERVAL >> CHIP_CONFIG_RMP_TIMER_DEFAULT_PERIOD_SHIFT,
+    CHIP_CONFIG_MRP_DEFAULT_IDLE_RETRY_INTERVAL >> CHIP_CONFIG_RMP_TIMER_DEFAULT_PERIOD_SHIFT,
     CHIP_CONFIG_MRP_DEFAULT_ACTIVE_RETRY_INTERVAL >> CHIP_CONFIG_RMP_TIMER_DEFAULT_PERIOD_SHIFT
 };
 

--- a/src/messaging/tests/TestReliableMessageProtocol.cpp
+++ b/src/messaging/tests/TestReliableMessageProtocol.cpp
@@ -232,7 +232,7 @@ void CheckResendApplicationMessage(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, rc != nullptr);
 
     rc->SetConfig({
-        1, // CHIP_CONFIG_MRP_DEFAULT_INITIAL_RETRY_INTERVAL
+        1, // CHIP_CONFIG_MRP_DEFAULT_IDLE_RETRY_INTERVAL
         1, // CHIP_CONFIG_MRP_DEFAULT_ACTIVE_RETRY_INTERVAL
     });
 
@@ -297,7 +297,7 @@ void CheckCloseExchangeAndResendApplicationMessage(nlTestSuite * inSuite, void *
     NL_TEST_ASSERT(inSuite, rc != nullptr);
 
     rc->SetConfig({
-        1, // CHIP_CONFIG_MRP_DEFAULT_INITIAL_RETRY_INTERVAL
+        1, // CHIP_CONFIG_MRP_DEFAULT_IDLE_RETRY_INTERVAL
         1, // CHIP_CONFIG_MRP_DEFAULT_ACTIVE_RETRY_INTERVAL
     });
 
@@ -359,7 +359,7 @@ void CheckFailedMessageRetainOnSend(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, rc != nullptr);
 
     rc->SetConfig({
-        1, // CHIP_CONFIG_MRP_DEFAULT_INITIAL_RETRY_INTERVAL
+        1, // CHIP_CONFIG_MRP_DEFAULT_IDLE_RETRY_INTERVAL
         1, // CHIP_CONFIG_MRP_DEFAULT_ACTIVE_RETRY_INTERVAL
     });
 
@@ -455,7 +455,7 @@ void CheckResendApplicationMessageWithPeerExchange(nlTestSuite * inSuite, void *
     NL_TEST_ASSERT(inSuite, rc != nullptr);
 
     rc->SetConfig({
-        1, // CHIP_CONFIG_MRP_DEFAULT_INITIAL_RETRY_INTERVAL
+        1, // CHIP_CONFIG_MRP_DEFAULT_IDLE_RETRY_INTERVAL
         1, // CHIP_CONFIG_MRP_DEFAULT_ACTIVE_RETRY_INTERVAL
     });
 
@@ -592,7 +592,7 @@ void CheckResendSessionEstablishmentMessageWithPeerExchange(nlTestSuite * inSuit
     NL_TEST_ASSERT(inSuite, rc != nullptr);
 
     rc->SetConfig({
-        1, // CHIP_CONFIG_MRP_DEFAULT_INITIAL_RETRY_INTERVAL
+        1, // CHIP_CONFIG_MRP_DEFAULT_IDLE_RETRY_INTERVAL
         1, // CHIP_CONFIG_MRP_DEFAULT_ACTIVE_RETRY_INTERVAL
     });
 
@@ -1146,7 +1146,7 @@ void CheckLostResponseWithPiggyback(nlTestSuite * inSuite, void * inContext)
     // Make sure that we resend our message before the other side does.
     ReliableMessageContext * rc = exchange->GetReliableMessageContext();
     rc->SetConfig({
-        1, // CHIP_CONFIG_MRP_DEFAULT_INITIAL_RETRY_INTERVAL
+        1, // CHIP_CONFIG_MRP_DEFAULT_IDLE_RETRY_INTERVAL
         1, // CHIP_CONFIG_MRP_DEFAULT_ACTIVE_RETRY_INTERVAL
     });
 
@@ -1182,7 +1182,7 @@ void CheckLostResponseWithPiggyback(nlTestSuite * inSuite, void * inContext)
     // that we are very unlikely to actually trigger the resends on the receiver
     // when we trigger the resends on the sender.
     receiverRc->SetConfig({
-        4, // CHIP_CONFIG_MRP_DEFAULT_INITIAL_RETRY_INTERVAL
+        4, // CHIP_CONFIG_MRP_DEFAULT_IDLE_RETRY_INTERVAL
         4, // CHIP_CONFIG_MRP_DEFAULT_ACTIVE_RETRY_INTERVAL
     });
 

--- a/src/protocols/secure_channel/tests/TestPASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestPASESession.cpp
@@ -175,7 +175,7 @@ void SecurePairingHandshakeTestCommon(nlTestSuite * inSuite, void * inContext, P
         NL_TEST_ASSERT(inSuite, rc != nullptr);
 
         rc->SetConfig({
-            1, // CHIP_CONFIG_MRP_DEFAULT_INITIAL_RETRY_INTERVAL
+            1, // CHIP_CONFIG_MRP_DEFAULT_IDLE_RETRY_INTERVAL
             1, // CHIP_CONFIG_MRP_DEFAULT_ACTIVE_RETRY_INTERVAL
         });
         gLoopback.mContext = &ctx;
@@ -245,7 +245,7 @@ void SecurePairingFailedHandshake(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, rc != nullptr);
 
     rc->SetConfig({
-        1, // CHIP_CONFIG_MRP_DEFAULT_INITIAL_RETRY_INTERVAL
+        1, // CHIP_CONFIG_MRP_DEFAULT_IDLE_RETRY_INTERVAL
         1, // CHIP_CONFIG_MRP_DEFAULT_ACTIVE_RETRY_INTERVAL
     });
     gLoopback.mContext = &ctx;

--- a/src/transport/SecureSession.h
+++ b/src/transport/SecureSession.h
@@ -67,6 +67,19 @@ public:
     void SetPeerAddress(const PeerAddress & address) { mPeerAddress = address; }
 
     NodeId GetPeerNodeId() const { return mPeerNodeId; }
+
+    void GetMRPIntervals(uint32_t & idleInterval, uint32_t & activeInterval)
+    {
+        idleInterval   = mMRPIdleInterval;
+        activeInterval = mMRPActiveInterval;
+    }
+
+    void SetMRPIntervals(uint32_t idleInterval, uint32_t activeInterval)
+    {
+        mMRPIdleInterval   = idleInterval;
+        mMRPActiveInterval = activeInterval;
+    }
+
     uint16_t GetLocalSessionId() const { return mLocalSessionId; }
     uint16_t GetPeerSessionId() const { return mPeerSessionId; }
     FabricIndex GetFabricIndex() const { return mFabric; }
@@ -98,6 +111,8 @@ private:
 
     PeerAddress mPeerAddress;
     System::Clock::Timestamp mLastActivityTime = System::Clock::kZero;
+    uint32_t mMRPIdleInterval                  = 0;
+    uint32_t mMRPActiveInterval                = 0;
     CryptoContext mCryptoContext;
     SessionMessageCounter mSessionMessageCounter;
 };

--- a/src/transport/SessionHandle.cpp
+++ b/src/transport/SessionHandle.cpp
@@ -39,4 +39,23 @@ const PeerAddress * SessionHandle::GetPeerAddress(SessionManager * sessionManage
     return &GetUnauthenticatedSession()->GetPeerAddress();
 }
 
+CHIP_ERROR SessionHandle::GetMRPIntervals(SessionManager * sessionManager, uint32_t & mrpIdleInterval, uint32_t & mrpActiveInterval)
+{
+    if (IsSecure())
+    {
+        SecureSession * secureSession = sessionManager->GetSecureSession(*this);
+        if (secureSession == nullptr)
+        {
+            return CHIP_ERROR_INVALID_ARGUMENT;
+        }
+        secureSession->GetMRPIntervals(mrpIdleInterval, mrpActiveInterval);
+
+        return CHIP_NO_ERROR;
+    }
+
+    GetUnauthenticatedSession()->GetMRPIntervals(mrpIdleInterval, mrpActiveInterval);
+
+    return CHIP_NO_ERROR;
+}
+
 } // namespace chip

--- a/src/transport/SessionHandle.h
+++ b/src/transport/SessionHandle.h
@@ -82,6 +82,8 @@ public:
     // torn down, at the very least.
     const Transport::PeerAddress * GetPeerAddress(SessionManager * sessionManager) const;
 
+    CHIP_ERROR GetMRPIntervals(SessionManager * sessionManager, uint32_t & mrpIdleInterval, uint32_t & mrpActiveInterval);
+
     Transport::UnauthenticatedSessionHandle GetUnauthenticatedSession() const { return mUnauthenticatedSessionHandle.Value(); }
 
 private:

--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -284,6 +284,8 @@ CHIP_ERROR SessionManager::NewPairing(const Optional<Transport::PeerAddress> & p
         return CHIP_ERROR_INVALID_ARGUMENT;
     }
 
+    session->SetMRPIntervals(CHIP_CONFIG_MRP_DEFAULT_IDLE_RETRY_INTERVAL, CHIP_CONFIG_MRP_DEFAULT_ACTIVE_RETRY_INTERVAL);
+
     ReturnErrorOnFailure(pairing->DeriveSecureSession(session->GetCryptoContext(), direction));
 
     if (mCB != nullptr)

--- a/src/transport/UnauthenticatedSessionTable.h
+++ b/src/transport/UnauthenticatedSessionTable.h
@@ -59,12 +59,26 @@ public:
 
     const PeerAddress & GetPeerAddress() const { return mPeerAddress; }
 
+    void GetMRPIntervals(uint32_t & idleInterval, uint32_t & activeInterval)
+    {
+        idleInterval   = mMRPIdleInterval;
+        activeInterval = mMRPActiveInterval;
+    }
+
+    void SetMRPIntervals(uint32_t idleInterval, uint32_t activeInterval)
+    {
+        mMRPIdleInterval   = idleInterval;
+        mMRPActiveInterval = activeInterval;
+    }
+
     PeerMessageCounter & GetPeerMessageCounter() { return mPeerMessageCounter; }
 
 private:
     System::Clock::Timestamp mLastActivityTime = System::Clock::kZero;
 
     const PeerAddress mPeerAddress;
+    uint32_t mMRPIdleInterval   = 0;
+    uint32_t mMRPActiveInterval = 0;
     PeerMessageCounter mPeerMessageCounter;
 };
 


### PR DESCRIPTION
#### Problem
Controller is using default MRP retransmission interval values for all of the devices. According to spec it should use
discovered CRA and CRI values for that purpose and set MRP parameters independently for every single device.

#### Change overview
* Added storing MRP intervals values in the CHIPDevice, SecureSession and UnathenticatedSession.
* Added setting MRP intervals for sessions using discovered device data or if they are not available with the default values.
* Added setting ReliableMessageContext config when creating every new ExchangeContext based on MRP intervals got from the SessionHandle
* Changed INITIAL retransmission interval name in the Reliable Message module to IDLE as that is compatible with the spec.

#### Testing
Verified manually using the Python CHIP controller and nrfconnect accessory that:
* After calling the `resolve` command MRP intervals are changed from the default one to the one found in the discovered CRA/CRI values
* Changing intervals on the accessory and calling `resolve` command again results in updating MRP intervals