### PR TITLE
Annotation of access control metadata to two clusters

### DIFF
--- a/src/app/zap-templates/zcl/data-model/chip/onoff-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/onoff-cluster.xml
@@ -76,19 +76,16 @@ limitations under the License.
 
     <command source="client" code="0x00" name="Off" optional="false">
       <description>On receipt of this command, a device SHALL enter its ‘Off’ state. This state is device dependent, but it is recommended that it is used for power off or similar functions. On receipt of the Off command, the OnTime attribute SHALL be set to 0.</description>
-      <access op="invoke" privilege="view"/>
       <access op="invoke" privilege="operate"/>
     </command>
 
     <command source="client" code="0x01" name="On" optional="false">
       <description>On receipt of this command, a device SHALL enter its ‘On’ state. This state is device dependent, but it is recommended that it is used for power on or similar functions. On receipt of the On command, if the value of the OnTime attribute is equal to 0, the device SHALL set the OffWaitTime attribute to 0.</description>
-      <access op="invoke" privilege="view"/>
       <access op="invoke" privilege="operate"/>
     </command>
 
     <command source="client" code="0x02" name="Toggle" optional="false">
       <description>On receipt of this command, if a device is in its ‘Off’ state it SHALL enter its ‘On’ state. Otherwise, if it is in its ‘On’ state it SHALL enter its ‘Off’ state. On receipt of the Toggle command, if the value of the OnOff attribute is equal to FALSE and if the value of the OnTime attribute is equal to 0, the device SHALL set the OffWaitTime attribute to 0. If the value of the OnOff attribute is equal to TRUE, the OnTime attribute SHALL be set to 0.</description>
-      <access op="invoke" privilege="view"/>
       <access op="invoke" privilege="operate"/>
     </command>
 
@@ -96,13 +93,11 @@ limitations under the License.
       <description>The OffWithEffect command allows devices to be turned off using enhanced ways of fading.</description>
       <arg name="EffectId" type="OnOffEffectIdentifier"/>
       <arg name="EffectVariant" type="OnOffDelayedAllOffEffectVariant"/>
-      <access op="invoke" privilege="view"/>
       <access op="invoke" privilege="operate"/>
     </command>
 
     <command source="client" code="0x41" name="OnWithRecallGlobalScene" optional="true">
       <description>The OnWithRecallGlobalScene command allows the recall of the settings when the device was turned off.</description>
-      <access op="invoke" privilege="view"/>
       <access op="invoke" privilege="operate"/>
     </command>
 
@@ -111,7 +106,6 @@ limitations under the License.
       <arg name="OnOffControl" type="OnOffControl"/>
       <arg name="OnTime" type="int16u"/><!-- min:0 max:0xfe -->
       <arg name="OffWaitTime" type="int16u"/><!-- min:0 max:0xfe -->
-      <access op="invoke" privilege="view"/>
       <access op="invoke" privilege="operate"/>
     </command>
 

--- a/src/app/zap-templates/zcl/data-model/chip/onoff-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/onoff-cluster.xml
@@ -48,32 +48,62 @@ limitations under the License.
     <description>Attributes and commands for switching devices between 'On' and 'Off' states.</description>
     <globalAttribute side="either" code="0xFFFD" value="4"/>
 
