### PR TITLE
Revert "Remove Microseconds from System::Clock (#11450)"

### DIFF
--- a/src/lib/dnssd/minimal_mdns/tests/TestActiveResolveAttempts.cpp
+++ b/src/lib/dnssd/minimal_mdns/tests/TestActiveResolveAttempts.cpp
@@ -29,6 +29,7 @@ using chip::System::Clock::Timeout;
 class MockClock : public System::Clock::ClockBase
 {
 public:
+    System::Clock::Microseconds64 GetMonotonicMicroseconds64() override { return mMsec; }
     System::Clock::Milliseconds64 GetMonotonicMilliseconds64() override { return mMsec; }
 
     void Advance(System::Clock::Milliseconds32 ms) { mMsec += ms; }

--- a/src/platform/ESP32/SystemTimeSupport.cpp
+++ b/src/platform/ESP32/SystemTimeSupport.cpp
@@ -38,9 +38,14 @@ namespace Internal {
 ClockImpl gClockImpl;
 } // namespace Internal
 
+Microseconds64 ClockImpl::GetMonotonicMicroseconds64(void)
+{
+    return Clock::Microseconds64(::esp_timer_get_time());
+}
+
 Milliseconds64 ClockImpl::GetMonotonicMilliseconds64(void)
 {
-    return std::chrono::duration_cast<Milliseconds64>(std::chrono::duration<uint64_t, std::micro>(::esp_timer_get_time()));
+    return std::chrono::duration_cast<Milliseconds64>(GetMonotonicMicroseconds64());
 }
 
 } // namespace Clock

--- a/src/platform/FreeRTOS/SystemTimeSupport.cpp
+++ b/src/platform/FreeRTOS/SystemTimeSupport.cpp
@@ -90,6 +90,11 @@ uint64_t FreeRTOSTicksSinceBoot(void)
     return static_cast<uint64_t>(timeOut.xTimeOnEntering) + (static_cast<uint64_t>(timeOut.xOverflowCount) << kTicksOverflowShift);
 }
 
+Clock::Microseconds64 ClockImpl::GetMonotonicMicroseconds64(void)
+{
+    return Clock::Microseconds64((FreeRTOSTicksSinceBoot() * kMicrosecondsPerSecond) / configTICK_RATE_HZ);
+}
+
 Clock::Milliseconds64 ClockImpl::GetMonotonicMilliseconds64(void)
 {
     return Clock::Milliseconds64((FreeRTOSTicksSinceBoot() * kMillisecondsPerSecond) / configTICK_RATE_HZ);

--- a/src/platform/Linux/SystemTimeSupport.cpp
+++ b/src/platform/Linux/SystemTimeSupport.cpp
@@ -40,6 +40,11 @@ namespace Internal {
 ClockImpl gClockImpl;
 } // namespace Internal
 
+Microseconds64 ClockImpl::GetMonotonicMicroseconds64()
+{
+    return std::chrono::duration_cast<Microseconds64>(std::chrono::steady_clock::now().time_since_epoch());
+}
+
 Milliseconds64 ClockImpl::GetMonotonicMilliseconds64()
 {
     return std::chrono::duration_cast<Milliseconds64>(std::chrono::steady_clock::now().time_since_epoch());

--- a/src/platform/Zephyr/SystemTimeSupport.cpp
+++ b/src/platform/Zephyr/SystemTimeSupport.cpp
@@ -38,6 +38,11 @@ namespace Internal {
 ClockImpl gClockImpl;
 } // namespace Internal
 
+Microseconds64 ClockImpl::GetMonotonicMicroseconds64(void)
+{
+    return Microseconds64(k_ticks_to_us_floor64(k_uptime_ticks()));
+}
+
 Milliseconds64 ClockImpl::GetMonotonicMilliseconds64(void)
 {
     return Milliseconds64(k_uptime_get());

--- a/src/platform/mbed/SystemTimeSupport.cpp
+++ b/src/platform/mbed/SystemTimeSupport.cpp
@@ -52,17 +52,23 @@ mbed::LowPowerTimer timer()
 }
 } // namespace
 
-// Returns count of microseconds
 extern "C" uint64_t get_clock_monotonic()
 {
     return timer().elapsed_time().count();
+}
+
+// Platform-specific function for getting monotonic system time in microseconds.
+// Returns elapsed time in microseconds since an arbitrary, platform-defined epoch.
+Microseconds64 ClockImpl::GetMonotonicMicroseconds64()
+{
+    return Microseconds64(get_clock_monotonic());
 }
 
 // Platform-specific function for getting monotonic system time in milliseconds.
 // Return elapsed time in milliseconds since an arbitrary, platform-defined epoch.
 Milliseconds64 ClockImpl::GetMonotonicMilliseconds64()
 {
-    return std::chrono::duration_cast<Milliseconds64>(std::chrono::duration<uint64_t, std::micro>(get_clock_monotonic()));
+    return std::chrono::duration_cast<Milliseconds64>(GetMonotonicMicroseconds64());
 }
 
 } // namespace Clock

