### PR TITLE
Increase MRP timeouts for Darwin to accomodate CI slowness

### DIFF
--- a/src/platform/Darwin/CHIPPlatformConfig.h
+++ b/src/platform/Darwin/CHIPPlatformConfig.h
@@ -106,6 +106,10 @@
 #define CHIP_CONFIG_BDX_MAX_NUM_TRANSFERS 1
 #endif // CHIP_CONFIG_BDX_MAX_NUM_TRANSFERS
 
+// TODO - Fine tune MRP default parameters for Darwin platform
+#define CHIP_CONFIG_MRP_DEFAULT_INITIAL_RETRY_INTERVAL (60000)
+#define CHIP_CONFIG_MRP_DEFAULT_ACTIVE_RETRY_INTERVAL (2000)
+
 // ==================== Security Configuration Overrides ====================
 
 #ifndef CHIP_CONFIG_MAX_APPLICATION_GROUPS


### PR DESCRIPTION
#### Problem
The CI for Darwin is seeing MRP timeouts and retries.

Failure during session setup
```
CHIP: [SC] Sent PBKDF param request[0m
CHIP: [DL] Mdns: OnGetAddrInfo hostname:Mac-1636122098856.local.[0m
CHIP: [DL] Mdns: OnGetAddrInfo hostname:Mac-1636122098856.local.[0m
CHIP: [IN] Sending plaintext msg 0x7b6800000080 with MessageCounter:3069700934 to 0x0000000000000000 at monotonic time: 2576476 msec[0m
CHIP: [EM] Retransmitted MessageCounter:3069700934 on exchange 35136i Send Cnt 1[0m
CHIP: [IN] Sending plaintext msg 0x7b6800000080 with MessageCounter:3069700934 to 0x0000000000000000 at monotonic time: 2576733 msec[0m
CHIP: [EM] Retransmitted MessageCounter:3069700934 on exchange 35136i Send Cnt 2[0m
CHIP: [IN] Sending plaintext msg 0x7b6800000080 with MessageCounter:3069700934 to 0x0000000000000000 at monotonic time: 2576988 msec[0m
```

Failure during data model command
```
CHIP: [IN] Prepared encrypted message 0x7b6800000080 to 0x0000000012344321 of type 0x8 and protocolId (0, 1) on exchange 3934i with MessageCounter:4.[0m
CHIP: [IN] Sending encrypted msg 0x7b6800000080 with MessageCounter:4 to 0x0000000012344321 at monotonic time: 2416801 msec[0m
CHIP: [DMG] ICR moving to [CommandSen][0m
CHIP: [IN] Sending encrypted msg 0x7b6800000080 with MessageCounter:4 to 0x0000000012344321 at monotonic time: 2421770 msec[0m
CHIP: [EM] Retransmitted MessageCounter:4 on exchange 3934i Send Cnt 1[0m
CHIP: [IN] Sending encrypted msg 0x7b6800000080 with MessageCounter:4 to 0x0000000012344321 at monotonic time: 2422027 msec[0m
CHIP: [EM] Retransmitted MessageCounter:4 on exchange 3934i Send Cnt 2[0m
CHIP: [IN] Sending encrypted msg 0x7b6800000080 with MessageCounter:4 to 0x0000000012344321 at monotonic time: 2422282 msec[0m
CHIP: [EM] Retransmitted MessageCounter:4 on exchange 3934i Send Cnt 3[0m
CHIP: [EM] Failed to Send CHIP MessageCounter:4 on exchange 3934i sendCount: 3 max retries: 3[0m
CHIP: [DMG] Time out! failed to receive invoke command response from Exchange: 3934i[0m
CHIP: [TOO]  ***** Test Failure: Expecting success response but got a failure response
```

#### Change overview
It seems the peer application is not able to process the packets fast enough to send acknowledgment back to the sender. This results in the sender timing out and retrying MRP exhausting all retries.

This PR ups the timeout for Darwin. The parameters needs fine tuning for Darwin platform. So added a TODO to track the changes. 

#### Testing
Darwin CI will run the tests with the new MRP configuration.