### PR TITLE
Remove unnecessary headers from all-clusters-app main.

### DIFF
--- a/examples/all-clusters-app/linux/main.cpp
+++ b/examples/all-clusters-app/linux/main.cpp
@@ -16,16 +16,11 @@
  *    limitations under the License.
  */
 
-#include <app-common/zap-generated/callback.h>
-#include <app-common/zap-generated/ids/Clusters.h>
 #include <app/Command.h>
-#include <app/ConcreteAttributePath.h>
 #include <app/clusters/identify-server/identify-server.h>
 #include <app/util/af.h>
 
 #include "AppMain.h"
-
-using namespace chip;
 
 bool emberAfBasicClusterMfgSpecificPingCallback(chip::app::Command * commandObj)
 {


### PR DESCRIPTION
These got added along with code in initial drafts of
https://github.com/project-chip/connectedhomeip/pull/11058 but then
the code was removed without removing the now-unnecessary headers.

#### Problem
Extra headers added that are not needed.

#### Change overview
Remove them.  Addresses https://github.com/project-chip/connectedhomeip/pull/11058#discussion_r745162379

#### Testing
File compiles fine.