--- a/src/platform/tests/TestPlatformTime.cpp
+++ b/src/platform/tests/TestPlatformTime.cpp
@@ -42,10 +42,42 @@ using namespace chip::System;
 using namespace chip::System::Clock::Literals;
 
 constexpr Clock::Milliseconds64 kTestTimeMarginMs = 2_ms64;
+constexpr Clock::Microseconds64 kTestTimeMarginUs = 500_us64;
 
 // =================================
 //      Unit tests
 // =================================
+
+static void TestDevice_GetMonotonicMicroseconds(nlTestSuite * inSuite, void * inContext)
+{
+    static const Clock::Microseconds64 kTestVectorSystemTimeUs[] = {
+        600_us64,
+        900_us64,
+        1500_us64,
+    };
+    int numOfTestsRan                      = 0;
+    constexpr Clock::Microseconds64 margin = kTestTimeMarginUs;
+
+    for (const Clock::Microseconds64 & Tdelay : kTestVectorSystemTimeUs)
+    {
+        const Clock::Microseconds64 Tstart = System::SystemClock().GetMonotonicMicroseconds64();
+
+        chip::test_utils::SleepMicros(Tdelay.count());
+
+        const Clock::Microseconds64 Tend   = System::SystemClock().GetMonotonicMicroseconds64();
+        const Clock::Microseconds64 Tdelta = Tend - Tstart;
+
+        ChipLogProgress(DeviceLayer, "Start=%" PRIu64 " End=%" PRIu64 " Delta=%" PRIu64 " Expected=%" PRIu64, Tstart.count(),
+                        Tend.count(), Tdelta.count(), Tdelay.count());
+
+        // verify that timers don't fire early
+        NL_TEST_ASSERT(inSuite, Tdelta > (Tdelay - margin));
+        // verify they're not too late
+        //        NL_TEST_ASSERT(inSuite, Tdelta < (Tdelay + margin));
+        numOfTestsRan++;
+    }
+    NL_TEST_ASSERT(inSuite, numOfTestsRan > 0);
+}
 
 static void TestDevice_GetMonotonicMilliseconds(nlTestSuite * inSuite, void * inContext)
 {
@@ -83,6 +115,7 @@ static void TestDevice_GetMonotonicMilliseconds(nlTestSuite * inSuite, void * in
  */
 static const nlTest sTests[] = {
 
+    NL_TEST_DEF("Test DeviceLayer::GetMonotonicMicroseconds", TestDevice_GetMonotonicMicroseconds),
     NL_TEST_DEF("Test DeviceLayer::GetMonotonicMilliseconds", TestDevice_GetMonotonicMilliseconds),
 
     NL_TEST_SENTINEL()

--- a/src/system/SystemClock.cpp
+++ b/src/system/SystemClock.cpp
@@ -82,25 +82,35 @@ ClockBase * gClockBase = &gClockImpl;
 #define MONOTONIC_CLOCK_ID CLOCK_MONOTONIC
 #endif
 
-Milliseconds64 ClockImpl::GetMonotonicMilliseconds64()
+Microseconds64 ClockImpl::GetMonotonicMicroseconds64()
 {
     struct timespec ts;
     int res = clock_gettime(MONOTONIC_CLOCK_ID, &ts);
     VerifyOrDie(res == 0);
     return Seconds64(ts.tv_sec) +
-        std::chrono::duration_cast<Milliseconds64>(std::chrono::duration<uint64_t, std::nano>(ts.tv_nsec));
+        std::chrono::duration_cast<Microseconds64>(std::chrono::duration<uint64_t, std::nano>(ts.tv_nsec));
+}
+
+Milliseconds64 ClockImpl::GetMonotonicMilliseconds64()
+{
+    return std::chrono::duration_cast<Milliseconds64>(GetMonotonicMicroseconds64());
 }
 
 #endif // HAVE_CLOCK_GETTIME
 
 #if HAVE_GETTIMEOFDAY
 
-Milliseconds64 ClockImpl::GetMonotonicMilliseconds64()
+Microseconds64 ClockImpl::GetMonotonicMicroseconds64()
 {
     struct timeval tv;
     int res = gettimeofday(&tv, NULL);
     VerifyOrDie(res == 0);
-    return TimevalToMilliseconds(tv);
+    return TimevalToMicroseconds(tv);
+}
+
+Milliseconds64 ClockImpl::GetMonotonicMilliseconds64()
+{
+    return std::chrono::duration_cast<Milliseconds64>(GetMonotonicMicroseconds64());
 }
 
 #endif // HAVE_GETTIMEOFDAY
@@ -110,6 +120,11 @@ Milliseconds64 ClockImpl::GetMonotonicMilliseconds64()
 #if CHIP_SYSTEM_CONFIG_USE_LWIP_MONOTONIC_TIME
 
 // -------------------- Default Get/SetClock Functions for LwIP Systems --------------------
+
+Microseconds64 ClockImpl::GetMonotonicMicroseconds64(void)
+{
+    return GetMonotonicMilliseconds64();
+}
 
 Milliseconds64 ClockImpl::GetMonotonicMilliseconds64(void)
 {
@@ -157,27 +172,31 @@ Milliseconds64 ClockImpl::GetMonotonicMilliseconds64(void)
 
 #if CHIP_SYSTEM_CONFIG_USE_POSIX_TIME_FUNCTS || CHIP_SYSTEM_CONFIG_USE_SOCKETS
 
-Milliseconds64 TimevalToMilliseconds(const timeval & tv)
+Microseconds64 TimevalToMicroseconds(const timeval & tv)
 {
-    return Seconds64(tv.tv_sec) + Milliseconds64(tv.tv_usec);
+    return Seconds64(tv.tv_sec) + Microseconds64(tv.tv_usec);
 }
 
-void ToTimeval(Milliseconds64 in, timeval & out)
+void ToTimeval(Microseconds64 in, timeval & out)
 {
     Seconds32 seconds = std::chrono::duration_cast<Seconds32>(in);
     in -= seconds;
     out.tv_sec  = static_cast<time_t>(seconds.count());
-    out.tv_usec = static_cast<suseconds_t>(1000 * in.count());
+    out.tv_usec = static_cast<suseconds_t>(in.count());
 }
 
 #endif // CHIP_SYSTEM_CONFIG_USE_POSIX_TIME_FUNCTS || CHIP_SYSTEM_CONFIG_USE_SOCKETS
 
+static_assert(std::numeric_limits<Microseconds64::rep>::is_integer, "Microseconds64 must be an integer type");
+static_assert(std::numeric_limits<Microseconds32::rep>::is_integer, "Microseconds32 must be an integer type");
 static_assert(std::numeric_limits<Milliseconds64::rep>::is_integer, "Milliseconds64 must be an integer type");
 static_assert(std::numeric_limits<Milliseconds32::rep>::is_integer, "Milliseconds32 must be an integer type");
 static_assert(std::numeric_limits<Seconds64::rep>::is_integer, "Seconds64 must be an integer type");
 static_assert(std::numeric_limits<Seconds32::rep>::is_integer, "Seconds32 must be an integer type");
 static_assert(std::numeric_limits<Seconds16::rep>::is_integer, "Seconds16 must be an integer type");
 
+static_assert(std::numeric_limits<Microseconds64::rep>::digits >= 64, "Microseconds64 must be at least 64 bits");
+static_assert(std::numeric_limits<Microseconds32::rep>::digits >= 32, "Microseconds32 must be at least 32 bits");
 static_assert(std::numeric_limits<Milliseconds64::rep>::digits >= 64, "Milliseconds64 must be at least 64 bits");
 static_assert(std::numeric_limits<Milliseconds32::rep>::digits >= 32, "Milliseconds32 must be at least 32 bits");
 static_assert(std::numeric_limits<Seconds64::rep>::digits >= 64, "Seconds64 must be at least 64 bits");

--- a/src/system/tests/TestSystemClock.cpp
+++ b/src/system/tests/TestSystemClock.cpp
@@ -51,8 +51,12 @@ void TestRealClock(nlTestSuite * inSuite, void * inContext)
     Clock::Milliseconds64 newMilli = SystemClock().GetMonotonicMilliseconds64();
     NL_TEST_ASSERT(inSuite, newMilli >= oldMilli);
 
-    Clock::Milliseconds64::rep milliseconds = newMilli.count();
-    NL_TEST_ASSERT(inSuite, (milliseconds & 0x8000'0000'0000'0000) == 0);
+    Clock::Microseconds64 oldMicro = SystemClock().GetMonotonicMicroseconds64();
+    Clock::Microseconds64 newMicro = SystemClock().GetMonotonicMicroseconds64();
+    NL_TEST_ASSERT(inSuite, newMicro >= oldMicro);
+
+    Clock::Microseconds64::rep microseconds = newMicro.count();
+    NL_TEST_ASSERT(inSuite, (microseconds & 0x8000'0000'0000'0000) == 0);
 
 #if !CHIP_SYSTEM_CONFIG_PLATFORM_PROVIDES_TIME &&                                                                                  \
     (CHIP_SYSTEM_CONFIG_USE_LWIP_MONOTONIC_TIME || CHIP_SYSTEM_CONFIG_USE_POSIX_TIME_FUNCTS)
@@ -72,6 +76,9 @@ void TestRealClock(nlTestSuite * inSuite, void * inContext)
     newMilli = SystemClock().GetMonotonicMilliseconds64();
     NL_TEST_ASSERT(inSuite, newMilli > oldMilli);
 
+    newMicro = SystemClock().GetMonotonicMicroseconds64();
+    NL_TEST_ASSERT(inSuite, newMicro > oldMicro);
+
 #endif // !CHIP_SYSTEM_CONFIG_PLATFORM_PROVIDES_TIME && (CHIP_SYSTEM_CONFIG_USE_LWIP_MONOTONIC_TIME ||
        // CHIP_SYSTEM_CONFIG_USE_POSIX_TIME_FUNCTS)
 }
@@ -81,6 +88,7 @@ void TestMockClock(nlTestSuite * inSuite, void * inContext)
     class MockClock : public Clock::ClockBase
     {
     public:
+        Clock::Microseconds64 GetMonotonicMicroseconds64() override { return mTime; }
         Clock::Milliseconds64 GetMonotonicMilliseconds64() override { return mTime; }
         Clock::Milliseconds64 mTime = Clock::kZero;
     };
@@ -90,10 +98,12 @@ void TestMockClock(nlTestSuite * inSuite, void * inContext)
     Clock::Internal::SetSystemClockForTesting(&clock);
 
     NL_TEST_ASSERT(inSuite, SystemClock().GetMonotonicMilliseconds64() == Clock::kZero);
+    NL_TEST_ASSERT(inSuite, SystemClock().GetMonotonicMicroseconds64() == Clock::kZero);
 
     constexpr Clock::Milliseconds64 k1234 = Clock::Milliseconds64(1234);
     clock.mTime                           = k1234;
     NL_TEST_ASSERT(inSuite, SystemClock().GetMonotonicMilliseconds64() == k1234);
+    NL_TEST_ASSERT(inSuite, SystemClock().GetMonotonicMicroseconds64() == k1234);
 
     Clock::Internal::SetSystemClockForTesting(savedRealClock);
 }


### PR DESCRIPTION
This reverts commit 11c32e8ee20b26ddb7421abd4849c5993de16940.

PWRPC tracing uses microseconds. Builds get:

```
2021-11-05 15:29:53 INFO    [1265/1352] Building CXX object esp-idf/main/CMakeFiles/__idf_main.dir/__/third_party/connectedhomeip/zzz_generated/all-clusters-app/zap-generated/callback-stub.cpp.obj
2021-11-05 15:29:54 INFO    [1266/1352] Building CXX object esp-idf/main/CMakeFiles/__idf_main.dir/Rpc.cpp.obj
2021-11-05 15:29:54 INFO    FAILED: esp-idf/main/CMakeFiles/__idf_main.dir/Rpc.cpp.obj 
2021-11-05 15:29:54 INFO    /opt/espressif/tools/tools/xtensa-esp32-elf/esp-2020r3-8.4.0/xtensa-esp32-el…1: error: 'class chip::System::Clock::ClockBase' has no member named 'GetMonotonicMicroseconds64'; did you mean 'GetMonotonicMilliseconds64'?
2021-11-05 15:29:54 INFO         return (PW_TRACE_TIME_TYPE) chip::System::SystemClock().GetMonotonicMicroseconds64().count();
2021-11-05 15:29:54 INFO                                                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~
2021-11-05 15:29:54 INFO                                                                 GetMonotonicMilliseconds64
```
