### PR TITLE
Simplify the commandValue partial template.

### DIFF
--- a/examples/chip-tool/templates/partials/test_cluster.zapt
+++ b/examples/chip-tool/templates/partials/test_cluster.zapt
@@ -139,7 +139,7 @@ class {{filename}}: public TestCommand
 
         chip::app::Clusters::{{asUpperCamelCase cluster}}::Commands::{{asUpperCamelCase command}}::Type request;
         {{#chip_tests_item_parameters}}
-        {{>commandValue ns=parent.cluster container="request" definedValue=definedValue}}
+        {{>commandValue ns=parent.cluster container=(concat "request." (asLowerCamelCase label)) definedValue=definedValue}}
         {{/chip_tests_item_parameters}}
 
         auto success = [](void * context, const responseType & data) {
@@ -153,7 +153,7 @@ class {{filename}}: public TestCommand
         {{else}}
         {{#chip_tests_item_parameters}}
         {{zapTypeToEncodableClusterObjectType type ns=parent.cluster}} {{asLowerCamelCase name}}Argument;
-        {{>commandValue ns=parent.cluster ignore=true container=(concat (asLowerCamelCase name) "Argument") definedValue=definedValue}}
+        {{>commandValue ns=parent.cluster container=(concat (asLowerCamelCase name) "Argument") definedValue=definedValue}}
         {{/chip_tests_item_parameters}}
 
         {{#if isWriteAttribute}}

--- a/examples/chip-tool/templates/partials/test_cluster_command_value.zapt
+++ b/examples/chip-tool/templates/partials/test_cluster_command_value.zapt
@@ -1,18 +1,10 @@
 {{#if isOptional}}
-  {{#if ignore}}
-    {{>commandValue ns=ns container=(concat container ".Emplace()") definedValue=definedValue type=type isOptional=false ignore=true}}
-  {{else}}
-    {{>commandValue ns=ns container=(concat container "." (asLowerCamelCase label) ".Emplace()") definedValue=definedValue type=type isOptional=false ignore=true}}
-  {{/if}}
+  {{>commandValue ns=ns container=(concat container ".Emplace()") definedValue=definedValue type=type isOptional=false}}
 {{else if isNullable}}
   {{#if (isLiteralNull definedValue)}}
-    {{container}}{{#unless ignore}}.{{asLowerCamelCase label}}{{/unless}}.SetNull();
+    {{container}}.SetNull();
   {{else}}
-    {{#if ignore}}
-      {{>commandValue ns=ns container=(concat container ".SetNonNull()") definedValue=definedValue type=type isNullable=false ignore=true}}
-    {{else}}
-      {{>commandValue ns=ns container=(concat container "." (asLowerCamelCase label) ".SetNonNull()") definedValue=definedValue type=type isNullable=false ignore=true}}
-    {{/if}}
+    {{>commandValue ns=ns container=(concat container ".SetNonNull()") definedValue=definedValue type=type isNullable=false}}
   {{/if}}
 {{else if isArray}}
 
@@ -22,25 +14,21 @@
   {{#if definedValue.length}}
   {{zapTypeToEncodableClusterObjectType type ns=ns forceNotList=true forceNotNullable=true forceNotOptional=true}} {{asLowerCamelCase label}}List[{{definedValue.length}}];
   {{#each definedValue}}
-  {{>commandValue ns=../ns container=(concat (asLowerCamelCase ../label) "List[" @index "]") definedValue=. type=../type ignore=true}}
+  {{>commandValue ns=../ns container=(concat (asLowerCamelCase ../label) "List[" @index "]") definedValue=. type=../type}}
   {{/each}}
-  {{container}}{{#unless ignore}}.{{asLowerCamelCase label}}{{/unless}} = {{asLowerCamelCase label}}List;
+  {{container}} = {{asLowerCamelCase label}}List;
   {{else}}
-  {{container}}{{#unless ignore}}.{{asLowerCamelCase label}}{{/unless}} = chip::app::DataModel::List<{{zapTypeToEncodableClusterObjectType type ns=ns forceNotList=true forceNotNullable=true forceNotOptional=true}}>();
+  {{container}} = chip::app::DataModel::List<{{zapTypeToEncodableClusterObjectType type ns=ns forceNotList=true forceNotNullable=true forceNotOptional=true}}>();
   {{/if}}
 {{else}}
   {{#if_is_struct type}}
 
     {{#zcl_struct_items_by_struct_name type}}
-      {{#if ../ignore}}
-      {{>commandValue ns=parent.ns container=(concat parent.container "." (asLowerCamelCase label)) definedValue=(lookup parent.definedValue name) ignore=../ignore}}
-      {{else}}
-      {{>commandValue ns=parent.ns container=(concat parent.container "." (asLowerCamelCase parent.label)) definedValue=(lookup parent.definedValue name) ignore=../ignore}}
-      {{/if}}
+      {{>commandValue ns=parent.ns container=(concat parent.container "." (asLowerCamelCase label)) definedValue=(lookup parent.definedValue name)}}
     {{/zcl_struct_items_by_struct_name}}
 
   {{else}}
-    {{container}}{{#unless ignore}}.{{asLowerCamelCase label}}{{/unless}} =
+    {{container}} =
     {{#if_chip_enum type}}
       static_cast<{{zapTypeToEncodableClusterObjectType type ns=ns}}>({{definedValue}});
     {{else if (isCharString type)}}


### PR DESCRIPTION
The complexity around ignore=true in commandValue was to handle the
difference between recursive calls (which have the full name of the
value we are trying to set) and the initial call (which just had the
struct the value was in, and needed to tack on ".memberName" to get
the actual place to store the value).

This change gets rid of all the ignore=false codepaths, and changes
the one toplevel entry site that used them to add the struct member
name itself.

#### Problem
See above.

#### Change overview
See above.

#### Testing
Ensured that generated output does not change.