### PR TITLE
Fix YAML checking of return values handle lists and structs correctly

### DIFF
--- a/examples/chip-tool/commands/tests/TestCommand.cpp
+++ b/examples/chip-tool/commands/tests/TestCommand.cpp
@@ -109,17 +109,6 @@ bool TestCommand::CheckConstraintMaxLength(const char * itemName, uint64_t curre
     return true;
 }
 
-bool TestCommand::CheckValueAsList(const char * itemName, uint64_t current, uint64_t expected)
-{
-    if (current != expected)
-    {
-        Exit(std::string(itemName) + " count mismatch: " + std::to_string(current) + " != " + std::to_string(expected));
-        return false;
-    }
-
-    return true;
-}
-
 bool TestCommand::CheckValueAsString(const char * itemName, const chip::ByteSpan current, const char * expected)
 {
     const chip::ByteSpan expectedArgument = chip::ByteSpan(chip::Uint8::from_const_char(expected), strlen(expected));

--- a/examples/chip-tool/commands/tests/TestCommand.cpp
+++ b/examples/chip-tool/commands/tests/TestCommand.cpp
@@ -127,7 +127,8 @@ bool TestCommand::CheckValueAsString(const char * itemName, const chip::CharSpan
     const chip::CharSpan expectedArgument(expected, strlen(expected));
     if (!current.data_equal(expectedArgument))
     {
-        Exit(std::string(itemName) + " value mismatch, expecting " + std::string(expected));
+        Exit(std::string(itemName) + " value mismatch, expected '" + expected + "' but got '" +
+             std::string(current.data(), current.size()) + "'");
         return false;
     }
 

--- a/examples/chip-tool/commands/tests/TestCommand.h
+++ b/examples/chip-tool/commands/tests/TestCommand.h
@@ -117,7 +117,7 @@ protected:
     template <typename T, typename U, typename std::enable_if_t<std::is_enum<T>::value, int> = 0>
     bool CheckValue(const char * itemName, T current, U expected)
     {
-        return CheckValue(itemName, to_underlying(current), expected);
+        return CheckValue(itemName, chip::to_underlying(current), expected);
     }
 
     /**

--- a/examples/chip-tool/commands/tests/TestCommand.h
+++ b/examples/chip-tool/commands/tests/TestCommand.h
@@ -106,7 +106,8 @@ protected:
     {
         if (current != expected)
         {
-            Exit(std::string(itemName) + " value mismatch: " + std::to_string(current) + " != " + std::to_string(expected));
+            Exit(std::string(itemName) + " value mismatch: expected " + std::to_string(expected) + " but got " +
+                 std::to_string(current));
             return false;
         }
 
@@ -119,75 +120,55 @@ protected:
         return CheckValue(itemName, to_underlying(current), expected);
     }
 
-    bool CheckValueAsList(const char * itemName, uint64_t current, uint64_t expected);
-
-    template <typename T>
-    bool CheckValueAsListHelper(const char * itemName, typename chip::app::DataModel::DecodableList<T>::Iterator iter)
+    /**
+     * Check that the next list item, which is at index "index", exists and
+     * decodes properly.
+     */
+    template <typename ListType>
+    bool CheckNextListItemDecodes(const char * listName, typename std::remove_reference_t<ListType>::Iterator & iter, size_t index)
     {
-        if (iter.Next())
-        {
-            Exit(std::string(itemName) + " value mismatch: expected no more items but found " + std::to_string(iter.GetValue()));
-            return false;
-        }
+        bool hasValue = iter.Next();
         if (iter.GetStatus() != CHIP_NO_ERROR)
         {
-            Exit(std::string(itemName) +
-                 " value mismatch: expected no more items but got an error: " + iter.GetStatus().AsString());
+            Exit(std::string(listName) + " value mismatch: error '" + iter.GetStatus().AsString() + "'decoding item at index " +
+                 std::to_string(index));
             return false;
         }
-        return true;
+
+        if (hasValue)
+        {
+            return true;
+        }
+
+        Exit(std::string(listName) + " value mismatch: should have value at index " + std::to_string(index) +
+             " but doesn't (actual value too short)");
+        return false;
     }
 
-    template <typename T, typename U, typename... ValueTypes>
-    bool CheckValueAsListHelper(const char * itemName, typename chip::app::DataModel::DecodableList<T>::Iterator & iter,
-                                const U & firstItem, ValueTypes &&... otherItems)
+    /**
+     * Check that there are no more list items now that we have seen
+     * "expectedCount" of them.
+     */
+    template <typename ListType>
+    bool CheckNoMoreListItems(const char * listName, typename std::remove_reference_t<ListType>::Iterator & iter,
+                              size_t expectedCount)
     {
-        bool haveValue = iter.Next();
+        bool hasValue = iter.Next();
         if (iter.GetStatus() != CHIP_NO_ERROR)
         {
-            Exit(std::string(itemName) + " value mismatch: expected " + std::to_string(firstItem) +
-                 " but got error: " + iter.GetStatus().AsString());
+            Exit(std::string(listName) + " value mismatch: error '" + iter.GetStatus().AsString() +
+                 "'decoding item after we have seen " + std::to_string(expectedCount) + " items");
             return false;
         }
-        if (!haveValue)
-        {
-            Exit(std::string(itemName) + " value mismatch: expected " + std::to_string(firstItem) +
-                 " but found nothing or an error");
-            return false;
-        }
-        if (iter.GetValue() != firstItem)
-        {
-            Exit(std::string(itemName) + " value mismatch: expected " + std::to_string(firstItem) + " but found " +
-                 std::to_string(iter.GetValue()));
-            return false;
-        }
-        return CheckValueAsListHelper<T>(itemName, iter, std::forward<ValueTypes>(otherItems)...);
-    }
 
-    template <typename T, typename... ValueTypes>
-    bool CheckValueAsList(const char * itemName, chip::app::DataModel::DecodableList<T> list, ValueTypes &&... items)
-    {
-        auto iter = list.begin();
-        return CheckValueAsListHelper<T>(itemName, iter, std::forward<ValueTypes>(items)...);
-    }
+        if (!hasValue)
+        {
+            return true;
+        }
 
-    template <typename T>
-    bool CheckValueAsListLength(const char * itemName, chip::app::DataModel::DecodableList<T> list, uint64_t expectedLength)
-    {
-        // We don't just use list.ComputeSize(), because we want to check that
-        // all the values in the list correctly decode to our type too.
-        auto iter      = list.begin();
-        uint64_t count = 0;
-        while (iter.Next())
-        {
-            ++count;
-        }
-        if (iter.GetStatus() != CHIP_NO_ERROR)
-        {
-            Exit(std::string(itemName) + " list length mismatch: expected " + std::to_string(expectedLength) + " but got an error");
-            return false;
-        }
-        return CheckValueAsList(itemName, count, expectedLength);
+        Exit(std::string(listName) + " value mismatch: expected only " + std::to_string(expectedCount) +
+             " items, but have more than that (actual value too long)");
+        return false;
     }
 
     bool CheckValueAsString(const char * itemName, chip::ByteSpan current, const char * expected);

--- a/examples/chip-tool/templates/partials/test_cluster_value_equals.zapt
+++ b/examples/chip-tool/templates/partials/test_cluster_value_equals.zapt
@@ -8,12 +8,21 @@
     VerifyOrReturn(CheckValueNonNull("{{label}}", {{actual}}));
     {{>valueEquals label=(concat label ".Value()") actual=(concat actual ".Value()") expected=expected isNullable=false}}
   {{/if}}
+{{else if isArray}}
+    auto iter = {{actual}}.begin();
+    {{#each expected}}
+      VerifyOrReturn(CheckNextListItemDecodes<decltype({{../actual}})>("{{../label}}", iter, {{@index}}));
+      {{>valueEquals label=(concat ../label "[" @index "]") actual="iter.GetValue()" expected=this isArray=false type=../type chipType=../chipType}}
+    {{/each}}
+    VerifyOrReturn(CheckNoMoreListItems<decltype({{actual}})>("{{label}}", iter, {{expected.length}}));
 {{else}}
-  VerifyOrReturn(CheckValue
-    {{~#if isList}}AsListLength("{{label}}", {{actual}}, {{expected.length}})
-    {{else if isArray}}AsList("{{label}}", {{actual}}{{#if expected.length}}, {{expected}}{{/if}})
-    {{else if (isString type)}}AsString("{{label}}", {{actual}}, "{{expected}}")
-    {{else}}<{{chipType}}>("{{label}}", {{actual}}, {{expected}}{{asTypeLiteralSuffix type}})
-    {{/if}}
-  );
+  {{#if_is_struct type}}
+  {{! NOT SUPPORTED YET }}
+  {{else}}
+    VerifyOrReturn(CheckValue
+      {{~#if (isString type)}}AsString("{{label}}", {{actual}}, "{{expected}}")
+      {{else}}<{{chipType}}>("{{label}}", {{actual}}, {{expected}}{{asTypeLiteralSuffix type}})
+      {{/if}}
+    );
+  {{/if_is_struct}}
 {{/if}}

--- a/examples/chip-tool/templates/partials/test_cluster_value_equals.zapt
+++ b/examples/chip-tool/templates/partials/test_cluster_value_equals.zapt
@@ -17,7 +17,16 @@
     VerifyOrReturn(CheckNoMoreListItems<decltype({{actual}})>("{{label}}", iter, {{expected.length}}));
 {{else}}
   {{#if_is_struct type}}
-  {{! NOT SUPPORTED YET }}
+    {{! Iterate over the actual types in the struct, so we pick up the right
+        type/optionality/nullability information for them for our recursive
+        call. }}
+    {{#zcl_struct_items_by_struct_name type}}
+      {{#if (expectedValueHasProp ../expected (asLowerCamelCase label))}}
+        {{>valueEquals label=(concat ../label "." (asLowerCamelCase label)) actual=(concat ../actual "." (asLowerCamelCase label)) expected=(lookup ../expected (asLowerCamelCase label))}}
+      {{/if}}
+    {{/zcl_struct_items_by_struct_name}}
+    {{! Maybe we should add a check for properties in the expected object (other
+        than "global") that are not present in the struct ? }}
   {{else}}
     VerifyOrReturn(CheckValue
       {{~#if (isString type)}}AsString("{{label}}", {{actual}}, "{{expected}}")

--- a/src/app/clusters/test-cluster-server/test-cluster-server.cpp
+++ b/src/app/clusters/test-cluster-server/test-cluster-server.cpp
@@ -129,10 +129,10 @@ EmberAfStatus writeTestListInt8uAttribute(EndpointId endpoint)
 CHIP_ERROR TestAttrAccess::ReadListInt8uAttribute(AttributeValueEncoder & aEncoder)
 {
     return aEncoder.EncodeList([](const TagBoundEncoder & encoder) -> CHIP_ERROR {
-        constexpr uint16_t attributeCount = 4;
-        for (uint8_t index = 0; index < attributeCount; index++)
+        constexpr uint8_t maxValue = 4;
+        for (uint8_t value = 1; value <= maxValue; value++)
         {
-            ReturnErrorOnFailure(encoder.Encode(index));
+            ReturnErrorOnFailure(encoder.Encode(value));
         }
         return CHIP_NO_ERROR;
     });

--- a/src/app/tests/suites/TV_AudioOutputCluster.yaml
+++ b/src/app/tests/suites/TV_AudioOutputCluster.yaml
@@ -25,9 +25,9 @@ tests:
       response:
           value:
               [
-                  { index: 1, outputType: 0, name: 12 },
-                  { index: 2, outputType: 0, name: 12 },
-                  { index: 3, outputType: 0, name: 12 },
+                  { index: 1, outputType: 0, name: "exampleName" },
+                  { index: 2, outputType: 0, name: "exampleName" },
+                  { index: 3, outputType: 0, name: "exampleName" },
               ]
 
     - label: "Select Output Command"

--- a/src/app/tests/suites/TV_MediaInputCluster.yaml
+++ b/src/app/tests/suites/TV_MediaInputCluster.yaml
@@ -25,8 +25,18 @@ tests:
       response:
           value:
               [
-                  { index: 1, inputType: 4, name: 12, description: 19 },
-                  { index: 2, inputType: 4, name: 12, description: 19 },
+                  {
+                      index: 1,
+                      inputType: 4,
+                      name: "exampleName",
+                      description: "exampleDescription",
+                  },
+                  {
+                      index: 2,
+                      inputType: 4,
+                      name: "exampleName",
+                      description: "exampleDescription",
+                  },
               ]
 
     - label: "Select Input Command"

--- a/src/app/tests/suites/TV_TargetNavigatorCluster.yaml
+++ b/src/app/tests/suites/TV_TargetNavigatorCluster.yaml
@@ -23,7 +23,11 @@ tests:
       command: "readAttribute"
       attribute: "Target Navigator List"
       response:
-          value: [{ identifier: 1, name: 12 }, { identifier: 2, name: 12 }]
+          value:
+              [
+                  { identifier: 1, name: "exampleName" },
+                  { identifier: 2, name: "exampleName" },
+              ]
 
     - label: "Navigate Target Command"
       command: "NavigateTarget"

--- a/src/app/tests/suites/TV_TvChannelCluster.yaml
+++ b/src/app/tests/suites/TV_TvChannelCluster.yaml
@@ -28,16 +28,16 @@ tests:
                   {
                       majorNumber: 1,
                       minorNumber: 2,
-                      name: 12,
-                      callSign: 13,
-                      affiliateCallSign: 13,
+                      name: "exampleName",
+                      callSign: "exampleCSign",
+                      affiliateCallSign: "exampleASign",
                   },
                   {
                       majorNumber: 2,
                       minorNumber: 3,
-                      name: 12,
-                      callSign: 13,
-                      affiliateCallSign: 13,
+                      name: "exampleName",
+                      callSign: "exampleCSign",
+                      affiliateCallSign: "exampleASign",
                   },
               ]
     # TODO: Enable the test once struct response is supported

--- a/src/app/tests/suites/TestDescriptorCluster.yaml
+++ b/src/app/tests/suites/TestDescriptorCluster.yaml
@@ -29,9 +29,26 @@ tests:
       command: "readAttribute"
       attribute: "Server List"
       response:
-          value: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
-    # CLUSTER_ID value is dummy 0 since yaml compares only the length of the List.
-    # right now
+          value: [
+                  0x0003, # Identify
+                  0x001D, # Descriptor
+                  0x0028, # Basic Information
+                  0x0029, # OTA Software Update Provider
+                  0x002A, # OTA Software Update Requestor
+                  0x0030, # General Commissioning
+                  0x0031, # Network Commissioning
+                  0x0032, # Diagnostic Logs
+                  0x0033, # General Diagnostics
+                  0x0034, # Software Diagnostics
+                  0x0035, # Thread Network Diagnostiscs
+                  0x0036, # WiFi Network Diagnostics
+                  0x0037, # Ethernet Network Diagnostics
+                  0x003C, # Administrator Commissioning
+                  0x003E, # Operational Credentials
+                  0x0405, # Relative Humidity Measurement (why on EP0?)
+                  0xF000, # Binding
+                  0xF004, # Group Key Management
+              ]
 
     - label: "Read attribute Client list"
       command: "readAttribute"

--- a/src/app/tests/suites/certification/Test_TC_DM_2_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_DM_2_2.yaml
@@ -80,6 +80,8 @@ tests:
       command: "readAttribute"
       attribute: "TrustedRootCertificates"
       response:
-          value: [237]
+          # Can't check for the expected value here, since we don't know it.
+          # TODO: Check the length, at least?
+          # value: [237]
           constraints:
               type: list

--- a/src/app/zap-templates/common/ClusterTestGeneration.js
+++ b/src/app/zap-templates/common/ClusterTestGeneration.js
@@ -591,6 +591,11 @@ function isLiteralNull(value, options)
   return (value === null) || (value instanceof NullObject);
 }
 
+function expectedValueHasProp(value, name)
+{
+  return name in value;
+}
+
 //
 // Module exports
 //
@@ -602,3 +607,4 @@ exports.chip_tests_item_response_parameters = chip_tests_item_response_parameter
 exports.chip_tests_pics                     = chip_tests_pics;
 exports.isTestOnlyCluster                   = isTestOnlyCluster;
 exports.isLiteralNull                       = isLiteralNull;
+exports.expectedValueHasProp                = expectedValueHasProp;

--- a/src/app/zap-templates/common/ClusterTestGeneration.js
+++ b/src/app/zap-templates/common/ClusterTestGeneration.js
@@ -467,6 +467,42 @@ function chip_tests_item_response_type(options)
   return asPromise.call(this, promise, options);
 }
 
+// test_cluster_command_value and test_cluster_value-equals are recursive partials using #each. At some point the |global|
+// context is lost and it fails. Make sure to attach the global context as a property of the | value |
+// that is evaluated.
+function attachGlobal(global, value)
+{
+  if (Array.isArray(value)) {
+    value = value.map(v => attachGlobal(global, v));
+  } else if (value instanceof Object) {
+    for (key in value) {
+      if (key == "global") {
+        continue;
+      }
+      value[key] = attachGlobal(global, value[key]);
+    }
+  } else if (value === null) {
+    value = new NullObject();
+  } else {
+    switch (typeof value) {
+    case 'number':
+      value = new Number(value);
+      break;
+    case 'string':
+      value = new String(value);
+      break;
+    case 'boolean':
+      value = new Boolean(value);
+      break;
+    default:
+      throw new Error('Unsupported value: ' + JSON.stringify(value));
+    }
+  }
+
+  value.global = global;
+  return value;
+}
+
 function chip_tests_item_parameters(options)
 {
   const commandValues = this.arguments.values;
@@ -493,41 +529,6 @@ function chip_tests_item_parameters(options)
         printErrorAndExit(this,
             'Missing "' + commandArg.name + '" in arguments list: \n\t* '
                 + commandValues.map(command => command.name).join('\n\t* '));
-      }
-      // test_cluster_command_value is a recursive partial using #each. At some point the |global|
-      // context is lost and it fails. Make sure to attach the global context as a property of the | value |
-      // that is evaluated.
-      function attachGlobal(global, value)
-      {
-        if (Array.isArray(value)) {
-          value = value.map(v => attachGlobal(global, v));
-        } else if (value instanceof Object) {
-          for (key in value) {
-            if (key == "global") {
-              continue;
-            }
-            value[key] = attachGlobal(global, value[key]);
-          }
-        } else if (value === null) {
-          value = new NullObject();
-        } else {
-          switch (typeof value) {
-          case 'number':
-            value = new Number(value);
-            break;
-          case 'string':
-            value = new String(value);
-            break;
-          case 'boolean':
-            value = new Boolean(value);
-            break;
-          default:
-            throw new Error('Unsupported value: ' + JSON.stringify(value));
-          }
-        }
-
-        value.global = global;
-        return value;
       }
       commandArg.definedValue = attachGlobal(this.global, expected.value);
 
@@ -558,7 +559,7 @@ function chip_tests_item_response_parameters(options)
         const expected = responseValues.splice(expectedIndex, 1)[0];
         if ('value' in expected) {
           responseArg.hasExpectedValue = true;
-          responseArg.expectedValue    = expected.value;
+          responseArg.expectedValue    = attachGlobal(this.global, expected.value);
         }
 
         if ('constraints' in expected) {

--- a/zzz_generated/chip-tool/zap-generated/test/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/test/Commands.h
@@ -23205,7 +23205,11 @@ private:
     {
         auto iter = targetNavigatorList.begin();
         VerifyOrReturn(CheckNextListItemDecodes<decltype(targetNavigatorList)>("targetNavigatorList", iter, 0));
+        VerifyOrReturn(CheckValue<>("targetNavigatorList[0].identifier", iter.GetValue().identifier, 1));
+        VerifyOrReturn(CheckValueAsString("targetNavigatorList[0].name", iter.GetValue().name, "exampleName"));
         VerifyOrReturn(CheckNextListItemDecodes<decltype(targetNavigatorList)>("targetNavigatorList", iter, 1));
+        VerifyOrReturn(CheckValue<>("targetNavigatorList[1].identifier", iter.GetValue().identifier, 2));
+        VerifyOrReturn(CheckValueAsString("targetNavigatorList[1].name", iter.GetValue().name, "exampleName"));
         VerifyOrReturn(CheckNoMoreListItems<decltype(targetNavigatorList)>("targetNavigatorList", iter, 2));
         NextTest();
     }
@@ -23332,8 +23336,17 @@ private:
     {
         auto iter = audioOutputList.begin();
         VerifyOrReturn(CheckNextListItemDecodes<decltype(audioOutputList)>("audioOutputList", iter, 0));
+        VerifyOrReturn(CheckValue<>("audioOutputList[0].index", iter.GetValue().index, 1));
+        VerifyOrReturn(CheckValue<>("audioOutputList[0].outputType", iter.GetValue().outputType, 0));
+        VerifyOrReturn(CheckValueAsString("audioOutputList[0].name", iter.GetValue().name, "exampleName"));
         VerifyOrReturn(CheckNextListItemDecodes<decltype(audioOutputList)>("audioOutputList", iter, 1));
+        VerifyOrReturn(CheckValue<>("audioOutputList[1].index", iter.GetValue().index, 2));
+        VerifyOrReturn(CheckValue<>("audioOutputList[1].outputType", iter.GetValue().outputType, 0));
+        VerifyOrReturn(CheckValueAsString("audioOutputList[1].name", iter.GetValue().name, "exampleName"));
         VerifyOrReturn(CheckNextListItemDecodes<decltype(audioOutputList)>("audioOutputList", iter, 2));
+        VerifyOrReturn(CheckValue<>("audioOutputList[2].index", iter.GetValue().index, 3));
+        VerifyOrReturn(CheckValue<>("audioOutputList[2].outputType", iter.GetValue().outputType, 0));
+        VerifyOrReturn(CheckValueAsString("audioOutputList[2].name", iter.GetValue().name, "exampleName"));
         VerifyOrReturn(CheckNoMoreListItems<decltype(audioOutputList)>("audioOutputList", iter, 3));
         NextTest();
     }
@@ -24515,7 +24528,17 @@ private:
     {
         auto iter = tvChannelList.begin();
         VerifyOrReturn(CheckNextListItemDecodes<decltype(tvChannelList)>("tvChannelList", iter, 0));
+        VerifyOrReturn(CheckValue<>("tvChannelList[0].majorNumber", iter.GetValue().majorNumber, 1U));
+        VerifyOrReturn(CheckValue<>("tvChannelList[0].minorNumber", iter.GetValue().minorNumber, 2U));
+        VerifyOrReturn(CheckValueAsString("tvChannelList[0].name", iter.GetValue().name, "exampleName"));
+        VerifyOrReturn(CheckValueAsString("tvChannelList[0].callSign", iter.GetValue().callSign, "exampleCSign"));
+        VerifyOrReturn(CheckValueAsString("tvChannelList[0].affiliateCallSign", iter.GetValue().affiliateCallSign, "exampleASign"));
         VerifyOrReturn(CheckNextListItemDecodes<decltype(tvChannelList)>("tvChannelList", iter, 1));
+        VerifyOrReturn(CheckValue<>("tvChannelList[1].majorNumber", iter.GetValue().majorNumber, 2U));
+        VerifyOrReturn(CheckValue<>("tvChannelList[1].minorNumber", iter.GetValue().minorNumber, 3U));
+        VerifyOrReturn(CheckValueAsString("tvChannelList[1].name", iter.GetValue().name, "exampleName"));
+        VerifyOrReturn(CheckValueAsString("tvChannelList[1].callSign", iter.GetValue().callSign, "exampleCSign"));
+        VerifyOrReturn(CheckValueAsString("tvChannelList[1].affiliateCallSign", iter.GetValue().affiliateCallSign, "exampleASign"));
         VerifyOrReturn(CheckNoMoreListItems<decltype(tvChannelList)>("tvChannelList", iter, 2));
         NextTest();
     }
@@ -24767,7 +24790,15 @@ private:
     {
         auto iter = mediaInputList.begin();
         VerifyOrReturn(CheckNextListItemDecodes<decltype(mediaInputList)>("mediaInputList", iter, 0));
+        VerifyOrReturn(CheckValue<>("mediaInputList[0].index", iter.GetValue().index, 1));
+        VerifyOrReturn(CheckValue<>("mediaInputList[0].inputType", iter.GetValue().inputType, 4));
+        VerifyOrReturn(CheckValueAsString("mediaInputList[0].name", iter.GetValue().name, "exampleName"));
+        VerifyOrReturn(CheckValueAsString("mediaInputList[0].description", iter.GetValue().description, "exampleDescription"));
         VerifyOrReturn(CheckNextListItemDecodes<decltype(mediaInputList)>("mediaInputList", iter, 1));
+        VerifyOrReturn(CheckValue<>("mediaInputList[1].index", iter.GetValue().index, 2));
+        VerifyOrReturn(CheckValue<>("mediaInputList[1].inputType", iter.GetValue().inputType, 4));
+        VerifyOrReturn(CheckValueAsString("mediaInputList[1].name", iter.GetValue().name, "exampleName"));
+        VerifyOrReturn(CheckValueAsString("mediaInputList[1].description", iter.GetValue().description, "exampleDescription"));
         VerifyOrReturn(CheckNoMoreListItems<decltype(mediaInputList)>("mediaInputList", iter, 2));
         NextTest();
     }
@@ -28484,9 +28515,17 @@ private:
     {
         auto iter = listStructOctetString.begin();
         VerifyOrReturn(CheckNextListItemDecodes<decltype(listStructOctetString)>("listStructOctetString", iter, 0));
+        VerifyOrReturn(CheckValue<>("listStructOctetString[0].fabricIndex", iter.GetValue().fabricIndex, 0ULL));
+        VerifyOrReturn(CheckValueAsString("listStructOctetString[0].operationalCert", iter.GetValue().operationalCert, "Test0"));
         VerifyOrReturn(CheckNextListItemDecodes<decltype(listStructOctetString)>("listStructOctetString", iter, 1));
+        VerifyOrReturn(CheckValue<>("listStructOctetString[1].fabricIndex", iter.GetValue().fabricIndex, 1ULL));
+        VerifyOrReturn(CheckValueAsString("listStructOctetString[1].operationalCert", iter.GetValue().operationalCert, "Test1"));
         VerifyOrReturn(CheckNextListItemDecodes<decltype(listStructOctetString)>("listStructOctetString", iter, 2));
+        VerifyOrReturn(CheckValue<>("listStructOctetString[2].fabricIndex", iter.GetValue().fabricIndex, 2ULL));
+        VerifyOrReturn(CheckValueAsString("listStructOctetString[2].operationalCert", iter.GetValue().operationalCert, "Test2"));
         VerifyOrReturn(CheckNextListItemDecodes<decltype(listStructOctetString)>("listStructOctetString", iter, 3));
+        VerifyOrReturn(CheckValue<>("listStructOctetString[3].fabricIndex", iter.GetValue().fabricIndex, 3ULL));
+        VerifyOrReturn(CheckValueAsString("listStructOctetString[3].operationalCert", iter.GetValue().operationalCert, "Test3"));
         VerifyOrReturn(CheckNoMoreListItems<decltype(listStructOctetString)>("listStructOctetString", iter, 4));
         NextTest();
     }
@@ -29763,6 +29802,7 @@ private:
     {
         auto iter = deviceList.begin();
         VerifyOrReturn(CheckNextListItemDecodes<decltype(deviceList)>("deviceList", iter, 0));
+        VerifyOrReturn(CheckValue<>("deviceList[0].revision", iter.GetValue().revision, 1U));
         VerifyOrReturn(CheckNoMoreListItems<decltype(deviceList)>("deviceList", iter, 1));
         NextTest();
     }
@@ -30494,8 +30534,17 @@ private:
     {
         auto iter = supportedModes.begin();
         VerifyOrReturn(CheckNextListItemDecodes<decltype(supportedModes)>("supportedModes", iter, 0));
+        VerifyOrReturn(CheckValueAsString("supportedModes[0].label", iter.GetValue().label, "Black"));
+        VerifyOrReturn(CheckValue<>("supportedModes[0].mode", iter.GetValue().mode, 0));
+        VerifyOrReturn(CheckValue<>("supportedModes[0].semanticTag", iter.GetValue().semanticTag, 0UL));
         VerifyOrReturn(CheckNextListItemDecodes<decltype(supportedModes)>("supportedModes", iter, 1));
+        VerifyOrReturn(CheckValueAsString("supportedModes[1].label", iter.GetValue().label, "Cappuccino"));
+        VerifyOrReturn(CheckValue<>("supportedModes[1].mode", iter.GetValue().mode, 4));
+        VerifyOrReturn(CheckValue<>("supportedModes[1].semanticTag", iter.GetValue().semanticTag, 0UL));
         VerifyOrReturn(CheckNextListItemDecodes<decltype(supportedModes)>("supportedModes", iter, 2));
+        VerifyOrReturn(CheckValueAsString("supportedModes[2].label", iter.GetValue().label, "Espresso"));
+        VerifyOrReturn(CheckValue<>("supportedModes[2].mode", iter.GetValue().mode, 7));
+        VerifyOrReturn(CheckValue<>("supportedModes[2].semanticTag", iter.GetValue().semanticTag, 0UL));
         VerifyOrReturn(CheckNoMoreListItems<decltype(supportedModes)>("supportedModes", iter, 3));
         NextTest();
     }

--- a/zzz_generated/chip-tool/zap-generated/test/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/test/Commands.h
@@ -13212,7 +13212,9 @@ private:
     void OnSuccessResponse_0(const chip::app::DataModel::DecodableList<
                              chip::app::Clusters::OperationalCredentials::Structs::FabricDescriptor::DecodableType> & fabricsList)
     {
-        VerifyOrReturn(CheckValueAsListLength("fabricsList", fabricsList, 1));
+        auto iter = fabricsList.begin();
+        VerifyOrReturn(CheckNextListItemDecodes<decltype(fabricsList)>("fabricsList", iter, 0));
+        VerifyOrReturn(CheckNoMoreListItems<decltype(fabricsList)>("fabricsList", iter, 1));
         NextTest();
     }
 
@@ -13260,7 +13262,7 @@ private:
 
     void OnSuccessResponse_3(const chip::app::DataModel::DecodableList<chip::ByteSpan> & trustedRootCertificates)
     {
-        VerifyOrReturn(CheckValueAsListLength("trustedRootCertificates", trustedRootCertificates, 1));
+        VerifyOrReturn(CheckConstraintType("trustedRootCertificates", "", "list"));
         NextTest();
     }
 };
@@ -23201,7 +23203,10 @@ private:
         const chip::app::DataModel::DecodableList<
             chip::app::Clusters::TargetNavigator::Structs::NavigateTargetTargetInfo::DecodableType> & targetNavigatorList)
     {
-        VerifyOrReturn(CheckValueAsListLength("targetNavigatorList", targetNavigatorList, 2));
+        auto iter = targetNavigatorList.begin();
+        VerifyOrReturn(CheckNextListItemDecodes<decltype(targetNavigatorList)>("targetNavigatorList", iter, 0));
+        VerifyOrReturn(CheckNextListItemDecodes<decltype(targetNavigatorList)>("targetNavigatorList", iter, 1));
+        VerifyOrReturn(CheckNoMoreListItems<decltype(targetNavigatorList)>("targetNavigatorList", iter, 2));
         NextTest();
     }
 
@@ -23325,7 +23330,11 @@ private:
         const chip::app::DataModel::DecodableList<chip::app::Clusters::AudioOutput::Structs::AudioOutputInfo::DecodableType> &
             audioOutputList)
     {
-        VerifyOrReturn(CheckValueAsListLength("audioOutputList", audioOutputList, 3));
+        auto iter = audioOutputList.begin();
+        VerifyOrReturn(CheckNextListItemDecodes<decltype(audioOutputList)>("audioOutputList", iter, 0));
+        VerifyOrReturn(CheckNextListItemDecodes<decltype(audioOutputList)>("audioOutputList", iter, 1));
+        VerifyOrReturn(CheckNextListItemDecodes<decltype(audioOutputList)>("audioOutputList", iter, 2));
+        VerifyOrReturn(CheckNoMoreListItems<decltype(audioOutputList)>("audioOutputList", iter, 3));
         NextTest();
     }
 
@@ -23495,7 +23504,12 @@ private:
 
     void OnSuccessResponse_0(const chip::app::DataModel::DecodableList<uint16_t> & applicationLauncherList)
     {
-        VerifyOrReturn(CheckValueAsListLength("applicationLauncherList", applicationLauncherList, 2));
+        auto iter = applicationLauncherList.begin();
+        VerifyOrReturn(CheckNextListItemDecodes<decltype(applicationLauncherList)>("applicationLauncherList", iter, 0));
+        VerifyOrReturn(CheckValue<uint16_t>("applicationLauncherList[0]", iter.GetValue(), 123U));
+        VerifyOrReturn(CheckNextListItemDecodes<decltype(applicationLauncherList)>("applicationLauncherList", iter, 1));
+        VerifyOrReturn(CheckValue<uint16_t>("applicationLauncherList[1]", iter.GetValue(), 456U));
+        VerifyOrReturn(CheckNoMoreListItems<decltype(applicationLauncherList)>("applicationLauncherList", iter, 2));
         NextTest();
     }
 
@@ -24499,7 +24513,10 @@ private:
         const chip::app::DataModel::DecodableList<chip::app::Clusters::TvChannel::Structs::TvChannelInfo::DecodableType> &
             tvChannelList)
     {
-        VerifyOrReturn(CheckValueAsListLength("tvChannelList", tvChannelList, 2));
+        auto iter = tvChannelList.begin();
+        VerifyOrReturn(CheckNextListItemDecodes<decltype(tvChannelList)>("tvChannelList", iter, 0));
+        VerifyOrReturn(CheckNextListItemDecodes<decltype(tvChannelList)>("tvChannelList", iter, 1));
+        VerifyOrReturn(CheckNoMoreListItems<decltype(tvChannelList)>("tvChannelList", iter, 2));
         NextTest();
     }
 
@@ -24748,7 +24765,10 @@ private:
         const chip::app::DataModel::DecodableList<chip::app::Clusters::MediaInput::Structs::MediaInputInfo::DecodableType> &
             mediaInputList)
     {
-        VerifyOrReturn(CheckValueAsListLength("mediaInputList", mediaInputList, 2));
+        auto iter = mediaInputList.begin();
+        VerifyOrReturn(CheckNextListItemDecodes<decltype(mediaInputList)>("mediaInputList", iter, 0));
+        VerifyOrReturn(CheckNextListItemDecodes<decltype(mediaInputList)>("mediaInputList", iter, 1));
+        VerifyOrReturn(CheckNoMoreListItems<decltype(mediaInputList)>("mediaInputList", iter, 2));
         NextTest();
     }
 
@@ -28410,7 +28430,16 @@ private:
 
     void OnSuccessResponse_106(const chip::app::DataModel::DecodableList<uint8_t> & listInt8u)
     {
-        VerifyOrReturn(CheckValueAsListLength("listInt8u", listInt8u, 4));
+        auto iter = listInt8u.begin();
+        VerifyOrReturn(CheckNextListItemDecodes<decltype(listInt8u)>("listInt8u", iter, 0));
+        VerifyOrReturn(CheckValue<uint8_t>("listInt8u[0]", iter.GetValue(), 1));
+        VerifyOrReturn(CheckNextListItemDecodes<decltype(listInt8u)>("listInt8u", iter, 1));
+        VerifyOrReturn(CheckValue<uint8_t>("listInt8u[1]", iter.GetValue(), 2));
+        VerifyOrReturn(CheckNextListItemDecodes<decltype(listInt8u)>("listInt8u", iter, 2));
+        VerifyOrReturn(CheckValue<uint8_t>("listInt8u[2]", iter.GetValue(), 3));
+        VerifyOrReturn(CheckNextListItemDecodes<decltype(listInt8u)>("listInt8u", iter, 3));
+        VerifyOrReturn(CheckValue<uint8_t>("listInt8u[3]", iter.GetValue(), 4));
+        VerifyOrReturn(CheckNoMoreListItems<decltype(listInt8u)>("listInt8u", iter, 4));
         NextTest();
     }
 
@@ -28426,7 +28455,16 @@ private:
 
     void OnSuccessResponse_107(const chip::app::DataModel::DecodableList<chip::ByteSpan> & listOctetString)
     {
-        VerifyOrReturn(CheckValueAsListLength("listOctetString", listOctetString, 4));
+        auto iter = listOctetString.begin();
+        VerifyOrReturn(CheckNextListItemDecodes<decltype(listOctetString)>("listOctetString", iter, 0));
+        VerifyOrReturn(CheckValueAsString("listOctetString[0]", iter.GetValue(), "Test0"));
+        VerifyOrReturn(CheckNextListItemDecodes<decltype(listOctetString)>("listOctetString", iter, 1));
+        VerifyOrReturn(CheckValueAsString("listOctetString[1]", iter.GetValue(), "Test1"));
+        VerifyOrReturn(CheckNextListItemDecodes<decltype(listOctetString)>("listOctetString", iter, 2));
+        VerifyOrReturn(CheckValueAsString("listOctetString[2]", iter.GetValue(), "Test2"));
+        VerifyOrReturn(CheckNextListItemDecodes<decltype(listOctetString)>("listOctetString", iter, 3));
+        VerifyOrReturn(CheckValueAsString("listOctetString[3]", iter.GetValue(), "Test3"));
+        VerifyOrReturn(CheckNoMoreListItems<decltype(listOctetString)>("listOctetString", iter, 4));
         NextTest();
     }
 
@@ -28444,7 +28482,12 @@ private:
         const chip::app::DataModel::DecodableList<chip::app::Clusters::TestCluster::Structs::TestListStructOctet::DecodableType> &
             listStructOctetString)
     {
-        VerifyOrReturn(CheckValueAsListLength("listStructOctetString", listStructOctetString, 4));
+        auto iter = listStructOctetString.begin();
+        VerifyOrReturn(CheckNextListItemDecodes<decltype(listStructOctetString)>("listStructOctetString", iter, 0));
+        VerifyOrReturn(CheckNextListItemDecodes<decltype(listStructOctetString)>("listStructOctetString", iter, 1));
+        VerifyOrReturn(CheckNextListItemDecodes<decltype(listStructOctetString)>("listStructOctetString", iter, 2));
+        VerifyOrReturn(CheckNextListItemDecodes<decltype(listStructOctetString)>("listStructOctetString", iter, 3));
+        VerifyOrReturn(CheckNoMoreListItems<decltype(listStructOctetString)>("listStructOctetString", iter, 4));
         NextTest();
     }
 
@@ -29049,7 +29092,26 @@ private:
 
     void OnSuccessResponse_4(const chip::app::DataModel::DecodableList<uint8_t> & arg1)
     {
-        VerifyOrReturn(CheckValueAsList("arg1", arg1, 9, 8, 7, 6, 5, 4, 3, 2, 1));
+        auto iter = arg1.begin();
+        VerifyOrReturn(CheckNextListItemDecodes<decltype(arg1)>("arg1", iter, 0));
+        VerifyOrReturn(CheckValue<uint8_t>("arg1[0]", iter.GetValue(), 9));
+        VerifyOrReturn(CheckNextListItemDecodes<decltype(arg1)>("arg1", iter, 1));
+        VerifyOrReturn(CheckValue<uint8_t>("arg1[1]", iter.GetValue(), 8));
+        VerifyOrReturn(CheckNextListItemDecodes<decltype(arg1)>("arg1", iter, 2));
+        VerifyOrReturn(CheckValue<uint8_t>("arg1[2]", iter.GetValue(), 7));
+        VerifyOrReturn(CheckNextListItemDecodes<decltype(arg1)>("arg1", iter, 3));
+        VerifyOrReturn(CheckValue<uint8_t>("arg1[3]", iter.GetValue(), 6));
+        VerifyOrReturn(CheckNextListItemDecodes<decltype(arg1)>("arg1", iter, 4));
+        VerifyOrReturn(CheckValue<uint8_t>("arg1[4]", iter.GetValue(), 5));
+        VerifyOrReturn(CheckNextListItemDecodes<decltype(arg1)>("arg1", iter, 5));
+        VerifyOrReturn(CheckValue<uint8_t>("arg1[5]", iter.GetValue(), 4));
+        VerifyOrReturn(CheckNextListItemDecodes<decltype(arg1)>("arg1", iter, 6));
+        VerifyOrReturn(CheckValue<uint8_t>("arg1[6]", iter.GetValue(), 3));
+        VerifyOrReturn(CheckNextListItemDecodes<decltype(arg1)>("arg1", iter, 7));
+        VerifyOrReturn(CheckValue<uint8_t>("arg1[7]", iter.GetValue(), 2));
+        VerifyOrReturn(CheckNextListItemDecodes<decltype(arg1)>("arg1", iter, 8));
+        VerifyOrReturn(CheckValue<uint8_t>("arg1[8]", iter.GetValue(), 1));
+        VerifyOrReturn(CheckNoMoreListItems<decltype(arg1)>("arg1", iter, 9));
         NextTest();
     }
 
@@ -29079,7 +29141,8 @@ private:
 
     void OnSuccessResponse_5(const chip::app::DataModel::DecodableList<uint8_t> & arg1)
     {
-        VerifyOrReturn(CheckValueAsList("arg1", arg1));
+        auto iter = arg1.begin();
+        VerifyOrReturn(CheckNoMoreListItems<decltype(arg1)>("arg1", iter, 0));
         NextTest();
     }
 
@@ -29698,7 +29761,9 @@ private:
     void OnSuccessResponse_0(
         const chip::app::DataModel::DecodableList<chip::app::Clusters::Descriptor::Structs::DeviceType::DecodableType> & deviceList)
     {
-        VerifyOrReturn(CheckValueAsListLength("deviceList", deviceList, 1));
+        auto iter = deviceList.begin();
+        VerifyOrReturn(CheckNextListItemDecodes<decltype(deviceList)>("deviceList", iter, 0));
+        VerifyOrReturn(CheckNoMoreListItems<decltype(deviceList)>("deviceList", iter, 1));
         NextTest();
     }
 
@@ -29714,7 +29779,44 @@ private:
 
     void OnSuccessResponse_1(const chip::app::DataModel::DecodableList<chip::ClusterId> & serverList)
     {
-        VerifyOrReturn(CheckValueAsListLength("serverList", serverList, 18));
+        auto iter = serverList.begin();
+        VerifyOrReturn(CheckNextListItemDecodes<decltype(serverList)>("serverList", iter, 0));
+        VerifyOrReturn(CheckValue<chip::ClusterId>("serverList[0]", iter.GetValue(), 3UL));
+        VerifyOrReturn(CheckNextListItemDecodes<decltype(serverList)>("serverList", iter, 1));
+        VerifyOrReturn(CheckValue<chip::ClusterId>("serverList[1]", iter.GetValue(), 29UL));
+        VerifyOrReturn(CheckNextListItemDecodes<decltype(serverList)>("serverList", iter, 2));
+        VerifyOrReturn(CheckValue<chip::ClusterId>("serverList[2]", iter.GetValue(), 40UL));
+        VerifyOrReturn(CheckNextListItemDecodes<decltype(serverList)>("serverList", iter, 3));
+        VerifyOrReturn(CheckValue<chip::ClusterId>("serverList[3]", iter.GetValue(), 41UL));
+        VerifyOrReturn(CheckNextListItemDecodes<decltype(serverList)>("serverList", iter, 4));
+        VerifyOrReturn(CheckValue<chip::ClusterId>("serverList[4]", iter.GetValue(), 42UL));
+        VerifyOrReturn(CheckNextListItemDecodes<decltype(serverList)>("serverList", iter, 5));
+        VerifyOrReturn(CheckValue<chip::ClusterId>("serverList[5]", iter.GetValue(), 48UL));
+        VerifyOrReturn(CheckNextListItemDecodes<decltype(serverList)>("serverList", iter, 6));
+        VerifyOrReturn(CheckValue<chip::ClusterId>("serverList[6]", iter.GetValue(), 49UL));
+        VerifyOrReturn(CheckNextListItemDecodes<decltype(serverList)>("serverList", iter, 7));
+        VerifyOrReturn(CheckValue<chip::ClusterId>("serverList[7]", iter.GetValue(), 50UL));
+        VerifyOrReturn(CheckNextListItemDecodes<decltype(serverList)>("serverList", iter, 8));
+        VerifyOrReturn(CheckValue<chip::ClusterId>("serverList[8]", iter.GetValue(), 51UL));
+        VerifyOrReturn(CheckNextListItemDecodes<decltype(serverList)>("serverList", iter, 9));
+        VerifyOrReturn(CheckValue<chip::ClusterId>("serverList[9]", iter.GetValue(), 52UL));
+        VerifyOrReturn(CheckNextListItemDecodes<decltype(serverList)>("serverList", iter, 10));
+        VerifyOrReturn(CheckValue<chip::ClusterId>("serverList[10]", iter.GetValue(), 53UL));
+        VerifyOrReturn(CheckNextListItemDecodes<decltype(serverList)>("serverList", iter, 11));
+        VerifyOrReturn(CheckValue<chip::ClusterId>("serverList[11]", iter.GetValue(), 54UL));
+        VerifyOrReturn(CheckNextListItemDecodes<decltype(serverList)>("serverList", iter, 12));
+        VerifyOrReturn(CheckValue<chip::ClusterId>("serverList[12]", iter.GetValue(), 55UL));
+        VerifyOrReturn(CheckNextListItemDecodes<decltype(serverList)>("serverList", iter, 13));
+        VerifyOrReturn(CheckValue<chip::ClusterId>("serverList[13]", iter.GetValue(), 60UL));
+        VerifyOrReturn(CheckNextListItemDecodes<decltype(serverList)>("serverList", iter, 14));
+        VerifyOrReturn(CheckValue<chip::ClusterId>("serverList[14]", iter.GetValue(), 62UL));
+        VerifyOrReturn(CheckNextListItemDecodes<decltype(serverList)>("serverList", iter, 15));
+        VerifyOrReturn(CheckValue<chip::ClusterId>("serverList[15]", iter.GetValue(), 1029UL));
+        VerifyOrReturn(CheckNextListItemDecodes<decltype(serverList)>("serverList", iter, 16));
+        VerifyOrReturn(CheckValue<chip::ClusterId>("serverList[16]", iter.GetValue(), 61440UL));
+        VerifyOrReturn(CheckNextListItemDecodes<decltype(serverList)>("serverList", iter, 17));
+        VerifyOrReturn(CheckValue<chip::ClusterId>("serverList[17]", iter.GetValue(), 61444UL));
+        VerifyOrReturn(CheckNoMoreListItems<decltype(serverList)>("serverList", iter, 18));
         NextTest();
     }
 
@@ -29730,7 +29832,8 @@ private:
 
     void OnSuccessResponse_2(const chip::app::DataModel::DecodableList<chip::ClusterId> & clientList)
     {
-        VerifyOrReturn(CheckValueAsListLength("clientList", clientList, 0));
+        auto iter = clientList.begin();
+        VerifyOrReturn(CheckNoMoreListItems<decltype(clientList)>("clientList", iter, 0));
         NextTest();
     }
 
@@ -29746,7 +29849,12 @@ private:
 
     void OnSuccessResponse_3(const chip::app::DataModel::DecodableList<chip::EndpointId> & partsList)
     {
-        VerifyOrReturn(CheckValueAsListLength("partsList", partsList, 2));
+        auto iter = partsList.begin();
+        VerifyOrReturn(CheckNextListItemDecodes<decltype(partsList)>("partsList", iter, 0));
+        VerifyOrReturn(CheckValue<chip::EndpointId>("partsList[0]", iter.GetValue(), 1U));
+        VerifyOrReturn(CheckNextListItemDecodes<decltype(partsList)>("partsList", iter, 1));
+        VerifyOrReturn(CheckValue<chip::EndpointId>("partsList[1]", iter.GetValue(), 2U));
+        VerifyOrReturn(CheckNoMoreListItems<decltype(partsList)>("partsList", iter, 2));
         NextTest();
     }
 };
@@ -30384,7 +30492,11 @@ private:
         const chip::app::DataModel::DecodableList<chip::app::Clusters::ModeSelect::Structs::ModeOptionStruct::DecodableType> &
             supportedModes)
     {
-        VerifyOrReturn(CheckValueAsListLength("supportedModes", supportedModes, 3));
+        auto iter = supportedModes.begin();
+        VerifyOrReturn(CheckNextListItemDecodes<decltype(supportedModes)>("supportedModes", iter, 0));
+        VerifyOrReturn(CheckNextListItemDecodes<decltype(supportedModes)>("supportedModes", iter, 1));
+        VerifyOrReturn(CheckNextListItemDecodes<decltype(supportedModes)>("supportedModes", iter, 2));
+        VerifyOrReturn(CheckNoMoreListItems<decltype(supportedModes)>("supportedModes", iter, 3));
         NextTest();
     }
 


### PR DESCRIPTION
#### Problem
YAML checking of return values currently only checks list lengths in most cases, and can't handle struct-typed command fields.

#### Change overview
Implement checking of arbitrarily-deeply-nested lists and structs.

#### Testing
Some test updates for existing tests that are now doing more checks.