### PR TITLE
Add session persistent API

### DIFF
--- a/src/lib/support/CHIPCounter.cpp
+++ b/src/lib/support/CHIPCounter.cpp
@@ -45,7 +45,7 @@ MonotonicallyIncreasingCounter::Advance()
     return err;
 }
 
-uint32_t MonotonicallyIncreasingCounter::GetValue()
+uint32_t MonotonicallyIncreasingCounter::GetValue() const
 {
     return mCounterValue;
 }

--- a/src/lib/support/CHIPCounter.h
+++ b/src/lib/support/CHIPCounter.h
@@ -57,7 +57,7 @@ public:
      *
      *  @return The current value of the counter.
      */
-    virtual uint32_t GetValue() = 0;
+    virtual uint32_t GetValue() const = 0;
 };
 
 /**
@@ -97,7 +97,7 @@ public:
      *
      *  @return The current value of the counter.
      */
-    uint32_t GetValue() override;
+    uint32_t GetValue() const override;
 
 protected:
     uint32_t mCounterValue;

--- a/src/lib/support/Serializer.h
+++ b/src/lib/support/Serializer.h
@@ -1,0 +1,101 @@
+/*
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <lib/support/Span.h>
+#include <lib/support/TypeSerializer.h>
+
+#include <initializer_list>
+#include <numeric>
+
+namespace chip {
+
+/*
+ * @brief
+ *   Serialize a given field of given type in target class.
+ *
+ *   @tparam Target the target class.
+ *   @tparam FieldType the type of the field.
+ *   @tparam Field the field to be serialized.
+ */
+template <typename Target, typename FieldType, FieldType Target::*Field>
+class FieldSerializer
+{
+public:
+    static constexpr const size_t Space = TypeSerializer<FieldType>::Space;
+
+    /// Load the field in the target from the given FixedSpan.
+    static void LoadField(Target & target, FixedSpan<const char, Space> bytes)
+    {
+        target.*Field = TypeSerializer<FieldType>::LoadValue(bytes);
+    }
+
+    /// Save the field value in the target into the given FixedSpan.
+    static void SaveField(const Target & target, FixedSpan<char, Space> bytes)
+    {
+        TypeSerializer<FieldType>::SaveValue(bytes, target.*Field);
+    }
+};
+
+/*
+ * @brief
+ *   Serialize a given class
+ *
+ *   @tparam Target the target class.
+ *   @tparam FieldSerializer the list of fields to be serialized.
+ */
+template <typename Target, typename... FieldSerializer>
+class Serializer
+{
+private:
+    static constexpr size_t AccumulateSpace(std::initializer_list<size_t> spaces)
+    {
+        size_t res = 0;
+        for (auto i : spaces)
+            res += i;
+        return res;
+    }
+
+public:
+    // Only if we have C++17
+    // static constexpr const size_t Space = (FieldSerializer::Space + ...);
+    static constexpr const size_t Space = AccumulateSpace({ FieldSerializer::Space... });
+
+    /// Load the target from the given FixedSpan.
+    static void LoadObject(Target & target, FixedSpan<const char, Space> bytes)
+    {
+        size_t pos = 0;
+        // Expand pack into a initializer list, because fold-expression is a C++17 feature.
+        int dummy[sizeof...(FieldSerializer)] = { (
+            FieldSerializer::LoadField(target, bytes.template subspan<FieldSerializer::Space>(pos)),
+            (pos += FieldSerializer::Space), 0)... };
+        (void) (dummy);
+    }
+
+    /// Save the target value into the given FixedSpan.
+    static void SaveObject(const Target & target, FixedSpan<char, Space> bytes)
+    {
+        size_t pos = 0;
+        // Expand pack into a initializer list, because fold-expression is a C++17 feature.
+        int dummy[sizeof...(FieldSerializer)] = { (
+            FieldSerializer::SaveField(target, bytes.template subspan<FieldSerializer::Space>(pos)),
+            (pos += FieldSerializer::Space), 0)... };
+        (void) (dummy);
+    }
+};
+
+} // namespace chip

