### PR TITLE
Make rpc-ipv6only variant actually be ipv6 only

### DIFF
--- a/scripts/build/builders/esp32.py
+++ b/scripts/build/builders/esp32.py
@@ -129,7 +129,7 @@ class Esp32Builder(Builder):
 
         if not self.enable_ipv4:
             self._Execute(
-                ['bash', '-c', 'echo -e "\nCONFIG_DISABLE_IPV4=y\n" >>%s' % shlex.quote(defaults_out)])
+                ['bash', '-c', 'echo -e "\\nCONFIG_DISABLE_IPV4=y\\n" >>%s' % shlex.quote(defaults_out)])
 
         cmd = "\nexport SDKCONFIG_DEFAULTS={defaults}\nidf.py -C {example_path} -B {out} reconfigure".format(
             defaults=shlex.quote(defaults_out),

--- a/scripts/build/builders/esp32.py
+++ b/scripts/build/builders/esp32.py
@@ -129,7 +129,7 @@ class Esp32Builder(Builder):
 
         if not self.enable_ipv4:
             self._Execute(
-                ['bash', '-c', 'echo CONFIG_DISABLE_IPV4=y >>%s' % shlex.quote(defaults_out)])
+                ['bash', '-c', 'echo -e "\nCONFIG_DISABLE_IPV4=y\n" >>%s' % shlex.quote(defaults_out)])
 
         cmd = "\nexport SDKCONFIG_DEFAULTS={defaults}\nidf.py -C {example_path} -B {out} reconfigure".format(
             defaults=shlex.quote(defaults_out),

--- a/scripts/build/testdata/build_all_except_host.txt
+++ b/scripts/build/testdata/build_all_except_host.txt
@@ -168,9 +168,7 @@ cp examples/all-clusters-app/esp32/sdkconfig.defaults {out}/esp32-devkitc-all-cl
 
 rm -f examples/all-clusters-app/esp32/sdkconfig
 
-bash -c 'echo -e "
-CONFIG_DISABLE_IPV4=y
-" >>{out}/esp32-devkitc-all-clusters-ipv6only/sdkconfig.defaults'
+bash -c 'echo -e "\nCONFIG_DISABLE_IPV4=y\n" >>{out}/esp32-devkitc-all-clusters-ipv6only/sdkconfig.defaults'
 
 bash -c 'source $IDF_PATH/export.sh; source scripts/activate.sh; 
 export SDKCONFIG_DEFAULTS={out}/esp32-devkitc-all-clusters-ipv6only/sdkconfig.defaults
@@ -238,9 +236,7 @@ cp examples/all-clusters-app/esp32/sdkconfig_m5stack.defaults {out}/esp32-m5stac
 
 rm -f examples/all-clusters-app/esp32/sdkconfig
 
-bash -c 'echo -e "
-CONFIG_DISABLE_IPV4=y
-" >>{out}/esp32-m5stack-all-clusters-ipv6only/sdkconfig.defaults'
+bash -c 'echo -e "\nCONFIG_DISABLE_IPV4=y\n" >>{out}/esp32-m5stack-all-clusters-ipv6only/sdkconfig.defaults'
 
 bash -c 'source $IDF_PATH/export.sh; source scripts/activate.sh; 
 export SDKCONFIG_DEFAULTS={out}/esp32-m5stack-all-clusters-ipv6only/sdkconfig.defaults
@@ -264,9 +260,7 @@ cp examples/all-clusters-app/esp32/sdkconfig_m5stack_rpc.defaults {out}/esp32-m5
 
 rm -f examples/all-clusters-app/esp32/sdkconfig
 
-bash -c 'echo -e "
-CONFIG_DISABLE_IPV4=y
-" >>{out}/esp32-m5stack-all-clusters-rpc-ipv6only/sdkconfig.defaults'
+bash -c 'echo -e "\nCONFIG_DISABLE_IPV4=y\n" >>{out}/esp32-m5stack-all-clusters-rpc-ipv6only/sdkconfig.defaults'
 
 bash -c 'source $IDF_PATH/export.sh; source scripts/activate.sh; 
 export SDKCONFIG_DEFAULTS={out}/esp32-m5stack-all-clusters-rpc-ipv6only/sdkconfig.defaults

--- a/scripts/build/testdata/build_all_except_host.txt
+++ b/scripts/build/testdata/build_all_except_host.txt
@@ -168,7 +168,9 @@ cp examples/all-clusters-app/esp32/sdkconfig.defaults {out}/esp32-devkitc-all-cl
 
 rm -f examples/all-clusters-app/esp32/sdkconfig
 
-bash -c 'echo CONFIG_DISABLE_IPV4=y >>{out}/esp32-devkitc-all-clusters-ipv6only/sdkconfig.defaults'
+bash -c 'echo -e "
+CONFIG_DISABLE_IPV4=y
+" >>{out}/esp32-devkitc-all-clusters-ipv6only/sdkconfig.defaults'
 
 bash -c 'source $IDF_PATH/export.sh; source scripts/activate.sh; 
 export SDKCONFIG_DEFAULTS={out}/esp32-devkitc-all-clusters-ipv6only/sdkconfig.defaults
@@ -236,7 +238,9 @@ cp examples/all-clusters-app/esp32/sdkconfig_m5stack.defaults {out}/esp32-m5stac
 
 rm -f examples/all-clusters-app/esp32/sdkconfig
 
-bash -c 'echo CONFIG_DISABLE_IPV4=y >>{out}/esp32-m5stack-all-clusters-ipv6only/sdkconfig.defaults'
+bash -c 'echo -e "
+CONFIG_DISABLE_IPV4=y
+" >>{out}/esp32-m5stack-all-clusters-ipv6only/sdkconfig.defaults'
 
 bash -c 'source $IDF_PATH/export.sh; source scripts/activate.sh; 
 export SDKCONFIG_DEFAULTS={out}/esp32-m5stack-all-clusters-ipv6only/sdkconfig.defaults
@@ -260,7 +264,9 @@ cp examples/all-clusters-app/esp32/sdkconfig_m5stack_rpc.defaults {out}/esp32-m5
 
 rm -f examples/all-clusters-app/esp32/sdkconfig
 
-bash -c 'echo CONFIG_DISABLE_IPV4=y >>{out}/esp32-m5stack-all-clusters-rpc-ipv6only/sdkconfig.defaults'
+bash -c 'echo -e "
+CONFIG_DISABLE_IPV4=y
+" >>{out}/esp32-m5stack-all-clusters-rpc-ipv6only/sdkconfig.defaults'
 
 bash -c 'source $IDF_PATH/export.sh; source scripts/activate.sh; 
 export SDKCONFIG_DEFAULTS={out}/esp32-m5stack-all-clusters-rpc-ipv6only/sdkconfig.defaults


### PR DESCRIPTION
#### Problem
sdkconfig.defaults for RPC builds is  missing a final newline, so when we were trying to append 'disableipv4' instead we got something like

```
CONFIG_CHIP_ENABLE_SHELL=nCONFIG_DISABLE_IPV4=y
```

which does not work

#### Change overview
Enforce newline before and after ipv4 disabling in the build script, so that settings take effect.

#### Testing
I added a conditional error in IPAddress.h if IPV4 is enabled and recompiled things. Error was not triggered (was triggered before).