-    <attribute side="server" code="0x0000" define="ON_OFF"               type="boolean" default="0" reportable="true"              >OnOff</attribute>
-    <attribute side="server" code="0x4000" define="GLOBAL_SCENE_CONTROL" type="boolean" default="1"                 optional="true">GlobalSceneControl</attribute>
-    <attribute side="server" code="0x4001" define="ON_TIME"              type="int16u"  default="0" writable="true" optional="true">OnTime</attribute>
-    <attribute side="server" code="0x4002" define="OFF_WAIT_TIME"        type="int16u"  default="0" writable="true" optional="true">OffWaitTime</attribute>
-    <attribute side="server" code="0x4003" define="START_UP_ON_OFF"      type="enum8"               writable="true" optional="true">StartUpOnOff</attribute>
+    <attribute side="server" code="0x0000" define="ON_OFF" type="boolean" default="0" writable="false" reportable="true" optional="false">
+      <description>OnOff</description>
+      <access op="read" privilege="view"/>
+    </attribute>
+    <attribute side="server" code="0x4000" define="GLOBAL_SCENE_CONTROL" type="boolean" default="1" writable="false" optional="true">
+      <description>GlobalSceneControl</description>
+      <access op="read" privilege="view"/>
+    </attribute>
+    <attribute side="server" code="0x4001" define="ON_TIME" type="int16u" default="0" writable="true" optional="true">
+      <description>OnTime</description>
+      <!-- The following required access privileges are the default, and could have been
+           omitted, but are included here as an example. -->
+      <access op="read" privilege="view"/>
+      <access op="write" privilege="operate"/>
+    </attribute>
+    <attribute side="server" code="0x4002" define="OFF_WAIT_TIME" type="int16u" default="0" writable="true" optional="true">
+      <description>OffWaitTime</description>
+      <access op="read" privilege="view"/>
+      <access op="write" privilege="operate"/>
+    </attribute>
+    <attribute side="server" code="0x4003" define="START_UP_ON_OFF" type="enum8" writable="true" optional="true">
+      <description>StartUpOnOff</description>
+      <access op="read" privilege="view"/>
+      <access op="write" privilege="operate"/>
+    </attribute>
 
     <command source="client" code="0x00" name="Off" optional="false">
       <description>On receipt of this command, a device SHALL enter its ‘Off’ state. This state is device dependent, but it is recommended that it is used for power off or similar functions. On receipt of the Off command, the OnTime attribute SHALL be set to 0.</description>
+      <access op="invoke" privilege="view"/>
+      <access op="invoke" privilege="operate"/>
     </command>
 
     <command source="client" code="0x01" name="On" optional="false">
       <description>On receipt of this command, a device SHALL enter its ‘On’ state. This state is device dependent, but it is recommended that it is used for power on or similar functions. On receipt of the On command, if the value of the OnTime attribute is equal to 0, the device SHALL set the OffWaitTime attribute to 0.</description>
+      <access op="invoke" privilege="view"/>
+      <access op="invoke" privilege="operate"/>
     </command>
 
     <command source="client" code="0x02" name="Toggle" optional="false">
       <description>On receipt of this command, if a device is in its ‘Off’ state it SHALL enter its ‘On’ state. Otherwise, if it is in its ‘On’ state it SHALL enter its ‘Off’ state. On receipt of the Toggle command, if the value of the OnOff attribute is equal to FALSE and if the value of the OnTime attribute is equal to 0, the device SHALL set the OffWaitTime attribute to 0. If the value of the OnOff attribute is equal to TRUE, the OnTime attribute SHALL be set to 0.</description>
+      <access op="invoke" privilege="view"/>
+      <access op="invoke" privilege="operate"/>
     </command>
 
     <command source="client" code="0x40" name="OffWithEffect" optional="true">
       <description>The OffWithEffect command allows devices to be turned off using enhanced ways of fading.</description>
       <arg name="EffectId" type="OnOffEffectIdentifier"/>
       <arg name="EffectVariant" type="OnOffDelayedAllOffEffectVariant"/>
+      <access op="invoke" privilege="view"/>
+      <access op="invoke" privilege="operate"/>
     </command>
 
     <command source="client" code="0x41" name="OnWithRecallGlobalScene" optional="true">
       <description>The OnWithRecallGlobalScene command allows the recall of the settings when the device was turned off.</description>
+      <access op="invoke" privilege="view"/>
+      <access op="invoke" privilege="operate"/>
     </command>
 
     <command source="client" code="0x42" name="OnWithTimedOff" optional="true">
@@ -81,6 +111,8 @@ limitations under the License.
       <arg name="OnOffControl" type="OnOffControl"/>
       <arg name="OnTime" type="int16u"/><!-- min:0 max:0xfe -->
       <arg name="OffWaitTime" type="int16u"/><!-- min:0 max:0xfe -->
+      <access op="invoke" privilege="view"/>
+      <access op="invoke" privilege="operate"/>
     </command>
 
   </cluster>

--- a/src/app/zap-templates/zcl/data-model/chip/operational-credentials-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/operational-credentials-cluster.xml
@@ -19,32 +19,35 @@ limitations under the License.
 
   <struct name="FabricDescriptor">
     <cluster code="0x003E"/>