--- a/src/lib/support/Span.h
+++ b/src/lib/support/Span.h
@@ -89,6 +89,13 @@ public:
         return Span(mDataBuf + offset, length);
     }
 
+    template <size_t N>
+    FixedSpan<T, N> subspan(size_t offset) const
+    {
+        VerifyOrDie(offset + N <= mDataLen);
+        return FixedSpan<T, N>(mDataBuf + offset);
+    }
+
     // Allow reducing the size of a span.
     void reduce_size(size_t new_size)
     {
@@ -178,6 +185,20 @@ public:
     bool data_equal(const Span<U> & other) const
     {
         return (size() == other.size() && (empty() || (memcmp(data(), other.data(), size() * sizeof(T)) == 0)));
+    }
+
+    template <std::size_t Offset, std::size_t Count>
+    constexpr FixedSpan<T, Count> subspan() const
+    {
+        static_assert(Offset + Count <= N, "subspan overflow");
+        return FixedSpan<T, Count>(mDataBuf + Offset);
+    }
+
+    template <std::size_t Count>
+    constexpr FixedSpan<T, Count> subspan(std::size_t offset) const
+    {
+        VerifyOrDie(offset + Count <= N);
+        return FixedSpan<T, Count>(mDataBuf + offset);
     }
 
 private:

--- a/src/lib/support/TypeSerializer.h
+++ b/src/lib/support/TypeSerializer.h
@@ -1,0 +1,102 @@
+/*
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <lib/support/Span.h>
+
+#include <array>
+#include <type_traits>
+
+namespace chip {
+
+template <typename Type, class Enable = void>
+class TypeSerializer;
+
+// specialization for arithmetic types
+template <typename T>
+class TypeSerializer<T, typename std::enable_if<std::is_arithmetic<T>::value>::type>
+{
+public:
+    static constexpr const size_t Space = sizeof(T);
+
+    static T LoadValue(FixedSpan<const char, Space> bytes)
+    {
+        // The span can pointing to arbitrary memory, probably not aligned, so casting data() to pointer may cause bus
+        // error on platform which requires aligned memory read/write. Use memcpy instead
+        T result;
+        ::memcpy(&result, bytes.data(), Space);
+        return result;
+    }
+
+    static void SaveValue(FixedSpan<char, Space> bytes, T data)
+    {
+        // The span can pointing to arbitrary memory, probably not aligned, so casting data() to pointer may cause bus
+        // error on platform which requires aligned memory read/write. Use memcpy instead
+        ::memcpy(bytes.data(), &data, Space);
+    }
+};
+
+// Specialization for enum
+template <typename T>
+class TypeSerializer<T, typename std::enable_if<std::is_enum<T>::value>::type>
+{
+private:
+    using UnderlyingType       = typename std::underlying_type<T>::type;
+    using UnderlyingSerializer = TypeSerializer<UnderlyingType>;
+
+public:
+    static constexpr const size_t Space = UnderlyingSerializer::Space;
+
+    static T LoadValue(FixedSpan<const char, Space> bytes) { return static_cast<T>(UnderlyingSerializer::LoadValue(bytes)); }
+
+    static void SaveValue(FixedSpan<char, Space> bytes, T data)
+    {
+        UnderlyingSerializer::SaveValue(bytes, static_cast<UnderlyingType>(data));
+    }
+};
+
+// specialization for std::array
+template <typename Type, size_t N>
+class TypeSerializer<std::array<Type, N>>
+{
+private:
+    using SubTypeSerializer = TypeSerializer<Type>;
+
+public:
+    static constexpr const size_t Space = N * SubTypeSerializer::Space;
+
+    static std::array<Type, N> LoadValue(FixedSpan<const char, Space> bytes)
+    {
+        std::array<Type, N> result;
+        for (size_t i = 0; i < N; ++i)
+        {
+            result[i] =
+                SubTypeSerializer::LoadValue(bytes.template subspan<SubTypeSerializer::Space>(i * SubTypeSerializer::Space));
+        }
+        return result;
+    }
+
+    static void SaveValue(FixedSpan<char, Space> bytes, const std::array<Type, N> & data)
+    {
+        for (size_t i = 0; i < N; ++i)
+        {
+            SubTypeSerializer::SaveValue(bytes.template subspan<SubTypeSerializer::Space>(i * SubTypeSerializer::Space), data[i]);
+        }
+    }
+};
+
+} // namespace chip

--- a/src/transport/CryptoContext.cpp
+++ b/src/transport/CryptoContext.cpp
@@ -62,7 +62,7 @@ CryptoContext::~CryptoContext()
 {
     for (auto & key : mKeys)
     {
-        ClearSecretData(key, sizeof(CryptoKey));
+        ClearSecretData(key.data(), key.size());
     }
 }
 
@@ -191,8 +191,8 @@ CHIP_ERROR CryptoContext::Encrypt(const uint8_t * input, size_t input_length, ui
         usage = kI2RKey;
     }
 
-    ReturnErrorOnFailure(AES_CCM_encrypt(input, input_length, AAD, aadLen, mKeys[usage], Crypto::kAES_CCM128_Key_Length, IV,
-                                         sizeof(IV), output, tag, taglen));
+    ReturnErrorOnFailure(AES_CCM_encrypt(input, input_length, AAD, aadLen, mKeys[usage].data(), mKeys[usage].size(), IV, sizeof(IV),
+                                         output, tag, taglen));
 
     mac.SetTag(&header, tag, taglen);
 
@@ -226,8 +226,8 @@ CHIP_ERROR CryptoContext::Decrypt(const uint8_t * input, size_t input_length, ui
         usage = kR2IKey;
     }
 
-    return AES_CCM_decrypt(input, input_length, AAD, aadLen, tag, taglen, mKeys[usage], Crypto::kAES_CCM128_Key_Length, IV,
-                           sizeof(IV), output);
+    return AES_CCM_decrypt(input, input_length, AAD, aadLen, tag, taglen, mKeys[usage].data(), mKeys[usage].size(), IV, sizeof(IV),
+                           output);
 }
 
 } // namespace chip

--- a/src/transport/MessageCounter.h
+++ b/src/transport/MessageCounter.h
@@ -47,8 +47,8 @@ public:
 
     virtual ~MessageCounter() = default;
 
-    virtual Type GetType()                        = 0;
-    virtual uint32_t Value()                      = 0; /** Get current value */
+    virtual Type GetType() const                  = 0;
+    virtual uint32_t Value() const                = 0; /** Get current value */
     virtual CHIP_ERROR Advance()                  = 0; /** Advance the counter */
     virtual CHIP_ERROR SetCounter(uint32_t count) = 0; /** Set the counter to the specified value */
 };
