### PR TITLE
[Ameba] Read General Diagnostic attributes from platform at runtime

### DIFF
--- a/src/platform/Ameba/AmebaConfig.cpp
+++ b/src/platform/Ameba/AmebaConfig.cpp
@@ -74,6 +74,12 @@ const AmebaConfig::Key AmebaConfig::kConfigKey_RegulatoryLocation          = { k
 const AmebaConfig::Key AmebaConfig::kConfigKey_CountryCode                 = { kConfigNamespace_ChipConfig, "country-code" };
 const AmebaConfig::Key AmebaConfig::kConfigKey_Breadcrumb                  = { kConfigNamespace_ChipConfig, "breadcrumb" };
 
+// Keys stored in the Chip-counters namespace
+const AmebaConfig::Key AmebaConfig::kCounterKey_RebootCount           = { kConfigNamespace_ChipCounters, "reboot-count" };
+const AmebaConfig::Key AmebaConfig::kCounterKey_UpTime                = { kConfigNamespace_ChipCounters, "up-time" };
+const AmebaConfig::Key AmebaConfig::kCounterKey_TotalOperationalHours = { kConfigNamespace_ChipCounters, "total-hours" };
+const AmebaConfig::Key AmebaConfig::kCounterKey_BootReason            = { kConfigNamespace_ChipCounters, "boot-reason" };
+
 CHIP_ERROR AmebaConfig::ReadConfigValue(Key key, bool & val)
 {
     uint32_t intVal;

--- a/src/platform/Ameba/AmebaConfig.h
+++ b/src/platform/Ameba/AmebaConfig.h
@@ -67,6 +67,10 @@ public:
     static const Key kConfigKey_RegulatoryLocation;
     static const Key kConfigKey_CountryCode;
     static const Key kConfigKey_Breadcrumb;
+    static const Key kCounterKey_RebootCount;
+    static const Key kCounterKey_UpTime;
+    static const Key kCounterKey_TotalOperationalHours;
+    static const Key kCounterKey_BootReason;
 
     static const char kGroupKeyNamePrefix[];
 

--- a/src/platform/Ameba/ConfigurationManagerImpl.cpp
+++ b/src/platform/Ameba/ConfigurationManagerImpl.cpp
@@ -43,6 +43,7 @@ ConfigurationManagerImpl ConfigurationManagerImpl::sInstance;
 CHIP_ERROR ConfigurationManagerImpl::Init()
 {
     CHIP_ERROR err;
+    uint32_t rebootCount;
     bool failSafeArmed;
 
     // Force initialization of NVS namespaces if they doesn't already exist.
@@ -52,6 +53,33 @@ CHIP_ERROR ConfigurationManagerImpl::Init()
     SuccessOrExit(err);
     err = EnsureNamespace(kConfigNamespace_ChipCounters);
     SuccessOrExit(err);
+
+    if (ConfigValueExists(kCounterKey_RebootCount))
+    {
+        err = GetRebootCount(rebootCount);
+        SuccessOrExit(err);
+
+        err = StoreRebootCount(rebootCount + 1);
+        SuccessOrExit(err);
+    }
+    else
+    {
+        // The first boot after factory reset of the Node.
+        err = StoreRebootCount(1);
+        SuccessOrExit(err);
+    }
+
+    if (!ConfigValueExists(kCounterKey_TotalOperationalHours))
+    {
+        err = StoreTotalOperationalHours(0);
+        SuccessOrExit(err);
+    }
+
+    if (!ConfigValueExists(kCounterKey_BootReason))
+    {
+        err = StoreBootReasons(EMBER_ZCL_BOOT_REASON_TYPE_UNSPECIFIED);
+        SuccessOrExit(err);
+    }
 
     // Initialize the generic implementation base class.
     err = Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>::Init();
@@ -67,6 +95,36 @@ CHIP_ERROR ConfigurationManagerImpl::Init()
 
 exit:
     return err;
+}
+
+CHIP_ERROR ConfigurationManagerImpl::GetRebootCount(uint32_t & rebootCount)
+{
+    return ReadConfigValue(kCounterKey_RebootCount, rebootCount);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::StoreRebootCount(uint32_t rebootCount)
+{
+    return WriteConfigValue(kCounterKey_RebootCount, rebootCount);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::GetTotalOperationalHours(uint32_t & totalOperationalHours)
+{
+    return ReadConfigValue(kCounterKey_TotalOperationalHours, totalOperationalHours);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::StoreTotalOperationalHours(uint32_t totalOperationalHours)
+{
+    return WriteConfigValue(kCounterKey_TotalOperationalHours, totalOperationalHours);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::GetBootReasons(uint32_t & bootReasons)
+{
+    return ReadConfigValue(kCounterKey_BootReason, bootReasons);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::StoreBootReasons(uint32_t bootReasons)
+{
+    return WriteConfigValue(kCounterKey_BootReason, bootReasons);
 }
 
 CHIP_ERROR ConfigurationManagerImpl::GetPrimaryWiFiMACAddress(uint8_t * buf)

--- a/src/platform/Ameba/ConfigurationManagerImpl.h
+++ b/src/platform/Ameba/ConfigurationManagerImpl.h
@@ -37,11 +37,19 @@ namespace DeviceLayer {
 class ConfigurationManagerImpl final : public Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>,
                                        private Internal::AmebaConfig
 {
+public:
+    CHIP_ERROR GetRebootCount(uint32_t & rebootCount);
+    CHIP_ERROR StoreRebootCount(uint32_t rebootCount);
+    CHIP_ERROR GetTotalOperationalHours(uint32_t & totalOperationalHours);
+    CHIP_ERROR StoreTotalOperationalHours(uint32_t totalOperationalHours);
+    CHIP_ERROR GetBootReasons(uint32_t & bootReasons);
+    CHIP_ERROR StoreBootReasons(uint32_t bootReasons);
+
+private:
     // Allow the ConfigurationManager interface class to delegate method calls to
     // the implementation methods provided by this class.
     friend class ConfigurationManager;
 
-private:
     // Allow the GenericConfigurationManagerImpl base class to access helper methods and types
     // defined on this class.
 #ifndef DOXYGEN_SHOULD_SKIP_THIS

--- a/src/platform/Ameba/ConnectivityManagerImpl.cpp
+++ b/src/platform/Ameba/ConnectivityManagerImpl.cpp
@@ -18,6 +18,8 @@
 /* this file behaves like a config.h, comes first */
 #include <platform/internal/CHIPDeviceLayerInternal.h>
 
+#include <platform/ConnectivityManager.h>
+
 #if CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
 #include <platform/internal/GenericConnectivityManagerImpl_BLE.cpp>
 #endif
@@ -26,7 +28,10 @@
 #include <platform/internal/GenericConnectivityManagerImpl_Thread.cpp>
 #endif
 
-#include <platform/ConnectivityManager.h>
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
+#include <platform/internal/GenericConnectivityManagerImpl_WiFi.cpp>
+#endif
+
 #include <platform/internal/BLEManager.h>
 #include <support/CodeUtils.h>
 #include <support/logging/CHIPLogging.h>
@@ -49,6 +54,100 @@ namespace DeviceLayer {
 
 ConnectivityManagerImpl ConnectivityManagerImpl::sInstance;
 
+// ==================== ConnectivityManager Platform Internal Methods ====================
+
+CHIP_ERROR ConnectivityManagerImpl::_Init()
+{
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
+    mLastStationConnectFailTime   = System::Clock::kZero;
+    mLastAPDemandTime             = System::Clock::kZero;
+    mWiFiStationMode              = kWiFiStationMode_Disabled;
+    mWiFiStationState             = kWiFiStationState_NotConnected;
+    mWiFiAPMode                   = kWiFiAPMode_Disabled;
+    mWiFiAPState                  = kWiFiAPState_NotActive;
+    mWiFiStationReconnectInterval = System::Clock::Milliseconds32(CHIP_DEVICE_CONFIG_WIFI_STATION_RECONNECT_INTERVAL);
+    mWiFiAPIdleTimeout            = System::Clock::Milliseconds32(CHIP_DEVICE_CONFIG_WIFI_AP_IDLE_TIMEOUT);
+    mFlags.SetRaw(0);
+
+    // Ensure that station mode is enabled.
+    wifi_on(RTW_MODE_STA);
+
+    // Ensure that station mode is enabled in the WiFi layer.
+    wifi_set_mode(RTW_MODE_STA);
+    ;
+
+    // If there is no persistent station provision...
+    if (!IsWiFiStationProvisioned())
+    {
+        // If the code has been compiled with a default WiFi station provision, configure that now.
+#if !defined(CONFIG_DEFAULT_WIFI_SSID)
+        printf("%s %d pls define CONFIG_DEFAULT_WIFI_SSID\r\n", __func__, __LINE__);
+#else
+        if (CONFIG_DEFAULT_WIFI_SSID[0] != 0)
+        {
+            ChipLogProgress(DeviceLayer, "Setting default WiFi station configuration (SSID: %s)", CONFIG_DEFAULT_WIFI_SSID);
+
+            // Set a default station configuration.
+            rtw_wifi_setting_t wifiConfig;
+
+            // Set the wifi configuration
+            memset(&wifiConfig, 0, sizeof(wifiConfig));
+            memcpy(wifiConfig.ssid, CONFIG_DEFAULT_WIFI_SSID, strlen(CONFIG_DEFAULT_WIFI_SSID) + 1);
+            memcpy(wifiConfig.password, CONFIG_DEFAULT_WIFI_PASSWORD, strlen(CONFIG_DEFAULT_WIFI_PASSWORD) + 1);
+            wifiConfig.mode = RTW_MODE_STA;
+
+            // Configure the WiFi interface.
+            int err = CHIP_SetWiFiConfig(&wifiConfig);
+            if (err != 0)
+            {
+                ChipLogError(DeviceLayer, "_Init _SetWiFiConfig() failed: %d", err);
+            }
+
+            // Enable WiFi station mode.
+            ReturnErrorOnFailure(SetWiFiStationMode(kWiFiStationMode_Enabled));
+        }
+
+        // Otherwise, ensure WiFi station mode is disabled.
+        else
+        {
+            ReturnErrorOnFailure(SetWiFiStationMode(kWiFiStationMode_Disabled));
+        }
+#endif
+    }
+
+    // Force AP mode off for now.
+
+    // Queue work items to bootstrap the AP and station state machines once the Chip event loop is running.
+    ReturnErrorOnFailure(DeviceLayer::SystemLayer().ScheduleWork(DriveStationState, NULL));
+    ReturnErrorOnFailure(DeviceLayer::SystemLayer().ScheduleWork(DriveAPState, NULL));
+
+#endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI
+
+    return CHIP_NO_ERROR;
+}
+
+void ConnectivityManagerImpl::_OnPlatformEvent(const ChipDeviceEvent * event)
+{
+    // Forward the event to the generic base classes as needed.
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
+    GenericConnectivityManagerImpl_Thread<ConnectivityManagerImpl>::_OnPlatformEvent(event);
+#endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD
+
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
+    if (event->Type == DeviceEventType::kRtkWiFiStationConnectedEvent)
+    {
+        ChipLogProgress(DeviceLayer, "WIFI_EVENT_STA_CONNECTED");
+        if (mWiFiStationState == kWiFiStationState_Connecting)
+        {
+            ChangeWiFiStationState(kWiFiStationState_Connecting_Succeeded);
+        }
+        DriveStationState();
+        DHCPProcess();
+    }
+#endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI
+}
+
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
 ConnectivityManager::WiFiStationMode ConnectivityManagerImpl::_GetWiFiStationMode(void)
 {
     if (mWiFiStationMode != kWiFiStationMode_ApplicationControlled)
@@ -328,94 +427,6 @@ static uint16_t MapFrequency(const uint16_t inBand, const uint8_t inChannel)
 CHIP_ERROR ConnectivityManagerImpl::_GetAndLogWifiStatsCounters(void)
 {
     return CHIP_NO_ERROR;
-}
-
-// ==================== ConnectivityManager Platform Internal Methods ====================
-
-CHIP_ERROR ConnectivityManagerImpl::_Init()
-{
-    mLastStationConnectFailTime   = System::Clock::kZero;
-    mLastAPDemandTime             = System::Clock::kZero;
-    mWiFiStationMode              = kWiFiStationMode_Disabled;
-    mWiFiStationState             = kWiFiStationState_NotConnected;
-    mWiFiAPMode                   = kWiFiAPMode_Disabled;
-    mWiFiAPState                  = kWiFiAPState_NotActive;
-    mWiFiStationReconnectInterval = System::Clock::Milliseconds32(CHIP_DEVICE_CONFIG_WIFI_STATION_RECONNECT_INTERVAL);
-    mWiFiAPIdleTimeout            = System::Clock::Milliseconds32(CHIP_DEVICE_CONFIG_WIFI_AP_IDLE_TIMEOUT);
-    mFlags.SetRaw(0);
-
-    // Ensure that station mode is enabled.
-    wifi_on(RTW_MODE_STA);
-
-    // Ensure that station mode is enabled in the WiFi layer.
-    wifi_set_mode(RTW_MODE_STA);
-    ;
-
-    // If there is no persistent station provision...
-    if (!IsWiFiStationProvisioned())
-    {
-        // If the code has been compiled with a default WiFi station provision, configure that now.
-#if !defined(CONFIG_DEFAULT_WIFI_SSID)
-        printf("%s %d pls define CONFIG_DEFAULT_WIFI_SSID\r\n", __func__, __LINE__);
-#else
-        if (CONFIG_DEFAULT_WIFI_SSID[0] != 0)
-        {
-            ChipLogProgress(DeviceLayer, "Setting default WiFi station configuration (SSID: %s)", CONFIG_DEFAULT_WIFI_SSID);
-
-            // Set a default station configuration.
-            rtw_wifi_setting_t wifiConfig;
-
-            // Set the wifi configuration
-            memset(&wifiConfig, 0, sizeof(wifiConfig));
-            memcpy(wifiConfig.ssid, CONFIG_DEFAULT_WIFI_SSID, strlen(CONFIG_DEFAULT_WIFI_SSID) + 1);
-            memcpy(wifiConfig.password, CONFIG_DEFAULT_WIFI_PASSWORD, strlen(CONFIG_DEFAULT_WIFI_PASSWORD) + 1);
-            wifiConfig.mode = RTW_MODE_STA;
-
-            // Configure the WiFi interface.
-            int err = CHIP_SetWiFiConfig(&wifiConfig);
-            if (err != 0)
-            {
-                ChipLogError(DeviceLayer, "_Init _SetWiFiConfig() failed: %d", err);
-            }
-
-            // Enable WiFi station mode.
-            ReturnErrorOnFailure(SetWiFiStationMode(kWiFiStationMode_Enabled));
-        }
-
-        // Otherwise, ensure WiFi station mode is disabled.
-        else
-        {
-            ReturnErrorOnFailure(SetWiFiStationMode(kWiFiStationMode_Disabled));
-        }
-#endif
-    }
-
-    // Force AP mode off for now.
-
-    // Queue work items to bootstrap the AP and station state machines once the Chip event loop is running.
-    ReturnErrorOnFailure(DeviceLayer::SystemLayer().ScheduleWork(DriveStationState, NULL));
-    ReturnErrorOnFailure(DeviceLayer::SystemLayer().ScheduleWork(DriveAPState, NULL));
-
-    return CHIP_NO_ERROR;
-}
-
-void ConnectivityManagerImpl::_OnPlatformEvent(const ChipDeviceEvent * event)
-{
-    // Forward the event to the generic base classes as needed.
-#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
-    GenericConnectivityManagerImpl_Thread<ConnectivityManagerImpl>::_OnPlatformEvent(event);
-#else
-    if (event->Type == DeviceEventType::kRtkWiFiStationConnectedEvent)
-    {
-        ChipLogProgress(DeviceLayer, "WIFI_EVENT_STA_CONNECTED");
-        if (mWiFiStationState == kWiFiStationState_Connecting)
-        {
-            ChangeWiFiStationState(kWiFiStationState_Connecting_Succeeded);
-        }
-        DriveStationState();
-        DHCPProcess();
-    }
-#endif
 }
 
 void ConnectivityManagerImpl::_OnWiFiScanDone()
@@ -786,6 +797,67 @@ void ConnectivityManagerImpl::DHCPProcess(void)
 {
     xTaskCreate(DHCPProcessThread, "DHCPProcess", 4096 / sizeof(StackType_t), this, 1, NULL);
 }
+
+CHIP_ERROR ConnectivityManagerImpl::_GetWiFiSecurityType(uint8_t & securityType)
+{
+    securityType = 0;
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR ConnectivityManagerImpl::_GetWiFiChannelNumber(uint16_t & channelNumber)
+{
+    channelNumber = 0;
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR ConnectivityManagerImpl::_GetWiFiRssi(int8_t & rssi)
+{
+    rssi = 0;
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR ConnectivityManagerImpl::_GetWiFiBeaconLostCount(uint32_t & beaconLostCount)
+{
+    beaconLostCount = 0;
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR ConnectivityManagerImpl::_GetWiFiCurrentMaxRate(uint64_t & currentMaxRate)
+{
+    currentMaxRate = 0;
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR ConnectivityManagerImpl::_GetWiFiPacketMulticastRxCount(uint32_t & packetMulticastRxCount)
+{
+    packetMulticastRxCount = 0;
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR ConnectivityManagerImpl::_GetWiFiPacketMulticastTxCount(uint32_t & packetMulticastTxCount)
+{
+    packetMulticastTxCount = 0;
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR ConnectivityManagerImpl::_GetWiFiPacketUnicastRxCount(uint32_t & packetUnicastRxCount)
+{
+    packetUnicastRxCount = 0;
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR ConnectivityManagerImpl::_GetWiFiPacketUnicastTxCount(uint32_t & packetUnicastTxCount)
+{
+    packetUnicastTxCount = 0;
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR ConnectivityManagerImpl::_GetWiFiOverrunCount(uint64_t & overrunCount)
+{
+    overrunCount = 0;
+    return CHIP_NO_ERROR;
+}
+#endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI
 
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/Ameba/ConnectivityManagerImpl.h
+++ b/src/platform/Ameba/ConnectivityManagerImpl.h
@@ -20,39 +20,66 @@
 
 #include <platform/ConnectivityManager.h>
 #include <platform/internal/GenericConnectivityManagerImpl.h>
+
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
 #include <platform/internal/GenericConnectivityManagerImpl_WiFi.h>
+#else
+#include <platform/internal/GenericConnectivityManagerImpl_NoWiFi.h>
+#endif
+
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
+#include <platform/internal/GenericConnectivityManagerImpl_Thread.h>
+#else
+#include <platform/internal/GenericConnectivityManagerImpl_NoThread.h>
+#endif
+
 #if CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
 #include <platform/internal/GenericConnectivityManagerImpl_BLE.h>
 #else
 #include <platform/internal/GenericConnectivityManagerImpl_NoBLE.h>
 #endif
+
 #include <lib/support/BitFlags.h>
-#include <platform/internal/GenericConnectivityManagerImpl_NoThread.h>
 
 #include <wifi_conf.h>
+
+namespace chip {
 
 namespace Inet {
 class IPAddress;
 } // namespace Inet
 
-namespace chip {
 namespace DeviceLayer {
+
+class PlatformManagerImpl;
 
 class ConnectivityManagerImpl final : public ConnectivityManager,
                                       public Internal::GenericConnectivityManagerImpl<ConnectivityManagerImpl>,
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
                                       public Internal::GenericConnectivityManagerImpl_WiFi<ConnectivityManagerImpl>,
+#else
+                                      public Internal::GenericConnectivityManagerImpl_NoWiFi<ConnectivityManagerImpl>,
+#endif
 #if CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
                                       public Internal::GenericConnectivityManagerImpl_BLE<ConnectivityManagerImpl>,
 #else
                                       public Internal::GenericConnectivityManagerImpl_NoBLE<ConnectivityManagerImpl>,
 #endif
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
+                                      public Internal::GenericConnectivityManagerImpl_Thread<ConnectivityManagerImpl>
+#else
                                       public Internal::GenericConnectivityManagerImpl_NoThread<ConnectivityManagerImpl>
+#endif
 {
     // Allow the ConnectivityManager interface class to delegate method calls to
     // the implementation methods provided by this class.
     friend class ConnectivityManager;
 
 private:
+    CHIP_ERROR _Init(void);
+    void _OnPlatformEvent(const ChipDeviceEvent * event);
+
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
     using Flags = GenericConnectivityManagerImpl_WiFi::ConnectivityFlags;
     // ===== Members that implement the ConnectivityManager abstract interface.
 
@@ -75,18 +102,20 @@ private:
     System::Clock::Timeout _GetWiFiAPIdleTimeout(void);
     void _SetWiFiAPIdleTimeout(System::Clock::Timeout val);
     CHIP_ERROR _GetAndLogWifiStatsCounters(void);
-    CHIP_ERROR _Init(void);
-    void _OnPlatformEvent(const ChipDeviceEvent * event);
     bool _CanStartWiFiScan();
     void _OnWiFiScanDone();
     void _OnWiFiStationProvisionChange();
 
-    // ===== Members for internal use by the following friends.
-
-    friend ConnectivityManager & ConnectivityMgr(void);
-    friend ConnectivityManagerImpl & ConnectivityMgrImpl(void);
-
-    static ConnectivityManagerImpl sInstance;
+    CHIP_ERROR _GetWiFiSecurityType(uint8_t & securityType);
+    CHIP_ERROR _GetWiFiChannelNumber(uint16_t & channelNumber);
+    CHIP_ERROR _GetWiFiRssi(int8_t & rssi);
+    CHIP_ERROR _GetWiFiBeaconLostCount(uint32_t & beaconLostCount);
+    CHIP_ERROR _GetWiFiPacketMulticastRxCount(uint32_t & packetMulticastRxCount);
+    CHIP_ERROR _GetWiFiPacketMulticastTxCount(uint32_t & packetMulticastTxCount);
+    CHIP_ERROR _GetWiFiPacketUnicastRxCount(uint32_t & packetUnicastRxCount);
+    CHIP_ERROR _GetWiFiPacketUnicastTxCount(uint32_t & packetUnicastTxCount);
+    CHIP_ERROR _GetWiFiCurrentMaxRate(uint64_t & currentMaxRate);
+    CHIP_ERROR _GetWiFiOverrunCount(uint64_t & overrunCount);
 
     // ===== Private members reserved for use by this class only.
 
@@ -116,12 +145,21 @@ private:
     void OnStationIPv4AddressLost(void);
     void OnIPv6AddressAvailable(void);
 
+#endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI
+
+    // ===== Members for internal use by the following friends.
+
+    friend ConnectivityManager & ConnectivityMgr(void);
+    friend ConnectivityManagerImpl & ConnectivityMgrImpl(void);
+
+    static ConnectivityManagerImpl sInstance;
     static void RefreshMessageLayer(void);
     static void RtkWiFiStationConnectedHandler(char * buf, int buf_len, int flags, void * userdata);
     void DHCPProcess(void);
     static void DHCPProcessThread(void * param);
 };
 
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
 inline bool ConnectivityManagerImpl::_IsWiFiStationApplicationControlled(void)
 {
     return mWiFiStationMode == kWiFiStationMode_ApplicationControlled;
@@ -161,6 +199,7 @@ inline bool ConnectivityManagerImpl::_CanStartWiFiScan()
 {
     return mWiFiStationState != kWiFiStationState_Connecting;
 }
+#endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI
 
 /**
  * Returns the public interface of the ConnectivityManager singleton object.

--- a/src/platform/Ameba/PlatformManagerImpl.cpp
+++ b/src/platform/Ameba/PlatformManagerImpl.cpp
@@ -62,6 +62,8 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
 
     SuccessOrExit(err);
 
+    mStartTime = System::SystemClock().GetMonotonicTimestamp();
+
     // TODO Wi-Fi Initialzation currently done through the example app needs to be moved into here.
     // for now we will let this happen that way and assume all is OK
 
@@ -74,6 +76,31 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
 
 exit:
     return err;
+}
+
+CHIP_ERROR PlatformManagerImpl::_Shutdown()
+{
+    uint64_t upTime = 0;
+
+    if (_GetUpTime(upTime) == CHIP_NO_ERROR)
+    {
+        uint32_t totalOperationalHours = 0;
+
+        if (ConfigurationMgrImpl().GetTotalOperationalHours(totalOperationalHours) == CHIP_NO_ERROR)
+        {
+            ConfigurationMgrImpl().StoreTotalOperationalHours(totalOperationalHours + static_cast<uint32_t>(upTime / 3600));
+        }
+        else
+        {
+            ChipLogError(DeviceLayer, "Failed to get total operational hours of the Node");
+        }
+    }
+    else
+    {
+        ChipLogError(DeviceLayer, "Failed to get current uptime since the Node’s last reboot");
+    }
+
+    return Internal::GenericPlatformManagerImpl_FreeRTOS<PlatformManagerImpl>::_Shutdown();
 }
 
 CHIP_ERROR PlatformManagerImpl::_GetCurrentHeapFree(uint64_t & currentHeapFree)
@@ -93,5 +120,66 @@ CHIP_ERROR PlatformManagerImpl::_GetCurrentHeapHighWatermark(uint64_t & currentH
     currentHeapHighWatermark = xPortGetTotalHeapSize() - xPortGetMinimumEverFreeHeapSize();
     return CHIP_NO_ERROR;
 }
+CHIP_ERROR PlatformManagerImpl::_GetRebootCount(uint16_t & rebootCount)
+{
+    uint32_t count = 0;
+
+    CHIP_ERROR err = ConfigurationMgrImpl().GetRebootCount(count);
+
+    if (err == CHIP_NO_ERROR)
+    {
+        VerifyOrReturnError(count <= UINT16_MAX, CHIP_ERROR_INVALID_INTEGER_VALUE);
+        rebootCount = static_cast<uint16_t>(count);
+    }
+
+    return err;
+}
+
+CHIP_ERROR PlatformManagerImpl::_GetUpTime(uint64_t & upTime)
+{
+    System::Clock::Timestamp currentTime = System::SystemClock().GetMonotonicTimestamp();
+
+    if (currentTime >= mStartTime)
+    {
+        upTime = std::chrono::duration_cast<System::Clock::Seconds64>(currentTime - mStartTime).count();
+        return CHIP_NO_ERROR;
+    }
+
+    return CHIP_ERROR_INVALID_TIME;
+}
+
+CHIP_ERROR PlatformManagerImpl::_GetTotalOperationalHours(uint32_t & totalOperationalHours)
+{
+    uint64_t upTime = 0;
+
+    if (_GetUpTime(upTime) == CHIP_NO_ERROR)
+    {
+        uint32_t totalHours = 0;
+        if (ConfigurationMgrImpl().GetTotalOperationalHours(totalHours) == CHIP_NO_ERROR)
+        {
+            VerifyOrReturnError(upTime / 3600 <= UINT32_MAX, CHIP_ERROR_INVALID_INTEGER_VALUE);
+            totalOperationalHours = totalHours + static_cast<uint32_t>(upTime / 3600);
+            return CHIP_NO_ERROR;
+        }
+    }
+
+    return CHIP_ERROR_INVALID_TIME;
+}
+
+CHIP_ERROR PlatformManagerImpl::_GetBootReasons(uint8_t & bootReasons)
+{
+    uint32_t reason = 0;
+
+    CHIP_ERROR err = ConfigurationMgrImpl().GetBootReasons(reason);
+
+    if (err == CHIP_NO_ERROR)
+    {
+        VerifyOrReturnError(reason <= UINT8_MAX, CHIP_ERROR_INVALID_INTEGER_VALUE);
+        bootReasons = static_cast<uint8_t>(reason);
+    }
+
+    return err;
+}
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/Ameba/PlatformManagerImpl.h
+++ b/src/platform/Ameba/PlatformManagerImpl.h
@@ -53,14 +53,22 @@ private:
     // ===== Methods that implement the PlatformManager abstract interface.
 
     CHIP_ERROR _InitChipStack(void);
+    CHIP_ERROR _Shutdown();
     CHIP_ERROR _GetCurrentHeapFree(uint64_t & currentHeapFree);
     CHIP_ERROR _GetCurrentHeapUsed(uint64_t & currentHeapUsed);
     CHIP_ERROR _GetCurrentHeapHighWatermark(uint64_t & currentHeapHighWatermark);
+
+    CHIP_ERROR _GetRebootCount(uint16_t & rebootCount);
+    CHIP_ERROR _GetUpTime(uint64_t & upTime);
+    CHIP_ERROR _GetTotalOperationalHours(uint32_t & totalOperationalHours);
+    CHIP_ERROR _GetBootReasons(uint8_t & bootReasons);
 
     // ===== Members for internal use by the following friends.
 
     friend PlatformManager & PlatformMgr(void);
     friend PlatformManagerImpl & PlatformMgrImpl(void);
+
+    chip::System::Clock::Timestamp mStartTime = System::Clock::kZero;
 
     static PlatformManagerImpl sInstance;
 

--- a/src/platform/BUILD.gn
+++ b/src/platform/BUILD.gn
@@ -208,6 +208,7 @@ if (chip_device_platform != "none") {
       defines += [
         "CHIP_DEVICE_LAYER_TARGET_AMEBA=1",
         "CHIP_DEVICE_LAYER_TARGET=Ameba",
+        "CHIP_DEVICE_CONFIG_ENABLE_WIFI=${chip_enable_wifi}",
       ]
     }
   }


### PR DESCRIPTION
#### Problem
* To be consistent with PR #9930, populate General Diagnostic attributes with the actual value from Ameba platform in run-time

#### Change overview
* Read General Diagnostics attributes from Ameba platform
* Add framework of WiFi Network Diagnostics attributes

#### Testing
* Tested all-clusters-app control via python controller.