### PR TITLE
Inet: Use constructors for Inet EndPoints

### DIFF
--- a/src/inet/EndPointBasis.h
+++ b/src/inet/EndPointBasis.h
@@ -38,36 +38,18 @@ class InetLayer;
 class DLL_EXPORT EndPointBase
 {
 public:
+    EndPointBase(InetLayer & aInetLayer, void * aAppState = nullptr) : mAppState(aAppState), mInetLayer(aInetLayer) {}
+    virtual ~EndPointBase() = default;
+
     /**
      *  Returns a reference to the Inet layer object that owns this basis object.
      */
-    InetLayer & Layer() const { return *mInetLayer; }
+    InetLayer & Layer() const { return mInetLayer; }
 
-    /**
-     *  Returns \c true if the basis object was obtained by the specified Inet layer instance.
-     *
-     *  @note
-     *      Does not check whether the object is actually obtained by the system layer instance associated with the Inet layer
-     *      instance. It merely tests whether \c aInetLayer is the Inet layer instance that was provided to \c InitInetLayerBasis.
-     */
-    bool IsCreatedByInetLayer(const InetLayer & aInetLayer) const { return mInetLayer == &aInetLayer; }
-
-    void * AppState;
+    void * mAppState;
 
 private:
-    InetLayer * mInetLayer; /**< Pointer to the InetLayer object that owns this object. */
-
-protected:
-    virtual ~EndPointBase() = default;
-
-    void InitEndPointBasis(InetLayer & aInetLayer, void * aAppState = nullptr)
-    {
-        AppState   = aAppState;
-        mInetLayer = &aInetLayer;
-        InitEndPointBasisImpl();
-    }
-
-    virtual void InitEndPointBasisImpl() = 0;
+    InetLayer & mInetLayer; /**< InetLayer object that owns this object. */
 };
 
 } // namespace Inet