@@ -60,8 +60,8 @@ public:
 
     void Init();
 
-    Type GetType() override { return GlobalUnencrypted; }
-    uint32_t Value() override { return value; }
+    Type GetType() const override { return GlobalUnencrypted; }
+    uint32_t Value() const override { return value; }
     CHIP_ERROR Advance() override
     {
         ++value;
@@ -83,8 +83,8 @@ public:
     GlobalEncryptedMessageCounter() {}
 
     CHIP_ERROR Init();
-    Type GetType() override { return GlobalEncrypted; }
-    uint32_t Value() override { return persisted.GetValue(); }
+    Type GetType() const override { return GlobalEncrypted; }
+    uint32_t Value() const override { return persisted.GetValue(); }
     CHIP_ERROR Advance() override { return persisted.Advance(); }
     CHIP_ERROR SetCounter(uint32_t count) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
 
@@ -115,9 +115,10 @@ class LocalSessionMessageCounter : public MessageCounter
 public:
     static constexpr uint32_t kInitialValue = 1;
     LocalSessionMessageCounter() : value(kInitialValue) {}
+    LocalSessionMessageCounter(uint32_t localSessionMessageCounterValue) : value(localSessionMessageCounterValue) {}
 
-    Type GetType() override { return Session; }
-    uint32_t Value() override { return value; }
+    Type GetType() const override { return Session; }
+    uint32_t Value() const override { return value; }
     CHIP_ERROR Advance() override
     {
         ++value;

--- a/src/transport/PeerMessageCounter.h
+++ b/src/transport/PeerMessageCounter.h
@@ -175,7 +175,7 @@ public:
         mSynced.mWindow.reset();
     }
 
-    uint32_t GetCounter() { return mSynced.mMaxCounter; }
+    uint32_t GetCounter() const { return mSynced.mMaxCounter; }
 
 private:
     enum class Status

--- a/src/transport/SecureSessionTable.h
+++ b/src/transport/SecureSessionTable.h
@@ -60,6 +60,9 @@ public:
         return mEntries.CreateObject(localSessionId, peerNodeId, peerSessionId, fabric, mTimeSource.GetMonotonicTimestamp());
     }
 
