### PR TITLE
Fix test_suites.sh to fail if the chip-tool command fails.

### DIFF
--- a/scripts/tests/test_suites.sh
+++ b/scripts/tests/test_suites.sh
@@ -16,7 +16,12 @@
 # limitations under the License.
 #
 
+# Fail if one of our sub-commands fails.
 set -e
+
+# Fail if anything in a pipeline fails, not just the last command (which for
+# us tends to be 'tee').
+set -o pipefail
 
 declare -i iterations=2
 declare -i delay=0


### PR DESCRIPTION
If chip-tool crashed, the script was not treating this as a failure,
because the default exit code of a pipeline is that of the last
command in the pipeline and we are piping through tee.

#### Problem
chip-tool crashes not being detected as CI failure in the "Tests" job.

#### Change overview
Fix it so they are.

#### Testing
Introduced a crash into chip-tool locally and made sure that now we get a failure exit from the test script.