-    <item name="FabricIndex" type="INT8U"/>
-    <item name="RootPublicKey" type="OCTET_STRING" length="65"/>
-    <item name="VendorId" type="INT16U"/> <!-- Change INT16U to new type VendorID #2395 -->
-    <item name="FabricId" type="FABRIC_ID"/>
-    <item name="NodeId" type="NODE_ID"/>
-    <item name="Label" type="CHAR_STRING" length="32"/>
+    <item fieldId="0" name="FabricIndex" type="fabric_idx"/>
+    <item fieldId="1" name="RootPublicKey" type="OCTET_STRING" length="65"/>
+    <item fieldId="2" name="VendorId" type="INT16U"/> <!-- Change INT16U to new type VendorID #2395 -->
+    <item fieldId="3" name="FabricId" type="FABRIC_ID"/>
+    <item fieldId="4" name="NodeId" type="NODE_ID"/>
+    <item fieldId="5" name="Label" type="CHAR_STRING" length="32"/>
   </struct>
 
   <enum name="NodeOperationalCertStatus" type="ENUM8">
     <cluster code="0x003E"/>
-    <item name="SUCCESS" value="0x00"/>
-    <item name="InvalidPublicKey" value="0x01"/>
-    <item name="InvalidNodeOpId" value="0x02"/>
-    <item name="InvalidNOC" value="0x03"/>
-    <item name="MissingCsr" value="0x04"/>
-    <item name="TableFull" value="0x05"/>
-    <item name="InsufficientPrivilege" value="0x08"/>
-    <item name="FabricConflict" value="0x09"/>
-    <item name="LabelConflict" value="0x0a"/>
-    <item name="InvalidFabricIndex" value="0x0b"/>
+    <item fieldId="0" name="SUCCESS" value="0x00"/>
+    <item fieldId="1" name="InvalidPublicKey" value="0x01"/>
+    <item fieldId="2" name="InvalidNodeOpId" value="0x02"/>
+    <item fieldId="3" name="InvalidNOC" value="0x03"/>
+    <item fieldId="4" name="MissingCsr" value="0x04"/>
+    <item fieldId="5" name="TableFull" value="0x05"/>
+    <item fieldId="6" name="MissingACL" value="0x06"/>
+    <item fieldId="7" name="MissingIpk" value="0x07"/>        
+    <item fieldId="8" name="InsufficientPrivilege" value="0x08"/>
+    <item fieldId="9" name="FabricConflict" value="0x09"/>
+    <item fieldId="10" name="LabelConflict" value="0x0a"/>
+    <item fieldId="11" name="InvalidFabricIndex" value="0x0b"/>
   </enum>
 
   <struct name="NOCStruct">
     <cluster code="0x003E"/>
-    <item name="FabricIndex" type="INT8U"/>
-    <item name="NOC" type="OCTET_STRING"/>
+    <item fieldId="0" name="FabricIndex" type="fabric_idx"/>
+    <item fieldId="1" name="NOC" type="OCTET_STRING" length="400" isFabricSensitive="true"/>
+    <item fieldId="2" name="ICAC" type="OCTET_STRING" length="400" isFabricSensitive="true" isNullable="true"/>
   </struct>
 
   <cluster>
@@ -54,37 +57,63 @@ limitations under the License.
     <define>OPERATIONAL_CREDENTIALS_CLUSTER</define>
     <description>This cluster is used to add or remove Operational Credentials on a Commissionee or Node, as well as manage the associated Fabrics.</description>
 
-    <attribute side="server" code="0x0001" define="FABRICS" type="ARRAY" entryType="FabricDescriptor" length="320" writable="false" optional="false">fabrics list</attribute>
-    <attribute side="server" code="0x0002" define="SUPPORTED_FABRICS" type="INT8U" writable="false" optional="false">SupportedFabrics</attribute>
-    <attribute side="server" code="0x0003" define="COMMISSIONED_FABRICS" type="INT8U" writable="false" optional="false">CommissionedFabrics</attribute>
+    <attribute side="server" code="0x0000" define="NOCs" type="ARRAY" entryType="NOCStruct" length="320" writable="false" optional="false">
+      <description>NOCs</description>
+      <access op="read" privilege="administer"/>
+      <access modifier="fabric-scoped"/>
+    </attribute>
+    <attribute side="server" code="0x0001" define="FABRICS" type="ARRAY" entryType="FabricDescriptor" length="320" writable="false" optional="false">
+      <description>Fabrics</description>
+      <access op="read" privilege="view"/>
+      <access modifier="fabric-scoped"/>
+    </attribute>
+    <attribute side="server" code="0x0002" define="SUPPORTED_FABRICS" type="INT8U" writable="false" optional="false">
+      <description>SupportedFabrics</description>
+      <access op="read" privilege="view"/>
+    </attribute>
+    <attribute side="server" code="0x0003" define="COMMISSIONED_FABRICS" type="INT8U" writable="false" optional="false">
+      <description>CommissionedFabrics</description>
+      <access op="read" privilege="view"/>
+    </attribute>
     <!-- 400 = 400 bytes for root cert -->
