### PR TITLE
[test_event_6.lts]Inject nodeId from subscribed path to path set by SetDirty

### DIFF
--- a/src/app/reporting/Engine.cpp
+++ b/src/app/reporting/Engine.cpp
@@ -119,7 +119,9 @@ CHIP_ERROR Engine::BuildSingleReportDataAttributeDataList(ReportData::Builder & 
             {
                 if (clusterInfo->IsAttributePathSupersetOf(*path))
                 {
-                    err = RetrieveClusterData(attributeDataList, *path);
+                    // SetDirty's path don't have the particular nodeId, need to reover nodeId
+                    path->mNodeId = clusterInfo->mNodeId;
+                    err           = RetrieveClusterData(attributeDataList, *path);
                 }
                 else if (path->IsAttributePathSupersetOf(*clusterInfo))
                 {


### PR DESCRIPTION
#### Problem
--SetDirty usually don't take the nodeId, it just mark all interested
attribute dirty, when generated report, we need explicitly inject node
Id from subscribed path to interested dirty path, then
construct correct tlv representation.

#### Change overview
See above

#### Testing
Local run