### PR TITLE
[Mbed] Unit tests improvements

### DIFF
--- a/src/BUILD.gn
+++ b/src/BUILD.gn
@@ -49,15 +49,21 @@ if (chip_build_tests) {
       "${chip_root}/src/inet/tests",
       "${chip_root}/src/lib/asn1/tests",
       "${chip_root}/src/lib/core/tests",
-      "${chip_root}/src/lib/dnssd/minimal_mdns/core/tests",
-      "${chip_root}/src/lib/dnssd/minimal_mdns/responders/tests",
-      "${chip_root}/src/lib/dnssd/minimal_mdns/tests",
-      "${chip_root}/src/lib/dnssd/tests",
       "${chip_root}/src/messaging/tests",
       "${chip_root}/src/protocols/bdx/tests",
       "${chip_root}/src/protocols/user_directed_commissioning/tests",
       "${chip_root}/src/transport/retransmit/tests",
     ]
+
+    if (current_os != "mbed")
+    {
+      deps += [
+          "${chip_root}/src/lib/dnssd/minimal_mdns/core/tests",
+          "${chip_root}/src/lib/dnssd/minimal_mdns/responders/tests",
+          "${chip_root}/src/lib/dnssd/minimal_mdns/tests",
+          "${chip_root}/src/lib/dnssd/tests"
+      ]
+    }
 
     if (current_os != "zephyr" && current_os != "mbed") {
       deps += [ "${chip_root}/src/lib/dnssd/minimal_mdns/records/tests" ]

--- a/src/BUILD.gn
+++ b/src/BUILD.gn
@@ -55,13 +55,12 @@ if (chip_build_tests) {
       "${chip_root}/src/transport/retransmit/tests",
     ]
 
-    if (current_os != "mbed")
-    {
+    if (current_os != "mbed") {
       deps += [
-          "${chip_root}/src/lib/dnssd/minimal_mdns/core/tests",
-          "${chip_root}/src/lib/dnssd/minimal_mdns/responders/tests",
-          "${chip_root}/src/lib/dnssd/minimal_mdns/tests",
-          "${chip_root}/src/lib/dnssd/tests"
+        "${chip_root}/src/lib/dnssd/minimal_mdns/core/tests",
+        "${chip_root}/src/lib/dnssd/minimal_mdns/responders/tests",
+        "${chip_root}/src/lib/dnssd/minimal_mdns/tests",
+        "${chip_root}/src/lib/dnssd/tests",
       ]
     }
 

--- a/src/BUILD.gn
+++ b/src/BUILD.gn
@@ -55,6 +55,7 @@ if (chip_build_tests) {
       "${chip_root}/src/transport/retransmit/tests",
     ]
 
+    # Skip DNSSD tests for Mbed platform due to flash memory size limitations
     if (current_os != "mbed") {
       deps += [
         "${chip_root}/src/lib/dnssd/minimal_mdns/core/tests",

--- a/src/inet/InetInterface.cpp
+++ b/src/inet/InetInterface.cpp
@@ -616,6 +616,9 @@ short InterfaceIterator::GetFlags()
             mIntfFlags       = intfData.ifr_flags;
             mIntfFlagsCached = true;
         }
+#if __MBED__
+        CloseIOCTLSocket();
+#endif
     }
 
     return mIntfFlags;
@@ -807,9 +810,6 @@ CHIP_ERROR InterfaceId::InterfaceNameToId(const char * intfName, InterfaceId & i
             interface = InterfaceId(currentId);
             return CHIP_NO_ERROR;
         }
-#if __MBED__
-        CloseIOCTLSocket();
-#endif
     }
     interface = InterfaceId::Null();
     return INET_ERROR_UNKNOWN_INTERFACE;

--- a/src/inet/tests/TestInetEndPoint.cpp
+++ b/src/inet/tests/TestInetEndPoint.cpp
@@ -133,8 +133,11 @@ static void TestInetInterface(nlTestSuite * inSuite, void * inContext)
     IPPrefix addrWithPrefix;
     CHIP_ERROR err;
 
+#ifndef __MBED__
+    // Mbed interface name has different format
     err = InterfaceId::InterfaceNameToId("0", intId);
     NL_TEST_ASSERT(inSuite, err != CHIP_NO_ERROR);
+#endif
 
     err = InterfaceId::Null().GetInterfaceName(intName, 0);
     NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_BUFFER_TOO_SMALL);

--- a/src/platform/mbed/MbedConfig.cpp
+++ b/src/platform/mbed/MbedConfig.cpp
@@ -174,11 +174,23 @@ CHIP_ERROR MbedConfig::ReadConfigValueBin(Key key, uint8_t * buf, size_t bufSize
         return CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND;
     }
 
-    int err = kv_get(key, reinterpret_cast<void *>(buf), bufSize, &outLen);
+    kv_info_t info;
 
+    int err = kv_get_info(key, &info);
     if (err != MBED_SUCCESS)
     {
         return CHIP_ERROR_INTERNAL;
+    }
+
+    err = kv_get(key, reinterpret_cast<void *>(buf), bufSize, &outLen);
+    if (err != MBED_SUCCESS)
+    {
+        return CHIP_ERROR_INTERNAL;
+    }
+
+    if (bufSize < info.size)
+    {
+        return CHIP_ERROR_BUFFER_TOO_SMALL;
     }
 
     return CHIP_NO_ERROR;

--- a/src/platform/tests/BUILD.gn
+++ b/src/platform/tests/BUILD.gn
@@ -75,7 +75,8 @@ if (chip_device_platform != "none" && chip_device_platform != "fake") {
       tests = [ "TestCHIPoBLEStackMgr" ]
     }
 
