### PR TITLE
Added a build argument to be able to change time delta between two retries during case session

### DIFF
--- a/scripts/build_python.sh
+++ b/scripts/build_python.sh
@@ -42,6 +42,7 @@ declare chip_detail_logging=false
 declare enable_pybindings=false
 declare chip_mdns
 declare clusters=true
+declare case_retry_delta
 
 help() {
 
@@ -57,6 +58,9 @@ Input Options:
   -c, --clusters_for_ip_commissioning  true/false           Specify whether to use clusters for IP commissioning.
                                                             By default it is true.
   -p, --enable_pybindings   EnableValue                     Specify whether to enable pybindings as python controller.
+
+  -t --time_between_case_retries MRPActiveRetryInterval     Specify MRPActiveRetryInterval value
+                                                            Default is 300 ms
 "
 }
 
@@ -84,6 +88,10 @@ while (($#)); do
             enable_pybindings=$2
             shift
             ;;
+        --time_between_case_retries | -t)
+            chip_case_retry_delta=$2
+            shift
+            ;;
         -*)
             help
             echo "Unknown Option \"$1\""
@@ -94,15 +102,16 @@ while (($#)); do
 done
 
 # Print input values
-echo "Input values: chip_detail_logging = $chip_detail_logging , chip_mdns = \"$chip_mdns\", enable_pybindings = $enable_pybindings"
+echo "Input values: chip_detail_logging = $chip_detail_logging , chip_mdns = \"$chip_mdns\", enable_pybindings = $enable_pybindings, chip_case_retry_delta=\"$chip_case_retry_delta\""
 
 # Ensure we have a compilation environment
 source "$CHIP_ROOT/scripts/activate.sh"
 
 # Generates ninja files
 [[ -n "$chip_mdns" ]] && chip_mdns_arg="chip_mdns=\"$chip_mdns\"" || chip_mdns_arg=""
+[[ -n "$chip_case_retry_delta" ]] && chip_case_retry_arg="chip_case_retry_delta=$chip_case_retry_delta" || chip_case_retry_arg=""
 
-gn --root="$CHIP_ROOT" gen "$OUTPUT_ROOT" --args="chip_detail_logging=$chip_detail_logging enable_pylib=$enable_pybindings enable_rtti=$enable_pybindings chip_use_clusters_for_ip_commissioning=$clusters chip_project_config_include_dirs=[\"//config/python\"] $chip_mdns_arg"
+gn --root="$CHIP_ROOT" gen "$OUTPUT_ROOT" --args="chip_detail_logging=$chip_detail_logging enable_pylib=$enable_pybindings enable_rtti=$enable_pybindings chip_use_clusters_for_ip_commissioning=$clusters chip_project_config_include_dirs=[\"//config/python\"] $chip_mdns_arg $chip_case_retry_arg"
 
 # Compiles python files
 # Check pybindings was requested

--- a/src/messaging/BUILD.gn
+++ b/src/messaging/BUILD.gn
@@ -14,6 +14,19 @@
 
 import("//build_overrides/chip.gni")
 
+declare_args() {
+  # Allows to change time between retries during the case session
+  chip_case_retry_delta = ""
+}
+
+defines = []
+
+if (chip_case_retry_delta != "") {
+  defines += [
+    "CHIP_CONFIG_MRP_DEFAULT_ACTIVE_RETRY_INTERVAL=${chip_case_retry_delta}",
+  ]
+}
+
 static_library("messaging") {
   output_name = "libMessagingLayer"
 


### PR DESCRIPTION
#### Problem
Time delta between two retries is by default 300ms for controller and chip-tool during case session. 300ms is too small as a reaction time for constrained device

#### Change overview
* Added build argument to be able to change delta between two retries for case session
* Updated python script to include build argument for python controller

#### Testing
* Manual testing with python controller with argument and without
* Manual testing with chip-tool with argument and without
* Build and manual testing example app to validate no regression