-    <attribute side="server" code="0x0004" define="TRUSTED_ROOTS" type="ARRAY" entryType="OCTET_STRING" length="400" writable="false" optional="false">TrustedRootCertificates</attribute>
-    <attribute side="server" code="0x0005" define="CURRENT_FABRIC_INDEX" type="fabric_idx" writable="false" optional="false">CurrentFabricIndex</attribute>
+    <attribute side="server" code="0x0004" define="TRUSTED_ROOTS" type="ARRAY" entryType="OCTET_STRING" length="400" writable="false" optional="false">
+      <description>TrustedRootCertificates</description>
+      <access op="read" privilege="view"/>
+    </attribute>
+    <attribute side="server" code="0x0005" define="CURRENT_FABRIC_INDEX" type="fabric_idx" writable="false" optional="false">
+      <description>CurrentFabricIndex</description>
+      <access op="read" privilege="view"/>
+    </attribute>
 
     <command source="client" code="0x00" name="AttestationRequest" optional="false">
       <description>Sender is requesting attestation information from the receiver.</description>
       <arg name="AttestationNonce" type="OCTET_STRING"/>
+      <access op="invoke" privilege="administer"/>
     </command>
 
     <command source="server" code="0x01" name="AttestationResponse" optional="false">
       <description>An attestation information confirmation from the server.</description>
       <arg name="AttestationElements" type="OCTET_STRING"/>
       <arg name="Signature" type="OCTET_STRING"/>
+      <access op="invoke" privilege="administer"/>
     </command>
 
     <command source="client" code="0x02" name="CertificateChainRequest" optional="false">
       <description>Sender is requesting a device attestation certificate from the receiver.</description>
       <arg name="CertificateType" type="INT8U"/>
+      <access op="invoke" privilege="administer"/>
     </command>
 
     <command source="server" code="0x03" name="CertificateChainResponse" optional="false">
       <description>A device attestation certificate (DAC) or product attestation intermediate (PAI) certificate from the server.</description>
       <arg name="Certificate" type="OCTET_STRING"/>
+      <access op="invoke" privilege="administer"/>
     </command>
 
     <command source="client" code="0x04" name="OpCSRRequest" optional="false">
       <description>Sender is requesting a certificate signing request (CSR) from the receiver.</description>
       <arg name="CSRNonce" type="OCTET_STRING"/>
+      <access op="invoke" privilege="administer"/>
     </command>
 
     <!-- TODO: Fix to match chip-spec:#3346 -->
@@ -92,6 +121,7 @@ limitations under the License.
       <description>A certificate signing request (CSR) from the server.</description>
       <arg name="NOCSRElements" type="OCTET_STRING"/>
       <arg name="AttestationSignature" type="OCTET_STRING"/>
+      <access op="invoke" privilege="administer"/>
     </command>
 
     <command source="client" code="0x06" name="AddNOC" response="NOCResponse" optional="false">
@@ -101,39 +131,46 @@ limitations under the License.
       <arg name="IPKValue" type="OCTET_STRING"/>
       <arg name="CaseAdminNode" type="NODE_ID"/>
       <arg name="AdminVendorId" type="INT16U"/>
+      <access op="invoke" privilege="administer"/>
     </command>
 
     <command source="client" code="0x07" name="UpdateNOC" response="NOCResponse" optional="false">
       <description>Sender is requesting to update the node operational certificates.</description>
       <arg name="NOCValue" type="OCTET_STRING"/>
       <arg name="ICACValue" type="OCTET_STRING" optional="true"/>
+      <access op="invoke" privilege="administer"/>
     </command>
 
     <command source="server" code="0x08" name="NOCResponse" optional="false">
       <description>Response to AddNOC or UpdateNOC commands.</description>
       <arg name="StatusCode" type="INT8U"/>
-      <arg name="FabricIndex" type="INT8U"/>
+      <arg name="FabricIndex" type="fabric_idx"/>
       <arg name="DebugText" type="CHAR_STRING"/>