+    CHECK_RETURN_VALUE
+    SecureSession * InstallSession(SecureSession && session) { return mEntries.CreateObject(std::move(session)); }
+
     void ReleaseSession(SecureSession * session) { mEntries.ReleaseObject(session); }
 
     template <typename Function>

--- a/src/transport/SessionManager.h
+++ b/src/transport/SessionManager.h
@@ -251,6 +251,23 @@ public:
      */
     void Shutdown();
 
+    /* Seal all session, so the state of the session will not be changed any more, no message can be send/received any
+     * more. Removing session is allowed.
+     */
+    void Seal();
+
+    CHIP_ERROR Load(const Span<const char> & storage);
+
+    /*
+     * @brief
+     *   Save live sessoins to the storage. The session manager muse be sealed before calling Save
+     *   Returns
+     *     CHIP_NO_ERROR               if successful.
+     *     CHIP_ERROR_INCORRECT_STATE  if the session manager is not sealed.
+     *     CHIP_ERROR_BUFFER_TOO_SMALL if the storage size isn't enough, the space required will be stored in byte_used.
+     */
+    CHIP_ERROR Save(const Span<char> & storage, size_t & byte_used);
+
     TransportMgrBase * GetTransportManager() const { return mTransportMgr; }
 
     /**
@@ -279,6 +296,8 @@ private:
     {
         kNotReady,    /**< State before initialization. */
         kInitialized, /**< State when the object is ready connect to other peers. */
+        kSealed,      /**< State when the manager is sealed, all states are immutable when sealed. */
+        kShutdown,    /**< State when the manager is shutdown. */
     };
 
     enum class EncryptionState

--- a/src/transport/SessionMessageCounter.h
+++ b/src/transport/SessionMessageCounter.h
@@ -33,8 +33,17 @@ namespace Transport {
 class SessionMessageCounter
 {
 public:
+    SessionMessageCounter() {}
+    SessionMessageCounter(uint32_t localSessionMessageCounterValue, uint32_t peerMessageCounterValue) :
+        mLocalMessageCounter(localSessionMessageCounterValue)
+    {
+        mPeerMessageCounter.SetCounter(peerMessageCounterValue);
+    }
+
     MessageCounter & GetLocalMessageCounter() { return mLocalMessageCounter; }
+    const MessageCounter & GetLocalMessageCounter() const { return mLocalMessageCounter; }
     PeerMessageCounter & GetPeerMessageCounter() { return mPeerMessageCounter; }
+    const PeerMessageCounter & GetPeerMessageCounter() const { return mPeerMessageCounter; }
 
 private:
     LocalSessionMessageCounter mLocalMessageCounter;


### PR DESCRIPTION
#### Problem
Allow persistent secure sessions to storage.

#### Change overview
Add 3 APIs to `SessionManager`
* `Seal`: To seal the session manager in order to save all states.
* `Save`: Persistent the session manager into a byte array
* `Load`: Install all sessions from the persistent snapshot

#### Testing
Verified by unit-tests