### PR TITLE
Change expected-value matching to a valueEquals recursive template.

### DIFF
--- a/examples/chip-tool/templates/partials/test_cluster.zapt
+++ b/examples/chip-tool/templates/partials/test_cluster.zapt
@@ -193,26 +193,8 @@ class {{filename}}: public TestCommand
           {{/if}}
           {{#chip_tests_item_response_parameters}}
             {{~#*inline "item"}}{{asLowerCamelCase name}}{{#if isOptional}}.Value(){{/if}}{{/inline}}
-            {{~#*inline "itemValue"}}{{>item}}{{#if isNullable}}.Value(){{/if}}{{/inline}}
             {{#if hasExpectedValue}}
-              {{#if isOptional}}
-                {{~#*inline "item"}}{{asLowerCamelCase name}}{{/inline}}
-                VerifyOrReturn(CheckValuePresent("{{> item}}", {{> item}}));
-              {{/if}}
-              {{#if (isLiteralNull expectedValue)}}
-                VerifyOrReturn(CheckValueNull("{{> item}}", {{> item}}));
-              {{else}}
-                {{#if isNullable}}
-                VerifyOrReturn(CheckValueNonNull("{{> item}}", {{> item}}));
-                {{/if}}
-                VerifyOrReturn(CheckValue
-                  {{~#if isList}}AsListLength("{{>itemValue}}", {{>itemValue}}, {{expectedValue.length}})
-                  {{else if isArray}}AsList("{{>itemValue}}", {{>itemValue}}{{#if expectedValue.length}}, {{expectedValue}}{{/if}})
-                  {{else if (isString type)}}AsString("{{>itemValue}}", {{>itemValue}}, "{{expectedValue}}")
-                  {{else}}<{{chipType}}>("{{>itemValue}}", {{>itemValue}}, {{expectedValue}}{{asTypeLiteralSuffix type}})
-                  {{/if}}
-                );
-              {{/if}}
+              {{>valueEquals actual=(asLowerCamelCase name) label=(asLowerCamelCase name) expected=expectedValue}}
             {{/if}}
             {{#if hasExpectedConstraints}}
               {{#if isOptional}}

--- a/examples/chip-tool/templates/partials/test_cluster_value_equals.zapt
+++ b/examples/chip-tool/templates/partials/test_cluster_value_equals.zapt
@@ -1,0 +1,19 @@
+{{#if isOptional}}
+  VerifyOrReturn(CheckValuePresent("{{label}}", {{actual}}));
+  {{>valueEquals label=(concat label ".Value()") actual=(concat actual ".Value()") expected=expected isOptional=false}}
+{{else if isNullable}}
+  {{#if (isLiteralNull expected)}}
+    VerifyOrReturn(CheckValueNull("{{label}}", {{actual}}));
+  {{else}}
+    VerifyOrReturn(CheckValueNonNull("{{label}}", {{actual}}));
+    {{>valueEquals label=(concat label ".Value()") actual=(concat actual ".Value()") expected=expected isNullable=false}}
+  {{/if}}
+{{else}}
+  VerifyOrReturn(CheckValue
+    {{~#if isList}}AsListLength("{{label}}", {{actual}}, {{expected.length}})
+    {{else if isArray}}AsList("{{label}}", {{actual}}{{#if expected.length}}, {{expected}}{{/if}})
+    {{else if (isString type)}}AsString("{{label}}", {{actual}}, "{{expected}}")
+    {{else}}<{{chipType}}>("{{label}}", {{actual}}, {{expected}}{{asTypeLiteralSuffix type}})
+    {{/if}}
+  );
+{{/if}}

--- a/examples/chip-tool/templates/templates.json
+++ b/examples/chip-tool/templates/templates.json
@@ -31,6 +31,10 @@
         {
             "name": "commandValue",
             "path": "partials/test_cluster_command_value.zapt"
+        },
+        {
+            "name": "valueEquals",
+            "path": "partials/test_cluster_value_equals.zapt"
         }
     ],
     "templates": [

--- a/examples/placeholder/templates/templates.json
+++ b/examples/placeholder/templates/templates.json
@@ -30,6 +30,10 @@
         {
             "name": "commandValue",
             "path": "../../../examples/chip-tool/templates/partials/test_cluster_command_value.zapt"
+        },
+        {
+            "name": "valueEquals",
+            "path": "../../../examples/chip-tool/templates/partials/test_cluster_value_equals.zapt"
         }
     ],
     "templates": [


### PR DESCRIPTION
For now this does not change any functionality: there is no change in
the generated code.  It just cleans up how nullable and optional are
handled.

#### Problem
Expected-value checking is too complicated.

#### Change overview
Make it simpler, so it's easier to extend for lists and structs.

#### Testing
No behavior changes so far.