+      <access op="invoke" privilege="administer"/>
     </command>
 
     <command source="client" code="0x09" name="UpdateFabricLabel" response="NOCResponse" optional="false">
       <description>This command SHALL be used by an Administrative Node to set the user-visible Label field for a given Fabric, as reflected by entries in the Fabrics attribute.</description>
       <arg name="Label" type="CHAR_STRING" length="32"/>
+      <access op="invoke" privilege="administer"/>
     </command>
 
     <command source="client" code="0x0a" name="RemoveFabric" response="NOCResponse" optional="false">
       <description>This command is used by Administrative Nodes to remove a given fabric index and delete all associated fabric-scoped data.</description>
-      <arg name="FabricIndex" type="INT8U"/>
+      <arg name="FabricIndex" type="fabric_idx"/>
+      <access op="invoke" privilege="administer"/>
     </command>
 
     <command source="client" code="0x0b" name="AddTrustedRootCertificate" optional="false">
       <description>This command SHALL add a Trusted Root CA Certificate, provided as its CHIP Certificate representation.</description>
       <arg name="RootCertificate" type="OCTET_STRING"/>
+      <access op="invoke" privilege="administer"/>
     </command>
 
     <command source="client" code="0x0c" name="RemoveTrustedRootCertificate" optional="false">
       <description>This command SHALL remove a Trusted Root CA Certificate, provided as its CHIP Certificate representation.</description>
       <arg name="TrustedRootIdentifier" type="OCTET_STRING"/>
+      <access op="invoke" privilege="administer"/>
     </command>
 
   </cluster>

--- a/src/app/zap-templates/zcl/data-model/chip/operational-credentials-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/operational-credentials-cluster.xml
@@ -95,7 +95,6 @@ limitations under the License.
       <description>An attestation information confirmation from the server.</description>
       <arg name="AttestationElements" type="OCTET_STRING"/>
       <arg name="Signature" type="OCTET_STRING"/>
-      <access op="invoke" privilege="administer"/>
     </command>
 
     <command source="client" code="0x02" name="CertificateChainRequest" optional="false">
@@ -107,7 +106,6 @@ limitations under the License.
     <command source="server" code="0x03" name="CertificateChainResponse" optional="false">
       <description>A device attestation certificate (DAC) or product attestation intermediate (PAI) certificate from the server.</description>
       <arg name="Certificate" type="OCTET_STRING"/>
-      <access op="invoke" privilege="administer"/>
     </command>
 
     <command source="client" code="0x04" name="OpCSRRequest" optional="false">
@@ -121,7 +119,6 @@ limitations under the License.
       <description>A certificate signing request (CSR) from the server.</description>
       <arg name="NOCSRElements" type="OCTET_STRING"/>
       <arg name="AttestationSignature" type="OCTET_STRING"/>
-      <access op="invoke" privilege="administer"/>
     </command>
 
     <command source="client" code="0x06" name="AddNOC" response="NOCResponse" optional="false">
@@ -146,7 +143,6 @@ limitations under the License.
       <arg name="StatusCode" type="INT8U"/>
       <arg name="FabricIndex" type="fabric_idx"/>
       <arg name="DebugText" type="CHAR_STRING"/>
-      <access op="invoke" privilege="administer"/>
     </command>
 
     <command source="client" code="0x09" name="UpdateFabricLabel" response="NOCResponse" optional="false">


### PR DESCRIPTION
#### Problem
Started annotating the XML cluster files with Access Control XML elements.
Normalized Normalized fabric_idx usage across the two updated cluster xml files.
- https://github.com/project-chip/connectedhomeip/issues/11204 (Define ACL cluster XML)
- https://github.com/project-chip/connectedhomeip/issues/11286 (Type fabric_idx is not used uniformly)

Issue #11204 
Issue #11286 
Issue #10246 

#### Change overview
Annotated the operational-credentials-cluster.xml and onoff-cluster.xml based on the Matter Specs, section 11.18, and appclusters, respectively.

- Normalized the <access> elements. Note that the writeable <attribute> attribute indicates if a field is writeable, or not. The <access> elements qualifies provileges on a per operation basis:
     * updated all <struct> elements to include <item> fieldId;
     * updated NodeOperationalCertStatus to include missing item elements;
     * updated NOCStruct to include a missing item element;

- Normalized fabric_idx usage across the two updated cluster xml files.


#### Testing
How was this tested? (at least one bullet point required)
* Not applicable, as it is a draft yet.