### PR TITLE
fix numpy build error on apple silicon

### DIFF
--- a/.github/.wordlist.txt
+++ b/.github/.wordlist.txt
@@ -435,6 +435,7 @@ hciconfig
 hdlc
 HKDF
 hoc
+homebrew
 hostapd
 hostname
 href

--- a/docs/guides/BUILDING.md
+++ b/docs/guides/BUILDING.md
@@ -60,6 +60,8 @@ brew install openssl pkg-config
 However, that does not expose the package to `pkg-config`. To fix that, one
 needs to run something like the following:
 
+Intel:
+
 ```
 cd /usr/local/lib/pkgconfig
 ln -s ../../Cellar/openssl@1.1/1.1.1g/lib/pkgconfig/* .
@@ -67,6 +69,12 @@ ln -s ../../Cellar/openssl@1.1/1.1.1g/lib/pkgconfig/* .
 
 where `openssl@1.1/1.1.1g` may need to be replaced with the actual version of
 OpenSSL installed by Brew.
+
+Apple Silicon:
+
+```
+export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:"/opt/homebrew/opt/openssl@3/lib/pkgconfig"
+```
 
 Note: If using MacPorts, `port install openssl` is sufficient to satisfy this
 dependency.

--- a/scripts/constraints.txt
+++ b/scripts/constraints.txt
@@ -113,7 +113,7 @@ numpy==1.20.3
     # via pandas
 packaging==20.9
     # via west
-pandas==1.2.4 ; platform_machine != "aarch64"
+pandas==1.2.4 ; platform_machine != "aarch64" and platform_machine != "arm64"
     # via -r requirements.txt
 parso==0.8.2
     # via jedi

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -42,7 +42,7 @@ protobuf
 anytree
 cxxfilt
 ghapi
-pandas ; platform_machine != 'aarch64'
+pandas ; platform_machine != 'aarch64' and platform_machine != 'arm64'
 
 # scripts/build
 click


### PR DESCRIPTION
* scripts/build/gn_bootstrap.sh failed on apple silicon with Homebrew 3.3.3 and Python 3.9.7
* ERROR: Failed building wheel for numpy

#### Change overview
*  platform.machine() return 'arm64' instead of 'aarch64', so we need also check it
*
% python3
Python 3.9.7 (default, Oct 12 2021, 22:38:23)
[Clang 13.0.0 (clang-1300.0.29.3)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import platform
>>> platform.machine()
'arm64'

#### Testing
* run scripts/build/gn_bootstrap.sh on apple silicon with Homebrew 3.3.3 and Python 3.9.7
