### PR TITLE
Inject nodeId from subscribed path to path set by SetDirty

### DIFF
--- a/src/app/reporting/Engine.cpp
+++ b/src/app/reporting/Engine.cpp
@@ -124,7 +124,11 @@ CHIP_ERROR Engine::BuildSingleReportDataAttributeDataList(ReportDataMessage::Bui
             {
                 if (clusterInfo->IsAttributePathSupersetOf(*path))
                 {
-                    err = RetrieveClusterData(apReadHandler->GetFabricIndex(), attributeDataList, *path);
+                    // SetDirty injects path into GlobalDirtySet path that don't have the particular nodeId,
+                    // need to inject nodeId from subscribed path here.
+                    ClusterInfo dirtyPath = *path;
+                    dirtyPath.mNodeId     = clusterInfo->mNodeId;
+                    err                   = RetrieveClusterData(apReadHandler->GetFabricIndex(), attributeDataList, dirtyPath);
                 }
                 else if (path->IsAttributePathSupersetOf(*clusterInfo))
                 {


### PR DESCRIPTION
#### Problem
--SetDirty's input parameter aClusterInfo don't have the nodeId, application just mark all interested
attribute dirty, when generated report, we need explicitly inject node
Id from subscribed path to interested dirty path, then construct correct tlv representation.

#### Change overview
See above

#### Testing
Manually check the tlv output
