### PR TITLE
[chip-tool] Add configure-fabric into the pairing module so chip-tool…

### DIFF
--- a/examples/chip-tool/BUILD.gn
+++ b/examples/chip-tool/BUILD.gn
@@ -38,6 +38,8 @@ executable("chip-tool") {
     # TODO - enable CommissionedListCommand once DNS Cache is implemented
     #    "commands/pairing/CommissionedListCommand.cpp",
     #    "commands/pairing/CommissionedListCommand.h",
+    "commands/pairing/ConfigureFabricCommand.cpp",
+    "commands/pairing/ConfigureFabricCommand.h",
     "commands/pairing/PairingCommand.cpp",
     "commands/payload/AdditionalDataParseCommand.cpp",
     "commands/payload/SetupPayloadParseCommand.cpp",

--- a/examples/chip-tool/commands/common/CHIPCommand.cpp
+++ b/examples/chip-tool/commands/common/CHIPCommand.cpp
@@ -61,8 +61,8 @@ CHIP_ERROR CHIPCommand::Run()
     // TODO - OpCreds should only be generated for pairing command
     //        store the credentials in persistent storage, and
     //        generate when not available in the storage.
-    ReturnLogErrorOnFailure(mOpCredsIssuer.GenerateNOCChainAfterValidation(mStorage.GetLocalNodeId(), 0, ephemeralKey.Pubkey(),
-                                                                           rcacSpan, icacSpan, nocSpan));
+    ReturnLogErrorOnFailure(mOpCredsIssuer.GenerateNOCChainAfterValidation(mStorage.GetLocalNodeId(), mStorage.GetFabricId(),
+                                                                           ephemeralKey.Pubkey(), rcacSpan, icacSpan, nocSpan));
 
     chip::Controller::FactoryInitParams factoryInitParams;
     factoryInitParams.fabricStorage = &mFabricStorage;

--- a/examples/chip-tool/commands/pairing/Commands.h
+++ b/examples/chip-tool/commands/pairing/Commands.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include "CommissionedListCommand.h"
+#include "ConfigureFabricCommand.h"
 #include "PairingCommand.h"
 
 class Unpair : public PairingCommand
@@ -172,6 +173,7 @@ void registerCommandsPairing(Commands & commands)
         make_unique<OpenCommissioningWindow>(),
         // TODO - enable CommissionedListCommand once DNS Cache is implemented
         //        make_unique<CommissionedListCommand>(),
+        make_unique<ConfigureFabricCommand>(),
     };
 
     commands.Register(clusterName, clusterCommands);

--- a/examples/chip-tool/commands/pairing/ConfigureFabricCommand.cpp
+++ b/examples/chip-tool/commands/pairing/ConfigureFabricCommand.cpp
@@ -1,0 +1,25 @@
+/*
+ *   Copyright (c) 2021 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+#include "ConfigureFabricCommand.h"
+
+CHIP_ERROR ConfigureFabricCommand::Run()
+{
+    ReturnLogErrorOnFailure(mStorage.Init());
+    return mStorage.SetFabric(mFabricName);
+}

--- a/examples/chip-tool/commands/pairing/ConfigureFabricCommand.h
+++ b/examples/chip-tool/commands/pairing/ConfigureFabricCommand.h
@@ -1,0 +1,33 @@
+/*
+ *   Copyright (c) 2021 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+#pragma once
+
+#include "../../config/PersistentStorage.h"
+#include "../common/Command.h"
+
+class ConfigureFabricCommand : public Command
+{
+public:
+    ConfigureFabricCommand() : Command("configure-fabric") { AddArgument("name", &mFabricName); }
+    CHIP_ERROR Run() override;
+
+private:
+    PersistentStorage mStorage;
+    char * mFabricName;
+};

--- a/examples/chip-tool/config/PersistentStorage.h
+++ b/examples/chip-tool/config/PersistentStorage.h
@@ -42,6 +42,25 @@ public:
     // Store local node id.
     CHIP_ERROR SetLocalNodeId(chip::NodeId nodeId);
 
+    /**
+     * @brief
+     *  Configure the fabric used for pairing and sending commands.
+     *
+     * @param[in] fabricName  The name of the fabric. It must be one of the following strings:
+     *                         - alpha
+     *                         - beta
+     *                         - gamma
+     *
+     * @return CHIP_ERROR CHIP_NO_ERROR on success, or corresponding error code.
+     */
+    CHIP_ERROR SetFabric(const char * fabricName);
+
+    /**
+     * @brief
+     *  Return the stored fabric id, or the one for the "alpha" fabric if nothing is stored.
+     */
+    chip::FabricId GetFabricId();
+
 private:
     CHIP_ERROR CommitConfig();
     inipp::Ini<char> mConfig;

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1341,7 +1341,9 @@ CHIP_ERROR DeviceCommissioner::ProcessOpCSR(const ByteSpan & NOCSRElements, cons
     ChipLogProgress(Controller, "Getting certificate chain for the device from the issuer");
 
     mOperationalCredentialsDelegate->SetNodeIdForNextNOCRequest(device->GetDeviceId());
-    mOperationalCredentialsDelegate->SetFabricIdForNextNOCRequest(0);
+
+    FabricInfo * fabric = mSystemState->Fabrics()->FindFabricWithIndex(mFabricIndex);
+    mOperationalCredentialsDelegate->SetFabricIdForNextNOCRequest(fabric->GetFabricId());
 
     return mOperationalCredentialsDelegate->GenerateNOCChain(NOCSRElements, AttestationSignature, ByteSpan(), ByteSpan(),
                                                              ByteSpan(), &mDeviceNOCChainCallback);


### PR DESCRIPTION
… can pair multiple times to the same accessory

#### Problem

`chip-tool` can not pair using a different fabric id.

This PR adds `alpha`, `beta`, `gamma` identities to `chip-tool`. Those identities are a fabric id + a listen port in order to let multiple `chip-tool` processes runs at the same time. a `chip-tool` identity can be selected with `chip-tool pairing configure-fabric alpha`


#### Change overview
 * Add `configure-fabric` to the pairing module
 * Update chip-tool `PersistentStorage.cpp` to save the configured fabric and returns a listen port depending on the selected identity by default


#### Testing
I have tested it on top of #11527 with the following commands:
```
$ rm /tmp/chip_tool_config.ini
$ ./out/debug/standalone/chip-all-clusters-app
# onto a other shell window
$ ./out/debug/standalone/chip-tool pairing onnetwork 0x12345 20202021
$ ./out/debug/standalone/chip-tool onoff read on-off 0x12345 1
$ ./out/debug/standalone/chip-tool pairing open-commissioning-window 0x12345 0 120 1 3840
$ ./out/debug/standalone/chip-tool onoff report on-off 1 20 1 0x12345 1
# onto an other shell window
$ ./out/debug/standalone/chip-tool pairing configure-fabric beta
$ ./out/debug/standalone/chip-tool pairing onnetwork 0x54321 20202021
$ ./out/debug/standalone/chip-tool onoff read on-off 0x54321 1
$ ./out/debug/standalone/chip-tool onoff on 0x54321 1
