### PR TITLE
Make doxygen run on a the doxygen image instead

### DIFF
--- a/.github/workflows/doxygen.yaml
+++ b/.github/workflows/doxygen.yaml
@@ -28,8 +28,11 @@ jobs:
         name: Build Doxygen
         timeout-minutes: 5
 
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-latest
         if: github.actor != 'restyled-io[bot]'
+
+        container:
+            image: connectedhomeip/chip-build-doxygen:0.5.27
 
         steps:
             - name: "Print Actor"

--- a/.github/workflows/doxygen.yaml
+++ b/.github/workflows/doxygen.yaml
@@ -35,8 +35,6 @@ jobs:
             image: connectedhomeip/chip-build-doxygen:0.5.27
 
         steps:
-            - name: "Print Actor"
-              run: echo ${{github.actor}}
             - name: Checkout
               uses: actions/checkout@v2
               with:


### PR DESCRIPTION
This is expected to make builds slightly faster (still not great because we also need graphviz, can add that later to the image too) and more consistent and not have errors like in #11463 
