### PR TITLE
[Controller] Enhance discovery output for testing purposes

### DIFF
--- a/examples/chip-tool/commands/discover/DiscoverCommissionablesCommand.cpp
+++ b/examples/chip-tool/commands/discover/DiscoverCommissionablesCommand.cpp
@@ -34,17 +34,18 @@ void DiscoverCommissionablesCommand::OnDiscoveredDevice(const chip::Dnssd::Disco
     Encoding::BytesToUppercaseHexString(nodeData.rotatingId, nodeData.rotatingIdLen, rotatingId, sizeof(rotatingId));
 
     ChipLogProgress(Discovery, "Discovered Node: ");
+    ChipLogProgress(Discovery, "\tInstance name:\t\t%s", nodeData.instanceName);
     ChipLogProgress(Discovery, "\tHost name:\t\t%s", nodeData.hostName);
     ChipLogProgress(Discovery, "\tPort:\t\t\t%u", nodeData.port);
     ChipLogProgress(Discovery, "\tLong discriminator:\t%u", nodeData.longDiscriminator);
     ChipLogProgress(Discovery, "\tVendor ID:\t\t%u", nodeData.vendorId);
     ChipLogProgress(Discovery, "\tProduct ID:\t\t%u", nodeData.productId);
-    ChipLogProgress(Discovery, "\tCommissioning Mode\t%u", nodeData.commissioningMode);
-    ChipLogProgress(Discovery, "\tDevice Type\t\t%u", nodeData.deviceType);
-    ChipLogProgress(Discovery, "\tDevice Name\t\t%s", nodeData.deviceName);
-    ChipLogProgress(Discovery, "\tRotating Id\t\t%s", rotatingId);
-    ChipLogProgress(Discovery, "\tPairing Instruction\t%s", nodeData.pairingInstruction);
-    ChipLogProgress(Discovery, "\tPairing Hint\t\t0x%x", nodeData.pairingHint);
+    ChipLogProgress(Discovery, "\tCommissioning Mode:\t%u", nodeData.commissioningMode);
+    ChipLogProgress(Discovery, "\tDevice Type:\t\t%u", nodeData.deviceType);
+    ChipLogProgress(Discovery, "\tDevice Name:\t\t%s", nodeData.deviceName);
+    ChipLogProgress(Discovery, "\tRotating Id:\t\t%s", rotatingId);
+    ChipLogProgress(Discovery, "\tPairing Instruction:\t%s", nodeData.pairingInstruction);
+    ChipLogProgress(Discovery, "\tPairing Hint:\t\t%u", nodeData.pairingHint);
     for (int i = 0; i < nodeData.numIPs; i++)
     {
         char buf[chip::Inet::IPAddress::kMaxStringLength];

--- a/src/controller/python/ChipCommissionableNodeController-ScriptBinding.cpp
+++ b/src/controller/python/ChipCommissionableNodeController-ScriptBinding.cpp
@@ -86,6 +86,7 @@ void pychip_CommissionableNodeController_PrintDiscoveredCommissioners(
         Encoding::BytesToUppercaseHexString(dnsSdInfo->rotatingId, dnsSdInfo->rotatingIdLen, rotatingId, sizeof(rotatingId));
 
         ChipLogProgress(Discovery, "Commissioner %d", i);
+        ChipLogProgress(Discovery, "\tInstance name:\t\t%s", dnsSdInfo->instanceName);
         ChipLogProgress(Discovery, "\tHost name:\t\t%s", dnsSdInfo->hostName);
         ChipLogProgress(Discovery, "\tPort:\t\t\t%u", dnsSdInfo->port);
         ChipLogProgress(Discovery, "\tLong discriminator:\t%u", dnsSdInfo->longDiscriminator);
@@ -96,7 +97,7 @@ void pychip_CommissionableNodeController_PrintDiscoveredCommissioners(
         ChipLogProgress(Discovery, "\tDevice Name\t\t%s", dnsSdInfo->deviceName);
         ChipLogProgress(Discovery, "\tRotating Id\t\t%s", rotatingId);
         ChipLogProgress(Discovery, "\tPairing Instruction\t%s", dnsSdInfo->pairingInstruction);
-        ChipLogProgress(Discovery, "\tPairing Hint\t\t0x%x", dnsSdInfo->pairingHint);
+        ChipLogProgress(Discovery, "\tPairing Hint\t\t%u", dnsSdInfo->pairingHint);
         if (dnsSdInfo->GetMrpRetryIntervalIdle().HasValue())
         {
             ChipLogProgress(Discovery, "\tMrp Interval idle\t%u", dnsSdInfo->GetMrpRetryIntervalIdle().Value());

--- a/src/controller/python/ChipDeviceController-ScriptBinding.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptBinding.cpp
@@ -407,6 +407,7 @@ void pychip_DeviceController_PrintDiscoveredDevices(chip::Controller::DeviceComm
         Encoding::BytesToUppercaseHexString(dnsSdInfo->rotatingId, dnsSdInfo->rotatingIdLen, rotatingId, sizeof(rotatingId));
 
         ChipLogProgress(Discovery, "Commissionable Node %d", i);
+        ChipLogProgress(Discovery, "\tInstance name:\t\t%s", dnsSdInfo->instanceName);
         ChipLogProgress(Discovery, "\tHost name:\t\t%s", dnsSdInfo->hostName);
         ChipLogProgress(Discovery, "\tPort:\t\t\t%u", dnsSdInfo->port);
         ChipLogProgress(Discovery, "\tLong discriminator:\t%u", dnsSdInfo->longDiscriminator);
@@ -417,7 +418,7 @@ void pychip_DeviceController_PrintDiscoveredDevices(chip::Controller::DeviceComm
         ChipLogProgress(Discovery, "\tDevice Name\t\t%s", dnsSdInfo->deviceName);
         ChipLogProgress(Discovery, "\tRotating Id\t\t%s", rotatingId);
         ChipLogProgress(Discovery, "\tPairing Instruction\t%s", dnsSdInfo->pairingInstruction);
-        ChipLogProgress(Discovery, "\tPairing Hint\t\t0x%x", dnsSdInfo->pairingHint);
+        ChipLogProgress(Discovery, "\tPairing Hint\t\t%u", dnsSdInfo->pairingHint);
         if (dnsSdInfo->GetMrpRetryIntervalIdle().HasValue())
         {
             ChipLogProgress(Discovery, "\tMrp Interval idle\t%u", dnsSdInfo->GetMrpRetryIntervalIdle().Value());

--- a/src/lib/dnssd/Discovery_ImplPlatform.cpp
+++ b/src/lib/dnssd/Discovery_ImplPlatform.cpp
@@ -514,6 +514,7 @@ void DiscoveryImplPlatform::HandleNodeResolve(void * context, DnssdService * res
     DiscoveryImplPlatform * mgr = static_cast<DiscoveryImplPlatform *>(context);
     DiscoveredNodeData data;
     Platform::CopyString(data.hostName, result->mHostName);
+    Platform::CopyString(data.instanceName, result->mName);
 
     if (result->mAddress.HasValue() && data.numIPs < DiscoveredNodeData::kMaxIPAddresses)
     {

--- a/src/lib/dnssd/Resolver.h
+++ b/src/lib/dnssd/Resolver.h
@@ -126,6 +126,7 @@ struct DiscoveredNodeData
     }
     DiscoveredNodeData() { Reset(); }
     bool IsHost(const char * host) const { return strcmp(host, hostName) == 0; }
+    bool IsInstanceName(const char * instance) const { return strcmp(instance, instanceName) == 0; }
     bool IsValid() const { return !IsHost("") && ipAddress[0] != chip::Inet::IPAddress::Any; }
 
     Optional<uint32_t> GetMrpRetryIntervalIdle() const
@@ -175,11 +176,15 @@ struct DiscoveredNodeData
         }
         if (pairingHint > 0)
         {
-            ChipLogDetail(Discovery, "\tPairing Hint: 0x%x", pairingHint);
+            ChipLogDetail(Discovery, "\tPairing Hint: %u", pairingHint);
         }
         if (!IsHost(""))
         {
             ChipLogDetail(Discovery, "\tHostname: %s", hostName);
+        }
+        if (!IsInstanceName(""))
+        {
+            ChipLogDetail(Discovery, "\tInstance Name: %s", instanceName);
         }
         for (int j = 0; j < numIPs; j++)
         {


### PR DESCRIPTION
#### Problem
* The discovery output presents a pairing hint value in the wrong representation (according to the spec value should be in decimal representation).
* Instance names of services should also be validated.

#### Change overview
* Change representation from hex to decimal for pairing hint's output field.
* Add output filed with the value of the service's instance name.

#### Testing
Tested using python-chip-controller:
```
discover -all
```
```
[1636467735.485210][22371:22377] CHIP:DIS: 	Instance name:		11D960ED59E86631
[1636467735.485288][22371:22377] CHIP:DIS: 	Host name:		06719295976DC84C
[1636467735.485362][22371:22377] CHIP:DIS: 	Port:			5540
[1636467735.485446][22371:22377] CHIP:DIS: 	Long discriminator:	3840
[1636467735.485520][22371:22377] CHIP:DIS: 	Vendor ID:		9050
[1636467735.485597][22371:22377] CHIP:DIS: 	Product ID:		20043
[1636467735.485664][22371:22377] CHIP:DIS: 	Commissioning Mode	0
[1636467735.485737][22371:22377] CHIP:DIS: 	Device Type		0
[1636467735.485807][22371:22377] CHIP:DIS: 	Device Name		
[1636467735.485870][22371:22377] CHIP:DIS: 	Rotating Id		00007C5F6E176CD40F68685D100A1CF8A98B
[1636467735.485946][22371:22377] CHIP:DIS: 	Pairing Instruction	
[1636467735.486005][22371:22377] CHIP:DIS: 	Pairing Hint		33
[1636467735.486073][22371:22377] CHIP:DIS: 	Mrp Interval idle	5000
[1636467735.486145][22371:22377] CHIP:DIS: 	Mrp Interval active	300
[1636467735.486205][22371:22377] CHIP:DIS: 	Supports TCP		0
[1636467735.486294][22371:22377] CHIP:DIS: 	Address 0:		fd11:22::a98:85ac:a9f1:887d
```

