### PR TITLE
Upload application logs to artifacts from test_suites

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -171,6 +171,13 @@ jobs:
               timeout-minutes: 35
               run: |
                   scripts/tests/test_suites.sh
+            - name: Uploading application log files
+              uses: actions/upload-artifact@v2
+              if: ${{ always() }} && ${{ !env.ACT }}
+              with:
+                  name: test_suite_app_logs
+                  path: /tmp/test_suites_app_logs/
+                  retention-days: 5
             - name: Uploading core files
               uses: actions/upload-artifact@v2
               if: ${{ failure() }} && ${{ !env.ACT }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -175,7 +175,7 @@ jobs:
               uses: actions/upload-artifact@v2
               if: ${{ always() }} && ${{ !env.ACT }}
               with:
-                  name: test_suite_app_logs
+                  name: test-suite-app-logs-${{ matrix.type }}-${{ matrix.eventloop }}
                   path: /tmp/test_suites_app_logs/
                   retention-days: 5
             - name: Uploading core files

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -171,9 +171,9 @@ jobs:
               timeout-minutes: 35
               run: |
                   scripts/tests/test_suites.sh
-            - name: Uploading application log files
+            - name: Uploading application logs
               uses: actions/upload-artifact@v2
-              if: ${{ always() }} && ${{ !env.ACT }}
+              if: ${{ failure() }} && ${{ !env.ACT }}
               with:
                   name: test-suite-app-logs-${{ matrix.type }}-${{ matrix.eventloop }}
                   path: /tmp/test_suites_app_logs/

--- a/scripts/tests/test_suites.sh
+++ b/scripts/tests/test_suites.sh
@@ -111,7 +111,11 @@ for j in "${iter_array[@]}"; do
         # will never see the string we want.
 
         application_log_file=/tmp/test_suites_app_logs/"$application-$i-$j"-log
+        pairing_log_file=/tmp/test_suites_app_logs/pairing-"$application-$i-$j"-log
+        chip_tool_log_file=/tmp/test_suites_app_logs/chip-tool-"$application-$i-$j"-log
         touch "$application_log_file"
+        touch "$pairing_log_file"
+        touch "$chip_tool_log_file"
         rm -rf /tmp/pid
         (
             stdbuf -o0 "${test_case_wrapper[@]}" out/debug/standalone/chip-"$application"-app &
@@ -126,9 +130,9 @@ for j in "${iter_array[@]}"; do
         # the data is there yet.
         background_pid="$(</tmp/pid)"
         echo "          * Pairing to device"
-        "${test_case_wrapper[@]}" out/debug/standalone/chip-tool pairing qrcode "$node_id" MT:D8XA0CQM00KA0648G00
+        "${test_case_wrapper[@]}" out/debug/standalone/chip-tool pairing qrcode "$node_id" MT:D8XA0CQM00KA0648G00 | tee "$pairing_log_file"
         echo "          * Starting test run: $i"
-        "${test_case_wrapper[@]}" out/debug/standalone/chip-tool tests "$i" "$node_id" "$delay"
+        "${test_case_wrapper[@]}" out/debug/standalone/chip-tool tests "$i" "$node_id" "$delay" | tee "$chip_tool_log_file"
         # Prevent cleanup trying to kill a process we already killed.
         temp_background_pid=$background_pid
         background_pid=0

--- a/scripts/tests/test_suites.sh
+++ b/scripts/tests/test_suites.sh
@@ -84,6 +84,9 @@ echo ""
 
 ulimit -c unlimited || true
 
+rm -rf /tmp/test_suites_app_logs
+mkdir -p /tmp/test_suites_app_logs
+
 declare -a iter_array="($(seq "$iterations"))"
 for j in "${iter_array[@]}"; do
     echo " ===== Iteration $j starting"
@@ -107,16 +110,13 @@ for j in "${iter_array[@]}"; do
         # tee expeditiously; otherwise it will buffer things up and we
         # will never see the string we want.
 
-        # Clear out our temp files so we don't accidentally do a stale
-        # read from them before we write to them.
-        rm -rf /tmp/"$application"-log
-        touch /tmp/"$application"-log
+        touch /tmp/test_suites_app_logs/"$application"-log
         rm -rf /tmp/pid
         (
             stdbuf -o0 "${test_case_wrapper[@]}" out/debug/standalone/chip-"$application"-app &
             echo $! >&3
-        ) 3>/tmp/pid | tee /tmp/"$application"-log &
-        while ! grep -q "Server Listening" /tmp/"$application"-log; do
+        ) 3>/tmp/pid | tee /tmp/test_suites_app_logs/"$application"-log &
+        while ! grep -q "Server Listening" /tmp/test_suites_app_logs/"$application"-log; do
             :
         done
         # Now read $background_pid from /tmp/pid; presumably it's

--- a/scripts/tests/test_suites.sh
+++ b/scripts/tests/test_suites.sh
@@ -110,13 +110,14 @@ for j in "${iter_array[@]}"; do
         # tee expeditiously; otherwise it will buffer things up and we
         # will never see the string we want.
 
-        touch /tmp/test_suites_app_logs/"$application"-log
+        application_log_file=/tmp/test_suites_app_logs/"$application-$i-$j"-log
+        touch "$application_log_file"
         rm -rf /tmp/pid
         (
             stdbuf -o0 "${test_case_wrapper[@]}" out/debug/standalone/chip-"$application"-app &
             echo $! >&3
-        ) 3>/tmp/pid | tee /tmp/test_suites_app_logs/"$application"-log &
-        while ! grep -q "Server Listening" /tmp/test_suites_app_logs/"$application"-log; do
+        ) 3>/tmp/pid | tee "$application_log_file" &
+        while ! grep -q "Server Listening" "$application_log_file"; do
             :
         done
         # Now read $background_pid from /tmp/pid; presumably it's

--- a/src/platform/Darwin/CHIPPlatformConfig.h
+++ b/src/platform/Darwin/CHIPPlatformConfig.h
@@ -107,7 +107,7 @@
 #endif // CHIP_CONFIG_BDX_MAX_NUM_TRANSFERS
 
 // TODO - Fine tune MRP default parameters for Darwin platform
-#define CHIP_CONFIG_MRP_DEFAULT_INITIAL_RETRY_INTERVAL (60000)
+#define CHIP_CONFIG_MRP_DEFAULT_INITIAL_RETRY_INTERVAL (15000)
 #define CHIP_CONFIG_MRP_DEFAULT_ACTIVE_RETRY_INTERVAL (2000)
 
 // ==================== Security Configuration Overrides ====================


### PR DESCRIPTION
#### Problem
In CI, the application logs are interleaved with the controller logs. Sometimes when the controller fails due to an error, it doesn't upload all the application side logs.

#### Change overview
This change will upload the applications logs to CI artifacts. So the logs should be isolated and complete.

#### Testing
Ran test_suites.sh locally to ensure the logs are getting copied to the correct file and folder.
The CI run will test that the logs get uploaded to artifacts.