-    if (current_os == "zephyr" || current_os == "android" || current_os == "mbed") {
+    if (current_os == "zephyr" || current_os == "android" ||
+        current_os == "mbed") {
       test_sources += [ "TestKeyValueStoreMgr.cpp" ]
     }
 

--- a/src/platform/tests/BUILD.gn
+++ b/src/platform/tests/BUILD.gn
@@ -75,7 +75,7 @@ if (chip_device_platform != "none" && chip_device_platform != "fake") {
       tests = [ "TestCHIPoBLEStackMgr" ]
     }
 
-    if (current_os == "zephyr" || current_os == "android") {
+    if (current_os == "zephyr" || current_os == "android" || current_os == "mbed") {
       test_sources += [ "TestKeyValueStoreMgr.cpp" ]
     }
 

--- a/src/platform/tests/TestConfigurationMgr.cpp
+++ b/src/platform/tests/TestConfigurationMgr.cpp
@@ -232,10 +232,12 @@ static void TestConfigurationMgr_GetPrimaryMACAddress(nlTestSuite * inSuite, voi
     {
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
+#ifndef __MBED__
         // Verify default MAC address value
         NL_TEST_ASSERT(inSuite,
                        strncmp(reinterpret_cast<char *>(mac6Bytes.data()), reinterpret_cast<const char *>(defaultMacAddress),
                                mac6Bytes.size()) == 0);
+#endif
     }
 }
 

--- a/src/platform/tests/TestKeyValueStoreMgr.cpp
+++ b/src/platform/tests/TestKeyValueStoreMgr.cpp
@@ -230,8 +230,8 @@ static const nlTest sTests[] = { NL_TEST_DEF("Test KeyValueStoreMgr_EmptyStringK
                                  NL_TEST_DEF("Test KeyValueStoreMgr_StructKey", TestKeyValueStoreMgr_StructKey),
                                  NL_TEST_DEF("Test KeyValueStoreMgr_UpdateKeyValue", TestKeyValueStoreMgr_UpdateKeyValue),
                                  NL_TEST_DEF("Test KeyValueStoreMgr_TooSmallBufferRead", TestKeyValueStoreMgr_TooSmallBufferRead),
-#ifndef __ZEPHYR__
-                                 // Zephyr platform does not support partial or offset reads yet.
+#if defined(__ZEPHYR__) || defined(__MBED_)
+                                 // Zephyr and Mbed platforms do not support partial or offset reads yet.
                                  NL_TEST_DEF("Test KeyValueStoreMgr_MultiReadKey", TestKeyValueStoreMgr_MultiReadKey),
 #endif
 #ifdef __ZEPHYR__

--- a/src/platform/tests/TestKeyValueStoreMgr.cpp
+++ b/src/platform/tests/TestKeyValueStoreMgr.cpp
@@ -230,7 +230,7 @@ static const nlTest sTests[] = { NL_TEST_DEF("Test KeyValueStoreMgr_EmptyStringK
                                  NL_TEST_DEF("Test KeyValueStoreMgr_StructKey", TestKeyValueStoreMgr_StructKey),
                                  NL_TEST_DEF("Test KeyValueStoreMgr_UpdateKeyValue", TestKeyValueStoreMgr_UpdateKeyValue),
                                  NL_TEST_DEF("Test KeyValueStoreMgr_TooSmallBufferRead", TestKeyValueStoreMgr_TooSmallBufferRead),
-#if defined(__ZEPHYR__) || defined(__MBED_)
+#if defined(__ZEPHYR__) || defined(__MBED__)
                                  // Zephyr and Mbed platforms do not support partial or offset reads yet.
                                  NL_TEST_DEF("Test KeyValueStoreMgr_MultiReadKey", TestKeyValueStoreMgr_MultiReadKey),
 #endif

--- a/src/platform/tests/TestKeyValueStoreMgr.cpp
+++ b/src/platform/tests/TestKeyValueStoreMgr.cpp
@@ -230,7 +230,7 @@ static const nlTest sTests[] = { NL_TEST_DEF("Test KeyValueStoreMgr_EmptyStringK
                                  NL_TEST_DEF("Test KeyValueStoreMgr_StructKey", TestKeyValueStoreMgr_StructKey),
                                  NL_TEST_DEF("Test KeyValueStoreMgr_UpdateKeyValue", TestKeyValueStoreMgr_UpdateKeyValue),
                                  NL_TEST_DEF("Test KeyValueStoreMgr_TooSmallBufferRead", TestKeyValueStoreMgr_TooSmallBufferRead),
-#if defined(__ZEPHYR__) || defined(__MBED__)
+#if !defined(__ZEPHYR__) && !defined(__MBED__)
                                  // Zephyr and Mbed platforms do not support partial or offset reads yet.
                                  NL_TEST_DEF("Test KeyValueStoreMgr_MultiReadKey", TestKeyValueStoreMgr_MultiReadKey),
 #endif


### PR DESCRIPTION
#### Problem
Mbed unit tests implementation needs improvement. Not all tests passed. We verified and fix all issues.

#### Change overview
Reduce Mbed unit test coverage (due to flash memory size limitations) - remove dnssd testing.
Fix TestConfigurationMgr_GetPrimaryMACAddress for Mbed platform - skip comparing with default address - Mbed implementation always return MAC address.
Add TestKeyValueStoreMgr for Mbed platform
Fix ReadConfigValueBin function for Mbed platform - check buffer size
Fix InetInterface.cpp - move CloseIOCTLSocket() function to the right place
Fix InetEndPoint test - skip InterfaceNameToId checking for Mbed

#### Testing
Build and run Mbed unit test on the device. The result should be `CHIP test status: 0`, which means all tests passed. 