--- a/src/inet/EndPointBasisImplLwIP.h
+++ b/src/inet/EndPointBasisImplLwIP.h
@@ -35,8 +35,9 @@ namespace Inet {
 class DLL_EXPORT EndPointImplLwIP : public EndPointBase
 {
 protected:
-    // EndPointBase overrides
-    void InitEndPointBasisImpl() override { mLwIPEndPointType = LwIPEndPointType::Unknown; }
+    EndPointImplLwIP(InetLayer & inetLayer, void * appState = nullptr) :
+        EndPointBase(inetLayer, appState), mLwIPEndPointType(LwIPEndPointType::Unknown)
+    {}
 
     /** Encapsulated LwIP protocol control block */
     union

--- a/src/inet/EndPointBasisImplNetworkFramework.h
+++ b/src/inet/EndPointBasisImplNetworkFramework.h
@@ -34,7 +34,7 @@ namespace Inet {
 class DLL_EXPORT EndPointImplNetworkFramework : public EndPointBase
 {
 protected:
-    void InitEndPointBasisImpl() override {}
+    EndPointImplNetworkFramework(InetLayer & inetLayer, void * appState = nullptr) : EndPointBase(inetLayer, appState) {}
 
     nw_parameters_t mParameters;
     IPAddressType mAddrType; /**< Protocol family, i.e. IPv4 or IPv6. */

--- a/src/inet/EndPointBasisImplSockets.h
+++ b/src/inet/EndPointBasisImplSockets.h
@@ -33,7 +33,9 @@ namespace Inet {
 class DLL_EXPORT EndPointImplSockets : public EndPointBase
 {
 protected:
-    void InitEndPointBasisImpl() override { mSocket = kInvalidSocketFd; }
+    EndPointImplSockets(InetLayer & inetLayer, void * appState = nullptr) :
+        EndPointBase(inetLayer, appState), mSocket(kInvalidSocketFd)
+    {}
 
     static constexpr int kInvalidSocketFd = -1;
     int mSocket;                     /**< Encapsulated socket descriptor. */

--- a/src/inet/TCPEndPoint.cpp
+++ b/src/inet/TCPEndPoint.cpp
@@ -2594,35 +2594,6 @@ bool TCPEndPoint::IsConnected(State state)
         state == State::kClosing;
 }
 
-void TCPEndPoint::Init(InetLayer * inetLayer)
-{
-    InitEndPointBasis(*inetLayer);
-
-    mReceiveEnabled = true;
-
-    // Initialize to zero for using system defaults.
-    mConnectTimeoutMsecs = 0;
-
-#if INET_CONFIG_OVERRIDE_SYSTEM_TCP_USER_TIMEOUT
-    mUserTimeoutMillis = INET_CONFIG_DEFAULT_TCP_USER_TIMEOUT_MSEC;
-
-    mUserTimeoutTimerRunning = false;
-
-#if INET_CONFIG_ENABLE_TCP_SEND_IDLE_CALLBACKS
-    mIsTCPSendIdle = true;
-
-    mTCPSendQueuePollPeriodMillis = INET_CONFIG_TCP_SEND_QUEUE_POLL_INTERVAL_MSEC;
-
-    mTCPSendQueueRemainingPollCount = MaxTCPSendQueuePolls();
-
-    OnTCPSendIdleChanged = NULL;
-#endif // INET_CONFIG_ENABLE_TCP_SEND_IDLE_CALLBACKS
-
-#endif // INET_CONFIG_OVERRIDE_SYSTEM_TCP_USER_TIMEOUT
-
-    InitImpl();
-}
-
 CHIP_ERROR TCPEndPoint::DriveSending()
 {
     CHIP_ERROR err = DriveSendingImpl();

--- a/src/inet/TCPEndPoint.h
+++ b/src/inet/TCPEndPoint.h
@@ -75,8 +75,9 @@ class DLL_EXPORT TCPEndPoint : public EndPointBasis, public ReferenceCounted<TCP
 
 public:
     TCPEndPoint(InetLayer & inetLayer, void * appState = nullptr) :
-        EndPointBasis(inetLayer, appState), mState(State::kReady), mReceiveEnabled(true),
-        mConnectTimeoutMsecs(0) // Initialize to zero for using system defaults.
+        EndPointBasis(inetLayer, appState), OnConnectComplete(nullptr), OnDataReceived(nullptr), OnDataSent(nullptr),
+        OnConnectionClosed(nullptr), OnPeerClose(nullptr), OnConnectionReceived(nullptr), OnAcceptError(nullptr),
+        mState(State::kReady), mReceiveEnabled(true), mConnectTimeoutMsecs(0) // Initialize to zero for using system defaults.
 #if INET_CONFIG_OVERRIDE_SYSTEM_TCP_USER_TIMEOUT
         ,
         mUserTimeoutMillis(INET_CONFIG_DEFAULT_TCP_USER_TIMEOUT_MSEC), mUserTimeoutTimerRunning(false)

--- a/src/inet/UDPEndPoint.cpp
+++ b/src/inet/UDPEndPoint.cpp
@@ -1988,7 +1988,7 @@ CHIP_ERROR UDPEndPoint::Listen(OnMessageReceivedFunct onMessageReceived, OnRecei
 
     OnMessageReceived = onMessageReceived;
     OnReceiveError    = onReceiveError;
-    AppState          = appState;
+    mAppState         = appState;
 
     ReturnErrorOnFailure(ListenImpl());
 
@@ -2026,12 +2026,6 @@ void UDPEndPoint::Close()
         CloseImpl();
         mState = State::kClosed;
     }
-}
-
-void UDPEndPoint::Init(InetLayer * inetLayer)
-{
-    InitEndPointBasis(*inetLayer);
-    InitImpl();
 }
 
 CHIP_ERROR UDPEndPoint::JoinMulticastGroup(InterfaceId aInterfaceId, const IPAddress & aAddress)

--- a/src/inet/UDPEndPoint.h
+++ b/src/inet/UDPEndPoint.h
@@ -63,7 +63,11 @@ public:
 class DLL_EXPORT UDPEndPoint : public EndPointBasis, public ReferenceCounted<UDPEndPoint, UDPEndPointDeletor>
 {
 public:
-    UDPEndPoint(InetLayer & inetLayer, void * appState = nullptr) : EndPointBasis(inetLayer, appState) { InitImpl(); }
+    UDPEndPoint(InetLayer & inetLayer, void * appState = nullptr) :
+        EndPointBasis(inetLayer, appState), mState(State::kReady), OnMessageReceived(nullptr), OnReceiveError(nullptr)
+    {
+        InitImpl();
+    }
 
     UDPEndPoint(const UDPEndPoint &) = delete;
     UDPEndPoint(UDPEndPoint &&)      = delete;

--- a/src/inet/UDPEndPoint.h
+++ b/src/inet/UDPEndPoint.h
@@ -63,7 +63,7 @@ public:
 class DLL_EXPORT UDPEndPoint : public EndPointBasis, public ReferenceCounted<UDPEndPoint, UDPEndPointDeletor>
 {
 public:
-    UDPEndPoint() = default;
+    UDPEndPoint(InetLayer & inetLayer, void * appState = nullptr) : EndPointBasis(inetLayer, appState) { InitImpl(); }
 
     UDPEndPoint(const UDPEndPoint &) = delete;
     UDPEndPoint(UDPEndPoint &&)      = delete;
@@ -261,8 +261,6 @@ public:
 
 private:
     friend class InetLayer;
-
-    void Init(InetLayer * inetLayer);
 
     /**
      * Basic dynamic state of the underlying endpoint.

--- a/src/lib/dnssd/minimal_mdns/Server.cpp
+++ b/src/lib/dnssd/minimal_mdns/Server.cpp
@@ -343,7 +343,7 @@ CHIP_ERROR ServerBase::BroadcastSend(chip::System::PacketBufferHandle && data, u
 void ServerBase::OnUdpPacketReceived(chip::Inet::UDPEndPoint * endPoint, chip::System::PacketBufferHandle && buffer,
                                      const chip::Inet::IPPacketInfo * info)
 {
-    ServerBase * srv = static_cast<ServerBase *>(endPoint->AppState);
+    ServerBase * srv = static_cast<ServerBase *>(endPoint->mAppState);
     if (!srv->mDelegate)
     {
         return;

--- a/src/transport/raw/TCP.cpp
+++ b/src/transport/raw/TCP.cpp
@@ -98,7 +98,7 @@ CHIP_ERROR TCPBase::Init(TcpListenParameters & params)
     err = mListenSocket->Listen(kListenBacklogSize);
     SuccessOrExit(err);
 
-    mListenSocket->AppState             = reinterpret_cast<void *>(this);
+    mListenSocket->mAppState            = reinterpret_cast<void *>(this);
     mListenSocket->OnDataReceived       = OnTcpReceive;
     mListenSocket->OnConnectComplete    = OnConnectionComplete;
     mListenSocket->OnConnectionClosed   = OnConnectionClosed;
@@ -254,7 +254,7 @@ CHIP_ERROR TCPBase::SendAfterConnect(const PeerAddress & addr, System::PacketBuf
 #endif
     SuccessOrExit(err);
 
-    endPoint->AppState             = reinterpret_cast<void *>(this);
+    endPoint->mAppState            = reinterpret_cast<void *>(this);
     endPoint->OnDataReceived       = OnTcpReceive;
     endPoint->OnConnectComplete    = OnConnectionComplete;
     endPoint->OnConnectionClosed   = OnConnectionClosed;
@@ -364,7 +364,7 @@ CHIP_ERROR TCPBase::OnTcpReceive(Inet::TCPEndPoint * endPoint, System::PacketBuf
     endPoint->GetInterfaceId(&interfaceId);
     PeerAddress peerAddress = PeerAddress::TCP(ipAddress, port, interfaceId);
 
-    TCPBase * tcp  = reinterpret_cast<TCPBase *>(endPoint->AppState);
+    TCPBase * tcp  = reinterpret_cast<TCPBase *>(endPoint->mAppState);
     CHIP_ERROR err = tcp->ProcessReceivedBuffer(endPoint, peerAddress, std::move(buffer));
 
     if (err != CHIP_NO_ERROR)
@@ -380,7 +380,7 @@ void TCPBase::OnConnectionComplete(Inet::TCPEndPoint * endPoint, CHIP_ERROR inet
 {
     CHIP_ERROR err          = CHIP_NO_ERROR;
     bool foundPendingPacket = false;
-    TCPBase * tcp           = reinterpret_cast<TCPBase *>(endPoint->AppState);
+    TCPBase * tcp           = reinterpret_cast<TCPBase *>(endPoint->mAppState);
     Inet::IPAddress ipAddress;
     uint16_t port;
     Inet::InterfaceId interfaceId;
@@ -452,7 +452,7 @@ void TCPBase::OnConnectionComplete(Inet::TCPEndPoint * endPoint, CHIP_ERROR inet
 
 void TCPBase::OnConnectionClosed(Inet::TCPEndPoint * endPoint, CHIP_ERROR err)
 {
-    TCPBase * tcp = reinterpret_cast<TCPBase *>(endPoint->AppState);
+    TCPBase * tcp = reinterpret_cast<TCPBase *>(endPoint->mAppState);
 
     ChipLogProgress(Inet, "Connection closed.");
 
@@ -470,7 +470,7 @@ void TCPBase::OnConnectionClosed(Inet::TCPEndPoint * endPoint, CHIP_ERROR err)
 void TCPBase::OnConnectionReceived(Inet::TCPEndPoint * listenEndPoint, Inet::TCPEndPoint * endPoint,
                                    const Inet::IPAddress & peerAddress, uint16_t peerPort)
 {
-    TCPBase * tcp = reinterpret_cast<TCPBase *>(listenEndPoint->AppState);
+    TCPBase * tcp = reinterpret_cast<TCPBase *>(listenEndPoint->mAppState);
 
     if (tcp->mUsedEndPointCount < tcp->mActiveConnectionsSize)
     {
@@ -484,7 +484,7 @@ void TCPBase::OnConnectionReceived(Inet::TCPEndPoint * listenEndPoint, Inet::TCP
             }
         }
 
-        endPoint->AppState             = listenEndPoint->AppState;
+        endPoint->mAppState            = listenEndPoint->mAppState;
         endPoint->OnDataReceived       = OnTcpReceive;
         endPoint->OnConnectComplete    = OnConnectionComplete;
         endPoint->OnConnectionClosed   = OnConnectionClosed;
@@ -531,7 +531,7 @@ void TCPBase::Disconnect(const PeerAddress & address)
 
 void TCPBase::OnPeerClosed(Inet::TCPEndPoint * endPoint)
 {
-    TCPBase * tcp = reinterpret_cast<TCPBase *>(endPoint->AppState);
+    TCPBase * tcp = reinterpret_cast<TCPBase *>(endPoint->mAppState);
 
     for (size_t i = 0; i < tcp->mActiveConnectionsSize; i++)
     {

--- a/src/transport/raw/UDP.cpp
+++ b/src/transport/raw/UDP.cpp
@@ -114,7 +114,7 @@ CHIP_ERROR UDP::SendMessage(const Transport::PeerAddress & address, System::Pack
 void UDP::OnUdpReceive(Inet::UDPEndPoint * endPoint, System::PacketBufferHandle && buffer, const Inet::IPPacketInfo * pktInfo)
 {
     CHIP_ERROR err          = CHIP_NO_ERROR;
-    UDP * udp               = reinterpret_cast<UDP *>(endPoint->AppState);
+    UDP * udp               = reinterpret_cast<UDP *>(endPoint->mAppState);
     PeerAddress peerAddress = PeerAddress::UDP(pktInfo->SrcAddress, pktInfo->SrcPort, pktInfo->Interface);
 
     udp->HandleMessageReceived(peerAddress, std::move(buffer));


### PR DESCRIPTION
#### Problem

`Inet::TCPEndPoint` and `Inet::UDPEndPoint` historically could not use
constructors because of `System::ObjectPool` limitations.

This is a step toward #7715 _Virtualize System and Inet interfaces_,
split off to reduce the complexity of an upcoming PR.

#### Change overview

Convert from `Init()` to constructors. Transitionally, the constructors
still call a per-implementation function `InitImpl()`.

Incidentally renamed `mAppState` for consistency (it had been in
`System::Object` prior to #11428).

#### Testing

CI; no changes to functionality.
