### PR TITLE
Release commissionee device once the device is visible on operational network

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -779,7 +779,8 @@ CHIP_ERROR DeviceCommissioner::GetDeviceBeingCommissioned(NodeId deviceId, Commi
 CHIP_ERROR DeviceCommissioner::GetConnectedDevice(NodeId deviceId, Callback::Callback<OnDeviceConnected> * onConnection,
                                                   Callback::Callback<OnDeviceConnectionFailure> * onFailure)
 {
-    if (mDeviceBeingCommissioned != nullptr && mDeviceBeingCommissioned->GetDeviceId() == deviceId)
+    if (mDeviceBeingCommissioned != nullptr && mDeviceBeingCommissioned->GetDeviceId() == deviceId &&
+        mDeviceBeingCommissioned->IsSecureConnected())
     {
         onConnection->mCall(onConnection->mContext, mDeviceBeingCommissioned);
         return CHIP_NO_ERROR;
@@ -1878,6 +1879,11 @@ void DeviceCommissioner::AdvanceCommissioningStage(CHIP_ERROR err)
             mPairingDelegate->OnStatusUpdate(DevicePairingDelegate::SecurePairingSuccess);
         }
         RendezvousCleanup(CHIP_NO_ERROR);
+        if (mDeviceBeingCommissioned != nullptr)
+        {
+            ReleaseCommissioneeDevice(mDeviceBeingCommissioned);
+            mDeviceBeingCommissioned = nullptr;
+        }
         break;
     case CommissioningStage::kSecurePairing:
     case CommissioningStage::kError:

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -973,6 +973,12 @@ void DeviceCommissioner::OnSessionEstablishmentError(CHIP_ERROR err)
     }
 
     RendezvousCleanup(err);
+
+    if (mDeviceBeingCommissioned != nullptr)
+    {
+        ReleaseCommissioneeDevice(mDeviceBeingCommissioned);
+        mDeviceBeingCommissioned = nullptr;
+    }
 }
 
 void DeviceCommissioner::OnSessionEstablished()


### PR DESCRIPTION
#### Problem
The network commissioning is failing after controller code was refactored.

#### Change overview
The controller was releasing the device handle for the commissionee device once the operational credentials were provisioned. The network commissioning also needs the handle to the device object. Since it was already freed, the network commissioning was failing.

The PR frees the device handle after the device is available on the operational network.

#### Testing
Tested using chip-tool and m5stack, using BLE pairing.
