### PR TITLE
Size reports: Fix stale-commit determination

### DIFF
--- a/scripts/tools/memory/gh_report.py
+++ b/scripts/tools/memory/gh_report.py
@@ -491,9 +491,10 @@ def gh_send_change_report(db: SizeDatabase, df: pd.DataFrame) -> bool:
     # Check the most recent commit on the PR, so that we don't comment on
     # builds that are already outdated.
     commit = df.attrs['commit']
-    commits = sorted(gh_get_commits_for_pr(db.gh, pr),
-                     key=lambda c: c.commit.committer.date,
-                     reverse=True)
+    commits = sorted(
+        gh_get_commits_for_pr(db.gh, pr),
+        key=lambda c: f'{c.commit.committer.date}{c.commit.author.date}',
+        reverse=True)
     if commits and commit != commits[0].sha:
         logging.info('SCS: PR #%s: not commenting for stale %s; newest is %s',
                      pr, commit, commits[0].sha)


### PR DESCRIPTION
#### Problem

Some size reports are missing. The reason is that `gh_report.py` uses
the commit ‘committer’ time to determine which commits are outdated,
and a rebase sets that to the same value for all commits in a PR.

#### Change overview

Use the ‘author’ timestamp as a secondary sort key.

#### Testing

Manual run confirming sort order.
