### PR TITLE
Switch YAML tests to using templated ReadAttribute.

### DIFF
--- a/examples/chip-tool/templates/partials/test_cluster.zapt
+++ b/examples/chip-tool/templates/partials/test_cluster.zapt
@@ -61,8 +61,10 @@ class {{filename}}: public TestCommand
     {{#unless isWait}}
     {{#unless isCommand}}
     {{#unless isWriteAttribute}}
+    {{#unless isReadAttribute}}
     chip::Callback::Callback<void (*) ({{>failureArguments}})> {{>failureCallback}} { {{>failureResponse}}, this };
     chip::Callback::Callback<void (*) ({{>successArguments}})> {{>successCallback}} { {{>successResponse}}, this };
+    {{/unless}}
     {{/unless}}
     {{/unless}}
     {{/unless}}
@@ -74,6 +76,11 @@ class {{filename}}: public TestCommand
     {{#unless isWait}}
     {{#unless isCommand}}
     {{#if isWriteAttribute}}
+    static void {{>failureResponse}}(void * context, EmberAfStatus status)
+    {
+        (static_cast<{{filename}} *>(context))->OnFailureResponse_{{index}}(chip::to_underlying(status));
+    }
+    {{else if isReadAttribute}}
     static void {{>failureResponse}}(void * context, EmberAfStatus status)
     {
         (static_cast<{{filename}} *>(context))->OnFailureResponse_{{index}}(chip::to_underlying(status));
@@ -160,6 +167,10 @@ class {{filename}}: public TestCommand
           {{#*inline "failureResponse"}}OnFailureCallback_{{index}}{{/inline}}
           {{#*inline "successResponse"}}OnSuccessCallback_{{index}}{{/inline}}
           {{#if async}}ReturnErrorOnFailure({{else}}return {{/if}}cluster.WriteAttribute<chip::app::Clusters::{{asUpperCamelCase cluster}}::Attributes::{{asUpperCamelCase attribute}}::TypeInfo>({{#chip_tests_item_parameters}}{{asLowerCamelCase name}}Argument, {{/chip_tests_item_parameters}}this, {{>successResponse}}, {{>failureResponse}}){{#if async}}){{/if}};
+        {{else if isReadAttribute}}
+          {{#*inline "failureResponse"}}OnFailureCallback_{{index}}{{/inline}}
+          {{#*inline "successResponse"}}OnSuccessCallback_{{index}}{{/inline}}
+          {{#if async}}ReturnErrorOnFailure({{else}}return {{/if}}cluster.ReadAttribute<chip::app::Clusters::{{asUpperCamelCase cluster}}::Attributes::{{asUpperCamelCase attribute}}::TypeInfo>({{#chip_tests_item_parameters}}{{asLowerCamelCase name}}Argument, {{/chip_tests_item_parameters}}this, {{>successResponse}}, {{>failureResponse}}){{#if async}}){{/if}};
         {{else}}
           {{~#*inline "commandName"}}{{asUpperCamelCase commandName}}{{#if isAttribute}}Attribute{{asUpperCamelCase attribute}}{{/if}}{{/inline}}
           {{#if async}}ReturnErrorOnFailure({{else}}return {{/if}}cluster.{{>commandName}}({{>successCallback}}.Cancel(){{#unless isWaitForReport}}, {{>failureCallback}}.Cancel(){{/unless}}{{#chip_tests_item_parameters}}, {{asLowerCamelCase name}}Argument{{/chip_tests_item_parameters}}){{#if async}}){{/if}};

--- a/src/app/tests/suites/TestDescriptorCluster.yaml
+++ b/src/app/tests/suites/TestDescriptorCluster.yaml
@@ -23,7 +23,7 @@ tests:
       command: "readAttribute"
       attribute: "Device List"
       response:
-          value: [{ deviceTypeId: 1, revision: 1 }]
+          value: [{ type: 0, revision: 1 }]
 
     - label: "Read attribute Server list"
       command: "readAttribute"

--- a/src/app/zap-templates/templates/app/cluster-objects.zapt
+++ b/src/app/zap-templates/templates/app/cluster-objects.zapt
@@ -139,9 +139,11 @@ namespace {{asUpperCamelCase label}} {
     {{#if entryType}}
         using Type = {{zapTypeToEncodableClusterObjectType entryType forceNotOptional=true}};
         using DecodableType = {{zapTypeToDecodableClusterObjectType entryType forceNotOptional=true}};
+        using DecodableArgType = {{zapTypeToDecodableClusterObjectType entryType forceNotOptional=true isArgument=true}};
     {{else}}
         using Type = {{zapTypeToEncodableClusterObjectType type forceNotOptional=true}};
         using DecodableType = {{zapTypeToDecodableClusterObjectType type forceNotOptional=true}};
+        using DecodableArgType = {{zapTypeToDecodableClusterObjectType type forceNotOptional=true isArgument=true}};
     {{/if}}
 
         static constexpr ClusterId GetClusterId() { return Clusters::{{asUpperCamelCase parent.name}}::Id; }

--- a/src/controller/ReadInteraction.h
+++ b/src/controller/ReadInteraction.h
@@ -36,12 +36,18 @@ namespace Controller {
  * GetAttributeId() methods is expected to work.
  *
  */
-template <typename AttributeTypeInfo>
+
+/**
+ * To avoid instantiating all the complicated code on a per-attribute basis, we
+ * have a helper that's just templated on the type.
+ */
+template <typename DecodableAttributeType>
 CHIP_ERROR ReadAttribute(Messaging::ExchangeManager * aExchangeMgr, const SessionHandle sessionHandle, EndpointId endpointId,
-                         typename TypedReadCallback<AttributeTypeInfo>::OnSuccessCallbackType onSuccessCb,
-                         typename TypedReadCallback<AttributeTypeInfo>::OnErrorCallbackType onErrorCb)
+                         ClusterId clusterId, AttributeId attributeId,
+                         typename TypedReadCallback<DecodableAttributeType>::OnSuccessCallbackType onSuccessCb,
+                         typename TypedReadCallback<DecodableAttributeType>::OnErrorCallbackType onErrorCb)
 {
-    app::AttributePathParams attributePath(endpointId, AttributeTypeInfo::GetClusterId(), AttributeTypeInfo::GetAttributeId());
+    app::AttributePathParams attributePath(endpointId, clusterId, attributeId);
     app::ReadPrepareParams readParams(sessionHandle);
     app::ReadClient * readClient         = nullptr;
     app::InteractionModelEngine * engine = app::InteractionModelEngine::GetInstance();
@@ -50,11 +56,12 @@ CHIP_ERROR ReadAttribute(Messaging::ExchangeManager * aExchangeMgr, const Sessio
     readParams.mpAttributePathParamsList    = &attributePath;
     readParams.mAttributePathParamsListSize = 1;
 
-    auto onDone = [](app::ReadClient * apReadClient, TypedReadCallback<AttributeTypeInfo> * callback) {
+    auto onDone = [](app::ReadClient * apReadClient, TypedReadCallback<DecodableAttributeType> * callback) {
         chip::Platform::Delete(callback);
     };
 
-    auto callback = chip::Platform::MakeUnique<TypedReadCallback<AttributeTypeInfo>>(onSuccessCb, onErrorCb, onDone);
+    auto callback = chip::Platform::MakeUnique<TypedReadCallback<DecodableAttributeType>>(clusterId, attributeId, onSuccessCb,
+                                                                                          onErrorCb, onDone);
     VerifyOrReturnError(callback != nullptr, CHIP_ERROR_NO_MEMORY);
 
     ReturnErrorOnFailure(engine->NewReadClient(&readClient, app::ReadClient::InteractionType::Read, callback.get()));
@@ -73,6 +80,16 @@ CHIP_ERROR ReadAttribute(Messaging::ExchangeManager * aExchangeMgr, const Sessio
     //
     callback.release();
     return err;
+}
+
+template <typename AttributeTypeInfo>
+CHIP_ERROR ReadAttribute(Messaging::ExchangeManager * aExchangeMgr, const SessionHandle sessionHandle, EndpointId endpointId,
+                         typename TypedReadCallback<typename AttributeTypeInfo::DecodableType>::OnSuccessCallbackType onSuccessCb,
+                         typename TypedReadCallback<typename AttributeTypeInfo::DecodableType>::OnErrorCallbackType onErrorCb)
+{
+    return ReadAttribute<typename AttributeTypeInfo::DecodableType>(aExchangeMgr, sessionHandle, endpointId,
+                                                                    AttributeTypeInfo::GetClusterId(),
+                                                                    AttributeTypeInfo::GetAttributeId(), onSuccessCb, onErrorCb);
 }
 
 } // namespace Controller

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
@@ -42,8 +42,9 @@ namespace Attributes {
 namespace MainsVoltage {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MainsVoltage::Id; }
@@ -52,8 +53,9 @@ struct TypeInfo
 namespace MainsFrequency {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MainsFrequency::Id; }
@@ -62,8 +64,9 @@ struct TypeInfo
 namespace MainsAlarmMask {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MainsAlarmMask::Id; }
@@ -72,8 +75,9 @@ struct TypeInfo
 namespace MainsVoltageMinThreshold {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MainsVoltageMinThreshold::Id; }
@@ -82,8 +86,9 @@ struct TypeInfo
 namespace MainsVoltageMaxThreshold {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MainsVoltageMaxThreshold::Id; }
@@ -92,8 +97,9 @@ struct TypeInfo
 namespace MainsVoltageDwellTrip {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MainsVoltageDwellTrip::Id; }
@@ -102,8 +108,9 @@ struct TypeInfo
 namespace BatteryVoltage {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::BatteryVoltage::Id; }
@@ -112,8 +119,9 @@ struct TypeInfo
 namespace BatteryPercentageRemaining {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::BatteryPercentageRemaining::Id; }
@@ -122,8 +130,9 @@ struct TypeInfo
 namespace BatteryManufacturer {
 struct TypeInfo
 {
-    using Type          = chip::CharSpan;
-    using DecodableType = chip::CharSpan;
+    using Type             = chip::CharSpan;
+    using DecodableType    = chip::CharSpan;
+    using DecodableArgType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::BatteryManufacturer::Id; }
@@ -132,8 +141,9 @@ struct TypeInfo
 namespace BatterySize {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::BatterySize::Id; }
@@ -142,8 +152,9 @@ struct TypeInfo
 namespace BatteryAhrRating {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::BatteryAhrRating::Id; }
@@ -152,8 +163,9 @@ struct TypeInfo
 namespace BatteryQuantity {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::BatteryQuantity::Id; }
@@ -162,8 +174,9 @@ struct TypeInfo
 namespace BatteryRatedVoltage {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::BatteryRatedVoltage::Id; }
@@ -172,8 +185,9 @@ struct TypeInfo
 namespace BatteryAlarmMask {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::BatteryAlarmMask::Id; }
@@ -182,8 +196,9 @@ struct TypeInfo
 namespace BatteryVoltageMinThreshold {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::BatteryVoltageMinThreshold::Id; }
@@ -192,8 +207,9 @@ struct TypeInfo
 namespace BatteryVoltageThreshold1 {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::BatteryVoltageThreshold1::Id; }
@@ -202,8 +218,9 @@ struct TypeInfo
 namespace BatteryVoltageThreshold2 {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::BatteryVoltageThreshold2::Id; }
@@ -212,8 +229,9 @@ struct TypeInfo
 namespace BatteryVoltageThreshold3 {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::BatteryVoltageThreshold3::Id; }
@@ -222,8 +240,9 @@ struct TypeInfo
 namespace BatteryPercentageMinThreshold {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::BatteryPercentageMinThreshold::Id; }
@@ -232,8 +251,9 @@ struct TypeInfo
 namespace BatteryPercentageThreshold1 {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::BatteryPercentageThreshold1::Id; }
@@ -242,8 +262,9 @@ struct TypeInfo
 namespace BatteryPercentageThreshold2 {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::BatteryPercentageThreshold2::Id; }
@@ -252,8 +273,9 @@ struct TypeInfo
 namespace BatteryPercentageThreshold3 {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::BatteryPercentageThreshold3::Id; }
@@ -262,8 +284,9 @@ struct TypeInfo
 namespace BatteryAlarmState {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::BatteryAlarmState::Id; }
@@ -272,8 +295,9 @@ struct TypeInfo
 namespace Battery2Voltage {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Battery2Voltage::Id; }
@@ -282,8 +306,9 @@ struct TypeInfo
 namespace Battery2PercentageRemaining {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Battery2PercentageRemaining::Id; }
@@ -292,8 +317,9 @@ struct TypeInfo
 namespace Battery2Manufacturer {
 struct TypeInfo
 {
-    using Type          = chip::CharSpan;
-    using DecodableType = chip::CharSpan;
+    using Type             = chip::CharSpan;
+    using DecodableType    = chip::CharSpan;
+    using DecodableArgType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Battery2Manufacturer::Id; }
@@ -302,8 +328,9 @@ struct TypeInfo
 namespace Battery2Size {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Battery2Size::Id; }
@@ -312,8 +339,9 @@ struct TypeInfo
 namespace Battery2AhrRating {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Battery2AhrRating::Id; }
@@ -322,8 +350,9 @@ struct TypeInfo
 namespace Battery2Quantity {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Battery2Quantity::Id; }
@@ -332,8 +361,9 @@ struct TypeInfo
 namespace Battery2RatedVoltage {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Battery2RatedVoltage::Id; }
@@ -342,8 +372,9 @@ struct TypeInfo
 namespace Battery2AlarmMask {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Battery2AlarmMask::Id; }
@@ -352,8 +383,9 @@ struct TypeInfo
 namespace Battery2VoltageMinThreshold {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Battery2VoltageMinThreshold::Id; }
@@ -362,8 +394,9 @@ struct TypeInfo
 namespace Battery2VoltageThreshold1 {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Battery2VoltageThreshold1::Id; }
@@ -372,8 +405,9 @@ struct TypeInfo
 namespace Battery2VoltageThreshold2 {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Battery2VoltageThreshold2::Id; }
@@ -382,8 +416,9 @@ struct TypeInfo
 namespace Battery2VoltageThreshold3 {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Battery2VoltageThreshold3::Id; }
@@ -392,8 +427,9 @@ struct TypeInfo
 namespace Battery2PercentageMinThreshold {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Battery2PercentageMinThreshold::Id; }
@@ -402,8 +438,9 @@ struct TypeInfo
 namespace Battery2PercentageThreshold1 {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Battery2PercentageThreshold1::Id; }
@@ -412,8 +449,9 @@ struct TypeInfo
 namespace Battery2PercentageThreshold2 {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Battery2PercentageThreshold2::Id; }
@@ -422,8 +460,9 @@ struct TypeInfo
 namespace Battery2PercentageThreshold3 {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Battery2PercentageThreshold3::Id; }
@@ -432,8 +471,9 @@ struct TypeInfo
 namespace Battery2AlarmState {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Battery2AlarmState::Id; }
@@ -442,8 +482,9 @@ struct TypeInfo
 namespace Battery3Voltage {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Battery3Voltage::Id; }
@@ -452,8 +493,9 @@ struct TypeInfo
 namespace Battery3PercentageRemaining {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Battery3PercentageRemaining::Id; }
@@ -462,8 +504,9 @@ struct TypeInfo
 namespace Battery3Manufacturer {
 struct TypeInfo
 {
-    using Type          = chip::CharSpan;
-    using DecodableType = chip::CharSpan;
+    using Type             = chip::CharSpan;
+    using DecodableType    = chip::CharSpan;
+    using DecodableArgType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Battery3Manufacturer::Id; }
@@ -472,8 +515,9 @@ struct TypeInfo
 namespace Battery3Size {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Battery3Size::Id; }
@@ -482,8 +526,9 @@ struct TypeInfo
 namespace Battery3AhrRating {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Battery3AhrRating::Id; }
@@ -492,8 +537,9 @@ struct TypeInfo
 namespace Battery3Quantity {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Battery3Quantity::Id; }
@@ -502,8 +548,9 @@ struct TypeInfo
 namespace Battery3RatedVoltage {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Battery3RatedVoltage::Id; }
@@ -512,8 +559,9 @@ struct TypeInfo
 namespace Battery3AlarmMask {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Battery3AlarmMask::Id; }
@@ -522,8 +570,9 @@ struct TypeInfo
 namespace Battery3VoltageMinThreshold {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Battery3VoltageMinThreshold::Id; }
@@ -532,8 +581,9 @@ struct TypeInfo
 namespace Battery3VoltageThreshold1 {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Battery3VoltageThreshold1::Id; }
@@ -542,8 +592,9 @@ struct TypeInfo
 namespace Battery3VoltageThreshold2 {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Battery3VoltageThreshold2::Id; }
@@ -552,8 +603,9 @@ struct TypeInfo
 namespace Battery3VoltageThreshold3 {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Battery3VoltageThreshold3::Id; }
@@ -562,8 +614,9 @@ struct TypeInfo
 namespace Battery3PercentageMinThreshold {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Battery3PercentageMinThreshold::Id; }
@@ -572,8 +625,9 @@ struct TypeInfo
 namespace Battery3PercentageThreshold1 {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Battery3PercentageThreshold1::Id; }
@@ -582,8 +636,9 @@ struct TypeInfo
 namespace Battery3PercentageThreshold2 {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Battery3PercentageThreshold2::Id; }
@@ -592,8 +647,9 @@ struct TypeInfo
 namespace Battery3PercentageThreshold3 {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Battery3PercentageThreshold3::Id; }
@@ -602,8 +658,9 @@ struct TypeInfo
 namespace Battery3AlarmState {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Battery3AlarmState::Id; }
@@ -612,8 +669,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -622,8 +680,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -637,8 +696,9 @@ namespace Attributes {
 namespace CurrentTemperature {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::DeviceTemperatureConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::CurrentTemperature::Id; }
@@ -647,8 +707,9 @@ struct TypeInfo
 namespace MinTempExperienced {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::DeviceTemperatureConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MinTempExperienced::Id; }
@@ -657,8 +718,9 @@ struct TypeInfo
 namespace MaxTempExperienced {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::DeviceTemperatureConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MaxTempExperienced::Id; }
@@ -667,8 +729,9 @@ struct TypeInfo
 namespace OverTempTotalDwell {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::DeviceTemperatureConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::OverTempTotalDwell::Id; }
@@ -677,8 +740,9 @@ struct TypeInfo
 namespace DeviceTempAlarmMask {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::DeviceTemperatureConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::DeviceTempAlarmMask::Id; }
@@ -687,8 +751,9 @@ struct TypeInfo
 namespace LowTempThreshold {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::DeviceTemperatureConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::LowTempThreshold::Id; }
@@ -697,8 +762,9 @@ struct TypeInfo
 namespace HighTempThreshold {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::DeviceTemperatureConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::HighTempThreshold::Id; }
@@ -707,8 +773,9 @@ struct TypeInfo
 namespace LowTempDwellTripPoint {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::DeviceTemperatureConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::LowTempDwellTripPoint::Id; }
@@ -717,8 +784,9 @@ struct TypeInfo
 namespace HighTempDwellTripPoint {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::DeviceTemperatureConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::HighTempDwellTripPoint::Id; }
@@ -727,8 +795,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::DeviceTemperatureConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -737,8 +806,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::DeviceTemperatureConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -909,8 +979,9 @@ namespace Attributes {
 namespace IdentifyTime {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Identify::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::IdentifyTime::Id; }
@@ -919,8 +990,9 @@ struct TypeInfo
 namespace IdentifyType {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Identify::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::IdentifyType::Id; }
@@ -929,8 +1001,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Identify::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -939,8 +1012,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Identify::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -1260,8 +1334,9 @@ namespace Attributes {
 namespace NameSupport {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Groups::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::NameSupport::Id; }
@@ -1270,8 +1345,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Groups::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -1280,8 +1356,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Groups::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -1990,8 +2067,9 @@ namespace Attributes {
 namespace SceneCount {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Scenes::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::SceneCount::Id; }
@@ -2000,8 +2078,9 @@ struct TypeInfo
 namespace CurrentScene {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Scenes::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::CurrentScene::Id; }
@@ -2010,8 +2089,9 @@ struct TypeInfo
 namespace CurrentGroup {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Scenes::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::CurrentGroup::Id; }
@@ -2020,8 +2100,9 @@ struct TypeInfo
 namespace SceneValid {
 struct TypeInfo
 {
-    using Type          = bool;
-    using DecodableType = bool;
+    using Type             = bool;
+    using DecodableType    = bool;
+    using DecodableArgType = bool;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Scenes::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::SceneValid::Id; }
@@ -2030,8 +2111,9 @@ struct TypeInfo
 namespace NameSupport {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Scenes::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::NameSupport::Id; }
@@ -2040,8 +2122,9 @@ struct TypeInfo
 namespace LastConfiguredBy {
 struct TypeInfo
 {
-    using Type          = chip::NodeId;
-    using DecodableType = chip::NodeId;
+    using Type             = chip::NodeId;
+    using DecodableType    = chip::NodeId;
+    using DecodableArgType = chip::NodeId;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Scenes::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::LastConfiguredBy::Id; }
@@ -2050,8 +2133,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Scenes::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -2060,8 +2144,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Scenes::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -2401,8 +2486,9 @@ namespace Attributes {
 namespace OnOff {
 struct TypeInfo
 {
-    using Type          = bool;
-    using DecodableType = bool;
+    using Type             = bool;
+    using DecodableType    = bool;
+    using DecodableArgType = bool;
 
     static constexpr ClusterId GetClusterId() { return Clusters::OnOff::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::OnOff::Id; }
@@ -2411,8 +2497,9 @@ struct TypeInfo
 namespace SampleMfgSpecificAttribute0x00000x1002 {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::OnOff::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::SampleMfgSpecificAttribute0x00000x1002::Id; }
@@ -2421,8 +2508,9 @@ struct TypeInfo
 namespace SampleMfgSpecificAttribute0x00000x1049 {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::OnOff::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::SampleMfgSpecificAttribute0x00000x1049::Id; }
@@ -2431,8 +2519,9 @@ struct TypeInfo
 namespace SampleMfgSpecificAttribute0x00010x1002 {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::OnOff::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::SampleMfgSpecificAttribute0x00010x1002::Id; }
@@ -2441,8 +2530,9 @@ struct TypeInfo
 namespace SampleMfgSpecificAttribute0x00010x1040 {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::OnOff::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::SampleMfgSpecificAttribute0x00010x1040::Id; }
@@ -2451,8 +2541,9 @@ struct TypeInfo
 namespace GlobalSceneControl {
 struct TypeInfo
 {
-    using Type          = bool;
-    using DecodableType = bool;
+    using Type             = bool;
+    using DecodableType    = bool;
+    using DecodableArgType = bool;
 
     static constexpr ClusterId GetClusterId() { return Clusters::OnOff::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::GlobalSceneControl::Id; }
@@ -2461,8 +2552,9 @@ struct TypeInfo
 namespace OnTime {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::OnOff::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::OnTime::Id; }
@@ -2471,8 +2563,9 @@ struct TypeInfo
 namespace OffWaitTime {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::OnOff::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::OffWaitTime::Id; }
@@ -2481,8 +2574,9 @@ struct TypeInfo
 namespace StartUpOnOff {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::OnOff::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::StartUpOnOff::Id; }
@@ -2491,8 +2585,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::OnOff::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -2501,8 +2596,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::OnOff::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -2516,8 +2612,9 @@ namespace Attributes {
 namespace SwitchType {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::OnOffSwitchConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::SwitchType::Id; }
@@ -2526,8 +2623,9 @@ struct TypeInfo
 namespace SwitchActions {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::OnOffSwitchConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::SwitchActions::Id; }
@@ -2536,8 +2634,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::OnOffSwitchConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -2546,8 +2645,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::OnOffSwitchConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -2853,8 +2953,9 @@ namespace Attributes {
 namespace CurrentLevel {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::LevelControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::CurrentLevel::Id; }
@@ -2863,8 +2964,9 @@ struct TypeInfo
 namespace RemainingTime {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::LevelControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::RemainingTime::Id; }
@@ -2873,8 +2975,9 @@ struct TypeInfo
 namespace MinLevel {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::LevelControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MinLevel::Id; }
@@ -2883,8 +2986,9 @@ struct TypeInfo
 namespace MaxLevel {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::LevelControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MaxLevel::Id; }
@@ -2893,8 +2997,9 @@ struct TypeInfo
 namespace CurrentFrequency {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::LevelControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::CurrentFrequency::Id; }
@@ -2903,8 +3008,9 @@ struct TypeInfo
 namespace MinFrequency {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::LevelControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MinFrequency::Id; }
@@ -2913,8 +3019,9 @@ struct TypeInfo
 namespace MaxFrequency {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::LevelControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MaxFrequency::Id; }
@@ -2923,8 +3030,9 @@ struct TypeInfo
 namespace Options {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::LevelControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Options::Id; }
@@ -2933,8 +3041,9 @@ struct TypeInfo
 namespace OnOffTransitionTime {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::LevelControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::OnOffTransitionTime::Id; }
@@ -2943,8 +3052,9 @@ struct TypeInfo
 namespace OnLevel {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::LevelControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::OnLevel::Id; }
@@ -2953,8 +3063,9 @@ struct TypeInfo
 namespace OnTransitionTime {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::LevelControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::OnTransitionTime::Id; }
@@ -2963,8 +3074,9 @@ struct TypeInfo
 namespace OffTransitionTime {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::LevelControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::OffTransitionTime::Id; }
@@ -2973,8 +3085,9 @@ struct TypeInfo
 namespace DefaultMoveRate {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::LevelControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::DefaultMoveRate::Id; }
@@ -2983,8 +3096,9 @@ struct TypeInfo
 namespace StartUpCurrentLevel {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::LevelControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::StartUpCurrentLevel::Id; }
@@ -2993,8 +3107,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::LevelControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -3003,8 +3118,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::LevelControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -3192,8 +3308,9 @@ namespace Attributes {
 namespace AlarmCount {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Alarms::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::AlarmCount::Id; }
@@ -3202,8 +3319,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Alarms::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -3212,8 +3330,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Alarms::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -3227,8 +3346,9 @@ namespace Attributes {
 namespace Time {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Time::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Time::Id; }
@@ -3237,8 +3357,9 @@ struct TypeInfo
 namespace TimeStatus {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Time::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::TimeStatus::Id; }
@@ -3247,8 +3368,9 @@ struct TypeInfo
 namespace TimeZone {
 struct TypeInfo
 {
-    using Type          = int32_t;
-    using DecodableType = int32_t;
+    using Type             = int32_t;
+    using DecodableType    = int32_t;
+    using DecodableArgType = int32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Time::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::TimeZone::Id; }
@@ -3257,8 +3379,9 @@ struct TypeInfo
 namespace DstStart {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Time::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::DstStart::Id; }
@@ -3267,8 +3390,9 @@ struct TypeInfo
 namespace DstEnd {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Time::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::DstEnd::Id; }
@@ -3277,8 +3401,9 @@ struct TypeInfo
 namespace DstShift {
 struct TypeInfo
 {
-    using Type          = int32_t;
-    using DecodableType = int32_t;
+    using Type             = int32_t;
+    using DecodableType    = int32_t;
+    using DecodableArgType = int32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Time::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::DstShift::Id; }
@@ -3287,8 +3412,9 @@ struct TypeInfo
 namespace StandardTime {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Time::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::StandardTime::Id; }
@@ -3297,8 +3423,9 @@ struct TypeInfo
 namespace LocalTime {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Time::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::LocalTime::Id; }
@@ -3307,8 +3434,9 @@ struct TypeInfo
 namespace LastSetTime {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Time::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::LastSetTime::Id; }
@@ -3317,8 +3445,9 @@ struct TypeInfo
 namespace ValidUntilTime {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Time::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ValidUntilTime::Id; }
@@ -3327,8 +3456,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Time::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -3337,8 +3467,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Time::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -3352,8 +3483,9 @@ namespace Attributes {
 namespace ActiveText {
 struct TypeInfo
 {
-    using Type          = chip::CharSpan;
-    using DecodableType = chip::CharSpan;
+    using Type             = chip::CharSpan;
+    using DecodableType    = chip::CharSpan;
+    using DecodableArgType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return Clusters::BinaryInputBasic::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ActiveText::Id; }
@@ -3362,8 +3494,9 @@ struct TypeInfo
 namespace Description {
 struct TypeInfo
 {
-    using Type          = chip::CharSpan;
-    using DecodableType = chip::CharSpan;
+    using Type             = chip::CharSpan;
+    using DecodableType    = chip::CharSpan;
+    using DecodableArgType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return Clusters::BinaryInputBasic::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Description::Id; }
@@ -3372,8 +3505,9 @@ struct TypeInfo
 namespace InactiveText {
 struct TypeInfo
 {
-    using Type          = chip::CharSpan;
-    using DecodableType = chip::CharSpan;
+    using Type             = chip::CharSpan;
+    using DecodableType    = chip::CharSpan;
+    using DecodableArgType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return Clusters::BinaryInputBasic::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::InactiveText::Id; }
@@ -3382,8 +3516,9 @@ struct TypeInfo
 namespace OutOfService {
 struct TypeInfo
 {
-    using Type          = bool;
-    using DecodableType = bool;
+    using Type             = bool;
+    using DecodableType    = bool;
+    using DecodableArgType = bool;
 
     static constexpr ClusterId GetClusterId() { return Clusters::BinaryInputBasic::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::OutOfService::Id; }
@@ -3392,8 +3527,9 @@ struct TypeInfo
 namespace Polarity {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::BinaryInputBasic::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Polarity::Id; }
@@ -3402,8 +3538,9 @@ struct TypeInfo
 namespace PresentValue {
 struct TypeInfo
 {
-    using Type          = bool;
-    using DecodableType = bool;
+    using Type             = bool;
+    using DecodableType    = bool;
+    using DecodableArgType = bool;
 
     static constexpr ClusterId GetClusterId() { return Clusters::BinaryInputBasic::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::PresentValue::Id; }
@@ -3412,8 +3549,9 @@ struct TypeInfo
 namespace Reliability {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::BinaryInputBasic::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Reliability::Id; }
@@ -3422,8 +3560,9 @@ struct TypeInfo
 namespace StatusFlags {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::BinaryInputBasic::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::StatusFlags::Id; }
@@ -3432,8 +3571,9 @@ struct TypeInfo
 namespace ApplicationType {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::BinaryInputBasic::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ApplicationType::Id; }
@@ -3442,8 +3582,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::BinaryInputBasic::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -3452,8 +3593,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::BinaryInputBasic::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -4215,8 +4357,9 @@ namespace Attributes {
 namespace TotalProfileNum {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::TotalProfileNum::Id; }
@@ -4225,8 +4368,9 @@ struct TypeInfo
 namespace MultipleScheduling {
 struct TypeInfo
 {
-    using Type          = bool;
-    using DecodableType = bool;
+    using Type             = bool;
+    using DecodableType    = bool;
+    using DecodableArgType = bool;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MultipleScheduling::Id; }
@@ -4235,8 +4379,9 @@ struct TypeInfo
 namespace EnergyFormatting {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::EnergyFormatting::Id; }
@@ -4245,8 +4390,9 @@ struct TypeInfo
 namespace EnergyRemote {
 struct TypeInfo
 {
-    using Type          = bool;
-    using DecodableType = bool;
+    using Type             = bool;
+    using DecodableType    = bool;
+    using DecodableArgType = bool;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::EnergyRemote::Id; }
@@ -4255,8 +4401,9 @@ struct TypeInfo
 namespace ScheduleMode {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ScheduleMode::Id; }
@@ -4265,8 +4412,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -4275,8 +4423,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -4591,8 +4740,9 @@ namespace Attributes {
 namespace StartTime {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ApplianceControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::StartTime::Id; }
@@ -4601,8 +4751,9 @@ struct TypeInfo
 namespace FinishTime {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ApplianceControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FinishTime::Id; }
@@ -4611,8 +4762,9 @@ struct TypeInfo
 namespace RemainingTime {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ApplianceControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::RemainingTime::Id; }
@@ -4621,8 +4773,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ApplianceControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -4631,8 +4784,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ApplianceControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -4669,8 +4823,9 @@ namespace Attributes {
 namespace DeviceList {
 struct TypeInfo
 {
-    using Type          = DataModel::List<const Structs::DeviceType::Type>;
-    using DecodableType = DataModel::DecodableList<Structs::DeviceType::DecodableType>;
+    using Type             = DataModel::List<const Structs::DeviceType::Type>;
+    using DecodableType    = DataModel::DecodableList<Structs::DeviceType::DecodableType>;
+    using DecodableArgType = const DataModel::DecodableList<Structs::DeviceType::DecodableType> &;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Descriptor::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::DeviceList::Id; }
@@ -4679,8 +4834,9 @@ struct TypeInfo
 namespace ServerList {
 struct TypeInfo
 {
-    using Type          = DataModel::List<const chip::ClusterId>;
-    using DecodableType = DataModel::DecodableList<chip::ClusterId>;
+    using Type             = DataModel::List<const chip::ClusterId>;
+    using DecodableType    = DataModel::DecodableList<chip::ClusterId>;
+    using DecodableArgType = const DataModel::DecodableList<chip::ClusterId> &;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Descriptor::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ServerList::Id; }
@@ -4689,8 +4845,9 @@ struct TypeInfo
 namespace ClientList {
 struct TypeInfo
 {
-    using Type          = DataModel::List<const chip::ClusterId>;
-    using DecodableType = DataModel::DecodableList<chip::ClusterId>;
+    using Type             = DataModel::List<const chip::ClusterId>;
+    using DecodableType    = DataModel::DecodableList<chip::ClusterId>;
+    using DecodableArgType = const DataModel::DecodableList<chip::ClusterId> &;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Descriptor::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClientList::Id; }
@@ -4699,8 +4856,9 @@ struct TypeInfo
 namespace PartsList {
 struct TypeInfo
 {
-    using Type          = DataModel::List<const chip::EndpointId>;
-    using DecodableType = DataModel::DecodableList<chip::EndpointId>;
+    using Type             = DataModel::List<const chip::EndpointId>;
+    using DecodableType    = DataModel::DecodableList<chip::EndpointId>;
+    using DecodableArgType = const DataModel::DecodableList<chip::EndpointId> &;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Descriptor::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::PartsList::Id; }
@@ -4709,8 +4867,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Descriptor::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -4719,8 +4878,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Descriptor::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -4872,8 +5032,9 @@ namespace Attributes {
 namespace CheckInInterval {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PollControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::CheckInInterval::Id; }
@@ -4882,8 +5043,9 @@ struct TypeInfo
 namespace LongPollInterval {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PollControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::LongPollInterval::Id; }
@@ -4892,8 +5054,9 @@ struct TypeInfo
 namespace ShortPollInterval {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PollControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ShortPollInterval::Id; }
@@ -4902,8 +5065,9 @@ struct TypeInfo
 namespace FastPollTimeout {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PollControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FastPollTimeout::Id; }
@@ -4912,8 +5076,9 @@ struct TypeInfo
 namespace CheckInIntervalMin {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PollControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::CheckInIntervalMin::Id; }
@@ -4922,8 +5087,9 @@ struct TypeInfo
 namespace LongPollIntervalMin {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PollControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::LongPollIntervalMin::Id; }
@@ -4932,8 +5098,9 @@ struct TypeInfo
 namespace FastPollTimeoutMax {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PollControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FastPollTimeoutMax::Id; }
@@ -4942,8 +5109,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PollControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -4952,8 +5120,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PollControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -5485,8 +5654,9 @@ namespace Attributes {
 namespace ActionList {
 struct TypeInfo
 {
-    using Type          = DataModel::List<const Structs::ActionStruct::Type>;
-    using DecodableType = DataModel::DecodableList<Structs::ActionStruct::DecodableType>;
+    using Type             = DataModel::List<const Structs::ActionStruct::Type>;
+    using DecodableType    = DataModel::DecodableList<Structs::ActionStruct::DecodableType>;
+    using DecodableArgType = const DataModel::DecodableList<Structs::ActionStruct::DecodableType> &;
 
     static constexpr ClusterId GetClusterId() { return Clusters::BridgedActions::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ActionList::Id; }
@@ -5495,8 +5665,9 @@ struct TypeInfo
 namespace EndpointList {
 struct TypeInfo
 {
-    using Type          = DataModel::List<const Structs::EndpointListStruct::Type>;
-    using DecodableType = DataModel::DecodableList<Structs::EndpointListStruct::DecodableType>;
+    using Type             = DataModel::List<const Structs::EndpointListStruct::Type>;
+    using DecodableType    = DataModel::DecodableList<Structs::EndpointListStruct::DecodableType>;
+    using DecodableArgType = const DataModel::DecodableList<Structs::EndpointListStruct::DecodableType> &;
 
     static constexpr ClusterId GetClusterId() { return Clusters::BridgedActions::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::EndpointList::Id; }
@@ -5505,8 +5676,9 @@ struct TypeInfo
 namespace SetupUrl {
 struct TypeInfo
 {
-    using Type          = chip::CharSpan;
-    using DecodableType = chip::CharSpan;
+    using Type             = chip::CharSpan;
+    using DecodableType    = chip::CharSpan;
+    using DecodableArgType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return Clusters::BridgedActions::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::SetupUrl::Id; }
@@ -5515,8 +5687,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::BridgedActions::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -5525,8 +5698,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::BridgedActions::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -5639,8 +5813,9 @@ namespace Attributes {
 namespace InteractionModelVersion {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Basic::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::InteractionModelVersion::Id; }
@@ -5649,8 +5824,9 @@ struct TypeInfo
 namespace VendorName {
 struct TypeInfo
 {
-    using Type          = chip::CharSpan;
-    using DecodableType = chip::CharSpan;
+    using Type             = chip::CharSpan;
+    using DecodableType    = chip::CharSpan;
+    using DecodableArgType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Basic::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::VendorName::Id; }
@@ -5659,8 +5835,9 @@ struct TypeInfo
 namespace VendorID {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Basic::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::VendorID::Id; }
@@ -5669,8 +5846,9 @@ struct TypeInfo
 namespace ProductName {
 struct TypeInfo
 {
-    using Type          = chip::CharSpan;
-    using DecodableType = chip::CharSpan;
+    using Type             = chip::CharSpan;
+    using DecodableType    = chip::CharSpan;
+    using DecodableArgType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Basic::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ProductName::Id; }
@@ -5679,8 +5857,9 @@ struct TypeInfo
 namespace ProductID {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Basic::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ProductID::Id; }
@@ -5689,8 +5868,9 @@ struct TypeInfo
 namespace UserLabel {
 struct TypeInfo
 {
-    using Type          = chip::CharSpan;
-    using DecodableType = chip::CharSpan;
+    using Type             = chip::CharSpan;
+    using DecodableType    = chip::CharSpan;
+    using DecodableArgType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Basic::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::UserLabel::Id; }
@@ -5699,8 +5879,9 @@ struct TypeInfo
 namespace Location {
 struct TypeInfo
 {
-    using Type          = chip::CharSpan;
-    using DecodableType = chip::CharSpan;
+    using Type             = chip::CharSpan;
+    using DecodableType    = chip::CharSpan;
+    using DecodableArgType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Basic::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Location::Id; }
@@ -5709,8 +5890,9 @@ struct TypeInfo
 namespace HardwareVersion {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Basic::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::HardwareVersion::Id; }
@@ -5719,8 +5901,9 @@ struct TypeInfo
 namespace HardwareVersionString {
 struct TypeInfo
 {
-    using Type          = chip::CharSpan;
-    using DecodableType = chip::CharSpan;
+    using Type             = chip::CharSpan;
+    using DecodableType    = chip::CharSpan;
+    using DecodableArgType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Basic::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::HardwareVersionString::Id; }
@@ -5729,8 +5912,9 @@ struct TypeInfo
 namespace SoftwareVersion {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Basic::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::SoftwareVersion::Id; }
@@ -5739,8 +5923,9 @@ struct TypeInfo
 namespace SoftwareVersionString {
 struct TypeInfo
 {
-    using Type          = chip::CharSpan;
-    using DecodableType = chip::CharSpan;
+    using Type             = chip::CharSpan;
+    using DecodableType    = chip::CharSpan;
+    using DecodableArgType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Basic::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::SoftwareVersionString::Id; }
@@ -5749,8 +5934,9 @@ struct TypeInfo
 namespace ManufacturingDate {
 struct TypeInfo
 {
-    using Type          = chip::CharSpan;
-    using DecodableType = chip::CharSpan;
+    using Type             = chip::CharSpan;
+    using DecodableType    = chip::CharSpan;
+    using DecodableArgType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Basic::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ManufacturingDate::Id; }
@@ -5759,8 +5945,9 @@ struct TypeInfo
 namespace PartNumber {
 struct TypeInfo
 {
-    using Type          = chip::CharSpan;
-    using DecodableType = chip::CharSpan;
+    using Type             = chip::CharSpan;
+    using DecodableType    = chip::CharSpan;
+    using DecodableArgType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Basic::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::PartNumber::Id; }
@@ -5769,8 +5956,9 @@ struct TypeInfo
 namespace ProductURL {
 struct TypeInfo
 {
-    using Type          = chip::CharSpan;
-    using DecodableType = chip::CharSpan;
+    using Type             = chip::CharSpan;
+    using DecodableType    = chip::CharSpan;
+    using DecodableArgType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Basic::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ProductURL::Id; }
@@ -5779,8 +5967,9 @@ struct TypeInfo
 namespace ProductLabel {
 struct TypeInfo
 {
-    using Type          = chip::CharSpan;
-    using DecodableType = chip::CharSpan;
+    using Type             = chip::CharSpan;
+    using DecodableType    = chip::CharSpan;
+    using DecodableArgType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Basic::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ProductLabel::Id; }
@@ -5789,8 +5978,9 @@ struct TypeInfo
 namespace SerialNumber {
 struct TypeInfo
 {
-    using Type          = chip::CharSpan;
-    using DecodableType = chip::CharSpan;
+    using Type             = chip::CharSpan;
+    using DecodableType    = chip::CharSpan;
+    using DecodableArgType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Basic::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::SerialNumber::Id; }
@@ -5799,8 +5989,9 @@ struct TypeInfo
 namespace LocalConfigDisabled {
 struct TypeInfo
 {
-    using Type          = bool;
-    using DecodableType = bool;
+    using Type             = bool;
+    using DecodableType    = bool;
+    using DecodableArgType = bool;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Basic::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::LocalConfigDisabled::Id; }
@@ -5809,8 +6000,9 @@ struct TypeInfo
 namespace Reachable {
 struct TypeInfo
 {
-    using Type          = bool;
-    using DecodableType = bool;
+    using Type             = bool;
+    using DecodableType    = bool;
+    using DecodableArgType = bool;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Basic::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Reachable::Id; }
@@ -5819,8 +6011,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Basic::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -5829,8 +6022,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Basic::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -6078,8 +6272,9 @@ namespace Attributes {
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::OtaSoftwareUpdateProvider::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -6088,8 +6283,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::OtaSoftwareUpdateProvider::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -6156,8 +6352,9 @@ namespace Attributes {
 namespace DefaultOtaProvider {
 struct TypeInfo
 {
-    using Type          = chip::ByteSpan;
-    using DecodableType = chip::ByteSpan;
+    using Type             = chip::ByteSpan;
+    using DecodableType    = chip::ByteSpan;
+    using DecodableArgType = chip::ByteSpan;
 
     static constexpr ClusterId GetClusterId() { return Clusters::OtaSoftwareUpdateRequestor::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::DefaultOtaProvider::Id; }
@@ -6166,8 +6363,9 @@ struct TypeInfo
 namespace UpdatePossible {
 struct TypeInfo
 {
-    using Type          = bool;
-    using DecodableType = bool;
+    using Type             = bool;
+    using DecodableType    = bool;
+    using DecodableArgType = bool;
 
     static constexpr ClusterId GetClusterId() { return Clusters::OtaSoftwareUpdateRequestor::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::UpdatePossible::Id; }
@@ -6176,8 +6374,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::OtaSoftwareUpdateRequestor::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -6186,8 +6385,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::OtaSoftwareUpdateRequestor::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -6201,8 +6401,9 @@ namespace Attributes {
 namespace Status {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerSource::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Status::Id; }
@@ -6211,8 +6412,9 @@ struct TypeInfo
 namespace Order {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerSource::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Order::Id; }
@@ -6221,8 +6423,9 @@ struct TypeInfo
 namespace Description {
 struct TypeInfo
 {
-    using Type          = chip::CharSpan;
-    using DecodableType = chip::CharSpan;
+    using Type             = chip::CharSpan;
+    using DecodableType    = chip::CharSpan;
+    using DecodableArgType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerSource::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Description::Id; }
@@ -6231,8 +6434,9 @@ struct TypeInfo
 namespace WiredAssessedInputVoltage {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerSource::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::WiredAssessedInputVoltage::Id; }
@@ -6241,8 +6445,9 @@ struct TypeInfo
 namespace WiredAssessedInputFrequency {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerSource::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::WiredAssessedInputFrequency::Id; }
@@ -6251,8 +6456,9 @@ struct TypeInfo
 namespace WiredCurrentType {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerSource::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::WiredCurrentType::Id; }
@@ -6261,8 +6467,9 @@ struct TypeInfo
 namespace WiredAssessedCurrent {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerSource::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::WiredAssessedCurrent::Id; }
@@ -6271,8 +6478,9 @@ struct TypeInfo
 namespace WiredNominalVoltage {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerSource::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::WiredNominalVoltage::Id; }
@@ -6281,8 +6489,9 @@ struct TypeInfo
 namespace WiredMaximumCurrent {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerSource::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::WiredMaximumCurrent::Id; }
@@ -6291,8 +6500,9 @@ struct TypeInfo
 namespace WiredPresent {
 struct TypeInfo
 {
-    using Type          = bool;
-    using DecodableType = bool;
+    using Type             = bool;
+    using DecodableType    = bool;
+    using DecodableArgType = bool;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerSource::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::WiredPresent::Id; }
@@ -6301,8 +6511,9 @@ struct TypeInfo
 namespace ActiveWiredFaults {
 struct TypeInfo
 {
-    using Type          = DataModel::List<const uint8_t>;
-    using DecodableType = DataModel::DecodableList<uint8_t>;
+    using Type             = DataModel::List<const uint8_t>;
+    using DecodableType    = DataModel::DecodableList<uint8_t>;
+    using DecodableArgType = const DataModel::DecodableList<uint8_t> &;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerSource::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ActiveWiredFaults::Id; }
@@ -6311,8 +6522,9 @@ struct TypeInfo
 namespace BatteryVoltage {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerSource::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::BatteryVoltage::Id; }
@@ -6321,8 +6533,9 @@ struct TypeInfo
 namespace BatteryPercentRemaining {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerSource::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::BatteryPercentRemaining::Id; }
@@ -6331,8 +6544,9 @@ struct TypeInfo
 namespace BatteryTimeRemaining {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerSource::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::BatteryTimeRemaining::Id; }
@@ -6341,8 +6555,9 @@ struct TypeInfo
 namespace BatteryChargeLevel {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerSource::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::BatteryChargeLevel::Id; }
@@ -6351,8 +6566,9 @@ struct TypeInfo
 namespace BatteryReplacementNeeded {
 struct TypeInfo
 {
-    using Type          = bool;
-    using DecodableType = bool;
+    using Type             = bool;
+    using DecodableType    = bool;
+    using DecodableArgType = bool;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerSource::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::BatteryReplacementNeeded::Id; }
@@ -6361,8 +6577,9 @@ struct TypeInfo
 namespace BatteryReplaceability {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerSource::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::BatteryReplaceability::Id; }
@@ -6371,8 +6588,9 @@ struct TypeInfo
 namespace BatteryPresent {
 struct TypeInfo
 {
-    using Type          = bool;
-    using DecodableType = bool;
+    using Type             = bool;
+    using DecodableType    = bool;
+    using DecodableArgType = bool;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerSource::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::BatteryPresent::Id; }
@@ -6381,8 +6599,9 @@ struct TypeInfo
 namespace ActiveBatteryFaults {
 struct TypeInfo
 {
-    using Type          = DataModel::List<const uint8_t>;
-    using DecodableType = DataModel::DecodableList<uint8_t>;
+    using Type             = DataModel::List<const uint8_t>;
+    using DecodableType    = DataModel::DecodableList<uint8_t>;
+    using DecodableArgType = const DataModel::DecodableList<uint8_t> &;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerSource::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ActiveBatteryFaults::Id; }
@@ -6391,8 +6610,9 @@ struct TypeInfo
 namespace BatteryReplacementDescription {
 struct TypeInfo
 {
-    using Type          = chip::CharSpan;
-    using DecodableType = chip::CharSpan;
+    using Type             = chip::CharSpan;
+    using DecodableType    = chip::CharSpan;
+    using DecodableArgType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerSource::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::BatteryReplacementDescription::Id; }
@@ -6401,8 +6621,9 @@ struct TypeInfo
 namespace BatteryCommonDesignation {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerSource::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::BatteryCommonDesignation::Id; }
@@ -6411,8 +6632,9 @@ struct TypeInfo
 namespace BatteryANSIDesignation {
 struct TypeInfo
 {
-    using Type          = chip::CharSpan;
-    using DecodableType = chip::CharSpan;
+    using Type             = chip::CharSpan;
+    using DecodableType    = chip::CharSpan;
+    using DecodableArgType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerSource::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::BatteryANSIDesignation::Id; }
@@ -6421,8 +6643,9 @@ struct TypeInfo
 namespace BatteryIECDesignation {
 struct TypeInfo
 {
-    using Type          = chip::CharSpan;
-    using DecodableType = chip::CharSpan;
+    using Type             = chip::CharSpan;
+    using DecodableType    = chip::CharSpan;
+    using DecodableArgType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerSource::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::BatteryIECDesignation::Id; }
@@ -6431,8 +6654,9 @@ struct TypeInfo
 namespace BatteryApprovedChemistry {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerSource::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::BatteryApprovedChemistry::Id; }
@@ -6441,8 +6665,9 @@ struct TypeInfo
 namespace BatteryCapacity {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerSource::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::BatteryCapacity::Id; }
@@ -6451,8 +6676,9 @@ struct TypeInfo
 namespace BatteryQuantity {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerSource::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::BatteryQuantity::Id; }
@@ -6461,8 +6687,9 @@ struct TypeInfo
 namespace BatteryChargeState {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerSource::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::BatteryChargeState::Id; }
@@ -6471,8 +6698,9 @@ struct TypeInfo
 namespace BatteryTimeToFullCharge {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerSource::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::BatteryTimeToFullCharge::Id; }
@@ -6481,8 +6709,9 @@ struct TypeInfo
 namespace BatteryFunctionalWhileCharging {
 struct TypeInfo
 {
-    using Type          = bool;
-    using DecodableType = bool;
+    using Type             = bool;
+    using DecodableType    = bool;
+    using DecodableArgType = bool;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerSource::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::BatteryFunctionalWhileCharging::Id; }
@@ -6491,8 +6720,9 @@ struct TypeInfo
 namespace BatteryChargingCurrent {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerSource::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::BatteryChargingCurrent::Id; }
@@ -6501,8 +6731,9 @@ struct TypeInfo
 namespace ActiveBatteryChargeFaults {
 struct TypeInfo
 {
-    using Type          = DataModel::List<const uint8_t>;
-    using DecodableType = DataModel::DecodableList<uint8_t>;
+    using Type             = DataModel::List<const uint8_t>;
+    using DecodableType    = DataModel::DecodableList<uint8_t>;
+    using DecodableArgType = const DataModel::DecodableList<uint8_t> &;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerSource::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ActiveBatteryChargeFaults::Id; }
@@ -6511,8 +6742,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerSource::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -6521,8 +6753,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PowerSource::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -6774,8 +7007,9 @@ namespace Attributes {
 namespace Breadcrumb {
 struct TypeInfo
 {
-    using Type          = uint64_t;
-    using DecodableType = uint64_t;
+    using Type             = uint64_t;
+    using DecodableType    = uint64_t;
+    using DecodableArgType = uint64_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::GeneralCommissioning::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Breadcrumb::Id; }
@@ -6784,8 +7018,9 @@ struct TypeInfo
 namespace BasicCommissioningInfoList {
 struct TypeInfo
 {
-    using Type          = DataModel::List<const Structs::BasicCommissioningInfoType::Type>;
-    using DecodableType = DataModel::DecodableList<Structs::BasicCommissioningInfoType::DecodableType>;
+    using Type             = DataModel::List<const Structs::BasicCommissioningInfoType::Type>;
+    using DecodableType    = DataModel::DecodableList<Structs::BasicCommissioningInfoType::DecodableType>;
+    using DecodableArgType = const DataModel::DecodableList<Structs::BasicCommissioningInfoType::DecodableType> &;
 
     static constexpr ClusterId GetClusterId() { return Clusters::GeneralCommissioning::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::BasicCommissioningInfoList::Id; }
@@ -6794,8 +7029,9 @@ struct TypeInfo
 namespace RegulatoryConfigList {
 struct TypeInfo
 {
-    using Type          = DataModel::List<const RegulatoryLocationType>;
-    using DecodableType = DataModel::DecodableList<RegulatoryLocationType>;
+    using Type             = DataModel::List<const RegulatoryLocationType>;
+    using DecodableType    = DataModel::DecodableList<RegulatoryLocationType>;
+    using DecodableArgType = const DataModel::DecodableList<RegulatoryLocationType> &;
 
     static constexpr ClusterId GetClusterId() { return Clusters::GeneralCommissioning::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::RegulatoryConfigList::Id; }
@@ -6804,8 +7040,9 @@ struct TypeInfo
 namespace LocationCapabilityList {
 struct TypeInfo
 {
-    using Type          = DataModel::List<const RegulatoryLocationType>;
-    using DecodableType = DataModel::DecodableList<RegulatoryLocationType>;
+    using Type             = DataModel::List<const RegulatoryLocationType>;
+    using DecodableType    = DataModel::DecodableList<RegulatoryLocationType>;
+    using DecodableArgType = const DataModel::DecodableList<RegulatoryLocationType> &;
 
     static constexpr ClusterId GetClusterId() { return Clusters::GeneralCommissioning::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::LocationCapabilityList::Id; }
@@ -6814,8 +7051,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::GeneralCommissioning::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -6824,8 +7062,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::GeneralCommissioning::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -7451,8 +7690,9 @@ namespace Attributes {
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::NetworkCommissioning::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -7461,8 +7701,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::NetworkCommissioning::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -7590,8 +7831,9 @@ namespace Attributes {
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::DiagnosticLogs::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -7600,8 +7842,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::DiagnosticLogs::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -7730,8 +7973,9 @@ namespace Attributes {
 namespace NetworkInterfaces {
 struct TypeInfo
 {
-    using Type          = DataModel::List<const Structs::NetworkInterfaceType::Type>;
-    using DecodableType = DataModel::DecodableList<Structs::NetworkInterfaceType::DecodableType>;
+    using Type             = DataModel::List<const Structs::NetworkInterfaceType::Type>;
+    using DecodableType    = DataModel::DecodableList<Structs::NetworkInterfaceType::DecodableType>;
+    using DecodableArgType = const DataModel::DecodableList<Structs::NetworkInterfaceType::DecodableType> &;
 
     static constexpr ClusterId GetClusterId() { return Clusters::GeneralDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::NetworkInterfaces::Id; }
@@ -7740,8 +7984,9 @@ struct TypeInfo
 namespace RebootCount {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::GeneralDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::RebootCount::Id; }
@@ -7750,8 +7995,9 @@ struct TypeInfo
 namespace UpTime {
 struct TypeInfo
 {
-    using Type          = uint64_t;
-    using DecodableType = uint64_t;
+    using Type             = uint64_t;
+    using DecodableType    = uint64_t;
+    using DecodableArgType = uint64_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::GeneralDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::UpTime::Id; }
@@ -7760,8 +8006,9 @@ struct TypeInfo
 namespace TotalOperationalHours {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::GeneralDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::TotalOperationalHours::Id; }
@@ -7770,8 +8017,9 @@ struct TypeInfo
 namespace BootReasons {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::GeneralDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::BootReasons::Id; }
@@ -7780,8 +8028,9 @@ struct TypeInfo
 namespace ActiveHardwareFaults {
 struct TypeInfo
 {
-    using Type          = DataModel::List<const uint8_t>;
-    using DecodableType = DataModel::DecodableList<uint8_t>;
+    using Type             = DataModel::List<const uint8_t>;
+    using DecodableType    = DataModel::DecodableList<uint8_t>;
+    using DecodableArgType = const DataModel::DecodableList<uint8_t> &;
 
     static constexpr ClusterId GetClusterId() { return Clusters::GeneralDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ActiveHardwareFaults::Id; }
@@ -7790,8 +8039,9 @@ struct TypeInfo
 namespace ActiveRadioFaults {
 struct TypeInfo
 {
-    using Type          = DataModel::List<const uint8_t>;
-    using DecodableType = DataModel::DecodableList<uint8_t>;
+    using Type             = DataModel::List<const uint8_t>;
+    using DecodableType    = DataModel::DecodableList<uint8_t>;
+    using DecodableArgType = const DataModel::DecodableList<uint8_t> &;
 
     static constexpr ClusterId GetClusterId() { return Clusters::GeneralDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ActiveRadioFaults::Id; }
@@ -7800,8 +8050,9 @@ struct TypeInfo
 namespace ActiveNetworkFaults {
 struct TypeInfo
 {
-    using Type          = DataModel::List<const uint8_t>;
-    using DecodableType = DataModel::DecodableList<uint8_t>;
+    using Type             = DataModel::List<const uint8_t>;
+    using DecodableType    = DataModel::DecodableList<uint8_t>;
+    using DecodableArgType = const DataModel::DecodableList<uint8_t> &;
 
     static constexpr ClusterId GetClusterId() { return Clusters::GeneralDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ActiveNetworkFaults::Id; }
@@ -7810,8 +8061,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::GeneralDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -7820,8 +8072,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::GeneralDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -7891,8 +8144,9 @@ namespace Attributes {
 namespace ThreadMetrics {
 struct TypeInfo
 {
-    using Type          = DataModel::List<const Structs::ThreadMetrics::Type>;
-    using DecodableType = DataModel::DecodableList<Structs::ThreadMetrics::DecodableType>;
+    using Type             = DataModel::List<const Structs::ThreadMetrics::Type>;
+    using DecodableType    = DataModel::DecodableList<Structs::ThreadMetrics::DecodableType>;
+    using DecodableArgType = const DataModel::DecodableList<Structs::ThreadMetrics::DecodableType> &;
 
     static constexpr ClusterId GetClusterId() { return Clusters::SoftwareDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ThreadMetrics::Id; }
@@ -7901,8 +8155,9 @@ struct TypeInfo
 namespace CurrentHeapFree {
 struct TypeInfo
 {
-    using Type          = uint64_t;
-    using DecodableType = uint64_t;
+    using Type             = uint64_t;
+    using DecodableType    = uint64_t;
+    using DecodableArgType = uint64_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::SoftwareDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::CurrentHeapFree::Id; }
@@ -7911,8 +8166,9 @@ struct TypeInfo
 namespace CurrentHeapUsed {
 struct TypeInfo
 {
-    using Type          = uint64_t;
-    using DecodableType = uint64_t;
+    using Type             = uint64_t;
+    using DecodableType    = uint64_t;
+    using DecodableArgType = uint64_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::SoftwareDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::CurrentHeapUsed::Id; }
@@ -7921,8 +8177,9 @@ struct TypeInfo
 namespace CurrentHeapHighWatermark {
 struct TypeInfo
 {
-    using Type          = uint64_t;
-    using DecodableType = uint64_t;
+    using Type             = uint64_t;
+    using DecodableType    = uint64_t;
+    using DecodableArgType = uint64_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::SoftwareDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::CurrentHeapHighWatermark::Id; }
@@ -7931,8 +8188,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::SoftwareDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -7941,8 +8199,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::SoftwareDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -8157,8 +8416,9 @@ namespace Attributes {
 namespace Channel {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ThreadNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Channel::Id; }
@@ -8167,8 +8427,9 @@ struct TypeInfo
 namespace RoutingRole {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ThreadNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::RoutingRole::Id; }
@@ -8177,8 +8438,9 @@ struct TypeInfo
 namespace NetworkName {
 struct TypeInfo
 {
-    using Type          = chip::ByteSpan;
-    using DecodableType = chip::ByteSpan;
+    using Type             = chip::ByteSpan;
+    using DecodableType    = chip::ByteSpan;
+    using DecodableArgType = chip::ByteSpan;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ThreadNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::NetworkName::Id; }
@@ -8187,8 +8449,9 @@ struct TypeInfo
 namespace PanId {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ThreadNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::PanId::Id; }
@@ -8197,8 +8460,9 @@ struct TypeInfo
 namespace ExtendedPanId {
 struct TypeInfo
 {
-    using Type          = uint64_t;
-    using DecodableType = uint64_t;
+    using Type             = uint64_t;
+    using DecodableType    = uint64_t;
+    using DecodableArgType = uint64_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ThreadNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ExtendedPanId::Id; }
@@ -8207,8 +8471,9 @@ struct TypeInfo
 namespace MeshLocalPrefix {
 struct TypeInfo
 {
-    using Type          = chip::ByteSpan;
-    using DecodableType = chip::ByteSpan;
+    using Type             = chip::ByteSpan;
+    using DecodableType    = chip::ByteSpan;
+    using DecodableArgType = chip::ByteSpan;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ThreadNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MeshLocalPrefix::Id; }
@@ -8217,8 +8482,9 @@ struct TypeInfo
 namespace OverrunCount {
 struct TypeInfo
 {
-    using Type          = uint64_t;
-    using DecodableType = uint64_t;
+    using Type             = uint64_t;
+    using DecodableType    = uint64_t;
+    using DecodableArgType = uint64_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ThreadNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::OverrunCount::Id; }
@@ -8227,8 +8493,9 @@ struct TypeInfo
 namespace NeighborTableList {
 struct TypeInfo
 {
-    using Type          = DataModel::List<const Structs::NeighborTable::Type>;
-    using DecodableType = DataModel::DecodableList<Structs::NeighborTable::DecodableType>;
+    using Type             = DataModel::List<const Structs::NeighborTable::Type>;
+    using DecodableType    = DataModel::DecodableList<Structs::NeighborTable::DecodableType>;
+    using DecodableArgType = const DataModel::DecodableList<Structs::NeighborTable::DecodableType> &;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ThreadNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::NeighborTableList::Id; }
@@ -8237,8 +8504,9 @@ struct TypeInfo
 namespace RouteTableList {
 struct TypeInfo
 {
-    using Type          = DataModel::List<const Structs::RouteTable::Type>;
-    using DecodableType = DataModel::DecodableList<Structs::RouteTable::DecodableType>;
+    using Type             = DataModel::List<const Structs::RouteTable::Type>;
+    using DecodableType    = DataModel::DecodableList<Structs::RouteTable::DecodableType>;
+    using DecodableArgType = const DataModel::DecodableList<Structs::RouteTable::DecodableType> &;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ThreadNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::RouteTableList::Id; }
@@ -8247,8 +8515,9 @@ struct TypeInfo
 namespace PartitionId {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ThreadNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::PartitionId::Id; }
@@ -8257,8 +8526,9 @@ struct TypeInfo
 namespace Weighting {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ThreadNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Weighting::Id; }
@@ -8267,8 +8537,9 @@ struct TypeInfo
 namespace DataVersion {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ThreadNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::DataVersion::Id; }
@@ -8277,8 +8548,9 @@ struct TypeInfo
 namespace StableDataVersion {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ThreadNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::StableDataVersion::Id; }
@@ -8287,8 +8559,9 @@ struct TypeInfo
 namespace LeaderRouterId {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ThreadNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::LeaderRouterId::Id; }
@@ -8297,8 +8570,9 @@ struct TypeInfo
 namespace DetachedRoleCount {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ThreadNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::DetachedRoleCount::Id; }
@@ -8307,8 +8581,9 @@ struct TypeInfo
 namespace ChildRoleCount {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ThreadNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ChildRoleCount::Id; }
@@ -8317,8 +8592,9 @@ struct TypeInfo
 namespace RouterRoleCount {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ThreadNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::RouterRoleCount::Id; }
@@ -8327,8 +8603,9 @@ struct TypeInfo
 namespace LeaderRoleCount {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ThreadNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::LeaderRoleCount::Id; }
@@ -8337,8 +8614,9 @@ struct TypeInfo
 namespace AttachAttemptCount {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ThreadNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::AttachAttemptCount::Id; }
@@ -8347,8 +8625,9 @@ struct TypeInfo
 namespace PartitionIdChangeCount {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ThreadNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::PartitionIdChangeCount::Id; }
@@ -8357,8 +8636,9 @@ struct TypeInfo
 namespace BetterPartitionAttachAttemptCount {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ThreadNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::BetterPartitionAttachAttemptCount::Id; }
@@ -8367,8 +8647,9 @@ struct TypeInfo
 namespace ParentChangeCount {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ThreadNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ParentChangeCount::Id; }
@@ -8377,8 +8658,9 @@ struct TypeInfo
 namespace TxTotalCount {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ThreadNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::TxTotalCount::Id; }
@@ -8387,8 +8669,9 @@ struct TypeInfo
 namespace TxUnicastCount {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ThreadNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::TxUnicastCount::Id; }
@@ -8397,8 +8680,9 @@ struct TypeInfo
 namespace TxBroadcastCount {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ThreadNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::TxBroadcastCount::Id; }
@@ -8407,8 +8691,9 @@ struct TypeInfo
 namespace TxAckRequestedCount {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ThreadNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::TxAckRequestedCount::Id; }
@@ -8417,8 +8702,9 @@ struct TypeInfo
 namespace TxAckedCount {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ThreadNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::TxAckedCount::Id; }
@@ -8427,8 +8713,9 @@ struct TypeInfo
 namespace TxNoAckRequestedCount {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ThreadNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::TxNoAckRequestedCount::Id; }
@@ -8437,8 +8724,9 @@ struct TypeInfo
 namespace TxDataCount {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ThreadNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::TxDataCount::Id; }
@@ -8447,8 +8735,9 @@ struct TypeInfo
 namespace TxDataPollCount {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ThreadNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::TxDataPollCount::Id; }
@@ -8457,8 +8746,9 @@ struct TypeInfo
 namespace TxBeaconCount {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ThreadNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::TxBeaconCount::Id; }
@@ -8467,8 +8757,9 @@ struct TypeInfo
 namespace TxBeaconRequestCount {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ThreadNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::TxBeaconRequestCount::Id; }
@@ -8477,8 +8768,9 @@ struct TypeInfo
 namespace TxOtherCount {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ThreadNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::TxOtherCount::Id; }
@@ -8487,8 +8779,9 @@ struct TypeInfo
 namespace TxRetryCount {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ThreadNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::TxRetryCount::Id; }
@@ -8497,8 +8790,9 @@ struct TypeInfo
 namespace TxDirectMaxRetryExpiryCount {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ThreadNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::TxDirectMaxRetryExpiryCount::Id; }
@@ -8507,8 +8801,9 @@ struct TypeInfo
 namespace TxIndirectMaxRetryExpiryCount {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ThreadNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::TxIndirectMaxRetryExpiryCount::Id; }
@@ -8517,8 +8812,9 @@ struct TypeInfo
 namespace TxErrCcaCount {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ThreadNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::TxErrCcaCount::Id; }
@@ -8527,8 +8823,9 @@ struct TypeInfo
 namespace TxErrAbortCount {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ThreadNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::TxErrAbortCount::Id; }
@@ -8537,8 +8834,9 @@ struct TypeInfo
 namespace TxErrBusyChannelCount {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ThreadNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::TxErrBusyChannelCount::Id; }
@@ -8547,8 +8845,9 @@ struct TypeInfo
 namespace RxTotalCount {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ThreadNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::RxTotalCount::Id; }
@@ -8557,8 +8856,9 @@ struct TypeInfo
 namespace RxUnicastCount {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ThreadNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::RxUnicastCount::Id; }
@@ -8567,8 +8867,9 @@ struct TypeInfo
 namespace RxBroadcastCount {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ThreadNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::RxBroadcastCount::Id; }
@@ -8577,8 +8878,9 @@ struct TypeInfo
 namespace RxDataCount {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ThreadNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::RxDataCount::Id; }
@@ -8587,8 +8889,9 @@ struct TypeInfo
 namespace RxDataPollCount {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ThreadNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::RxDataPollCount::Id; }
@@ -8597,8 +8900,9 @@ struct TypeInfo
 namespace RxBeaconCount {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ThreadNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::RxBeaconCount::Id; }
@@ -8607,8 +8911,9 @@ struct TypeInfo
 namespace RxBeaconRequestCount {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ThreadNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::RxBeaconRequestCount::Id; }
@@ -8617,8 +8922,9 @@ struct TypeInfo
 namespace RxOtherCount {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ThreadNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::RxOtherCount::Id; }
@@ -8627,8 +8933,9 @@ struct TypeInfo
 namespace RxAddressFilteredCount {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ThreadNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::RxAddressFilteredCount::Id; }
@@ -8637,8 +8944,9 @@ struct TypeInfo
 namespace RxDestAddrFilteredCount {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ThreadNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::RxDestAddrFilteredCount::Id; }
@@ -8647,8 +8955,9 @@ struct TypeInfo
 namespace RxDuplicatedCount {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ThreadNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::RxDuplicatedCount::Id; }
@@ -8657,8 +8966,9 @@ struct TypeInfo
 namespace RxErrNoFrameCount {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ThreadNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::RxErrNoFrameCount::Id; }
@@ -8667,8 +8977,9 @@ struct TypeInfo
 namespace RxErrUnknownNeighborCount {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ThreadNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::RxErrUnknownNeighborCount::Id; }
@@ -8677,8 +8988,9 @@ struct TypeInfo
 namespace RxErrInvalidSrcAddrCount {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ThreadNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::RxErrInvalidSrcAddrCount::Id; }
@@ -8687,8 +8999,9 @@ struct TypeInfo
 namespace RxErrSecCount {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ThreadNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::RxErrSecCount::Id; }
@@ -8697,8 +9010,9 @@ struct TypeInfo
 namespace RxErrFcsCount {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ThreadNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::RxErrFcsCount::Id; }
@@ -8707,8 +9021,9 @@ struct TypeInfo
 namespace RxErrOtherCount {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ThreadNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::RxErrOtherCount::Id; }
@@ -8717,8 +9032,9 @@ struct TypeInfo
 namespace ActiveTimestamp {
 struct TypeInfo
 {
-    using Type          = uint64_t;
-    using DecodableType = uint64_t;
+    using Type             = uint64_t;
+    using DecodableType    = uint64_t;
+    using DecodableArgType = uint64_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ThreadNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ActiveTimestamp::Id; }
@@ -8727,8 +9043,9 @@ struct TypeInfo
 namespace PendingTimestamp {
 struct TypeInfo
 {
-    using Type          = uint64_t;
-    using DecodableType = uint64_t;
+    using Type             = uint64_t;
+    using DecodableType    = uint64_t;
+    using DecodableArgType = uint64_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ThreadNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::PendingTimestamp::Id; }
@@ -8737,8 +9054,9 @@ struct TypeInfo
 namespace Delay {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ThreadNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Delay::Id; }
@@ -8747,8 +9065,9 @@ struct TypeInfo
 namespace SecurityPolicy {
 struct TypeInfo
 {
-    using Type          = DataModel::List<const Structs::SecurityPolicy::Type>;
-    using DecodableType = DataModel::DecodableList<Structs::SecurityPolicy::DecodableType>;
+    using Type             = DataModel::List<const Structs::SecurityPolicy::Type>;
+    using DecodableType    = DataModel::DecodableList<Structs::SecurityPolicy::DecodableType>;
+    using DecodableArgType = const DataModel::DecodableList<Structs::SecurityPolicy::DecodableType> &;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ThreadNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::SecurityPolicy::Id; }
@@ -8757,8 +9076,9 @@ struct TypeInfo
 namespace ChannelMask {
 struct TypeInfo
 {
-    using Type          = chip::ByteSpan;
-    using DecodableType = chip::ByteSpan;
+    using Type             = chip::ByteSpan;
+    using DecodableType    = chip::ByteSpan;
+    using DecodableArgType = chip::ByteSpan;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ThreadNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ChannelMask::Id; }
@@ -8767,8 +9087,9 @@ struct TypeInfo
 namespace OperationalDatasetComponents {
 struct TypeInfo
 {
-    using Type          = DataModel::List<const Structs::OperationalDatasetComponents::Type>;
-    using DecodableType = DataModel::DecodableList<Structs::OperationalDatasetComponents::DecodableType>;
+    using Type             = DataModel::List<const Structs::OperationalDatasetComponents::Type>;
+    using DecodableType    = DataModel::DecodableList<Structs::OperationalDatasetComponents::DecodableType>;
+    using DecodableArgType = const DataModel::DecodableList<Structs::OperationalDatasetComponents::DecodableType> &;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ThreadNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::OperationalDatasetComponents::Id; }
@@ -8777,8 +9098,9 @@ struct TypeInfo
 namespace ActiveNetworkFaultsList {
 struct TypeInfo
 {
-    using Type          = DataModel::List<const NetworkFault>;
-    using DecodableType = DataModel::DecodableList<NetworkFault>;
+    using Type             = DataModel::List<const NetworkFault>;
+    using DecodableType    = DataModel::DecodableList<NetworkFault>;
+    using DecodableArgType = const DataModel::DecodableList<NetworkFault> &;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ThreadNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ActiveNetworkFaultsList::Id; }
@@ -8787,8 +9109,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ThreadNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -8797,8 +9120,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ThreadNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -8871,8 +9195,9 @@ namespace Attributes {
 namespace Bssid {
 struct TypeInfo
 {
-    using Type          = chip::ByteSpan;
-    using DecodableType = chip::ByteSpan;
+    using Type             = chip::ByteSpan;
+    using DecodableType    = chip::ByteSpan;
+    using DecodableArgType = chip::ByteSpan;
 
     static constexpr ClusterId GetClusterId() { return Clusters::WiFiNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Bssid::Id; }
@@ -8881,8 +9206,9 @@ struct TypeInfo
 namespace SecurityType {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::WiFiNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::SecurityType::Id; }
@@ -8891,8 +9217,9 @@ struct TypeInfo
 namespace WiFiVersion {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::WiFiNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::WiFiVersion::Id; }
@@ -8901,8 +9228,9 @@ struct TypeInfo
 namespace ChannelNumber {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::WiFiNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ChannelNumber::Id; }
@@ -8911,8 +9239,9 @@ struct TypeInfo
 namespace Rssi {
 struct TypeInfo
 {
-    using Type          = int8_t;
-    using DecodableType = int8_t;
+    using Type             = int8_t;
+    using DecodableType    = int8_t;
+    using DecodableArgType = int8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::WiFiNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Rssi::Id; }
@@ -8921,8 +9250,9 @@ struct TypeInfo
 namespace BeaconLostCount {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::WiFiNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::BeaconLostCount::Id; }
@@ -8931,8 +9261,9 @@ struct TypeInfo
 namespace BeaconRxCount {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::WiFiNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::BeaconRxCount::Id; }
@@ -8941,8 +9272,9 @@ struct TypeInfo
 namespace PacketMulticastRxCount {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::WiFiNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::PacketMulticastRxCount::Id; }
@@ -8951,8 +9283,9 @@ struct TypeInfo
 namespace PacketMulticastTxCount {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::WiFiNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::PacketMulticastTxCount::Id; }
@@ -8961,8 +9294,9 @@ struct TypeInfo
 namespace PacketUnicastRxCount {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::WiFiNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::PacketUnicastRxCount::Id; }
@@ -8971,8 +9305,9 @@ struct TypeInfo
 namespace PacketUnicastTxCount {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::WiFiNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::PacketUnicastTxCount::Id; }
@@ -8981,8 +9316,9 @@ struct TypeInfo
 namespace CurrentMaxRate {
 struct TypeInfo
 {
-    using Type          = uint64_t;
-    using DecodableType = uint64_t;
+    using Type             = uint64_t;
+    using DecodableType    = uint64_t;
+    using DecodableArgType = uint64_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::WiFiNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::CurrentMaxRate::Id; }
@@ -8991,8 +9327,9 @@ struct TypeInfo
 namespace OverrunCount {
 struct TypeInfo
 {
-    using Type          = uint64_t;
-    using DecodableType = uint64_t;
+    using Type             = uint64_t;
+    using DecodableType    = uint64_t;
+    using DecodableArgType = uint64_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::WiFiNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::OverrunCount::Id; }
@@ -9001,8 +9338,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::WiFiNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -9011,8 +9349,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::WiFiNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -9073,8 +9412,9 @@ namespace Attributes {
 namespace PHYRate {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::EthernetNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::PHYRate::Id; }
@@ -9083,8 +9423,9 @@ struct TypeInfo
 namespace FullDuplex {
 struct TypeInfo
 {
-    using Type          = bool;
-    using DecodableType = bool;
+    using Type             = bool;
+    using DecodableType    = bool;
+    using DecodableArgType = bool;
 
     static constexpr ClusterId GetClusterId() { return Clusters::EthernetNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FullDuplex::Id; }
@@ -9093,8 +9434,9 @@ struct TypeInfo
 namespace PacketRxCount {
 struct TypeInfo
 {
-    using Type          = uint64_t;
-    using DecodableType = uint64_t;
+    using Type             = uint64_t;
+    using DecodableType    = uint64_t;
+    using DecodableArgType = uint64_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::EthernetNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::PacketRxCount::Id; }
@@ -9103,8 +9445,9 @@ struct TypeInfo
 namespace PacketTxCount {
 struct TypeInfo
 {
-    using Type          = uint64_t;
-    using DecodableType = uint64_t;
+    using Type             = uint64_t;
+    using DecodableType    = uint64_t;
+    using DecodableArgType = uint64_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::EthernetNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::PacketTxCount::Id; }
@@ -9113,8 +9456,9 @@ struct TypeInfo
 namespace TxErrCount {
 struct TypeInfo
 {
-    using Type          = uint64_t;
-    using DecodableType = uint64_t;
+    using Type             = uint64_t;
+    using DecodableType    = uint64_t;
+    using DecodableArgType = uint64_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::EthernetNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::TxErrCount::Id; }
@@ -9123,8 +9467,9 @@ struct TypeInfo
 namespace CollisionCount {
 struct TypeInfo
 {
-    using Type          = uint64_t;
-    using DecodableType = uint64_t;
+    using Type             = uint64_t;
+    using DecodableType    = uint64_t;
+    using DecodableArgType = uint64_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::EthernetNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::CollisionCount::Id; }
@@ -9133,8 +9478,9 @@ struct TypeInfo
 namespace OverrunCount {
 struct TypeInfo
 {
-    using Type          = uint64_t;
-    using DecodableType = uint64_t;
+    using Type             = uint64_t;
+    using DecodableType    = uint64_t;
+    using DecodableArgType = uint64_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::EthernetNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::OverrunCount::Id; }
@@ -9143,8 +9489,9 @@ struct TypeInfo
 namespace CarrierDetect {
 struct TypeInfo
 {
-    using Type          = bool;
-    using DecodableType = bool;
+    using Type             = bool;
+    using DecodableType    = bool;
+    using DecodableArgType = bool;
 
     static constexpr ClusterId GetClusterId() { return Clusters::EthernetNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::CarrierDetect::Id; }
@@ -9153,8 +9500,9 @@ struct TypeInfo
 namespace TimeSinceReset {
 struct TypeInfo
 {
-    using Type          = uint64_t;
-    using DecodableType = uint64_t;
+    using Type             = uint64_t;
+    using DecodableType    = uint64_t;
+    using DecodableArgType = uint64_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::EthernetNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::TimeSinceReset::Id; }
@@ -9163,8 +9511,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::EthernetNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -9173,8 +9522,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::EthernetNetworkDiagnostics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -9287,8 +9637,9 @@ namespace Attributes {
 namespace VendorName {
 struct TypeInfo
 {
-    using Type          = chip::CharSpan;
-    using DecodableType = chip::CharSpan;
+    using Type             = chip::CharSpan;
+    using DecodableType    = chip::CharSpan;
+    using DecodableArgType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return Clusters::BridgedDeviceBasic::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::VendorName::Id; }
@@ -9297,8 +9648,9 @@ struct TypeInfo
 namespace VendorID {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::BridgedDeviceBasic::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::VendorID::Id; }
@@ -9307,8 +9659,9 @@ struct TypeInfo
 namespace ProductName {
 struct TypeInfo
 {
-    using Type          = chip::CharSpan;
-    using DecodableType = chip::CharSpan;
+    using Type             = chip::CharSpan;
+    using DecodableType    = chip::CharSpan;
+    using DecodableArgType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return Clusters::BridgedDeviceBasic::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ProductName::Id; }
@@ -9317,8 +9670,9 @@ struct TypeInfo
 namespace UserLabel {
 struct TypeInfo
 {
-    using Type          = chip::CharSpan;
-    using DecodableType = chip::CharSpan;
+    using Type             = chip::CharSpan;
+    using DecodableType    = chip::CharSpan;
+    using DecodableArgType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return Clusters::BridgedDeviceBasic::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::UserLabel::Id; }
@@ -9327,8 +9681,9 @@ struct TypeInfo
 namespace HardwareVersion {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::BridgedDeviceBasic::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::HardwareVersion::Id; }
@@ -9337,8 +9692,9 @@ struct TypeInfo
 namespace HardwareVersionString {
 struct TypeInfo
 {
-    using Type          = chip::CharSpan;
-    using DecodableType = chip::CharSpan;
+    using Type             = chip::CharSpan;
+    using DecodableType    = chip::CharSpan;
+    using DecodableArgType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return Clusters::BridgedDeviceBasic::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::HardwareVersionString::Id; }
@@ -9347,8 +9703,9 @@ struct TypeInfo
 namespace SoftwareVersion {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::BridgedDeviceBasic::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::SoftwareVersion::Id; }
@@ -9357,8 +9714,9 @@ struct TypeInfo
 namespace SoftwareVersionString {
 struct TypeInfo
 {
-    using Type          = chip::CharSpan;
-    using DecodableType = chip::CharSpan;
+    using Type             = chip::CharSpan;
+    using DecodableType    = chip::CharSpan;
+    using DecodableArgType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return Clusters::BridgedDeviceBasic::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::SoftwareVersionString::Id; }
@@ -9367,8 +9725,9 @@ struct TypeInfo
 namespace ManufacturingDate {
 struct TypeInfo
 {
-    using Type          = chip::CharSpan;
-    using DecodableType = chip::CharSpan;
+    using Type             = chip::CharSpan;
+    using DecodableType    = chip::CharSpan;
+    using DecodableArgType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return Clusters::BridgedDeviceBasic::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ManufacturingDate::Id; }
@@ -9377,8 +9736,9 @@ struct TypeInfo
 namespace PartNumber {
 struct TypeInfo
 {
-    using Type          = chip::CharSpan;
-    using DecodableType = chip::CharSpan;
+    using Type             = chip::CharSpan;
+    using DecodableType    = chip::CharSpan;
+    using DecodableArgType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return Clusters::BridgedDeviceBasic::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::PartNumber::Id; }
@@ -9387,8 +9747,9 @@ struct TypeInfo
 namespace ProductURL {
 struct TypeInfo
 {
-    using Type          = chip::CharSpan;
-    using DecodableType = chip::CharSpan;
+    using Type             = chip::CharSpan;
+    using DecodableType    = chip::CharSpan;
+    using DecodableArgType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return Clusters::BridgedDeviceBasic::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ProductURL::Id; }
@@ -9397,8 +9758,9 @@ struct TypeInfo
 namespace ProductLabel {
 struct TypeInfo
 {
-    using Type          = chip::CharSpan;
-    using DecodableType = chip::CharSpan;
+    using Type             = chip::CharSpan;
+    using DecodableType    = chip::CharSpan;
+    using DecodableArgType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return Clusters::BridgedDeviceBasic::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ProductLabel::Id; }
@@ -9407,8 +9769,9 @@ struct TypeInfo
 namespace SerialNumber {
 struct TypeInfo
 {
-    using Type          = chip::CharSpan;
-    using DecodableType = chip::CharSpan;
+    using Type             = chip::CharSpan;
+    using DecodableType    = chip::CharSpan;
+    using DecodableArgType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return Clusters::BridgedDeviceBasic::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::SerialNumber::Id; }
@@ -9417,8 +9780,9 @@ struct TypeInfo
 namespace Reachable {
 struct TypeInfo
 {
-    using Type          = bool;
-    using DecodableType = bool;
+    using Type             = bool;
+    using DecodableType    = bool;
+    using DecodableArgType = bool;
 
     static constexpr ClusterId GetClusterId() { return Clusters::BridgedDeviceBasic::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Reachable::Id; }
@@ -9427,8 +9791,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::BridgedDeviceBasic::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -9437,8 +9802,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::BridgedDeviceBasic::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -9452,8 +9818,9 @@ namespace Attributes {
 namespace NumberOfPositions {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Switch::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::NumberOfPositions::Id; }
@@ -9462,8 +9829,9 @@ struct TypeInfo
 namespace CurrentPosition {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Switch::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::CurrentPosition::Id; }
@@ -9472,8 +9840,9 @@ struct TypeInfo
 namespace MultiPressMax {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Switch::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MultiPressMax::Id; }
@@ -9482,8 +9851,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Switch::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -9492,8 +9862,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Switch::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -9618,8 +9989,9 @@ namespace Attributes {
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::AdministratorCommissioning::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -9628,8 +10000,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::AdministratorCommissioning::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -10108,8 +10481,9 @@ namespace Attributes {
 namespace FabricsList {
 struct TypeInfo
 {
-    using Type          = DataModel::List<const Structs::FabricDescriptor::Type>;
-    using DecodableType = DataModel::DecodableList<Structs::FabricDescriptor::DecodableType>;
+    using Type             = DataModel::List<const Structs::FabricDescriptor::Type>;
+    using DecodableType    = DataModel::DecodableList<Structs::FabricDescriptor::DecodableType>;
+    using DecodableArgType = const DataModel::DecodableList<Structs::FabricDescriptor::DecodableType> &;
 
     static constexpr ClusterId GetClusterId() { return Clusters::OperationalCredentials::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FabricsList::Id; }
@@ -10118,8 +10492,9 @@ struct TypeInfo
 namespace SupportedFabrics {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::OperationalCredentials::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::SupportedFabrics::Id; }
@@ -10128,8 +10503,9 @@ struct TypeInfo
 namespace CommissionedFabrics {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::OperationalCredentials::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::CommissionedFabrics::Id; }
@@ -10138,8 +10514,9 @@ struct TypeInfo
 namespace TrustedRootCertificates {
 struct TypeInfo
 {
-    using Type          = DataModel::List<const chip::ByteSpan>;
-    using DecodableType = DataModel::DecodableList<chip::ByteSpan>;
+    using Type             = DataModel::List<const chip::ByteSpan>;
+    using DecodableType    = DataModel::DecodableList<chip::ByteSpan>;
+    using DecodableArgType = const DataModel::DecodableList<chip::ByteSpan> &;
 
     static constexpr ClusterId GetClusterId() { return Clusters::OperationalCredentials::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::TrustedRootCertificates::Id; }
@@ -10148,8 +10525,9 @@ struct TypeInfo
 namespace CurrentFabricIndex {
 struct TypeInfo
 {
-    using Type          = chip::FabricIndex;
-    using DecodableType = chip::FabricIndex;
+    using Type             = chip::FabricIndex;
+    using DecodableType    = chip::FabricIndex;
+    using DecodableArgType = chip::FabricIndex;
 
     static constexpr ClusterId GetClusterId() { return Clusters::OperationalCredentials::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::CurrentFabricIndex::Id; }
@@ -10158,8 +10536,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::OperationalCredentials::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -10168,8 +10547,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::OperationalCredentials::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -10206,8 +10586,9 @@ namespace Attributes {
 namespace LabelList {
 struct TypeInfo
 {
-    using Type          = DataModel::List<const Structs::LabelStruct::Type>;
-    using DecodableType = DataModel::DecodableList<Structs::LabelStruct::DecodableType>;
+    using Type             = DataModel::List<const Structs::LabelStruct::Type>;
+    using DecodableType    = DataModel::DecodableList<Structs::LabelStruct::DecodableType>;
+    using DecodableArgType = const DataModel::DecodableList<Structs::LabelStruct::DecodableType> &;
 
     static constexpr ClusterId GetClusterId() { return Clusters::FixedLabel::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::LabelList::Id; }
@@ -10216,8 +10597,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::FixedLabel::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -10226,8 +10608,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::FixedLabel::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -10241,8 +10624,9 @@ namespace Attributes {
 namespace StateValue {
 struct TypeInfo
 {
-    using Type          = bool;
-    using DecodableType = bool;
+    using Type             = bool;
+    using DecodableType    = bool;
+    using DecodableArgType = bool;
 
     static constexpr ClusterId GetClusterId() { return Clusters::BooleanState::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::StateValue::Id; }
@@ -10251,8 +10635,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::BooleanState::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -10261,8 +10646,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::BooleanState::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -10387,8 +10773,9 @@ namespace Attributes {
 namespace CurrentMode {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ModeSelect::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::CurrentMode::Id; }
@@ -10397,8 +10784,9 @@ struct TypeInfo
 namespace SupportedModes {
 struct TypeInfo
 {
-    using Type          = DataModel::List<const Structs::ModeOptionStruct::Type>;
-    using DecodableType = DataModel::DecodableList<Structs::ModeOptionStruct::DecodableType>;
+    using Type             = DataModel::List<const Structs::ModeOptionStruct::Type>;
+    using DecodableType    = DataModel::DecodableList<Structs::ModeOptionStruct::DecodableType>;
+    using DecodableArgType = const DataModel::DecodableList<Structs::ModeOptionStruct::DecodableType> &;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ModeSelect::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::SupportedModes::Id; }
@@ -10407,8 +10795,9 @@ struct TypeInfo
 namespace OnMode {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ModeSelect::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::OnMode::Id; }
@@ -10417,8 +10806,9 @@ struct TypeInfo
 namespace StartUpMode {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ModeSelect::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::StartUpMode::Id; }
@@ -10427,8 +10817,9 @@ struct TypeInfo
 namespace Description {
 struct TypeInfo
 {
-    using Type          = chip::CharSpan;
-    using DecodableType = chip::CharSpan;
+    using Type             = chip::CharSpan;
+    using DecodableType    = chip::CharSpan;
+    using DecodableArgType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ModeSelect::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Description::Id; }
@@ -10437,8 +10828,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ModeSelect::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -10447,8 +10839,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ModeSelect::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -10462,8 +10855,9 @@ namespace Attributes {
 namespace PhysicalClosedLimit {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ShadeConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::PhysicalClosedLimit::Id; }
@@ -10472,8 +10866,9 @@ struct TypeInfo
 namespace MotorStepSize {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ShadeConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MotorStepSize::Id; }
@@ -10482,8 +10877,9 @@ struct TypeInfo
 namespace Status {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ShadeConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Status::Id; }
@@ -10492,8 +10888,9 @@ struct TypeInfo
 namespace ClosedLimit {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ShadeConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClosedLimit::Id; }
@@ -10502,8 +10899,9 @@ struct TypeInfo
 namespace Mode {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ShadeConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Mode::Id; }
@@ -10512,8 +10910,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ShadeConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -10522,8 +10921,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ShadeConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -12340,8 +12740,9 @@ namespace Attributes {
 namespace LockState {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::LockState::Id; }
@@ -12350,8 +12751,9 @@ struct TypeInfo
 namespace LockType {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::LockType::Id; }
@@ -12360,8 +12762,9 @@ struct TypeInfo
 namespace ActuatorEnabled {
 struct TypeInfo
 {
-    using Type          = bool;
-    using DecodableType = bool;
+    using Type             = bool;
+    using DecodableType    = bool;
+    using DecodableArgType = bool;
 
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ActuatorEnabled::Id; }
@@ -12370,8 +12773,9 @@ struct TypeInfo
 namespace DoorState {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::DoorState::Id; }
@@ -12380,8 +12784,9 @@ struct TypeInfo
 namespace DoorOpenEvents {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::DoorOpenEvents::Id; }
@@ -12390,8 +12795,9 @@ struct TypeInfo
 namespace DoorClosedEvents {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::DoorClosedEvents::Id; }
@@ -12400,8 +12806,9 @@ struct TypeInfo
 namespace OpenPeriod {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::OpenPeriod::Id; }
@@ -12410,8 +12817,9 @@ struct TypeInfo
 namespace NumLockRecordsSupported {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::NumLockRecordsSupported::Id; }
@@ -12420,8 +12828,9 @@ struct TypeInfo
 namespace NumTotalUsersSupported {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::NumTotalUsersSupported::Id; }
@@ -12430,8 +12839,9 @@ struct TypeInfo
 namespace NumPinUsersSupported {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::NumPinUsersSupported::Id; }
@@ -12440,8 +12850,9 @@ struct TypeInfo
 namespace NumRfidUsersSupported {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::NumRfidUsersSupported::Id; }
@@ -12450,8 +12861,9 @@ struct TypeInfo
 namespace NumWeekdaySchedulesSupportedPerUser {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::NumWeekdaySchedulesSupportedPerUser::Id; }
@@ -12460,8 +12872,9 @@ struct TypeInfo
 namespace NumYeardaySchedulesSupportedPerUser {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::NumYeardaySchedulesSupportedPerUser::Id; }
@@ -12470,8 +12883,9 @@ struct TypeInfo
 namespace NumHolidaySchedulesSupportedPerUser {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::NumHolidaySchedulesSupportedPerUser::Id; }
@@ -12480,8 +12894,9 @@ struct TypeInfo
 namespace MaxPinLength {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MaxPinLength::Id; }
@@ -12490,8 +12905,9 @@ struct TypeInfo
 namespace MinPinLength {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MinPinLength::Id; }
@@ -12500,8 +12916,9 @@ struct TypeInfo
 namespace MaxRfidCodeLength {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MaxRfidCodeLength::Id; }
@@ -12510,8 +12927,9 @@ struct TypeInfo
 namespace MinRfidCodeLength {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MinRfidCodeLength::Id; }
@@ -12520,8 +12938,9 @@ struct TypeInfo
 namespace EnableLogging {
 struct TypeInfo
 {
-    using Type          = bool;
-    using DecodableType = bool;
+    using Type             = bool;
+    using DecodableType    = bool;
+    using DecodableArgType = bool;
 
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::EnableLogging::Id; }
@@ -12530,8 +12949,9 @@ struct TypeInfo
 namespace Language {
 struct TypeInfo
 {
-    using Type          = chip::CharSpan;
-    using DecodableType = chip::CharSpan;
+    using Type             = chip::CharSpan;
+    using DecodableType    = chip::CharSpan;
+    using DecodableArgType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Language::Id; }
@@ -12540,8 +12960,9 @@ struct TypeInfo
 namespace LedSettings {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::LedSettings::Id; }
@@ -12550,8 +12971,9 @@ struct TypeInfo
 namespace AutoRelockTime {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::AutoRelockTime::Id; }
@@ -12560,8 +12982,9 @@ struct TypeInfo
 namespace SoundVolume {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::SoundVolume::Id; }
@@ -12570,8 +12993,9 @@ struct TypeInfo
 namespace OperatingMode {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::OperatingMode::Id; }
@@ -12580,8 +13004,9 @@ struct TypeInfo
 namespace SupportedOperatingModes {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::SupportedOperatingModes::Id; }
@@ -12590,8 +13015,9 @@ struct TypeInfo
 namespace DefaultConfigurationRegister {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::DefaultConfigurationRegister::Id; }
@@ -12600,8 +13026,9 @@ struct TypeInfo
 namespace EnableLocalProgramming {
 struct TypeInfo
 {
-    using Type          = bool;
-    using DecodableType = bool;
+    using Type             = bool;
+    using DecodableType    = bool;
+    using DecodableArgType = bool;
 
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::EnableLocalProgramming::Id; }
@@ -12610,8 +13037,9 @@ struct TypeInfo
 namespace EnableOneTouchLocking {
 struct TypeInfo
 {
-    using Type          = bool;
-    using DecodableType = bool;
+    using Type             = bool;
+    using DecodableType    = bool;
+    using DecodableArgType = bool;
 
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::EnableOneTouchLocking::Id; }
@@ -12620,8 +13048,9 @@ struct TypeInfo
 namespace EnableInsideStatusLed {
 struct TypeInfo
 {
-    using Type          = bool;
-    using DecodableType = bool;
+    using Type             = bool;
+    using DecodableType    = bool;
+    using DecodableArgType = bool;
 
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::EnableInsideStatusLed::Id; }
@@ -12630,8 +13059,9 @@ struct TypeInfo
 namespace EnablePrivacyModeButton {
 struct TypeInfo
 {
-    using Type          = bool;
-    using DecodableType = bool;
+    using Type             = bool;
+    using DecodableType    = bool;
+    using DecodableArgType = bool;
 
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::EnablePrivacyModeButton::Id; }
@@ -12640,8 +13070,9 @@ struct TypeInfo
 namespace WrongCodeEntryLimit {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::WrongCodeEntryLimit::Id; }
@@ -12650,8 +13081,9 @@ struct TypeInfo
 namespace UserCodeTemporaryDisableTime {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::UserCodeTemporaryDisableTime::Id; }
@@ -12660,8 +13092,9 @@ struct TypeInfo
 namespace SendPinOverTheAir {
 struct TypeInfo
 {
-    using Type          = bool;
-    using DecodableType = bool;
+    using Type             = bool;
+    using DecodableType    = bool;
+    using DecodableArgType = bool;
 
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::SendPinOverTheAir::Id; }
@@ -12670,8 +13103,9 @@ struct TypeInfo
 namespace RequirePinForRfOperation {
 struct TypeInfo
 {
-    using Type          = bool;
-    using DecodableType = bool;
+    using Type             = bool;
+    using DecodableType    = bool;
+    using DecodableArgType = bool;
 
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::RequirePinForRfOperation::Id; }
@@ -12680,8 +13114,9 @@ struct TypeInfo
 namespace ZigbeeSecurityLevel {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ZigbeeSecurityLevel::Id; }
@@ -12690,8 +13125,9 @@ struct TypeInfo
 namespace AlarmMask {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::AlarmMask::Id; }
@@ -12700,8 +13136,9 @@ struct TypeInfo
 namespace KeypadOperationEventMask {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::KeypadOperationEventMask::Id; }
@@ -12710,8 +13147,9 @@ struct TypeInfo
 namespace RfOperationEventMask {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::RfOperationEventMask::Id; }
@@ -12720,8 +13158,9 @@ struct TypeInfo
 namespace ManualOperationEventMask {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ManualOperationEventMask::Id; }
@@ -12730,8 +13169,9 @@ struct TypeInfo
 namespace RfidOperationEventMask {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::RfidOperationEventMask::Id; }
@@ -12740,8 +13180,9 @@ struct TypeInfo
 namespace KeypadProgrammingEventMask {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::KeypadProgrammingEventMask::Id; }
@@ -12750,8 +13191,9 @@ struct TypeInfo
 namespace RfProgrammingEventMask {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::RfProgrammingEventMask::Id; }
@@ -12760,8 +13202,9 @@ struct TypeInfo
 namespace RfidProgrammingEventMask {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::RfidProgrammingEventMask::Id; }
@@ -12770,8 +13213,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -12780,8 +13224,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -13034,8 +13479,9 @@ namespace Attributes {
 namespace Type {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::WindowCovering::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Type::Id; }
@@ -13044,8 +13490,9 @@ struct TypeInfo
 namespace PhysicalClosedLimitLift {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::WindowCovering::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::PhysicalClosedLimitLift::Id; }
@@ -13054,8 +13501,9 @@ struct TypeInfo
 namespace PhysicalClosedLimitTilt {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::WindowCovering::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::PhysicalClosedLimitTilt::Id; }
@@ -13064,8 +13512,9 @@ struct TypeInfo
 namespace CurrentPositionLift {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::WindowCovering::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::CurrentPositionLift::Id; }
@@ -13074,8 +13523,9 @@ struct TypeInfo
 namespace CurrentPositionTilt {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::WindowCovering::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::CurrentPositionTilt::Id; }
@@ -13084,8 +13534,9 @@ struct TypeInfo
 namespace NumberOfActuationsLift {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::WindowCovering::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::NumberOfActuationsLift::Id; }
@@ -13094,8 +13545,9 @@ struct TypeInfo
 namespace NumberOfActuationsTilt {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::WindowCovering::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::NumberOfActuationsTilt::Id; }
@@ -13104,8 +13556,9 @@ struct TypeInfo
 namespace ConfigStatus {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::WindowCovering::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ConfigStatus::Id; }
@@ -13114,8 +13567,9 @@ struct TypeInfo
 namespace CurrentPositionLiftPercentage {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::WindowCovering::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::CurrentPositionLiftPercentage::Id; }
@@ -13124,8 +13578,9 @@ struct TypeInfo
 namespace CurrentPositionTiltPercentage {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::WindowCovering::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::CurrentPositionTiltPercentage::Id; }
@@ -13134,8 +13589,9 @@ struct TypeInfo
 namespace OperationalStatus {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::WindowCovering::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::OperationalStatus::Id; }
@@ -13144,8 +13600,9 @@ struct TypeInfo
 namespace TargetPositionLiftPercent100ths {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::WindowCovering::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::TargetPositionLiftPercent100ths::Id; }
@@ -13154,8 +13611,9 @@ struct TypeInfo
 namespace TargetPositionTiltPercent100ths {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::WindowCovering::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::TargetPositionTiltPercent100ths::Id; }
@@ -13164,8 +13622,9 @@ struct TypeInfo
 namespace EndProductType {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::WindowCovering::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::EndProductType::Id; }
@@ -13174,8 +13633,9 @@ struct TypeInfo
 namespace CurrentPositionLiftPercent100ths {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::WindowCovering::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::CurrentPositionLiftPercent100ths::Id; }
@@ -13184,8 +13644,9 @@ struct TypeInfo
 namespace CurrentPositionTiltPercent100ths {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::WindowCovering::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::CurrentPositionTiltPercent100ths::Id; }
@@ -13194,8 +13655,9 @@ struct TypeInfo
 namespace InstalledOpenLimitLift {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::WindowCovering::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::InstalledOpenLimitLift::Id; }
@@ -13204,8 +13666,9 @@ struct TypeInfo
 namespace InstalledClosedLimitLift {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::WindowCovering::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::InstalledClosedLimitLift::Id; }
@@ -13214,8 +13677,9 @@ struct TypeInfo
 namespace InstalledOpenLimitTilt {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::WindowCovering::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::InstalledOpenLimitTilt::Id; }
@@ -13224,8 +13688,9 @@ struct TypeInfo
 namespace InstalledClosedLimitTilt {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::WindowCovering::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::InstalledClosedLimitTilt::Id; }
@@ -13234,8 +13699,9 @@ struct TypeInfo
 namespace VelocityLift {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::WindowCovering::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::VelocityLift::Id; }
@@ -13244,8 +13710,9 @@ struct TypeInfo
 namespace AccelerationTimeLift {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::WindowCovering::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::AccelerationTimeLift::Id; }
@@ -13254,8 +13721,9 @@ struct TypeInfo
 namespace DecelerationTimeLift {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::WindowCovering::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::DecelerationTimeLift::Id; }
@@ -13264,8 +13732,9 @@ struct TypeInfo
 namespace Mode {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::WindowCovering::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Mode::Id; }
@@ -13274,8 +13743,9 @@ struct TypeInfo
 namespace IntermediateSetpointsLift {
 struct TypeInfo
 {
-    using Type          = chip::ByteSpan;
-    using DecodableType = chip::ByteSpan;
+    using Type             = chip::ByteSpan;
+    using DecodableType    = chip::ByteSpan;
+    using DecodableArgType = chip::ByteSpan;
 
     static constexpr ClusterId GetClusterId() { return Clusters::WindowCovering::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::IntermediateSetpointsLift::Id; }
@@ -13284,8 +13754,9 @@ struct TypeInfo
 namespace IntermediateSetpointsTilt {
 struct TypeInfo
 {
-    using Type          = chip::ByteSpan;
-    using DecodableType = chip::ByteSpan;
+    using Type             = chip::ByteSpan;
+    using DecodableType    = chip::ByteSpan;
+    using DecodableArgType = chip::ByteSpan;
 
     static constexpr ClusterId GetClusterId() { return Clusters::WindowCovering::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::IntermediateSetpointsTilt::Id; }
@@ -13294,8 +13765,9 @@ struct TypeInfo
 namespace SafetyStatus {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::WindowCovering::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::SafetyStatus::Id; }
@@ -13304,8 +13776,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::WindowCovering::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -13314,8 +13787,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::WindowCovering::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -13384,8 +13858,9 @@ namespace Attributes {
 namespace BarrierMovingState {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::BarrierControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::BarrierMovingState::Id; }
@@ -13394,8 +13869,9 @@ struct TypeInfo
 namespace BarrierSafetyStatus {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::BarrierControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::BarrierSafetyStatus::Id; }
@@ -13404,8 +13880,9 @@ struct TypeInfo
 namespace BarrierCapabilities {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::BarrierControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::BarrierCapabilities::Id; }
@@ -13414,8 +13891,9 @@ struct TypeInfo
 namespace BarrierOpenEvents {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::BarrierControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::BarrierOpenEvents::Id; }
@@ -13424,8 +13902,9 @@ struct TypeInfo
 namespace BarrierCloseEvents {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::BarrierControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::BarrierCloseEvents::Id; }
@@ -13434,8 +13913,9 @@ struct TypeInfo
 namespace BarrierCommandOpenEvents {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::BarrierControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::BarrierCommandOpenEvents::Id; }
@@ -13444,8 +13924,9 @@ struct TypeInfo
 namespace BarrierCommandCloseEvents {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::BarrierControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::BarrierCommandCloseEvents::Id; }
@@ -13454,8 +13935,9 @@ struct TypeInfo
 namespace BarrierOpenPeriod {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::BarrierControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::BarrierOpenPeriod::Id; }
@@ -13464,8 +13946,9 @@ struct TypeInfo
 namespace BarrierClosePeriod {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::BarrierControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::BarrierClosePeriod::Id; }
@@ -13474,8 +13957,9 @@ struct TypeInfo
 namespace BarrierPosition {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::BarrierControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::BarrierPosition::Id; }
@@ -13484,8 +13968,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::BarrierControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -13494,8 +13979,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::BarrierControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -13553,8 +14039,9 @@ namespace Attributes {
 namespace MaxPressure {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PumpConfigurationAndControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MaxPressure::Id; }
@@ -13563,8 +14050,9 @@ struct TypeInfo
 namespace MaxSpeed {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PumpConfigurationAndControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MaxSpeed::Id; }
@@ -13573,8 +14061,9 @@ struct TypeInfo
 namespace MaxFlow {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PumpConfigurationAndControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MaxFlow::Id; }
@@ -13583,8 +14072,9 @@ struct TypeInfo
 namespace MinConstPressure {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PumpConfigurationAndControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MinConstPressure::Id; }
@@ -13593,8 +14083,9 @@ struct TypeInfo
 namespace MaxConstPressure {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PumpConfigurationAndControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MaxConstPressure::Id; }
@@ -13603,8 +14094,9 @@ struct TypeInfo
 namespace MinCompPressure {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PumpConfigurationAndControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MinCompPressure::Id; }
@@ -13613,8 +14105,9 @@ struct TypeInfo
 namespace MaxCompPressure {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PumpConfigurationAndControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MaxCompPressure::Id; }
@@ -13623,8 +14116,9 @@ struct TypeInfo
 namespace MinConstSpeed {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PumpConfigurationAndControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MinConstSpeed::Id; }
@@ -13633,8 +14127,9 @@ struct TypeInfo
 namespace MaxConstSpeed {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PumpConfigurationAndControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MaxConstSpeed::Id; }
@@ -13643,8 +14138,9 @@ struct TypeInfo
 namespace MinConstFlow {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PumpConfigurationAndControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MinConstFlow::Id; }
@@ -13653,8 +14149,9 @@ struct TypeInfo
 namespace MaxConstFlow {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PumpConfigurationAndControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MaxConstFlow::Id; }
@@ -13663,8 +14160,9 @@ struct TypeInfo
 namespace MinConstTemp {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PumpConfigurationAndControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MinConstTemp::Id; }
@@ -13673,8 +14171,9 @@ struct TypeInfo
 namespace MaxConstTemp {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PumpConfigurationAndControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MaxConstTemp::Id; }
@@ -13683,8 +14182,9 @@ struct TypeInfo
 namespace PumpStatus {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PumpConfigurationAndControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::PumpStatus::Id; }
@@ -13693,8 +14193,9 @@ struct TypeInfo
 namespace EffectiveOperationMode {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PumpConfigurationAndControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::EffectiveOperationMode::Id; }
@@ -13703,8 +14204,9 @@ struct TypeInfo
 namespace EffectiveControlMode {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PumpConfigurationAndControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::EffectiveControlMode::Id; }
@@ -13713,8 +14215,9 @@ struct TypeInfo
 namespace Capacity {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PumpConfigurationAndControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Capacity::Id; }
@@ -13723,8 +14226,9 @@ struct TypeInfo
 namespace Speed {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PumpConfigurationAndControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Speed::Id; }
@@ -13733,8 +14237,9 @@ struct TypeInfo
 namespace LifetimeRunningHours {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PumpConfigurationAndControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::LifetimeRunningHours::Id; }
@@ -13743,8 +14248,9 @@ struct TypeInfo
 namespace Power {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PumpConfigurationAndControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Power::Id; }
@@ -13753,8 +14259,9 @@ struct TypeInfo
 namespace LifetimeEnergyConsumed {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PumpConfigurationAndControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::LifetimeEnergyConsumed::Id; }
@@ -13763,8 +14270,9 @@ struct TypeInfo
 namespace OperationMode {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PumpConfigurationAndControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::OperationMode::Id; }
@@ -13773,8 +14281,9 @@ struct TypeInfo
 namespace ControlMode {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PumpConfigurationAndControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ControlMode::Id; }
@@ -13783,8 +14292,9 @@ struct TypeInfo
 namespace AlarmMask {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PumpConfigurationAndControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::AlarmMask::Id; }
@@ -13793,8 +14303,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PumpConfigurationAndControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -13803,8 +14314,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PumpConfigurationAndControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -14559,8 +15071,9 @@ namespace Attributes {
 namespace LocalTemperature {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Thermostat::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::LocalTemperature::Id; }
@@ -14569,8 +15082,9 @@ struct TypeInfo
 namespace OutdoorTemperature {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Thermostat::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::OutdoorTemperature::Id; }
@@ -14579,8 +15093,9 @@ struct TypeInfo
 namespace Occupancy {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Thermostat::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Occupancy::Id; }
@@ -14589,8 +15104,9 @@ struct TypeInfo
 namespace AbsMinHeatSetpointLimit {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Thermostat::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::AbsMinHeatSetpointLimit::Id; }
@@ -14599,8 +15115,9 @@ struct TypeInfo
 namespace AbsMaxHeatSetpointLimit {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Thermostat::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::AbsMaxHeatSetpointLimit::Id; }
@@ -14609,8 +15126,9 @@ struct TypeInfo
 namespace AbsMinCoolSetpointLimit {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Thermostat::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::AbsMinCoolSetpointLimit::Id; }
@@ -14619,8 +15137,9 @@ struct TypeInfo
 namespace AbsMaxCoolSetpointLimit {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Thermostat::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::AbsMaxCoolSetpointLimit::Id; }
@@ -14629,8 +15148,9 @@ struct TypeInfo
 namespace PiCoolingDemand {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Thermostat::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::PiCoolingDemand::Id; }
@@ -14639,8 +15159,9 @@ struct TypeInfo
 namespace PiHeatingDemand {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Thermostat::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::PiHeatingDemand::Id; }
@@ -14649,8 +15170,9 @@ struct TypeInfo
 namespace HvacSystemTypeConfiguration {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Thermostat::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::HvacSystemTypeConfiguration::Id; }
@@ -14659,8 +15181,9 @@ struct TypeInfo
 namespace LocalTemperatureCalibration {
 struct TypeInfo
 {
-    using Type          = int8_t;
-    using DecodableType = int8_t;
+    using Type             = int8_t;
+    using DecodableType    = int8_t;
+    using DecodableArgType = int8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Thermostat::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::LocalTemperatureCalibration::Id; }
@@ -14669,8 +15192,9 @@ struct TypeInfo
 namespace OccupiedCoolingSetpoint {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Thermostat::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::OccupiedCoolingSetpoint::Id; }
@@ -14679,8 +15203,9 @@ struct TypeInfo
 namespace OccupiedHeatingSetpoint {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Thermostat::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::OccupiedHeatingSetpoint::Id; }
@@ -14689,8 +15214,9 @@ struct TypeInfo
 namespace UnoccupiedCoolingSetpoint {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Thermostat::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::UnoccupiedCoolingSetpoint::Id; }
@@ -14699,8 +15225,9 @@ struct TypeInfo
 namespace UnoccupiedHeatingSetpoint {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Thermostat::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::UnoccupiedHeatingSetpoint::Id; }
@@ -14709,8 +15236,9 @@ struct TypeInfo
 namespace MinHeatSetpointLimit {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Thermostat::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MinHeatSetpointLimit::Id; }
@@ -14719,8 +15247,9 @@ struct TypeInfo
 namespace MaxHeatSetpointLimit {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Thermostat::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MaxHeatSetpointLimit::Id; }
@@ -14729,8 +15258,9 @@ struct TypeInfo
 namespace MinCoolSetpointLimit {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Thermostat::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MinCoolSetpointLimit::Id; }
@@ -14739,8 +15269,9 @@ struct TypeInfo
 namespace MaxCoolSetpointLimit {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Thermostat::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MaxCoolSetpointLimit::Id; }
@@ -14749,8 +15280,9 @@ struct TypeInfo
 namespace MinSetpointDeadBand {
 struct TypeInfo
 {
-    using Type          = int8_t;
-    using DecodableType = int8_t;
+    using Type             = int8_t;
+    using DecodableType    = int8_t;
+    using DecodableArgType = int8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Thermostat::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MinSetpointDeadBand::Id; }
@@ -14759,8 +15291,9 @@ struct TypeInfo
 namespace RemoteSensing {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Thermostat::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::RemoteSensing::Id; }
@@ -14769,8 +15302,9 @@ struct TypeInfo
 namespace ControlSequenceOfOperation {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Thermostat::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ControlSequenceOfOperation::Id; }
@@ -14779,8 +15313,9 @@ struct TypeInfo
 namespace SystemMode {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Thermostat::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::SystemMode::Id; }
@@ -14789,8 +15324,9 @@ struct TypeInfo
 namespace AlarmMask {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Thermostat::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::AlarmMask::Id; }
@@ -14799,8 +15335,9 @@ struct TypeInfo
 namespace ThermostatRunningMode {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Thermostat::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ThermostatRunningMode::Id; }
@@ -14809,8 +15346,9 @@ struct TypeInfo
 namespace StartOfWeek {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Thermostat::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::StartOfWeek::Id; }
@@ -14819,8 +15357,9 @@ struct TypeInfo
 namespace NumberOfWeeklyTransitions {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Thermostat::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::NumberOfWeeklyTransitions::Id; }
@@ -14829,8 +15368,9 @@ struct TypeInfo
 namespace NumberOfDailyTransitions {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Thermostat::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::NumberOfDailyTransitions::Id; }
@@ -14839,8 +15379,9 @@ struct TypeInfo
 namespace TemperatureSetpointHold {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Thermostat::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::TemperatureSetpointHold::Id; }
@@ -14849,8 +15390,9 @@ struct TypeInfo
 namespace TemperatureSetpointHoldDuration {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Thermostat::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::TemperatureSetpointHoldDuration::Id; }
@@ -14859,8 +15401,9 @@ struct TypeInfo
 namespace ThermostatProgrammingOperationMode {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Thermostat::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ThermostatProgrammingOperationMode::Id; }
@@ -14869,8 +15412,9 @@ struct TypeInfo
 namespace HvacRelayState {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Thermostat::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::HvacRelayState::Id; }
@@ -14879,8 +15423,9 @@ struct TypeInfo
 namespace SetpointChangeSource {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Thermostat::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::SetpointChangeSource::Id; }
@@ -14889,8 +15434,9 @@ struct TypeInfo
 namespace SetpointChangeAmount {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Thermostat::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::SetpointChangeAmount::Id; }
@@ -14899,8 +15445,9 @@ struct TypeInfo
 namespace SetpointChangeSourceTimestamp {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Thermostat::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::SetpointChangeSourceTimestamp::Id; }
@@ -14909,8 +15456,9 @@ struct TypeInfo
 namespace AcType {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Thermostat::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::AcType::Id; }
@@ -14919,8 +15467,9 @@ struct TypeInfo
 namespace AcCapacity {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Thermostat::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::AcCapacity::Id; }
@@ -14929,8 +15478,9 @@ struct TypeInfo
 namespace AcRefrigerantType {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Thermostat::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::AcRefrigerantType::Id; }
@@ -14939,8 +15489,9 @@ struct TypeInfo
 namespace AcCompressor {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Thermostat::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::AcCompressor::Id; }
@@ -14949,8 +15500,9 @@ struct TypeInfo
 namespace AcErrorCode {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Thermostat::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::AcErrorCode::Id; }
@@ -14959,8 +15511,9 @@ struct TypeInfo
 namespace AcLouverPosition {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Thermostat::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::AcLouverPosition::Id; }
@@ -14969,8 +15522,9 @@ struct TypeInfo
 namespace AcCoilTemperature {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Thermostat::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::AcCoilTemperature::Id; }
@@ -14979,8 +15533,9 @@ struct TypeInfo
 namespace AcCapacityFormat {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Thermostat::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::AcCapacityFormat::Id; }
@@ -14989,8 +15544,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Thermostat::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -14999,8 +15555,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Thermostat::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -15014,8 +15571,9 @@ namespace Attributes {
 namespace FanMode {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::FanControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FanMode::Id; }
@@ -15024,8 +15582,9 @@ struct TypeInfo
 namespace FanModeSequence {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::FanControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FanModeSequence::Id; }
@@ -15034,8 +15593,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::FanControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -15044,8 +15604,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::FanControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -15059,8 +15620,9 @@ namespace Attributes {
 namespace RelativeHumidity {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::DehumidificationControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::RelativeHumidity::Id; }
@@ -15069,8 +15631,9 @@ struct TypeInfo
 namespace DehumidificationCooling {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::DehumidificationControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::DehumidificationCooling::Id; }
@@ -15079,8 +15642,9 @@ struct TypeInfo
 namespace RhDehumidificationSetpoint {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::DehumidificationControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::RhDehumidificationSetpoint::Id; }
@@ -15089,8 +15653,9 @@ struct TypeInfo
 namespace RelativeHumidityMode {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::DehumidificationControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::RelativeHumidityMode::Id; }
@@ -15099,8 +15664,9 @@ struct TypeInfo
 namespace DehumidificationLockout {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::DehumidificationControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::DehumidificationLockout::Id; }
@@ -15109,8 +15675,9 @@ struct TypeInfo
 namespace DehumidificationHysteresis {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::DehumidificationControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::DehumidificationHysteresis::Id; }
@@ -15119,8 +15686,9 @@ struct TypeInfo
 namespace DehumidificationMaxCool {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::DehumidificationControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::DehumidificationMaxCool::Id; }
@@ -15129,8 +15697,9 @@ struct TypeInfo
 namespace RelativeHumidityDisplay {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::DehumidificationControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::RelativeHumidityDisplay::Id; }
@@ -15139,8 +15708,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::DehumidificationControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -15149,8 +15719,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::DehumidificationControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -15164,8 +15735,9 @@ namespace Attributes {
 namespace TemperatureDisplayMode {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ThermostatUserInterfaceConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::TemperatureDisplayMode::Id; }
@@ -15174,8 +15746,9 @@ struct TypeInfo
 namespace KeypadLockout {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ThermostatUserInterfaceConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::KeypadLockout::Id; }
@@ -15184,8 +15757,9 @@ struct TypeInfo
 namespace ScheduleProgrammingVisibility {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ThermostatUserInterfaceConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ScheduleProgrammingVisibility::Id; }
@@ -15194,8 +15768,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ThermostatUserInterfaceConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -15204,8 +15779,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ThermostatUserInterfaceConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -16091,8 +16667,9 @@ namespace Attributes {
 namespace CurrentHue {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::CurrentHue::Id; }
@@ -16101,8 +16678,9 @@ struct TypeInfo
 namespace CurrentSaturation {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::CurrentSaturation::Id; }
@@ -16111,8 +16689,9 @@ struct TypeInfo
 namespace RemainingTime {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::RemainingTime::Id; }
@@ -16121,8 +16700,9 @@ struct TypeInfo
 namespace CurrentX {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::CurrentX::Id; }
@@ -16131,8 +16711,9 @@ struct TypeInfo
 namespace CurrentY {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::CurrentY::Id; }
@@ -16141,8 +16722,9 @@ struct TypeInfo
 namespace DriftCompensation {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::DriftCompensation::Id; }
@@ -16151,8 +16733,9 @@ struct TypeInfo
 namespace CompensationText {
 struct TypeInfo
 {
-    using Type          = chip::CharSpan;
-    using DecodableType = chip::CharSpan;
+    using Type             = chip::CharSpan;
+    using DecodableType    = chip::CharSpan;
+    using DecodableArgType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::CompensationText::Id; }
@@ -16161,8 +16744,9 @@ struct TypeInfo
 namespace ColorTemperature {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ColorTemperature::Id; }
@@ -16171,8 +16755,9 @@ struct TypeInfo
 namespace ColorMode {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ColorMode::Id; }
@@ -16181,8 +16766,9 @@ struct TypeInfo
 namespace ColorControlOptions {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ColorControlOptions::Id; }
@@ -16191,8 +16777,9 @@ struct TypeInfo
 namespace NumberOfPrimaries {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::NumberOfPrimaries::Id; }
@@ -16201,8 +16788,9 @@ struct TypeInfo
 namespace Primary1X {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Primary1X::Id; }
@@ -16211,8 +16799,9 @@ struct TypeInfo
 namespace Primary1Y {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Primary1Y::Id; }
@@ -16221,8 +16810,9 @@ struct TypeInfo
 namespace Primary1Intensity {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Primary1Intensity::Id; }
@@ -16231,8 +16821,9 @@ struct TypeInfo
 namespace Primary2X {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Primary2X::Id; }
@@ -16241,8 +16832,9 @@ struct TypeInfo
 namespace Primary2Y {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Primary2Y::Id; }
@@ -16251,8 +16843,9 @@ struct TypeInfo
 namespace Primary2Intensity {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Primary2Intensity::Id; }
@@ -16261,8 +16854,9 @@ struct TypeInfo
 namespace Primary3X {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Primary3X::Id; }
@@ -16271,8 +16865,9 @@ struct TypeInfo
 namespace Primary3Y {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Primary3Y::Id; }
@@ -16281,8 +16876,9 @@ struct TypeInfo
 namespace Primary3Intensity {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Primary3Intensity::Id; }
@@ -16291,8 +16887,9 @@ struct TypeInfo
 namespace Primary4X {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Primary4X::Id; }
@@ -16301,8 +16898,9 @@ struct TypeInfo
 namespace Primary4Y {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Primary4Y::Id; }
@@ -16311,8 +16909,9 @@ struct TypeInfo
 namespace Primary4Intensity {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Primary4Intensity::Id; }
@@ -16321,8 +16920,9 @@ struct TypeInfo
 namespace Primary5X {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Primary5X::Id; }
@@ -16331,8 +16931,9 @@ struct TypeInfo
 namespace Primary5Y {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Primary5Y::Id; }
@@ -16341,8 +16942,9 @@ struct TypeInfo
 namespace Primary5Intensity {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Primary5Intensity::Id; }
@@ -16351,8 +16953,9 @@ struct TypeInfo
 namespace Primary6X {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Primary6X::Id; }
@@ -16361,8 +16964,9 @@ struct TypeInfo
 namespace Primary6Y {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Primary6Y::Id; }
@@ -16371,8 +16975,9 @@ struct TypeInfo
 namespace Primary6Intensity {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Primary6Intensity::Id; }
@@ -16381,8 +16986,9 @@ struct TypeInfo
 namespace WhitePointX {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::WhitePointX::Id; }
@@ -16391,8 +16997,9 @@ struct TypeInfo
 namespace WhitePointY {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::WhitePointY::Id; }
@@ -16401,8 +17008,9 @@ struct TypeInfo
 namespace ColorPointRX {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ColorPointRX::Id; }
@@ -16411,8 +17019,9 @@ struct TypeInfo
 namespace ColorPointRY {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ColorPointRY::Id; }
@@ -16421,8 +17030,9 @@ struct TypeInfo
 namespace ColorPointRIntensity {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ColorPointRIntensity::Id; }
@@ -16431,8 +17041,9 @@ struct TypeInfo
 namespace ColorPointGX {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ColorPointGX::Id; }
@@ -16441,8 +17052,9 @@ struct TypeInfo
 namespace ColorPointGY {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ColorPointGY::Id; }
@@ -16451,8 +17063,9 @@ struct TypeInfo
 namespace ColorPointGIntensity {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ColorPointGIntensity::Id; }
@@ -16461,8 +17074,9 @@ struct TypeInfo
 namespace ColorPointBX {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ColorPointBX::Id; }
@@ -16471,8 +17085,9 @@ struct TypeInfo
 namespace ColorPointBY {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ColorPointBY::Id; }
@@ -16481,8 +17096,9 @@ struct TypeInfo
 namespace ColorPointBIntensity {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ColorPointBIntensity::Id; }
@@ -16491,8 +17107,9 @@ struct TypeInfo
 namespace EnhancedCurrentHue {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::EnhancedCurrentHue::Id; }
@@ -16501,8 +17118,9 @@ struct TypeInfo
 namespace EnhancedColorMode {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::EnhancedColorMode::Id; }
@@ -16511,8 +17129,9 @@ struct TypeInfo
 namespace ColorLoopActive {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ColorLoopActive::Id; }
@@ -16521,8 +17140,9 @@ struct TypeInfo
 namespace ColorLoopDirection {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ColorLoopDirection::Id; }
@@ -16531,8 +17151,9 @@ struct TypeInfo
 namespace ColorLoopTime {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ColorLoopTime::Id; }
@@ -16541,8 +17162,9 @@ struct TypeInfo
 namespace ColorLoopStartEnhancedHue {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ColorLoopStartEnhancedHue::Id; }
@@ -16551,8 +17173,9 @@ struct TypeInfo
 namespace ColorLoopStoredEnhancedHue {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ColorLoopStoredEnhancedHue::Id; }
@@ -16561,8 +17184,9 @@ struct TypeInfo
 namespace ColorCapabilities {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ColorCapabilities::Id; }
@@ -16571,8 +17195,9 @@ struct TypeInfo
 namespace ColorTempPhysicalMin {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ColorTempPhysicalMin::Id; }
@@ -16581,8 +17206,9 @@ struct TypeInfo
 namespace ColorTempPhysicalMax {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ColorTempPhysicalMax::Id; }
@@ -16591,8 +17217,9 @@ struct TypeInfo
 namespace CoupleColorTempToLevelMinMireds {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::CoupleColorTempToLevelMinMireds::Id; }
@@ -16601,8 +17228,9 @@ struct TypeInfo
 namespace StartUpColorTemperatureMireds {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::StartUpColorTemperatureMireds::Id; }
@@ -16611,8 +17239,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -16621,8 +17250,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ColorControl::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -16636,8 +17266,9 @@ namespace Attributes {
 namespace PhysicalMinLevel {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::BallastConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::PhysicalMinLevel::Id; }
@@ -16646,8 +17277,9 @@ struct TypeInfo
 namespace PhysicalMaxLevel {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::BallastConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::PhysicalMaxLevel::Id; }
@@ -16656,8 +17288,9 @@ struct TypeInfo
 namespace BallastStatus {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::BallastConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::BallastStatus::Id; }
@@ -16666,8 +17299,9 @@ struct TypeInfo
 namespace MinLevel {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::BallastConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MinLevel::Id; }
@@ -16676,8 +17310,9 @@ struct TypeInfo
 namespace MaxLevel {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::BallastConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MaxLevel::Id; }
@@ -16686,8 +17321,9 @@ struct TypeInfo
 namespace PowerOnLevel {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::BallastConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::PowerOnLevel::Id; }
@@ -16696,8 +17332,9 @@ struct TypeInfo
 namespace PowerOnFadeTime {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::BallastConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::PowerOnFadeTime::Id; }
@@ -16706,8 +17343,9 @@ struct TypeInfo
 namespace IntrinsicBallastFactor {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::BallastConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::IntrinsicBallastFactor::Id; }
@@ -16716,8 +17354,9 @@ struct TypeInfo
 namespace BallastFactorAdjustment {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::BallastConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::BallastFactorAdjustment::Id; }
@@ -16726,8 +17365,9 @@ struct TypeInfo
 namespace LampQuality {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::BallastConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::LampQuality::Id; }
@@ -16736,8 +17376,9 @@ struct TypeInfo
 namespace LampType {
 struct TypeInfo
 {
-    using Type          = chip::CharSpan;
-    using DecodableType = chip::CharSpan;
+    using Type             = chip::CharSpan;
+    using DecodableType    = chip::CharSpan;
+    using DecodableArgType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return Clusters::BallastConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::LampType::Id; }
@@ -16746,8 +17387,9 @@ struct TypeInfo
 namespace LampManufacturer {
 struct TypeInfo
 {
-    using Type          = chip::CharSpan;
-    using DecodableType = chip::CharSpan;
+    using Type             = chip::CharSpan;
+    using DecodableType    = chip::CharSpan;
+    using DecodableArgType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return Clusters::BallastConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::LampManufacturer::Id; }
@@ -16756,8 +17398,9 @@ struct TypeInfo
 namespace LampRatedHours {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::BallastConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::LampRatedHours::Id; }
@@ -16766,8 +17409,9 @@ struct TypeInfo
 namespace LampBurnHours {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::BallastConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::LampBurnHours::Id; }
@@ -16776,8 +17420,9 @@ struct TypeInfo
 namespace LampAlarmMode {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::BallastConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::LampAlarmMode::Id; }
@@ -16786,8 +17431,9 @@ struct TypeInfo
 namespace LampBurnHoursTripPoint {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::BallastConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::LampBurnHoursTripPoint::Id; }
@@ -16796,8 +17442,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::BallastConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -16806,8 +17453,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::BallastConfiguration::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -16833,8 +17481,9 @@ namespace Attributes {
 namespace MeasuredValue {
 struct TypeInfo
 {
-    using Type          = DataModel::Nullable<uint16_t>;
-    using DecodableType = DataModel::Nullable<uint16_t>;
+    using Type             = DataModel::Nullable<uint16_t>;
+    using DecodableType    = DataModel::Nullable<uint16_t>;
+    using DecodableArgType = const DataModel::Nullable<uint16_t> &;
 
     static constexpr ClusterId GetClusterId() { return Clusters::IlluminanceMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MeasuredValue::Id; }
@@ -16843,8 +17492,9 @@ struct TypeInfo
 namespace MinMeasuredValue {
 struct TypeInfo
 {
-    using Type          = DataModel::Nullable<uint16_t>;
-    using DecodableType = DataModel::Nullable<uint16_t>;
+    using Type             = DataModel::Nullable<uint16_t>;
+    using DecodableType    = DataModel::Nullable<uint16_t>;
+    using DecodableArgType = const DataModel::Nullable<uint16_t> &;
 
     static constexpr ClusterId GetClusterId() { return Clusters::IlluminanceMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MinMeasuredValue::Id; }
@@ -16853,8 +17503,9 @@ struct TypeInfo
 namespace MaxMeasuredValue {
 struct TypeInfo
 {
-    using Type          = DataModel::Nullable<uint16_t>;
-    using DecodableType = DataModel::Nullable<uint16_t>;
+    using Type             = DataModel::Nullable<uint16_t>;
+    using DecodableType    = DataModel::Nullable<uint16_t>;
+    using DecodableArgType = const DataModel::Nullable<uint16_t> &;
 
     static constexpr ClusterId GetClusterId() { return Clusters::IlluminanceMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MaxMeasuredValue::Id; }
@@ -16863,8 +17514,9 @@ struct TypeInfo
 namespace Tolerance {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::IlluminanceMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Tolerance::Id; }
@@ -16873,8 +17525,9 @@ struct TypeInfo
 namespace LightSensorType {
 struct TypeInfo
 {
-    using Type          = DataModel::Nullable<uint8_t>;
-    using DecodableType = DataModel::Nullable<uint8_t>;
+    using Type             = DataModel::Nullable<uint8_t>;
+    using DecodableType    = DataModel::Nullable<uint8_t>;
+    using DecodableArgType = const DataModel::Nullable<uint8_t> &;
 
     static constexpr ClusterId GetClusterId() { return Clusters::IlluminanceMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::LightSensorType::Id; }
@@ -16883,8 +17536,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::IlluminanceMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -16893,8 +17547,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::IlluminanceMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -16908,8 +17563,9 @@ namespace Attributes {
 namespace MeasuredValue {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::TemperatureMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MeasuredValue::Id; }
@@ -16918,8 +17574,9 @@ struct TypeInfo
 namespace MinMeasuredValue {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::TemperatureMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MinMeasuredValue::Id; }
@@ -16928,8 +17585,9 @@ struct TypeInfo
 namespace MaxMeasuredValue {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::TemperatureMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MaxMeasuredValue::Id; }
@@ -16938,8 +17596,9 @@ struct TypeInfo
 namespace Tolerance {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::TemperatureMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Tolerance::Id; }
@@ -16948,8 +17607,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::TemperatureMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -16958,8 +17618,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::TemperatureMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -16973,8 +17634,9 @@ namespace Attributes {
 namespace MeasuredValue {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PressureMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MeasuredValue::Id; }
@@ -16983,8 +17645,9 @@ struct TypeInfo
 namespace MinMeasuredValue {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PressureMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MinMeasuredValue::Id; }
@@ -16993,8 +17656,9 @@ struct TypeInfo
 namespace MaxMeasuredValue {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PressureMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MaxMeasuredValue::Id; }
@@ -17003,8 +17667,9 @@ struct TypeInfo
 namespace Tolerance {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PressureMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Tolerance::Id; }
@@ -17013,8 +17678,9 @@ struct TypeInfo
 namespace ScaledValue {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PressureMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ScaledValue::Id; }
@@ -17023,8 +17689,9 @@ struct TypeInfo
 namespace MinScaledValue {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PressureMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MinScaledValue::Id; }
@@ -17033,8 +17700,9 @@ struct TypeInfo
 namespace MaxScaledValue {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PressureMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MaxScaledValue::Id; }
@@ -17043,8 +17711,9 @@ struct TypeInfo
 namespace ScaledTolerance {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PressureMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ScaledTolerance::Id; }
@@ -17053,8 +17722,9 @@ struct TypeInfo
 namespace Scale {
 struct TypeInfo
 {
-    using Type          = int8_t;
-    using DecodableType = int8_t;
+    using Type             = int8_t;
+    using DecodableType    = int8_t;
+    using DecodableArgType = int8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PressureMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Scale::Id; }
@@ -17063,8 +17733,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PressureMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -17073,8 +17744,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::PressureMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -17088,8 +17760,9 @@ namespace Attributes {
 namespace MeasuredValue {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::FlowMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MeasuredValue::Id; }
@@ -17098,8 +17771,9 @@ struct TypeInfo
 namespace MinMeasuredValue {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::FlowMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MinMeasuredValue::Id; }
@@ -17108,8 +17782,9 @@ struct TypeInfo
 namespace MaxMeasuredValue {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::FlowMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MaxMeasuredValue::Id; }
@@ -17118,8 +17793,9 @@ struct TypeInfo
 namespace Tolerance {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::FlowMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Tolerance::Id; }
@@ -17128,8 +17804,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::FlowMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -17138,8 +17815,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::FlowMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -17153,8 +17831,9 @@ namespace Attributes {
 namespace MeasuredValue {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::RelativeHumidityMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MeasuredValue::Id; }
@@ -17163,8 +17842,9 @@ struct TypeInfo
 namespace MinMeasuredValue {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::RelativeHumidityMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MinMeasuredValue::Id; }
@@ -17173,8 +17853,9 @@ struct TypeInfo
 namespace MaxMeasuredValue {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::RelativeHumidityMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MaxMeasuredValue::Id; }
@@ -17183,8 +17864,9 @@ struct TypeInfo
 namespace Tolerance {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::RelativeHumidityMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Tolerance::Id; }
@@ -17193,8 +17875,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::RelativeHumidityMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -17203,8 +17886,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::RelativeHumidityMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -17218,8 +17902,9 @@ namespace Attributes {
 namespace Occupancy {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::OccupancySensing::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Occupancy::Id; }
@@ -17228,8 +17913,9 @@ struct TypeInfo
 namespace OccupancySensorType {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::OccupancySensing::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::OccupancySensorType::Id; }
@@ -17238,8 +17924,9 @@ struct TypeInfo
 namespace OccupancySensorTypeBitmap {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::OccupancySensing::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::OccupancySensorTypeBitmap::Id; }
@@ -17248,8 +17935,9 @@ struct TypeInfo
 namespace PirOccupiedToUnoccupiedDelay {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::OccupancySensing::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::PirOccupiedToUnoccupiedDelay::Id; }
@@ -17258,8 +17946,9 @@ struct TypeInfo
 namespace PirUnoccupiedToOccupiedDelay {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::OccupancySensing::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::PirUnoccupiedToOccupiedDelay::Id; }
@@ -17268,8 +17957,9 @@ struct TypeInfo
 namespace PirUnoccupiedToOccupiedThreshold {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::OccupancySensing::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::PirUnoccupiedToOccupiedThreshold::Id; }
@@ -17278,8 +17968,9 @@ struct TypeInfo
 namespace UltrasonicOccupiedToUnoccupiedDelay {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::OccupancySensing::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::UltrasonicOccupiedToUnoccupiedDelay::Id; }
@@ -17288,8 +17979,9 @@ struct TypeInfo
 namespace UltrasonicUnoccupiedToOccupiedDelay {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::OccupancySensing::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::UltrasonicUnoccupiedToOccupiedDelay::Id; }
@@ -17298,8 +17990,9 @@ struct TypeInfo
 namespace UltrasonicUnoccupiedToOccupiedThreshold {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::OccupancySensing::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::UltrasonicUnoccupiedToOccupiedThreshold::Id; }
@@ -17308,8 +18001,9 @@ struct TypeInfo
 namespace PhysicalContactOccupiedToUnoccupiedDelay {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::OccupancySensing::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::PhysicalContactOccupiedToUnoccupiedDelay::Id; }
@@ -17318,8 +18012,9 @@ struct TypeInfo
 namespace PhysicalContactUnoccupiedToOccupiedDelay {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::OccupancySensing::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::PhysicalContactUnoccupiedToOccupiedDelay::Id; }
@@ -17328,8 +18023,9 @@ struct TypeInfo
 namespace PhysicalContactUnoccupiedToOccupiedThreshold {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::OccupancySensing::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::PhysicalContactUnoccupiedToOccupiedThreshold::Id; }
@@ -17338,8 +18034,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::OccupancySensing::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -17348,8 +18045,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::OccupancySensing::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -17363,8 +18061,9 @@ namespace Attributes {
 namespace MeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::CarbonMonoxideConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MeasuredValue::Id; }
@@ -17373,8 +18072,9 @@ struct TypeInfo
 namespace MinMeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::CarbonMonoxideConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MinMeasuredValue::Id; }
@@ -17383,8 +18083,9 @@ struct TypeInfo
 namespace MaxMeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::CarbonMonoxideConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MaxMeasuredValue::Id; }
@@ -17393,8 +18094,9 @@ struct TypeInfo
 namespace Tolerance {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::CarbonMonoxideConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Tolerance::Id; }
@@ -17403,8 +18105,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::CarbonMonoxideConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -17413,8 +18116,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::CarbonMonoxideConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -17428,8 +18132,9 @@ namespace Attributes {
 namespace MeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::CarbonDioxideConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MeasuredValue::Id; }
@@ -17438,8 +18143,9 @@ struct TypeInfo
 namespace MinMeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::CarbonDioxideConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MinMeasuredValue::Id; }
@@ -17448,8 +18154,9 @@ struct TypeInfo
 namespace MaxMeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::CarbonDioxideConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MaxMeasuredValue::Id; }
@@ -17458,8 +18165,9 @@ struct TypeInfo
 namespace Tolerance {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::CarbonDioxideConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Tolerance::Id; }
@@ -17468,8 +18176,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::CarbonDioxideConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -17478,8 +18187,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::CarbonDioxideConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -17493,8 +18203,9 @@ namespace Attributes {
 namespace MeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::EthyleneConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MeasuredValue::Id; }
@@ -17503,8 +18214,9 @@ struct TypeInfo
 namespace MinMeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::EthyleneConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MinMeasuredValue::Id; }
@@ -17513,8 +18225,9 @@ struct TypeInfo
 namespace MaxMeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::EthyleneConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MaxMeasuredValue::Id; }
@@ -17523,8 +18236,9 @@ struct TypeInfo
 namespace Tolerance {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::EthyleneConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Tolerance::Id; }
@@ -17533,8 +18247,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::EthyleneConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -17543,8 +18258,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::EthyleneConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -17558,8 +18274,9 @@ namespace Attributes {
 namespace MeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::EthyleneOxideConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MeasuredValue::Id; }
@@ -17568,8 +18285,9 @@ struct TypeInfo
 namespace MinMeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::EthyleneOxideConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MinMeasuredValue::Id; }
@@ -17578,8 +18296,9 @@ struct TypeInfo
 namespace MaxMeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::EthyleneOxideConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MaxMeasuredValue::Id; }
@@ -17588,8 +18307,9 @@ struct TypeInfo
 namespace Tolerance {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::EthyleneOxideConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Tolerance::Id; }
@@ -17598,8 +18318,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::EthyleneOxideConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -17608,8 +18329,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::EthyleneOxideConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -17623,8 +18345,9 @@ namespace Attributes {
 namespace MeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::HydrogenConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MeasuredValue::Id; }
@@ -17633,8 +18356,9 @@ struct TypeInfo
 namespace MinMeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::HydrogenConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MinMeasuredValue::Id; }
@@ -17643,8 +18367,9 @@ struct TypeInfo
 namespace MaxMeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::HydrogenConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MaxMeasuredValue::Id; }
@@ -17653,8 +18378,9 @@ struct TypeInfo
 namespace Tolerance {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::HydrogenConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Tolerance::Id; }
@@ -17663,8 +18389,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::HydrogenConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -17673,8 +18400,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::HydrogenConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -17688,8 +18416,9 @@ namespace Attributes {
 namespace MeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::HydrogenSulphideConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MeasuredValue::Id; }
@@ -17698,8 +18427,9 @@ struct TypeInfo
 namespace MinMeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::HydrogenSulphideConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MinMeasuredValue::Id; }
@@ -17708,8 +18438,9 @@ struct TypeInfo
 namespace MaxMeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::HydrogenSulphideConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MaxMeasuredValue::Id; }
@@ -17718,8 +18449,9 @@ struct TypeInfo
 namespace Tolerance {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::HydrogenSulphideConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Tolerance::Id; }
@@ -17728,8 +18460,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::HydrogenSulphideConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -17738,8 +18471,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::HydrogenSulphideConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -17753,8 +18487,9 @@ namespace Attributes {
 namespace MeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::NitricOxideConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MeasuredValue::Id; }
@@ -17763,8 +18498,9 @@ struct TypeInfo
 namespace MinMeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::NitricOxideConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MinMeasuredValue::Id; }
@@ -17773,8 +18509,9 @@ struct TypeInfo
 namespace MaxMeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::NitricOxideConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MaxMeasuredValue::Id; }
@@ -17783,8 +18520,9 @@ struct TypeInfo
 namespace Tolerance {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::NitricOxideConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Tolerance::Id; }
@@ -17793,8 +18531,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::NitricOxideConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -17803,8 +18542,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::NitricOxideConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -17818,8 +18558,9 @@ namespace Attributes {
 namespace MeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::NitrogenDioxideConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MeasuredValue::Id; }
@@ -17828,8 +18569,9 @@ struct TypeInfo
 namespace MinMeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::NitrogenDioxideConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MinMeasuredValue::Id; }
@@ -17838,8 +18580,9 @@ struct TypeInfo
 namespace MaxMeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::NitrogenDioxideConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MaxMeasuredValue::Id; }
@@ -17848,8 +18591,9 @@ struct TypeInfo
 namespace Tolerance {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::NitrogenDioxideConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Tolerance::Id; }
@@ -17858,8 +18602,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::NitrogenDioxideConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -17868,8 +18613,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::NitrogenDioxideConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -17883,8 +18629,9 @@ namespace Attributes {
 namespace MeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::OxygenConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MeasuredValue::Id; }
@@ -17893,8 +18640,9 @@ struct TypeInfo
 namespace MinMeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::OxygenConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MinMeasuredValue::Id; }
@@ -17903,8 +18651,9 @@ struct TypeInfo
 namespace MaxMeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::OxygenConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MaxMeasuredValue::Id; }
@@ -17913,8 +18662,9 @@ struct TypeInfo
 namespace Tolerance {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::OxygenConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Tolerance::Id; }
@@ -17923,8 +18673,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::OxygenConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -17933,8 +18684,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::OxygenConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -17948,8 +18700,9 @@ namespace Attributes {
 namespace MeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::OzoneConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MeasuredValue::Id; }
@@ -17958,8 +18711,9 @@ struct TypeInfo
 namespace MinMeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::OzoneConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MinMeasuredValue::Id; }
@@ -17968,8 +18722,9 @@ struct TypeInfo
 namespace MaxMeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::OzoneConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MaxMeasuredValue::Id; }
@@ -17978,8 +18733,9 @@ struct TypeInfo
 namespace Tolerance {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::OzoneConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Tolerance::Id; }
@@ -17988,8 +18744,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::OzoneConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -17998,8 +18755,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::OzoneConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -18013,8 +18771,9 @@ namespace Attributes {
 namespace MeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::SulfurDioxideConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MeasuredValue::Id; }
@@ -18023,8 +18782,9 @@ struct TypeInfo
 namespace MinMeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::SulfurDioxideConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MinMeasuredValue::Id; }
@@ -18033,8 +18793,9 @@ struct TypeInfo
 namespace MaxMeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::SulfurDioxideConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MaxMeasuredValue::Id; }
@@ -18043,8 +18804,9 @@ struct TypeInfo
 namespace Tolerance {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::SulfurDioxideConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Tolerance::Id; }
@@ -18053,8 +18815,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::SulfurDioxideConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -18063,8 +18826,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::SulfurDioxideConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -18078,8 +18842,9 @@ namespace Attributes {
 namespace MeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::DissolvedOxygenConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MeasuredValue::Id; }
@@ -18088,8 +18853,9 @@ struct TypeInfo
 namespace MinMeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::DissolvedOxygenConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MinMeasuredValue::Id; }
@@ -18098,8 +18864,9 @@ struct TypeInfo
 namespace MaxMeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::DissolvedOxygenConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MaxMeasuredValue::Id; }
@@ -18108,8 +18875,9 @@ struct TypeInfo
 namespace Tolerance {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::DissolvedOxygenConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Tolerance::Id; }
@@ -18118,8 +18886,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::DissolvedOxygenConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -18128,8 +18897,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::DissolvedOxygenConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -18143,8 +18913,9 @@ namespace Attributes {
 namespace MeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::BromateConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MeasuredValue::Id; }
@@ -18153,8 +18924,9 @@ struct TypeInfo
 namespace MinMeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::BromateConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MinMeasuredValue::Id; }
@@ -18163,8 +18935,9 @@ struct TypeInfo
 namespace MaxMeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::BromateConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MaxMeasuredValue::Id; }
@@ -18173,8 +18946,9 @@ struct TypeInfo
 namespace Tolerance {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::BromateConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Tolerance::Id; }
@@ -18183,8 +18957,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::BromateConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -18193,8 +18968,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::BromateConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -18208,8 +18984,9 @@ namespace Attributes {
 namespace MeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ChloraminesConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MeasuredValue::Id; }
@@ -18218,8 +18995,9 @@ struct TypeInfo
 namespace MinMeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ChloraminesConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MinMeasuredValue::Id; }
@@ -18228,8 +19006,9 @@ struct TypeInfo
 namespace MaxMeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ChloraminesConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MaxMeasuredValue::Id; }
@@ -18238,8 +19017,9 @@ struct TypeInfo
 namespace Tolerance {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ChloraminesConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Tolerance::Id; }
@@ -18248,8 +19028,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ChloraminesConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -18258,8 +19039,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ChloraminesConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -18273,8 +19055,9 @@ namespace Attributes {
 namespace MeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ChlorineConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MeasuredValue::Id; }
@@ -18283,8 +19066,9 @@ struct TypeInfo
 namespace MinMeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ChlorineConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MinMeasuredValue::Id; }
@@ -18293,8 +19077,9 @@ struct TypeInfo
 namespace MaxMeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ChlorineConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MaxMeasuredValue::Id; }
@@ -18303,8 +19088,9 @@ struct TypeInfo
 namespace Tolerance {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ChlorineConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Tolerance::Id; }
@@ -18313,8 +19099,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ChlorineConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -18323,8 +19110,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ChlorineConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -18338,8 +19126,9 @@ namespace Attributes {
 namespace MeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::FecalColiformAndEColiConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MeasuredValue::Id; }
@@ -18348,8 +19137,9 @@ struct TypeInfo
 namespace MinMeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::FecalColiformAndEColiConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MinMeasuredValue::Id; }
@@ -18358,8 +19148,9 @@ struct TypeInfo
 namespace MaxMeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::FecalColiformAndEColiConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MaxMeasuredValue::Id; }
@@ -18368,8 +19159,9 @@ struct TypeInfo
 namespace Tolerance {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::FecalColiformAndEColiConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Tolerance::Id; }
@@ -18378,8 +19170,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::FecalColiformAndEColiConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -18388,8 +19181,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::FecalColiformAndEColiConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -18403,8 +19197,9 @@ namespace Attributes {
 namespace MeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::FluorideConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MeasuredValue::Id; }
@@ -18413,8 +19208,9 @@ struct TypeInfo
 namespace MinMeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::FluorideConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MinMeasuredValue::Id; }
@@ -18423,8 +19219,9 @@ struct TypeInfo
 namespace MaxMeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::FluorideConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MaxMeasuredValue::Id; }
@@ -18433,8 +19230,9 @@ struct TypeInfo
 namespace Tolerance {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::FluorideConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Tolerance::Id; }
@@ -18443,8 +19241,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::FluorideConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -18453,8 +19252,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::FluorideConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -18468,8 +19268,9 @@ namespace Attributes {
 namespace MeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::HaloaceticAcidsConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MeasuredValue::Id; }
@@ -18478,8 +19279,9 @@ struct TypeInfo
 namespace MinMeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::HaloaceticAcidsConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MinMeasuredValue::Id; }
@@ -18488,8 +19290,9 @@ struct TypeInfo
 namespace MaxMeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::HaloaceticAcidsConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MaxMeasuredValue::Id; }
@@ -18498,8 +19301,9 @@ struct TypeInfo
 namespace Tolerance {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::HaloaceticAcidsConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Tolerance::Id; }
@@ -18508,8 +19312,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::HaloaceticAcidsConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -18518,8 +19323,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::HaloaceticAcidsConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -18533,8 +19339,9 @@ namespace Attributes {
 namespace MeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::TotalTrihalomethanesConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MeasuredValue::Id; }
@@ -18543,8 +19350,9 @@ struct TypeInfo
 namespace MinMeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::TotalTrihalomethanesConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MinMeasuredValue::Id; }
@@ -18553,8 +19361,9 @@ struct TypeInfo
 namespace MaxMeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::TotalTrihalomethanesConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MaxMeasuredValue::Id; }
@@ -18563,8 +19372,9 @@ struct TypeInfo
 namespace Tolerance {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::TotalTrihalomethanesConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Tolerance::Id; }
@@ -18573,8 +19383,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::TotalTrihalomethanesConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -18583,8 +19394,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::TotalTrihalomethanesConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -18598,8 +19410,9 @@ namespace Attributes {
 namespace MeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::TotalColiformBacteriaConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MeasuredValue::Id; }
@@ -18608,8 +19421,9 @@ struct TypeInfo
 namespace MinMeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::TotalColiformBacteriaConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MinMeasuredValue::Id; }
@@ -18618,8 +19432,9 @@ struct TypeInfo
 namespace MaxMeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::TotalColiformBacteriaConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MaxMeasuredValue::Id; }
@@ -18628,8 +19443,9 @@ struct TypeInfo
 namespace Tolerance {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::TotalColiformBacteriaConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Tolerance::Id; }
@@ -18638,8 +19454,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::TotalColiformBacteriaConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -18648,8 +19465,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::TotalColiformBacteriaConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -18663,8 +19481,9 @@ namespace Attributes {
 namespace MeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::TurbidityConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MeasuredValue::Id; }
@@ -18673,8 +19492,9 @@ struct TypeInfo
 namespace MinMeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::TurbidityConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MinMeasuredValue::Id; }
@@ -18683,8 +19503,9 @@ struct TypeInfo
 namespace MaxMeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::TurbidityConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MaxMeasuredValue::Id; }
@@ -18693,8 +19514,9 @@ struct TypeInfo
 namespace Tolerance {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::TurbidityConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Tolerance::Id; }
@@ -18703,8 +19525,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::TurbidityConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -18713,8 +19536,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::TurbidityConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -18728,8 +19552,9 @@ namespace Attributes {
 namespace MeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::CopperConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MeasuredValue::Id; }
@@ -18738,8 +19563,9 @@ struct TypeInfo
 namespace MinMeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::CopperConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MinMeasuredValue::Id; }
@@ -18748,8 +19574,9 @@ struct TypeInfo
 namespace MaxMeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::CopperConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MaxMeasuredValue::Id; }
@@ -18758,8 +19585,9 @@ struct TypeInfo
 namespace Tolerance {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::CopperConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Tolerance::Id; }
@@ -18768,8 +19596,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::CopperConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -18778,8 +19607,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::CopperConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -18793,8 +19623,9 @@ namespace Attributes {
 namespace MeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::LeadConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MeasuredValue::Id; }
@@ -18803,8 +19634,9 @@ struct TypeInfo
 namespace MinMeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::LeadConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MinMeasuredValue::Id; }
@@ -18813,8 +19645,9 @@ struct TypeInfo
 namespace MaxMeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::LeadConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MaxMeasuredValue::Id; }
@@ -18823,8 +19656,9 @@ struct TypeInfo
 namespace Tolerance {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::LeadConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Tolerance::Id; }
@@ -18833,8 +19667,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::LeadConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -18843,8 +19678,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::LeadConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -18858,8 +19694,9 @@ namespace Attributes {
 namespace MeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ManganeseConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MeasuredValue::Id; }
@@ -18868,8 +19705,9 @@ struct TypeInfo
 namespace MinMeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ManganeseConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MinMeasuredValue::Id; }
@@ -18878,8 +19716,9 @@ struct TypeInfo
 namespace MaxMeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ManganeseConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MaxMeasuredValue::Id; }
@@ -18888,8 +19727,9 @@ struct TypeInfo
 namespace Tolerance {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ManganeseConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Tolerance::Id; }
@@ -18898,8 +19738,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ManganeseConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -18908,8 +19749,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ManganeseConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -18923,8 +19765,9 @@ namespace Attributes {
 namespace MeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::SulfateConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MeasuredValue::Id; }
@@ -18933,8 +19776,9 @@ struct TypeInfo
 namespace MinMeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::SulfateConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MinMeasuredValue::Id; }
@@ -18943,8 +19787,9 @@ struct TypeInfo
 namespace MaxMeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::SulfateConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MaxMeasuredValue::Id; }
@@ -18953,8 +19798,9 @@ struct TypeInfo
 namespace Tolerance {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::SulfateConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Tolerance::Id; }
@@ -18963,8 +19809,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::SulfateConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -18973,8 +19820,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::SulfateConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -18988,8 +19836,9 @@ namespace Attributes {
 namespace MeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::BromodichloromethaneConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MeasuredValue::Id; }
@@ -18998,8 +19847,9 @@ struct TypeInfo
 namespace MinMeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::BromodichloromethaneConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MinMeasuredValue::Id; }
@@ -19008,8 +19858,9 @@ struct TypeInfo
 namespace MaxMeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::BromodichloromethaneConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MaxMeasuredValue::Id; }
@@ -19018,8 +19869,9 @@ struct TypeInfo
 namespace Tolerance {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::BromodichloromethaneConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Tolerance::Id; }
@@ -19028,8 +19880,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::BromodichloromethaneConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -19038,8 +19891,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::BromodichloromethaneConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -19053,8 +19907,9 @@ namespace Attributes {
 namespace MeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::BromoformConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MeasuredValue::Id; }
@@ -19063,8 +19918,9 @@ struct TypeInfo
 namespace MinMeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::BromoformConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MinMeasuredValue::Id; }
@@ -19073,8 +19929,9 @@ struct TypeInfo
 namespace MaxMeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::BromoformConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MaxMeasuredValue::Id; }
@@ -19083,8 +19940,9 @@ struct TypeInfo
 namespace Tolerance {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::BromoformConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Tolerance::Id; }
@@ -19093,8 +19951,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::BromoformConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -19103,8 +19962,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::BromoformConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -19118,8 +19978,9 @@ namespace Attributes {
 namespace MeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ChlorodibromomethaneConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MeasuredValue::Id; }
@@ -19128,8 +19989,9 @@ struct TypeInfo
 namespace MinMeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ChlorodibromomethaneConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MinMeasuredValue::Id; }
@@ -19138,8 +20000,9 @@ struct TypeInfo
 namespace MaxMeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ChlorodibromomethaneConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MaxMeasuredValue::Id; }
@@ -19148,8 +20011,9 @@ struct TypeInfo
 namespace Tolerance {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ChlorodibromomethaneConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Tolerance::Id; }
@@ -19158,8 +20022,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ChlorodibromomethaneConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -19168,8 +20033,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ChlorodibromomethaneConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -19183,8 +20049,9 @@ namespace Attributes {
 namespace MeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ChloroformConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MeasuredValue::Id; }
@@ -19193,8 +20060,9 @@ struct TypeInfo
 namespace MinMeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ChloroformConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MinMeasuredValue::Id; }
@@ -19203,8 +20071,9 @@ struct TypeInfo
 namespace MaxMeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ChloroformConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MaxMeasuredValue::Id; }
@@ -19213,8 +20082,9 @@ struct TypeInfo
 namespace Tolerance {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ChloroformConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Tolerance::Id; }
@@ -19223,8 +20093,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ChloroformConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -19233,8 +20104,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ChloroformConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -19248,8 +20120,9 @@ namespace Attributes {
 namespace MeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::SodiumConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MeasuredValue::Id; }
@@ -19258,8 +20131,9 @@ struct TypeInfo
 namespace MinMeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::SodiumConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MinMeasuredValue::Id; }
@@ -19268,8 +20142,9 @@ struct TypeInfo
 namespace MaxMeasuredValue {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::SodiumConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MaxMeasuredValue::Id; }
@@ -19278,8 +20153,9 @@ struct TypeInfo
 namespace Tolerance {
 struct TypeInfo
 {
-    using Type          = float;
-    using DecodableType = float;
+    using Type             = float;
+    using DecodableType    = float;
+    using DecodableArgType = float;
 
     static constexpr ClusterId GetClusterId() { return Clusters::SodiumConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Tolerance::Id; }
@@ -19288,8 +20164,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::SodiumConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -19298,8 +20175,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::SodiumConcentrationMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -19573,8 +20451,9 @@ namespace Attributes {
 namespace ZoneState {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::IasZone::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ZoneState::Id; }
@@ -19583,8 +20462,9 @@ struct TypeInfo
 namespace ZoneType {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::IasZone::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ZoneType::Id; }
@@ -19593,8 +20473,9 @@ struct TypeInfo
 namespace ZoneStatus {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::IasZone::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ZoneStatus::Id; }
@@ -19603,8 +20484,9 @@ struct TypeInfo
 namespace IasCieAddress {
 struct TypeInfo
 {
-    using Type          = chip::NodeId;
-    using DecodableType = chip::NodeId;
+    using Type             = chip::NodeId;
+    using DecodableType    = chip::NodeId;
+    using DecodableArgType = chip::NodeId;
 
     static constexpr ClusterId GetClusterId() { return Clusters::IasZone::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::IasCieAddress::Id; }
@@ -19613,8 +20495,9 @@ struct TypeInfo
 namespace ZoneId {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::IasZone::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ZoneId::Id; }
@@ -19623,8 +20506,9 @@ struct TypeInfo
 namespace NumberOfZoneSensitivityLevelsSupported {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::IasZone::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::NumberOfZoneSensitivityLevelsSupported::Id; }
@@ -19633,8 +20517,9 @@ struct TypeInfo
 namespace CurrentZoneSensitivityLevel {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::IasZone::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::CurrentZoneSensitivityLevel::Id; }
@@ -19643,8 +20528,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::IasZone::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -19653,8 +20539,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::IasZone::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -20454,8 +21341,9 @@ namespace Attributes {
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::IasAce::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -20464,8 +21352,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::IasAce::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -20563,8 +21452,9 @@ namespace Attributes {
 namespace MaxDuration {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::IasWd::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MaxDuration::Id; }
@@ -20573,8 +21463,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::IasWd::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -20583,8 +21474,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::IasWd::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -20598,8 +21490,9 @@ namespace Attributes {
 namespace WakeOnLanMacAddress {
 struct TypeInfo
 {
-    using Type          = chip::CharSpan;
-    using DecodableType = chip::CharSpan;
+    using Type             = chip::CharSpan;
+    using DecodableType    = chip::CharSpan;
+    using DecodableArgType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return Clusters::WakeOnLan::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::WakeOnLanMacAddress::Id; }
@@ -20608,8 +21501,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::WakeOnLan::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -20618,8 +21512,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::WakeOnLan::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -20830,8 +21725,9 @@ namespace Attributes {
 namespace TvChannelList {
 struct TypeInfo
 {
-    using Type          = DataModel::List<const Structs::TvChannelInfo::Type>;
-    using DecodableType = DataModel::DecodableList<Structs::TvChannelInfo::DecodableType>;
+    using Type             = DataModel::List<const Structs::TvChannelInfo::Type>;
+    using DecodableType    = DataModel::DecodableList<Structs::TvChannelInfo::DecodableType>;
+    using DecodableArgType = const DataModel::DecodableList<Structs::TvChannelInfo::DecodableType> &;
 
     static constexpr ClusterId GetClusterId() { return Clusters::TvChannel::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::TvChannelList::Id; }
@@ -20840,8 +21736,9 @@ struct TypeInfo
 namespace TvChannelLineup {
 struct TypeInfo
 {
-    using Type          = chip::ByteSpan;
-    using DecodableType = chip::ByteSpan;
+    using Type             = chip::ByteSpan;
+    using DecodableType    = chip::ByteSpan;
+    using DecodableArgType = chip::ByteSpan;
 
     static constexpr ClusterId GetClusterId() { return Clusters::TvChannel::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::TvChannelLineup::Id; }
@@ -20850,8 +21747,9 @@ struct TypeInfo
 namespace CurrentTvChannel {
 struct TypeInfo
 {
-    using Type          = chip::ByteSpan;
-    using DecodableType = chip::ByteSpan;
+    using Type             = chip::ByteSpan;
+    using DecodableType    = chip::ByteSpan;
+    using DecodableArgType = chip::ByteSpan;
 
     static constexpr ClusterId GetClusterId() { return Clusters::TvChannel::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::CurrentTvChannel::Id; }
@@ -20860,8 +21758,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::TvChannel::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -20870,8 +21769,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::TvChannel::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -20986,8 +21886,9 @@ namespace Attributes {
 namespace TargetNavigatorList {
 struct TypeInfo
 {
-    using Type          = DataModel::List<const Structs::NavigateTargetTargetInfo::Type>;
-    using DecodableType = DataModel::DecodableList<Structs::NavigateTargetTargetInfo::DecodableType>;
+    using Type             = DataModel::List<const Structs::NavigateTargetTargetInfo::Type>;
+    using DecodableType    = DataModel::DecodableList<Structs::NavigateTargetTargetInfo::DecodableType>;
+    using DecodableArgType = const DataModel::DecodableList<Structs::NavigateTargetTargetInfo::DecodableType> &;
 
     static constexpr ClusterId GetClusterId() { return Clusters::TargetNavigator::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::TargetNavigatorList::Id; }
@@ -20996,8 +21897,9 @@ struct TypeInfo
 namespace CurrentNavigatorTarget {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::TargetNavigator::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::CurrentNavigatorTarget::Id; }
@@ -21006,8 +21908,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::TargetNavigator::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -21016,8 +21919,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::TargetNavigator::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -21671,8 +22575,9 @@ namespace Attributes {
 namespace PlaybackState {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::MediaPlayback::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::PlaybackState::Id; }
@@ -21681,8 +22586,9 @@ struct TypeInfo
 namespace StartTime {
 struct TypeInfo
 {
-    using Type          = uint64_t;
-    using DecodableType = uint64_t;
+    using Type             = uint64_t;
+    using DecodableType    = uint64_t;
+    using DecodableArgType = uint64_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::MediaPlayback::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::StartTime::Id; }
@@ -21691,8 +22597,9 @@ struct TypeInfo
 namespace Duration {
 struct TypeInfo
 {
-    using Type          = uint64_t;
-    using DecodableType = uint64_t;
+    using Type             = uint64_t;
+    using DecodableType    = uint64_t;
+    using DecodableArgType = uint64_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::MediaPlayback::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Duration::Id; }
@@ -21701,8 +22608,9 @@ struct TypeInfo
 namespace PositionUpdatedAt {
 struct TypeInfo
 {
-    using Type          = uint64_t;
-    using DecodableType = uint64_t;
+    using Type             = uint64_t;
+    using DecodableType    = uint64_t;
+    using DecodableArgType = uint64_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::MediaPlayback::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::PositionUpdatedAt::Id; }
@@ -21711,8 +22619,9 @@ struct TypeInfo
 namespace Position {
 struct TypeInfo
 {
-    using Type          = uint64_t;
-    using DecodableType = uint64_t;
+    using Type             = uint64_t;
+    using DecodableType    = uint64_t;
+    using DecodableArgType = uint64_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::MediaPlayback::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Position::Id; }
@@ -21721,8 +22630,9 @@ struct TypeInfo
 namespace PlaybackSpeed {
 struct TypeInfo
 {
-    using Type          = uint64_t;
-    using DecodableType = uint64_t;
+    using Type             = uint64_t;
+    using DecodableType    = uint64_t;
+    using DecodableArgType = uint64_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::MediaPlayback::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::PlaybackSpeed::Id; }
@@ -21731,8 +22641,9 @@ struct TypeInfo
 namespace SeekRangeEnd {
 struct TypeInfo
 {
-    using Type          = uint64_t;
-    using DecodableType = uint64_t;
+    using Type             = uint64_t;
+    using DecodableType    = uint64_t;
+    using DecodableArgType = uint64_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::MediaPlayback::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::SeekRangeEnd::Id; }
@@ -21741,8 +22652,9 @@ struct TypeInfo
 namespace SeekRangeStart {
 struct TypeInfo
 {
-    using Type          = uint64_t;
-    using DecodableType = uint64_t;
+    using Type             = uint64_t;
+    using DecodableType    = uint64_t;
+    using DecodableArgType = uint64_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::MediaPlayback::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::SeekRangeStart::Id; }
@@ -21751,8 +22663,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::MediaPlayback::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -21761,8 +22674,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::MediaPlayback::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -21935,8 +22849,9 @@ namespace Attributes {
 namespace MediaInputList {
 struct TypeInfo
 {
-    using Type          = DataModel::List<const Structs::MediaInputInfo::Type>;
-    using DecodableType = DataModel::DecodableList<Structs::MediaInputInfo::DecodableType>;
+    using Type             = DataModel::List<const Structs::MediaInputInfo::Type>;
+    using DecodableType    = DataModel::DecodableList<Structs::MediaInputInfo::DecodableType>;
+    using DecodableArgType = const DataModel::DecodableList<Structs::MediaInputInfo::DecodableType> &;
 
     static constexpr ClusterId GetClusterId() { return Clusters::MediaInput::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MediaInputList::Id; }
@@ -21945,8 +22860,9 @@ struct TypeInfo
 namespace CurrentMediaInput {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::MediaInput::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::CurrentMediaInput::Id; }
@@ -21955,8 +22871,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::MediaInput::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -21965,8 +22882,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::MediaInput::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -22007,8 +22925,9 @@ namespace Attributes {
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::LowPower::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -22017,8 +22936,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::LowPower::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -22200,8 +23120,9 @@ namespace Attributes {
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::KeypadInput::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -22210,8 +23131,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::KeypadInput::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -22533,8 +23455,9 @@ namespace Attributes {
 namespace AcceptsHeaderList {
 struct TypeInfo
 {
-    using Type          = DataModel::List<const chip::ByteSpan>;
-    using DecodableType = DataModel::DecodableList<chip::ByteSpan>;
+    using Type             = DataModel::List<const chip::ByteSpan>;
+    using DecodableType    = DataModel::DecodableList<chip::ByteSpan>;
+    using DecodableArgType = const DataModel::DecodableList<chip::ByteSpan> &;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ContentLauncher::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::AcceptsHeaderList::Id; }
@@ -22543,8 +23466,9 @@ struct TypeInfo
 namespace SupportedStreamingTypes {
 struct TypeInfo
 {
-    using Type          = DataModel::List<const ContentLaunchStreamingType>;
-    using DecodableType = DataModel::DecodableList<ContentLaunchStreamingType>;
+    using Type             = DataModel::List<const ContentLaunchStreamingType>;
+    using DecodableType    = DataModel::DecodableList<ContentLaunchStreamingType>;
+    using DecodableArgType = const DataModel::DecodableList<ContentLaunchStreamingType> &;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ContentLauncher::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::SupportedStreamingTypes::Id; }
@@ -22553,8 +23477,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ContentLauncher::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -22563,8 +23488,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ContentLauncher::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -22681,8 +23607,9 @@ namespace Attributes {
 namespace AudioOutputList {
 struct TypeInfo
 {
-    using Type          = DataModel::List<const Structs::AudioOutputInfo::Type>;
-    using DecodableType = DataModel::DecodableList<Structs::AudioOutputInfo::DecodableType>;
+    using Type             = DataModel::List<const Structs::AudioOutputInfo::Type>;
+    using DecodableType    = DataModel::DecodableList<Structs::AudioOutputInfo::DecodableType>;
+    using DecodableArgType = const DataModel::DecodableList<Structs::AudioOutputInfo::DecodableType> &;
 
     static constexpr ClusterId GetClusterId() { return Clusters::AudioOutput::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::AudioOutputList::Id; }
@@ -22691,8 +23618,9 @@ struct TypeInfo
 namespace CurrentAudioOutput {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::AudioOutput::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::CurrentAudioOutput::Id; }
@@ -22701,8 +23629,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::AudioOutput::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -22711,8 +23640,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::AudioOutput::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -22830,8 +23760,9 @@ namespace Attributes {
 namespace ApplicationLauncherList {
 struct TypeInfo
 {
-    using Type          = DataModel::List<const uint16_t>;
-    using DecodableType = DataModel::DecodableList<uint16_t>;
+    using Type             = DataModel::List<const uint16_t>;
+    using DecodableType    = DataModel::DecodableList<uint16_t>;
+    using DecodableArgType = const DataModel::DecodableList<uint16_t> &;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ApplicationLauncher::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ApplicationLauncherList::Id; }
@@ -22840,8 +23771,9 @@ struct TypeInfo
 namespace CatalogVendorId {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ApplicationLauncher::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::CatalogVendorId::Id; }
@@ -22850,8 +23782,9 @@ struct TypeInfo
 namespace ApplicationId {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ApplicationLauncher::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ApplicationId::Id; }
@@ -22860,8 +23793,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ApplicationLauncher::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -22870,8 +23804,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ApplicationLauncher::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -22930,8 +23865,9 @@ namespace Attributes {
 namespace VendorName {
 struct TypeInfo
 {
-    using Type          = chip::CharSpan;
-    using DecodableType = chip::CharSpan;
+    using Type             = chip::CharSpan;
+    using DecodableType    = chip::CharSpan;
+    using DecodableArgType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ApplicationBasic::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::VendorName::Id; }
@@ -22940,8 +23876,9 @@ struct TypeInfo
 namespace VendorId {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ApplicationBasic::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::VendorId::Id; }
@@ -22950,8 +23887,9 @@ struct TypeInfo
 namespace ApplicationName {
 struct TypeInfo
 {
-    using Type          = chip::CharSpan;
-    using DecodableType = chip::CharSpan;
+    using Type             = chip::CharSpan;
+    using DecodableType    = chip::CharSpan;
+    using DecodableArgType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ApplicationBasic::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ApplicationName::Id; }
@@ -22960,8 +23898,9 @@ struct TypeInfo
 namespace ProductId {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ApplicationBasic::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ProductId::Id; }
@@ -22970,8 +23909,9 @@ struct TypeInfo
 namespace ApplicationId {
 struct TypeInfo
 {
-    using Type          = chip::CharSpan;
-    using DecodableType = chip::CharSpan;
+    using Type             = chip::CharSpan;
+    using DecodableType    = chip::CharSpan;
+    using DecodableArgType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ApplicationBasic::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ApplicationId::Id; }
@@ -22980,8 +23920,9 @@ struct TypeInfo
 namespace CatalogVendorId {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ApplicationBasic::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::CatalogVendorId::Id; }
@@ -22990,8 +23931,9 @@ struct TypeInfo
 namespace ApplicationStatus {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ApplicationBasic::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ApplicationStatus::Id; }
@@ -23000,8 +23942,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ApplicationBasic::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -23010,8 +23953,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ApplicationBasic::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -23115,8 +24059,9 @@ namespace Attributes {
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::AccountLogin::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -23125,8 +24070,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::AccountLogin::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -24229,8 +25175,9 @@ namespace Attributes {
 namespace Boolean {
 struct TypeInfo
 {
-    using Type          = bool;
-    using DecodableType = bool;
+    using Type             = bool;
+    using DecodableType    = bool;
+    using DecodableArgType = bool;
 
     static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Boolean::Id; }
@@ -24239,8 +25186,9 @@ struct TypeInfo
 namespace Bitmap8 {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Bitmap8::Id; }
@@ -24249,8 +25197,9 @@ struct TypeInfo
 namespace Bitmap16 {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Bitmap16::Id; }
@@ -24259,8 +25208,9 @@ struct TypeInfo
 namespace Bitmap32 {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Bitmap32::Id; }
@@ -24269,8 +25219,9 @@ struct TypeInfo
 namespace Bitmap64 {
 struct TypeInfo
 {
-    using Type          = uint64_t;
-    using DecodableType = uint64_t;
+    using Type             = uint64_t;
+    using DecodableType    = uint64_t;
+    using DecodableArgType = uint64_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Bitmap64::Id; }
@@ -24279,8 +25230,9 @@ struct TypeInfo
 namespace Int8u {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Int8u::Id; }
@@ -24289,8 +25241,9 @@ struct TypeInfo
 namespace Int16u {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Int16u::Id; }
@@ -24299,8 +25252,9 @@ struct TypeInfo
 namespace Int32u {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Int32u::Id; }
@@ -24309,8 +25263,9 @@ struct TypeInfo
 namespace Int64u {
 struct TypeInfo
 {
-    using Type          = uint64_t;
-    using DecodableType = uint64_t;
+    using Type             = uint64_t;
+    using DecodableType    = uint64_t;
+    using DecodableArgType = uint64_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Int64u::Id; }
@@ -24319,8 +25274,9 @@ struct TypeInfo
 namespace Int8s {
 struct TypeInfo
 {
-    using Type          = int8_t;
-    using DecodableType = int8_t;
+    using Type             = int8_t;
+    using DecodableType    = int8_t;
+    using DecodableArgType = int8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Int8s::Id; }
@@ -24329,8 +25285,9 @@ struct TypeInfo
 namespace Int16s {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Int16s::Id; }
@@ -24339,8 +25296,9 @@ struct TypeInfo
 namespace Int32s {
 struct TypeInfo
 {
-    using Type          = int32_t;
-    using DecodableType = int32_t;
+    using Type             = int32_t;
+    using DecodableType    = int32_t;
+    using DecodableArgType = int32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Int32s::Id; }
@@ -24349,8 +25307,9 @@ struct TypeInfo
 namespace Int64s {
 struct TypeInfo
 {
-    using Type          = int64_t;
-    using DecodableType = int64_t;
+    using Type             = int64_t;
+    using DecodableType    = int64_t;
+    using DecodableArgType = int64_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Int64s::Id; }
@@ -24359,8 +25318,9 @@ struct TypeInfo
 namespace Enum8 {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Enum8::Id; }
@@ -24369,8 +25329,9 @@ struct TypeInfo
 namespace Enum16 {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Enum16::Id; }
@@ -24379,8 +25340,9 @@ struct TypeInfo
 namespace OctetString {
 struct TypeInfo
 {
-    using Type          = chip::ByteSpan;
-    using DecodableType = chip::ByteSpan;
+    using Type             = chip::ByteSpan;
+    using DecodableType    = chip::ByteSpan;
+    using DecodableArgType = chip::ByteSpan;
 
     static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::OctetString::Id; }
@@ -24389,8 +25351,9 @@ struct TypeInfo
 namespace ListInt8u {
 struct TypeInfo
 {
-    using Type          = DataModel::List<const uint8_t>;
-    using DecodableType = DataModel::DecodableList<uint8_t>;
+    using Type             = DataModel::List<const uint8_t>;
+    using DecodableType    = DataModel::DecodableList<uint8_t>;
+    using DecodableArgType = const DataModel::DecodableList<uint8_t> &;
 
     static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ListInt8u::Id; }
@@ -24399,8 +25362,9 @@ struct TypeInfo
 namespace ListOctetString {
 struct TypeInfo
 {
-    using Type          = DataModel::List<const chip::ByteSpan>;
-    using DecodableType = DataModel::DecodableList<chip::ByteSpan>;
+    using Type             = DataModel::List<const chip::ByteSpan>;
+    using DecodableType    = DataModel::DecodableList<chip::ByteSpan>;
+    using DecodableArgType = const DataModel::DecodableList<chip::ByteSpan> &;
 
     static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ListOctetString::Id; }
@@ -24409,8 +25373,9 @@ struct TypeInfo
 namespace ListStructOctetString {
 struct TypeInfo
 {
-    using Type          = DataModel::List<const Structs::TestListStructOctet::Type>;
-    using DecodableType = DataModel::DecodableList<Structs::TestListStructOctet::DecodableType>;
+    using Type             = DataModel::List<const Structs::TestListStructOctet::Type>;
+    using DecodableType    = DataModel::DecodableList<Structs::TestListStructOctet::DecodableType>;
+    using DecodableArgType = const DataModel::DecodableList<Structs::TestListStructOctet::DecodableType> &;
 
     static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ListStructOctetString::Id; }
@@ -24419,8 +25384,9 @@ struct TypeInfo
 namespace LongOctetString {
 struct TypeInfo
 {
-    using Type          = chip::ByteSpan;
-    using DecodableType = chip::ByteSpan;
+    using Type             = chip::ByteSpan;
+    using DecodableType    = chip::ByteSpan;
+    using DecodableArgType = chip::ByteSpan;
 
     static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::LongOctetString::Id; }
@@ -24429,8 +25395,9 @@ struct TypeInfo
 namespace CharString {
 struct TypeInfo
 {
-    using Type          = chip::CharSpan;
-    using DecodableType = chip::CharSpan;
+    using Type             = chip::CharSpan;
+    using DecodableType    = chip::CharSpan;
+    using DecodableArgType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::CharString::Id; }
@@ -24439,8 +25406,9 @@ struct TypeInfo
 namespace LongCharString {
 struct TypeInfo
 {
-    using Type          = chip::CharSpan;
-    using DecodableType = chip::CharSpan;
+    using Type             = chip::CharSpan;
+    using DecodableType    = chip::CharSpan;
+    using DecodableArgType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::LongCharString::Id; }
@@ -24449,8 +25417,9 @@ struct TypeInfo
 namespace EpochUs {
 struct TypeInfo
 {
-    using Type          = uint64_t;
-    using DecodableType = uint64_t;
+    using Type             = uint64_t;
+    using DecodableType    = uint64_t;
+    using DecodableArgType = uint64_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::EpochUs::Id; }
@@ -24459,8 +25428,9 @@ struct TypeInfo
 namespace EpochS {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::EpochS::Id; }
@@ -24469,8 +25439,9 @@ struct TypeInfo
 namespace VendorId {
 struct TypeInfo
 {
-    using Type          = chip::VendorId;
-    using DecodableType = chip::VendorId;
+    using Type             = chip::VendorId;
+    using DecodableType    = chip::VendorId;
+    using DecodableArgType = chip::VendorId;
 
     static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::VendorId::Id; }
@@ -24479,8 +25450,9 @@ struct TypeInfo
 namespace ListNullablesAndOptionalsStruct {
 struct TypeInfo
 {
-    using Type          = DataModel::List<const Structs::NullablesAndOptionalsStruct::Type>;
-    using DecodableType = DataModel::DecodableList<Structs::NullablesAndOptionalsStruct::DecodableType>;
+    using Type             = DataModel::List<const Structs::NullablesAndOptionalsStruct::Type>;
+    using DecodableType    = DataModel::DecodableList<Structs::NullablesAndOptionalsStruct::DecodableType>;
+    using DecodableArgType = const DataModel::DecodableList<Structs::NullablesAndOptionalsStruct::DecodableType> &;
 
     static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ListNullablesAndOptionalsStruct::Id; }
@@ -24489,8 +25461,9 @@ struct TypeInfo
 namespace Unsupported {
 struct TypeInfo
 {
-    using Type          = bool;
-    using DecodableType = bool;
+    using Type             = bool;
+    using DecodableType    = bool;
+    using DecodableArgType = bool;
 
     static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Unsupported::Id; }
@@ -24499,8 +25472,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -24509,8 +25483,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -24976,8 +25951,9 @@ namespace Attributes {
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Messaging::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -24986,8 +25962,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Messaging::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -25001,8 +25978,9 @@ namespace Attributes {
 namespace BasicIdentification {
 struct TypeInfo
 {
-    using Type          = uint64_t;
-    using DecodableType = uint64_t;
+    using Type             = uint64_t;
+    using DecodableType    = uint64_t;
+    using DecodableArgType = uint64_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ApplianceIdentification::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::BasicIdentification::Id; }
@@ -25011,8 +25989,9 @@ struct TypeInfo
 namespace CompanyName {
 struct TypeInfo
 {
-    using Type          = chip::CharSpan;
-    using DecodableType = chip::CharSpan;
+    using Type             = chip::CharSpan;
+    using DecodableType    = chip::CharSpan;
+    using DecodableArgType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ApplianceIdentification::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::CompanyName::Id; }
@@ -25021,8 +26000,9 @@ struct TypeInfo
 namespace CompanyId {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ApplianceIdentification::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::CompanyId::Id; }
@@ -25031,8 +26011,9 @@ struct TypeInfo
 namespace BrandName {
 struct TypeInfo
 {
-    using Type          = chip::CharSpan;
-    using DecodableType = chip::CharSpan;
+    using Type             = chip::CharSpan;
+    using DecodableType    = chip::CharSpan;
+    using DecodableArgType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ApplianceIdentification::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::BrandName::Id; }
@@ -25041,8 +26022,9 @@ struct TypeInfo
 namespace BrandId {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ApplianceIdentification::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::BrandId::Id; }
@@ -25051,8 +26033,9 @@ struct TypeInfo
 namespace Model {
 struct TypeInfo
 {
-    using Type          = chip::ByteSpan;
-    using DecodableType = chip::ByteSpan;
+    using Type             = chip::ByteSpan;
+    using DecodableType    = chip::ByteSpan;
+    using DecodableArgType = chip::ByteSpan;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ApplianceIdentification::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Model::Id; }
@@ -25061,8 +26044,9 @@ struct TypeInfo
 namespace PartNumber {
 struct TypeInfo
 {
-    using Type          = chip::ByteSpan;
-    using DecodableType = chip::ByteSpan;
+    using Type             = chip::ByteSpan;
+    using DecodableType    = chip::ByteSpan;
+    using DecodableArgType = chip::ByteSpan;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ApplianceIdentification::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::PartNumber::Id; }
@@ -25071,8 +26055,9 @@ struct TypeInfo
 namespace ProductRevision {
 struct TypeInfo
 {
-    using Type          = chip::ByteSpan;
-    using DecodableType = chip::ByteSpan;
+    using Type             = chip::ByteSpan;
+    using DecodableType    = chip::ByteSpan;
+    using DecodableArgType = chip::ByteSpan;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ApplianceIdentification::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ProductRevision::Id; }
@@ -25081,8 +26066,9 @@ struct TypeInfo
 namespace SoftwareRevision {
 struct TypeInfo
 {
-    using Type          = chip::ByteSpan;
-    using DecodableType = chip::ByteSpan;
+    using Type             = chip::ByteSpan;
+    using DecodableType    = chip::ByteSpan;
+    using DecodableArgType = chip::ByteSpan;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ApplianceIdentification::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::SoftwareRevision::Id; }
@@ -25091,8 +26077,9 @@ struct TypeInfo
 namespace ProductTypeName {
 struct TypeInfo
 {
-    using Type          = chip::ByteSpan;
-    using DecodableType = chip::ByteSpan;
+    using Type             = chip::ByteSpan;
+    using DecodableType    = chip::ByteSpan;
+    using DecodableArgType = chip::ByteSpan;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ApplianceIdentification::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ProductTypeName::Id; }
@@ -25101,8 +26088,9 @@ struct TypeInfo
 namespace ProductTypeId {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ApplianceIdentification::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ProductTypeId::Id; }
@@ -25111,8 +26099,9 @@ struct TypeInfo
 namespace CecedSpecificationVersion {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ApplianceIdentification::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::CecedSpecificationVersion::Id; }
@@ -25121,8 +26110,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ApplianceIdentification::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -25131,8 +26121,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ApplianceIdentification::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -25146,8 +26137,9 @@ namespace Attributes {
 namespace CompanyName {
 struct TypeInfo
 {
-    using Type          = chip::CharSpan;
-    using DecodableType = chip::CharSpan;
+    using Type             = chip::CharSpan;
+    using DecodableType    = chip::CharSpan;
+    using DecodableArgType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return Clusters::MeterIdentification::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::CompanyName::Id; }
@@ -25156,8 +26148,9 @@ struct TypeInfo
 namespace MeterTypeId {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::MeterIdentification::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MeterTypeId::Id; }
@@ -25166,8 +26159,9 @@ struct TypeInfo
 namespace DataQualityId {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::MeterIdentification::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::DataQualityId::Id; }
@@ -25176,8 +26170,9 @@ struct TypeInfo
 namespace CustomerName {
 struct TypeInfo
 {
-    using Type          = chip::CharSpan;
-    using DecodableType = chip::CharSpan;
+    using Type             = chip::CharSpan;
+    using DecodableType    = chip::CharSpan;
+    using DecodableArgType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return Clusters::MeterIdentification::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::CustomerName::Id; }
@@ -25186,8 +26181,9 @@ struct TypeInfo
 namespace Model {
 struct TypeInfo
 {
-    using Type          = chip::ByteSpan;
-    using DecodableType = chip::ByteSpan;
+    using Type             = chip::ByteSpan;
+    using DecodableType    = chip::ByteSpan;
+    using DecodableArgType = chip::ByteSpan;
 
     static constexpr ClusterId GetClusterId() { return Clusters::MeterIdentification::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Model::Id; }
@@ -25196,8 +26192,9 @@ struct TypeInfo
 namespace PartNumber {
 struct TypeInfo
 {
-    using Type          = chip::ByteSpan;
-    using DecodableType = chip::ByteSpan;
+    using Type             = chip::ByteSpan;
+    using DecodableType    = chip::ByteSpan;
+    using DecodableArgType = chip::ByteSpan;
 
     static constexpr ClusterId GetClusterId() { return Clusters::MeterIdentification::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::PartNumber::Id; }
@@ -25206,8 +26203,9 @@ struct TypeInfo
 namespace ProductRevision {
 struct TypeInfo
 {
-    using Type          = chip::ByteSpan;
-    using DecodableType = chip::ByteSpan;
+    using Type             = chip::ByteSpan;
+    using DecodableType    = chip::ByteSpan;
+    using DecodableArgType = chip::ByteSpan;
 
     static constexpr ClusterId GetClusterId() { return Clusters::MeterIdentification::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ProductRevision::Id; }
@@ -25216,8 +26214,9 @@ struct TypeInfo
 namespace SoftwareRevision {
 struct TypeInfo
 {
-    using Type          = chip::ByteSpan;
-    using DecodableType = chip::ByteSpan;
+    using Type             = chip::ByteSpan;
+    using DecodableType    = chip::ByteSpan;
+    using DecodableArgType = chip::ByteSpan;
 
     static constexpr ClusterId GetClusterId() { return Clusters::MeterIdentification::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::SoftwareRevision::Id; }
@@ -25226,8 +26225,9 @@ struct TypeInfo
 namespace UtilityName {
 struct TypeInfo
 {
-    using Type          = chip::CharSpan;
-    using DecodableType = chip::CharSpan;
+    using Type             = chip::CharSpan;
+    using DecodableType    = chip::CharSpan;
+    using DecodableArgType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return Clusters::MeterIdentification::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::UtilityName::Id; }
@@ -25236,8 +26236,9 @@ struct TypeInfo
 namespace Pod {
 struct TypeInfo
 {
-    using Type          = chip::CharSpan;
-    using DecodableType = chip::CharSpan;
+    using Type             = chip::CharSpan;
+    using DecodableType    = chip::CharSpan;
+    using DecodableArgType = chip::CharSpan;
 
     static constexpr ClusterId GetClusterId() { return Clusters::MeterIdentification::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Pod::Id; }
@@ -25246,8 +26247,9 @@ struct TypeInfo
 namespace AvailablePower {
 struct TypeInfo
 {
-    using Type          = int32_t;
-    using DecodableType = int32_t;
+    using Type             = int32_t;
+    using DecodableType    = int32_t;
+    using DecodableArgType = int32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::MeterIdentification::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::AvailablePower::Id; }
@@ -25256,8 +26258,9 @@ struct TypeInfo
 namespace PowerThreshold {
 struct TypeInfo
 {
-    using Type          = int32_t;
-    using DecodableType = int32_t;
+    using Type             = int32_t;
+    using DecodableType    = int32_t;
+    using DecodableArgType = int32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::MeterIdentification::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::PowerThreshold::Id; }
@@ -25266,8 +26269,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::MeterIdentification::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -25276,8 +26280,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::MeterIdentification::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -25441,8 +26446,9 @@ namespace Attributes {
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ApplianceEventsAndAlert::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -25451,8 +26457,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ApplianceEventsAndAlert::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -25657,8 +26664,9 @@ namespace Attributes {
 namespace LogMaxSize {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ApplianceStatistics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::LogMaxSize::Id; }
@@ -25667,8 +26675,9 @@ struct TypeInfo
 namespace LogQueueMaxSize {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ApplianceStatistics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::LogQueueMaxSize::Id; }
@@ -25677,8 +26686,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ApplianceStatistics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -25687,8 +26697,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ApplianceStatistics::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -25843,8 +26854,9 @@ namespace Attributes {
 namespace MeasurementType {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MeasurementType::Id; }
@@ -25853,8 +26865,9 @@ struct TypeInfo
 namespace DcVoltage {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::DcVoltage::Id; }
@@ -25863,8 +26876,9 @@ struct TypeInfo
 namespace DcVoltageMin {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::DcVoltageMin::Id; }
@@ -25873,8 +26887,9 @@ struct TypeInfo
 namespace DcVoltageMax {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::DcVoltageMax::Id; }
@@ -25883,8 +26898,9 @@ struct TypeInfo
 namespace DcCurrent {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::DcCurrent::Id; }
@@ -25893,8 +26909,9 @@ struct TypeInfo
 namespace DcCurrentMin {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::DcCurrentMin::Id; }
@@ -25903,8 +26920,9 @@ struct TypeInfo
 namespace DcCurrentMax {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::DcCurrentMax::Id; }
@@ -25913,8 +26931,9 @@ struct TypeInfo
 namespace DcPower {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::DcPower::Id; }
@@ -25923,8 +26942,9 @@ struct TypeInfo
 namespace DcPowerMin {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::DcPowerMin::Id; }
@@ -25933,8 +26953,9 @@ struct TypeInfo
 namespace DcPowerMax {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::DcPowerMax::Id; }
@@ -25943,8 +26964,9 @@ struct TypeInfo
 namespace DcVoltageMultiplier {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::DcVoltageMultiplier::Id; }
@@ -25953,8 +26975,9 @@ struct TypeInfo
 namespace DcVoltageDivisor {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::DcVoltageDivisor::Id; }
@@ -25963,8 +26986,9 @@ struct TypeInfo
 namespace DcCurrentMultiplier {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::DcCurrentMultiplier::Id; }
@@ -25973,8 +26997,9 @@ struct TypeInfo
 namespace DcCurrentDivisor {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::DcCurrentDivisor::Id; }
@@ -25983,8 +27008,9 @@ struct TypeInfo
 namespace DcPowerMultiplier {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::DcPowerMultiplier::Id; }
@@ -25993,8 +27019,9 @@ struct TypeInfo
 namespace DcPowerDivisor {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::DcPowerDivisor::Id; }
@@ -26003,8 +27030,9 @@ struct TypeInfo
 namespace AcFrequency {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::AcFrequency::Id; }
@@ -26013,8 +27041,9 @@ struct TypeInfo
 namespace AcFrequencyMin {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::AcFrequencyMin::Id; }
@@ -26023,8 +27052,9 @@ struct TypeInfo
 namespace AcFrequencyMax {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::AcFrequencyMax::Id; }
@@ -26033,8 +27063,9 @@ struct TypeInfo
 namespace NeutralCurrent {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::NeutralCurrent::Id; }
@@ -26043,8 +27074,9 @@ struct TypeInfo
 namespace TotalActivePower {
 struct TypeInfo
 {
-    using Type          = int32_t;
-    using DecodableType = int32_t;
+    using Type             = int32_t;
+    using DecodableType    = int32_t;
+    using DecodableArgType = int32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::TotalActivePower::Id; }
@@ -26053,8 +27085,9 @@ struct TypeInfo
 namespace TotalReactivePower {
 struct TypeInfo
 {
-    using Type          = int32_t;
-    using DecodableType = int32_t;
+    using Type             = int32_t;
+    using DecodableType    = int32_t;
+    using DecodableArgType = int32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::TotalReactivePower::Id; }
@@ -26063,8 +27096,9 @@ struct TypeInfo
 namespace TotalApparentPower {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::TotalApparentPower::Id; }
@@ -26073,8 +27107,9 @@ struct TypeInfo
 namespace Measured1stHarmonicCurrent {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Measured1stHarmonicCurrent::Id; }
@@ -26083,8 +27118,9 @@ struct TypeInfo
 namespace Measured3rdHarmonicCurrent {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Measured3rdHarmonicCurrent::Id; }
@@ -26093,8 +27129,9 @@ struct TypeInfo
 namespace Measured5thHarmonicCurrent {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Measured5thHarmonicCurrent::Id; }
@@ -26103,8 +27140,9 @@ struct TypeInfo
 namespace Measured7thHarmonicCurrent {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Measured7thHarmonicCurrent::Id; }
@@ -26113,8 +27151,9 @@ struct TypeInfo
 namespace Measured9thHarmonicCurrent {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Measured9thHarmonicCurrent::Id; }
@@ -26123,8 +27162,9 @@ struct TypeInfo
 namespace Measured11thHarmonicCurrent {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Measured11thHarmonicCurrent::Id; }
@@ -26133,8 +27173,9 @@ struct TypeInfo
 namespace MeasuredPhase1stHarmonicCurrent {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MeasuredPhase1stHarmonicCurrent::Id; }
@@ -26143,8 +27184,9 @@ struct TypeInfo
 namespace MeasuredPhase3rdHarmonicCurrent {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MeasuredPhase3rdHarmonicCurrent::Id; }
@@ -26153,8 +27195,9 @@ struct TypeInfo
 namespace MeasuredPhase5thHarmonicCurrent {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MeasuredPhase5thHarmonicCurrent::Id; }
@@ -26163,8 +27206,9 @@ struct TypeInfo
 namespace MeasuredPhase7thHarmonicCurrent {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MeasuredPhase7thHarmonicCurrent::Id; }
@@ -26173,8 +27217,9 @@ struct TypeInfo
 namespace MeasuredPhase9thHarmonicCurrent {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MeasuredPhase9thHarmonicCurrent::Id; }
@@ -26183,8 +27228,9 @@ struct TypeInfo
 namespace MeasuredPhase11thHarmonicCurrent {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::MeasuredPhase11thHarmonicCurrent::Id; }
@@ -26193,8 +27239,9 @@ struct TypeInfo
 namespace AcFrequencyMultiplier {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::AcFrequencyMultiplier::Id; }
@@ -26203,8 +27250,9 @@ struct TypeInfo
 namespace AcFrequencyDivisor {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::AcFrequencyDivisor::Id; }
@@ -26213,8 +27261,9 @@ struct TypeInfo
 namespace PowerMultiplier {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::PowerMultiplier::Id; }
@@ -26223,8 +27272,9 @@ struct TypeInfo
 namespace PowerDivisor {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::PowerDivisor::Id; }
@@ -26233,8 +27283,9 @@ struct TypeInfo
 namespace HarmonicCurrentMultiplier {
 struct TypeInfo
 {
-    using Type          = int8_t;
-    using DecodableType = int8_t;
+    using Type             = int8_t;
+    using DecodableType    = int8_t;
+    using DecodableArgType = int8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::HarmonicCurrentMultiplier::Id; }
@@ -26243,8 +27294,9 @@ struct TypeInfo
 namespace PhaseHarmonicCurrentMultiplier {
 struct TypeInfo
 {
-    using Type          = int8_t;
-    using DecodableType = int8_t;
+    using Type             = int8_t;
+    using DecodableType    = int8_t;
+    using DecodableArgType = int8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::PhaseHarmonicCurrentMultiplier::Id; }
@@ -26253,8 +27305,9 @@ struct TypeInfo
 namespace InstantaneousVoltage {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::InstantaneousVoltage::Id; }
@@ -26263,8 +27316,9 @@ struct TypeInfo
 namespace InstantaneousLineCurrent {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::InstantaneousLineCurrent::Id; }
@@ -26273,8 +27327,9 @@ struct TypeInfo
 namespace InstantaneousActiveCurrent {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::InstantaneousActiveCurrent::Id; }
@@ -26283,8 +27338,9 @@ struct TypeInfo
 namespace InstantaneousReactiveCurrent {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::InstantaneousReactiveCurrent::Id; }
@@ -26293,8 +27349,9 @@ struct TypeInfo
 namespace InstantaneousPower {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::InstantaneousPower::Id; }
@@ -26303,8 +27360,9 @@ struct TypeInfo
 namespace RmsVoltage {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::RmsVoltage::Id; }
@@ -26313,8 +27371,9 @@ struct TypeInfo
 namespace RmsVoltageMin {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::RmsVoltageMin::Id; }
@@ -26323,8 +27382,9 @@ struct TypeInfo
 namespace RmsVoltageMax {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::RmsVoltageMax::Id; }
@@ -26333,8 +27393,9 @@ struct TypeInfo
 namespace RmsCurrent {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::RmsCurrent::Id; }
@@ -26343,8 +27404,9 @@ struct TypeInfo
 namespace RmsCurrentMin {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::RmsCurrentMin::Id; }
@@ -26353,8 +27415,9 @@ struct TypeInfo
 namespace RmsCurrentMax {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::RmsCurrentMax::Id; }
@@ -26363,8 +27426,9 @@ struct TypeInfo
 namespace ActivePower {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ActivePower::Id; }
@@ -26373,8 +27437,9 @@ struct TypeInfo
 namespace ActivePowerMin {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ActivePowerMin::Id; }
@@ -26383,8 +27448,9 @@ struct TypeInfo
 namespace ActivePowerMax {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ActivePowerMax::Id; }
@@ -26393,8 +27459,9 @@ struct TypeInfo
 namespace ReactivePower {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ReactivePower::Id; }
@@ -26403,8 +27470,9 @@ struct TypeInfo
 namespace ApparentPower {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ApparentPower::Id; }
@@ -26413,8 +27481,9 @@ struct TypeInfo
 namespace PowerFactor {
 struct TypeInfo
 {
-    using Type          = int8_t;
-    using DecodableType = int8_t;
+    using Type             = int8_t;
+    using DecodableType    = int8_t;
+    using DecodableArgType = int8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::PowerFactor::Id; }
@@ -26423,8 +27492,9 @@ struct TypeInfo
 namespace AverageRmsVoltageMeasurementPeriod {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::AverageRmsVoltageMeasurementPeriod::Id; }
@@ -26433,8 +27503,9 @@ struct TypeInfo
 namespace AverageRmsUnderVoltageCounter {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::AverageRmsUnderVoltageCounter::Id; }
@@ -26443,8 +27514,9 @@ struct TypeInfo
 namespace RmsExtremeOverVoltagePeriod {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::RmsExtremeOverVoltagePeriod::Id; }
@@ -26453,8 +27525,9 @@ struct TypeInfo
 namespace RmsExtremeUnderVoltagePeriod {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::RmsExtremeUnderVoltagePeriod::Id; }
@@ -26463,8 +27536,9 @@ struct TypeInfo
 namespace RmsVoltageSagPeriod {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::RmsVoltageSagPeriod::Id; }
@@ -26473,8 +27547,9 @@ struct TypeInfo
 namespace RmsVoltageSwellPeriod {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::RmsVoltageSwellPeriod::Id; }
@@ -26483,8 +27558,9 @@ struct TypeInfo
 namespace AcVoltageMultiplier {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::AcVoltageMultiplier::Id; }
@@ -26493,8 +27569,9 @@ struct TypeInfo
 namespace AcVoltageDivisor {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::AcVoltageDivisor::Id; }
@@ -26503,8 +27580,9 @@ struct TypeInfo
 namespace AcCurrentMultiplier {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::AcCurrentMultiplier::Id; }
@@ -26513,8 +27591,9 @@ struct TypeInfo
 namespace AcCurrentDivisor {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::AcCurrentDivisor::Id; }
@@ -26523,8 +27602,9 @@ struct TypeInfo
 namespace AcPowerMultiplier {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::AcPowerMultiplier::Id; }
@@ -26533,8 +27613,9 @@ struct TypeInfo
 namespace AcPowerDivisor {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::AcPowerDivisor::Id; }
@@ -26543,8 +27624,9 @@ struct TypeInfo
 namespace OverloadAlarmsMask {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::OverloadAlarmsMask::Id; }
@@ -26553,8 +27635,9 @@ struct TypeInfo
 namespace VoltageOverload {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::VoltageOverload::Id; }
@@ -26563,8 +27646,9 @@ struct TypeInfo
 namespace CurrentOverload {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::CurrentOverload::Id; }
@@ -26573,8 +27657,9 @@ struct TypeInfo
 namespace AcOverloadAlarmsMask {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::AcOverloadAlarmsMask::Id; }
@@ -26583,8 +27668,9 @@ struct TypeInfo
 namespace AcVoltageOverload {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::AcVoltageOverload::Id; }
@@ -26593,8 +27679,9 @@ struct TypeInfo
 namespace AcCurrentOverload {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::AcCurrentOverload::Id; }
@@ -26603,8 +27690,9 @@ struct TypeInfo
 namespace AcActivePowerOverload {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::AcActivePowerOverload::Id; }
@@ -26613,8 +27701,9 @@ struct TypeInfo
 namespace AcReactivePowerOverload {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::AcReactivePowerOverload::Id; }
@@ -26623,8 +27712,9 @@ struct TypeInfo
 namespace AverageRmsOverVoltage {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::AverageRmsOverVoltage::Id; }
@@ -26633,8 +27723,9 @@ struct TypeInfo
 namespace AverageRmsUnderVoltage {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::AverageRmsUnderVoltage::Id; }
@@ -26643,8 +27734,9 @@ struct TypeInfo
 namespace RmsExtremeOverVoltage {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::RmsExtremeOverVoltage::Id; }
@@ -26653,8 +27745,9 @@ struct TypeInfo
 namespace RmsExtremeUnderVoltage {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::RmsExtremeUnderVoltage::Id; }
@@ -26663,8 +27756,9 @@ struct TypeInfo
 namespace RmsVoltageSag {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::RmsVoltageSag::Id; }
@@ -26673,8 +27767,9 @@ struct TypeInfo
 namespace RmsVoltageSwell {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::RmsVoltageSwell::Id; }
@@ -26683,8 +27778,9 @@ struct TypeInfo
 namespace LineCurrentPhaseB {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::LineCurrentPhaseB::Id; }
@@ -26693,8 +27789,9 @@ struct TypeInfo
 namespace ActiveCurrentPhaseB {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ActiveCurrentPhaseB::Id; }
@@ -26703,8 +27800,9 @@ struct TypeInfo
 namespace ReactiveCurrentPhaseB {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ReactiveCurrentPhaseB::Id; }
@@ -26713,8 +27811,9 @@ struct TypeInfo
 namespace RmsVoltagePhaseB {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::RmsVoltagePhaseB::Id; }
@@ -26723,8 +27822,9 @@ struct TypeInfo
 namespace RmsVoltageMinPhaseB {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::RmsVoltageMinPhaseB::Id; }
@@ -26733,8 +27833,9 @@ struct TypeInfo
 namespace RmsVoltageMaxPhaseB {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::RmsVoltageMaxPhaseB::Id; }
@@ -26743,8 +27844,9 @@ struct TypeInfo
 namespace RmsCurrentPhaseB {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::RmsCurrentPhaseB::Id; }
@@ -26753,8 +27855,9 @@ struct TypeInfo
 namespace RmsCurrentMinPhaseB {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::RmsCurrentMinPhaseB::Id; }
@@ -26763,8 +27866,9 @@ struct TypeInfo
 namespace RmsCurrentMaxPhaseB {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::RmsCurrentMaxPhaseB::Id; }
@@ -26773,8 +27877,9 @@ struct TypeInfo
 namespace ActivePowerPhaseB {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ActivePowerPhaseB::Id; }
@@ -26783,8 +27888,9 @@ struct TypeInfo
 namespace ActivePowerMinPhaseB {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ActivePowerMinPhaseB::Id; }
@@ -26793,8 +27899,9 @@ struct TypeInfo
 namespace ActivePowerMaxPhaseB {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ActivePowerMaxPhaseB::Id; }
@@ -26803,8 +27910,9 @@ struct TypeInfo
 namespace ReactivePowerPhaseB {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ReactivePowerPhaseB::Id; }
@@ -26813,8 +27921,9 @@ struct TypeInfo
 namespace ApparentPowerPhaseB {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ApparentPowerPhaseB::Id; }
@@ -26823,8 +27932,9 @@ struct TypeInfo
 namespace PowerFactorPhaseB {
 struct TypeInfo
 {
-    using Type          = int8_t;
-    using DecodableType = int8_t;
+    using Type             = int8_t;
+    using DecodableType    = int8_t;
+    using DecodableArgType = int8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::PowerFactorPhaseB::Id; }
@@ -26833,8 +27943,9 @@ struct TypeInfo
 namespace AverageRmsVoltageMeasurementPeriodPhaseB {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::AverageRmsVoltageMeasurementPeriodPhaseB::Id; }
@@ -26843,8 +27954,9 @@ struct TypeInfo
 namespace AverageRmsOverVoltageCounterPhaseB {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::AverageRmsOverVoltageCounterPhaseB::Id; }
@@ -26853,8 +27965,9 @@ struct TypeInfo
 namespace AverageRmsUnderVoltageCounterPhaseB {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::AverageRmsUnderVoltageCounterPhaseB::Id; }
@@ -26863,8 +27976,9 @@ struct TypeInfo
 namespace RmsExtremeOverVoltagePeriodPhaseB {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::RmsExtremeOverVoltagePeriodPhaseB::Id; }
@@ -26873,8 +27987,9 @@ struct TypeInfo
 namespace RmsExtremeUnderVoltagePeriodPhaseB {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::RmsExtremeUnderVoltagePeriodPhaseB::Id; }
@@ -26883,8 +27998,9 @@ struct TypeInfo
 namespace RmsVoltageSagPeriodPhaseB {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::RmsVoltageSagPeriodPhaseB::Id; }
@@ -26893,8 +28009,9 @@ struct TypeInfo
 namespace RmsVoltageSwellPeriodPhaseB {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::RmsVoltageSwellPeriodPhaseB::Id; }
@@ -26903,8 +28020,9 @@ struct TypeInfo
 namespace LineCurrentPhaseC {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::LineCurrentPhaseC::Id; }
@@ -26913,8 +28031,9 @@ struct TypeInfo
 namespace ActiveCurrentPhaseC {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ActiveCurrentPhaseC::Id; }
@@ -26923,8 +28042,9 @@ struct TypeInfo
 namespace ReactiveCurrentPhaseC {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ReactiveCurrentPhaseC::Id; }
@@ -26933,8 +28053,9 @@ struct TypeInfo
 namespace RmsVoltagePhaseC {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::RmsVoltagePhaseC::Id; }
@@ -26943,8 +28064,9 @@ struct TypeInfo
 namespace RmsVoltageMinPhaseC {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::RmsVoltageMinPhaseC::Id; }
@@ -26953,8 +28075,9 @@ struct TypeInfo
 namespace RmsVoltageMaxPhaseC {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::RmsVoltageMaxPhaseC::Id; }
@@ -26963,8 +28086,9 @@ struct TypeInfo
 namespace RmsCurrentPhaseC {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::RmsCurrentPhaseC::Id; }
@@ -26973,8 +28097,9 @@ struct TypeInfo
 namespace RmsCurrentMinPhaseC {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::RmsCurrentMinPhaseC::Id; }
@@ -26983,8 +28108,9 @@ struct TypeInfo
 namespace RmsCurrentMaxPhaseC {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::RmsCurrentMaxPhaseC::Id; }
@@ -26993,8 +28119,9 @@ struct TypeInfo
 namespace ActivePowerPhaseC {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ActivePowerPhaseC::Id; }
@@ -27003,8 +28130,9 @@ struct TypeInfo
 namespace ActivePowerMinPhaseC {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ActivePowerMinPhaseC::Id; }
@@ -27013,8 +28141,9 @@ struct TypeInfo
 namespace ActivePowerMaxPhaseC {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ActivePowerMaxPhaseC::Id; }
@@ -27023,8 +28152,9 @@ struct TypeInfo
 namespace ReactivePowerPhaseC {
 struct TypeInfo
 {
-    using Type          = int16_t;
-    using DecodableType = int16_t;
+    using Type             = int16_t;
+    using DecodableType    = int16_t;
+    using DecodableArgType = int16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ReactivePowerPhaseC::Id; }
@@ -27033,8 +28163,9 @@ struct TypeInfo
 namespace ApparentPowerPhaseC {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ApparentPowerPhaseC::Id; }
@@ -27043,8 +28174,9 @@ struct TypeInfo
 namespace PowerFactorPhaseC {
 struct TypeInfo
 {
-    using Type          = int8_t;
-    using DecodableType = int8_t;
+    using Type             = int8_t;
+    using DecodableType    = int8_t;
+    using DecodableArgType = int8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::PowerFactorPhaseC::Id; }
@@ -27053,8 +28185,9 @@ struct TypeInfo
 namespace AverageRmsVoltageMeasurementPeriodPhaseC {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::AverageRmsVoltageMeasurementPeriodPhaseC::Id; }
@@ -27063,8 +28196,9 @@ struct TypeInfo
 namespace AverageRmsOverVoltageCounterPhaseC {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::AverageRmsOverVoltageCounterPhaseC::Id; }
@@ -27073,8 +28207,9 @@ struct TypeInfo
 namespace AverageRmsUnderVoltageCounterPhaseC {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::AverageRmsUnderVoltageCounterPhaseC::Id; }
@@ -27083,8 +28218,9 @@ struct TypeInfo
 namespace RmsExtremeOverVoltagePeriodPhaseC {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::RmsExtremeOverVoltagePeriodPhaseC::Id; }
@@ -27093,8 +28229,9 @@ struct TypeInfo
 namespace RmsExtremeUnderVoltagePeriodPhaseC {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::RmsExtremeUnderVoltagePeriodPhaseC::Id; }
@@ -27103,8 +28240,9 @@ struct TypeInfo
 namespace RmsVoltageSagPeriodPhaseC {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::RmsVoltageSagPeriodPhaseC::Id; }
@@ -27113,8 +28251,9 @@ struct TypeInfo
 namespace RmsVoltageSwellPeriodPhaseC {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::RmsVoltageSwellPeriodPhaseC::Id; }
@@ -27123,8 +28262,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -27133,8 +28273,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -27225,8 +28366,9 @@ namespace Attributes {
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Binding::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -27235,8 +28377,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::Binding::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -27313,8 +28456,9 @@ namespace Attributes {
 namespace Groups {
 struct TypeInfo
 {
-    using Type          = DataModel::List<const Structs::GroupState::Type>;
-    using DecodableType = DataModel::DecodableList<Structs::GroupState::DecodableType>;
+    using Type             = DataModel::List<const Structs::GroupState::Type>;
+    using DecodableType    = DataModel::DecodableList<Structs::GroupState::DecodableType>;
+    using DecodableArgType = const DataModel::DecodableList<Structs::GroupState::DecodableType> &;
 
     static constexpr ClusterId GetClusterId() { return Clusters::GroupKeyManagement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::Groups::Id; }
@@ -27323,8 +28467,9 @@ struct TypeInfo
 namespace GroupKeys {
 struct TypeInfo
 {
-    using Type          = DataModel::List<const Structs::GroupKey::Type>;
-    using DecodableType = DataModel::DecodableList<Structs::GroupKey::DecodableType>;
+    using Type             = DataModel::List<const Structs::GroupKey::Type>;
+    using DecodableType    = DataModel::DecodableList<Structs::GroupKey::DecodableType>;
+    using DecodableArgType = const DataModel::DecodableList<Structs::GroupKey::DecodableType> &;
 
     static constexpr ClusterId GetClusterId() { return Clusters::GroupKeyManagement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::GroupKeys::Id; }
@@ -27333,8 +28478,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::GroupKeyManagement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -27343,8 +28489,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::GroupKeyManagement::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -27389,8 +28536,9 @@ namespace Attributes {
 namespace EmberSampleAttribute {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::SampleMfgSpecificCluster::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::EmberSampleAttribute::Id; }
@@ -27399,8 +28547,9 @@ struct TypeInfo
 namespace EmberSampleAttribute2 {
 struct TypeInfo
 {
-    using Type          = uint8_t;
-    using DecodableType = uint8_t;
+    using Type             = uint8_t;
+    using DecodableType    = uint8_t;
+    using DecodableArgType = uint8_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::SampleMfgSpecificCluster::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::EmberSampleAttribute2::Id; }
@@ -27409,8 +28558,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::SampleMfgSpecificCluster::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -27419,8 +28569,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::SampleMfgSpecificCluster::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }
@@ -27465,8 +28616,9 @@ namespace Attributes {
 namespace EmberSampleAttribute3 {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::SampleMfgSpecificCluster2::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::EmberSampleAttribute3::Id; }
@@ -27475,8 +28627,9 @@ struct TypeInfo
 namespace EmberSampleAttribute4 {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::SampleMfgSpecificCluster2::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::EmberSampleAttribute4::Id; }
@@ -27485,8 +28638,9 @@ struct TypeInfo
 namespace FeatureMap {
 struct TypeInfo
 {
-    using Type          = uint32_t;
-    using DecodableType = uint32_t;
+    using Type             = uint32_t;
+    using DecodableType    = uint32_t;
+    using DecodableArgType = uint32_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::SampleMfgSpecificCluster2::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::FeatureMap::Id; }
@@ -27495,8 +28649,9 @@ struct TypeInfo
 namespace ClusterRevision {
 struct TypeInfo
 {
-    using Type          = uint16_t;
-    using DecodableType = uint16_t;
+    using Type             = uint16_t;
+    using DecodableType    = uint16_t;
+    using DecodableArgType = uint16_t;
 
     static constexpr ClusterId GetClusterId() { return Clusters::SampleMfgSpecificCluster2::Id; }
     static constexpr AttributeId GetAttributeId() { return Attributes::ClusterRevision::Id; }

--- a/zzz_generated/chip-tool/zap-generated/test/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/test/Commands.h
@@ -77,14 +77,9 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 3;
 
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_0{ OnFailureCallback_0, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t clusterRevision)> mOnSuccessCallback_0{ OnSuccessCallback_0, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_2{ OnFailureCallback_2, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t clusterRevision)> mOnSuccessCallback_2{ OnSuccessCallback_2, this };
-
-    static void OnFailureCallback_0(void * context, uint8_t status)
+    static void OnFailureCallback_0(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_BI_1_1 *>(context))->OnFailureResponse_0(status);
+        (static_cast<Test_TC_BI_1_1 *>(context))->OnFailureResponse_0(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_0(void * context, uint16_t clusterRevision)
@@ -99,9 +94,9 @@ private:
 
     static void OnSuccessCallback_1(void * context) { (static_cast<Test_TC_BI_1_1 *>(context))->OnSuccessResponse_1(); }
 
-    static void OnFailureCallback_2(void * context, uint8_t status)
+    static void OnFailureCallback_2(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_BI_1_1 *>(context))->OnFailureResponse_2(status);
+        (static_cast<Test_TC_BI_1_1 *>(context))->OnFailureResponse_2(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_2(void * context, uint16_t clusterRevision)
@@ -118,7 +113,8 @@ private:
         chip::Controller::BinaryInputBasicClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeClusterRevision(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::BinaryInputBasic::Attributes::ClusterRevision::TypeInfo>(
+            this, OnSuccessCallback_0, OnFailureCallback_0);
     }
 
     void OnFailureResponse_0(uint8_t status) { ThrowFailureResponse(); }
@@ -150,7 +146,8 @@ private:
         chip::Controller::BinaryInputBasicClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeClusterRevision(mOnSuccessCallback_2.Cancel(), mOnFailureCallback_2.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::BinaryInputBasic::Attributes::ClusterRevision::TypeInfo>(
+            this, OnSuccessCallback_2, OnFailureCallback_2);
     }
 
     void OnFailureResponse_2(uint8_t status) { ThrowFailureResponse(); }
@@ -252,26 +249,9 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 11;
 
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_0{ OnFailureCallback_0, this };
-    chip::Callback::Callback<void (*)(void * context, bool outOfService)> mOnSuccessCallback_0{ OnSuccessCallback_0, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_1{ OnFailureCallback_1, this };
-    chip::Callback::Callback<void (*)(void * context, bool outOfService)> mOnSuccessCallback_1{ OnSuccessCallback_1, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_3{ OnFailureCallback_3, this };
-    chip::Callback::Callback<void (*)(void * context, bool outOfService)> mOnSuccessCallback_3{ OnSuccessCallback_3, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_4{ OnFailureCallback_4, this };
-    chip::Callback::Callback<void (*)(void * context, bool presentValue)> mOnSuccessCallback_4{ OnSuccessCallback_4, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_6{ OnFailureCallback_6, this };
-    chip::Callback::Callback<void (*)(void * context, bool presentValue)> mOnSuccessCallback_6{ OnSuccessCallback_6, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_7{ OnFailureCallback_7, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t statusFlags)> mOnSuccessCallback_7{ OnSuccessCallback_7, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_8{ OnFailureCallback_8, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t statusFlags)> mOnSuccessCallback_8{ OnSuccessCallback_8, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_10{ OnFailureCallback_10, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t statusFlags)> mOnSuccessCallback_10{ OnSuccessCallback_10, this };
-
-    static void OnFailureCallback_0(void * context, uint8_t status)
+    static void OnFailureCallback_0(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_BI_2_1 *>(context))->OnFailureResponse_0(status);
+        (static_cast<Test_TC_BI_2_1 *>(context))->OnFailureResponse_0(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_0(void * context, bool outOfService)
@@ -279,9 +259,9 @@ private:
         (static_cast<Test_TC_BI_2_1 *>(context))->OnSuccessResponse_0(outOfService);
     }
 
-    static void OnFailureCallback_1(void * context, uint8_t status)
+    static void OnFailureCallback_1(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_BI_2_1 *>(context))->OnFailureResponse_1(status);
+        (static_cast<Test_TC_BI_2_1 *>(context))->OnFailureResponse_1(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_1(void * context, bool outOfService)
@@ -296,9 +276,9 @@ private:
 
     static void OnSuccessCallback_2(void * context) { (static_cast<Test_TC_BI_2_1 *>(context))->OnSuccessResponse_2(); }
 
-    static void OnFailureCallback_3(void * context, uint8_t status)
+    static void OnFailureCallback_3(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_BI_2_1 *>(context))->OnFailureResponse_3(status);
+        (static_cast<Test_TC_BI_2_1 *>(context))->OnFailureResponse_3(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_3(void * context, bool outOfService)
@@ -306,9 +286,9 @@ private:
         (static_cast<Test_TC_BI_2_1 *>(context))->OnSuccessResponse_3(outOfService);
     }
 
-    static void OnFailureCallback_4(void * context, uint8_t status)
+    static void OnFailureCallback_4(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_BI_2_1 *>(context))->OnFailureResponse_4(status);
+        (static_cast<Test_TC_BI_2_1 *>(context))->OnFailureResponse_4(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_4(void * context, bool presentValue)
@@ -323,9 +303,9 @@ private:
 
     static void OnSuccessCallback_5(void * context) { (static_cast<Test_TC_BI_2_1 *>(context))->OnSuccessResponse_5(); }
 
-    static void OnFailureCallback_6(void * context, uint8_t status)
+    static void OnFailureCallback_6(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_BI_2_1 *>(context))->OnFailureResponse_6(status);
+        (static_cast<Test_TC_BI_2_1 *>(context))->OnFailureResponse_6(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_6(void * context, bool presentValue)
@@ -333,9 +313,9 @@ private:
         (static_cast<Test_TC_BI_2_1 *>(context))->OnSuccessResponse_6(presentValue);
     }
 
-    static void OnFailureCallback_7(void * context, uint8_t status)
+    static void OnFailureCallback_7(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_BI_2_1 *>(context))->OnFailureResponse_7(status);
+        (static_cast<Test_TC_BI_2_1 *>(context))->OnFailureResponse_7(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_7(void * context, uint8_t statusFlags)
@@ -343,9 +323,9 @@ private:
         (static_cast<Test_TC_BI_2_1 *>(context))->OnSuccessResponse_7(statusFlags);
     }
 
-    static void OnFailureCallback_8(void * context, uint8_t status)
+    static void OnFailureCallback_8(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_BI_2_1 *>(context))->OnFailureResponse_8(status);
+        (static_cast<Test_TC_BI_2_1 *>(context))->OnFailureResponse_8(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_8(void * context, uint8_t statusFlags)
@@ -360,9 +340,9 @@ private:
 
     static void OnSuccessCallback_9(void * context) { (static_cast<Test_TC_BI_2_1 *>(context))->OnSuccessResponse_9(); }
 
-    static void OnFailureCallback_10(void * context, uint8_t status)
+    static void OnFailureCallback_10(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_BI_2_1 *>(context))->OnFailureResponse_10(status);
+        (static_cast<Test_TC_BI_2_1 *>(context))->OnFailureResponse_10(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_10(void * context, uint8_t statusFlags)
@@ -379,7 +359,8 @@ private:
         chip::Controller::BinaryInputBasicClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOutOfService(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::BinaryInputBasic::Attributes::OutOfService::TypeInfo>(
+            this, OnSuccessCallback_0, OnFailureCallback_0);
     }
 
     void OnFailureResponse_0(uint8_t status) { ThrowFailureResponse(); }
@@ -395,7 +376,8 @@ private:
         chip::Controller::BinaryInputBasicClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOutOfService(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::BinaryInputBasic::Attributes::OutOfService::TypeInfo>(
+            this, OnSuccessCallback_1, OnFailureCallback_1);
     }
 
     void OnFailureResponse_1(uint8_t status) { ThrowFailureResponse(); }
@@ -427,7 +409,8 @@ private:
         chip::Controller::BinaryInputBasicClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOutOfService(mOnSuccessCallback_3.Cancel(), mOnFailureCallback_3.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::BinaryInputBasic::Attributes::OutOfService::TypeInfo>(
+            this, OnSuccessCallback_3, OnFailureCallback_3);
     }
 
     void OnFailureResponse_3(uint8_t status) { ThrowFailureResponse(); }
@@ -443,7 +426,8 @@ private:
         chip::Controller::BinaryInputBasicClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributePresentValue(mOnSuccessCallback_4.Cancel(), mOnFailureCallback_4.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::BinaryInputBasic::Attributes::PresentValue::TypeInfo>(
+            this, OnSuccessCallback_4, OnFailureCallback_4);
     }
 
     void OnFailureResponse_4(uint8_t status) { ThrowFailureResponse(); }
@@ -475,7 +459,8 @@ private:
         chip::Controller::BinaryInputBasicClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributePresentValue(mOnSuccessCallback_6.Cancel(), mOnFailureCallback_6.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::BinaryInputBasic::Attributes::PresentValue::TypeInfo>(
+            this, OnSuccessCallback_6, OnFailureCallback_6);
     }
 
     void OnFailureResponse_6(uint8_t status) { ThrowFailureResponse(); }
@@ -491,7 +476,8 @@ private:
         chip::Controller::BinaryInputBasicClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeStatusFlags(mOnSuccessCallback_7.Cancel(), mOnFailureCallback_7.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::BinaryInputBasic::Attributes::StatusFlags::TypeInfo>(
+            this, OnSuccessCallback_7, OnFailureCallback_7);
     }
 
     void OnFailureResponse_7(uint8_t status) { ThrowFailureResponse(); }
@@ -507,7 +493,8 @@ private:
         chip::Controller::BinaryInputBasicClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeStatusFlags(mOnSuccessCallback_8.Cancel(), mOnFailureCallback_8.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::BinaryInputBasic::Attributes::StatusFlags::TypeInfo>(
+            this, OnSuccessCallback_8, OnFailureCallback_8);
     }
 
     void OnFailureResponse_8(uint8_t status) { ThrowFailureResponse(); }
@@ -540,7 +527,8 @@ private:
         chip::Controller::BinaryInputBasicClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeStatusFlags(mOnSuccessCallback_10.Cancel(), mOnFailureCallback_10.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::BinaryInputBasic::Attributes::StatusFlags::TypeInfo>(
+            this, OnSuccessCallback_10, OnFailureCallback_10);
     }
 
     void OnFailureResponse_10(uint8_t status) { ThrowFailureResponse(); }
@@ -608,14 +596,9 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 3;
 
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_0{ OnFailureCallback_0, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t clusterRevision)> mOnSuccessCallback_0{ OnSuccessCallback_0, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_2{ OnFailureCallback_2, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t clusterRevision)> mOnSuccessCallback_2{ OnSuccessCallback_2, this };
-
-    static void OnFailureCallback_0(void * context, uint8_t status)
+    static void OnFailureCallback_0(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_BOOL_1_1 *>(context))->OnFailureResponse_0(status);
+        (static_cast<Test_TC_BOOL_1_1 *>(context))->OnFailureResponse_0(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_0(void * context, uint16_t clusterRevision)
@@ -630,9 +613,9 @@ private:
 
     static void OnSuccessCallback_1(void * context) { (static_cast<Test_TC_BOOL_1_1 *>(context))->OnSuccessResponse_1(); }
 
-    static void OnFailureCallback_2(void * context, uint8_t status)
+    static void OnFailureCallback_2(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_BOOL_1_1 *>(context))->OnFailureResponse_2(status);
+        (static_cast<Test_TC_BOOL_1_1 *>(context))->OnFailureResponse_2(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_2(void * context, uint16_t clusterRevision)
@@ -649,7 +632,8 @@ private:
         chip::Controller::BooleanStateClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeClusterRevision(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::BooleanState::Attributes::ClusterRevision::TypeInfo>(
+            this, OnSuccessCallback_0, OnFailureCallback_0);
     }
 
     void OnFailureResponse_0(uint8_t status) { ThrowFailureResponse(); }
@@ -681,7 +665,8 @@ private:
         chip::Controller::BooleanStateClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeClusterRevision(mOnSuccessCallback_2.Cancel(), mOnFailureCallback_2.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::BooleanState::Attributes::ClusterRevision::TypeInfo>(
+            this, OnSuccessCallback_2, OnFailureCallback_2);
     }
 
     void OnFailureResponse_2(uint8_t status) { ThrowFailureResponse(); }
@@ -753,16 +738,9 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 4;
 
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_0{ OnFailureCallback_0, this };
-    chip::Callback::Callback<void (*)(void * context, bool stateValue)> mOnSuccessCallback_0{ OnSuccessCallback_0, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_1{ OnFailureCallback_1, this };
-    chip::Callback::Callback<void (*)(void * context, bool stateValue)> mOnSuccessCallback_1{ OnSuccessCallback_1, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_3{ OnFailureCallback_3, this };
-    chip::Callback::Callback<void (*)(void * context, bool stateValue)> mOnSuccessCallback_3{ OnSuccessCallback_3, this };
-
-    static void OnFailureCallback_0(void * context, uint8_t status)
+    static void OnFailureCallback_0(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_BOOL_2_1 *>(context))->OnFailureResponse_0(status);
+        (static_cast<Test_TC_BOOL_2_1 *>(context))->OnFailureResponse_0(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_0(void * context, bool stateValue)
@@ -770,9 +748,9 @@ private:
         (static_cast<Test_TC_BOOL_2_1 *>(context))->OnSuccessResponse_0(stateValue);
     }
 
-    static void OnFailureCallback_1(void * context, uint8_t status)
+    static void OnFailureCallback_1(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_BOOL_2_1 *>(context))->OnFailureResponse_1(status);
+        (static_cast<Test_TC_BOOL_2_1 *>(context))->OnFailureResponse_1(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_1(void * context, bool stateValue)
@@ -787,9 +765,9 @@ private:
 
     static void OnSuccessCallback_2(void * context) { (static_cast<Test_TC_BOOL_2_1 *>(context))->OnSuccessResponse_2(); }
 
-    static void OnFailureCallback_3(void * context, uint8_t status)
+    static void OnFailureCallback_3(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_BOOL_2_1 *>(context))->OnFailureResponse_3(status);
+        (static_cast<Test_TC_BOOL_2_1 *>(context))->OnFailureResponse_3(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_3(void * context, bool stateValue)
@@ -806,7 +784,8 @@ private:
         chip::Controller::BooleanStateClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeStateValue(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::BooleanState::Attributes::StateValue::TypeInfo>(this, OnSuccessCallback_0,
+                                                                                                          OnFailureCallback_0);
     }
 
     void OnFailureResponse_0(uint8_t status) { ThrowFailureResponse(); }
@@ -822,7 +801,8 @@ private:
         chip::Controller::BooleanStateClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeStateValue(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::BooleanState::Attributes::StateValue::TypeInfo>(this, OnSuccessCallback_1,
+                                                                                                          OnFailureCallback_1);
     }
 
     void OnFailureResponse_1(uint8_t status) { ThrowFailureResponse(); }
@@ -854,7 +834,8 @@ private:
         chip::Controller::BooleanStateClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeStateValue(mOnSuccessCallback_3.Cancel(), mOnFailureCallback_3.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::BooleanState::Attributes::StateValue::TypeInfo>(this, OnSuccessCallback_3,
+                                                                                                          OnFailureCallback_3);
     }
 
     void OnFailureResponse_3(uint8_t status) { ThrowFailureResponse(); }
@@ -1574,276 +1555,9 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 145;
 
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_0{ OnFailureCallback_0, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t currentHue)> mOnSuccessCallback_0{ OnSuccessCallback_0, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_1{ OnFailureCallback_1, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t currentHue)> mOnSuccessCallback_1{ OnSuccessCallback_1, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_3{ OnFailureCallback_3, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t currentHue)> mOnSuccessCallback_3{ OnSuccessCallback_3, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_4{ OnFailureCallback_4, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t currentSaturation)> mOnSuccessCallback_4{ OnSuccessCallback_4, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_5{ OnFailureCallback_5, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t currentSaturation)> mOnSuccessCallback_5{ OnSuccessCallback_5, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_7{ OnFailureCallback_7, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t currentSaturation)> mOnSuccessCallback_7{ OnSuccessCallback_7, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_8{ OnFailureCallback_8, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t currentX)> mOnSuccessCallback_8{ OnSuccessCallback_8, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_9{ OnFailureCallback_9, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t currentX)> mOnSuccessCallback_9{ OnSuccessCallback_9, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_11{ OnFailureCallback_11, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t currentX)> mOnSuccessCallback_11{ OnSuccessCallback_11, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_12{ OnFailureCallback_12, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t currentY)> mOnSuccessCallback_12{ OnSuccessCallback_12, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_13{ OnFailureCallback_13, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t currentY)> mOnSuccessCallback_13{ OnSuccessCallback_13, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_15{ OnFailureCallback_15, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t currentY)> mOnSuccessCallback_15{ OnSuccessCallback_15, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_16{ OnFailureCallback_16, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t colorTemperature)> mOnSuccessCallback_16{ OnSuccessCallback_16,
-                                                                                                         this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_17{ OnFailureCallback_17, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t colorMode)> mOnSuccessCallback_17{ OnSuccessCallback_17, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_18{ OnFailureCallback_18, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t colorControlOptions)> mOnSuccessCallback_18{ OnSuccessCallback_18,
-                                                                                                           this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_19{ OnFailureCallback_19, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t colorControlOptions)> mOnSuccessCallback_19{ OnSuccessCallback_19,
-                                                                                                           this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_21{ OnFailureCallback_21, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t colorControlOptions)> mOnSuccessCallback_21{ OnSuccessCallback_21,
-                                                                                                           this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_22{ OnFailureCallback_22, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t enhancedCurrentHue)> mOnSuccessCallback_22{ OnSuccessCallback_22,
-                                                                                                           this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_23{ OnFailureCallback_23, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t enhancedCurrentHue)> mOnSuccessCallback_23{ OnSuccessCallback_23,
-                                                                                                           this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_25{ OnFailureCallback_25, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t enhancedCurrentHue)> mOnSuccessCallback_25{ OnSuccessCallback_25,
-                                                                                                           this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_26{ OnFailureCallback_26, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t enhancedColorMode)> mOnSuccessCallback_26{ OnSuccessCallback_26,
-                                                                                                         this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_27{ OnFailureCallback_27, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t colorLoopActive)> mOnSuccessCallback_27{ OnSuccessCallback_27, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_28{ OnFailureCallback_28, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t colorLoopActive)> mOnSuccessCallback_28{ OnSuccessCallback_28, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_30{ OnFailureCallback_30, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t colorLoopActive)> mOnSuccessCallback_30{ OnSuccessCallback_30, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_31{ OnFailureCallback_31, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t colorLoopDirection)> mOnSuccessCallback_31{ OnSuccessCallback_31,
-                                                                                                          this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_32{ OnFailureCallback_32, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t colorLoopDirection)> mOnSuccessCallback_32{ OnSuccessCallback_32,
-                                                                                                          this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_34{ OnFailureCallback_34, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t colorLoopDirection)> mOnSuccessCallback_34{ OnSuccessCallback_34,
-                                                                                                          this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_35{ OnFailureCallback_35, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t colorLoopTime)> mOnSuccessCallback_35{ OnSuccessCallback_35, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_36{ OnFailureCallback_36, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t colorLoopTime)> mOnSuccessCallback_36{ OnSuccessCallback_36, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_38{ OnFailureCallback_38, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t colorLoopTime)> mOnSuccessCallback_38{ OnSuccessCallback_38, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_39{ OnFailureCallback_39, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t colorLoopStartEnhancedHue)> mOnSuccessCallback_39{
-        OnSuccessCallback_39, this
-    };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_40{ OnFailureCallback_40, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t colorLoopStartEnhancedHue)> mOnSuccessCallback_40{
-        OnSuccessCallback_40, this
-    };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_42{ OnFailureCallback_42, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t colorLoopStartEnhancedHue)> mOnSuccessCallback_42{
-        OnSuccessCallback_42, this
-    };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_43{ OnFailureCallback_43, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t colorLoopStoredEnhancedHue)> mOnSuccessCallback_43{
-        OnSuccessCallback_43, this
-    };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_44{ OnFailureCallback_44, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t colorLoopStoredEnhancedHue)> mOnSuccessCallback_44{
-        OnSuccessCallback_44, this
-    };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_46{ OnFailureCallback_46, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t colorLoopStoredEnhancedHue)> mOnSuccessCallback_46{
-        OnSuccessCallback_46, this
-    };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_47{ OnFailureCallback_47, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t colorCapabilities)> mOnSuccessCallback_47{ OnSuccessCallback_47,
-                                                                                                          this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_48{ OnFailureCallback_48, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t colorCapabilities)> mOnSuccessCallback_48{ OnSuccessCallback_48,
-                                                                                                          this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_50{ OnFailureCallback_50, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t colorCapabilities)> mOnSuccessCallback_50{ OnSuccessCallback_50,
-                                                                                                          this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_51{ OnFailureCallback_51, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t colorTempPhysicalMin)> mOnSuccessCallback_51{ OnSuccessCallback_51,
-                                                                                                             this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_52{ OnFailureCallback_52, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t colorTempPhysicalMin)> mOnSuccessCallback_52{ OnSuccessCallback_52,
-                                                                                                             this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_54{ OnFailureCallback_54, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t colorTempPhysicalMin)> mOnSuccessCallback_54{ OnSuccessCallback_54,
-                                                                                                             this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_55{ OnFailureCallback_55, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t colorTempPhysicalMax)> mOnSuccessCallback_55{ OnSuccessCallback_55,
-                                                                                                             this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_56{ OnFailureCallback_56, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t colorTempPhysicalMax)> mOnSuccessCallback_56{ OnSuccessCallback_56,
-                                                                                                             this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_58{ OnFailureCallback_58, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t colorTempPhysicalMax)> mOnSuccessCallback_58{ OnSuccessCallback_58,
-                                                                                                             this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_59{ OnFailureCallback_59, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t coupleColorTempToLevelMinMireds)> mOnSuccessCallback_59{
-        OnSuccessCallback_59, this
-    };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_61{ OnFailureCallback_61, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t coupleColorTempToLevelMinMireds)> mOnSuccessCallback_61{
-        OnSuccessCallback_61, this
-    };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_62{ OnFailureCallback_62, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t startUpColorTemperatureMireds)> mOnSuccessCallback_62{
-        OnSuccessCallback_62, this
-    };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_64{ OnFailureCallback_64, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t startUpColorTemperatureMireds)> mOnSuccessCallback_64{
-        OnSuccessCallback_64, this
-    };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_65{ OnFailureCallback_65, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t remainingTime)> mOnSuccessCallback_65{ OnSuccessCallback_65, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_66{ OnFailureCallback_66, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t remainingTime)> mOnSuccessCallback_66{ OnSuccessCallback_66, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_68{ OnFailureCallback_68, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t remainingTime)> mOnSuccessCallback_68{ OnSuccessCallback_68, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_69{ OnFailureCallback_69, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t driftCompensation)> mOnSuccessCallback_69{ OnSuccessCallback_69,
-                                                                                                         this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_71{ OnFailureCallback_71, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t driftCompensation)> mOnSuccessCallback_71{ OnSuccessCallback_71,
-                                                                                                         this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_72{ OnFailureCallback_72, this };
-    chip::Callback::Callback<void (*)(void * context, chip::CharSpan compensationText)> mOnSuccessCallback_72{ OnSuccessCallback_72,
-                                                                                                               this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_73{ OnFailureCallback_73, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t numberOfPrimaries)> mOnSuccessCallback_73{ OnSuccessCallback_73,
-                                                                                                         this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_75{ OnFailureCallback_75, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t numberOfPrimaries)> mOnSuccessCallback_75{ OnSuccessCallback_75,
-                                                                                                         this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_76{ OnFailureCallback_76, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t primary1X)> mOnSuccessCallback_76{ OnSuccessCallback_76, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_78{ OnFailureCallback_78, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t primary1X)> mOnSuccessCallback_78{ OnSuccessCallback_78, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_79{ OnFailureCallback_79, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t primary1Y)> mOnSuccessCallback_79{ OnSuccessCallback_79, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_81{ OnFailureCallback_81, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t primary1Y)> mOnSuccessCallback_81{ OnSuccessCallback_81, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_82{ OnFailureCallback_82, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t primary1Intensity)> mOnSuccessCallback_82{ OnSuccessCallback_82,
-                                                                                                         this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_83{ OnFailureCallback_83, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t primary2X)> mOnSuccessCallback_83{ OnSuccessCallback_83, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_85{ OnFailureCallback_85, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t primary2X)> mOnSuccessCallback_85{ OnSuccessCallback_85, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_86{ OnFailureCallback_86, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t primary2Y)> mOnSuccessCallback_86{ OnSuccessCallback_86, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_88{ OnFailureCallback_88, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t primary2Y)> mOnSuccessCallback_88{ OnSuccessCallback_88, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_89{ OnFailureCallback_89, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t primary2Intensity)> mOnSuccessCallback_89{ OnSuccessCallback_89,
-                                                                                                         this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_90{ OnFailureCallback_90, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t primary3X)> mOnSuccessCallback_90{ OnSuccessCallback_90, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_92{ OnFailureCallback_92, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t primary3X)> mOnSuccessCallback_92{ OnSuccessCallback_92, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_93{ OnFailureCallback_93, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t primary3Y)> mOnSuccessCallback_93{ OnSuccessCallback_93, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_95{ OnFailureCallback_95, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t primary3Y)> mOnSuccessCallback_95{ OnSuccessCallback_95, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_96{ OnFailureCallback_96, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t primary3Intensity)> mOnSuccessCallback_96{ OnSuccessCallback_96,
-                                                                                                         this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_97{ OnFailureCallback_97, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t primary4X)> mOnSuccessCallback_97{ OnSuccessCallback_97, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_99{ OnFailureCallback_99, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t primary4X)> mOnSuccessCallback_99{ OnSuccessCallback_99, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_100{ OnFailureCallback_100, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t primary4Y)> mOnSuccessCallback_100{ OnSuccessCallback_100, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_102{ OnFailureCallback_102, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t primary4Y)> mOnSuccessCallback_102{ OnSuccessCallback_102, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_103{ OnFailureCallback_103, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t primary4Intensity)> mOnSuccessCallback_103{ OnSuccessCallback_103,
-                                                                                                          this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_104{ OnFailureCallback_104, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t primary5X)> mOnSuccessCallback_104{ OnSuccessCallback_104, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_106{ OnFailureCallback_106, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t primary5X)> mOnSuccessCallback_106{ OnSuccessCallback_106, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_107{ OnFailureCallback_107, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t primary5Y)> mOnSuccessCallback_107{ OnSuccessCallback_107, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_109{ OnFailureCallback_109, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t primary5Y)> mOnSuccessCallback_109{ OnSuccessCallback_109, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_110{ OnFailureCallback_110, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t primary5Intensity)> mOnSuccessCallback_110{ OnSuccessCallback_110,
-                                                                                                          this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_111{ OnFailureCallback_111, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t primary6X)> mOnSuccessCallback_111{ OnSuccessCallback_111, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_113{ OnFailureCallback_113, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t primary6X)> mOnSuccessCallback_113{ OnSuccessCallback_113, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_114{ OnFailureCallback_114, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t primary6Y)> mOnSuccessCallback_114{ OnSuccessCallback_114, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_116{ OnFailureCallback_116, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t primary6Y)> mOnSuccessCallback_116{ OnSuccessCallback_116, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_117{ OnFailureCallback_117, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t primary6Intensity)> mOnSuccessCallback_117{ OnSuccessCallback_117,
-                                                                                                          this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_118{ OnFailureCallback_118, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t whitePointX)> mOnSuccessCallback_118{ OnSuccessCallback_118, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_120{ OnFailureCallback_120, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t whitePointX)> mOnSuccessCallback_120{ OnSuccessCallback_120, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_121{ OnFailureCallback_121, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t whitePointY)> mOnSuccessCallback_121{ OnSuccessCallback_121, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_123{ OnFailureCallback_123, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t whitePointY)> mOnSuccessCallback_123{ OnSuccessCallback_123, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_124{ OnFailureCallback_124, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t colorPointRX)> mOnSuccessCallback_124{ OnSuccessCallback_124, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_126{ OnFailureCallback_126, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t colorPointRX)> mOnSuccessCallback_126{ OnSuccessCallback_126, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_127{ OnFailureCallback_127, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t colorPointRY)> mOnSuccessCallback_127{ OnSuccessCallback_127, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_129{ OnFailureCallback_129, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t colorPointRY)> mOnSuccessCallback_129{ OnSuccessCallback_129, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_130{ OnFailureCallback_130, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t colorPointRIntensity)> mOnSuccessCallback_130{ OnSuccessCallback_130,
-                                                                                                             this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_131{ OnFailureCallback_131, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t colorPointGX)> mOnSuccessCallback_131{ OnSuccessCallback_131, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_133{ OnFailureCallback_133, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t colorPointGX)> mOnSuccessCallback_133{ OnSuccessCallback_133, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_134{ OnFailureCallback_134, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t colorPointGY)> mOnSuccessCallback_134{ OnSuccessCallback_134, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_136{ OnFailureCallback_136, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t colorPointGY)> mOnSuccessCallback_136{ OnSuccessCallback_136, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_137{ OnFailureCallback_137, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t colorPointGIntensity)> mOnSuccessCallback_137{ OnSuccessCallback_137,
-                                                                                                             this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_138{ OnFailureCallback_138, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t colorPointBX)> mOnSuccessCallback_138{ OnSuccessCallback_138, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_140{ OnFailureCallback_140, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t colorPointBX)> mOnSuccessCallback_140{ OnSuccessCallback_140, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_141{ OnFailureCallback_141, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t colorPointBY)> mOnSuccessCallback_141{ OnSuccessCallback_141, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_143{ OnFailureCallback_143, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t colorPointBY)> mOnSuccessCallback_143{ OnSuccessCallback_143, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_144{ OnFailureCallback_144, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t colorPointBIntensity)> mOnSuccessCallback_144{ OnSuccessCallback_144,
-                                                                                                             this };
-
-    static void OnFailureCallback_0(void * context, uint8_t status)
+    static void OnFailureCallback_0(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_0(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_0(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_0(void * context, uint8_t currentHue)
@@ -1851,9 +1565,9 @@ private:
         (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_0(currentHue);
     }
 
-    static void OnFailureCallback_1(void * context, uint8_t status)
+    static void OnFailureCallback_1(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_1(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_1(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_1(void * context, uint8_t currentHue)
@@ -1868,9 +1582,9 @@ private:
 
     static void OnSuccessCallback_2(void * context) { (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_2(); }
 
-    static void OnFailureCallback_3(void * context, uint8_t status)
+    static void OnFailureCallback_3(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_3(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_3(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_3(void * context, uint8_t currentHue)
@@ -1878,9 +1592,9 @@ private:
         (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_3(currentHue);
     }
 
-    static void OnFailureCallback_4(void * context, uint8_t status)
+    static void OnFailureCallback_4(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_4(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_4(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_4(void * context, uint8_t currentSaturation)
@@ -1888,9 +1602,9 @@ private:
         (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_4(currentSaturation);
     }
 
-    static void OnFailureCallback_5(void * context, uint8_t status)
+    static void OnFailureCallback_5(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_5(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_5(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_5(void * context, uint8_t currentSaturation)
@@ -1905,9 +1619,9 @@ private:
 
     static void OnSuccessCallback_6(void * context) { (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_6(); }
 
-    static void OnFailureCallback_7(void * context, uint8_t status)
+    static void OnFailureCallback_7(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_7(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_7(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_7(void * context, uint8_t currentSaturation)
@@ -1915,9 +1629,9 @@ private:
         (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_7(currentSaturation);
     }
 
-    static void OnFailureCallback_8(void * context, uint8_t status)
+    static void OnFailureCallback_8(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_8(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_8(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_8(void * context, uint16_t currentX)
@@ -1925,9 +1639,9 @@ private:
         (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_8(currentX);
     }
 
-    static void OnFailureCallback_9(void * context, uint8_t status)
+    static void OnFailureCallback_9(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_9(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_9(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_9(void * context, uint16_t currentX)
@@ -1942,9 +1656,9 @@ private:
 
     static void OnSuccessCallback_10(void * context) { (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_10(); }
 
-    static void OnFailureCallback_11(void * context, uint8_t status)
+    static void OnFailureCallback_11(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_11(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_11(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_11(void * context, uint16_t currentX)
@@ -1952,9 +1666,9 @@ private:
         (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_11(currentX);
     }
 
-    static void OnFailureCallback_12(void * context, uint8_t status)
+    static void OnFailureCallback_12(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_12(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_12(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_12(void * context, uint16_t currentY)
@@ -1962,9 +1676,9 @@ private:
         (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_12(currentY);
     }
 
-    static void OnFailureCallback_13(void * context, uint8_t status)
+    static void OnFailureCallback_13(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_13(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_13(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_13(void * context, uint16_t currentY)
@@ -1979,9 +1693,9 @@ private:
 
     static void OnSuccessCallback_14(void * context) { (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_14(); }
 
-    static void OnFailureCallback_15(void * context, uint8_t status)
+    static void OnFailureCallback_15(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_15(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_15(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_15(void * context, uint16_t currentY)
@@ -1989,9 +1703,9 @@ private:
         (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_15(currentY);
     }
 
-    static void OnFailureCallback_16(void * context, uint8_t status)
+    static void OnFailureCallback_16(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_16(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_16(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_16(void * context, uint16_t colorTemperature)
@@ -1999,9 +1713,9 @@ private:
         (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_16(colorTemperature);
     }
 
-    static void OnFailureCallback_17(void * context, uint8_t status)
+    static void OnFailureCallback_17(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_17(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_17(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_17(void * context, uint8_t colorMode)
@@ -2009,9 +1723,9 @@ private:
         (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_17(colorMode);
     }
 
-    static void OnFailureCallback_18(void * context, uint8_t status)
+    static void OnFailureCallback_18(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_18(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_18(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_18(void * context, uint8_t colorControlOptions)
@@ -2019,9 +1733,9 @@ private:
         (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_18(colorControlOptions);
     }
 
-    static void OnFailureCallback_19(void * context, uint8_t status)
+    static void OnFailureCallback_19(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_19(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_19(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_19(void * context, uint8_t colorControlOptions)
@@ -2036,9 +1750,9 @@ private:
 
     static void OnSuccessCallback_20(void * context) { (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_20(); }
 
-    static void OnFailureCallback_21(void * context, uint8_t status)
+    static void OnFailureCallback_21(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_21(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_21(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_21(void * context, uint8_t colorControlOptions)
@@ -2046,9 +1760,9 @@ private:
         (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_21(colorControlOptions);
     }
 
-    static void OnFailureCallback_22(void * context, uint8_t status)
+    static void OnFailureCallback_22(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_22(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_22(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_22(void * context, uint16_t enhancedCurrentHue)
@@ -2056,9 +1770,9 @@ private:
         (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_22(enhancedCurrentHue);
     }
 
-    static void OnFailureCallback_23(void * context, uint8_t status)
+    static void OnFailureCallback_23(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_23(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_23(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_23(void * context, uint16_t enhancedCurrentHue)
@@ -2073,9 +1787,9 @@ private:
 
     static void OnSuccessCallback_24(void * context) { (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_24(); }
 
-    static void OnFailureCallback_25(void * context, uint8_t status)
+    static void OnFailureCallback_25(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_25(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_25(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_25(void * context, uint16_t enhancedCurrentHue)
@@ -2083,9 +1797,9 @@ private:
         (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_25(enhancedCurrentHue);
     }
 
-    static void OnFailureCallback_26(void * context, uint8_t status)
+    static void OnFailureCallback_26(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_26(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_26(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_26(void * context, uint8_t enhancedColorMode)
@@ -2093,9 +1807,9 @@ private:
         (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_26(enhancedColorMode);
     }
 
-    static void OnFailureCallback_27(void * context, uint8_t status)
+    static void OnFailureCallback_27(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_27(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_27(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_27(void * context, uint8_t colorLoopActive)
@@ -2103,9 +1817,9 @@ private:
         (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_27(colorLoopActive);
     }
 
-    static void OnFailureCallback_28(void * context, uint8_t status)
+    static void OnFailureCallback_28(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_28(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_28(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_28(void * context, uint8_t colorLoopActive)
@@ -2120,9 +1834,9 @@ private:
 
     static void OnSuccessCallback_29(void * context) { (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_29(); }
 
-    static void OnFailureCallback_30(void * context, uint8_t status)
+    static void OnFailureCallback_30(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_30(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_30(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_30(void * context, uint8_t colorLoopActive)
@@ -2130,9 +1844,9 @@ private:
         (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_30(colorLoopActive);
     }
 
-    static void OnFailureCallback_31(void * context, uint8_t status)
+    static void OnFailureCallback_31(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_31(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_31(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_31(void * context, uint8_t colorLoopDirection)
@@ -2140,9 +1854,9 @@ private:
         (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_31(colorLoopDirection);
     }
 
-    static void OnFailureCallback_32(void * context, uint8_t status)
+    static void OnFailureCallback_32(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_32(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_32(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_32(void * context, uint8_t colorLoopDirection)
@@ -2157,9 +1871,9 @@ private:
 
     static void OnSuccessCallback_33(void * context) { (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_33(); }
 
-    static void OnFailureCallback_34(void * context, uint8_t status)
+    static void OnFailureCallback_34(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_34(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_34(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_34(void * context, uint8_t colorLoopDirection)
@@ -2167,9 +1881,9 @@ private:
         (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_34(colorLoopDirection);
     }
 
-    static void OnFailureCallback_35(void * context, uint8_t status)
+    static void OnFailureCallback_35(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_35(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_35(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_35(void * context, uint16_t colorLoopTime)
@@ -2177,9 +1891,9 @@ private:
         (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_35(colorLoopTime);
     }
 
-    static void OnFailureCallback_36(void * context, uint8_t status)
+    static void OnFailureCallback_36(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_36(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_36(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_36(void * context, uint16_t colorLoopTime)
@@ -2194,9 +1908,9 @@ private:
 
     static void OnSuccessCallback_37(void * context) { (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_37(); }
 
-    static void OnFailureCallback_38(void * context, uint8_t status)
+    static void OnFailureCallback_38(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_38(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_38(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_38(void * context, uint16_t colorLoopTime)
@@ -2204,9 +1918,9 @@ private:
         (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_38(colorLoopTime);
     }
 
-    static void OnFailureCallback_39(void * context, uint8_t status)
+    static void OnFailureCallback_39(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_39(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_39(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_39(void * context, uint16_t colorLoopStartEnhancedHue)
@@ -2214,9 +1928,9 @@ private:
         (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_39(colorLoopStartEnhancedHue);
     }
 
-    static void OnFailureCallback_40(void * context, uint8_t status)
+    static void OnFailureCallback_40(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_40(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_40(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_40(void * context, uint16_t colorLoopStartEnhancedHue)
@@ -2231,9 +1945,9 @@ private:
 
     static void OnSuccessCallback_41(void * context) { (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_41(); }
 
-    static void OnFailureCallback_42(void * context, uint8_t status)
+    static void OnFailureCallback_42(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_42(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_42(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_42(void * context, uint16_t colorLoopStartEnhancedHue)
@@ -2241,9 +1955,9 @@ private:
         (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_42(colorLoopStartEnhancedHue);
     }
 
-    static void OnFailureCallback_43(void * context, uint8_t status)
+    static void OnFailureCallback_43(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_43(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_43(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_43(void * context, uint16_t colorLoopStoredEnhancedHue)
@@ -2251,9 +1965,9 @@ private:
         (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_43(colorLoopStoredEnhancedHue);
     }
 
-    static void OnFailureCallback_44(void * context, uint8_t status)
+    static void OnFailureCallback_44(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_44(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_44(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_44(void * context, uint16_t colorLoopStoredEnhancedHue)
@@ -2268,9 +1982,9 @@ private:
 
     static void OnSuccessCallback_45(void * context) { (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_45(); }
 
-    static void OnFailureCallback_46(void * context, uint8_t status)
+    static void OnFailureCallback_46(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_46(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_46(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_46(void * context, uint16_t colorLoopStoredEnhancedHue)
@@ -2278,9 +1992,9 @@ private:
         (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_46(colorLoopStoredEnhancedHue);
     }
 
-    static void OnFailureCallback_47(void * context, uint8_t status)
+    static void OnFailureCallback_47(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_47(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_47(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_47(void * context, uint16_t colorCapabilities)
@@ -2288,9 +2002,9 @@ private:
         (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_47(colorCapabilities);
     }
 
-    static void OnFailureCallback_48(void * context, uint8_t status)
+    static void OnFailureCallback_48(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_48(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_48(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_48(void * context, uint16_t colorCapabilities)
@@ -2305,9 +2019,9 @@ private:
 
     static void OnSuccessCallback_49(void * context) { (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_49(); }
 
-    static void OnFailureCallback_50(void * context, uint8_t status)
+    static void OnFailureCallback_50(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_50(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_50(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_50(void * context, uint16_t colorCapabilities)
@@ -2315,9 +2029,9 @@ private:
         (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_50(colorCapabilities);
     }
 
-    static void OnFailureCallback_51(void * context, uint8_t status)
+    static void OnFailureCallback_51(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_51(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_51(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_51(void * context, uint16_t colorTempPhysicalMin)
@@ -2325,9 +2039,9 @@ private:
         (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_51(colorTempPhysicalMin);
     }
 
-    static void OnFailureCallback_52(void * context, uint8_t status)
+    static void OnFailureCallback_52(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_52(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_52(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_52(void * context, uint16_t colorTempPhysicalMin)
@@ -2342,9 +2056,9 @@ private:
 
     static void OnSuccessCallback_53(void * context) { (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_53(); }
 
-    static void OnFailureCallback_54(void * context, uint8_t status)
+    static void OnFailureCallback_54(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_54(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_54(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_54(void * context, uint16_t colorTempPhysicalMin)
@@ -2352,9 +2066,9 @@ private:
         (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_54(colorTempPhysicalMin);
     }
 
-    static void OnFailureCallback_55(void * context, uint8_t status)
+    static void OnFailureCallback_55(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_55(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_55(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_55(void * context, uint16_t colorTempPhysicalMax)
@@ -2362,9 +2076,9 @@ private:
         (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_55(colorTempPhysicalMax);
     }
 
-    static void OnFailureCallback_56(void * context, uint8_t status)
+    static void OnFailureCallback_56(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_56(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_56(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_56(void * context, uint16_t colorTempPhysicalMax)
@@ -2379,9 +2093,9 @@ private:
 
     static void OnSuccessCallback_57(void * context) { (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_57(); }
 
-    static void OnFailureCallback_58(void * context, uint8_t status)
+    static void OnFailureCallback_58(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_58(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_58(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_58(void * context, uint16_t colorTempPhysicalMax)
@@ -2389,9 +2103,9 @@ private:
         (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_58(colorTempPhysicalMax);
     }
 
-    static void OnFailureCallback_59(void * context, uint8_t status)
+    static void OnFailureCallback_59(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_59(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_59(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_59(void * context, uint16_t coupleColorTempToLevelMinMireds)
@@ -2406,9 +2120,9 @@ private:
 
     static void OnSuccessCallback_60(void * context) { (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_60(); }
 
-    static void OnFailureCallback_61(void * context, uint8_t status)
+    static void OnFailureCallback_61(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_61(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_61(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_61(void * context, uint16_t coupleColorTempToLevelMinMireds)
@@ -2416,9 +2130,9 @@ private:
         (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_61(coupleColorTempToLevelMinMireds);
     }
 
-    static void OnFailureCallback_62(void * context, uint8_t status)
+    static void OnFailureCallback_62(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_62(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_62(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_62(void * context, uint16_t startUpColorTemperatureMireds)
@@ -2433,9 +2147,9 @@ private:
 
     static void OnSuccessCallback_63(void * context) { (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_63(); }
 
-    static void OnFailureCallback_64(void * context, uint8_t status)
+    static void OnFailureCallback_64(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_64(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_64(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_64(void * context, uint16_t startUpColorTemperatureMireds)
@@ -2443,9 +2157,9 @@ private:
         (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_64(startUpColorTemperatureMireds);
     }
 
-    static void OnFailureCallback_65(void * context, uint8_t status)
+    static void OnFailureCallback_65(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_65(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_65(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_65(void * context, uint16_t remainingTime)
@@ -2453,9 +2167,9 @@ private:
         (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_65(remainingTime);
     }
 
-    static void OnFailureCallback_66(void * context, uint8_t status)
+    static void OnFailureCallback_66(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_66(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_66(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_66(void * context, uint16_t remainingTime)
@@ -2470,9 +2184,9 @@ private:
 
     static void OnSuccessCallback_67(void * context) { (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_67(); }
 
-    static void OnFailureCallback_68(void * context, uint8_t status)
+    static void OnFailureCallback_68(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_68(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_68(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_68(void * context, uint16_t remainingTime)
@@ -2480,9 +2194,9 @@ private:
         (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_68(remainingTime);
     }
 
-    static void OnFailureCallback_69(void * context, uint8_t status)
+    static void OnFailureCallback_69(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_69(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_69(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_69(void * context, uint8_t driftCompensation)
@@ -2497,9 +2211,9 @@ private:
 
     static void OnSuccessCallback_70(void * context) { (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_70(); }
 
-    static void OnFailureCallback_71(void * context, uint8_t status)
+    static void OnFailureCallback_71(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_71(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_71(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_71(void * context, uint8_t driftCompensation)
@@ -2507,9 +2221,9 @@ private:
         (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_71(driftCompensation);
     }
 
-    static void OnFailureCallback_72(void * context, uint8_t status)
+    static void OnFailureCallback_72(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_72(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_72(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_72(void * context, chip::CharSpan compensationText)
@@ -2517,9 +2231,9 @@ private:
         (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_72(compensationText);
     }
 
-    static void OnFailureCallback_73(void * context, uint8_t status)
+    static void OnFailureCallback_73(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_73(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_73(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_73(void * context, uint8_t numberOfPrimaries)
@@ -2534,9 +2248,9 @@ private:
 
     static void OnSuccessCallback_74(void * context) { (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_74(); }
 
-    static void OnFailureCallback_75(void * context, uint8_t status)
+    static void OnFailureCallback_75(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_75(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_75(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_75(void * context, uint8_t numberOfPrimaries)
@@ -2544,9 +2258,9 @@ private:
         (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_75(numberOfPrimaries);
     }
 
-    static void OnFailureCallback_76(void * context, uint8_t status)
+    static void OnFailureCallback_76(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_76(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_76(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_76(void * context, uint16_t primary1X)
@@ -2561,9 +2275,9 @@ private:
 
     static void OnSuccessCallback_77(void * context) { (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_77(); }
 
-    static void OnFailureCallback_78(void * context, uint8_t status)
+    static void OnFailureCallback_78(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_78(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_78(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_78(void * context, uint16_t primary1X)
@@ -2571,9 +2285,9 @@ private:
         (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_78(primary1X);
     }
 
-    static void OnFailureCallback_79(void * context, uint8_t status)
+    static void OnFailureCallback_79(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_79(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_79(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_79(void * context, uint16_t primary1Y)
@@ -2588,9 +2302,9 @@ private:
 
     static void OnSuccessCallback_80(void * context) { (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_80(); }
 
-    static void OnFailureCallback_81(void * context, uint8_t status)
+    static void OnFailureCallback_81(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_81(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_81(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_81(void * context, uint16_t primary1Y)
@@ -2598,9 +2312,9 @@ private:
         (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_81(primary1Y);
     }
 
-    static void OnFailureCallback_82(void * context, uint8_t status)
+    static void OnFailureCallback_82(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_82(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_82(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_82(void * context, uint8_t primary1Intensity)
@@ -2608,9 +2322,9 @@ private:
         (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_82(primary1Intensity);
     }
 
-    static void OnFailureCallback_83(void * context, uint8_t status)
+    static void OnFailureCallback_83(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_83(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_83(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_83(void * context, uint16_t primary2X)
@@ -2625,9 +2339,9 @@ private:
 
     static void OnSuccessCallback_84(void * context) { (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_84(); }
 
-    static void OnFailureCallback_85(void * context, uint8_t status)
+    static void OnFailureCallback_85(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_85(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_85(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_85(void * context, uint16_t primary2X)
@@ -2635,9 +2349,9 @@ private:
         (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_85(primary2X);
     }
 
-    static void OnFailureCallback_86(void * context, uint8_t status)
+    static void OnFailureCallback_86(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_86(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_86(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_86(void * context, uint16_t primary2Y)
@@ -2652,9 +2366,9 @@ private:
 
     static void OnSuccessCallback_87(void * context) { (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_87(); }
 
-    static void OnFailureCallback_88(void * context, uint8_t status)
+    static void OnFailureCallback_88(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_88(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_88(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_88(void * context, uint16_t primary2Y)
@@ -2662,9 +2376,9 @@ private:
         (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_88(primary2Y);
     }
 
-    static void OnFailureCallback_89(void * context, uint8_t status)
+    static void OnFailureCallback_89(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_89(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_89(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_89(void * context, uint8_t primary2Intensity)
@@ -2672,9 +2386,9 @@ private:
         (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_89(primary2Intensity);
     }
 
-    static void OnFailureCallback_90(void * context, uint8_t status)
+    static void OnFailureCallback_90(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_90(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_90(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_90(void * context, uint16_t primary3X)
@@ -2689,9 +2403,9 @@ private:
 
     static void OnSuccessCallback_91(void * context) { (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_91(); }
 
-    static void OnFailureCallback_92(void * context, uint8_t status)
+    static void OnFailureCallback_92(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_92(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_92(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_92(void * context, uint16_t primary3X)
@@ -2699,9 +2413,9 @@ private:
         (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_92(primary3X);
     }
 
-    static void OnFailureCallback_93(void * context, uint8_t status)
+    static void OnFailureCallback_93(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_93(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_93(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_93(void * context, uint16_t primary3Y)
@@ -2716,9 +2430,9 @@ private:
 
     static void OnSuccessCallback_94(void * context) { (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_94(); }
 
-    static void OnFailureCallback_95(void * context, uint8_t status)
+    static void OnFailureCallback_95(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_95(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_95(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_95(void * context, uint16_t primary3Y)
@@ -2726,9 +2440,9 @@ private:
         (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_95(primary3Y);
     }
 
-    static void OnFailureCallback_96(void * context, uint8_t status)
+    static void OnFailureCallback_96(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_96(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_96(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_96(void * context, uint8_t primary3Intensity)
@@ -2736,9 +2450,9 @@ private:
         (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_96(primary3Intensity);
     }
 
-    static void OnFailureCallback_97(void * context, uint8_t status)
+    static void OnFailureCallback_97(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_97(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_97(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_97(void * context, uint16_t primary4X)
@@ -2753,9 +2467,9 @@ private:
 
     static void OnSuccessCallback_98(void * context) { (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_98(); }
 
-    static void OnFailureCallback_99(void * context, uint8_t status)
+    static void OnFailureCallback_99(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_99(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_99(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_99(void * context, uint16_t primary4X)
@@ -2763,9 +2477,9 @@ private:
         (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_99(primary4X);
     }
 
-    static void OnFailureCallback_100(void * context, uint8_t status)
+    static void OnFailureCallback_100(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_100(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_100(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_100(void * context, uint16_t primary4Y)
@@ -2780,9 +2494,9 @@ private:
 
     static void OnSuccessCallback_101(void * context) { (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_101(); }
 
-    static void OnFailureCallback_102(void * context, uint8_t status)
+    static void OnFailureCallback_102(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_102(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_102(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_102(void * context, uint16_t primary4Y)
@@ -2790,9 +2504,9 @@ private:
         (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_102(primary4Y);
     }
 
-    static void OnFailureCallback_103(void * context, uint8_t status)
+    static void OnFailureCallback_103(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_103(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_103(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_103(void * context, uint8_t primary4Intensity)
@@ -2800,9 +2514,9 @@ private:
         (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_103(primary4Intensity);
     }
 
-    static void OnFailureCallback_104(void * context, uint8_t status)
+    static void OnFailureCallback_104(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_104(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_104(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_104(void * context, uint16_t primary5X)
@@ -2817,9 +2531,9 @@ private:
 
     static void OnSuccessCallback_105(void * context) { (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_105(); }
 
-    static void OnFailureCallback_106(void * context, uint8_t status)
+    static void OnFailureCallback_106(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_106(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_106(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_106(void * context, uint16_t primary5X)
@@ -2827,9 +2541,9 @@ private:
         (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_106(primary5X);
     }
 
-    static void OnFailureCallback_107(void * context, uint8_t status)
+    static void OnFailureCallback_107(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_107(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_107(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_107(void * context, uint16_t primary5Y)
@@ -2844,9 +2558,9 @@ private:
 
     static void OnSuccessCallback_108(void * context) { (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_108(); }
 
-    static void OnFailureCallback_109(void * context, uint8_t status)
+    static void OnFailureCallback_109(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_109(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_109(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_109(void * context, uint16_t primary5Y)
@@ -2854,9 +2568,9 @@ private:
         (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_109(primary5Y);
     }
 
-    static void OnFailureCallback_110(void * context, uint8_t status)
+    static void OnFailureCallback_110(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_110(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_110(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_110(void * context, uint8_t primary5Intensity)
@@ -2864,9 +2578,9 @@ private:
         (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_110(primary5Intensity);
     }
 
-    static void OnFailureCallback_111(void * context, uint8_t status)
+    static void OnFailureCallback_111(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_111(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_111(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_111(void * context, uint16_t primary6X)
@@ -2881,9 +2595,9 @@ private:
 
     static void OnSuccessCallback_112(void * context) { (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_112(); }
 
-    static void OnFailureCallback_113(void * context, uint8_t status)
+    static void OnFailureCallback_113(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_113(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_113(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_113(void * context, uint16_t primary6X)
@@ -2891,9 +2605,9 @@ private:
         (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_113(primary6X);
     }
 
-    static void OnFailureCallback_114(void * context, uint8_t status)
+    static void OnFailureCallback_114(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_114(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_114(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_114(void * context, uint16_t primary6Y)
@@ -2908,9 +2622,9 @@ private:
 
     static void OnSuccessCallback_115(void * context) { (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_115(); }
 
-    static void OnFailureCallback_116(void * context, uint8_t status)
+    static void OnFailureCallback_116(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_116(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_116(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_116(void * context, uint16_t primary6Y)
@@ -2918,9 +2632,9 @@ private:
         (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_116(primary6Y);
     }
 
-    static void OnFailureCallback_117(void * context, uint8_t status)
+    static void OnFailureCallback_117(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_117(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_117(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_117(void * context, uint8_t primary6Intensity)
@@ -2928,9 +2642,9 @@ private:
         (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_117(primary6Intensity);
     }
 
-    static void OnFailureCallback_118(void * context, uint8_t status)
+    static void OnFailureCallback_118(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_118(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_118(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_118(void * context, uint16_t whitePointX)
@@ -2945,9 +2659,9 @@ private:
 
     static void OnSuccessCallback_119(void * context) { (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_119(); }
 
-    static void OnFailureCallback_120(void * context, uint8_t status)
+    static void OnFailureCallback_120(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_120(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_120(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_120(void * context, uint16_t whitePointX)
@@ -2955,9 +2669,9 @@ private:
         (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_120(whitePointX);
     }
 
-    static void OnFailureCallback_121(void * context, uint8_t status)
+    static void OnFailureCallback_121(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_121(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_121(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_121(void * context, uint16_t whitePointY)
@@ -2972,9 +2686,9 @@ private:
 
     static void OnSuccessCallback_122(void * context) { (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_122(); }
 
-    static void OnFailureCallback_123(void * context, uint8_t status)
+    static void OnFailureCallback_123(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_123(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_123(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_123(void * context, uint16_t whitePointY)
@@ -2982,9 +2696,9 @@ private:
         (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_123(whitePointY);
     }
 
-    static void OnFailureCallback_124(void * context, uint8_t status)
+    static void OnFailureCallback_124(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_124(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_124(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_124(void * context, uint16_t colorPointRX)
@@ -2999,9 +2713,9 @@ private:
 
     static void OnSuccessCallback_125(void * context) { (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_125(); }
 
-    static void OnFailureCallback_126(void * context, uint8_t status)
+    static void OnFailureCallback_126(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_126(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_126(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_126(void * context, uint16_t colorPointRX)
@@ -3009,9 +2723,9 @@ private:
         (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_126(colorPointRX);
     }
 
-    static void OnFailureCallback_127(void * context, uint8_t status)
+    static void OnFailureCallback_127(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_127(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_127(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_127(void * context, uint16_t colorPointRY)
@@ -3026,9 +2740,9 @@ private:
 
     static void OnSuccessCallback_128(void * context) { (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_128(); }
 
-    static void OnFailureCallback_129(void * context, uint8_t status)
+    static void OnFailureCallback_129(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_129(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_129(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_129(void * context, uint16_t colorPointRY)
@@ -3036,9 +2750,9 @@ private:
         (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_129(colorPointRY);
     }
 
-    static void OnFailureCallback_130(void * context, uint8_t status)
+    static void OnFailureCallback_130(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_130(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_130(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_130(void * context, uint8_t colorPointRIntensity)
@@ -3046,9 +2760,9 @@ private:
         (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_130(colorPointRIntensity);
     }
 
-    static void OnFailureCallback_131(void * context, uint8_t status)
+    static void OnFailureCallback_131(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_131(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_131(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_131(void * context, uint16_t colorPointGX)
@@ -3063,9 +2777,9 @@ private:
 
     static void OnSuccessCallback_132(void * context) { (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_132(); }
 
-    static void OnFailureCallback_133(void * context, uint8_t status)
+    static void OnFailureCallback_133(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_133(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_133(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_133(void * context, uint16_t colorPointGX)
@@ -3073,9 +2787,9 @@ private:
         (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_133(colorPointGX);
     }
 
-    static void OnFailureCallback_134(void * context, uint8_t status)
+    static void OnFailureCallback_134(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_134(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_134(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_134(void * context, uint16_t colorPointGY)
@@ -3090,9 +2804,9 @@ private:
 
     static void OnSuccessCallback_135(void * context) { (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_135(); }
 
-    static void OnFailureCallback_136(void * context, uint8_t status)
+    static void OnFailureCallback_136(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_136(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_136(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_136(void * context, uint16_t colorPointGY)
@@ -3100,9 +2814,9 @@ private:
         (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_136(colorPointGY);
     }
 
-    static void OnFailureCallback_137(void * context, uint8_t status)
+    static void OnFailureCallback_137(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_137(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_137(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_137(void * context, uint8_t colorPointGIntensity)
@@ -3110,9 +2824,9 @@ private:
         (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_137(colorPointGIntensity);
     }
 
-    static void OnFailureCallback_138(void * context, uint8_t status)
+    static void OnFailureCallback_138(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_138(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_138(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_138(void * context, uint16_t colorPointBX)
@@ -3127,9 +2841,9 @@ private:
 
     static void OnSuccessCallback_139(void * context) { (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_139(); }
 
-    static void OnFailureCallback_140(void * context, uint8_t status)
+    static void OnFailureCallback_140(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_140(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_140(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_140(void * context, uint16_t colorPointBX)
@@ -3137,9 +2851,9 @@ private:
         (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_140(colorPointBX);
     }
 
-    static void OnFailureCallback_141(void * context, uint8_t status)
+    static void OnFailureCallback_141(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_141(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_141(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_141(void * context, uint16_t colorPointBY)
@@ -3154,9 +2868,9 @@ private:
 
     static void OnSuccessCallback_142(void * context) { (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_142(); }
 
-    static void OnFailureCallback_143(void * context, uint8_t status)
+    static void OnFailureCallback_143(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_143(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_143(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_143(void * context, uint16_t colorPointBY)
@@ -3164,9 +2878,9 @@ private:
         (static_cast<Test_TC_CC_2_1 *>(context))->OnSuccessResponse_143(colorPointBY);
     }
 
-    static void OnFailureCallback_144(void * context, uint8_t status)
+    static void OnFailureCallback_144(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_144(status);
+        (static_cast<Test_TC_CC_2_1 *>(context))->OnFailureResponse_144(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_144(void * context, uint8_t colorPointBIntensity)
@@ -3183,7 +2897,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeCurrentHue(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::CurrentHue::TypeInfo>(this, OnSuccessCallback_0,
+                                                                                                          OnFailureCallback_0);
     }
 
     void OnFailureResponse_0(uint8_t status) { ThrowFailureResponse(); }
@@ -3199,7 +2914,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeCurrentHue(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::CurrentHue::TypeInfo>(this, OnSuccessCallback_1,
+                                                                                                          OnFailureCallback_1);
     }
 
     void OnFailureResponse_1(uint8_t status) { ThrowFailureResponse(); }
@@ -3232,7 +2948,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeCurrentHue(mOnSuccessCallback_3.Cancel(), mOnFailureCallback_3.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::CurrentHue::TypeInfo>(this, OnSuccessCallback_3,
+                                                                                                          OnFailureCallback_3);
     }
 
     void OnFailureResponse_3(uint8_t status) { ThrowFailureResponse(); }
@@ -3248,7 +2965,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeCurrentSaturation(mOnSuccessCallback_4.Cancel(), mOnFailureCallback_4.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::CurrentSaturation::TypeInfo>(
+            this, OnSuccessCallback_4, OnFailureCallback_4);
     }
 
     void OnFailureResponse_4(uint8_t status) { ThrowFailureResponse(); }
@@ -3264,7 +2982,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeCurrentSaturation(mOnSuccessCallback_5.Cancel(), mOnFailureCallback_5.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::CurrentSaturation::TypeInfo>(
+            this, OnSuccessCallback_5, OnFailureCallback_5);
     }
 
     void OnFailureResponse_5(uint8_t status) { ThrowFailureResponse(); }
@@ -3297,7 +3016,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeCurrentSaturation(mOnSuccessCallback_7.Cancel(), mOnFailureCallback_7.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::CurrentSaturation::TypeInfo>(
+            this, OnSuccessCallback_7, OnFailureCallback_7);
     }
 
     void OnFailureResponse_7(uint8_t status) { ThrowFailureResponse(); }
@@ -3313,7 +3033,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeCurrentX(mOnSuccessCallback_8.Cancel(), mOnFailureCallback_8.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::CurrentX::TypeInfo>(this, OnSuccessCallback_8,
+                                                                                                        OnFailureCallback_8);
     }
 
     void OnFailureResponse_8(uint8_t status) { ThrowFailureResponse(); }
@@ -3329,7 +3050,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeCurrentX(mOnSuccessCallback_9.Cancel(), mOnFailureCallback_9.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::CurrentX::TypeInfo>(this, OnSuccessCallback_9,
+                                                                                                        OnFailureCallback_9);
     }
 
     void OnFailureResponse_9(uint8_t status) { ThrowFailureResponse(); }
@@ -3362,7 +3084,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeCurrentX(mOnSuccessCallback_11.Cancel(), mOnFailureCallback_11.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::CurrentX::TypeInfo>(this, OnSuccessCallback_11,
+                                                                                                        OnFailureCallback_11);
     }
 
     void OnFailureResponse_11(uint8_t status) { ThrowFailureResponse(); }
@@ -3378,7 +3101,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeCurrentY(mOnSuccessCallback_12.Cancel(), mOnFailureCallback_12.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::CurrentY::TypeInfo>(this, OnSuccessCallback_12,
+                                                                                                        OnFailureCallback_12);
     }
 
     void OnFailureResponse_12(uint8_t status) { ThrowFailureResponse(); }
@@ -3394,7 +3118,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeCurrentY(mOnSuccessCallback_13.Cancel(), mOnFailureCallback_13.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::CurrentY::TypeInfo>(this, OnSuccessCallback_13,
+                                                                                                        OnFailureCallback_13);
     }
 
     void OnFailureResponse_13(uint8_t status) { ThrowFailureResponse(); }
@@ -3427,7 +3152,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeCurrentY(mOnSuccessCallback_15.Cancel(), mOnFailureCallback_15.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::CurrentY::TypeInfo>(this, OnSuccessCallback_15,
+                                                                                                        OnFailureCallback_15);
     }
 
     void OnFailureResponse_15(uint8_t status) { ThrowFailureResponse(); }
@@ -3443,7 +3169,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeColorTemperature(mOnSuccessCallback_16.Cancel(), mOnFailureCallback_16.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorTemperature::TypeInfo>(
+            this, OnSuccessCallback_16, OnFailureCallback_16);
     }
 
     void OnFailureResponse_16(uint8_t status) { ThrowFailureResponse(); }
@@ -3460,7 +3187,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeColorMode(mOnSuccessCallback_17.Cancel(), mOnFailureCallback_17.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorMode::TypeInfo>(this, OnSuccessCallback_17,
+                                                                                                         OnFailureCallback_17);
     }
 
     void OnFailureResponse_17(uint8_t status) { ThrowFailureResponse(); }
@@ -3477,7 +3205,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeColorControlOptions(mOnSuccessCallback_18.Cancel(), mOnFailureCallback_18.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorControlOptions::TypeInfo>(
+            this, OnSuccessCallback_18, OnFailureCallback_18);
     }
 
     void OnFailureResponse_18(uint8_t status) { ThrowFailureResponse(); }
@@ -3493,7 +3222,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeColorControlOptions(mOnSuccessCallback_19.Cancel(), mOnFailureCallback_19.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorControlOptions::TypeInfo>(
+            this, OnSuccessCallback_19, OnFailureCallback_19);
     }
 
     void OnFailureResponse_19(uint8_t status) { ThrowFailureResponse(); }
@@ -3525,7 +3255,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeColorControlOptions(mOnSuccessCallback_21.Cancel(), mOnFailureCallback_21.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorControlOptions::TypeInfo>(
+            this, OnSuccessCallback_21, OnFailureCallback_21);
     }
 
     void OnFailureResponse_21(uint8_t status) { ThrowFailureResponse(); }
@@ -3541,7 +3272,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeEnhancedCurrentHue(mOnSuccessCallback_22.Cancel(), mOnFailureCallback_22.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::EnhancedCurrentHue::TypeInfo>(
+            this, OnSuccessCallback_22, OnFailureCallback_22);
     }
 
     void OnFailureResponse_22(uint8_t status) { ThrowFailureResponse(); }
@@ -3557,7 +3289,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeEnhancedCurrentHue(mOnSuccessCallback_23.Cancel(), mOnFailureCallback_23.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::EnhancedCurrentHue::TypeInfo>(
+            this, OnSuccessCallback_23, OnFailureCallback_23);
     }
 
     void OnFailureResponse_23(uint8_t status) { ThrowFailureResponse(); }
@@ -3589,7 +3322,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeEnhancedCurrentHue(mOnSuccessCallback_25.Cancel(), mOnFailureCallback_25.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::EnhancedCurrentHue::TypeInfo>(
+            this, OnSuccessCallback_25, OnFailureCallback_25);
     }
 
     void OnFailureResponse_25(uint8_t status) { ThrowFailureResponse(); }
@@ -3605,7 +3339,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeEnhancedColorMode(mOnSuccessCallback_26.Cancel(), mOnFailureCallback_26.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::EnhancedColorMode::TypeInfo>(
+            this, OnSuccessCallback_26, OnFailureCallback_26);
     }
 
     void OnFailureResponse_26(uint8_t status) { ThrowFailureResponse(); }
@@ -3621,7 +3356,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeColorLoopActive(mOnSuccessCallback_27.Cancel(), mOnFailureCallback_27.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopActive::TypeInfo>(
+            this, OnSuccessCallback_27, OnFailureCallback_27);
     }
 
     void OnFailureResponse_27(uint8_t status) { ThrowFailureResponse(); }
@@ -3637,7 +3373,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeColorLoopActive(mOnSuccessCallback_28.Cancel(), mOnFailureCallback_28.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopActive::TypeInfo>(
+            this, OnSuccessCallback_28, OnFailureCallback_28);
     }
 
     void OnFailureResponse_28(uint8_t status) { ThrowFailureResponse(); }
@@ -3669,7 +3406,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeColorLoopActive(mOnSuccessCallback_30.Cancel(), mOnFailureCallback_30.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopActive::TypeInfo>(
+            this, OnSuccessCallback_30, OnFailureCallback_30);
     }
 
     void OnFailureResponse_30(uint8_t status) { ThrowFailureResponse(); }
@@ -3685,7 +3423,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeColorLoopDirection(mOnSuccessCallback_31.Cancel(), mOnFailureCallback_31.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopDirection::TypeInfo>(
+            this, OnSuccessCallback_31, OnFailureCallback_31);
     }
 
     void OnFailureResponse_31(uint8_t status) { ThrowFailureResponse(); }
@@ -3701,7 +3440,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeColorLoopDirection(mOnSuccessCallback_32.Cancel(), mOnFailureCallback_32.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopDirection::TypeInfo>(
+            this, OnSuccessCallback_32, OnFailureCallback_32);
     }
 
     void OnFailureResponse_32(uint8_t status) { ThrowFailureResponse(); }
@@ -3733,7 +3473,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeColorLoopDirection(mOnSuccessCallback_34.Cancel(), mOnFailureCallback_34.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopDirection::TypeInfo>(
+            this, OnSuccessCallback_34, OnFailureCallback_34);
     }
 
     void OnFailureResponse_34(uint8_t status) { ThrowFailureResponse(); }
@@ -3749,7 +3490,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeColorLoopTime(mOnSuccessCallback_35.Cancel(), mOnFailureCallback_35.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopTime::TypeInfo>(
+            this, OnSuccessCallback_35, OnFailureCallback_35);
     }
 
     void OnFailureResponse_35(uint8_t status) { ThrowFailureResponse(); }
@@ -3765,7 +3507,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeColorLoopTime(mOnSuccessCallback_36.Cancel(), mOnFailureCallback_36.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopTime::TypeInfo>(
+            this, OnSuccessCallback_36, OnFailureCallback_36);
     }
 
     void OnFailureResponse_36(uint8_t status) { ThrowFailureResponse(); }
@@ -3797,7 +3540,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeColorLoopTime(mOnSuccessCallback_38.Cancel(), mOnFailureCallback_38.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopTime::TypeInfo>(
+            this, OnSuccessCallback_38, OnFailureCallback_38);
     }
 
     void OnFailureResponse_38(uint8_t status) { ThrowFailureResponse(); }
@@ -3813,7 +3557,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeColorLoopStartEnhancedHue(mOnSuccessCallback_39.Cancel(), mOnFailureCallback_39.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopStartEnhancedHue::TypeInfo>(
+            this, OnSuccessCallback_39, OnFailureCallback_39);
     }
 
     void OnFailureResponse_39(uint8_t status) { ThrowFailureResponse(); }
@@ -3829,7 +3574,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeColorLoopStartEnhancedHue(mOnSuccessCallback_40.Cancel(), mOnFailureCallback_40.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopStartEnhancedHue::TypeInfo>(
+            this, OnSuccessCallback_40, OnFailureCallback_40);
     }
 
     void OnFailureResponse_40(uint8_t status) { ThrowFailureResponse(); }
@@ -3861,7 +3607,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeColorLoopStartEnhancedHue(mOnSuccessCallback_42.Cancel(), mOnFailureCallback_42.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopStartEnhancedHue::TypeInfo>(
+            this, OnSuccessCallback_42, OnFailureCallback_42);
     }
 
     void OnFailureResponse_42(uint8_t status) { ThrowFailureResponse(); }
@@ -3877,7 +3624,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeColorLoopStoredEnhancedHue(mOnSuccessCallback_43.Cancel(), mOnFailureCallback_43.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopStoredEnhancedHue::TypeInfo>(
+            this, OnSuccessCallback_43, OnFailureCallback_43);
     }
 
     void OnFailureResponse_43(uint8_t status) { ThrowFailureResponse(); }
@@ -3893,7 +3641,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeColorLoopStoredEnhancedHue(mOnSuccessCallback_44.Cancel(), mOnFailureCallback_44.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopStoredEnhancedHue::TypeInfo>(
+            this, OnSuccessCallback_44, OnFailureCallback_44);
     }
 
     void OnFailureResponse_44(uint8_t status) { ThrowFailureResponse(); }
@@ -3925,7 +3674,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeColorLoopStoredEnhancedHue(mOnSuccessCallback_46.Cancel(), mOnFailureCallback_46.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopStoredEnhancedHue::TypeInfo>(
+            this, OnSuccessCallback_46, OnFailureCallback_46);
     }
 
     void OnFailureResponse_46(uint8_t status) { ThrowFailureResponse(); }
@@ -3941,7 +3691,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeColorCapabilities(mOnSuccessCallback_47.Cancel(), mOnFailureCallback_47.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorCapabilities::TypeInfo>(
+            this, OnSuccessCallback_47, OnFailureCallback_47);
     }
 
     void OnFailureResponse_47(uint8_t status) { ThrowFailureResponse(); }
@@ -3957,7 +3708,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeColorCapabilities(mOnSuccessCallback_48.Cancel(), mOnFailureCallback_48.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorCapabilities::TypeInfo>(
+            this, OnSuccessCallback_48, OnFailureCallback_48);
     }
 
     void OnFailureResponse_48(uint8_t status) { ThrowFailureResponse(); }
@@ -3990,7 +3742,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeColorCapabilities(mOnSuccessCallback_50.Cancel(), mOnFailureCallback_50.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorCapabilities::TypeInfo>(
+            this, OnSuccessCallback_50, OnFailureCallback_50);
     }
 
     void OnFailureResponse_50(uint8_t status) { ThrowFailureResponse(); }
@@ -4006,7 +3759,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeColorTempPhysicalMin(mOnSuccessCallback_51.Cancel(), mOnFailureCallback_51.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorTempPhysicalMin::TypeInfo>(
+            this, OnSuccessCallback_51, OnFailureCallback_51);
     }
 
     void OnFailureResponse_51(uint8_t status) { ThrowFailureResponse(); }
@@ -4022,7 +3776,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeColorTempPhysicalMin(mOnSuccessCallback_52.Cancel(), mOnFailureCallback_52.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorTempPhysicalMin::TypeInfo>(
+            this, OnSuccessCallback_52, OnFailureCallback_52);
     }
 
     void OnFailureResponse_52(uint8_t status) { ThrowFailureResponse(); }
@@ -4055,7 +3810,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeColorTempPhysicalMin(mOnSuccessCallback_54.Cancel(), mOnFailureCallback_54.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorTempPhysicalMin::TypeInfo>(
+            this, OnSuccessCallback_54, OnFailureCallback_54);
     }
 
     void OnFailureResponse_54(uint8_t status) { ThrowFailureResponse(); }
@@ -4071,7 +3827,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeColorTempPhysicalMax(mOnSuccessCallback_55.Cancel(), mOnFailureCallback_55.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorTempPhysicalMax::TypeInfo>(
+            this, OnSuccessCallback_55, OnFailureCallback_55);
     }
 
     void OnFailureResponse_55(uint8_t status) { ThrowFailureResponse(); }
@@ -4087,7 +3844,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeColorTempPhysicalMax(mOnSuccessCallback_56.Cancel(), mOnFailureCallback_56.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorTempPhysicalMax::TypeInfo>(
+            this, OnSuccessCallback_56, OnFailureCallback_56);
     }
 
     void OnFailureResponse_56(uint8_t status) { ThrowFailureResponse(); }
@@ -4120,7 +3878,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeColorTempPhysicalMax(mOnSuccessCallback_58.Cancel(), mOnFailureCallback_58.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorTempPhysicalMax::TypeInfo>(
+            this, OnSuccessCallback_58, OnFailureCallback_58);
     }
 
     void OnFailureResponse_58(uint8_t status) { ThrowFailureResponse(); }
@@ -4136,7 +3895,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeCoupleColorTempToLevelMinMireds(mOnSuccessCallback_59.Cancel(), mOnFailureCallback_59.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::CoupleColorTempToLevelMinMireds::TypeInfo>(
+            this, OnSuccessCallback_59, OnFailureCallback_59);
     }
 
     void OnFailureResponse_59(uint8_t status) { ThrowFailureResponse(); }
@@ -4168,7 +3928,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeCoupleColorTempToLevelMinMireds(mOnSuccessCallback_61.Cancel(), mOnFailureCallback_61.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::CoupleColorTempToLevelMinMireds::TypeInfo>(
+            this, OnSuccessCallback_61, OnFailureCallback_61);
     }
 
     void OnFailureResponse_61(uint8_t status) { ThrowFailureResponse(); }
@@ -4184,7 +3945,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeStartUpColorTemperatureMireds(mOnSuccessCallback_62.Cancel(), mOnFailureCallback_62.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::StartUpColorTemperatureMireds::TypeInfo>(
+            this, OnSuccessCallback_62, OnFailureCallback_62);
     }
 
     void OnFailureResponse_62(uint8_t status) { ThrowFailureResponse(); }
@@ -4217,7 +3979,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeStartUpColorTemperatureMireds(mOnSuccessCallback_64.Cancel(), mOnFailureCallback_64.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::StartUpColorTemperatureMireds::TypeInfo>(
+            this, OnSuccessCallback_64, OnFailureCallback_64);
     }
 
     void OnFailureResponse_64(uint8_t status) { ThrowFailureResponse(); }
@@ -4233,7 +3996,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeRemainingTime(mOnSuccessCallback_65.Cancel(), mOnFailureCallback_65.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::RemainingTime::TypeInfo>(
+            this, OnSuccessCallback_65, OnFailureCallback_65);
     }
 
     void OnFailureResponse_65(uint8_t status) { ThrowFailureResponse(); }
@@ -4249,7 +4013,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeRemainingTime(mOnSuccessCallback_66.Cancel(), mOnFailureCallback_66.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::RemainingTime::TypeInfo>(
+            this, OnSuccessCallback_66, OnFailureCallback_66);
     }
 
     void OnFailureResponse_66(uint8_t status) { ThrowFailureResponse(); }
@@ -4282,7 +4047,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeRemainingTime(mOnSuccessCallback_68.Cancel(), mOnFailureCallback_68.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::RemainingTime::TypeInfo>(
+            this, OnSuccessCallback_68, OnFailureCallback_68);
     }
 
     void OnFailureResponse_68(uint8_t status) { ThrowFailureResponse(); }
@@ -4298,7 +4064,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeDriftCompensation(mOnSuccessCallback_69.Cancel(), mOnFailureCallback_69.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::DriftCompensation::TypeInfo>(
+            this, OnSuccessCallback_69, OnFailureCallback_69);
     }
 
     void OnFailureResponse_69(uint8_t status) { ThrowFailureResponse(); }
@@ -4331,7 +4098,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeDriftCompensation(mOnSuccessCallback_71.Cancel(), mOnFailureCallback_71.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::DriftCompensation::TypeInfo>(
+            this, OnSuccessCallback_71, OnFailureCallback_71);
     }
 
     void OnFailureResponse_71(uint8_t status) { ThrowFailureResponse(); }
@@ -4347,7 +4115,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeCompensationText(mOnSuccessCallback_72.Cancel(), mOnFailureCallback_72.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::CompensationText::TypeInfo>(
+            this, OnSuccessCallback_72, OnFailureCallback_72);
     }
 
     void OnFailureResponse_72(uint8_t status) { ThrowFailureResponse(); }
@@ -4364,7 +4133,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeNumberOfPrimaries(mOnSuccessCallback_73.Cancel(), mOnFailureCallback_73.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::NumberOfPrimaries::TypeInfo>(
+            this, OnSuccessCallback_73, OnFailureCallback_73);
     }
 
     void OnFailureResponse_73(uint8_t status) { ThrowFailureResponse(); }
@@ -4397,7 +4167,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeNumberOfPrimaries(mOnSuccessCallback_75.Cancel(), mOnFailureCallback_75.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::NumberOfPrimaries::TypeInfo>(
+            this, OnSuccessCallback_75, OnFailureCallback_75);
     }
 
     void OnFailureResponse_75(uint8_t status) { ThrowFailureResponse(); }
@@ -4413,7 +4184,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributePrimary1X(mOnSuccessCallback_76.Cancel(), mOnFailureCallback_76.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::Primary1X::TypeInfo>(this, OnSuccessCallback_76,
+                                                                                                         OnFailureCallback_76);
     }
 
     void OnFailureResponse_76(uint8_t status) { ThrowFailureResponse(); }
@@ -4446,7 +4218,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributePrimary1X(mOnSuccessCallback_78.Cancel(), mOnFailureCallback_78.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::Primary1X::TypeInfo>(this, OnSuccessCallback_78,
+                                                                                                         OnFailureCallback_78);
     }
 
     void OnFailureResponse_78(uint8_t status) { ThrowFailureResponse(); }
@@ -4462,7 +4235,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributePrimary1Y(mOnSuccessCallback_79.Cancel(), mOnFailureCallback_79.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::Primary1Y::TypeInfo>(this, OnSuccessCallback_79,
+                                                                                                         OnFailureCallback_79);
     }
 
     void OnFailureResponse_79(uint8_t status) { ThrowFailureResponse(); }
@@ -4495,7 +4269,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributePrimary1Y(mOnSuccessCallback_81.Cancel(), mOnFailureCallback_81.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::Primary1Y::TypeInfo>(this, OnSuccessCallback_81,
+                                                                                                         OnFailureCallback_81);
     }
 
     void OnFailureResponse_81(uint8_t status) { ThrowFailureResponse(); }
@@ -4511,7 +4286,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributePrimary1Intensity(mOnSuccessCallback_82.Cancel(), mOnFailureCallback_82.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::Primary1Intensity::TypeInfo>(
+            this, OnSuccessCallback_82, OnFailureCallback_82);
     }
 
     void OnFailureResponse_82(uint8_t status) { ThrowFailureResponse(); }
@@ -4527,7 +4303,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributePrimary2X(mOnSuccessCallback_83.Cancel(), mOnFailureCallback_83.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::Primary2X::TypeInfo>(this, OnSuccessCallback_83,
+                                                                                                         OnFailureCallback_83);
     }
 
     void OnFailureResponse_83(uint8_t status) { ThrowFailureResponse(); }
@@ -4560,7 +4337,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributePrimary2X(mOnSuccessCallback_85.Cancel(), mOnFailureCallback_85.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::Primary2X::TypeInfo>(this, OnSuccessCallback_85,
+                                                                                                         OnFailureCallback_85);
     }
 
     void OnFailureResponse_85(uint8_t status) { ThrowFailureResponse(); }
@@ -4576,7 +4354,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributePrimary2Y(mOnSuccessCallback_86.Cancel(), mOnFailureCallback_86.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::Primary2Y::TypeInfo>(this, OnSuccessCallback_86,
+                                                                                                         OnFailureCallback_86);
     }
 
     void OnFailureResponse_86(uint8_t status) { ThrowFailureResponse(); }
@@ -4609,7 +4388,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributePrimary2Y(mOnSuccessCallback_88.Cancel(), mOnFailureCallback_88.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::Primary2Y::TypeInfo>(this, OnSuccessCallback_88,
+                                                                                                         OnFailureCallback_88);
     }
 
     void OnFailureResponse_88(uint8_t status) { ThrowFailureResponse(); }
@@ -4625,7 +4405,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributePrimary2Intensity(mOnSuccessCallback_89.Cancel(), mOnFailureCallback_89.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::Primary2Intensity::TypeInfo>(
+            this, OnSuccessCallback_89, OnFailureCallback_89);
     }
 
     void OnFailureResponse_89(uint8_t status) { ThrowFailureResponse(); }
@@ -4641,7 +4422,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributePrimary3X(mOnSuccessCallback_90.Cancel(), mOnFailureCallback_90.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::Primary3X::TypeInfo>(this, OnSuccessCallback_90,
+                                                                                                         OnFailureCallback_90);
     }
 
     void OnFailureResponse_90(uint8_t status) { ThrowFailureResponse(); }
@@ -4674,7 +4456,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributePrimary3X(mOnSuccessCallback_92.Cancel(), mOnFailureCallback_92.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::Primary3X::TypeInfo>(this, OnSuccessCallback_92,
+                                                                                                         OnFailureCallback_92);
     }
 
     void OnFailureResponse_92(uint8_t status) { ThrowFailureResponse(); }
@@ -4690,7 +4473,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributePrimary3Y(mOnSuccessCallback_93.Cancel(), mOnFailureCallback_93.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::Primary3Y::TypeInfo>(this, OnSuccessCallback_93,
+                                                                                                         OnFailureCallback_93);
     }
 
     void OnFailureResponse_93(uint8_t status) { ThrowFailureResponse(); }
@@ -4723,7 +4507,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributePrimary3Y(mOnSuccessCallback_95.Cancel(), mOnFailureCallback_95.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::Primary3Y::TypeInfo>(this, OnSuccessCallback_95,
+                                                                                                         OnFailureCallback_95);
     }
 
     void OnFailureResponse_95(uint8_t status) { ThrowFailureResponse(); }
@@ -4739,7 +4524,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributePrimary3Intensity(mOnSuccessCallback_96.Cancel(), mOnFailureCallback_96.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::Primary3Intensity::TypeInfo>(
+            this, OnSuccessCallback_96, OnFailureCallback_96);
     }
 
     void OnFailureResponse_96(uint8_t status) { ThrowFailureResponse(); }
@@ -4755,7 +4541,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributePrimary4X(mOnSuccessCallback_97.Cancel(), mOnFailureCallback_97.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::Primary4X::TypeInfo>(this, OnSuccessCallback_97,
+                                                                                                         OnFailureCallback_97);
     }
 
     void OnFailureResponse_97(uint8_t status) { ThrowFailureResponse(); }
@@ -4788,7 +4575,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributePrimary4X(mOnSuccessCallback_99.Cancel(), mOnFailureCallback_99.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::Primary4X::TypeInfo>(this, OnSuccessCallback_99,
+                                                                                                         OnFailureCallback_99);
     }
 
     void OnFailureResponse_99(uint8_t status) { ThrowFailureResponse(); }
@@ -4804,7 +4592,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributePrimary4Y(mOnSuccessCallback_100.Cancel(), mOnFailureCallback_100.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::Primary4Y::TypeInfo>(
+            this, OnSuccessCallback_100, OnFailureCallback_100);
     }
 
     void OnFailureResponse_100(uint8_t status) { ThrowFailureResponse(); }
@@ -4837,7 +4626,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributePrimary4Y(mOnSuccessCallback_102.Cancel(), mOnFailureCallback_102.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::Primary4Y::TypeInfo>(
+            this, OnSuccessCallback_102, OnFailureCallback_102);
     }
 
     void OnFailureResponse_102(uint8_t status) { ThrowFailureResponse(); }
@@ -4853,7 +4643,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributePrimary4Intensity(mOnSuccessCallback_103.Cancel(), mOnFailureCallback_103.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::Primary4Intensity::TypeInfo>(
+            this, OnSuccessCallback_103, OnFailureCallback_103);
     }
 
     void OnFailureResponse_103(uint8_t status) { ThrowFailureResponse(); }
@@ -4869,7 +4660,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributePrimary5X(mOnSuccessCallback_104.Cancel(), mOnFailureCallback_104.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::Primary5X::TypeInfo>(
+            this, OnSuccessCallback_104, OnFailureCallback_104);
     }
 
     void OnFailureResponse_104(uint8_t status) { ThrowFailureResponse(); }
@@ -4902,7 +4694,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributePrimary5X(mOnSuccessCallback_106.Cancel(), mOnFailureCallback_106.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::Primary5X::TypeInfo>(
+            this, OnSuccessCallback_106, OnFailureCallback_106);
     }
 
     void OnFailureResponse_106(uint8_t status) { ThrowFailureResponse(); }
@@ -4918,7 +4711,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributePrimary5Y(mOnSuccessCallback_107.Cancel(), mOnFailureCallback_107.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::Primary5Y::TypeInfo>(
+            this, OnSuccessCallback_107, OnFailureCallback_107);
     }
 
     void OnFailureResponse_107(uint8_t status) { ThrowFailureResponse(); }
@@ -4951,7 +4745,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributePrimary5Y(mOnSuccessCallback_109.Cancel(), mOnFailureCallback_109.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::Primary5Y::TypeInfo>(
+            this, OnSuccessCallback_109, OnFailureCallback_109);
     }
 
     void OnFailureResponse_109(uint8_t status) { ThrowFailureResponse(); }
@@ -4967,7 +4762,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributePrimary5Intensity(mOnSuccessCallback_110.Cancel(), mOnFailureCallback_110.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::Primary5Intensity::TypeInfo>(
+            this, OnSuccessCallback_110, OnFailureCallback_110);
     }
 
     void OnFailureResponse_110(uint8_t status) { ThrowFailureResponse(); }
@@ -4983,7 +4779,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributePrimary6X(mOnSuccessCallback_111.Cancel(), mOnFailureCallback_111.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::Primary6X::TypeInfo>(
+            this, OnSuccessCallback_111, OnFailureCallback_111);
     }
 
     void OnFailureResponse_111(uint8_t status) { ThrowFailureResponse(); }
@@ -5016,7 +4813,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributePrimary6X(mOnSuccessCallback_113.Cancel(), mOnFailureCallback_113.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::Primary6X::TypeInfo>(
+            this, OnSuccessCallback_113, OnFailureCallback_113);
     }
 
     void OnFailureResponse_113(uint8_t status) { ThrowFailureResponse(); }
@@ -5032,7 +4830,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributePrimary6Y(mOnSuccessCallback_114.Cancel(), mOnFailureCallback_114.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::Primary6Y::TypeInfo>(
+            this, OnSuccessCallback_114, OnFailureCallback_114);
     }
 
     void OnFailureResponse_114(uint8_t status) { ThrowFailureResponse(); }
@@ -5065,7 +4864,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributePrimary6Y(mOnSuccessCallback_116.Cancel(), mOnFailureCallback_116.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::Primary6Y::TypeInfo>(
+            this, OnSuccessCallback_116, OnFailureCallback_116);
     }
 
     void OnFailureResponse_116(uint8_t status) { ThrowFailureResponse(); }
@@ -5081,7 +4881,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributePrimary6Intensity(mOnSuccessCallback_117.Cancel(), mOnFailureCallback_117.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::Primary6Intensity::TypeInfo>(
+            this, OnSuccessCallback_117, OnFailureCallback_117);
     }
 
     void OnFailureResponse_117(uint8_t status) { ThrowFailureResponse(); }
@@ -5097,7 +4898,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeWhitePointX(mOnSuccessCallback_118.Cancel(), mOnFailureCallback_118.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::WhitePointX::TypeInfo>(
+            this, OnSuccessCallback_118, OnFailureCallback_118);
     }
 
     void OnFailureResponse_118(uint8_t status) { ThrowFailureResponse(); }
@@ -5130,7 +4932,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeWhitePointX(mOnSuccessCallback_120.Cancel(), mOnFailureCallback_120.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::WhitePointX::TypeInfo>(
+            this, OnSuccessCallback_120, OnFailureCallback_120);
     }
 
     void OnFailureResponse_120(uint8_t status) { ThrowFailureResponse(); }
@@ -5146,7 +4949,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeWhitePointY(mOnSuccessCallback_121.Cancel(), mOnFailureCallback_121.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::WhitePointY::TypeInfo>(
+            this, OnSuccessCallback_121, OnFailureCallback_121);
     }
 
     void OnFailureResponse_121(uint8_t status) { ThrowFailureResponse(); }
@@ -5179,7 +4983,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeWhitePointY(mOnSuccessCallback_123.Cancel(), mOnFailureCallback_123.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::WhitePointY::TypeInfo>(
+            this, OnSuccessCallback_123, OnFailureCallback_123);
     }
 
     void OnFailureResponse_123(uint8_t status) { ThrowFailureResponse(); }
@@ -5195,7 +5000,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeColorPointRX(mOnSuccessCallback_124.Cancel(), mOnFailureCallback_124.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorPointRX::TypeInfo>(
+            this, OnSuccessCallback_124, OnFailureCallback_124);
     }
 
     void OnFailureResponse_124(uint8_t status) { ThrowFailureResponse(); }
@@ -5228,7 +5034,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeColorPointRX(mOnSuccessCallback_126.Cancel(), mOnFailureCallback_126.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorPointRX::TypeInfo>(
+            this, OnSuccessCallback_126, OnFailureCallback_126);
     }
 
     void OnFailureResponse_126(uint8_t status) { ThrowFailureResponse(); }
@@ -5244,7 +5051,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeColorPointRY(mOnSuccessCallback_127.Cancel(), mOnFailureCallback_127.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorPointRY::TypeInfo>(
+            this, OnSuccessCallback_127, OnFailureCallback_127);
     }
 
     void OnFailureResponse_127(uint8_t status) { ThrowFailureResponse(); }
@@ -5277,7 +5085,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeColorPointRY(mOnSuccessCallback_129.Cancel(), mOnFailureCallback_129.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorPointRY::TypeInfo>(
+            this, OnSuccessCallback_129, OnFailureCallback_129);
     }
 
     void OnFailureResponse_129(uint8_t status) { ThrowFailureResponse(); }
@@ -5293,7 +5102,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeColorPointRIntensity(mOnSuccessCallback_130.Cancel(), mOnFailureCallback_130.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorPointRIntensity::TypeInfo>(
+            this, OnSuccessCallback_130, OnFailureCallback_130);
     }
 
     void OnFailureResponse_130(uint8_t status) { ThrowFailureResponse(); }
@@ -5309,7 +5119,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeColorPointGX(mOnSuccessCallback_131.Cancel(), mOnFailureCallback_131.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorPointGX::TypeInfo>(
+            this, OnSuccessCallback_131, OnFailureCallback_131);
     }
 
     void OnFailureResponse_131(uint8_t status) { ThrowFailureResponse(); }
@@ -5342,7 +5153,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeColorPointGX(mOnSuccessCallback_133.Cancel(), mOnFailureCallback_133.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorPointGX::TypeInfo>(
+            this, OnSuccessCallback_133, OnFailureCallback_133);
     }
 
     void OnFailureResponse_133(uint8_t status) { ThrowFailureResponse(); }
@@ -5358,7 +5170,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeColorPointGY(mOnSuccessCallback_134.Cancel(), mOnFailureCallback_134.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorPointGY::TypeInfo>(
+            this, OnSuccessCallback_134, OnFailureCallback_134);
     }
 
     void OnFailureResponse_134(uint8_t status) { ThrowFailureResponse(); }
@@ -5391,7 +5204,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeColorPointGY(mOnSuccessCallback_136.Cancel(), mOnFailureCallback_136.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorPointGY::TypeInfo>(
+            this, OnSuccessCallback_136, OnFailureCallback_136);
     }
 
     void OnFailureResponse_136(uint8_t status) { ThrowFailureResponse(); }
@@ -5407,7 +5221,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeColorPointGIntensity(mOnSuccessCallback_137.Cancel(), mOnFailureCallback_137.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorPointGIntensity::TypeInfo>(
+            this, OnSuccessCallback_137, OnFailureCallback_137);
     }
 
     void OnFailureResponse_137(uint8_t status) { ThrowFailureResponse(); }
@@ -5423,7 +5238,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeColorPointBX(mOnSuccessCallback_138.Cancel(), mOnFailureCallback_138.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorPointBX::TypeInfo>(
+            this, OnSuccessCallback_138, OnFailureCallback_138);
     }
 
     void OnFailureResponse_138(uint8_t status) { ThrowFailureResponse(); }
@@ -5456,7 +5272,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeColorPointBX(mOnSuccessCallback_140.Cancel(), mOnFailureCallback_140.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorPointBX::TypeInfo>(
+            this, OnSuccessCallback_140, OnFailureCallback_140);
     }
 
     void OnFailureResponse_140(uint8_t status) { ThrowFailureResponse(); }
@@ -5472,7 +5289,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeColorPointBY(mOnSuccessCallback_141.Cancel(), mOnFailureCallback_141.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorPointBY::TypeInfo>(
+            this, OnSuccessCallback_141, OnFailureCallback_141);
     }
 
     void OnFailureResponse_141(uint8_t status) { ThrowFailureResponse(); }
@@ -5505,7 +5323,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeColorPointBY(mOnSuccessCallback_143.Cancel(), mOnFailureCallback_143.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorPointBY::TypeInfo>(
+            this, OnSuccessCallback_143, OnFailureCallback_143);
     }
 
     void OnFailureResponse_143(uint8_t status) { ThrowFailureResponse(); }
@@ -5521,7 +5340,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeColorPointBIntensity(mOnSuccessCallback_144.Cancel(), mOnFailureCallback_144.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorPointBIntensity::TypeInfo>(
+            this, OnSuccessCallback_144, OnFailureCallback_144);
     }
 
     void OnFailureResponse_144(uint8_t status) { ThrowFailureResponse(); }
@@ -5608,14 +5428,9 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 8;
 
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_1{ OnFailureCallback_1, this };
-    chip::Callback::Callback<void (*)(void * context, bool onOff)> mOnSuccessCallback_1{ OnSuccessCallback_1, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_7{ OnFailureCallback_7, this };
-    chip::Callback::Callback<void (*)(void * context, bool onOff)> mOnSuccessCallback_7{ OnSuccessCallback_7, this };
-
-    static void OnFailureCallback_1(void * context, uint8_t status)
+    static void OnFailureCallback_1(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_3_1 *>(context))->OnFailureResponse_1(status);
+        (static_cast<Test_TC_CC_3_1 *>(context))->OnFailureResponse_1(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_1(void * context, bool onOff)
@@ -5623,9 +5438,9 @@ private:
         (static_cast<Test_TC_CC_3_1 *>(context))->OnSuccessResponse_1(onOff);
     }
 
-    static void OnFailureCallback_7(void * context, uint8_t status)
+    static void OnFailureCallback_7(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_3_1 *>(context))->OnFailureResponse_7(status);
+        (static_cast<Test_TC_CC_3_1 *>(context))->OnFailureResponse_7(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_7(void * context, bool onOff)
@@ -5666,7 +5481,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOnOff(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(this, OnSuccessCallback_1,
+                                                                                              OnFailureCallback_1);
     }
 
     void OnFailureResponse_1(uint8_t status) { ThrowFailureResponse(); }
@@ -5822,7 +5638,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOnOff(mOnSuccessCallback_7.Cancel(), mOnFailureCallback_7.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(this, OnSuccessCallback_7,
+                                                                                              OnFailureCallback_7);
     }
 
     void OnFailureResponse_7(uint8_t status) { ThrowFailureResponse(); }
@@ -5909,14 +5726,9 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 8;
 
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_1{ OnFailureCallback_1, this };
-    chip::Callback::Callback<void (*)(void * context, bool onOff)> mOnSuccessCallback_1{ OnSuccessCallback_1, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_7{ OnFailureCallback_7, this };
-    chip::Callback::Callback<void (*)(void * context, bool onOff)> mOnSuccessCallback_7{ OnSuccessCallback_7, this };
-
-    static void OnFailureCallback_1(void * context, uint8_t status)
+    static void OnFailureCallback_1(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_3_2 *>(context))->OnFailureResponse_1(status);
+        (static_cast<Test_TC_CC_3_2 *>(context))->OnFailureResponse_1(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_1(void * context, bool onOff)
@@ -5924,9 +5736,9 @@ private:
         (static_cast<Test_TC_CC_3_2 *>(context))->OnSuccessResponse_1(onOff);
     }
 
-    static void OnFailureCallback_7(void * context, uint8_t status)
+    static void OnFailureCallback_7(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_3_2 *>(context))->OnFailureResponse_7(status);
+        (static_cast<Test_TC_CC_3_2 *>(context))->OnFailureResponse_7(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_7(void * context, bool onOff)
@@ -5967,7 +5779,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOnOff(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(this, OnSuccessCallback_1,
+                                                                                              OnFailureCallback_1);
     }
 
     void OnFailureResponse_1(uint8_t status) { ThrowFailureResponse(); }
@@ -6119,7 +5932,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOnOff(mOnSuccessCallback_7.Cancel(), mOnFailureCallback_7.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(this, OnSuccessCallback_7,
+                                                                                              OnFailureCallback_7);
     }
 
     void OnFailureResponse_7(uint8_t status) { ThrowFailureResponse(); }
@@ -6198,14 +6012,9 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 6;
 
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_1{ OnFailureCallback_1, this };
-    chip::Callback::Callback<void (*)(void * context, bool onOff)> mOnSuccessCallback_1{ OnSuccessCallback_1, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_5{ OnFailureCallback_5, this };
-    chip::Callback::Callback<void (*)(void * context, bool onOff)> mOnSuccessCallback_5{ OnSuccessCallback_5, this };
-
-    static void OnFailureCallback_1(void * context, uint8_t status)
+    static void OnFailureCallback_1(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_3_3 *>(context))->OnFailureResponse_1(status);
+        (static_cast<Test_TC_CC_3_3 *>(context))->OnFailureResponse_1(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_1(void * context, bool onOff)
@@ -6213,9 +6022,9 @@ private:
         (static_cast<Test_TC_CC_3_3 *>(context))->OnSuccessResponse_1(onOff);
     }
 
-    static void OnFailureCallback_5(void * context, uint8_t status)
+    static void OnFailureCallback_5(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_3_3 *>(context))->OnFailureResponse_5(status);
+        (static_cast<Test_TC_CC_3_3 *>(context))->OnFailureResponse_5(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_5(void * context, bool onOff)
@@ -6256,7 +6065,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOnOff(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(this, OnSuccessCallback_1,
+                                                                                              OnFailureCallback_1);
     }
 
     void OnFailureResponse_1(uint8_t status) { ThrowFailureResponse(); }
@@ -6354,7 +6164,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOnOff(mOnSuccessCallback_5.Cancel(), mOnFailureCallback_5.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(this, OnSuccessCallback_5,
+                                                                                              OnFailureCallback_5);
     }
 
     void OnFailureResponse_5(uint8_t status) { ThrowFailureResponse(); }
@@ -6429,14 +6240,9 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 5;
 
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_1{ OnFailureCallback_1, this };
-    chip::Callback::Callback<void (*)(void * context, bool onOff)> mOnSuccessCallback_1{ OnSuccessCallback_1, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_4{ OnFailureCallback_4, this };
-    chip::Callback::Callback<void (*)(void * context, bool onOff)> mOnSuccessCallback_4{ OnSuccessCallback_4, this };
-
-    static void OnFailureCallback_1(void * context, uint8_t status)
+    static void OnFailureCallback_1(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_4_1 *>(context))->OnFailureResponse_1(status);
+        (static_cast<Test_TC_CC_4_1 *>(context))->OnFailureResponse_1(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_1(void * context, bool onOff)
@@ -6444,9 +6250,9 @@ private:
         (static_cast<Test_TC_CC_4_1 *>(context))->OnSuccessResponse_1(onOff);
     }
 
-    static void OnFailureCallback_4(void * context, uint8_t status)
+    static void OnFailureCallback_4(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_4_1 *>(context))->OnFailureResponse_4(status);
+        (static_cast<Test_TC_CC_4_1 *>(context))->OnFailureResponse_4(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_4(void * context, bool onOff)
@@ -6487,7 +6293,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOnOff(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(this, OnSuccessCallback_1,
+                                                                                              OnFailureCallback_1);
     }
 
     void OnFailureResponse_1(uint8_t status) { ThrowFailureResponse(); }
@@ -6555,7 +6362,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOnOff(mOnSuccessCallback_4.Cancel(), mOnFailureCallback_4.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(this, OnSuccessCallback_4,
+                                                                                              OnFailureCallback_4);
     }
 
     void OnFailureResponse_4(uint8_t status) { ThrowFailureResponse(); }
@@ -6634,14 +6442,9 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 6;
 
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_1{ OnFailureCallback_1, this };
-    chip::Callback::Callback<void (*)(void * context, bool onOff)> mOnSuccessCallback_1{ OnSuccessCallback_1, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_5{ OnFailureCallback_5, this };
-    chip::Callback::Callback<void (*)(void * context, bool onOff)> mOnSuccessCallback_5{ OnSuccessCallback_5, this };
-
-    static void OnFailureCallback_1(void * context, uint8_t status)
+    static void OnFailureCallback_1(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_4_2 *>(context))->OnFailureResponse_1(status);
+        (static_cast<Test_TC_CC_4_2 *>(context))->OnFailureResponse_1(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_1(void * context, bool onOff)
@@ -6649,9 +6452,9 @@ private:
         (static_cast<Test_TC_CC_4_2 *>(context))->OnSuccessResponse_1(onOff);
     }
 
-    static void OnFailureCallback_5(void * context, uint8_t status)
+    static void OnFailureCallback_5(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_4_2 *>(context))->OnFailureResponse_5(status);
+        (static_cast<Test_TC_CC_4_2 *>(context))->OnFailureResponse_5(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_5(void * context, bool onOff)
@@ -6692,7 +6495,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOnOff(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(this, OnSuccessCallback_1,
+                                                                                              OnFailureCallback_1);
     }
 
     void OnFailureResponse_1(uint8_t status) { ThrowFailureResponse(); }
@@ -6788,7 +6592,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOnOff(mOnSuccessCallback_5.Cancel(), mOnFailureCallback_5.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(this, OnSuccessCallback_5,
+                                                                                              OnFailureCallback_5);
     }
 
     void OnFailureResponse_5(uint8_t status) { ThrowFailureResponse(); }
@@ -6867,14 +6672,9 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 6;
 
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_1{ OnFailureCallback_1, this };
-    chip::Callback::Callback<void (*)(void * context, bool onOff)> mOnSuccessCallback_1{ OnSuccessCallback_1, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_5{ OnFailureCallback_5, this };
-    chip::Callback::Callback<void (*)(void * context, bool onOff)> mOnSuccessCallback_5{ OnSuccessCallback_5, this };
-
-    static void OnFailureCallback_1(void * context, uint8_t status)
+    static void OnFailureCallback_1(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_4_3 *>(context))->OnFailureResponse_1(status);
+        (static_cast<Test_TC_CC_4_3 *>(context))->OnFailureResponse_1(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_1(void * context, bool onOff)
@@ -6882,9 +6682,9 @@ private:
         (static_cast<Test_TC_CC_4_3 *>(context))->OnSuccessResponse_1(onOff);
     }
 
-    static void OnFailureCallback_5(void * context, uint8_t status)
+    static void OnFailureCallback_5(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_4_3 *>(context))->OnFailureResponse_5(status);
+        (static_cast<Test_TC_CC_4_3 *>(context))->OnFailureResponse_5(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_5(void * context, bool onOff)
@@ -6925,7 +6725,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOnOff(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(this, OnSuccessCallback_1,
+                                                                                              OnFailureCallback_1);
     }
 
     void OnFailureResponse_1(uint8_t status) { ThrowFailureResponse(); }
@@ -7023,7 +6824,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOnOff(mOnSuccessCallback_5.Cancel(), mOnFailureCallback_5.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(this, OnSuccessCallback_5,
+                                                                                              OnFailureCallback_5);
     }
 
     void OnFailureResponse_5(uint8_t status) { ThrowFailureResponse(); }
@@ -7098,14 +6900,9 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 5;
 
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_1{ OnFailureCallback_1, this };
-    chip::Callback::Callback<void (*)(void * context, bool onOff)> mOnSuccessCallback_1{ OnSuccessCallback_1, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_4{ OnFailureCallback_4, this };
-    chip::Callback::Callback<void (*)(void * context, bool onOff)> mOnSuccessCallback_4{ OnSuccessCallback_4, this };
-
-    static void OnFailureCallback_1(void * context, uint8_t status)
+    static void OnFailureCallback_1(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_4_4 *>(context))->OnFailureResponse_1(status);
+        (static_cast<Test_TC_CC_4_4 *>(context))->OnFailureResponse_1(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_1(void * context, bool onOff)
@@ -7113,9 +6910,9 @@ private:
         (static_cast<Test_TC_CC_4_4 *>(context))->OnSuccessResponse_1(onOff);
     }
 
-    static void OnFailureCallback_4(void * context, uint8_t status)
+    static void OnFailureCallback_4(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_4_4 *>(context))->OnFailureResponse_4(status);
+        (static_cast<Test_TC_CC_4_4 *>(context))->OnFailureResponse_4(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_4(void * context, bool onOff)
@@ -7156,7 +6953,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOnOff(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(this, OnSuccessCallback_1,
+                                                                                              OnFailureCallback_1);
     }
 
     void OnFailureResponse_1(uint8_t status) { ThrowFailureResponse(); }
@@ -7225,7 +7023,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOnOff(mOnSuccessCallback_4.Cancel(), mOnFailureCallback_4.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(this, OnSuccessCallback_4,
+                                                                                              OnFailureCallback_4);
     }
 
     void OnFailureResponse_4(uint8_t status) { ThrowFailureResponse(); }
@@ -7300,14 +7099,9 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 5;
 
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_1{ OnFailureCallback_1, this };
-    chip::Callback::Callback<void (*)(void * context, bool onOff)> mOnSuccessCallback_1{ OnSuccessCallback_1, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_4{ OnFailureCallback_4, this };
-    chip::Callback::Callback<void (*)(void * context, bool onOff)> mOnSuccessCallback_4{ OnSuccessCallback_4, this };
-
-    static void OnFailureCallback_1(void * context, uint8_t status)
+    static void OnFailureCallback_1(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_5_1 *>(context))->OnFailureResponse_1(status);
+        (static_cast<Test_TC_CC_5_1 *>(context))->OnFailureResponse_1(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_1(void * context, bool onOff)
@@ -7315,9 +7109,9 @@ private:
         (static_cast<Test_TC_CC_5_1 *>(context))->OnSuccessResponse_1(onOff);
     }
 
-    static void OnFailureCallback_4(void * context, uint8_t status)
+    static void OnFailureCallback_4(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_5_1 *>(context))->OnFailureResponse_4(status);
+        (static_cast<Test_TC_CC_5_1 *>(context))->OnFailureResponse_4(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_4(void * context, bool onOff)
@@ -7358,7 +7152,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOnOff(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(this, OnSuccessCallback_1,
+                                                                                              OnFailureCallback_1);
     }
 
     void OnFailureResponse_1(uint8_t status) { ThrowFailureResponse(); }
@@ -7427,7 +7222,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOnOff(mOnSuccessCallback_4.Cancel(), mOnFailureCallback_4.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(this, OnSuccessCallback_4,
+                                                                                              OnFailureCallback_4);
     }
 
     void OnFailureResponse_4(uint8_t status) { ThrowFailureResponse(); }
@@ -7506,14 +7302,9 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 6;
 
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_1{ OnFailureCallback_1, this };
-    chip::Callback::Callback<void (*)(void * context, bool onOff)> mOnSuccessCallback_1{ OnSuccessCallback_1, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_5{ OnFailureCallback_5, this };
-    chip::Callback::Callback<void (*)(void * context, bool onOff)> mOnSuccessCallback_5{ OnSuccessCallback_5, this };
-
-    static void OnFailureCallback_1(void * context, uint8_t status)
+    static void OnFailureCallback_1(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_5_2 *>(context))->OnFailureResponse_1(status);
+        (static_cast<Test_TC_CC_5_2 *>(context))->OnFailureResponse_1(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_1(void * context, bool onOff)
@@ -7521,9 +7312,9 @@ private:
         (static_cast<Test_TC_CC_5_2 *>(context))->OnSuccessResponse_1(onOff);
     }
 
-    static void OnFailureCallback_5(void * context, uint8_t status)
+    static void OnFailureCallback_5(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_5_2 *>(context))->OnFailureResponse_5(status);
+        (static_cast<Test_TC_CC_5_2 *>(context))->OnFailureResponse_5(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_5(void * context, bool onOff)
@@ -7564,7 +7355,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOnOff(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(this, OnSuccessCallback_1,
+                                                                                              OnFailureCallback_1);
     }
 
     void OnFailureResponse_1(uint8_t status) { ThrowFailureResponse(); }
@@ -7658,7 +7450,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOnOff(mOnSuccessCallback_5.Cancel(), mOnFailureCallback_5.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(this, OnSuccessCallback_5,
+                                                                                              OnFailureCallback_5);
     }
 
     void OnFailureResponse_5(uint8_t status) { ThrowFailureResponse(); }
@@ -7733,14 +7526,9 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 5;
 
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_1{ OnFailureCallback_1, this };
-    chip::Callback::Callback<void (*)(void * context, bool onOff)> mOnSuccessCallback_1{ OnSuccessCallback_1, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_4{ OnFailureCallback_4, this };
-    chip::Callback::Callback<void (*)(void * context, bool onOff)> mOnSuccessCallback_4{ OnSuccessCallback_4, this };
-
-    static void OnFailureCallback_1(void * context, uint8_t status)
+    static void OnFailureCallback_1(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_5_3 *>(context))->OnFailureResponse_1(status);
+        (static_cast<Test_TC_CC_5_3 *>(context))->OnFailureResponse_1(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_1(void * context, bool onOff)
@@ -7748,9 +7536,9 @@ private:
         (static_cast<Test_TC_CC_5_3 *>(context))->OnSuccessResponse_1(onOff);
     }
 
-    static void OnFailureCallback_4(void * context, uint8_t status)
+    static void OnFailureCallback_4(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_5_3 *>(context))->OnFailureResponse_4(status);
+        (static_cast<Test_TC_CC_5_3 *>(context))->OnFailureResponse_4(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_4(void * context, bool onOff)
@@ -7791,7 +7579,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOnOff(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(this, OnSuccessCallback_1,
+                                                                                              OnFailureCallback_1);
     }
 
     void OnFailureResponse_1(uint8_t status) { ThrowFailureResponse(); }
@@ -7860,7 +7649,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOnOff(mOnSuccessCallback_4.Cancel(), mOnFailureCallback_4.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(this, OnSuccessCallback_4,
+                                                                                              OnFailureCallback_4);
     }
 
     void OnFailureResponse_4(uint8_t status) { ThrowFailureResponse(); }
@@ -7935,14 +7725,9 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 5;
 
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_1{ OnFailureCallback_1, this };
-    chip::Callback::Callback<void (*)(void * context, bool onOff)> mOnSuccessCallback_1{ OnSuccessCallback_1, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_4{ OnFailureCallback_4, this };
-    chip::Callback::Callback<void (*)(void * context, bool onOff)> mOnSuccessCallback_4{ OnSuccessCallback_4, this };
-
-    static void OnFailureCallback_1(void * context, uint8_t status)
+    static void OnFailureCallback_1(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_6_1 *>(context))->OnFailureResponse_1(status);
+        (static_cast<Test_TC_CC_6_1 *>(context))->OnFailureResponse_1(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_1(void * context, bool onOff)
@@ -7950,9 +7735,9 @@ private:
         (static_cast<Test_TC_CC_6_1 *>(context))->OnSuccessResponse_1(onOff);
     }
 
-    static void OnFailureCallback_4(void * context, uint8_t status)
+    static void OnFailureCallback_4(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_6_1 *>(context))->OnFailureResponse_4(status);
+        (static_cast<Test_TC_CC_6_1 *>(context))->OnFailureResponse_4(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_4(void * context, bool onOff)
@@ -7993,7 +7778,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOnOff(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(this, OnSuccessCallback_1,
+                                                                                              OnFailureCallback_1);
     }
 
     void OnFailureResponse_1(uint8_t status) { ThrowFailureResponse(); }
@@ -8061,7 +7847,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOnOff(mOnSuccessCallback_4.Cancel(), mOnFailureCallback_4.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(this, OnSuccessCallback_4,
+                                                                                              OnFailureCallback_4);
     }
 
     void OnFailureResponse_4(uint8_t status) { ThrowFailureResponse(); }
@@ -8144,14 +7931,9 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 7;
 
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_1{ OnFailureCallback_1, this };
-    chip::Callback::Callback<void (*)(void * context, bool onOff)> mOnSuccessCallback_1{ OnSuccessCallback_1, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_6{ OnFailureCallback_6, this };
-    chip::Callback::Callback<void (*)(void * context, bool onOff)> mOnSuccessCallback_6{ OnSuccessCallback_6, this };
-
-    static void OnFailureCallback_1(void * context, uint8_t status)
+    static void OnFailureCallback_1(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_6_2 *>(context))->OnFailureResponse_1(status);
+        (static_cast<Test_TC_CC_6_2 *>(context))->OnFailureResponse_1(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_1(void * context, bool onOff)
@@ -8159,9 +7941,9 @@ private:
         (static_cast<Test_TC_CC_6_2 *>(context))->OnSuccessResponse_1(onOff);
     }
 
-    static void OnFailureCallback_6(void * context, uint8_t status)
+    static void OnFailureCallback_6(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_6_2 *>(context))->OnFailureResponse_6(status);
+        (static_cast<Test_TC_CC_6_2 *>(context))->OnFailureResponse_6(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_6(void * context, bool onOff)
@@ -8202,7 +7984,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOnOff(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(this, OnSuccessCallback_1,
+                                                                                              OnFailureCallback_1);
     }
 
     void OnFailureResponse_1(uint8_t status) { ThrowFailureResponse(); }
@@ -8332,7 +8115,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOnOff(mOnSuccessCallback_6.Cancel(), mOnFailureCallback_6.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(this, OnSuccessCallback_6,
+                                                                                              OnFailureCallback_6);
     }
 
     void OnFailureResponse_6(uint8_t status) { ThrowFailureResponse(); }
@@ -8411,14 +8195,9 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 6;
 
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_1{ OnFailureCallback_1, this };
-    chip::Callback::Callback<void (*)(void * context, bool onOff)> mOnSuccessCallback_1{ OnSuccessCallback_1, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_5{ OnFailureCallback_5, this };
-    chip::Callback::Callback<void (*)(void * context, bool onOff)> mOnSuccessCallback_5{ OnSuccessCallback_5, this };
-
-    static void OnFailureCallback_1(void * context, uint8_t status)
+    static void OnFailureCallback_1(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_6_3 *>(context))->OnFailureResponse_1(status);
+        (static_cast<Test_TC_CC_6_3 *>(context))->OnFailureResponse_1(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_1(void * context, bool onOff)
@@ -8426,9 +8205,9 @@ private:
         (static_cast<Test_TC_CC_6_3 *>(context))->OnSuccessResponse_1(onOff);
     }
 
-    static void OnFailureCallback_5(void * context, uint8_t status)
+    static void OnFailureCallback_5(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_6_3 *>(context))->OnFailureResponse_5(status);
+        (static_cast<Test_TC_CC_6_3 *>(context))->OnFailureResponse_5(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_5(void * context, bool onOff)
@@ -8469,7 +8248,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOnOff(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(this, OnSuccessCallback_1,
+                                                                                              OnFailureCallback_1);
     }
 
     void OnFailureResponse_1(uint8_t status) { ThrowFailureResponse(); }
@@ -8571,7 +8351,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOnOff(mOnSuccessCallback_5.Cancel(), mOnFailureCallback_5.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(this, OnSuccessCallback_5,
+                                                                                              OnFailureCallback_5);
     }
 
     void OnFailureResponse_5(uint8_t status) { ThrowFailureResponse(); }
@@ -8651,16 +8432,9 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 6;
 
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_1{ OnFailureCallback_1, this };
-    chip::Callback::Callback<void (*)(void * context, bool onOff)> mOnSuccessCallback_1{ OnSuccessCallback_1, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_3{ OnFailureCallback_3, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t remainingTime)> mOnSuccessCallback_3{ OnSuccessCallback_3, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_5{ OnFailureCallback_5, this };
-    chip::Callback::Callback<void (*)(void * context, bool onOff)> mOnSuccessCallback_5{ OnSuccessCallback_5, this };
-
-    static void OnFailureCallback_1(void * context, uint8_t status)
+    static void OnFailureCallback_1(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_7_1 *>(context))->OnFailureResponse_1(status);
+        (static_cast<Test_TC_CC_7_1 *>(context))->OnFailureResponse_1(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_1(void * context, bool onOff)
@@ -8668,9 +8442,9 @@ private:
         (static_cast<Test_TC_CC_7_1 *>(context))->OnSuccessResponse_1(onOff);
     }
 
-    static void OnFailureCallback_3(void * context, uint8_t status)
+    static void OnFailureCallback_3(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_7_1 *>(context))->OnFailureResponse_3(status);
+        (static_cast<Test_TC_CC_7_1 *>(context))->OnFailureResponse_3(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_3(void * context, uint16_t remainingTime)
@@ -8678,9 +8452,9 @@ private:
         (static_cast<Test_TC_CC_7_1 *>(context))->OnSuccessResponse_3(remainingTime);
     }
 
-    static void OnFailureCallback_5(void * context, uint8_t status)
+    static void OnFailureCallback_5(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_7_1 *>(context))->OnFailureResponse_5(status);
+        (static_cast<Test_TC_CC_7_1 *>(context))->OnFailureResponse_5(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_5(void * context, bool onOff)
@@ -8721,7 +8495,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOnOff(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(this, OnSuccessCallback_1,
+                                                                                              OnFailureCallback_1);
     }
 
     void OnFailureResponse_1(uint8_t status) { ThrowFailureResponse(); }
@@ -8766,7 +8541,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeRemainingTime(mOnSuccessCallback_3.Cancel(), mOnFailureCallback_3.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::RemainingTime::TypeInfo>(
+            this, OnSuccessCallback_3, OnFailureCallback_3);
     }
 
     void OnFailureResponse_3(uint8_t status) { ThrowFailureResponse(); }
@@ -8806,7 +8582,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOnOff(mOnSuccessCallback_5.Cancel(), mOnFailureCallback_5.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(this, OnSuccessCallback_5,
+                                                                                              OnFailureCallback_5);
     }
 
     void OnFailureResponse_5(uint8_t status) { ThrowFailureResponse(); }
@@ -8893,14 +8670,9 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 8;
 
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_1{ OnFailureCallback_1, this };
-    chip::Callback::Callback<void (*)(void * context, bool onOff)> mOnSuccessCallback_1{ OnSuccessCallback_1, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_7{ OnFailureCallback_7, this };
-    chip::Callback::Callback<void (*)(void * context, bool onOff)> mOnSuccessCallback_7{ OnSuccessCallback_7, this };
-
-    static void OnFailureCallback_1(void * context, uint8_t status)
+    static void OnFailureCallback_1(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_7_2 *>(context))->OnFailureResponse_1(status);
+        (static_cast<Test_TC_CC_7_2 *>(context))->OnFailureResponse_1(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_1(void * context, bool onOff)
@@ -8908,9 +8680,9 @@ private:
         (static_cast<Test_TC_CC_7_2 *>(context))->OnSuccessResponse_1(onOff);
     }
 
-    static void OnFailureCallback_7(void * context, uint8_t status)
+    static void OnFailureCallback_7(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_7_2 *>(context))->OnFailureResponse_7(status);
+        (static_cast<Test_TC_CC_7_2 *>(context))->OnFailureResponse_7(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_7(void * context, bool onOff)
@@ -8951,7 +8723,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOnOff(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(this, OnSuccessCallback_1,
+                                                                                              OnFailureCallback_1);
     }
 
     void OnFailureResponse_1(uint8_t status) { ThrowFailureResponse(); }
@@ -9103,7 +8876,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOnOff(mOnSuccessCallback_7.Cancel(), mOnFailureCallback_7.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(this, OnSuccessCallback_7,
+                                                                                              OnFailureCallback_7);
     }
 
     void OnFailureResponse_7(uint8_t status) { ThrowFailureResponse(); }
@@ -9182,14 +8956,9 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 6;
 
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_1{ OnFailureCallback_1, this };
-    chip::Callback::Callback<void (*)(void * context, bool onOff)> mOnSuccessCallback_1{ OnSuccessCallback_1, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_5{ OnFailureCallback_5, this };
-    chip::Callback::Callback<void (*)(void * context, bool onOff)> mOnSuccessCallback_5{ OnSuccessCallback_5, this };
-
-    static void OnFailureCallback_1(void * context, uint8_t status)
+    static void OnFailureCallback_1(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_7_3 *>(context))->OnFailureResponse_1(status);
+        (static_cast<Test_TC_CC_7_3 *>(context))->OnFailureResponse_1(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_1(void * context, bool onOff)
@@ -9197,9 +8966,9 @@ private:
         (static_cast<Test_TC_CC_7_3 *>(context))->OnSuccessResponse_1(onOff);
     }
 
-    static void OnFailureCallback_5(void * context, uint8_t status)
+    static void OnFailureCallback_5(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_7_3 *>(context))->OnFailureResponse_5(status);
+        (static_cast<Test_TC_CC_7_3 *>(context))->OnFailureResponse_5(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_5(void * context, bool onOff)
@@ -9240,7 +9009,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOnOff(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(this, OnSuccessCallback_1,
+                                                                                              OnFailureCallback_1);
     }
 
     void OnFailureResponse_1(uint8_t status) { ThrowFailureResponse(); }
@@ -9338,7 +9108,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOnOff(mOnSuccessCallback_5.Cancel(), mOnFailureCallback_5.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(this, OnSuccessCallback_5,
+                                                                                              OnFailureCallback_5);
     }
 
     void OnFailureResponse_5(uint8_t status) { ThrowFailureResponse(); }
@@ -9413,14 +9184,9 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 5;
 
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_1{ OnFailureCallback_1, this };
-    chip::Callback::Callback<void (*)(void * context, bool onOff)> mOnSuccessCallback_1{ OnSuccessCallback_1, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_4{ OnFailureCallback_4, this };
-    chip::Callback::Callback<void (*)(void * context, bool onOff)> mOnSuccessCallback_4{ OnSuccessCallback_4, this };
-
-    static void OnFailureCallback_1(void * context, uint8_t status)
+    static void OnFailureCallback_1(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_7_4 *>(context))->OnFailureResponse_1(status);
+        (static_cast<Test_TC_CC_7_4 *>(context))->OnFailureResponse_1(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_1(void * context, bool onOff)
@@ -9428,9 +9194,9 @@ private:
         (static_cast<Test_TC_CC_7_4 *>(context))->OnSuccessResponse_1(onOff);
     }
 
-    static void OnFailureCallback_4(void * context, uint8_t status)
+    static void OnFailureCallback_4(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_7_4 *>(context))->OnFailureResponse_4(status);
+        (static_cast<Test_TC_CC_7_4 *>(context))->OnFailureResponse_4(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_4(void * context, bool onOff)
@@ -9471,7 +9237,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOnOff(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(this, OnSuccessCallback_1,
+                                                                                              OnFailureCallback_1);
     }
 
     void OnFailureResponse_1(uint8_t status) { ThrowFailureResponse(); }
@@ -9540,7 +9307,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOnOff(mOnSuccessCallback_4.Cancel(), mOnFailureCallback_4.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(this, OnSuccessCallback_4,
+                                                                                              OnFailureCallback_4);
     }
 
     void OnFailureResponse_4(uint8_t status) { ThrowFailureResponse(); }
@@ -9659,35 +9427,9 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 16;
 
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_1{ OnFailureCallback_1, this };
-    chip::Callback::Callback<void (*)(void * context, bool onOff)> mOnSuccessCallback_1{ OnSuccessCallback_1, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_3{ OnFailureCallback_3, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t colorLoopDirection)> mOnSuccessCallback_3{ OnSuccessCallback_3,
-                                                                                                         this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_4{ OnFailureCallback_4, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t colorLoopTime)> mOnSuccessCallback_4{ OnSuccessCallback_4, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_5{ OnFailureCallback_5, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t colorLoopStartEnhancedHue)> mOnSuccessCallback_5{
-        OnSuccessCallback_5, this
-    };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_6{ OnFailureCallback_6, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t colorLoopActive)> mOnSuccessCallback_6{ OnSuccessCallback_6, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_8{ OnFailureCallback_8, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t colorLoopActive)> mOnSuccessCallback_8{ OnSuccessCallback_8, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_10{ OnFailureCallback_10, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t colorLoopDirection)> mOnSuccessCallback_10{ OnSuccessCallback_10,
-                                                                                                          this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_11{ OnFailureCallback_11, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t colorLoopTime)> mOnSuccessCallback_11{ OnSuccessCallback_11, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_13{ OnFailureCallback_13, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t colorLoopDirection)> mOnSuccessCallback_13{ OnSuccessCallback_13,
-                                                                                                          this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_15{ OnFailureCallback_15, this };
-    chip::Callback::Callback<void (*)(void * context, bool onOff)> mOnSuccessCallback_15{ OnSuccessCallback_15, this };
-
-    static void OnFailureCallback_1(void * context, uint8_t status)
+    static void OnFailureCallback_1(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_8_1 *>(context))->OnFailureResponse_1(status);
+        (static_cast<Test_TC_CC_8_1 *>(context))->OnFailureResponse_1(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_1(void * context, bool onOff)
@@ -9695,9 +9437,9 @@ private:
         (static_cast<Test_TC_CC_8_1 *>(context))->OnSuccessResponse_1(onOff);
     }
 
-    static void OnFailureCallback_3(void * context, uint8_t status)
+    static void OnFailureCallback_3(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_8_1 *>(context))->OnFailureResponse_3(status);
+        (static_cast<Test_TC_CC_8_1 *>(context))->OnFailureResponse_3(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_3(void * context, uint8_t colorLoopDirection)
@@ -9705,9 +9447,9 @@ private:
         (static_cast<Test_TC_CC_8_1 *>(context))->OnSuccessResponse_3(colorLoopDirection);
     }
 
-    static void OnFailureCallback_4(void * context, uint8_t status)
+    static void OnFailureCallback_4(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_8_1 *>(context))->OnFailureResponse_4(status);
+        (static_cast<Test_TC_CC_8_1 *>(context))->OnFailureResponse_4(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_4(void * context, uint16_t colorLoopTime)
@@ -9715,9 +9457,9 @@ private:
         (static_cast<Test_TC_CC_8_1 *>(context))->OnSuccessResponse_4(colorLoopTime);
     }
 
-    static void OnFailureCallback_5(void * context, uint8_t status)
+    static void OnFailureCallback_5(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_8_1 *>(context))->OnFailureResponse_5(status);
+        (static_cast<Test_TC_CC_8_1 *>(context))->OnFailureResponse_5(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_5(void * context, uint16_t colorLoopStartEnhancedHue)
@@ -9725,9 +9467,9 @@ private:
         (static_cast<Test_TC_CC_8_1 *>(context))->OnSuccessResponse_5(colorLoopStartEnhancedHue);
     }
 
-    static void OnFailureCallback_6(void * context, uint8_t status)
+    static void OnFailureCallback_6(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_8_1 *>(context))->OnFailureResponse_6(status);
+        (static_cast<Test_TC_CC_8_1 *>(context))->OnFailureResponse_6(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_6(void * context, uint8_t colorLoopActive)
@@ -9735,9 +9477,9 @@ private:
         (static_cast<Test_TC_CC_8_1 *>(context))->OnSuccessResponse_6(colorLoopActive);
     }
 
-    static void OnFailureCallback_8(void * context, uint8_t status)
+    static void OnFailureCallback_8(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_8_1 *>(context))->OnFailureResponse_8(status);
+        (static_cast<Test_TC_CC_8_1 *>(context))->OnFailureResponse_8(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_8(void * context, uint8_t colorLoopActive)
@@ -9745,9 +9487,9 @@ private:
         (static_cast<Test_TC_CC_8_1 *>(context))->OnSuccessResponse_8(colorLoopActive);
     }
 
-    static void OnFailureCallback_10(void * context, uint8_t status)
+    static void OnFailureCallback_10(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_8_1 *>(context))->OnFailureResponse_10(status);
+        (static_cast<Test_TC_CC_8_1 *>(context))->OnFailureResponse_10(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_10(void * context, uint8_t colorLoopDirection)
@@ -9755,9 +9497,9 @@ private:
         (static_cast<Test_TC_CC_8_1 *>(context))->OnSuccessResponse_10(colorLoopDirection);
     }
 
-    static void OnFailureCallback_11(void * context, uint8_t status)
+    static void OnFailureCallback_11(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_8_1 *>(context))->OnFailureResponse_11(status);
+        (static_cast<Test_TC_CC_8_1 *>(context))->OnFailureResponse_11(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_11(void * context, uint16_t colorLoopTime)
@@ -9765,9 +9507,9 @@ private:
         (static_cast<Test_TC_CC_8_1 *>(context))->OnSuccessResponse_11(colorLoopTime);
     }
 
-    static void OnFailureCallback_13(void * context, uint8_t status)
+    static void OnFailureCallback_13(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_8_1 *>(context))->OnFailureResponse_13(status);
+        (static_cast<Test_TC_CC_8_1 *>(context))->OnFailureResponse_13(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_13(void * context, uint8_t colorLoopDirection)
@@ -9775,9 +9517,9 @@ private:
         (static_cast<Test_TC_CC_8_1 *>(context))->OnSuccessResponse_13(colorLoopDirection);
     }
 
-    static void OnFailureCallback_15(void * context, uint8_t status)
+    static void OnFailureCallback_15(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_8_1 *>(context))->OnFailureResponse_15(status);
+        (static_cast<Test_TC_CC_8_1 *>(context))->OnFailureResponse_15(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_15(void * context, bool onOff)
@@ -9818,7 +9560,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOnOff(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(this, OnSuccessCallback_1,
+                                                                                              OnFailureCallback_1);
     }
 
     void OnFailureResponse_1(uint8_t status) { ThrowFailureResponse(); }
@@ -9865,7 +9608,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeColorLoopDirection(mOnSuccessCallback_3.Cancel(), mOnFailureCallback_3.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopDirection::TypeInfo>(
+            this, OnSuccessCallback_3, OnFailureCallback_3);
     }
 
     void OnFailureResponse_3(uint8_t status) { ThrowFailureResponse(); }
@@ -9881,7 +9625,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeColorLoopTime(mOnSuccessCallback_4.Cancel(), mOnFailureCallback_4.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopTime::TypeInfo>(
+            this, OnSuccessCallback_4, OnFailureCallback_4);
     }
 
     void OnFailureResponse_4(uint8_t status) { ThrowFailureResponse(); }
@@ -9897,7 +9642,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeColorLoopStartEnhancedHue(mOnSuccessCallback_5.Cancel(), mOnFailureCallback_5.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopStartEnhancedHue::TypeInfo>(
+            this, OnSuccessCallback_5, OnFailureCallback_5);
     }
 
     void OnFailureResponse_5(uint8_t status) { ThrowFailureResponse(); }
@@ -9913,7 +9659,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeColorLoopActive(mOnSuccessCallback_6.Cancel(), mOnFailureCallback_6.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopActive::TypeInfo>(
+            this, OnSuccessCallback_6, OnFailureCallback_6);
     }
 
     void OnFailureResponse_6(uint8_t status) { ThrowFailureResponse(); }
@@ -9960,7 +9707,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeColorLoopActive(mOnSuccessCallback_8.Cancel(), mOnFailureCallback_8.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopActive::TypeInfo>(
+            this, OnSuccessCallback_8, OnFailureCallback_8);
     }
 
     void OnFailureResponse_8(uint8_t status) { ThrowFailureResponse(); }
@@ -10007,7 +9755,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeColorLoopDirection(mOnSuccessCallback_10.Cancel(), mOnFailureCallback_10.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopDirection::TypeInfo>(
+            this, OnSuccessCallback_10, OnFailureCallback_10);
     }
 
     void OnFailureResponse_10(uint8_t status) { ThrowFailureResponse(); }
@@ -10023,7 +9772,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeColorLoopTime(mOnSuccessCallback_11.Cancel(), mOnFailureCallback_11.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopTime::TypeInfo>(
+            this, OnSuccessCallback_11, OnFailureCallback_11);
     }
 
     void OnFailureResponse_11(uint8_t status) { ThrowFailureResponse(); }
@@ -10070,7 +9820,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeColorLoopDirection(mOnSuccessCallback_13.Cancel(), mOnFailureCallback_13.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopDirection::TypeInfo>(
+            this, OnSuccessCallback_13, OnFailureCallback_13);
     }
 
     void OnFailureResponse_13(uint8_t status) { ThrowFailureResponse(); }
@@ -10110,7 +9861,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOnOff(mOnSuccessCallback_15.Cancel(), mOnFailureCallback_15.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(this, OnSuccessCallback_15,
+                                                                                              OnFailureCallback_15);
     }
 
     void OnFailureResponse_15(uint8_t status) { ThrowFailureResponse(); }
@@ -10309,51 +10061,9 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 36;
 
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_1{ OnFailureCallback_1, this };
-    chip::Callback::Callback<void (*)(void * context, bool onOff)> mOnSuccessCallback_1{ OnSuccessCallback_1, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_3{ OnFailureCallback_3, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t colorLoopActive)> mOnSuccessCallback_3{ OnSuccessCallback_3, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_5{ OnFailureCallback_5, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t colorLoopDirection)> mOnSuccessCallback_5{ OnSuccessCallback_5,
-                                                                                                         this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_7{ OnFailureCallback_7, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t colorLoopTime)> mOnSuccessCallback_7{ OnSuccessCallback_7, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_9{ OnFailureCallback_9, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t colorLoopStartEnhancedHue)> mOnSuccessCallback_9{
-        OnSuccessCallback_9, this
-    };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_11{ OnFailureCallback_11, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t colorLoopActive)> mOnSuccessCallback_11{ OnSuccessCallback_11, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_13{ OnFailureCallback_13, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t colorLoopActive)> mOnSuccessCallback_13{ OnSuccessCallback_13, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_15{ OnFailureCallback_15, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t colorLoopDirection)> mOnSuccessCallback_15{ OnSuccessCallback_15,
-                                                                                                          this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_17{ OnFailureCallback_17, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t colorLoopActive)> mOnSuccessCallback_17{ OnSuccessCallback_17, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_19{ OnFailureCallback_19, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t colorLoopActive)> mOnSuccessCallback_19{ OnSuccessCallback_19, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_22{ OnFailureCallback_22, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t enhancedCurrentHue)> mOnSuccessCallback_22{ OnSuccessCallback_22,
-                                                                                                           this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_24{ OnFailureCallback_24, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t colorLoopDirection)> mOnSuccessCallback_24{ OnSuccessCallback_24,
-                                                                                                          this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_26{ OnFailureCallback_26, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t colorLoopActive)> mOnSuccessCallback_26{ OnSuccessCallback_26, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_28{ OnFailureCallback_28, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t colorLoopActive)> mOnSuccessCallback_28{ OnSuccessCallback_28, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_30{ OnFailureCallback_30, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t colorLoopDirection)> mOnSuccessCallback_30{ OnSuccessCallback_30,
-                                                                                                          this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_32{ OnFailureCallback_32, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t colorLoopActive)> mOnSuccessCallback_32{ OnSuccessCallback_32, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_34{ OnFailureCallback_34, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t colorLoopActive)> mOnSuccessCallback_34{ OnSuccessCallback_34, this };
-
-    static void OnFailureCallback_1(void * context, uint8_t status)
+    static void OnFailureCallback_1(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_9_1 *>(context))->OnFailureResponse_1(status);
+        (static_cast<Test_TC_CC_9_1 *>(context))->OnFailureResponse_1(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_1(void * context, bool onOff)
@@ -10361,9 +10071,9 @@ private:
         (static_cast<Test_TC_CC_9_1 *>(context))->OnSuccessResponse_1(onOff);
     }
 
-    static void OnFailureCallback_3(void * context, uint8_t status)
+    static void OnFailureCallback_3(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_9_1 *>(context))->OnFailureResponse_3(status);
+        (static_cast<Test_TC_CC_9_1 *>(context))->OnFailureResponse_3(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_3(void * context, uint8_t colorLoopActive)
@@ -10371,9 +10081,9 @@ private:
         (static_cast<Test_TC_CC_9_1 *>(context))->OnSuccessResponse_3(colorLoopActive);
     }
 
-    static void OnFailureCallback_5(void * context, uint8_t status)
+    static void OnFailureCallback_5(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_9_1 *>(context))->OnFailureResponse_5(status);
+        (static_cast<Test_TC_CC_9_1 *>(context))->OnFailureResponse_5(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_5(void * context, uint8_t colorLoopDirection)
@@ -10381,9 +10091,9 @@ private:
         (static_cast<Test_TC_CC_9_1 *>(context))->OnSuccessResponse_5(colorLoopDirection);
     }
 
-    static void OnFailureCallback_7(void * context, uint8_t status)
+    static void OnFailureCallback_7(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_9_1 *>(context))->OnFailureResponse_7(status);
+        (static_cast<Test_TC_CC_9_1 *>(context))->OnFailureResponse_7(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_7(void * context, uint16_t colorLoopTime)
@@ -10391,9 +10101,9 @@ private:
         (static_cast<Test_TC_CC_9_1 *>(context))->OnSuccessResponse_7(colorLoopTime);
     }
 
-    static void OnFailureCallback_9(void * context, uint8_t status)
+    static void OnFailureCallback_9(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_9_1 *>(context))->OnFailureResponse_9(status);
+        (static_cast<Test_TC_CC_9_1 *>(context))->OnFailureResponse_9(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_9(void * context, uint16_t colorLoopStartEnhancedHue)
@@ -10401,9 +10111,9 @@ private:
         (static_cast<Test_TC_CC_9_1 *>(context))->OnSuccessResponse_9(colorLoopStartEnhancedHue);
     }
 
-    static void OnFailureCallback_11(void * context, uint8_t status)
+    static void OnFailureCallback_11(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_9_1 *>(context))->OnFailureResponse_11(status);
+        (static_cast<Test_TC_CC_9_1 *>(context))->OnFailureResponse_11(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_11(void * context, uint8_t colorLoopActive)
@@ -10411,9 +10121,9 @@ private:
         (static_cast<Test_TC_CC_9_1 *>(context))->OnSuccessResponse_11(colorLoopActive);
     }
 
-    static void OnFailureCallback_13(void * context, uint8_t status)
+    static void OnFailureCallback_13(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_9_1 *>(context))->OnFailureResponse_13(status);
+        (static_cast<Test_TC_CC_9_1 *>(context))->OnFailureResponse_13(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_13(void * context, uint8_t colorLoopActive)
@@ -10421,9 +10131,9 @@ private:
         (static_cast<Test_TC_CC_9_1 *>(context))->OnSuccessResponse_13(colorLoopActive);
     }
 
-    static void OnFailureCallback_15(void * context, uint8_t status)
+    static void OnFailureCallback_15(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_9_1 *>(context))->OnFailureResponse_15(status);
+        (static_cast<Test_TC_CC_9_1 *>(context))->OnFailureResponse_15(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_15(void * context, uint8_t colorLoopDirection)
@@ -10431,9 +10141,9 @@ private:
         (static_cast<Test_TC_CC_9_1 *>(context))->OnSuccessResponse_15(colorLoopDirection);
     }
 
-    static void OnFailureCallback_17(void * context, uint8_t status)
+    static void OnFailureCallback_17(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_9_1 *>(context))->OnFailureResponse_17(status);
+        (static_cast<Test_TC_CC_9_1 *>(context))->OnFailureResponse_17(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_17(void * context, uint8_t colorLoopActive)
@@ -10441,9 +10151,9 @@ private:
         (static_cast<Test_TC_CC_9_1 *>(context))->OnSuccessResponse_17(colorLoopActive);
     }
 
-    static void OnFailureCallback_19(void * context, uint8_t status)
+    static void OnFailureCallback_19(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_9_1 *>(context))->OnFailureResponse_19(status);
+        (static_cast<Test_TC_CC_9_1 *>(context))->OnFailureResponse_19(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_19(void * context, uint8_t colorLoopActive)
@@ -10451,9 +10161,9 @@ private:
         (static_cast<Test_TC_CC_9_1 *>(context))->OnSuccessResponse_19(colorLoopActive);
     }
 
-    static void OnFailureCallback_22(void * context, uint8_t status)
+    static void OnFailureCallback_22(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_9_1 *>(context))->OnFailureResponse_22(status);
+        (static_cast<Test_TC_CC_9_1 *>(context))->OnFailureResponse_22(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_22(void * context, uint16_t enhancedCurrentHue)
@@ -10461,9 +10171,9 @@ private:
         (static_cast<Test_TC_CC_9_1 *>(context))->OnSuccessResponse_22(enhancedCurrentHue);
     }
 
-    static void OnFailureCallback_24(void * context, uint8_t status)
+    static void OnFailureCallback_24(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_9_1 *>(context))->OnFailureResponse_24(status);
+        (static_cast<Test_TC_CC_9_1 *>(context))->OnFailureResponse_24(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_24(void * context, uint8_t colorLoopDirection)
@@ -10471,9 +10181,9 @@ private:
         (static_cast<Test_TC_CC_9_1 *>(context))->OnSuccessResponse_24(colorLoopDirection);
     }
 
-    static void OnFailureCallback_26(void * context, uint8_t status)
+    static void OnFailureCallback_26(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_9_1 *>(context))->OnFailureResponse_26(status);
+        (static_cast<Test_TC_CC_9_1 *>(context))->OnFailureResponse_26(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_26(void * context, uint8_t colorLoopActive)
@@ -10481,9 +10191,9 @@ private:
         (static_cast<Test_TC_CC_9_1 *>(context))->OnSuccessResponse_26(colorLoopActive);
     }
 
-    static void OnFailureCallback_28(void * context, uint8_t status)
+    static void OnFailureCallback_28(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_9_1 *>(context))->OnFailureResponse_28(status);
+        (static_cast<Test_TC_CC_9_1 *>(context))->OnFailureResponse_28(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_28(void * context, uint8_t colorLoopActive)
@@ -10491,9 +10201,9 @@ private:
         (static_cast<Test_TC_CC_9_1 *>(context))->OnSuccessResponse_28(colorLoopActive);
     }
 
-    static void OnFailureCallback_30(void * context, uint8_t status)
+    static void OnFailureCallback_30(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_9_1 *>(context))->OnFailureResponse_30(status);
+        (static_cast<Test_TC_CC_9_1 *>(context))->OnFailureResponse_30(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_30(void * context, uint8_t colorLoopDirection)
@@ -10501,9 +10211,9 @@ private:
         (static_cast<Test_TC_CC_9_1 *>(context))->OnSuccessResponse_30(colorLoopDirection);
     }
 
-    static void OnFailureCallback_32(void * context, uint8_t status)
+    static void OnFailureCallback_32(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_9_1 *>(context))->OnFailureResponse_32(status);
+        (static_cast<Test_TC_CC_9_1 *>(context))->OnFailureResponse_32(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_32(void * context, uint8_t colorLoopActive)
@@ -10511,9 +10221,9 @@ private:
         (static_cast<Test_TC_CC_9_1 *>(context))->OnSuccessResponse_32(colorLoopActive);
     }
 
-    static void OnFailureCallback_34(void * context, uint8_t status)
+    static void OnFailureCallback_34(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_9_1 *>(context))->OnFailureResponse_34(status);
+        (static_cast<Test_TC_CC_9_1 *>(context))->OnFailureResponse_34(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_34(void * context, uint8_t colorLoopActive)
@@ -10554,7 +10264,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOnOff(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(this, OnSuccessCallback_1,
+                                                                                              OnFailureCallback_1);
     }
 
     void OnFailureResponse_1(uint8_t status) { ThrowFailureResponse(); }
@@ -10601,7 +10312,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeColorLoopActive(mOnSuccessCallback_3.Cancel(), mOnFailureCallback_3.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopActive::TypeInfo>(
+            this, OnSuccessCallback_3, OnFailureCallback_3);
     }
 
     void OnFailureResponse_3(uint8_t status) { ThrowFailureResponse(); }
@@ -10648,7 +10360,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeColorLoopDirection(mOnSuccessCallback_5.Cancel(), mOnFailureCallback_5.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopDirection::TypeInfo>(
+            this, OnSuccessCallback_5, OnFailureCallback_5);
     }
 
     void OnFailureResponse_5(uint8_t status) { ThrowFailureResponse(); }
@@ -10695,7 +10408,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeColorLoopTime(mOnSuccessCallback_7.Cancel(), mOnFailureCallback_7.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopTime::TypeInfo>(
+            this, OnSuccessCallback_7, OnFailureCallback_7);
     }
 
     void OnFailureResponse_7(uint8_t status) { ThrowFailureResponse(); }
@@ -10742,7 +10456,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeColorLoopStartEnhancedHue(mOnSuccessCallback_9.Cancel(), mOnFailureCallback_9.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopStartEnhancedHue::TypeInfo>(
+            this, OnSuccessCallback_9, OnFailureCallback_9);
     }
 
     void OnFailureResponse_9(uint8_t status) { ThrowFailureResponse(); }
@@ -10789,7 +10504,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeColorLoopActive(mOnSuccessCallback_11.Cancel(), mOnFailureCallback_11.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopActive::TypeInfo>(
+            this, OnSuccessCallback_11, OnFailureCallback_11);
     }
 
     void OnFailureResponse_11(uint8_t status) { ThrowFailureResponse(); }
@@ -10836,7 +10552,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeColorLoopActive(mOnSuccessCallback_13.Cancel(), mOnFailureCallback_13.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopActive::TypeInfo>(
+            this, OnSuccessCallback_13, OnFailureCallback_13);
     }
 
     void OnFailureResponse_13(uint8_t status) { ThrowFailureResponse(); }
@@ -10883,7 +10600,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeColorLoopDirection(mOnSuccessCallback_15.Cancel(), mOnFailureCallback_15.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopDirection::TypeInfo>(
+            this, OnSuccessCallback_15, OnFailureCallback_15);
     }
 
     void OnFailureResponse_15(uint8_t status) { ThrowFailureResponse(); }
@@ -10930,7 +10648,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeColorLoopActive(mOnSuccessCallback_17.Cancel(), mOnFailureCallback_17.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopActive::TypeInfo>(
+            this, OnSuccessCallback_17, OnFailureCallback_17);
     }
 
     void OnFailureResponse_17(uint8_t status) { ThrowFailureResponse(); }
@@ -10977,7 +10696,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeColorLoopActive(mOnSuccessCallback_19.Cancel(), mOnFailureCallback_19.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopActive::TypeInfo>(
+            this, OnSuccessCallback_19, OnFailureCallback_19);
     }
 
     void OnFailureResponse_19(uint8_t status) { ThrowFailureResponse(); }
@@ -11024,7 +10744,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeEnhancedCurrentHue(mOnSuccessCallback_22.Cancel(), mOnFailureCallback_22.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::EnhancedCurrentHue::TypeInfo>(
+            this, OnSuccessCallback_22, OnFailureCallback_22);
     }
 
     void OnFailureResponse_22(uint8_t status) { ThrowFailureResponse(); }
@@ -11071,7 +10792,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeColorLoopDirection(mOnSuccessCallback_24.Cancel(), mOnFailureCallback_24.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopDirection::TypeInfo>(
+            this, OnSuccessCallback_24, OnFailureCallback_24);
     }
 
     void OnFailureResponse_24(uint8_t status) { ThrowFailureResponse(); }
@@ -11118,7 +10840,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeColorLoopActive(mOnSuccessCallback_26.Cancel(), mOnFailureCallback_26.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopActive::TypeInfo>(
+            this, OnSuccessCallback_26, OnFailureCallback_26);
     }
 
     void OnFailureResponse_26(uint8_t status) { ThrowFailureResponse(); }
@@ -11165,7 +10888,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeColorLoopActive(mOnSuccessCallback_28.Cancel(), mOnFailureCallback_28.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopActive::TypeInfo>(
+            this, OnSuccessCallback_28, OnFailureCallback_28);
     }
 
     void OnFailureResponse_28(uint8_t status) { ThrowFailureResponse(); }
@@ -11212,7 +10936,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeColorLoopDirection(mOnSuccessCallback_30.Cancel(), mOnFailureCallback_30.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopDirection::TypeInfo>(
+            this, OnSuccessCallback_30, OnFailureCallback_30);
     }
 
     void OnFailureResponse_30(uint8_t status) { ThrowFailureResponse(); }
@@ -11259,7 +10984,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeColorLoopActive(mOnSuccessCallback_32.Cancel(), mOnFailureCallback_32.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopActive::TypeInfo>(
+            this, OnSuccessCallback_32, OnFailureCallback_32);
     }
 
     void OnFailureResponse_32(uint8_t status) { ThrowFailureResponse(); }
@@ -11306,7 +11032,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeColorLoopActive(mOnSuccessCallback_34.Cancel(), mOnFailureCallback_34.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopActive::TypeInfo>(
+            this, OnSuccessCallback_34, OnFailureCallback_34);
     }
 
     void OnFailureResponse_34(uint8_t status) { ThrowFailureResponse(); }
@@ -11441,30 +11168,9 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 14;
 
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_1{ OnFailureCallback_1, this };
-    chip::Callback::Callback<void (*)(void * context, bool onOff)> mOnSuccessCallback_1{ OnSuccessCallback_1, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_3{ OnFailureCallback_3, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t colorLoopActive)> mOnSuccessCallback_3{ OnSuccessCallback_3, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_4{ OnFailureCallback_4, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t colorLoopDirection)> mOnSuccessCallback_4{ OnSuccessCallback_4,
-                                                                                                         this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_5{ OnFailureCallback_5, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t colorLoopTime)> mOnSuccessCallback_5{ OnSuccessCallback_5, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_6{ OnFailureCallback_6, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t colorLoopStartEnhancedHue)> mOnSuccessCallback_6{
-        OnSuccessCallback_6, this
-    };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_8{ OnFailureCallback_8, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t colorLoopActive)> mOnSuccessCallback_8{ OnSuccessCallback_8, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_10{ OnFailureCallback_10, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t colorLoopDirection)> mOnSuccessCallback_10{ OnSuccessCallback_10,
-                                                                                                          this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_12{ OnFailureCallback_12, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t colorLoopActive)> mOnSuccessCallback_12{ OnSuccessCallback_12, this };
-
-    static void OnFailureCallback_1(void * context, uint8_t status)
+    static void OnFailureCallback_1(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_9_2 *>(context))->OnFailureResponse_1(status);
+        (static_cast<Test_TC_CC_9_2 *>(context))->OnFailureResponse_1(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_1(void * context, bool onOff)
@@ -11472,9 +11178,9 @@ private:
         (static_cast<Test_TC_CC_9_2 *>(context))->OnSuccessResponse_1(onOff);
     }
 
-    static void OnFailureCallback_3(void * context, uint8_t status)
+    static void OnFailureCallback_3(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_9_2 *>(context))->OnFailureResponse_3(status);
+        (static_cast<Test_TC_CC_9_2 *>(context))->OnFailureResponse_3(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_3(void * context, uint8_t colorLoopActive)
@@ -11482,9 +11188,9 @@ private:
         (static_cast<Test_TC_CC_9_2 *>(context))->OnSuccessResponse_3(colorLoopActive);
     }
 
-    static void OnFailureCallback_4(void * context, uint8_t status)
+    static void OnFailureCallback_4(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_9_2 *>(context))->OnFailureResponse_4(status);
+        (static_cast<Test_TC_CC_9_2 *>(context))->OnFailureResponse_4(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_4(void * context, uint8_t colorLoopDirection)
@@ -11492,9 +11198,9 @@ private:
         (static_cast<Test_TC_CC_9_2 *>(context))->OnSuccessResponse_4(colorLoopDirection);
     }
 
-    static void OnFailureCallback_5(void * context, uint8_t status)
+    static void OnFailureCallback_5(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_9_2 *>(context))->OnFailureResponse_5(status);
+        (static_cast<Test_TC_CC_9_2 *>(context))->OnFailureResponse_5(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_5(void * context, uint16_t colorLoopTime)
@@ -11502,9 +11208,9 @@ private:
         (static_cast<Test_TC_CC_9_2 *>(context))->OnSuccessResponse_5(colorLoopTime);
     }
 
-    static void OnFailureCallback_6(void * context, uint8_t status)
+    static void OnFailureCallback_6(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_9_2 *>(context))->OnFailureResponse_6(status);
+        (static_cast<Test_TC_CC_9_2 *>(context))->OnFailureResponse_6(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_6(void * context, uint16_t colorLoopStartEnhancedHue)
@@ -11512,9 +11218,9 @@ private:
         (static_cast<Test_TC_CC_9_2 *>(context))->OnSuccessResponse_6(colorLoopStartEnhancedHue);
     }
 
-    static void OnFailureCallback_8(void * context, uint8_t status)
+    static void OnFailureCallback_8(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_9_2 *>(context))->OnFailureResponse_8(status);
+        (static_cast<Test_TC_CC_9_2 *>(context))->OnFailureResponse_8(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_8(void * context, uint8_t colorLoopActive)
@@ -11522,9 +11228,9 @@ private:
         (static_cast<Test_TC_CC_9_2 *>(context))->OnSuccessResponse_8(colorLoopActive);
     }
 
-    static void OnFailureCallback_10(void * context, uint8_t status)
+    static void OnFailureCallback_10(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_9_2 *>(context))->OnFailureResponse_10(status);
+        (static_cast<Test_TC_CC_9_2 *>(context))->OnFailureResponse_10(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_10(void * context, uint8_t colorLoopDirection)
@@ -11532,9 +11238,9 @@ private:
         (static_cast<Test_TC_CC_9_2 *>(context))->OnSuccessResponse_10(colorLoopDirection);
     }
 
-    static void OnFailureCallback_12(void * context, uint8_t status)
+    static void OnFailureCallback_12(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_9_2 *>(context))->OnFailureResponse_12(status);
+        (static_cast<Test_TC_CC_9_2 *>(context))->OnFailureResponse_12(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_12(void * context, uint8_t colorLoopActive)
@@ -11575,7 +11281,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOnOff(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(this, OnSuccessCallback_1,
+                                                                                              OnFailureCallback_1);
     }
 
     void OnFailureResponse_1(uint8_t status) { ThrowFailureResponse(); }
@@ -11622,7 +11329,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeColorLoopActive(mOnSuccessCallback_3.Cancel(), mOnFailureCallback_3.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopActive::TypeInfo>(
+            this, OnSuccessCallback_3, OnFailureCallback_3);
     }
 
     void OnFailureResponse_3(uint8_t status) { ThrowFailureResponse(); }
@@ -11638,7 +11346,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeColorLoopDirection(mOnSuccessCallback_4.Cancel(), mOnFailureCallback_4.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopDirection::TypeInfo>(
+            this, OnSuccessCallback_4, OnFailureCallback_4);
     }
 
     void OnFailureResponse_4(uint8_t status) { ThrowFailureResponse(); }
@@ -11654,7 +11363,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeColorLoopTime(mOnSuccessCallback_5.Cancel(), mOnFailureCallback_5.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopTime::TypeInfo>(
+            this, OnSuccessCallback_5, OnFailureCallback_5);
     }
 
     void OnFailureResponse_5(uint8_t status) { ThrowFailureResponse(); }
@@ -11670,7 +11380,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeColorLoopStartEnhancedHue(mOnSuccessCallback_6.Cancel(), mOnFailureCallback_6.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopStartEnhancedHue::TypeInfo>(
+            this, OnSuccessCallback_6, OnFailureCallback_6);
     }
 
     void OnFailureResponse_6(uint8_t status) { ThrowFailureResponse(); }
@@ -11717,7 +11428,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeColorLoopActive(mOnSuccessCallback_8.Cancel(), mOnFailureCallback_8.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopActive::TypeInfo>(
+            this, OnSuccessCallback_8, OnFailureCallback_8);
     }
 
     void OnFailureResponse_8(uint8_t status) { ThrowFailureResponse(); }
@@ -11764,7 +11476,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeColorLoopDirection(mOnSuccessCallback_10.Cancel(), mOnFailureCallback_10.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopDirection::TypeInfo>(
+            this, OnSuccessCallback_10, OnFailureCallback_10);
     }
 
     void OnFailureResponse_10(uint8_t status) { ThrowFailureResponse(); }
@@ -11811,7 +11524,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeColorLoopActive(mOnSuccessCallback_12.Cancel(), mOnFailureCallback_12.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopActive::TypeInfo>(
+            this, OnSuccessCallback_12, OnFailureCallback_12);
     }
 
     void OnFailureResponse_12(uint8_t status) { ThrowFailureResponse(); }
@@ -11946,29 +11660,9 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 14;
 
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_1{ OnFailureCallback_1, this };
-    chip::Callback::Callback<void (*)(void * context, bool onOff)> mOnSuccessCallback_1{ OnSuccessCallback_1, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_3{ OnFailureCallback_3, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t colorLoopActive)> mOnSuccessCallback_3{ OnSuccessCallback_3, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_4{ OnFailureCallback_4, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t colorLoopDirection)> mOnSuccessCallback_4{ OnSuccessCallback_4,
-                                                                                                         this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_5{ OnFailureCallback_5, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t colorLoopTime)> mOnSuccessCallback_5{ OnSuccessCallback_5, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_6{ OnFailureCallback_6, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t colorLoopStartEnhancedHue)> mOnSuccessCallback_6{
-        OnSuccessCallback_6, this
-    };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_8{ OnFailureCallback_8, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t colorLoopActive)> mOnSuccessCallback_8{ OnSuccessCallback_8, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_10{ OnFailureCallback_10, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t colorLoopTime)> mOnSuccessCallback_10{ OnSuccessCallback_10, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_12{ OnFailureCallback_12, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t colorLoopActive)> mOnSuccessCallback_12{ OnSuccessCallback_12, this };
-
-    static void OnFailureCallback_1(void * context, uint8_t status)
+    static void OnFailureCallback_1(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_9_3 *>(context))->OnFailureResponse_1(status);
+        (static_cast<Test_TC_CC_9_3 *>(context))->OnFailureResponse_1(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_1(void * context, bool onOff)
@@ -11976,9 +11670,9 @@ private:
         (static_cast<Test_TC_CC_9_3 *>(context))->OnSuccessResponse_1(onOff);
     }
 
-    static void OnFailureCallback_3(void * context, uint8_t status)
+    static void OnFailureCallback_3(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_9_3 *>(context))->OnFailureResponse_3(status);
+        (static_cast<Test_TC_CC_9_3 *>(context))->OnFailureResponse_3(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_3(void * context, uint8_t colorLoopActive)
@@ -11986,9 +11680,9 @@ private:
         (static_cast<Test_TC_CC_9_3 *>(context))->OnSuccessResponse_3(colorLoopActive);
     }
 
-    static void OnFailureCallback_4(void * context, uint8_t status)
+    static void OnFailureCallback_4(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_9_3 *>(context))->OnFailureResponse_4(status);
+        (static_cast<Test_TC_CC_9_3 *>(context))->OnFailureResponse_4(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_4(void * context, uint8_t colorLoopDirection)
@@ -11996,9 +11690,9 @@ private:
         (static_cast<Test_TC_CC_9_3 *>(context))->OnSuccessResponse_4(colorLoopDirection);
     }
 
-    static void OnFailureCallback_5(void * context, uint8_t status)
+    static void OnFailureCallback_5(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_9_3 *>(context))->OnFailureResponse_5(status);
+        (static_cast<Test_TC_CC_9_3 *>(context))->OnFailureResponse_5(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_5(void * context, uint16_t colorLoopTime)
@@ -12006,9 +11700,9 @@ private:
         (static_cast<Test_TC_CC_9_3 *>(context))->OnSuccessResponse_5(colorLoopTime);
     }
 
-    static void OnFailureCallback_6(void * context, uint8_t status)
+    static void OnFailureCallback_6(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_9_3 *>(context))->OnFailureResponse_6(status);
+        (static_cast<Test_TC_CC_9_3 *>(context))->OnFailureResponse_6(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_6(void * context, uint16_t colorLoopStartEnhancedHue)
@@ -12016,9 +11710,9 @@ private:
         (static_cast<Test_TC_CC_9_3 *>(context))->OnSuccessResponse_6(colorLoopStartEnhancedHue);
     }
 
-    static void OnFailureCallback_8(void * context, uint8_t status)
+    static void OnFailureCallback_8(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_9_3 *>(context))->OnFailureResponse_8(status);
+        (static_cast<Test_TC_CC_9_3 *>(context))->OnFailureResponse_8(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_8(void * context, uint8_t colorLoopActive)
@@ -12026,9 +11720,9 @@ private:
         (static_cast<Test_TC_CC_9_3 *>(context))->OnSuccessResponse_8(colorLoopActive);
     }
 
-    static void OnFailureCallback_10(void * context, uint8_t status)
+    static void OnFailureCallback_10(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_9_3 *>(context))->OnFailureResponse_10(status);
+        (static_cast<Test_TC_CC_9_3 *>(context))->OnFailureResponse_10(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_10(void * context, uint16_t colorLoopTime)
@@ -12036,9 +11730,9 @@ private:
         (static_cast<Test_TC_CC_9_3 *>(context))->OnSuccessResponse_10(colorLoopTime);
     }
 
-    static void OnFailureCallback_12(void * context, uint8_t status)
+    static void OnFailureCallback_12(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_CC_9_3 *>(context))->OnFailureResponse_12(status);
+        (static_cast<Test_TC_CC_9_3 *>(context))->OnFailureResponse_12(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_12(void * context, uint8_t colorLoopActive)
@@ -12079,7 +11773,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOnOff(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(this, OnSuccessCallback_1,
+                                                                                              OnFailureCallback_1);
     }
 
     void OnFailureResponse_1(uint8_t status) { ThrowFailureResponse(); }
@@ -12126,7 +11821,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeColorLoopActive(mOnSuccessCallback_3.Cancel(), mOnFailureCallback_3.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopActive::TypeInfo>(
+            this, OnSuccessCallback_3, OnFailureCallback_3);
     }
 
     void OnFailureResponse_3(uint8_t status) { ThrowFailureResponse(); }
@@ -12142,7 +11838,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeColorLoopDirection(mOnSuccessCallback_4.Cancel(), mOnFailureCallback_4.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopDirection::TypeInfo>(
+            this, OnSuccessCallback_4, OnFailureCallback_4);
     }
 
     void OnFailureResponse_4(uint8_t status) { ThrowFailureResponse(); }
@@ -12158,7 +11855,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeColorLoopTime(mOnSuccessCallback_5.Cancel(), mOnFailureCallback_5.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopTime::TypeInfo>(
+            this, OnSuccessCallback_5, OnFailureCallback_5);
     }
 
     void OnFailureResponse_5(uint8_t status) { ThrowFailureResponse(); }
@@ -12174,7 +11872,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeColorLoopStartEnhancedHue(mOnSuccessCallback_6.Cancel(), mOnFailureCallback_6.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopStartEnhancedHue::TypeInfo>(
+            this, OnSuccessCallback_6, OnFailureCallback_6);
     }
 
     void OnFailureResponse_6(uint8_t status) { ThrowFailureResponse(); }
@@ -12221,7 +11920,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeColorLoopActive(mOnSuccessCallback_8.Cancel(), mOnFailureCallback_8.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopActive::TypeInfo>(
+            this, OnSuccessCallback_8, OnFailureCallback_8);
     }
 
     void OnFailureResponse_8(uint8_t status) { ThrowFailureResponse(); }
@@ -12268,7 +11968,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeColorLoopTime(mOnSuccessCallback_10.Cancel(), mOnFailureCallback_10.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopTime::TypeInfo>(
+            this, OnSuccessCallback_10, OnFailureCallback_10);
     }
 
     void OnFailureResponse_10(uint8_t status) { ThrowFailureResponse(); }
@@ -12315,7 +12016,8 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeColorLoopActive(mOnSuccessCallback_12.Cancel(), mOnFailureCallback_12.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ColorControl::Attributes::ColorLoopActive::TypeInfo>(
+            this, OnSuccessCallback_12, OnFailureCallback_12);
     }
 
     void OnFailureResponse_12(uint8_t status) { ThrowFailureResponse(); }
@@ -12466,59 +12168,9 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 18;
 
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_0{ OnFailureCallback_0, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t interactionModelVersion)> mOnSuccessCallback_0{ OnSuccessCallback_0,
-                                                                                                               this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_1{ OnFailureCallback_1, this };
-    chip::Callback::Callback<void (*)(void * context, chip::CharSpan vendorName)> mOnSuccessCallback_1{ OnSuccessCallback_1, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_2{ OnFailureCallback_2, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t vendorID)> mOnSuccessCallback_2{ OnSuccessCallback_2, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_3{ OnFailureCallback_3, this };
-    chip::Callback::Callback<void (*)(void * context, chip::CharSpan productName)> mOnSuccessCallback_3{ OnSuccessCallback_3,
-                                                                                                         this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_4{ OnFailureCallback_4, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t productID)> mOnSuccessCallback_4{ OnSuccessCallback_4, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_5{ OnFailureCallback_5, this };
-    chip::Callback::Callback<void (*)(void * context, chip::CharSpan userLabel)> mOnSuccessCallback_5{ OnSuccessCallback_5, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_6{ OnFailureCallback_6, this };
-    chip::Callback::Callback<void (*)(void * context, chip::CharSpan location)> mOnSuccessCallback_6{ OnSuccessCallback_6, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_7{ OnFailureCallback_7, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t hardwareVersion)> mOnSuccessCallback_7{ OnSuccessCallback_7, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_8{ OnFailureCallback_8, this };
-    chip::Callback::Callback<void (*)(void * context, chip::CharSpan hardwareVersionString)> mOnSuccessCallback_8{
-        OnSuccessCallback_8, this
-    };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_9{ OnFailureCallback_9, this };
-    chip::Callback::Callback<void (*)(void * context, uint32_t softwareVersion)> mOnSuccessCallback_9{ OnSuccessCallback_9, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_10{ OnFailureCallback_10, this };
-    chip::Callback::Callback<void (*)(void * context, chip::CharSpan softwareVersionString)> mOnSuccessCallback_10{
-        OnSuccessCallback_10, this
-    };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_11{ OnFailureCallback_11, this };
-    chip::Callback::Callback<void (*)(void * context, chip::CharSpan manufacturingDate)> mOnSuccessCallback_11{
-        OnSuccessCallback_11, this
-    };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_12{ OnFailureCallback_12, this };
-    chip::Callback::Callback<void (*)(void * context, chip::CharSpan partNumber)> mOnSuccessCallback_12{ OnSuccessCallback_12,
-                                                                                                         this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_13{ OnFailureCallback_13, this };
-    chip::Callback::Callback<void (*)(void * context, chip::CharSpan productURL)> mOnSuccessCallback_13{ OnSuccessCallback_13,
-                                                                                                         this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_14{ OnFailureCallback_14, this };
-    chip::Callback::Callback<void (*)(void * context, chip::CharSpan productLabel)> mOnSuccessCallback_14{ OnSuccessCallback_14,
-                                                                                                           this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_15{ OnFailureCallback_15, this };
-    chip::Callback::Callback<void (*)(void * context, chip::CharSpan serialNumber)> mOnSuccessCallback_15{ OnSuccessCallback_15,
-                                                                                                           this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_16{ OnFailureCallback_16, this };
-    chip::Callback::Callback<void (*)(void * context, bool localConfigDisabled)> mOnSuccessCallback_16{ OnSuccessCallback_16,
-                                                                                                        this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_17{ OnFailureCallback_17, this };
-    chip::Callback::Callback<void (*)(void * context, bool reachable)> mOnSuccessCallback_17{ OnSuccessCallback_17, this };
-
-    static void OnFailureCallback_0(void * context, uint8_t status)
+    static void OnFailureCallback_0(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_DM_1_1 *>(context))->OnFailureResponse_0(status);
+        (static_cast<Test_TC_DM_1_1 *>(context))->OnFailureResponse_0(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_0(void * context, uint16_t interactionModelVersion)
@@ -12526,9 +12178,9 @@ private:
         (static_cast<Test_TC_DM_1_1 *>(context))->OnSuccessResponse_0(interactionModelVersion);
     }
 
-    static void OnFailureCallback_1(void * context, uint8_t status)
+    static void OnFailureCallback_1(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_DM_1_1 *>(context))->OnFailureResponse_1(status);
+        (static_cast<Test_TC_DM_1_1 *>(context))->OnFailureResponse_1(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_1(void * context, chip::CharSpan vendorName)
@@ -12536,9 +12188,9 @@ private:
         (static_cast<Test_TC_DM_1_1 *>(context))->OnSuccessResponse_1(vendorName);
     }
 
-    static void OnFailureCallback_2(void * context, uint8_t status)
+    static void OnFailureCallback_2(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_DM_1_1 *>(context))->OnFailureResponse_2(status);
+        (static_cast<Test_TC_DM_1_1 *>(context))->OnFailureResponse_2(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_2(void * context, uint16_t vendorID)
@@ -12546,9 +12198,9 @@ private:
         (static_cast<Test_TC_DM_1_1 *>(context))->OnSuccessResponse_2(vendorID);
     }
 
-    static void OnFailureCallback_3(void * context, uint8_t status)
+    static void OnFailureCallback_3(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_DM_1_1 *>(context))->OnFailureResponse_3(status);
+        (static_cast<Test_TC_DM_1_1 *>(context))->OnFailureResponse_3(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_3(void * context, chip::CharSpan productName)
@@ -12556,9 +12208,9 @@ private:
         (static_cast<Test_TC_DM_1_1 *>(context))->OnSuccessResponse_3(productName);
     }
 
-    static void OnFailureCallback_4(void * context, uint8_t status)
+    static void OnFailureCallback_4(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_DM_1_1 *>(context))->OnFailureResponse_4(status);
+        (static_cast<Test_TC_DM_1_1 *>(context))->OnFailureResponse_4(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_4(void * context, uint16_t productID)
@@ -12566,9 +12218,9 @@ private:
         (static_cast<Test_TC_DM_1_1 *>(context))->OnSuccessResponse_4(productID);
     }
 
-    static void OnFailureCallback_5(void * context, uint8_t status)
+    static void OnFailureCallback_5(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_DM_1_1 *>(context))->OnFailureResponse_5(status);
+        (static_cast<Test_TC_DM_1_1 *>(context))->OnFailureResponse_5(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_5(void * context, chip::CharSpan userLabel)
@@ -12576,9 +12228,9 @@ private:
         (static_cast<Test_TC_DM_1_1 *>(context))->OnSuccessResponse_5(userLabel);
     }
 
-    static void OnFailureCallback_6(void * context, uint8_t status)
+    static void OnFailureCallback_6(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_DM_1_1 *>(context))->OnFailureResponse_6(status);
+        (static_cast<Test_TC_DM_1_1 *>(context))->OnFailureResponse_6(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_6(void * context, chip::CharSpan location)
@@ -12586,9 +12238,9 @@ private:
         (static_cast<Test_TC_DM_1_1 *>(context))->OnSuccessResponse_6(location);
     }
 
-    static void OnFailureCallback_7(void * context, uint8_t status)
+    static void OnFailureCallback_7(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_DM_1_1 *>(context))->OnFailureResponse_7(status);
+        (static_cast<Test_TC_DM_1_1 *>(context))->OnFailureResponse_7(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_7(void * context, uint16_t hardwareVersion)
@@ -12596,9 +12248,9 @@ private:
         (static_cast<Test_TC_DM_1_1 *>(context))->OnSuccessResponse_7(hardwareVersion);
     }
 
-    static void OnFailureCallback_8(void * context, uint8_t status)
+    static void OnFailureCallback_8(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_DM_1_1 *>(context))->OnFailureResponse_8(status);
+        (static_cast<Test_TC_DM_1_1 *>(context))->OnFailureResponse_8(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_8(void * context, chip::CharSpan hardwareVersionString)
@@ -12606,9 +12258,9 @@ private:
         (static_cast<Test_TC_DM_1_1 *>(context))->OnSuccessResponse_8(hardwareVersionString);
     }
 
-    static void OnFailureCallback_9(void * context, uint8_t status)
+    static void OnFailureCallback_9(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_DM_1_1 *>(context))->OnFailureResponse_9(status);
+        (static_cast<Test_TC_DM_1_1 *>(context))->OnFailureResponse_9(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_9(void * context, uint32_t softwareVersion)
@@ -12616,9 +12268,9 @@ private:
         (static_cast<Test_TC_DM_1_1 *>(context))->OnSuccessResponse_9(softwareVersion);
     }
 
-    static void OnFailureCallback_10(void * context, uint8_t status)
+    static void OnFailureCallback_10(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_DM_1_1 *>(context))->OnFailureResponse_10(status);
+        (static_cast<Test_TC_DM_1_1 *>(context))->OnFailureResponse_10(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_10(void * context, chip::CharSpan softwareVersionString)
@@ -12626,9 +12278,9 @@ private:
         (static_cast<Test_TC_DM_1_1 *>(context))->OnSuccessResponse_10(softwareVersionString);
     }
 
-    static void OnFailureCallback_11(void * context, uint8_t status)
+    static void OnFailureCallback_11(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_DM_1_1 *>(context))->OnFailureResponse_11(status);
+        (static_cast<Test_TC_DM_1_1 *>(context))->OnFailureResponse_11(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_11(void * context, chip::CharSpan manufacturingDate)
@@ -12636,9 +12288,9 @@ private:
         (static_cast<Test_TC_DM_1_1 *>(context))->OnSuccessResponse_11(manufacturingDate);
     }
 
-    static void OnFailureCallback_12(void * context, uint8_t status)
+    static void OnFailureCallback_12(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_DM_1_1 *>(context))->OnFailureResponse_12(status);
+        (static_cast<Test_TC_DM_1_1 *>(context))->OnFailureResponse_12(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_12(void * context, chip::CharSpan partNumber)
@@ -12646,9 +12298,9 @@ private:
         (static_cast<Test_TC_DM_1_1 *>(context))->OnSuccessResponse_12(partNumber);
     }
 
-    static void OnFailureCallback_13(void * context, uint8_t status)
+    static void OnFailureCallback_13(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_DM_1_1 *>(context))->OnFailureResponse_13(status);
+        (static_cast<Test_TC_DM_1_1 *>(context))->OnFailureResponse_13(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_13(void * context, chip::CharSpan productURL)
@@ -12656,9 +12308,9 @@ private:
         (static_cast<Test_TC_DM_1_1 *>(context))->OnSuccessResponse_13(productURL);
     }
 
-    static void OnFailureCallback_14(void * context, uint8_t status)
+    static void OnFailureCallback_14(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_DM_1_1 *>(context))->OnFailureResponse_14(status);
+        (static_cast<Test_TC_DM_1_1 *>(context))->OnFailureResponse_14(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_14(void * context, chip::CharSpan productLabel)
@@ -12666,9 +12318,9 @@ private:
         (static_cast<Test_TC_DM_1_1 *>(context))->OnSuccessResponse_14(productLabel);
     }
 
-    static void OnFailureCallback_15(void * context, uint8_t status)
+    static void OnFailureCallback_15(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_DM_1_1 *>(context))->OnFailureResponse_15(status);
+        (static_cast<Test_TC_DM_1_1 *>(context))->OnFailureResponse_15(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_15(void * context, chip::CharSpan serialNumber)
@@ -12676,9 +12328,9 @@ private:
         (static_cast<Test_TC_DM_1_1 *>(context))->OnSuccessResponse_15(serialNumber);
     }
 
-    static void OnFailureCallback_16(void * context, uint8_t status)
+    static void OnFailureCallback_16(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_DM_1_1 *>(context))->OnFailureResponse_16(status);
+        (static_cast<Test_TC_DM_1_1 *>(context))->OnFailureResponse_16(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_16(void * context, bool localConfigDisabled)
@@ -12686,9 +12338,9 @@ private:
         (static_cast<Test_TC_DM_1_1 *>(context))->OnSuccessResponse_16(localConfigDisabled);
     }
 
-    static void OnFailureCallback_17(void * context, uint8_t status)
+    static void OnFailureCallback_17(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_DM_1_1 *>(context))->OnFailureResponse_17(status);
+        (static_cast<Test_TC_DM_1_1 *>(context))->OnFailureResponse_17(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_17(void * context, bool reachable)
@@ -12705,7 +12357,8 @@ private:
         chip::Controller::BasicClusterTest cluster;
         cluster.Associate(mDevice, 0);
 
-        return cluster.ReadAttributeInteractionModelVersion(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::Basic::Attributes::InteractionModelVersion::TypeInfo>(
+            this, OnSuccessCallback_0, OnFailureCallback_0);
     }
 
     void OnFailureResponse_0(uint8_t status) { ThrowFailureResponse(); }
@@ -12721,7 +12374,8 @@ private:
         chip::Controller::BasicClusterTest cluster;
         cluster.Associate(mDevice, 0);
 
-        return cluster.ReadAttributeVendorName(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::Basic::Attributes::VendorName::TypeInfo>(this, OnSuccessCallback_1,
+                                                                                                   OnFailureCallback_1);
     }
 
     void OnFailureResponse_1(uint8_t status) { ThrowFailureResponse(); }
@@ -12738,7 +12392,8 @@ private:
         chip::Controller::BasicClusterTest cluster;
         cluster.Associate(mDevice, 0);
 
-        return cluster.ReadAttributeVendorID(mOnSuccessCallback_2.Cancel(), mOnFailureCallback_2.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::Basic::Attributes::VendorID::TypeInfo>(this, OnSuccessCallback_2,
+                                                                                                 OnFailureCallback_2);
     }
 
     void OnFailureResponse_2(uint8_t status) { ThrowFailureResponse(); }
@@ -12754,7 +12409,8 @@ private:
         chip::Controller::BasicClusterTest cluster;
         cluster.Associate(mDevice, 0);
 
-        return cluster.ReadAttributeProductName(mOnSuccessCallback_3.Cancel(), mOnFailureCallback_3.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::Basic::Attributes::ProductName::TypeInfo>(this, OnSuccessCallback_3,
+                                                                                                    OnFailureCallback_3);
     }
 
     void OnFailureResponse_3(uint8_t status) { ThrowFailureResponse(); }
@@ -12771,7 +12427,8 @@ private:
         chip::Controller::BasicClusterTest cluster;
         cluster.Associate(mDevice, 0);
 
-        return cluster.ReadAttributeProductID(mOnSuccessCallback_4.Cancel(), mOnFailureCallback_4.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::Basic::Attributes::ProductID::TypeInfo>(this, OnSuccessCallback_4,
+                                                                                                  OnFailureCallback_4);
     }
 
     void OnFailureResponse_4(uint8_t status) { ThrowFailureResponse(); }
@@ -12787,7 +12444,8 @@ private:
         chip::Controller::BasicClusterTest cluster;
         cluster.Associate(mDevice, 0);
 
-        return cluster.ReadAttributeUserLabel(mOnSuccessCallback_5.Cancel(), mOnFailureCallback_5.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::Basic::Attributes::UserLabel::TypeInfo>(this, OnSuccessCallback_5,
+                                                                                                  OnFailureCallback_5);
     }
 
     void OnFailureResponse_5(uint8_t status) { ThrowFailureResponse(); }
@@ -12804,7 +12462,8 @@ private:
         chip::Controller::BasicClusterTest cluster;
         cluster.Associate(mDevice, 0);
 
-        return cluster.ReadAttributeLocation(mOnSuccessCallback_6.Cancel(), mOnFailureCallback_6.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::Basic::Attributes::Location::TypeInfo>(this, OnSuccessCallback_6,
+                                                                                                 OnFailureCallback_6);
     }
 
     void OnFailureResponse_6(uint8_t status) { ThrowFailureResponse(); }
@@ -12822,7 +12481,8 @@ private:
         chip::Controller::BasicClusterTest cluster;
         cluster.Associate(mDevice, 0);
 
-        return cluster.ReadAttributeHardwareVersion(mOnSuccessCallback_7.Cancel(), mOnFailureCallback_7.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::Basic::Attributes::HardwareVersion::TypeInfo>(this, OnSuccessCallback_7,
+                                                                                                        OnFailureCallback_7);
     }
 
     void OnFailureResponse_7(uint8_t status) { ThrowFailureResponse(); }
@@ -12838,7 +12498,8 @@ private:
         chip::Controller::BasicClusterTest cluster;
         cluster.Associate(mDevice, 0);
 
-        return cluster.ReadAttributeHardwareVersionString(mOnSuccessCallback_8.Cancel(), mOnFailureCallback_8.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::Basic::Attributes::HardwareVersionString::TypeInfo>(
+            this, OnSuccessCallback_8, OnFailureCallback_8);
     }
 
     void OnFailureResponse_8(uint8_t status) { ThrowFailureResponse(); }
@@ -12856,7 +12517,8 @@ private:
         chip::Controller::BasicClusterTest cluster;
         cluster.Associate(mDevice, 0);
 
-        return cluster.ReadAttributeSoftwareVersion(mOnSuccessCallback_9.Cancel(), mOnFailureCallback_9.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::Basic::Attributes::SoftwareVersion::TypeInfo>(this, OnSuccessCallback_9,
+                                                                                                        OnFailureCallback_9);
     }
 
     void OnFailureResponse_9(uint8_t status) { ThrowFailureResponse(); }
@@ -12872,7 +12534,8 @@ private:
         chip::Controller::BasicClusterTest cluster;
         cluster.Associate(mDevice, 0);
 
-        return cluster.ReadAttributeSoftwareVersionString(mOnSuccessCallback_10.Cancel(), mOnFailureCallback_10.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::Basic::Attributes::SoftwareVersionString::TypeInfo>(
+            this, OnSuccessCallback_10, OnFailureCallback_10);
     }
 
     void OnFailureResponse_10(uint8_t status) { ThrowFailureResponse(); }
@@ -12891,7 +12554,8 @@ private:
         chip::Controller::BasicClusterTest cluster;
         cluster.Associate(mDevice, 0);
 
-        return cluster.ReadAttributeManufacturingDate(mOnSuccessCallback_11.Cancel(), mOnFailureCallback_11.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::Basic::Attributes::ManufacturingDate::TypeInfo>(
+            this, OnSuccessCallback_11, OnFailureCallback_11);
     }
 
     void OnFailureResponse_11(uint8_t status)
@@ -12913,7 +12577,8 @@ private:
         chip::Controller::BasicClusterTest cluster;
         cluster.Associate(mDevice, 0);
 
-        return cluster.ReadAttributePartNumber(mOnSuccessCallback_12.Cancel(), mOnFailureCallback_12.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::Basic::Attributes::PartNumber::TypeInfo>(this, OnSuccessCallback_12,
+                                                                                                   OnFailureCallback_12);
     }
 
     void OnFailureResponse_12(uint8_t status)
@@ -12933,7 +12598,8 @@ private:
         chip::Controller::BasicClusterTest cluster;
         cluster.Associate(mDevice, 0);
 
-        return cluster.ReadAttributeProductURL(mOnSuccessCallback_13.Cancel(), mOnFailureCallback_13.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::Basic::Attributes::ProductURL::TypeInfo>(this, OnSuccessCallback_13,
+                                                                                                   OnFailureCallback_13);
     }
 
     void OnFailureResponse_13(uint8_t status)
@@ -12954,7 +12620,8 @@ private:
         chip::Controller::BasicClusterTest cluster;
         cluster.Associate(mDevice, 0);
 
-        return cluster.ReadAttributeProductLabel(mOnSuccessCallback_14.Cancel(), mOnFailureCallback_14.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::Basic::Attributes::ProductLabel::TypeInfo>(this, OnSuccessCallback_14,
+                                                                                                     OnFailureCallback_14);
     }
 
     void OnFailureResponse_14(uint8_t status)
@@ -12974,7 +12641,8 @@ private:
         chip::Controller::BasicClusterTest cluster;
         cluster.Associate(mDevice, 0);
 
-        return cluster.ReadAttributeSerialNumber(mOnSuccessCallback_15.Cancel(), mOnFailureCallback_15.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::Basic::Attributes::SerialNumber::TypeInfo>(this, OnSuccessCallback_15,
+                                                                                                     OnFailureCallback_15);
     }
 
     void OnFailureResponse_15(uint8_t status)
@@ -12994,7 +12662,8 @@ private:
         chip::Controller::BasicClusterTest cluster;
         cluster.Associate(mDevice, 0);
 
-        return cluster.ReadAttributeLocalConfigDisabled(mOnSuccessCallback_16.Cancel(), mOnFailureCallback_16.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::Basic::Attributes::LocalConfigDisabled::TypeInfo>(
+            this, OnSuccessCallback_16, OnFailureCallback_16);
     }
 
     void OnFailureResponse_16(uint8_t status)
@@ -13013,7 +12682,8 @@ private:
         chip::Controller::BasicClusterTest cluster;
         cluster.Associate(mDevice, 0);
 
-        return cluster.ReadAttributeReachable(mOnSuccessCallback_17.Cancel(), mOnFailureCallback_17.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::Basic::Attributes::Reachable::TypeInfo>(this, OnSuccessCallback_17,
+                                                                                                  OnFailureCallback_17);
     }
 
     void OnFailureResponse_17(uint8_t status)
@@ -13135,25 +12805,9 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 4;
 
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_0{ OnFailureCallback_0, this };
-    chip::Callback::Callback<void (*)(
-        void * context,
-        const chip::app::DataModel::DecodableList<
-            chip::app::Clusters::OperationalCredentials::Structs::FabricDescriptor::DecodableType> & fabricsList)>
-        mOnSuccessCallback_0{ OnSuccessCallback_0, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_1{ OnFailureCallback_1, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t supportedFabrics)> mOnSuccessCallback_1{ OnSuccessCallback_1, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_2{ OnFailureCallback_2, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t commissionedFabrics)> mOnSuccessCallback_2{ OnSuccessCallback_2,
-                                                                                                          this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_3{ OnFailureCallback_3, this };
-    chip::Callback::Callback<void (*)(void * context,
-                                      const chip::app::DataModel::DecodableList<chip::ByteSpan> & trustedRootCertificates)>
-        mOnSuccessCallback_3{ OnSuccessCallback_3, this };
-
-    static void OnFailureCallback_0(void * context, uint8_t status)
+    static void OnFailureCallback_0(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_DM_2_2 *>(context))->OnFailureResponse_0(status);
+        (static_cast<Test_TC_DM_2_2 *>(context))->OnFailureResponse_0(chip::to_underlying(status));
     }
 
     static void
@@ -13164,9 +12818,9 @@ private:
         (static_cast<Test_TC_DM_2_2 *>(context))->OnSuccessResponse_0(fabricsList);
     }
 
-    static void OnFailureCallback_1(void * context, uint8_t status)
+    static void OnFailureCallback_1(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_DM_2_2 *>(context))->OnFailureResponse_1(status);
+        (static_cast<Test_TC_DM_2_2 *>(context))->OnFailureResponse_1(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_1(void * context, uint8_t supportedFabrics)
@@ -13174,9 +12828,9 @@ private:
         (static_cast<Test_TC_DM_2_2 *>(context))->OnSuccessResponse_1(supportedFabrics);
     }
 
-    static void OnFailureCallback_2(void * context, uint8_t status)
+    static void OnFailureCallback_2(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_DM_2_2 *>(context))->OnFailureResponse_2(status);
+        (static_cast<Test_TC_DM_2_2 *>(context))->OnFailureResponse_2(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_2(void * context, uint8_t commissionedFabrics)
@@ -13184,9 +12838,9 @@ private:
         (static_cast<Test_TC_DM_2_2 *>(context))->OnSuccessResponse_2(commissionedFabrics);
     }
 
-    static void OnFailureCallback_3(void * context, uint8_t status)
+    static void OnFailureCallback_3(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_DM_2_2 *>(context))->OnFailureResponse_3(status);
+        (static_cast<Test_TC_DM_2_2 *>(context))->OnFailureResponse_3(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_3(void * context,
@@ -13204,7 +12858,8 @@ private:
         chip::Controller::OperationalCredentialsClusterTest cluster;
         cluster.Associate(mDevice, 0);
 
-        return cluster.ReadAttributeFabricsList(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OperationalCredentials::Attributes::FabricsList::TypeInfo>(
+            this, OnSuccessCallback_0, OnFailureCallback_0);
     }
 
     void OnFailureResponse_0(uint8_t status) { ThrowFailureResponse(); }
@@ -13223,7 +12878,8 @@ private:
         chip::Controller::OperationalCredentialsClusterTest cluster;
         cluster.Associate(mDevice, 0);
 
-        return cluster.ReadAttributeSupportedFabrics(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OperationalCredentials::Attributes::SupportedFabrics::TypeInfo>(
+            this, OnSuccessCallback_1, OnFailureCallback_1);
     }
 
     void OnFailureResponse_1(uint8_t status) { ThrowFailureResponse(); }
@@ -13239,7 +12895,8 @@ private:
         chip::Controller::OperationalCredentialsClusterTest cluster;
         cluster.Associate(mDevice, 0);
 
-        return cluster.ReadAttributeCommissionedFabrics(mOnSuccessCallback_2.Cancel(), mOnFailureCallback_2.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OperationalCredentials::Attributes::CommissionedFabrics::TypeInfo>(
+            this, OnSuccessCallback_2, OnFailureCallback_2);
     }
 
     void OnFailureResponse_2(uint8_t status) { ThrowFailureResponse(); }
@@ -13255,7 +12912,8 @@ private:
         chip::Controller::OperationalCredentialsClusterTest cluster;
         cluster.Associate(mDevice, 0);
 
-        return cluster.ReadAttributeTrustedRootCertificates(mOnSuccessCallback_3.Cancel(), mOnFailureCallback_3.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OperationalCredentials::Attributes::TrustedRootCertificates::TypeInfo>(
+            this, OnSuccessCallback_3, OnFailureCallback_3);
     }
 
     void OnFailureResponse_3(uint8_t status) { ThrowFailureResponse(); }
@@ -13323,14 +12981,9 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 3;
 
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_0{ OnFailureCallback_0, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t clusterRevision)> mOnSuccessCallback_0{ OnSuccessCallback_0, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_2{ OnFailureCallback_2, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t clusterRevision)> mOnSuccessCallback_2{ OnSuccessCallback_2, this };
-
-    static void OnFailureCallback_0(void * context, uint8_t status)
+    static void OnFailureCallback_0(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_EMR_1_1 *>(context))->OnFailureResponse_0(status);
+        (static_cast<Test_TC_EMR_1_1 *>(context))->OnFailureResponse_0(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_0(void * context, uint16_t clusterRevision)
@@ -13345,9 +12998,9 @@ private:
 
     static void OnSuccessCallback_1(void * context) { (static_cast<Test_TC_EMR_1_1 *>(context))->OnSuccessResponse_1(); }
 
-    static void OnFailureCallback_2(void * context, uint8_t status)
+    static void OnFailureCallback_2(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_EMR_1_1 *>(context))->OnFailureResponse_2(status);
+        (static_cast<Test_TC_EMR_1_1 *>(context))->OnFailureResponse_2(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_2(void * context, uint16_t clusterRevision)
@@ -13364,7 +13017,8 @@ private:
         chip::Controller::ElectricalMeasurementClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeClusterRevision(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ElectricalMeasurement::Attributes::ClusterRevision::TypeInfo>(
+            this, OnSuccessCallback_0, OnFailureCallback_0);
     }
 
     void OnFailureResponse_0(uint8_t status) { ThrowFailureResponse(); }
@@ -13396,7 +13050,8 @@ private:
         chip::Controller::ElectricalMeasurementClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeClusterRevision(mOnSuccessCallback_2.Cancel(), mOnFailureCallback_2.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ElectricalMeasurement::Attributes::ClusterRevision::TypeInfo>(
+            this, OnSuccessCallback_2, OnFailureCallback_2);
     }
 
     void OnFailureResponse_2(uint8_t status) { ThrowFailureResponse(); }
@@ -13559,22 +13214,9 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 8;
 
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_0{ OnFailureCallback_0, this };
-    chip::Callback::Callback<void (*)(void * context, int16_t measuredValue)> mOnSuccessCallback_0{ OnSuccessCallback_0, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_1{ OnFailureCallback_1, this };
-    chip::Callback::Callback<void (*)(void * context, int16_t minMeasuredValue)> mOnSuccessCallback_1{ OnSuccessCallback_1, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_2{ OnFailureCallback_2, this };
-    chip::Callback::Callback<void (*)(void * context, int16_t maxMeasuredValue)> mOnSuccessCallback_2{ OnSuccessCallback_2, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_5{ OnFailureCallback_5, this };
-    chip::Callback::Callback<void (*)(void * context, int16_t measuredValue)> mOnSuccessCallback_5{ OnSuccessCallback_5, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_6{ OnFailureCallback_6, this };
-    chip::Callback::Callback<void (*)(void * context, int16_t minMeasuredValue)> mOnSuccessCallback_6{ OnSuccessCallback_6, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_7{ OnFailureCallback_7, this };
-    chip::Callback::Callback<void (*)(void * context, int16_t maxMeasuredValue)> mOnSuccessCallback_7{ OnSuccessCallback_7, this };
-
-    static void OnFailureCallback_0(void * context, uint8_t status)
+    static void OnFailureCallback_0(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_FLW_2_1 *>(context))->OnFailureResponse_0(status);
+        (static_cast<Test_TC_FLW_2_1 *>(context))->OnFailureResponse_0(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_0(void * context, int16_t measuredValue)
@@ -13582,9 +13224,9 @@ private:
         (static_cast<Test_TC_FLW_2_1 *>(context))->OnSuccessResponse_0(measuredValue);
     }
 
-    static void OnFailureCallback_1(void * context, uint8_t status)
+    static void OnFailureCallback_1(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_FLW_2_1 *>(context))->OnFailureResponse_1(status);
+        (static_cast<Test_TC_FLW_2_1 *>(context))->OnFailureResponse_1(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_1(void * context, int16_t minMeasuredValue)
@@ -13592,9 +13234,9 @@ private:
         (static_cast<Test_TC_FLW_2_1 *>(context))->OnSuccessResponse_1(minMeasuredValue);
     }
 
-    static void OnFailureCallback_2(void * context, uint8_t status)
+    static void OnFailureCallback_2(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_FLW_2_1 *>(context))->OnFailureResponse_2(status);
+        (static_cast<Test_TC_FLW_2_1 *>(context))->OnFailureResponse_2(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_2(void * context, int16_t maxMeasuredValue)
@@ -13616,9 +13258,9 @@ private:
 
     static void OnSuccessCallback_4(void * context) { (static_cast<Test_TC_FLW_2_1 *>(context))->OnSuccessResponse_4(); }
 
-    static void OnFailureCallback_5(void * context, uint8_t status)
+    static void OnFailureCallback_5(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_FLW_2_1 *>(context))->OnFailureResponse_5(status);
+        (static_cast<Test_TC_FLW_2_1 *>(context))->OnFailureResponse_5(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_5(void * context, int16_t measuredValue)
@@ -13626,9 +13268,9 @@ private:
         (static_cast<Test_TC_FLW_2_1 *>(context))->OnSuccessResponse_5(measuredValue);
     }
 
-    static void OnFailureCallback_6(void * context, uint8_t status)
+    static void OnFailureCallback_6(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_FLW_2_1 *>(context))->OnFailureResponse_6(status);
+        (static_cast<Test_TC_FLW_2_1 *>(context))->OnFailureResponse_6(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_6(void * context, int16_t minMeasuredValue)
@@ -13636,9 +13278,9 @@ private:
         (static_cast<Test_TC_FLW_2_1 *>(context))->OnSuccessResponse_6(minMeasuredValue);
     }
 
-    static void OnFailureCallback_7(void * context, uint8_t status)
+    static void OnFailureCallback_7(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_FLW_2_1 *>(context))->OnFailureResponse_7(status);
+        (static_cast<Test_TC_FLW_2_1 *>(context))->OnFailureResponse_7(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_7(void * context, int16_t maxMeasuredValue)
@@ -13655,7 +13297,8 @@ private:
         chip::Controller::FlowMeasurementClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeMeasuredValue(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::FlowMeasurement::Attributes::MeasuredValue::TypeInfo>(
+            this, OnSuccessCallback_0, OnFailureCallback_0);
     }
 
     void OnFailureResponse_0(uint8_t status) { ThrowFailureResponse(); }
@@ -13671,7 +13314,8 @@ private:
         chip::Controller::FlowMeasurementClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeMinMeasuredValue(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::FlowMeasurement::Attributes::MinMeasuredValue::TypeInfo>(
+            this, OnSuccessCallback_1, OnFailureCallback_1);
     }
 
     void OnFailureResponse_1(uint8_t status) { ThrowFailureResponse(); }
@@ -13687,7 +13331,8 @@ private:
         chip::Controller::FlowMeasurementClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeMaxMeasuredValue(mOnSuccessCallback_2.Cancel(), mOnFailureCallback_2.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::FlowMeasurement::Attributes::MaxMeasuredValue::TypeInfo>(
+            this, OnSuccessCallback_2, OnFailureCallback_2);
     }
 
     void OnFailureResponse_2(uint8_t status) { ThrowFailureResponse(); }
@@ -13735,7 +13380,8 @@ private:
         chip::Controller::FlowMeasurementClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeMeasuredValue(mOnSuccessCallback_5.Cancel(), mOnFailureCallback_5.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::FlowMeasurement::Attributes::MeasuredValue::TypeInfo>(
+            this, OnSuccessCallback_5, OnFailureCallback_5);
     }
 
     void OnFailureResponse_5(uint8_t status) { ThrowFailureResponse(); }
@@ -13751,7 +13397,8 @@ private:
         chip::Controller::FlowMeasurementClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeMinMeasuredValue(mOnSuccessCallback_6.Cancel(), mOnFailureCallback_6.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::FlowMeasurement::Attributes::MinMeasuredValue::TypeInfo>(
+            this, OnSuccessCallback_6, OnFailureCallback_6);
     }
 
     void OnFailureResponse_6(uint8_t status) { ThrowFailureResponse(); }
@@ -13767,7 +13414,8 @@ private:
         chip::Controller::FlowMeasurementClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeMaxMeasuredValue(mOnSuccessCallback_7.Cancel(), mOnFailureCallback_7.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::FlowMeasurement::Attributes::MaxMeasuredValue::TypeInfo>(
+            this, OnSuccessCallback_7, OnFailureCallback_7);
     }
 
     void OnFailureResponse_7(uint8_t status) { ThrowFailureResponse(); }
@@ -13830,14 +13478,9 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 2;
 
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_0{ OnFailureCallback_0, this };
-    chip::Callback::Callback<void (*)(void * context, int16_t measuredValue)> mOnSuccessCallback_0{ OnSuccessCallback_0, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_1{ OnFailureCallback_1, this };
-    chip::Callback::Callback<void (*)(void * context, int16_t measuredValue)> mOnSuccessCallback_1{ OnSuccessCallback_1, this };
-
-    static void OnFailureCallback_0(void * context, uint8_t status)
+    static void OnFailureCallback_0(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_FLW_2_2 *>(context))->OnFailureResponse_0(status);
+        (static_cast<Test_TC_FLW_2_2 *>(context))->OnFailureResponse_0(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_0(void * context, int16_t measuredValue)
@@ -13845,9 +13488,9 @@ private:
         (static_cast<Test_TC_FLW_2_2 *>(context))->OnSuccessResponse_0(measuredValue);
     }
 
-    static void OnFailureCallback_1(void * context, uint8_t status)
+    static void OnFailureCallback_1(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_FLW_2_2 *>(context))->OnFailureResponse_1(status);
+        (static_cast<Test_TC_FLW_2_2 *>(context))->OnFailureResponse_1(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_1(void * context, int16_t measuredValue)
@@ -13864,7 +13507,8 @@ private:
         chip::Controller::FlowMeasurementClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeMeasuredValue(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::FlowMeasurement::Attributes::MeasuredValue::TypeInfo>(
+            this, OnSuccessCallback_0, OnFailureCallback_0);
     }
 
     void OnFailureResponse_0(uint8_t status) { ThrowFailureResponse(); }
@@ -13880,7 +13524,8 @@ private:
         chip::Controller::FlowMeasurementClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeMeasuredValue(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::FlowMeasurement::Attributes::MeasuredValue::TypeInfo>(
+            this, OnSuccessCallback_1, OnFailureCallback_1);
     }
 
     void OnFailureResponse_1(uint8_t status) { ThrowFailureResponse(); }
@@ -14063,21 +13708,9 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 13;
 
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_0{ OnFailureCallback_0, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t currentLevel)> mOnSuccessCallback_0{ OnSuccessCallback_0, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_3{ OnFailureCallback_3, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t currentLevel)> mOnSuccessCallback_3{ OnSuccessCallback_3, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_6{ OnFailureCallback_6, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t currentLevel)> mOnSuccessCallback_6{ OnSuccessCallback_6, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_7{ OnFailureCallback_7, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t onOffTransitionTime)> mOnSuccessCallback_7{ OnSuccessCallback_7,
-                                                                                                           this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_10{ OnFailureCallback_10, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t currentLevel)> mOnSuccessCallback_10{ OnSuccessCallback_10, this };
-
-    static void OnFailureCallback_0(void * context, uint8_t status)
+    static void OnFailureCallback_0(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_LVL_2_1 *>(context))->OnFailureResponse_0(status);
+        (static_cast<Test_TC_LVL_2_1 *>(context))->OnFailureResponse_0(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_0(void * context, uint8_t currentLevel)
@@ -14085,9 +13718,9 @@ private:
         (static_cast<Test_TC_LVL_2_1 *>(context))->OnSuccessResponse_0(currentLevel);
     }
 
-    static void OnFailureCallback_3(void * context, uint8_t status)
+    static void OnFailureCallback_3(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_LVL_2_1 *>(context))->OnFailureResponse_3(status);
+        (static_cast<Test_TC_LVL_2_1 *>(context))->OnFailureResponse_3(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_3(void * context, uint8_t currentLevel)
@@ -14095,9 +13728,9 @@ private:
         (static_cast<Test_TC_LVL_2_1 *>(context))->OnSuccessResponse_3(currentLevel);
     }
 
-    static void OnFailureCallback_6(void * context, uint8_t status)
+    static void OnFailureCallback_6(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_LVL_2_1 *>(context))->OnFailureResponse_6(status);
+        (static_cast<Test_TC_LVL_2_1 *>(context))->OnFailureResponse_6(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_6(void * context, uint8_t currentLevel)
@@ -14105,9 +13738,9 @@ private:
         (static_cast<Test_TC_LVL_2_1 *>(context))->OnSuccessResponse_6(currentLevel);
     }
 
-    static void OnFailureCallback_7(void * context, uint8_t status)
+    static void OnFailureCallback_7(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_LVL_2_1 *>(context))->OnFailureResponse_7(status);
+        (static_cast<Test_TC_LVL_2_1 *>(context))->OnFailureResponse_7(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_7(void * context, uint16_t onOffTransitionTime)
@@ -14115,9 +13748,9 @@ private:
         (static_cast<Test_TC_LVL_2_1 *>(context))->OnSuccessResponse_7(onOffTransitionTime);
     }
 
-    static void OnFailureCallback_10(void * context, uint8_t status)
+    static void OnFailureCallback_10(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_LVL_2_1 *>(context))->OnFailureResponse_10(status);
+        (static_cast<Test_TC_LVL_2_1 *>(context))->OnFailureResponse_10(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_10(void * context, uint8_t currentLevel)
@@ -14134,7 +13767,8 @@ private:
         chip::Controller::LevelControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeCurrentLevel(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::LevelControl::Attributes::CurrentLevel::TypeInfo>(
+            this, OnSuccessCallback_0, OnFailureCallback_0);
     }
 
     void OnFailureResponse_0(uint8_t status) { ThrowFailureResponse(); }
@@ -14180,7 +13814,8 @@ private:
         chip::Controller::LevelControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeCurrentLevel(mOnSuccessCallback_3.Cancel(), mOnFailureCallback_3.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::LevelControl::Attributes::CurrentLevel::TypeInfo>(
+            this, OnSuccessCallback_3, OnFailureCallback_3);
     }
 
     void OnFailureResponse_3(uint8_t status) { ThrowFailureResponse(); }
@@ -14226,7 +13861,8 @@ private:
         chip::Controller::LevelControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeCurrentLevel(mOnSuccessCallback_6.Cancel(), mOnFailureCallback_6.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::LevelControl::Attributes::CurrentLevel::TypeInfo>(
+            this, OnSuccessCallback_6, OnFailureCallback_6);
     }
 
     void OnFailureResponse_6(uint8_t status) { ThrowFailureResponse(); }
@@ -14242,7 +13878,8 @@ private:
         chip::Controller::LevelControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOnOffTransitionTime(mOnSuccessCallback_7.Cancel(), mOnFailureCallback_7.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::LevelControl::Attributes::OnOffTransitionTime::TypeInfo>(
+            this, OnSuccessCallback_7, OnFailureCallback_7);
     }
 
     void OnFailureResponse_7(uint8_t status) { ThrowFailureResponse(); }
@@ -14288,7 +13925,8 @@ private:
         chip::Controller::LevelControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeCurrentLevel(mOnSuccessCallback_10.Cancel(), mOnFailureCallback_10.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::LevelControl::Attributes::CurrentLevel::TypeInfo>(
+            this, OnSuccessCallback_10, OnFailureCallback_10);
     }
 
     void OnFailureResponse_10(uint8_t status) { ThrowFailureResponse(); }
@@ -14429,24 +14067,9 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 14;
 
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_0{ OnFailureCallback_0, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t currentLevel)> mOnSuccessCallback_0{ OnSuccessCallback_0, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_1{ OnFailureCallback_1, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t maxLevel)> mOnSuccessCallback_1{ OnSuccessCallback_1, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_4{ OnFailureCallback_4, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t currentLevel)> mOnSuccessCallback_4{ OnSuccessCallback_4, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_5{ OnFailureCallback_5, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t minLevel)> mOnSuccessCallback_5{ OnSuccessCallback_5, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_8{ OnFailureCallback_8, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t currentLevel)> mOnSuccessCallback_8{ OnSuccessCallback_8, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_10{ OnFailureCallback_10, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t defaultMoveRate)> mOnSuccessCallback_10{ OnSuccessCallback_10, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_13{ OnFailureCallback_13, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t currentLevel)> mOnSuccessCallback_13{ OnSuccessCallback_13, this };
-
-    static void OnFailureCallback_0(void * context, uint8_t status)
+    static void OnFailureCallback_0(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_LVL_3_1 *>(context))->OnFailureResponse_0(status);
+        (static_cast<Test_TC_LVL_3_1 *>(context))->OnFailureResponse_0(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_0(void * context, uint8_t currentLevel)
@@ -14454,9 +14077,9 @@ private:
         (static_cast<Test_TC_LVL_3_1 *>(context))->OnSuccessResponse_0(currentLevel);
     }
 
-    static void OnFailureCallback_1(void * context, uint8_t status)
+    static void OnFailureCallback_1(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_LVL_3_1 *>(context))->OnFailureResponse_1(status);
+        (static_cast<Test_TC_LVL_3_1 *>(context))->OnFailureResponse_1(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_1(void * context, uint8_t maxLevel)
@@ -14464,9 +14087,9 @@ private:
         (static_cast<Test_TC_LVL_3_1 *>(context))->OnSuccessResponse_1(maxLevel);
     }
 
-    static void OnFailureCallback_4(void * context, uint8_t status)
+    static void OnFailureCallback_4(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_LVL_3_1 *>(context))->OnFailureResponse_4(status);
+        (static_cast<Test_TC_LVL_3_1 *>(context))->OnFailureResponse_4(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_4(void * context, uint8_t currentLevel)
@@ -14474,9 +14097,9 @@ private:
         (static_cast<Test_TC_LVL_3_1 *>(context))->OnSuccessResponse_4(currentLevel);
     }
 
-    static void OnFailureCallback_5(void * context, uint8_t status)
+    static void OnFailureCallback_5(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_LVL_3_1 *>(context))->OnFailureResponse_5(status);
+        (static_cast<Test_TC_LVL_3_1 *>(context))->OnFailureResponse_5(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_5(void * context, uint8_t minLevel)
@@ -14484,9 +14107,9 @@ private:
         (static_cast<Test_TC_LVL_3_1 *>(context))->OnSuccessResponse_5(minLevel);
     }
 
-    static void OnFailureCallback_8(void * context, uint8_t status)
+    static void OnFailureCallback_8(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_LVL_3_1 *>(context))->OnFailureResponse_8(status);
+        (static_cast<Test_TC_LVL_3_1 *>(context))->OnFailureResponse_8(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_8(void * context, uint8_t currentLevel)
@@ -14501,9 +14124,9 @@ private:
 
     static void OnSuccessCallback_9(void * context) { (static_cast<Test_TC_LVL_3_1 *>(context))->OnSuccessResponse_9(); }
 
-    static void OnFailureCallback_10(void * context, uint8_t status)
+    static void OnFailureCallback_10(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_LVL_3_1 *>(context))->OnFailureResponse_10(status);
+        (static_cast<Test_TC_LVL_3_1 *>(context))->OnFailureResponse_10(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_10(void * context, uint8_t defaultMoveRate)
@@ -14511,9 +14134,9 @@ private:
         (static_cast<Test_TC_LVL_3_1 *>(context))->OnSuccessResponse_10(defaultMoveRate);
     }
 
-    static void OnFailureCallback_13(void * context, uint8_t status)
+    static void OnFailureCallback_13(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_LVL_3_1 *>(context))->OnFailureResponse_13(status);
+        (static_cast<Test_TC_LVL_3_1 *>(context))->OnFailureResponse_13(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_13(void * context, uint8_t currentLevel)
@@ -14530,7 +14153,8 @@ private:
         chip::Controller::LevelControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeCurrentLevel(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::LevelControl::Attributes::CurrentLevel::TypeInfo>(
+            this, OnSuccessCallback_0, OnFailureCallback_0);
     }
 
     void OnFailureResponse_0(uint8_t status) { ThrowFailureResponse(); }
@@ -14546,7 +14170,8 @@ private:
         chip::Controller::LevelControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeMaxLevel(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::LevelControl::Attributes::MaxLevel::TypeInfo>(this, OnSuccessCallback_1,
+                                                                                                        OnFailureCallback_1);
     }
 
     void OnFailureResponse_1(uint8_t status) { ThrowFailureResponse(); }
@@ -14592,7 +14217,8 @@ private:
         chip::Controller::LevelControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeCurrentLevel(mOnSuccessCallback_4.Cancel(), mOnFailureCallback_4.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::LevelControl::Attributes::CurrentLevel::TypeInfo>(
+            this, OnSuccessCallback_4, OnFailureCallback_4);
     }
 
     void OnFailureResponse_4(uint8_t status) { ThrowFailureResponse(); }
@@ -14608,7 +14234,8 @@ private:
         chip::Controller::LevelControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeMinLevel(mOnSuccessCallback_5.Cancel(), mOnFailureCallback_5.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::LevelControl::Attributes::MinLevel::TypeInfo>(this, OnSuccessCallback_5,
+                                                                                                        OnFailureCallback_5);
     }
 
     void OnFailureResponse_5(uint8_t status) { ThrowFailureResponse(); }
@@ -14654,7 +14281,8 @@ private:
         chip::Controller::LevelControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeCurrentLevel(mOnSuccessCallback_8.Cancel(), mOnFailureCallback_8.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::LevelControl::Attributes::CurrentLevel::TypeInfo>(
+            this, OnSuccessCallback_8, OnFailureCallback_8);
     }
 
     void OnFailureResponse_8(uint8_t status) { ThrowFailureResponse(); }
@@ -14686,7 +14314,8 @@ private:
         chip::Controller::LevelControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeDefaultMoveRate(mOnSuccessCallback_10.Cancel(), mOnFailureCallback_10.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::LevelControl::Attributes::DefaultMoveRate::TypeInfo>(
+            this, OnSuccessCallback_10, OnFailureCallback_10);
     }
 
     void OnFailureResponse_10(uint8_t status) { ThrowFailureResponse(); }
@@ -14732,7 +14361,8 @@ private:
         chip::Controller::LevelControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeCurrentLevel(mOnSuccessCallback_13.Cancel(), mOnFailureCallback_13.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::LevelControl::Attributes::CurrentLevel::TypeInfo>(
+            this, OnSuccessCallback_13, OnFailureCallback_13);
     }
 
     void OnFailureResponse_13(uint8_t status) { ThrowFailureResponse(); }
@@ -14831,16 +14461,9 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 11;
 
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_3{ OnFailureCallback_3, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t currentLevel)> mOnSuccessCallback_3{ OnSuccessCallback_3, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_6{ OnFailureCallback_6, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t currentLevel)> mOnSuccessCallback_6{ OnSuccessCallback_6, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_9{ OnFailureCallback_9, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t currentLevel)> mOnSuccessCallback_9{ OnSuccessCallback_9, this };
-
-    static void OnFailureCallback_3(void * context, uint8_t status)
+    static void OnFailureCallback_3(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_LVL_4_1 *>(context))->OnFailureResponse_3(status);
+        (static_cast<Test_TC_LVL_4_1 *>(context))->OnFailureResponse_3(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_3(void * context, uint8_t currentLevel)
@@ -14848,9 +14471,9 @@ private:
         (static_cast<Test_TC_LVL_4_1 *>(context))->OnSuccessResponse_3(currentLevel);
     }
 
-    static void OnFailureCallback_6(void * context, uint8_t status)
+    static void OnFailureCallback_6(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_LVL_4_1 *>(context))->OnFailureResponse_6(status);
+        (static_cast<Test_TC_LVL_4_1 *>(context))->OnFailureResponse_6(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_6(void * context, uint8_t currentLevel)
@@ -14858,9 +14481,9 @@ private:
         (static_cast<Test_TC_LVL_4_1 *>(context))->OnSuccessResponse_6(currentLevel);
     }
 
-    static void OnFailureCallback_9(void * context, uint8_t status)
+    static void OnFailureCallback_9(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_LVL_4_1 *>(context))->OnFailureResponse_9(status);
+        (static_cast<Test_TC_LVL_4_1 *>(context))->OnFailureResponse_9(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_9(void * context, uint8_t currentLevel)
@@ -14932,7 +14555,8 @@ private:
         chip::Controller::LevelControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeCurrentLevel(mOnSuccessCallback_3.Cancel(), mOnFailureCallback_3.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::LevelControl::Attributes::CurrentLevel::TypeInfo>(
+            this, OnSuccessCallback_3, OnFailureCallback_3);
     }
 
     void OnFailureResponse_3(uint8_t status) { ThrowFailureResponse(); }
@@ -14979,7 +14603,8 @@ private:
         chip::Controller::LevelControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeCurrentLevel(mOnSuccessCallback_6.Cancel(), mOnFailureCallback_6.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::LevelControl::Attributes::CurrentLevel::TypeInfo>(
+            this, OnSuccessCallback_6, OnFailureCallback_6);
     }
 
     void OnFailureResponse_6(uint8_t status) { ThrowFailureResponse(); }
@@ -15026,7 +14651,8 @@ private:
         chip::Controller::LevelControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeCurrentLevel(mOnSuccessCallback_9.Cancel(), mOnFailureCallback_9.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::LevelControl::Attributes::CurrentLevel::TypeInfo>(
+            this, OnSuccessCallback_9, OnFailureCallback_9);
     }
 
     void OnFailureResponse_9(uint8_t status) { ThrowFailureResponse(); }
@@ -16005,12 +15631,9 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 2;
 
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_0{ OnFailureCallback_0, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t clusterRevision)> mOnSuccessCallback_0{ OnSuccessCallback_0, this };
-
-    static void OnFailureCallback_0(void * context, uint8_t status)
+    static void OnFailureCallback_0(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_OCC_1_1 *>(context))->OnFailureResponse_0(status);
+        (static_cast<Test_TC_OCC_1_1 *>(context))->OnFailureResponse_0(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_0(void * context, uint16_t clusterRevision)
@@ -16034,7 +15657,8 @@ private:
         chip::Controller::OccupancySensingClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeClusterRevision(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OccupancySensing::Attributes::ClusterRevision::TypeInfo>(
+            this, OnSuccessCallback_0, OnFailureCallback_0);
     }
 
     void OnFailureResponse_0(uint8_t status) { ThrowFailureResponse(); }
@@ -16145,26 +15769,9 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 9;
 
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_0{ OnFailureCallback_0, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t occupancy)> mOnSuccessCallback_0{ OnSuccessCallback_0, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_2{ OnFailureCallback_2, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t occupancy)> mOnSuccessCallback_2{ OnSuccessCallback_2, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_3{ OnFailureCallback_3, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t occupancySensorType)> mOnSuccessCallback_3{ OnSuccessCallback_3,
-                                                                                                          this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_5{ OnFailureCallback_5, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t occupancySensorType)> mOnSuccessCallback_5{ OnSuccessCallback_5,
-                                                                                                          this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_6{ OnFailureCallback_6, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t occupancySensorTypeBitmap)> mOnSuccessCallback_6{ OnSuccessCallback_6,
-                                                                                                                this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_8{ OnFailureCallback_8, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t occupancySensorTypeBitmap)> mOnSuccessCallback_8{ OnSuccessCallback_8,
-                                                                                                                this };
-
-    static void OnFailureCallback_0(void * context, uint8_t status)
+    static void OnFailureCallback_0(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_OCC_2_1 *>(context))->OnFailureResponse_0(status);
+        (static_cast<Test_TC_OCC_2_1 *>(context))->OnFailureResponse_0(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_0(void * context, uint8_t occupancy)
@@ -16179,9 +15786,9 @@ private:
 
     static void OnSuccessCallback_1(void * context) { (static_cast<Test_TC_OCC_2_1 *>(context))->OnSuccessResponse_1(); }
 
-    static void OnFailureCallback_2(void * context, uint8_t status)
+    static void OnFailureCallback_2(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_OCC_2_1 *>(context))->OnFailureResponse_2(status);
+        (static_cast<Test_TC_OCC_2_1 *>(context))->OnFailureResponse_2(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_2(void * context, uint8_t occupancy)
@@ -16189,9 +15796,9 @@ private:
         (static_cast<Test_TC_OCC_2_1 *>(context))->OnSuccessResponse_2(occupancy);
     }
 
-    static void OnFailureCallback_3(void * context, uint8_t status)
+    static void OnFailureCallback_3(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_OCC_2_1 *>(context))->OnFailureResponse_3(status);
+        (static_cast<Test_TC_OCC_2_1 *>(context))->OnFailureResponse_3(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_3(void * context, uint8_t occupancySensorType)
@@ -16206,9 +15813,9 @@ private:
 
     static void OnSuccessCallback_4(void * context) { (static_cast<Test_TC_OCC_2_1 *>(context))->OnSuccessResponse_4(); }
 
-    static void OnFailureCallback_5(void * context, uint8_t status)
+    static void OnFailureCallback_5(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_OCC_2_1 *>(context))->OnFailureResponse_5(status);
+        (static_cast<Test_TC_OCC_2_1 *>(context))->OnFailureResponse_5(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_5(void * context, uint8_t occupancySensorType)
@@ -16216,9 +15823,9 @@ private:
         (static_cast<Test_TC_OCC_2_1 *>(context))->OnSuccessResponse_5(occupancySensorType);
     }
 
-    static void OnFailureCallback_6(void * context, uint8_t status)
+    static void OnFailureCallback_6(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_OCC_2_1 *>(context))->OnFailureResponse_6(status);
+        (static_cast<Test_TC_OCC_2_1 *>(context))->OnFailureResponse_6(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_6(void * context, uint8_t occupancySensorTypeBitmap)
@@ -16233,9 +15840,9 @@ private:
 
     static void OnSuccessCallback_7(void * context) { (static_cast<Test_TC_OCC_2_1 *>(context))->OnSuccessResponse_7(); }
 
-    static void OnFailureCallback_8(void * context, uint8_t status)
+    static void OnFailureCallback_8(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_OCC_2_1 *>(context))->OnFailureResponse_8(status);
+        (static_cast<Test_TC_OCC_2_1 *>(context))->OnFailureResponse_8(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_8(void * context, uint8_t occupancySensorTypeBitmap)
@@ -16252,7 +15859,8 @@ private:
         chip::Controller::OccupancySensingClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOccupancy(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OccupancySensing::Attributes::Occupancy::TypeInfo>(
+            this, OnSuccessCallback_0, OnFailureCallback_0);
     }
 
     void OnFailureResponse_0(uint8_t status) { ThrowFailureResponse(); }
@@ -16285,7 +15893,8 @@ private:
         chip::Controller::OccupancySensingClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOccupancy(mOnSuccessCallback_2.Cancel(), mOnFailureCallback_2.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OccupancySensing::Attributes::Occupancy::TypeInfo>(
+            this, OnSuccessCallback_2, OnFailureCallback_2);
     }
 
     void OnFailureResponse_2(uint8_t status) { ThrowFailureResponse(); }
@@ -16301,7 +15910,8 @@ private:
         chip::Controller::OccupancySensingClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOccupancySensorType(mOnSuccessCallback_3.Cancel(), mOnFailureCallback_3.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OccupancySensing::Attributes::OccupancySensorType::TypeInfo>(
+            this, OnSuccessCallback_3, OnFailureCallback_3);
     }
 
     void OnFailureResponse_3(uint8_t status) { ThrowFailureResponse(); }
@@ -16334,7 +15944,8 @@ private:
         chip::Controller::OccupancySensingClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOccupancySensorType(mOnSuccessCallback_5.Cancel(), mOnFailureCallback_5.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OccupancySensing::Attributes::OccupancySensorType::TypeInfo>(
+            this, OnSuccessCallback_5, OnFailureCallback_5);
     }
 
     void OnFailureResponse_5(uint8_t status) { ThrowFailureResponse(); }
@@ -16350,7 +15961,8 @@ private:
         chip::Controller::OccupancySensingClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOccupancySensorTypeBitmap(mOnSuccessCallback_6.Cancel(), mOnFailureCallback_6.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OccupancySensing::Attributes::OccupancySensorTypeBitmap::TypeInfo>(
+            this, OnSuccessCallback_6, OnFailureCallback_6);
     }
 
     void OnFailureResponse_6(uint8_t status) { ThrowFailureResponse(); }
@@ -16384,7 +15996,8 @@ private:
         chip::Controller::OccupancySensingClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOccupancySensorTypeBitmap(mOnSuccessCallback_8.Cancel(), mOnFailureCallback_8.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OccupancySensing::Attributes::OccupancySensorTypeBitmap::TypeInfo>(
+            this, OnSuccessCallback_8, OnFailureCallback_8);
     }
 
     void OnFailureResponse_8(uint8_t status) { ThrowFailureResponse(); }
@@ -16447,14 +16060,9 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 2;
 
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_0{ OnFailureCallback_0, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t occupancy)> mOnSuccessCallback_0{ OnSuccessCallback_0, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_1{ OnFailureCallback_1, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t occupancy)> mOnSuccessCallback_1{ OnSuccessCallback_1, this };
-
-    static void OnFailureCallback_0(void * context, uint8_t status)
+    static void OnFailureCallback_0(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_OCC_2_2 *>(context))->OnFailureResponse_0(status);
+        (static_cast<Test_TC_OCC_2_2 *>(context))->OnFailureResponse_0(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_0(void * context, uint8_t occupancy)
@@ -16462,9 +16070,9 @@ private:
         (static_cast<Test_TC_OCC_2_2 *>(context))->OnSuccessResponse_0(occupancy);
     }
 
-    static void OnFailureCallback_1(void * context, uint8_t status)
+    static void OnFailureCallback_1(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_OCC_2_2 *>(context))->OnFailureResponse_1(status);
+        (static_cast<Test_TC_OCC_2_2 *>(context))->OnFailureResponse_1(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_1(void * context, uint8_t occupancy)
@@ -16481,7 +16089,8 @@ private:
         chip::Controller::OccupancySensingClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOccupancy(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OccupancySensing::Attributes::Occupancy::TypeInfo>(
+            this, OnSuccessCallback_0, OnFailureCallback_0);
     }
 
     void OnFailureResponse_0(uint8_t status) { ThrowFailureResponse(); }
@@ -16497,7 +16106,8 @@ private:
         chip::Controller::OccupancySensingClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOccupancy(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OccupancySensing::Attributes::Occupancy::TypeInfo>(
+            this, OnSuccessCallback_1, OnFailureCallback_1);
     }
 
     void OnFailureResponse_1(uint8_t status) { ThrowFailureResponse(); }
@@ -16577,18 +16187,9 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 6;
 
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_0{ OnFailureCallback_0, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t clusterRevision)> mOnSuccessCallback_0{ OnSuccessCallback_0, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_2{ OnFailureCallback_2, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t clusterRevision)> mOnSuccessCallback_2{ OnSuccessCallback_2, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_3{ OnFailureCallback_3, this };
-    chip::Callback::Callback<void (*)(void * context, uint32_t featureMap)> mOnSuccessCallback_3{ OnSuccessCallback_3, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_5{ OnFailureCallback_5, this };
-    chip::Callback::Callback<void (*)(void * context, uint32_t featureMap)> mOnSuccessCallback_5{ OnSuccessCallback_5, this };
-
-    static void OnFailureCallback_0(void * context, uint8_t status)
+    static void OnFailureCallback_0(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_OO_1_1 *>(context))->OnFailureResponse_0(status);
+        (static_cast<Test_TC_OO_1_1 *>(context))->OnFailureResponse_0(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_0(void * context, uint16_t clusterRevision)
@@ -16603,9 +16204,9 @@ private:
 
     static void OnSuccessCallback_1(void * context) { (static_cast<Test_TC_OO_1_1 *>(context))->OnSuccessResponse_1(); }
 
-    static void OnFailureCallback_2(void * context, uint8_t status)
+    static void OnFailureCallback_2(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_OO_1_1 *>(context))->OnFailureResponse_2(status);
+        (static_cast<Test_TC_OO_1_1 *>(context))->OnFailureResponse_2(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_2(void * context, uint16_t clusterRevision)
@@ -16613,9 +16214,9 @@ private:
         (static_cast<Test_TC_OO_1_1 *>(context))->OnSuccessResponse_2(clusterRevision);
     }
 
-    static void OnFailureCallback_3(void * context, uint8_t status)
+    static void OnFailureCallback_3(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_OO_1_1 *>(context))->OnFailureResponse_3(status);
+        (static_cast<Test_TC_OO_1_1 *>(context))->OnFailureResponse_3(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_3(void * context, uint32_t featureMap)
@@ -16630,9 +16231,9 @@ private:
 
     static void OnSuccessCallback_4(void * context) { (static_cast<Test_TC_OO_1_1 *>(context))->OnSuccessResponse_4(); }
 
-    static void OnFailureCallback_5(void * context, uint8_t status)
+    static void OnFailureCallback_5(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_OO_1_1 *>(context))->OnFailureResponse_5(status);
+        (static_cast<Test_TC_OO_1_1 *>(context))->OnFailureResponse_5(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_5(void * context, uint32_t featureMap)
@@ -16649,7 +16250,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeClusterRevision(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::ClusterRevision::TypeInfo>(this, OnSuccessCallback_0,
+                                                                                                        OnFailureCallback_0);
     }
 
     void OnFailureResponse_0(uint8_t status) { ThrowFailureResponse(); }
@@ -16681,7 +16283,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeClusterRevision(mOnSuccessCallback_2.Cancel(), mOnFailureCallback_2.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::ClusterRevision::TypeInfo>(this, OnSuccessCallback_2,
+                                                                                                        OnFailureCallback_2);
     }
 
     void OnFailureResponse_2(uint8_t status) { ThrowFailureResponse(); }
@@ -16697,7 +16300,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeFeatureMap(mOnSuccessCallback_3.Cancel(), mOnFailureCallback_3.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::FeatureMap::TypeInfo>(this, OnSuccessCallback_3,
+                                                                                                   OnFailureCallback_3);
     }
 
     void OnFailureResponse_3(uint8_t status) { ThrowFailureResponse(); }
@@ -16729,7 +16333,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeFeatureMap(mOnSuccessCallback_5.Cancel(), mOnFailureCallback_5.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::FeatureMap::TypeInfo>(this, OnSuccessCallback_5,
+                                                                                                   OnFailureCallback_5);
     }
 
     void OnFailureResponse_5(uint8_t status) { ThrowFailureResponse(); }
@@ -16832,28 +16437,9 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 12;
 
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_0{ OnFailureCallback_0, this };
-    chip::Callback::Callback<void (*)(void * context, bool onOff)> mOnSuccessCallback_0{ OnSuccessCallback_0, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_1{ OnFailureCallback_1, this };
-    chip::Callback::Callback<void (*)(void * context, bool onOff)> mOnSuccessCallback_1{ OnSuccessCallback_1, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_2{ OnFailureCallback_2, this };
-    chip::Callback::Callback<void (*)(void * context, bool globalSceneControl)> mOnSuccessCallback_2{ OnSuccessCallback_2, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_3{ OnFailureCallback_3, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t onTime)> mOnSuccessCallback_3{ OnSuccessCallback_3, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_4{ OnFailureCallback_4, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t offWaitTime)> mOnSuccessCallback_4{ OnSuccessCallback_4, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_5{ OnFailureCallback_5, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t startUpOnOff)> mOnSuccessCallback_5{ OnSuccessCallback_5, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_9{ OnFailureCallback_9, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t onTime)> mOnSuccessCallback_9{ OnSuccessCallback_9, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_10{ OnFailureCallback_10, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t offWaitTime)> mOnSuccessCallback_10{ OnSuccessCallback_10, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_11{ OnFailureCallback_11, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t startUpOnOff)> mOnSuccessCallback_11{ OnSuccessCallback_11, this };
-
-    static void OnFailureCallback_0(void * context, uint8_t status)
+    static void OnFailureCallback_0(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_OO_2_1 *>(context))->OnFailureResponse_0(status);
+        (static_cast<Test_TC_OO_2_1 *>(context))->OnFailureResponse_0(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_0(void * context, bool onOff)
@@ -16861,9 +16447,9 @@ private:
         (static_cast<Test_TC_OO_2_1 *>(context))->OnSuccessResponse_0(onOff);
     }
 
-    static void OnFailureCallback_1(void * context, uint8_t status)
+    static void OnFailureCallback_1(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_OO_2_1 *>(context))->OnFailureResponse_1(status);
+        (static_cast<Test_TC_OO_2_1 *>(context))->OnFailureResponse_1(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_1(void * context, bool onOff)
@@ -16871,9 +16457,9 @@ private:
         (static_cast<Test_TC_OO_2_1 *>(context))->OnSuccessResponse_1(onOff);
     }
 
-    static void OnFailureCallback_2(void * context, uint8_t status)
+    static void OnFailureCallback_2(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_OO_2_1 *>(context))->OnFailureResponse_2(status);
+        (static_cast<Test_TC_OO_2_1 *>(context))->OnFailureResponse_2(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_2(void * context, bool globalSceneControl)
@@ -16881,9 +16467,9 @@ private:
         (static_cast<Test_TC_OO_2_1 *>(context))->OnSuccessResponse_2(globalSceneControl);
     }
 
-    static void OnFailureCallback_3(void * context, uint8_t status)
+    static void OnFailureCallback_3(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_OO_2_1 *>(context))->OnFailureResponse_3(status);
+        (static_cast<Test_TC_OO_2_1 *>(context))->OnFailureResponse_3(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_3(void * context, uint16_t onTime)
@@ -16891,9 +16477,9 @@ private:
         (static_cast<Test_TC_OO_2_1 *>(context))->OnSuccessResponse_3(onTime);
     }
 
-    static void OnFailureCallback_4(void * context, uint8_t status)
+    static void OnFailureCallback_4(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_OO_2_1 *>(context))->OnFailureResponse_4(status);
+        (static_cast<Test_TC_OO_2_1 *>(context))->OnFailureResponse_4(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_4(void * context, uint16_t offWaitTime)
@@ -16901,9 +16487,9 @@ private:
         (static_cast<Test_TC_OO_2_1 *>(context))->OnSuccessResponse_4(offWaitTime);
     }
 
-    static void OnFailureCallback_5(void * context, uint8_t status)
+    static void OnFailureCallback_5(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_OO_2_1 *>(context))->OnFailureResponse_5(status);
+        (static_cast<Test_TC_OO_2_1 *>(context))->OnFailureResponse_5(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_5(void * context, uint8_t startUpOnOff)
@@ -16932,9 +16518,9 @@ private:
 
     static void OnSuccessCallback_8(void * context) { (static_cast<Test_TC_OO_2_1 *>(context))->OnSuccessResponse_8(); }
 
-    static void OnFailureCallback_9(void * context, uint8_t status)
+    static void OnFailureCallback_9(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_OO_2_1 *>(context))->OnFailureResponse_9(status);
+        (static_cast<Test_TC_OO_2_1 *>(context))->OnFailureResponse_9(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_9(void * context, uint16_t onTime)
@@ -16942,9 +16528,9 @@ private:
         (static_cast<Test_TC_OO_2_1 *>(context))->OnSuccessResponse_9(onTime);
     }
 
-    static void OnFailureCallback_10(void * context, uint8_t status)
+    static void OnFailureCallback_10(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_OO_2_1 *>(context))->OnFailureResponse_10(status);
+        (static_cast<Test_TC_OO_2_1 *>(context))->OnFailureResponse_10(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_10(void * context, uint16_t offWaitTime)
@@ -16952,9 +16538,9 @@ private:
         (static_cast<Test_TC_OO_2_1 *>(context))->OnSuccessResponse_10(offWaitTime);
     }
 
-    static void OnFailureCallback_11(void * context, uint8_t status)
+    static void OnFailureCallback_11(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_OO_2_1 *>(context))->OnFailureResponse_11(status);
+        (static_cast<Test_TC_OO_2_1 *>(context))->OnFailureResponse_11(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_11(void * context, uint8_t startUpOnOff)
@@ -16971,7 +16557,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOnOff(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(this, OnSuccessCallback_0,
+                                                                                              OnFailureCallback_0);
     }
 
     void OnFailureResponse_0(uint8_t status) { ThrowFailureResponse(); }
@@ -16987,7 +16574,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOnOff(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(this, OnSuccessCallback_1,
+                                                                                              OnFailureCallback_1);
     }
 
     void OnFailureResponse_1(uint8_t status) { ThrowFailureResponse(); }
@@ -17003,7 +16591,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeGlobalSceneControl(mOnSuccessCallback_2.Cancel(), mOnFailureCallback_2.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::GlobalSceneControl::TypeInfo>(
+            this, OnSuccessCallback_2, OnFailureCallback_2);
     }
 
     void OnFailureResponse_2(uint8_t status) { ThrowFailureResponse(); }
@@ -17019,7 +16608,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOnTime(mOnSuccessCallback_3.Cancel(), mOnFailureCallback_3.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnTime::TypeInfo>(this, OnSuccessCallback_3,
+                                                                                               OnFailureCallback_3);
     }
 
     void OnFailureResponse_3(uint8_t status) { ThrowFailureResponse(); }
@@ -17035,7 +16625,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOffWaitTime(mOnSuccessCallback_4.Cancel(), mOnFailureCallback_4.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OffWaitTime::TypeInfo>(this, OnSuccessCallback_4,
+                                                                                                    OnFailureCallback_4);
     }
 
     void OnFailureResponse_4(uint8_t status) { ThrowFailureResponse(); }
@@ -17051,7 +16642,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeStartUpOnOff(mOnSuccessCallback_5.Cancel(), mOnFailureCallback_5.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::StartUpOnOff::TypeInfo>(this, OnSuccessCallback_5,
+                                                                                                     OnFailureCallback_5);
     }
 
     void OnFailureResponse_5(uint8_t status) { ThrowFailureResponse(); }
@@ -17115,7 +16707,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOnTime(mOnSuccessCallback_9.Cancel(), mOnFailureCallback_9.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnTime::TypeInfo>(this, OnSuccessCallback_9,
+                                                                                               OnFailureCallback_9);
     }
 
     void OnFailureResponse_9(uint8_t status) { ThrowFailureResponse(); }
@@ -17131,7 +16724,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOffWaitTime(mOnSuccessCallback_10.Cancel(), mOnFailureCallback_10.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OffWaitTime::TypeInfo>(this, OnSuccessCallback_10,
+                                                                                                    OnFailureCallback_10);
     }
 
     void OnFailureResponse_10(uint8_t status) { ThrowFailureResponse(); }
@@ -17147,7 +16741,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeStartUpOnOff(mOnSuccessCallback_11.Cancel(), mOnFailureCallback_11.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::StartUpOnOff::TypeInfo>(this, OnSuccessCallback_11,
+                                                                                                     OnFailureCallback_11);
     }
 
     void OnFailureResponse_11(uint8_t status) { ThrowFailureResponse(); }
@@ -17258,24 +16853,9 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 14;
 
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_1{ OnFailureCallback_1, this };
-    chip::Callback::Callback<void (*)(void * context, bool onOff)> mOnSuccessCallback_1{ OnSuccessCallback_1, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_3{ OnFailureCallback_3, this };
-    chip::Callback::Callback<void (*)(void * context, bool onOff)> mOnSuccessCallback_3{ OnSuccessCallback_3, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_5{ OnFailureCallback_5, this };
-    chip::Callback::Callback<void (*)(void * context, bool onOff)> mOnSuccessCallback_5{ OnSuccessCallback_5, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_7{ OnFailureCallback_7, this };
-    chip::Callback::Callback<void (*)(void * context, bool onOff)> mOnSuccessCallback_7{ OnSuccessCallback_7, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_9{ OnFailureCallback_9, this };
-    chip::Callback::Callback<void (*)(void * context, bool onOff)> mOnSuccessCallback_9{ OnSuccessCallback_9, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_11{ OnFailureCallback_11, this };
-    chip::Callback::Callback<void (*)(void * context, bool onOff)> mOnSuccessCallback_11{ OnSuccessCallback_11, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_13{ OnFailureCallback_13, this };
-    chip::Callback::Callback<void (*)(void * context, bool onOff)> mOnSuccessCallback_13{ OnSuccessCallback_13, this };
-
-    static void OnFailureCallback_1(void * context, uint8_t status)
+    static void OnFailureCallback_1(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_OO_2_2 *>(context))->OnFailureResponse_1(status);
+        (static_cast<Test_TC_OO_2_2 *>(context))->OnFailureResponse_1(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_1(void * context, bool onOff)
@@ -17283,9 +16863,9 @@ private:
         (static_cast<Test_TC_OO_2_2 *>(context))->OnSuccessResponse_1(onOff);
     }
 
-    static void OnFailureCallback_3(void * context, uint8_t status)
+    static void OnFailureCallback_3(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_OO_2_2 *>(context))->OnFailureResponse_3(status);
+        (static_cast<Test_TC_OO_2_2 *>(context))->OnFailureResponse_3(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_3(void * context, bool onOff)
@@ -17293,9 +16873,9 @@ private:
         (static_cast<Test_TC_OO_2_2 *>(context))->OnSuccessResponse_3(onOff);
     }
 
-    static void OnFailureCallback_5(void * context, uint8_t status)
+    static void OnFailureCallback_5(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_OO_2_2 *>(context))->OnFailureResponse_5(status);
+        (static_cast<Test_TC_OO_2_2 *>(context))->OnFailureResponse_5(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_5(void * context, bool onOff)
@@ -17303,9 +16883,9 @@ private:
         (static_cast<Test_TC_OO_2_2 *>(context))->OnSuccessResponse_5(onOff);
     }
 
-    static void OnFailureCallback_7(void * context, uint8_t status)
+    static void OnFailureCallback_7(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_OO_2_2 *>(context))->OnFailureResponse_7(status);
+        (static_cast<Test_TC_OO_2_2 *>(context))->OnFailureResponse_7(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_7(void * context, bool onOff)
@@ -17313,9 +16893,9 @@ private:
         (static_cast<Test_TC_OO_2_2 *>(context))->OnSuccessResponse_7(onOff);
     }
 
-    static void OnFailureCallback_9(void * context, uint8_t status)
+    static void OnFailureCallback_9(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_OO_2_2 *>(context))->OnFailureResponse_9(status);
+        (static_cast<Test_TC_OO_2_2 *>(context))->OnFailureResponse_9(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_9(void * context, bool onOff)
@@ -17323,9 +16903,9 @@ private:
         (static_cast<Test_TC_OO_2_2 *>(context))->OnSuccessResponse_9(onOff);
     }
 
-    static void OnFailureCallback_11(void * context, uint8_t status)
+    static void OnFailureCallback_11(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_OO_2_2 *>(context))->OnFailureResponse_11(status);
+        (static_cast<Test_TC_OO_2_2 *>(context))->OnFailureResponse_11(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_11(void * context, bool onOff)
@@ -17333,9 +16913,9 @@ private:
         (static_cast<Test_TC_OO_2_2 *>(context))->OnSuccessResponse_11(onOff);
     }
 
-    static void OnFailureCallback_13(void * context, uint8_t status)
+    static void OnFailureCallback_13(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_OO_2_2 *>(context))->OnFailureResponse_13(status);
+        (static_cast<Test_TC_OO_2_2 *>(context))->OnFailureResponse_13(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_13(void * context, bool onOff)
@@ -17376,7 +16956,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOnOff(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(this, OnSuccessCallback_1,
+                                                                                              OnFailureCallback_1);
     }
 
     void OnFailureResponse_1(uint8_t status) { ThrowFailureResponse(); }
@@ -17416,7 +16997,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOnOff(mOnSuccessCallback_3.Cancel(), mOnFailureCallback_3.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(this, OnSuccessCallback_3,
+                                                                                              OnFailureCallback_3);
     }
 
     void OnFailureResponse_3(uint8_t status) { ThrowFailureResponse(); }
@@ -17456,7 +17038,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOnOff(mOnSuccessCallback_5.Cancel(), mOnFailureCallback_5.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(this, OnSuccessCallback_5,
+                                                                                              OnFailureCallback_5);
     }
 
     void OnFailureResponse_5(uint8_t status) { ThrowFailureResponse(); }
@@ -17496,7 +17079,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOnOff(mOnSuccessCallback_7.Cancel(), mOnFailureCallback_7.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(this, OnSuccessCallback_7,
+                                                                                              OnFailureCallback_7);
     }
 
     void OnFailureResponse_7(uint8_t status) { ThrowFailureResponse(); }
@@ -17536,7 +17120,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOnOff(mOnSuccessCallback_9.Cancel(), mOnFailureCallback_9.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(this, OnSuccessCallback_9,
+                                                                                              OnFailureCallback_9);
     }
 
     void OnFailureResponse_9(uint8_t status) { ThrowFailureResponse(); }
@@ -17576,7 +17161,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOnOff(mOnSuccessCallback_11.Cancel(), mOnFailureCallback_11.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(this, OnSuccessCallback_11,
+                                                                                              OnFailureCallback_11);
     }
 
     void OnFailureResponse_11(uint8_t status) { ThrowFailureResponse(); }
@@ -17616,7 +17202,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOnOff(mOnSuccessCallback_13.Cancel(), mOnFailureCallback_13.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(this, OnSuccessCallback_13,
+                                                                                              OnFailureCallback_13);
     }
 
     void OnFailureResponse_13(uint8_t status) { ThrowFailureResponse(); }
@@ -17855,76 +17442,9 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 46;
 
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_2{ OnFailureCallback_2, this };
-    chip::Callback::Callback<void (*)(void * context, bool onOff)> mOnSuccessCallback_2{ OnSuccessCallback_2, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_3{ OnFailureCallback_3, this };
-    chip::Callback::Callback<void (*)(void * context, bool globalSceneControl)> mOnSuccessCallback_3{ OnSuccessCallback_3, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_6{ OnFailureCallback_6, this };
-    chip::Callback::Callback<void (*)(void * context, bool onOff)> mOnSuccessCallback_6{ OnSuccessCallback_6, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_7{ OnFailureCallback_7, this };
-    chip::Callback::Callback<void (*)(void * context, bool globalSceneControl)> mOnSuccessCallback_7{ OnSuccessCallback_7, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_10{ OnFailureCallback_10, this };
-    chip::Callback::Callback<void (*)(void * context, bool onOff)> mOnSuccessCallback_10{ OnSuccessCallback_10, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_11{ OnFailureCallback_11, this };
-    chip::Callback::Callback<void (*)(void * context, bool globalSceneControl)> mOnSuccessCallback_11{ OnSuccessCallback_11, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_12{ OnFailureCallback_12, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t onTime)> mOnSuccessCallback_12{ OnSuccessCallback_12, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_13{ OnFailureCallback_13, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t offWaitTime)> mOnSuccessCallback_13{ OnSuccessCallback_13, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_15{ OnFailureCallback_15, this };
-    chip::Callback::Callback<void (*)(void * context, bool onOff)> mOnSuccessCallback_15{ OnSuccessCallback_15, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_16{ OnFailureCallback_16, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t onTime)> mOnSuccessCallback_16{ OnSuccessCallback_16, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_17{ OnFailureCallback_17, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t offWaitTime)> mOnSuccessCallback_17{ OnSuccessCallback_17, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_19{ OnFailureCallback_19, this };
-    chip::Callback::Callback<void (*)(void * context, bool onOff)> mOnSuccessCallback_19{ OnSuccessCallback_19, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_20{ OnFailureCallback_20, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t onTime)> mOnSuccessCallback_20{ OnSuccessCallback_20, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_21{ OnFailureCallback_21, this };
-    chip::Callback::Callback<void (*)(void * context, bool onOff)> mOnSuccessCallback_21{ OnSuccessCallback_21, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_22{ OnFailureCallback_22, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t onTime)> mOnSuccessCallback_22{ OnSuccessCallback_22, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_23{ OnFailureCallback_23, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t offWaitTime)> mOnSuccessCallback_23{ OnSuccessCallback_23, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_25{ OnFailureCallback_25, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t onTime)> mOnSuccessCallback_25{ OnSuccessCallback_25, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_26{ OnFailureCallback_26, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t offWaitTime)> mOnSuccessCallback_26{ OnSuccessCallback_26, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_28{ OnFailureCallback_28, this };
-    chip::Callback::Callback<void (*)(void * context, bool onOff)> mOnSuccessCallback_28{ OnSuccessCallback_28, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_29{ OnFailureCallback_29, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t onTime)> mOnSuccessCallback_29{ OnSuccessCallback_29, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_30{ OnFailureCallback_30, this };
-    chip::Callback::Callback<void (*)(void * context, bool onOff)> mOnSuccessCallback_30{ OnSuccessCallback_30, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_31{ OnFailureCallback_31, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t onTime)> mOnSuccessCallback_31{ OnSuccessCallback_31, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_33{ OnFailureCallback_33, this };
-    chip::Callback::Callback<void (*)(void * context, bool onOff)> mOnSuccessCallback_33{ OnSuccessCallback_33, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_34{ OnFailureCallback_34, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t onTime)> mOnSuccessCallback_34{ OnSuccessCallback_34, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_35{ OnFailureCallback_35, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t offWaitTime)> mOnSuccessCallback_35{ OnSuccessCallback_35, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_37{ OnFailureCallback_37, this };
-    chip::Callback::Callback<void (*)(void * context, bool onOff)> mOnSuccessCallback_37{ OnSuccessCallback_37, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_38{ OnFailureCallback_38, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t onTime)> mOnSuccessCallback_38{ OnSuccessCallback_38, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_39{ OnFailureCallback_39, this };
-    chip::Callback::Callback<void (*)(void * context, bool onOff)> mOnSuccessCallback_39{ OnSuccessCallback_39, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_40{ OnFailureCallback_40, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t onTime)> mOnSuccessCallback_40{ OnSuccessCallback_40, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_41{ OnFailureCallback_41, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t offWaitTime)> mOnSuccessCallback_41{ OnSuccessCallback_41, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_42{ OnFailureCallback_42, this };
-    chip::Callback::Callback<void (*)(void * context, bool onOff)> mOnSuccessCallback_42{ OnSuccessCallback_42, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_43{ OnFailureCallback_43, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t onTime)> mOnSuccessCallback_43{ OnSuccessCallback_43, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_44{ OnFailureCallback_44, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t offWaitTime)> mOnSuccessCallback_44{ OnSuccessCallback_44, this };
-
-    static void OnFailureCallback_2(void * context, uint8_t status)
+    static void OnFailureCallback_2(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_OO_2_3 *>(context))->OnFailureResponse_2(status);
+        (static_cast<Test_TC_OO_2_3 *>(context))->OnFailureResponse_2(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_2(void * context, bool onOff)
@@ -17932,9 +17452,9 @@ private:
         (static_cast<Test_TC_OO_2_3 *>(context))->OnSuccessResponse_2(onOff);
     }
 
-    static void OnFailureCallback_3(void * context, uint8_t status)
+    static void OnFailureCallback_3(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_OO_2_3 *>(context))->OnFailureResponse_3(status);
+        (static_cast<Test_TC_OO_2_3 *>(context))->OnFailureResponse_3(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_3(void * context, bool globalSceneControl)
@@ -17942,9 +17462,9 @@ private:
         (static_cast<Test_TC_OO_2_3 *>(context))->OnSuccessResponse_3(globalSceneControl);
     }
 
-    static void OnFailureCallback_6(void * context, uint8_t status)
+    static void OnFailureCallback_6(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_OO_2_3 *>(context))->OnFailureResponse_6(status);
+        (static_cast<Test_TC_OO_2_3 *>(context))->OnFailureResponse_6(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_6(void * context, bool onOff)
@@ -17952,9 +17472,9 @@ private:
         (static_cast<Test_TC_OO_2_3 *>(context))->OnSuccessResponse_6(onOff);
     }
 
-    static void OnFailureCallback_7(void * context, uint8_t status)
+    static void OnFailureCallback_7(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_OO_2_3 *>(context))->OnFailureResponse_7(status);
+        (static_cast<Test_TC_OO_2_3 *>(context))->OnFailureResponse_7(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_7(void * context, bool globalSceneControl)
@@ -17962,9 +17482,9 @@ private:
         (static_cast<Test_TC_OO_2_3 *>(context))->OnSuccessResponse_7(globalSceneControl);
     }
 
-    static void OnFailureCallback_10(void * context, uint8_t status)
+    static void OnFailureCallback_10(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_OO_2_3 *>(context))->OnFailureResponse_10(status);
+        (static_cast<Test_TC_OO_2_3 *>(context))->OnFailureResponse_10(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_10(void * context, bool onOff)
@@ -17972,9 +17492,9 @@ private:
         (static_cast<Test_TC_OO_2_3 *>(context))->OnSuccessResponse_10(onOff);
     }
 
-    static void OnFailureCallback_11(void * context, uint8_t status)
+    static void OnFailureCallback_11(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_OO_2_3 *>(context))->OnFailureResponse_11(status);
+        (static_cast<Test_TC_OO_2_3 *>(context))->OnFailureResponse_11(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_11(void * context, bool globalSceneControl)
@@ -17982,9 +17502,9 @@ private:
         (static_cast<Test_TC_OO_2_3 *>(context))->OnSuccessResponse_11(globalSceneControl);
     }
 
-    static void OnFailureCallback_12(void * context, uint8_t status)
+    static void OnFailureCallback_12(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_OO_2_3 *>(context))->OnFailureResponse_12(status);
+        (static_cast<Test_TC_OO_2_3 *>(context))->OnFailureResponse_12(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_12(void * context, uint16_t onTime)
@@ -17992,9 +17512,9 @@ private:
         (static_cast<Test_TC_OO_2_3 *>(context))->OnSuccessResponse_12(onTime);
     }
 
-    static void OnFailureCallback_13(void * context, uint8_t status)
+    static void OnFailureCallback_13(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_OO_2_3 *>(context))->OnFailureResponse_13(status);
+        (static_cast<Test_TC_OO_2_3 *>(context))->OnFailureResponse_13(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_13(void * context, uint16_t offWaitTime)
@@ -18002,9 +17522,9 @@ private:
         (static_cast<Test_TC_OO_2_3 *>(context))->OnSuccessResponse_13(offWaitTime);
     }
 
-    static void OnFailureCallback_15(void * context, uint8_t status)
+    static void OnFailureCallback_15(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_OO_2_3 *>(context))->OnFailureResponse_15(status);
+        (static_cast<Test_TC_OO_2_3 *>(context))->OnFailureResponse_15(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_15(void * context, bool onOff)
@@ -18012,9 +17532,9 @@ private:
         (static_cast<Test_TC_OO_2_3 *>(context))->OnSuccessResponse_15(onOff);
     }
 
-    static void OnFailureCallback_16(void * context, uint8_t status)
+    static void OnFailureCallback_16(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_OO_2_3 *>(context))->OnFailureResponse_16(status);
+        (static_cast<Test_TC_OO_2_3 *>(context))->OnFailureResponse_16(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_16(void * context, uint16_t onTime)
@@ -18022,9 +17542,9 @@ private:
         (static_cast<Test_TC_OO_2_3 *>(context))->OnSuccessResponse_16(onTime);
     }
 
-    static void OnFailureCallback_17(void * context, uint8_t status)
+    static void OnFailureCallback_17(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_OO_2_3 *>(context))->OnFailureResponse_17(status);
+        (static_cast<Test_TC_OO_2_3 *>(context))->OnFailureResponse_17(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_17(void * context, uint16_t offWaitTime)
@@ -18032,9 +17552,9 @@ private:
         (static_cast<Test_TC_OO_2_3 *>(context))->OnSuccessResponse_17(offWaitTime);
     }
 
-    static void OnFailureCallback_19(void * context, uint8_t status)
+    static void OnFailureCallback_19(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_OO_2_3 *>(context))->OnFailureResponse_19(status);
+        (static_cast<Test_TC_OO_2_3 *>(context))->OnFailureResponse_19(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_19(void * context, bool onOff)
@@ -18042,9 +17562,9 @@ private:
         (static_cast<Test_TC_OO_2_3 *>(context))->OnSuccessResponse_19(onOff);
     }
 
-    static void OnFailureCallback_20(void * context, uint8_t status)
+    static void OnFailureCallback_20(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_OO_2_3 *>(context))->OnFailureResponse_20(status);
+        (static_cast<Test_TC_OO_2_3 *>(context))->OnFailureResponse_20(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_20(void * context, uint16_t onTime)
@@ -18052,9 +17572,9 @@ private:
         (static_cast<Test_TC_OO_2_3 *>(context))->OnSuccessResponse_20(onTime);
     }
 
-    static void OnFailureCallback_21(void * context, uint8_t status)
+    static void OnFailureCallback_21(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_OO_2_3 *>(context))->OnFailureResponse_21(status);
+        (static_cast<Test_TC_OO_2_3 *>(context))->OnFailureResponse_21(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_21(void * context, bool onOff)
@@ -18062,9 +17582,9 @@ private:
         (static_cast<Test_TC_OO_2_3 *>(context))->OnSuccessResponse_21(onOff);
     }
 
-    static void OnFailureCallback_22(void * context, uint8_t status)
+    static void OnFailureCallback_22(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_OO_2_3 *>(context))->OnFailureResponse_22(status);
+        (static_cast<Test_TC_OO_2_3 *>(context))->OnFailureResponse_22(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_22(void * context, uint16_t onTime)
@@ -18072,9 +17592,9 @@ private:
         (static_cast<Test_TC_OO_2_3 *>(context))->OnSuccessResponse_22(onTime);
     }
 
-    static void OnFailureCallback_23(void * context, uint8_t status)
+    static void OnFailureCallback_23(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_OO_2_3 *>(context))->OnFailureResponse_23(status);
+        (static_cast<Test_TC_OO_2_3 *>(context))->OnFailureResponse_23(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_23(void * context, uint16_t offWaitTime)
@@ -18082,9 +17602,9 @@ private:
         (static_cast<Test_TC_OO_2_3 *>(context))->OnSuccessResponse_23(offWaitTime);
     }
 
-    static void OnFailureCallback_25(void * context, uint8_t status)
+    static void OnFailureCallback_25(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_OO_2_3 *>(context))->OnFailureResponse_25(status);
+        (static_cast<Test_TC_OO_2_3 *>(context))->OnFailureResponse_25(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_25(void * context, uint16_t onTime)
@@ -18092,9 +17612,9 @@ private:
         (static_cast<Test_TC_OO_2_3 *>(context))->OnSuccessResponse_25(onTime);
     }
 
-    static void OnFailureCallback_26(void * context, uint8_t status)
+    static void OnFailureCallback_26(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_OO_2_3 *>(context))->OnFailureResponse_26(status);
+        (static_cast<Test_TC_OO_2_3 *>(context))->OnFailureResponse_26(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_26(void * context, uint16_t offWaitTime)
@@ -18102,9 +17622,9 @@ private:
         (static_cast<Test_TC_OO_2_3 *>(context))->OnSuccessResponse_26(offWaitTime);
     }
 
-    static void OnFailureCallback_28(void * context, uint8_t status)
+    static void OnFailureCallback_28(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_OO_2_3 *>(context))->OnFailureResponse_28(status);
+        (static_cast<Test_TC_OO_2_3 *>(context))->OnFailureResponse_28(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_28(void * context, bool onOff)
@@ -18112,9 +17632,9 @@ private:
         (static_cast<Test_TC_OO_2_3 *>(context))->OnSuccessResponse_28(onOff);
     }
 
-    static void OnFailureCallback_29(void * context, uint8_t status)
+    static void OnFailureCallback_29(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_OO_2_3 *>(context))->OnFailureResponse_29(status);
+        (static_cast<Test_TC_OO_2_3 *>(context))->OnFailureResponse_29(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_29(void * context, uint16_t onTime)
@@ -18122,9 +17642,9 @@ private:
         (static_cast<Test_TC_OO_2_3 *>(context))->OnSuccessResponse_29(onTime);
     }
 
-    static void OnFailureCallback_30(void * context, uint8_t status)
+    static void OnFailureCallback_30(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_OO_2_3 *>(context))->OnFailureResponse_30(status);
+        (static_cast<Test_TC_OO_2_3 *>(context))->OnFailureResponse_30(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_30(void * context, bool onOff)
@@ -18132,9 +17652,9 @@ private:
         (static_cast<Test_TC_OO_2_3 *>(context))->OnSuccessResponse_30(onOff);
     }
 
-    static void OnFailureCallback_31(void * context, uint8_t status)
+    static void OnFailureCallback_31(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_OO_2_3 *>(context))->OnFailureResponse_31(status);
+        (static_cast<Test_TC_OO_2_3 *>(context))->OnFailureResponse_31(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_31(void * context, uint16_t onTime)
@@ -18142,9 +17662,9 @@ private:
         (static_cast<Test_TC_OO_2_3 *>(context))->OnSuccessResponse_31(onTime);
     }
 
-    static void OnFailureCallback_33(void * context, uint8_t status)
+    static void OnFailureCallback_33(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_OO_2_3 *>(context))->OnFailureResponse_33(status);
+        (static_cast<Test_TC_OO_2_3 *>(context))->OnFailureResponse_33(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_33(void * context, bool onOff)
@@ -18152,9 +17672,9 @@ private:
         (static_cast<Test_TC_OO_2_3 *>(context))->OnSuccessResponse_33(onOff);
     }
 
-    static void OnFailureCallback_34(void * context, uint8_t status)
+    static void OnFailureCallback_34(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_OO_2_3 *>(context))->OnFailureResponse_34(status);
+        (static_cast<Test_TC_OO_2_3 *>(context))->OnFailureResponse_34(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_34(void * context, uint16_t onTime)
@@ -18162,9 +17682,9 @@ private:
         (static_cast<Test_TC_OO_2_3 *>(context))->OnSuccessResponse_34(onTime);
     }
 
-    static void OnFailureCallback_35(void * context, uint8_t status)
+    static void OnFailureCallback_35(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_OO_2_3 *>(context))->OnFailureResponse_35(status);
+        (static_cast<Test_TC_OO_2_3 *>(context))->OnFailureResponse_35(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_35(void * context, uint16_t offWaitTime)
@@ -18172,9 +17692,9 @@ private:
         (static_cast<Test_TC_OO_2_3 *>(context))->OnSuccessResponse_35(offWaitTime);
     }
 
-    static void OnFailureCallback_37(void * context, uint8_t status)
+    static void OnFailureCallback_37(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_OO_2_3 *>(context))->OnFailureResponse_37(status);
+        (static_cast<Test_TC_OO_2_3 *>(context))->OnFailureResponse_37(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_37(void * context, bool onOff)
@@ -18182,9 +17702,9 @@ private:
         (static_cast<Test_TC_OO_2_3 *>(context))->OnSuccessResponse_37(onOff);
     }
 
-    static void OnFailureCallback_38(void * context, uint8_t status)
+    static void OnFailureCallback_38(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_OO_2_3 *>(context))->OnFailureResponse_38(status);
+        (static_cast<Test_TC_OO_2_3 *>(context))->OnFailureResponse_38(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_38(void * context, uint16_t onTime)
@@ -18192,9 +17712,9 @@ private:
         (static_cast<Test_TC_OO_2_3 *>(context))->OnSuccessResponse_38(onTime);
     }
 
-    static void OnFailureCallback_39(void * context, uint8_t status)
+    static void OnFailureCallback_39(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_OO_2_3 *>(context))->OnFailureResponse_39(status);
+        (static_cast<Test_TC_OO_2_3 *>(context))->OnFailureResponse_39(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_39(void * context, bool onOff)
@@ -18202,9 +17722,9 @@ private:
         (static_cast<Test_TC_OO_2_3 *>(context))->OnSuccessResponse_39(onOff);
     }
 
-    static void OnFailureCallback_40(void * context, uint8_t status)
+    static void OnFailureCallback_40(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_OO_2_3 *>(context))->OnFailureResponse_40(status);
+        (static_cast<Test_TC_OO_2_3 *>(context))->OnFailureResponse_40(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_40(void * context, uint16_t onTime)
@@ -18212,9 +17732,9 @@ private:
         (static_cast<Test_TC_OO_2_3 *>(context))->OnSuccessResponse_40(onTime);
     }
 
-    static void OnFailureCallback_41(void * context, uint8_t status)
+    static void OnFailureCallback_41(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_OO_2_3 *>(context))->OnFailureResponse_41(status);
+        (static_cast<Test_TC_OO_2_3 *>(context))->OnFailureResponse_41(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_41(void * context, uint16_t offWaitTime)
@@ -18222,9 +17742,9 @@ private:
         (static_cast<Test_TC_OO_2_3 *>(context))->OnSuccessResponse_41(offWaitTime);
     }
 
-    static void OnFailureCallback_42(void * context, uint8_t status)
+    static void OnFailureCallback_42(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_OO_2_3 *>(context))->OnFailureResponse_42(status);
+        (static_cast<Test_TC_OO_2_3 *>(context))->OnFailureResponse_42(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_42(void * context, bool onOff)
@@ -18232,9 +17752,9 @@ private:
         (static_cast<Test_TC_OO_2_3 *>(context))->OnSuccessResponse_42(onOff);
     }
 
-    static void OnFailureCallback_43(void * context, uint8_t status)
+    static void OnFailureCallback_43(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_OO_2_3 *>(context))->OnFailureResponse_43(status);
+        (static_cast<Test_TC_OO_2_3 *>(context))->OnFailureResponse_43(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_43(void * context, uint16_t onTime)
@@ -18242,9 +17762,9 @@ private:
         (static_cast<Test_TC_OO_2_3 *>(context))->OnSuccessResponse_43(onTime);
     }
 
-    static void OnFailureCallback_44(void * context, uint8_t status)
+    static void OnFailureCallback_44(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_OO_2_3 *>(context))->OnFailureResponse_44(status);
+        (static_cast<Test_TC_OO_2_3 *>(context))->OnFailureResponse_44(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_44(void * context, uint16_t offWaitTime)
@@ -18287,7 +17807,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOnOff(mOnSuccessCallback_2.Cancel(), mOnFailureCallback_2.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(this, OnSuccessCallback_2,
+                                                                                              OnFailureCallback_2);
     }
 
     void OnFailureResponse_2(uint8_t status) { ThrowFailureResponse(); }
@@ -18303,7 +17824,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeGlobalSceneControl(mOnSuccessCallback_3.Cancel(), mOnFailureCallback_3.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::GlobalSceneControl::TypeInfo>(
+            this, OnSuccessCallback_3, OnFailureCallback_3);
     }
 
     void OnFailureResponse_3(uint8_t status) { ThrowFailureResponse(); }
@@ -18345,7 +17867,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOnOff(mOnSuccessCallback_6.Cancel(), mOnFailureCallback_6.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(this, OnSuccessCallback_6,
+                                                                                              OnFailureCallback_6);
     }
 
     void OnFailureResponse_6(uint8_t status) { ThrowFailureResponse(); }
@@ -18361,7 +17884,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeGlobalSceneControl(mOnSuccessCallback_7.Cancel(), mOnFailureCallback_7.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::GlobalSceneControl::TypeInfo>(
+            this, OnSuccessCallback_7, OnFailureCallback_7);
     }
 
     void OnFailureResponse_7(uint8_t status) { ThrowFailureResponse(); }
@@ -18403,7 +17927,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOnOff(mOnSuccessCallback_10.Cancel(), mOnFailureCallback_10.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(this, OnSuccessCallback_10,
+                                                                                              OnFailureCallback_10);
     }
 
     void OnFailureResponse_10(uint8_t status) { ThrowFailureResponse(); }
@@ -18419,7 +17944,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeGlobalSceneControl(mOnSuccessCallback_11.Cancel(), mOnFailureCallback_11.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::GlobalSceneControl::TypeInfo>(
+            this, OnSuccessCallback_11, OnFailureCallback_11);
     }
 
     void OnFailureResponse_11(uint8_t status) { ThrowFailureResponse(); }
@@ -18435,7 +17961,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOnTime(mOnSuccessCallback_12.Cancel(), mOnFailureCallback_12.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnTime::TypeInfo>(this, OnSuccessCallback_12,
+                                                                                               OnFailureCallback_12);
     }
 
     void OnFailureResponse_12(uint8_t status) { ThrowFailureResponse(); }
@@ -18451,7 +17978,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOffWaitTime(mOnSuccessCallback_13.Cancel(), mOnFailureCallback_13.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OffWaitTime::TypeInfo>(this, OnSuccessCallback_13,
+                                                                                                    OnFailureCallback_13);
     }
 
     void OnFailureResponse_13(uint8_t status) { ThrowFailureResponse(); }
@@ -18491,7 +18019,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOnOff(mOnSuccessCallback_15.Cancel(), mOnFailureCallback_15.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(this, OnSuccessCallback_15,
+                                                                                              OnFailureCallback_15);
     }
 
     void OnFailureResponse_15(uint8_t status) { ThrowFailureResponse(); }
@@ -18507,7 +18036,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOnTime(mOnSuccessCallback_16.Cancel(), mOnFailureCallback_16.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnTime::TypeInfo>(this, OnSuccessCallback_16,
+                                                                                               OnFailureCallback_16);
     }
 
     void OnFailureResponse_16(uint8_t status) { ThrowFailureResponse(); }
@@ -18523,7 +18053,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOffWaitTime(mOnSuccessCallback_17.Cancel(), mOnFailureCallback_17.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OffWaitTime::TypeInfo>(this, OnSuccessCallback_17,
+                                                                                                    OnFailureCallback_17);
     }
 
     void OnFailureResponse_17(uint8_t status) { ThrowFailureResponse(); }
@@ -18563,7 +18094,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOnOff(mOnSuccessCallback_19.Cancel(), mOnFailureCallback_19.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(this, OnSuccessCallback_19,
+                                                                                              OnFailureCallback_19);
     }
 
     void OnFailureResponse_19(uint8_t status) { ThrowFailureResponse(); }
@@ -18579,7 +18111,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOnTime(mOnSuccessCallback_20.Cancel(), mOnFailureCallback_20.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnTime::TypeInfo>(this, OnSuccessCallback_20,
+                                                                                               OnFailureCallback_20);
     }
 
     void OnFailureResponse_20(uint8_t status) { ThrowFailureResponse(); }
@@ -18595,7 +18128,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOnOff(mOnSuccessCallback_21.Cancel(), mOnFailureCallback_21.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(this, OnSuccessCallback_21,
+                                                                                              OnFailureCallback_21);
     }
 
     void OnFailureResponse_21(uint8_t status) { ThrowFailureResponse(); }
@@ -18611,7 +18145,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOnTime(mOnSuccessCallback_22.Cancel(), mOnFailureCallback_22.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnTime::TypeInfo>(this, OnSuccessCallback_22,
+                                                                                               OnFailureCallback_22);
     }
 
     void OnFailureResponse_22(uint8_t status) { ThrowFailureResponse(); }
@@ -18627,7 +18162,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOffWaitTime(mOnSuccessCallback_23.Cancel(), mOnFailureCallback_23.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OffWaitTime::TypeInfo>(this, OnSuccessCallback_23,
+                                                                                                    OnFailureCallback_23);
     }
 
     void OnFailureResponse_23(uint8_t status) { ThrowFailureResponse(); }
@@ -18667,7 +18203,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOnTime(mOnSuccessCallback_25.Cancel(), mOnFailureCallback_25.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnTime::TypeInfo>(this, OnSuccessCallback_25,
+                                                                                               OnFailureCallback_25);
     }
 
     void OnFailureResponse_25(uint8_t status) { ThrowFailureResponse(); }
@@ -18683,7 +18220,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOffWaitTime(mOnSuccessCallback_26.Cancel(), mOnFailureCallback_26.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OffWaitTime::TypeInfo>(this, OnSuccessCallback_26,
+                                                                                                    OnFailureCallback_26);
     }
 
     void OnFailureResponse_26(uint8_t status) { ThrowFailureResponse(); }
@@ -18723,7 +18261,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOnOff(mOnSuccessCallback_28.Cancel(), mOnFailureCallback_28.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(this, OnSuccessCallback_28,
+                                                                                              OnFailureCallback_28);
     }
 
     void OnFailureResponse_28(uint8_t status) { ThrowFailureResponse(); }
@@ -18739,7 +18278,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOnTime(mOnSuccessCallback_29.Cancel(), mOnFailureCallback_29.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnTime::TypeInfo>(this, OnSuccessCallback_29,
+                                                                                               OnFailureCallback_29);
     }
 
     void OnFailureResponse_29(uint8_t status) { ThrowFailureResponse(); }
@@ -18755,7 +18295,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOnOff(mOnSuccessCallback_30.Cancel(), mOnFailureCallback_30.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(this, OnSuccessCallback_30,
+                                                                                              OnFailureCallback_30);
     }
 
     void OnFailureResponse_30(uint8_t status) { ThrowFailureResponse(); }
@@ -18771,7 +18312,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOnTime(mOnSuccessCallback_31.Cancel(), mOnFailureCallback_31.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnTime::TypeInfo>(this, OnSuccessCallback_31,
+                                                                                               OnFailureCallback_31);
     }
 
     void OnFailureResponse_31(uint8_t status) { ThrowFailureResponse(); }
@@ -18811,7 +18353,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOnOff(mOnSuccessCallback_33.Cancel(), mOnFailureCallback_33.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(this, OnSuccessCallback_33,
+                                                                                              OnFailureCallback_33);
     }
 
     void OnFailureResponse_33(uint8_t status) { ThrowFailureResponse(); }
@@ -18827,7 +18370,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOnTime(mOnSuccessCallback_34.Cancel(), mOnFailureCallback_34.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnTime::TypeInfo>(this, OnSuccessCallback_34,
+                                                                                               OnFailureCallback_34);
     }
 
     void OnFailureResponse_34(uint8_t status) { ThrowFailureResponse(); }
@@ -18843,7 +18387,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOffWaitTime(mOnSuccessCallback_35.Cancel(), mOnFailureCallback_35.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OffWaitTime::TypeInfo>(this, OnSuccessCallback_35,
+                                                                                                    OnFailureCallback_35);
     }
 
     void OnFailureResponse_35(uint8_t status) { ThrowFailureResponse(); }
@@ -18883,7 +18428,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOnOff(mOnSuccessCallback_37.Cancel(), mOnFailureCallback_37.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(this, OnSuccessCallback_37,
+                                                                                              OnFailureCallback_37);
     }
 
     void OnFailureResponse_37(uint8_t status) { ThrowFailureResponse(); }
@@ -18899,7 +18445,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOnTime(mOnSuccessCallback_38.Cancel(), mOnFailureCallback_38.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnTime::TypeInfo>(this, OnSuccessCallback_38,
+                                                                                               OnFailureCallback_38);
     }
 
     void OnFailureResponse_38(uint8_t status) { ThrowFailureResponse(); }
@@ -18915,7 +18462,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOnOff(mOnSuccessCallback_39.Cancel(), mOnFailureCallback_39.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(this, OnSuccessCallback_39,
+                                                                                              OnFailureCallback_39);
     }
 
     void OnFailureResponse_39(uint8_t status) { ThrowFailureResponse(); }
@@ -18931,7 +18479,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOnTime(mOnSuccessCallback_40.Cancel(), mOnFailureCallback_40.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnTime::TypeInfo>(this, OnSuccessCallback_40,
+                                                                                               OnFailureCallback_40);
     }
 
     void OnFailureResponse_40(uint8_t status) { ThrowFailureResponse(); }
@@ -18947,7 +18496,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOffWaitTime(mOnSuccessCallback_41.Cancel(), mOnFailureCallback_41.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OffWaitTime::TypeInfo>(this, OnSuccessCallback_41,
+                                                                                                    OnFailureCallback_41);
     }
 
     void OnFailureResponse_41(uint8_t status) { ThrowFailureResponse(); }
@@ -18963,7 +18513,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOnOff(mOnSuccessCallback_42.Cancel(), mOnFailureCallback_42.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnOff::TypeInfo>(this, OnSuccessCallback_42,
+                                                                                              OnFailureCallback_42);
     }
 
     void OnFailureResponse_42(uint8_t status) { ThrowFailureResponse(); }
@@ -18979,7 +18530,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOnTime(mOnSuccessCallback_43.Cancel(), mOnFailureCallback_43.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OnTime::TypeInfo>(this, OnSuccessCallback_43,
+                                                                                               OnFailureCallback_43);
     }
 
     void OnFailureResponse_43(uint8_t status) { ThrowFailureResponse(); }
@@ -18995,7 +18547,8 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOffWaitTime(mOnSuccessCallback_44.Cancel(), mOnFailureCallback_44.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OnOff::Attributes::OffWaitTime::TypeInfo>(this, OnSuccessCallback_44,
+                                                                                                    OnFailureCallback_44);
     }
 
     void OnFailureResponse_44(uint8_t status) { ThrowFailureResponse(); }
@@ -19091,16 +18644,9 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 4;
 
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_0{ OnFailureCallback_0, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t clusterRevision)> mOnSuccessCallback_0{ OnSuccessCallback_0, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_1{ OnFailureCallback_1, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t clusterRevision)> mOnSuccessCallback_1{ OnSuccessCallback_1, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_3{ OnFailureCallback_3, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t clusterRevision)> mOnSuccessCallback_3{ OnSuccessCallback_3, this };
-
-    static void OnFailureCallback_0(void * context, uint8_t status)
+    static void OnFailureCallback_0(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_PRS_1_1 *>(context))->OnFailureResponse_0(status);
+        (static_cast<Test_TC_PRS_1_1 *>(context))->OnFailureResponse_0(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_0(void * context, uint16_t clusterRevision)
@@ -19108,9 +18654,9 @@ private:
         (static_cast<Test_TC_PRS_1_1 *>(context))->OnSuccessResponse_0(clusterRevision);
     }
 
-    static void OnFailureCallback_1(void * context, uint8_t status)
+    static void OnFailureCallback_1(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_PRS_1_1 *>(context))->OnFailureResponse_1(status);
+        (static_cast<Test_TC_PRS_1_1 *>(context))->OnFailureResponse_1(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_1(void * context, uint16_t clusterRevision)
@@ -19125,9 +18671,9 @@ private:
 
     static void OnSuccessCallback_2(void * context) { (static_cast<Test_TC_PRS_1_1 *>(context))->OnSuccessResponse_2(); }
 
-    static void OnFailureCallback_3(void * context, uint8_t status)
+    static void OnFailureCallback_3(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_PRS_1_1 *>(context))->OnFailureResponse_3(status);
+        (static_cast<Test_TC_PRS_1_1 *>(context))->OnFailureResponse_3(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_3(void * context, uint16_t clusterRevision)
@@ -19144,7 +18690,8 @@ private:
         chip::Controller::PressureMeasurementClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeClusterRevision(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::PressureMeasurement::Attributes::ClusterRevision::TypeInfo>(
+            this, OnSuccessCallback_0, OnFailureCallback_0);
     }
 
     void OnFailureResponse_0(uint8_t status) { ThrowFailureResponse(); }
@@ -19160,7 +18707,8 @@ private:
         chip::Controller::PressureMeasurementClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeClusterRevision(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::PressureMeasurement::Attributes::ClusterRevision::TypeInfo>(
+            this, OnSuccessCallback_1, OnFailureCallback_1);
     }
 
     void OnFailureResponse_1(uint8_t status) { ThrowFailureResponse(); }
@@ -19192,7 +18740,8 @@ private:
         chip::Controller::PressureMeasurementClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeClusterRevision(mOnSuccessCallback_3.Cancel(), mOnFailureCallback_3.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::PressureMeasurement::Attributes::ClusterRevision::TypeInfo>(
+            this, OnSuccessCallback_3, OnFailureCallback_3);
     }
 
     void OnFailureResponse_3(uint8_t status) { ThrowFailureResponse(); }
@@ -19283,22 +18832,9 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 9;
 
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_0{ OnFailureCallback_0, this };
-    chip::Callback::Callback<void (*)(void * context, int16_t measuredValue)> mOnSuccessCallback_0{ OnSuccessCallback_0, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_2{ OnFailureCallback_2, this };
-    chip::Callback::Callback<void (*)(void * context, int16_t measuredValue)> mOnSuccessCallback_2{ OnSuccessCallback_2, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_3{ OnFailureCallback_3, this };
-    chip::Callback::Callback<void (*)(void * context, int16_t minMeasuredValue)> mOnSuccessCallback_3{ OnSuccessCallback_3, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_5{ OnFailureCallback_5, this };
-    chip::Callback::Callback<void (*)(void * context, int16_t minMeasuredValue)> mOnSuccessCallback_5{ OnSuccessCallback_5, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_6{ OnFailureCallback_6, this };
-    chip::Callback::Callback<void (*)(void * context, int16_t maxMeasuredValue)> mOnSuccessCallback_6{ OnSuccessCallback_6, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_8{ OnFailureCallback_8, this };
-    chip::Callback::Callback<void (*)(void * context, int16_t maxMeasuredValue)> mOnSuccessCallback_8{ OnSuccessCallback_8, this };
-
-    static void OnFailureCallback_0(void * context, uint8_t status)
+    static void OnFailureCallback_0(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_PRS_2_1 *>(context))->OnFailureResponse_0(status);
+        (static_cast<Test_TC_PRS_2_1 *>(context))->OnFailureResponse_0(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_0(void * context, int16_t measuredValue)
@@ -19313,9 +18849,9 @@ private:
 
     static void OnSuccessCallback_1(void * context) { (static_cast<Test_TC_PRS_2_1 *>(context))->OnSuccessResponse_1(); }
 
-    static void OnFailureCallback_2(void * context, uint8_t status)
+    static void OnFailureCallback_2(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_PRS_2_1 *>(context))->OnFailureResponse_2(status);
+        (static_cast<Test_TC_PRS_2_1 *>(context))->OnFailureResponse_2(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_2(void * context, int16_t measuredValue)
@@ -19323,9 +18859,9 @@ private:
         (static_cast<Test_TC_PRS_2_1 *>(context))->OnSuccessResponse_2(measuredValue);
     }
 
-    static void OnFailureCallback_3(void * context, uint8_t status)
+    static void OnFailureCallback_3(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_PRS_2_1 *>(context))->OnFailureResponse_3(status);
+        (static_cast<Test_TC_PRS_2_1 *>(context))->OnFailureResponse_3(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_3(void * context, int16_t minMeasuredValue)
@@ -19340,9 +18876,9 @@ private:
 
     static void OnSuccessCallback_4(void * context) { (static_cast<Test_TC_PRS_2_1 *>(context))->OnSuccessResponse_4(); }
 
-    static void OnFailureCallback_5(void * context, uint8_t status)
+    static void OnFailureCallback_5(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_PRS_2_1 *>(context))->OnFailureResponse_5(status);
+        (static_cast<Test_TC_PRS_2_1 *>(context))->OnFailureResponse_5(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_5(void * context, int16_t minMeasuredValue)
@@ -19350,9 +18886,9 @@ private:
         (static_cast<Test_TC_PRS_2_1 *>(context))->OnSuccessResponse_5(minMeasuredValue);
     }
 
-    static void OnFailureCallback_6(void * context, uint8_t status)
+    static void OnFailureCallback_6(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_PRS_2_1 *>(context))->OnFailureResponse_6(status);
+        (static_cast<Test_TC_PRS_2_1 *>(context))->OnFailureResponse_6(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_6(void * context, int16_t maxMeasuredValue)
@@ -19367,9 +18903,9 @@ private:
 
     static void OnSuccessCallback_7(void * context) { (static_cast<Test_TC_PRS_2_1 *>(context))->OnSuccessResponse_7(); }
 
-    static void OnFailureCallback_8(void * context, uint8_t status)
+    static void OnFailureCallback_8(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_PRS_2_1 *>(context))->OnFailureResponse_8(status);
+        (static_cast<Test_TC_PRS_2_1 *>(context))->OnFailureResponse_8(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_8(void * context, int16_t maxMeasuredValue)
@@ -19386,7 +18922,8 @@ private:
         chip::Controller::PressureMeasurementClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeMeasuredValue(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::PressureMeasurement::Attributes::MeasuredValue::TypeInfo>(
+            this, OnSuccessCallback_0, OnFailureCallback_0);
     }
 
     void OnFailureResponse_0(uint8_t status) { ThrowFailureResponse(); }
@@ -19418,7 +18955,8 @@ private:
         chip::Controller::PressureMeasurementClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeMeasuredValue(mOnSuccessCallback_2.Cancel(), mOnFailureCallback_2.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::PressureMeasurement::Attributes::MeasuredValue::TypeInfo>(
+            this, OnSuccessCallback_2, OnFailureCallback_2);
     }
 
     void OnFailureResponse_2(uint8_t status) { ThrowFailureResponse(); }
@@ -19434,7 +18972,8 @@ private:
         chip::Controller::PressureMeasurementClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeMinMeasuredValue(mOnSuccessCallback_3.Cancel(), mOnFailureCallback_3.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::PressureMeasurement::Attributes::MinMeasuredValue::TypeInfo>(
+            this, OnSuccessCallback_3, OnFailureCallback_3);
     }
 
     void OnFailureResponse_3(uint8_t status) { ThrowFailureResponse(); }
@@ -19466,7 +19005,8 @@ private:
         chip::Controller::PressureMeasurementClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeMinMeasuredValue(mOnSuccessCallback_5.Cancel(), mOnFailureCallback_5.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::PressureMeasurement::Attributes::MinMeasuredValue::TypeInfo>(
+            this, OnSuccessCallback_5, OnFailureCallback_5);
     }
 
     void OnFailureResponse_5(uint8_t status) { ThrowFailureResponse(); }
@@ -19482,7 +19022,8 @@ private:
         chip::Controller::PressureMeasurementClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeMaxMeasuredValue(mOnSuccessCallback_6.Cancel(), mOnFailureCallback_6.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::PressureMeasurement::Attributes::MaxMeasuredValue::TypeInfo>(
+            this, OnSuccessCallback_6, OnFailureCallback_6);
     }
 
     void OnFailureResponse_6(uint8_t status) { ThrowFailureResponse(); }
@@ -19514,7 +19055,8 @@ private:
         chip::Controller::PressureMeasurementClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeMaxMeasuredValue(mOnSuccessCallback_8.Cancel(), mOnFailureCallback_8.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::PressureMeasurement::Attributes::MaxMeasuredValue::TypeInfo>(
+            this, OnSuccessCallback_8, OnFailureCallback_8);
     }
 
     void OnFailureResponse_8(uint8_t status) { ThrowFailureResponse(); }
@@ -19677,30 +19219,9 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 8;
 
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_0{ OnFailureCallback_0, this };
-    chip::Callback::Callback<void (*)(void * context, int16_t maxPressure)> mOnSuccessCallback_0{ OnSuccessCallback_0, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_1{ OnFailureCallback_1, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t effectiveOperationMode)> mOnSuccessCallback_1{ OnSuccessCallback_1,
-                                                                                                             this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_2{ OnFailureCallback_2, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t effectiveControlMode)> mOnSuccessCallback_2{ OnSuccessCallback_2,
-                                                                                                           this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_3{ OnFailureCallback_3, this };
-    chip::Callback::Callback<void (*)(void * context, int16_t capacity)> mOnSuccessCallback_3{ OnSuccessCallback_3, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_4{ OnFailureCallback_4, this };
-    chip::Callback::Callback<void (*)(void * context, int16_t maxPressure)> mOnSuccessCallback_4{ OnSuccessCallback_4, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_5{ OnFailureCallback_5, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t effectiveOperationMode)> mOnSuccessCallback_5{ OnSuccessCallback_5,
-                                                                                                             this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_6{ OnFailureCallback_6, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t effectiveControlMode)> mOnSuccessCallback_6{ OnSuccessCallback_6,
-                                                                                                           this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_7{ OnFailureCallback_7, this };
-    chip::Callback::Callback<void (*)(void * context, int16_t capacity)> mOnSuccessCallback_7{ OnSuccessCallback_7, this };
-
-    static void OnFailureCallback_0(void * context, uint8_t status)
+    static void OnFailureCallback_0(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_PCC_2_1 *>(context))->OnFailureResponse_0(status);
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnFailureResponse_0(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_0(void * context, int16_t maxPressure)
@@ -19708,9 +19229,9 @@ private:
         (static_cast<Test_TC_PCC_2_1 *>(context))->OnSuccessResponse_0(maxPressure);
     }
 
-    static void OnFailureCallback_1(void * context, uint8_t status)
+    static void OnFailureCallback_1(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_PCC_2_1 *>(context))->OnFailureResponse_1(status);
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnFailureResponse_1(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_1(void * context, uint8_t effectiveOperationMode)
@@ -19718,9 +19239,9 @@ private:
         (static_cast<Test_TC_PCC_2_1 *>(context))->OnSuccessResponse_1(effectiveOperationMode);
     }
 
-    static void OnFailureCallback_2(void * context, uint8_t status)
+    static void OnFailureCallback_2(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_PCC_2_1 *>(context))->OnFailureResponse_2(status);
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnFailureResponse_2(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_2(void * context, uint8_t effectiveControlMode)
@@ -19728,9 +19249,9 @@ private:
         (static_cast<Test_TC_PCC_2_1 *>(context))->OnSuccessResponse_2(effectiveControlMode);
     }
 
-    static void OnFailureCallback_3(void * context, uint8_t status)
+    static void OnFailureCallback_3(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_PCC_2_1 *>(context))->OnFailureResponse_3(status);
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnFailureResponse_3(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_3(void * context, int16_t capacity)
@@ -19738,9 +19259,9 @@ private:
         (static_cast<Test_TC_PCC_2_1 *>(context))->OnSuccessResponse_3(capacity);
     }
 
-    static void OnFailureCallback_4(void * context, uint8_t status)
+    static void OnFailureCallback_4(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_PCC_2_1 *>(context))->OnFailureResponse_4(status);
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnFailureResponse_4(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_4(void * context, int16_t maxPressure)
@@ -19748,9 +19269,9 @@ private:
         (static_cast<Test_TC_PCC_2_1 *>(context))->OnSuccessResponse_4(maxPressure);
     }
 
-    static void OnFailureCallback_5(void * context, uint8_t status)
+    static void OnFailureCallback_5(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_PCC_2_1 *>(context))->OnFailureResponse_5(status);
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnFailureResponse_5(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_5(void * context, uint8_t effectiveOperationMode)
@@ -19758,9 +19279,9 @@ private:
         (static_cast<Test_TC_PCC_2_1 *>(context))->OnSuccessResponse_5(effectiveOperationMode);
     }
 
-    static void OnFailureCallback_6(void * context, uint8_t status)
+    static void OnFailureCallback_6(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_PCC_2_1 *>(context))->OnFailureResponse_6(status);
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnFailureResponse_6(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_6(void * context, uint8_t effectiveControlMode)
@@ -19768,9 +19289,9 @@ private:
         (static_cast<Test_TC_PCC_2_1 *>(context))->OnSuccessResponse_6(effectiveControlMode);
     }
 
-    static void OnFailureCallback_7(void * context, uint8_t status)
+    static void OnFailureCallback_7(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_PCC_2_1 *>(context))->OnFailureResponse_7(status);
+        (static_cast<Test_TC_PCC_2_1 *>(context))->OnFailureResponse_7(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_7(void * context, int16_t capacity)
@@ -19787,7 +19308,8 @@ private:
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeMaxPressure(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::MaxPressure::TypeInfo>(
+            this, OnSuccessCallback_0, OnFailureCallback_0);
     }
 
     void OnFailureResponse_0(uint8_t status) { ThrowFailureResponse(); }
@@ -19803,7 +19325,9 @@ private:
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeEffectiveOperationMode(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
+        return cluster
+            .ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::EffectiveOperationMode::TypeInfo>(
+                this, OnSuccessCallback_1, OnFailureCallback_1);
     }
 
     void OnFailureResponse_1(uint8_t status) { ThrowFailureResponse(); }
@@ -19819,7 +19343,8 @@ private:
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeEffectiveControlMode(mOnSuccessCallback_2.Cancel(), mOnFailureCallback_2.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::EffectiveControlMode::TypeInfo>(
+            this, OnSuccessCallback_2, OnFailureCallback_2);
     }
 
     void OnFailureResponse_2(uint8_t status) { ThrowFailureResponse(); }
@@ -19835,7 +19360,8 @@ private:
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeCapacity(mOnSuccessCallback_3.Cancel(), mOnFailureCallback_3.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::Capacity::TypeInfo>(
+            this, OnSuccessCallback_3, OnFailureCallback_3);
     }
 
     void OnFailureResponse_3(uint8_t status) { ThrowFailureResponse(); }
@@ -19851,7 +19377,8 @@ private:
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeMaxPressure(mOnSuccessCallback_4.Cancel(), mOnFailureCallback_4.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::MaxPressure::TypeInfo>(
+            this, OnSuccessCallback_4, OnFailureCallback_4);
     }
 
     void OnFailureResponse_4(uint8_t status) { ThrowFailureResponse(); }
@@ -19867,7 +19394,9 @@ private:
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeEffectiveOperationMode(mOnSuccessCallback_5.Cancel(), mOnFailureCallback_5.Cancel());
+        return cluster
+            .ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::EffectiveOperationMode::TypeInfo>(
+                this, OnSuccessCallback_5, OnFailureCallback_5);
     }
 
     void OnFailureResponse_5(uint8_t status) { ThrowFailureResponse(); }
@@ -19883,7 +19412,8 @@ private:
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeEffectiveControlMode(mOnSuccessCallback_6.Cancel(), mOnFailureCallback_6.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::EffectiveControlMode::TypeInfo>(
+            this, OnSuccessCallback_6, OnFailureCallback_6);
     }
 
     void OnFailureResponse_6(uint8_t status) { ThrowFailureResponse(); }
@@ -19899,7 +19429,8 @@ private:
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeCapacity(mOnSuccessCallback_7.Cancel(), mOnFailureCallback_7.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::Capacity::TypeInfo>(
+            this, OnSuccessCallback_7, OnFailureCallback_7);
     }
 
     void OnFailureResponse_7(uint8_t status) { ThrowFailureResponse(); }
@@ -20091,10 +19622,6 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 2;
 
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_1{ OnFailureCallback_1, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t effectiveOperationMode)> mOnSuccessCallback_1{ OnSuccessCallback_1,
-                                                                                                             this };
-
     static void OnFailureCallback_0(void * context, EmberAfStatus status)
     {
         (static_cast<Test_TC_PCC_2_3 *>(context))->OnFailureResponse_0(chip::to_underlying(status));
@@ -20102,9 +19629,9 @@ private:
 
     static void OnSuccessCallback_0(void * context) { (static_cast<Test_TC_PCC_2_3 *>(context))->OnSuccessResponse_0(); }
 
-    static void OnFailureCallback_1(void * context, uint8_t status)
+    static void OnFailureCallback_1(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_PCC_2_3 *>(context))->OnFailureResponse_1(status);
+        (static_cast<Test_TC_PCC_2_3 *>(context))->OnFailureResponse_1(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_1(void * context, uint8_t effectiveOperationMode)
@@ -20137,7 +19664,9 @@ private:
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeEffectiveOperationMode(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
+        return cluster
+            .ReadAttribute<chip::app::Clusters::PumpConfigurationAndControl::Attributes::EffectiveOperationMode::TypeInfo>(
+                this, OnSuccessCallback_1, OnFailureCallback_1);
     }
 
     void OnFailureResponse_1(uint8_t status) { ThrowFailureResponse(); }
@@ -20276,14 +19805,9 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 2;
 
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_0{ OnFailureCallback_0, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t measuredValue)> mOnSuccessCallback_0{ OnSuccessCallback_0, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_1{ OnFailureCallback_1, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t minMeasuredValue)> mOnSuccessCallback_1{ OnSuccessCallback_1, this };
-
-    static void OnFailureCallback_0(void * context, uint8_t status)
+    static void OnFailureCallback_0(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_RH_2_1 *>(context))->OnFailureResponse_0(status);
+        (static_cast<Test_TC_RH_2_1 *>(context))->OnFailureResponse_0(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_0(void * context, uint16_t measuredValue)
@@ -20291,9 +19815,9 @@ private:
         (static_cast<Test_TC_RH_2_1 *>(context))->OnSuccessResponse_0(measuredValue);
     }
 
-    static void OnFailureCallback_1(void * context, uint8_t status)
+    static void OnFailureCallback_1(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_RH_2_1 *>(context))->OnFailureResponse_1(status);
+        (static_cast<Test_TC_RH_2_1 *>(context))->OnFailureResponse_1(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_1(void * context, uint16_t minMeasuredValue)
@@ -20310,7 +19834,8 @@ private:
         chip::Controller::RelativeHumidityMeasurementClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeMeasuredValue(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::RelativeHumidityMeasurement::Attributes::MeasuredValue::TypeInfo>(
+            this, OnSuccessCallback_0, OnFailureCallback_0);
     }
 
     void OnFailureResponse_0(uint8_t status) { ThrowFailureResponse(); }
@@ -20326,7 +19851,8 @@ private:
         chip::Controller::RelativeHumidityMeasurementClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeMinMeasuredValue(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::RelativeHumidityMeasurement::Attributes::MinMeasuredValue::TypeInfo>(
+            this, OnSuccessCallback_1, OnFailureCallback_1);
     }
 
     void OnFailureResponse_1(uint8_t status) { ThrowFailureResponse(); }
@@ -20390,14 +19916,9 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 2;
 
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_0{ OnFailureCallback_0, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t measuredValue)> mOnSuccessCallback_0{ OnSuccessCallback_0, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_1{ OnFailureCallback_1, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t measuredValue)> mOnSuccessCallback_1{ OnSuccessCallback_1, this };
-
-    static void OnFailureCallback_0(void * context, uint8_t status)
+    static void OnFailureCallback_0(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_RH_2_2 *>(context))->OnFailureResponse_0(status);
+        (static_cast<Test_TC_RH_2_2 *>(context))->OnFailureResponse_0(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_0(void * context, uint16_t measuredValue)
@@ -20405,9 +19926,9 @@ private:
         (static_cast<Test_TC_RH_2_2 *>(context))->OnSuccessResponse_0(measuredValue);
     }
 
-    static void OnFailureCallback_1(void * context, uint8_t status)
+    static void OnFailureCallback_1(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_RH_2_2 *>(context))->OnFailureResponse_1(status);
+        (static_cast<Test_TC_RH_2_2 *>(context))->OnFailureResponse_1(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_1(void * context, uint16_t measuredValue)
@@ -20424,7 +19945,8 @@ private:
         chip::Controller::RelativeHumidityMeasurementClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeMeasuredValue(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::RelativeHumidityMeasurement::Attributes::MeasuredValue::TypeInfo>(
+            this, OnSuccessCallback_0, OnFailureCallback_0);
     }
 
     void OnFailureResponse_0(uint8_t status) { ThrowFailureResponse(); }
@@ -20440,7 +19962,8 @@ private:
         chip::Controller::RelativeHumidityMeasurementClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeMeasuredValue(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::RelativeHumidityMeasurement::Attributes::MeasuredValue::TypeInfo>(
+            this, OnSuccessCallback_1, OnFailureCallback_1);
     }
 
     void OnFailureResponse_1(uint8_t status) { ThrowFailureResponse(); }
@@ -20508,14 +20031,9 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 3;
 
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_0{ OnFailureCallback_0, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t clusterRevision)> mOnSuccessCallback_0{ OnSuccessCallback_0, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_2{ OnFailureCallback_2, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t clusterRevision)> mOnSuccessCallback_2{ OnSuccessCallback_2, this };
-
-    static void OnFailureCallback_0(void * context, uint8_t status)
+    static void OnFailureCallback_0(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_TM_1_1 *>(context))->OnFailureResponse_0(status);
+        (static_cast<Test_TC_TM_1_1 *>(context))->OnFailureResponse_0(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_0(void * context, uint16_t clusterRevision)
@@ -20530,9 +20048,9 @@ private:
 
     static void OnSuccessCallback_1(void * context) { (static_cast<Test_TC_TM_1_1 *>(context))->OnSuccessResponse_1(); }
 
-    static void OnFailureCallback_2(void * context, uint8_t status)
+    static void OnFailureCallback_2(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_TM_1_1 *>(context))->OnFailureResponse_2(status);
+        (static_cast<Test_TC_TM_1_1 *>(context))->OnFailureResponse_2(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_2(void * context, uint16_t clusterRevision)
@@ -20549,7 +20067,8 @@ private:
         chip::Controller::TemperatureMeasurementClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeClusterRevision(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TemperatureMeasurement::Attributes::ClusterRevision::TypeInfo>(
+            this, OnSuccessCallback_0, OnFailureCallback_0);
     }
 
     void OnFailureResponse_0(uint8_t status) { ThrowFailureResponse(); }
@@ -20581,7 +20100,8 @@ private:
         chip::Controller::TemperatureMeasurementClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeClusterRevision(mOnSuccessCallback_2.Cancel(), mOnFailureCallback_2.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TemperatureMeasurement::Attributes::ClusterRevision::TypeInfo>(
+            this, OnSuccessCallback_2, OnFailureCallback_2);
     }
 
     void OnFailureResponse_2(uint8_t status) { ThrowFailureResponse(); }
@@ -20640,12 +20160,9 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 1;
 
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_0{ OnFailureCallback_0, this };
-    chip::Callback::Callback<void (*)(void * context, int16_t measuredValue)> mOnSuccessCallback_0{ OnSuccessCallback_0, this };
-
-    static void OnFailureCallback_0(void * context, uint8_t status)
+    static void OnFailureCallback_0(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_TM_2_1 *>(context))->OnFailureResponse_0(status);
+        (static_cast<Test_TC_TM_2_1 *>(context))->OnFailureResponse_0(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_0(void * context, int16_t measuredValue)
@@ -20662,7 +20179,8 @@ private:
         chip::Controller::TemperatureMeasurementClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeMeasuredValue(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TemperatureMeasurement::Attributes::MeasuredValue::TypeInfo>(
+            this, OnSuccessCallback_0, OnFailureCallback_0);
     }
 
     void OnFailureResponse_0(uint8_t status) { ThrowFailureResponse(); }
@@ -20725,14 +20243,9 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 2;
 
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_0{ OnFailureCallback_0, this };
-    chip::Callback::Callback<void (*)(void * context, int16_t measuredValue)> mOnSuccessCallback_0{ OnSuccessCallback_0, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_1{ OnFailureCallback_1, this };
-    chip::Callback::Callback<void (*)(void * context, int16_t measuredValue)> mOnSuccessCallback_1{ OnSuccessCallback_1, this };
-
-    static void OnFailureCallback_0(void * context, uint8_t status)
+    static void OnFailureCallback_0(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_TM_2_2 *>(context))->OnFailureResponse_0(status);
+        (static_cast<Test_TC_TM_2_2 *>(context))->OnFailureResponse_0(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_0(void * context, int16_t measuredValue)
@@ -20740,9 +20253,9 @@ private:
         (static_cast<Test_TC_TM_2_2 *>(context))->OnSuccessResponse_0(measuredValue);
     }
 
-    static void OnFailureCallback_1(void * context, uint8_t status)
+    static void OnFailureCallback_1(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_TM_2_2 *>(context))->OnFailureResponse_1(status);
+        (static_cast<Test_TC_TM_2_2 *>(context))->OnFailureResponse_1(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_1(void * context, int16_t measuredValue)
@@ -20759,7 +20272,8 @@ private:
         chip::Controller::TemperatureMeasurementClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeMeasuredValue(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TemperatureMeasurement::Attributes::MeasuredValue::TypeInfo>(
+            this, OnSuccessCallback_0, OnFailureCallback_0);
     }
 
     void OnFailureResponse_0(uint8_t status) { ThrowFailureResponse(); }
@@ -20775,7 +20289,8 @@ private:
         chip::Controller::TemperatureMeasurementClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeMeasuredValue(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TemperatureMeasurement::Attributes::MeasuredValue::TypeInfo>(
+            this, OnSuccessCallback_1, OnFailureCallback_1);
     }
 
     void OnFailureResponse_1(uint8_t status) { ThrowFailureResponse(); }
@@ -21043,46 +20558,9 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 15;
 
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_0{ OnFailureCallback_0, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t temperatureDisplayMode)> mOnSuccessCallback_0{ OnSuccessCallback_0,
-                                                                                                             this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_1{ OnFailureCallback_1, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t temperatureDisplayMode)> mOnSuccessCallback_1{ OnSuccessCallback_1,
-                                                                                                             this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_3{ OnFailureCallback_3, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t temperatureDisplayMode)> mOnSuccessCallback_3{ OnSuccessCallback_3,
-                                                                                                             this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_4{ OnFailureCallback_4, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t temperatureDisplayMode)> mOnSuccessCallback_4{ OnSuccessCallback_4,
-                                                                                                             this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_5{ OnFailureCallback_5, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t keypadLockout)> mOnSuccessCallback_5{ OnSuccessCallback_5, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_6{ OnFailureCallback_6, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t keypadLockout)> mOnSuccessCallback_6{ OnSuccessCallback_6, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_8{ OnFailureCallback_8, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t keypadLockout)> mOnSuccessCallback_8{ OnSuccessCallback_8, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_9{ OnFailureCallback_9, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t keypadLockout)> mOnSuccessCallback_9{ OnSuccessCallback_9, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_10{ OnFailureCallback_10, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t scheduleProgrammingVisibility)> mOnSuccessCallback_10{
-        OnSuccessCallback_10, this
-    };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_11{ OnFailureCallback_11, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t scheduleProgrammingVisibility)> mOnSuccessCallback_11{
-        OnSuccessCallback_11, this
-    };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_13{ OnFailureCallback_13, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t scheduleProgrammingVisibility)> mOnSuccessCallback_13{
-        OnSuccessCallback_13, this
-    };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_14{ OnFailureCallback_14, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t scheduleProgrammingVisibility)> mOnSuccessCallback_14{
-        OnSuccessCallback_14, this
-    };
-
-    static void OnFailureCallback_0(void * context, uint8_t status)
+    static void OnFailureCallback_0(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_TSUIC_2_1 *>(context))->OnFailureResponse_0(status);
+        (static_cast<Test_TC_TSUIC_2_1 *>(context))->OnFailureResponse_0(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_0(void * context, uint8_t temperatureDisplayMode)
@@ -21090,9 +20568,9 @@ private:
         (static_cast<Test_TC_TSUIC_2_1 *>(context))->OnSuccessResponse_0(temperatureDisplayMode);
     }
 
-    static void OnFailureCallback_1(void * context, uint8_t status)
+    static void OnFailureCallback_1(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_TSUIC_2_1 *>(context))->OnFailureResponse_1(status);
+        (static_cast<Test_TC_TSUIC_2_1 *>(context))->OnFailureResponse_1(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_1(void * context, uint8_t temperatureDisplayMode)
@@ -21107,9 +20585,9 @@ private:
 
     static void OnSuccessCallback_2(void * context) { (static_cast<Test_TC_TSUIC_2_1 *>(context))->OnSuccessResponse_2(); }
 
-    static void OnFailureCallback_3(void * context, uint8_t status)
+    static void OnFailureCallback_3(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_TSUIC_2_1 *>(context))->OnFailureResponse_3(status);
+        (static_cast<Test_TC_TSUIC_2_1 *>(context))->OnFailureResponse_3(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_3(void * context, uint8_t temperatureDisplayMode)
@@ -21117,9 +20595,9 @@ private:
         (static_cast<Test_TC_TSUIC_2_1 *>(context))->OnSuccessResponse_3(temperatureDisplayMode);
     }
 
-    static void OnFailureCallback_4(void * context, uint8_t status)
+    static void OnFailureCallback_4(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_TSUIC_2_1 *>(context))->OnFailureResponse_4(status);
+        (static_cast<Test_TC_TSUIC_2_1 *>(context))->OnFailureResponse_4(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_4(void * context, uint8_t temperatureDisplayMode)
@@ -21127,9 +20605,9 @@ private:
         (static_cast<Test_TC_TSUIC_2_1 *>(context))->OnSuccessResponse_4(temperatureDisplayMode);
     }
 
-    static void OnFailureCallback_5(void * context, uint8_t status)
+    static void OnFailureCallback_5(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_TSUIC_2_1 *>(context))->OnFailureResponse_5(status);
+        (static_cast<Test_TC_TSUIC_2_1 *>(context))->OnFailureResponse_5(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_5(void * context, uint8_t keypadLockout)
@@ -21137,9 +20615,9 @@ private:
         (static_cast<Test_TC_TSUIC_2_1 *>(context))->OnSuccessResponse_5(keypadLockout);
     }
 
-    static void OnFailureCallback_6(void * context, uint8_t status)
+    static void OnFailureCallback_6(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_TSUIC_2_1 *>(context))->OnFailureResponse_6(status);
+        (static_cast<Test_TC_TSUIC_2_1 *>(context))->OnFailureResponse_6(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_6(void * context, uint8_t keypadLockout)
@@ -21154,9 +20632,9 @@ private:
 
     static void OnSuccessCallback_7(void * context) { (static_cast<Test_TC_TSUIC_2_1 *>(context))->OnSuccessResponse_7(); }
 
-    static void OnFailureCallback_8(void * context, uint8_t status)
+    static void OnFailureCallback_8(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_TSUIC_2_1 *>(context))->OnFailureResponse_8(status);
+        (static_cast<Test_TC_TSUIC_2_1 *>(context))->OnFailureResponse_8(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_8(void * context, uint8_t keypadLockout)
@@ -21164,9 +20642,9 @@ private:
         (static_cast<Test_TC_TSUIC_2_1 *>(context))->OnSuccessResponse_8(keypadLockout);
     }
 
-    static void OnFailureCallback_9(void * context, uint8_t status)
+    static void OnFailureCallback_9(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_TSUIC_2_1 *>(context))->OnFailureResponse_9(status);
+        (static_cast<Test_TC_TSUIC_2_1 *>(context))->OnFailureResponse_9(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_9(void * context, uint8_t keypadLockout)
@@ -21174,9 +20652,9 @@ private:
         (static_cast<Test_TC_TSUIC_2_1 *>(context))->OnSuccessResponse_9(keypadLockout);
     }
 
-    static void OnFailureCallback_10(void * context, uint8_t status)
+    static void OnFailureCallback_10(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_TSUIC_2_1 *>(context))->OnFailureResponse_10(status);
+        (static_cast<Test_TC_TSUIC_2_1 *>(context))->OnFailureResponse_10(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_10(void * context, uint8_t scheduleProgrammingVisibility)
@@ -21184,9 +20662,9 @@ private:
         (static_cast<Test_TC_TSUIC_2_1 *>(context))->OnSuccessResponse_10(scheduleProgrammingVisibility);
     }
 
-    static void OnFailureCallback_11(void * context, uint8_t status)
+    static void OnFailureCallback_11(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_TSUIC_2_1 *>(context))->OnFailureResponse_11(status);
+        (static_cast<Test_TC_TSUIC_2_1 *>(context))->OnFailureResponse_11(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_11(void * context, uint8_t scheduleProgrammingVisibility)
@@ -21201,9 +20679,9 @@ private:
 
     static void OnSuccessCallback_12(void * context) { (static_cast<Test_TC_TSUIC_2_1 *>(context))->OnSuccessResponse_12(); }
 
-    static void OnFailureCallback_13(void * context, uint8_t status)
+    static void OnFailureCallback_13(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_TSUIC_2_1 *>(context))->OnFailureResponse_13(status);
+        (static_cast<Test_TC_TSUIC_2_1 *>(context))->OnFailureResponse_13(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_13(void * context, uint8_t scheduleProgrammingVisibility)
@@ -21211,9 +20689,9 @@ private:
         (static_cast<Test_TC_TSUIC_2_1 *>(context))->OnSuccessResponse_13(scheduleProgrammingVisibility);
     }
 
-    static void OnFailureCallback_14(void * context, uint8_t status)
+    static void OnFailureCallback_14(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_TSUIC_2_1 *>(context))->OnFailureResponse_14(status);
+        (static_cast<Test_TC_TSUIC_2_1 *>(context))->OnFailureResponse_14(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_14(void * context, uint8_t scheduleProgrammingVisibility)
@@ -21230,7 +20708,9 @@ private:
         chip::Controller::ThermostatUserInterfaceConfigurationClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeTemperatureDisplayMode(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel());
+        return cluster
+            .ReadAttribute<chip::app::Clusters::ThermostatUserInterfaceConfiguration::Attributes::TemperatureDisplayMode::TypeInfo>(
+                this, OnSuccessCallback_0, OnFailureCallback_0);
     }
 
     void OnFailureResponse_0(uint8_t status) { ThrowFailureResponse(); }
@@ -21246,7 +20726,9 @@ private:
         chip::Controller::ThermostatUserInterfaceConfigurationClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeTemperatureDisplayMode(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
+        return cluster
+            .ReadAttribute<chip::app::Clusters::ThermostatUserInterfaceConfiguration::Attributes::TemperatureDisplayMode::TypeInfo>(
+                this, OnSuccessCallback_1, OnFailureCallback_1);
     }
 
     void OnFailureResponse_1(uint8_t status) { ThrowFailureResponse(); }
@@ -21279,7 +20761,9 @@ private:
         chip::Controller::ThermostatUserInterfaceConfigurationClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeTemperatureDisplayMode(mOnSuccessCallback_3.Cancel(), mOnFailureCallback_3.Cancel());
+        return cluster
+            .ReadAttribute<chip::app::Clusters::ThermostatUserInterfaceConfiguration::Attributes::TemperatureDisplayMode::TypeInfo>(
+                this, OnSuccessCallback_3, OnFailureCallback_3);
     }
 
     void OnFailureResponse_3(uint8_t status) { ThrowFailureResponse(); }
@@ -21295,7 +20779,9 @@ private:
         chip::Controller::ThermostatUserInterfaceConfigurationClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeTemperatureDisplayMode(mOnSuccessCallback_4.Cancel(), mOnFailureCallback_4.Cancel());
+        return cluster
+            .ReadAttribute<chip::app::Clusters::ThermostatUserInterfaceConfiguration::Attributes::TemperatureDisplayMode::TypeInfo>(
+                this, OnSuccessCallback_4, OnFailureCallback_4);
     }
 
     void OnFailureResponse_4(uint8_t status) { ThrowFailureResponse(); }
@@ -21311,7 +20797,9 @@ private:
         chip::Controller::ThermostatUserInterfaceConfigurationClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeKeypadLockout(mOnSuccessCallback_5.Cancel(), mOnFailureCallback_5.Cancel());
+        return cluster
+            .ReadAttribute<chip::app::Clusters::ThermostatUserInterfaceConfiguration::Attributes::KeypadLockout::TypeInfo>(
+                this, OnSuccessCallback_5, OnFailureCallback_5);
     }
 
     void OnFailureResponse_5(uint8_t status) { ThrowFailureResponse(); }
@@ -21327,7 +20815,9 @@ private:
         chip::Controller::ThermostatUserInterfaceConfigurationClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeKeypadLockout(mOnSuccessCallback_6.Cancel(), mOnFailureCallback_6.Cancel());
+        return cluster
+            .ReadAttribute<chip::app::Clusters::ThermostatUserInterfaceConfiguration::Attributes::KeypadLockout::TypeInfo>(
+                this, OnSuccessCallback_6, OnFailureCallback_6);
     }
 
     void OnFailureResponse_6(uint8_t status) { ThrowFailureResponse(); }
@@ -21360,7 +20850,9 @@ private:
         chip::Controller::ThermostatUserInterfaceConfigurationClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeKeypadLockout(mOnSuccessCallback_8.Cancel(), mOnFailureCallback_8.Cancel());
+        return cluster
+            .ReadAttribute<chip::app::Clusters::ThermostatUserInterfaceConfiguration::Attributes::KeypadLockout::TypeInfo>(
+                this, OnSuccessCallback_8, OnFailureCallback_8);
     }
 
     void OnFailureResponse_8(uint8_t status) { ThrowFailureResponse(); }
@@ -21376,7 +20868,9 @@ private:
         chip::Controller::ThermostatUserInterfaceConfigurationClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeKeypadLockout(mOnSuccessCallback_9.Cancel(), mOnFailureCallback_9.Cancel());
+        return cluster
+            .ReadAttribute<chip::app::Clusters::ThermostatUserInterfaceConfiguration::Attributes::KeypadLockout::TypeInfo>(
+                this, OnSuccessCallback_9, OnFailureCallback_9);
     }
 
     void OnFailureResponse_9(uint8_t status) { ThrowFailureResponse(); }
@@ -21392,7 +20886,9 @@ private:
         chip::Controller::ThermostatUserInterfaceConfigurationClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeScheduleProgrammingVisibility(mOnSuccessCallback_10.Cancel(), mOnFailureCallback_10.Cancel());
+        return cluster.ReadAttribute<
+            chip::app::Clusters::ThermostatUserInterfaceConfiguration::Attributes::ScheduleProgrammingVisibility::TypeInfo>(
+            this, OnSuccessCallback_10, OnFailureCallback_10);
     }
 
     void OnFailureResponse_10(uint8_t status) { ThrowFailureResponse(); }
@@ -21408,7 +20904,9 @@ private:
         chip::Controller::ThermostatUserInterfaceConfigurationClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeScheduleProgrammingVisibility(mOnSuccessCallback_11.Cancel(), mOnFailureCallback_11.Cancel());
+        return cluster.ReadAttribute<
+            chip::app::Clusters::ThermostatUserInterfaceConfiguration::Attributes::ScheduleProgrammingVisibility::TypeInfo>(
+            this, OnSuccessCallback_11, OnFailureCallback_11);
     }
 
     void OnFailureResponse_11(uint8_t status) { ThrowFailureResponse(); }
@@ -21441,7 +20939,9 @@ private:
         chip::Controller::ThermostatUserInterfaceConfigurationClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeScheduleProgrammingVisibility(mOnSuccessCallback_13.Cancel(), mOnFailureCallback_13.Cancel());
+        return cluster.ReadAttribute<
+            chip::app::Clusters::ThermostatUserInterfaceConfiguration::Attributes::ScheduleProgrammingVisibility::TypeInfo>(
+            this, OnSuccessCallback_13, OnFailureCallback_13);
     }
 
     void OnFailureResponse_13(uint8_t status) { ThrowFailureResponse(); }
@@ -21457,7 +20957,9 @@ private:
         chip::Controller::ThermostatUserInterfaceConfigurationClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeScheduleProgrammingVisibility(mOnSuccessCallback_14.Cancel(), mOnFailureCallback_14.Cancel());
+        return cluster.ReadAttribute<
+            chip::app::Clusters::ThermostatUserInterfaceConfiguration::Attributes::ScheduleProgrammingVisibility::TypeInfo>(
+            this, OnSuccessCallback_14, OnFailureCallback_14);
     }
 
     void OnFailureResponse_14(uint8_t status) { ThrowFailureResponse(); }
@@ -21855,14 +21357,9 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 3;
 
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_0{ OnFailureCallback_0, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t clusterRevision)> mOnSuccessCallback_0{ OnSuccessCallback_0, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_2{ OnFailureCallback_2, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t clusterRevision)> mOnSuccessCallback_2{ OnSuccessCallback_2, this };
-
-    static void OnFailureCallback_0(void * context, uint8_t status)
+    static void OnFailureCallback_0(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_DIAGTH_1_1 *>(context))->OnFailureResponse_0(status);
+        (static_cast<Test_TC_DIAGTH_1_1 *>(context))->OnFailureResponse_0(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_0(void * context, uint16_t clusterRevision)
@@ -21877,9 +21374,9 @@ private:
 
     static void OnSuccessCallback_1(void * context) { (static_cast<Test_TC_DIAGTH_1_1 *>(context))->OnSuccessResponse_1(); }
 
-    static void OnFailureCallback_2(void * context, uint8_t status)
+    static void OnFailureCallback_2(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_DIAGTH_1_1 *>(context))->OnFailureResponse_2(status);
+        (static_cast<Test_TC_DIAGTH_1_1 *>(context))->OnFailureResponse_2(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_2(void * context, uint16_t clusterRevision)
@@ -21896,7 +21393,8 @@ private:
         chip::Controller::ThreadNetworkDiagnosticsClusterTest cluster;
         cluster.Associate(mDevice, 0);
 
-        return cluster.ReadAttributeClusterRevision(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ThreadNetworkDiagnostics::Attributes::ClusterRevision::TypeInfo>(
+            this, OnSuccessCallback_0, OnFailureCallback_0);
     }
 
     void OnFailureResponse_0(uint8_t status) { ThrowFailureResponse(); }
@@ -21928,7 +21426,8 @@ private:
         chip::Controller::ThreadNetworkDiagnosticsClusterTest cluster;
         cluster.Associate(mDevice, 0);
 
-        return cluster.ReadAttributeClusterRevision(mOnSuccessCallback_2.Cancel(), mOnFailureCallback_2.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ThreadNetworkDiagnostics::Attributes::ClusterRevision::TypeInfo>(
+            this, OnSuccessCallback_2, OnFailureCallback_2);
     }
 
     void OnFailureResponse_2(uint8_t status) { ThrowFailureResponse(); }
@@ -22004,18 +21503,9 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 5;
 
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_0{ OnFailureCallback_0, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t clusterRevision)> mOnSuccessCallback_0{ OnSuccessCallback_0, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_2{ OnFailureCallback_2, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t clusterRevision)> mOnSuccessCallback_2{ OnSuccessCallback_2, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_3{ OnFailureCallback_3, this };
-    chip::Callback::Callback<void (*)(void * context, uint32_t featureMap)> mOnSuccessCallback_3{ OnSuccessCallback_3, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_4{ OnFailureCallback_4, this };
-    chip::Callback::Callback<void (*)(void * context, uint32_t featureMap)> mOnSuccessCallback_4{ OnSuccessCallback_4, this };
-
-    static void OnFailureCallback_0(void * context, uint8_t status)
+    static void OnFailureCallback_0(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_WNCV_1_1 *>(context))->OnFailureResponse_0(status);
+        (static_cast<Test_TC_WNCV_1_1 *>(context))->OnFailureResponse_0(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_0(void * context, uint16_t clusterRevision)
@@ -22030,9 +21520,9 @@ private:
 
     static void OnSuccessCallback_1(void * context) { (static_cast<Test_TC_WNCV_1_1 *>(context))->OnSuccessResponse_1(); }
 
-    static void OnFailureCallback_2(void * context, uint8_t status)
+    static void OnFailureCallback_2(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_WNCV_1_1 *>(context))->OnFailureResponse_2(status);
+        (static_cast<Test_TC_WNCV_1_1 *>(context))->OnFailureResponse_2(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_2(void * context, uint16_t clusterRevision)
@@ -22040,9 +21530,9 @@ private:
         (static_cast<Test_TC_WNCV_1_1 *>(context))->OnSuccessResponse_2(clusterRevision);
     }
 
-    static void OnFailureCallback_3(void * context, uint8_t status)
+    static void OnFailureCallback_3(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_WNCV_1_1 *>(context))->OnFailureResponse_3(status);
+        (static_cast<Test_TC_WNCV_1_1 *>(context))->OnFailureResponse_3(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_3(void * context, uint32_t featureMap)
@@ -22050,9 +21540,9 @@ private:
         (static_cast<Test_TC_WNCV_1_1 *>(context))->OnSuccessResponse_3(featureMap);
     }
 
-    static void OnFailureCallback_4(void * context, uint8_t status)
+    static void OnFailureCallback_4(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_WNCV_1_1 *>(context))->OnFailureResponse_4(status);
+        (static_cast<Test_TC_WNCV_1_1 *>(context))->OnFailureResponse_4(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_4(void * context, uint32_t featureMap)
@@ -22069,7 +21559,8 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeClusterRevision(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::ClusterRevision::TypeInfo>(
+            this, OnSuccessCallback_0, OnFailureCallback_0);
     }
 
     void OnFailureResponse_0(uint8_t status) { ThrowFailureResponse(); }
@@ -22101,7 +21592,8 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeClusterRevision(mOnSuccessCallback_2.Cancel(), mOnFailureCallback_2.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::ClusterRevision::TypeInfo>(
+            this, OnSuccessCallback_2, OnFailureCallback_2);
     }
 
     void OnFailureResponse_2(uint8_t status) { ThrowFailureResponse(); }
@@ -22117,7 +21609,8 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeFeatureMap(mOnSuccessCallback_3.Cancel(), mOnFailureCallback_3.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::FeatureMap::TypeInfo>(
+            this, OnSuccessCallback_3, OnFailureCallback_3);
     }
 
     void OnFailureResponse_3(uint8_t status) { ThrowFailureResponse(); }
@@ -22133,7 +21626,8 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeFeatureMap(mOnSuccessCallback_4.Cancel(), mOnFailureCallback_4.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::FeatureMap::TypeInfo>(
+            this, OnSuccessCallback_4, OnFailureCallback_4);
     }
 
     void OnFailureResponse_4(uint8_t status) { ThrowFailureResponse(); }
@@ -22232,30 +21726,9 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 11;
 
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_0{ OnFailureCallback_0, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t type)> mOnSuccessCallback_0{ OnSuccessCallback_0, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_1{ OnFailureCallback_1, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t type)> mOnSuccessCallback_1{ OnSuccessCallback_1, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_2{ OnFailureCallback_2, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t configStatus)> mOnSuccessCallback_2{ OnSuccessCallback_2, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_3{ OnFailureCallback_3, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t configStatus)> mOnSuccessCallback_3{ OnSuccessCallback_3, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_4{ OnFailureCallback_4, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t operationalStatus)> mOnSuccessCallback_4{ OnSuccessCallback_4, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_5{ OnFailureCallback_5, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t operationalStatus)> mOnSuccessCallback_5{ OnSuccessCallback_5, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_6{ OnFailureCallback_6, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t endProductType)> mOnSuccessCallback_6{ OnSuccessCallback_6, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_7{ OnFailureCallback_7, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t endProductType)> mOnSuccessCallback_7{ OnSuccessCallback_7, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_8{ OnFailureCallback_8, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t mode)> mOnSuccessCallback_8{ OnSuccessCallback_8, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_10{ OnFailureCallback_10, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t mode)> mOnSuccessCallback_10{ OnSuccessCallback_10, this };
-
-    static void OnFailureCallback_0(void * context, uint8_t status)
+    static void OnFailureCallback_0(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_WNCV_2_1 *>(context))->OnFailureResponse_0(status);
+        (static_cast<Test_TC_WNCV_2_1 *>(context))->OnFailureResponse_0(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_0(void * context, uint8_t type)
@@ -22263,9 +21736,9 @@ private:
         (static_cast<Test_TC_WNCV_2_1 *>(context))->OnSuccessResponse_0(type);
     }
 
-    static void OnFailureCallback_1(void * context, uint8_t status)
+    static void OnFailureCallback_1(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_WNCV_2_1 *>(context))->OnFailureResponse_1(status);
+        (static_cast<Test_TC_WNCV_2_1 *>(context))->OnFailureResponse_1(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_1(void * context, uint8_t type)
@@ -22273,9 +21746,9 @@ private:
         (static_cast<Test_TC_WNCV_2_1 *>(context))->OnSuccessResponse_1(type);
     }
 
-    static void OnFailureCallback_2(void * context, uint8_t status)
+    static void OnFailureCallback_2(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_WNCV_2_1 *>(context))->OnFailureResponse_2(status);
+        (static_cast<Test_TC_WNCV_2_1 *>(context))->OnFailureResponse_2(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_2(void * context, uint8_t configStatus)
@@ -22283,9 +21756,9 @@ private:
         (static_cast<Test_TC_WNCV_2_1 *>(context))->OnSuccessResponse_2(configStatus);
     }
 
-    static void OnFailureCallback_3(void * context, uint8_t status)
+    static void OnFailureCallback_3(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_WNCV_2_1 *>(context))->OnFailureResponse_3(status);
+        (static_cast<Test_TC_WNCV_2_1 *>(context))->OnFailureResponse_3(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_3(void * context, uint8_t configStatus)
@@ -22293,9 +21766,9 @@ private:
         (static_cast<Test_TC_WNCV_2_1 *>(context))->OnSuccessResponse_3(configStatus);
     }
 
-    static void OnFailureCallback_4(void * context, uint8_t status)
+    static void OnFailureCallback_4(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_WNCV_2_1 *>(context))->OnFailureResponse_4(status);
+        (static_cast<Test_TC_WNCV_2_1 *>(context))->OnFailureResponse_4(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_4(void * context, uint8_t operationalStatus)
@@ -22303,9 +21776,9 @@ private:
         (static_cast<Test_TC_WNCV_2_1 *>(context))->OnSuccessResponse_4(operationalStatus);
     }
 
-    static void OnFailureCallback_5(void * context, uint8_t status)
+    static void OnFailureCallback_5(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_WNCV_2_1 *>(context))->OnFailureResponse_5(status);
+        (static_cast<Test_TC_WNCV_2_1 *>(context))->OnFailureResponse_5(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_5(void * context, uint8_t operationalStatus)
@@ -22313,9 +21786,9 @@ private:
         (static_cast<Test_TC_WNCV_2_1 *>(context))->OnSuccessResponse_5(operationalStatus);
     }
 
-    static void OnFailureCallback_6(void * context, uint8_t status)
+    static void OnFailureCallback_6(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_WNCV_2_1 *>(context))->OnFailureResponse_6(status);
+        (static_cast<Test_TC_WNCV_2_1 *>(context))->OnFailureResponse_6(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_6(void * context, uint8_t endProductType)
@@ -22323,9 +21796,9 @@ private:
         (static_cast<Test_TC_WNCV_2_1 *>(context))->OnSuccessResponse_6(endProductType);
     }
 
-    static void OnFailureCallback_7(void * context, uint8_t status)
+    static void OnFailureCallback_7(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_WNCV_2_1 *>(context))->OnFailureResponse_7(status);
+        (static_cast<Test_TC_WNCV_2_1 *>(context))->OnFailureResponse_7(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_7(void * context, uint8_t endProductType)
@@ -22333,9 +21806,9 @@ private:
         (static_cast<Test_TC_WNCV_2_1 *>(context))->OnSuccessResponse_7(endProductType);
     }
 
-    static void OnFailureCallback_8(void * context, uint8_t status)
+    static void OnFailureCallback_8(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_WNCV_2_1 *>(context))->OnFailureResponse_8(status);
+        (static_cast<Test_TC_WNCV_2_1 *>(context))->OnFailureResponse_8(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_8(void * context, uint8_t mode)
@@ -22350,9 +21823,9 @@ private:
 
     static void OnSuccessCallback_9(void * context) { (static_cast<Test_TC_WNCV_2_1 *>(context))->OnSuccessResponse_9(); }
 
-    static void OnFailureCallback_10(void * context, uint8_t status)
+    static void OnFailureCallback_10(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_WNCV_2_1 *>(context))->OnFailureResponse_10(status);
+        (static_cast<Test_TC_WNCV_2_1 *>(context))->OnFailureResponse_10(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_10(void * context, uint8_t mode)
@@ -22369,7 +21842,8 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeType(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::Type::TypeInfo>(this, OnSuccessCallback_0,
+                                                                                                      OnFailureCallback_0);
     }
 
     void OnFailureResponse_0(uint8_t status) { ThrowFailureResponse(); }
@@ -22385,7 +21859,8 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeType(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::Type::TypeInfo>(this, OnSuccessCallback_1,
+                                                                                                      OnFailureCallback_1);
     }
 
     void OnFailureResponse_1(uint8_t status) { ThrowFailureResponse(); }
@@ -22401,7 +21876,8 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeConfigStatus(mOnSuccessCallback_2.Cancel(), mOnFailureCallback_2.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::ConfigStatus::TypeInfo>(
+            this, OnSuccessCallback_2, OnFailureCallback_2);
     }
 
     void OnFailureResponse_2(uint8_t status) { ThrowFailureResponse(); }
@@ -22417,7 +21893,8 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeConfigStatus(mOnSuccessCallback_3.Cancel(), mOnFailureCallback_3.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::ConfigStatus::TypeInfo>(
+            this, OnSuccessCallback_3, OnFailureCallback_3);
     }
 
     void OnFailureResponse_3(uint8_t status) { ThrowFailureResponse(); }
@@ -22433,7 +21910,8 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOperationalStatus(mOnSuccessCallback_4.Cancel(), mOnFailureCallback_4.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::OperationalStatus::TypeInfo>(
+            this, OnSuccessCallback_4, OnFailureCallback_4);
     }
 
     void OnFailureResponse_4(uint8_t status) { ThrowFailureResponse(); }
@@ -22449,7 +21927,8 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOperationalStatus(mOnSuccessCallback_5.Cancel(), mOnFailureCallback_5.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::OperationalStatus::TypeInfo>(
+            this, OnSuccessCallback_5, OnFailureCallback_5);
     }
 
     void OnFailureResponse_5(uint8_t status) { ThrowFailureResponse(); }
@@ -22465,7 +21944,8 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeEndProductType(mOnSuccessCallback_6.Cancel(), mOnFailureCallback_6.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::EndProductType::TypeInfo>(
+            this, OnSuccessCallback_6, OnFailureCallback_6);
     }
 
     void OnFailureResponse_6(uint8_t status) { ThrowFailureResponse(); }
@@ -22481,7 +21961,8 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeEndProductType(mOnSuccessCallback_7.Cancel(), mOnFailureCallback_7.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::EndProductType::TypeInfo>(
+            this, OnSuccessCallback_7, OnFailureCallback_7);
     }
 
     void OnFailureResponse_7(uint8_t status) { ThrowFailureResponse(); }
@@ -22497,7 +21978,8 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeMode(mOnSuccessCallback_8.Cancel(), mOnFailureCallback_8.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::Mode::TypeInfo>(this, OnSuccessCallback_8,
+                                                                                                      OnFailureCallback_8);
     }
 
     void OnFailureResponse_8(uint8_t status) { ThrowFailureResponse(); }
@@ -22529,7 +22011,8 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeMode(mOnSuccessCallback_10.Cancel(), mOnFailureCallback_10.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::Mode::TypeInfo>(this, OnSuccessCallback_10,
+                                                                                                      OnFailureCallback_10);
     }
 
     void OnFailureResponse_10(uint8_t status) { ThrowFailureResponse(); }
@@ -22640,14 +22123,9 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 2;
 
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_0{ OnFailureCallback_0, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t endProductType)> mOnSuccessCallback_0{ OnSuccessCallback_0, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_1{ OnFailureCallback_1, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t endProductType)> mOnSuccessCallback_1{ OnSuccessCallback_1, this };
-
-    static void OnFailureCallback_0(void * context, uint8_t status)
+    static void OnFailureCallback_0(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_WNCV_2_5 *>(context))->OnFailureResponse_0(status);
+        (static_cast<Test_TC_WNCV_2_5 *>(context))->OnFailureResponse_0(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_0(void * context, uint8_t endProductType)
@@ -22655,9 +22133,9 @@ private:
         (static_cast<Test_TC_WNCV_2_5 *>(context))->OnSuccessResponse_0(endProductType);
     }
 
-    static void OnFailureCallback_1(void * context, uint8_t status)
+    static void OnFailureCallback_1(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_WNCV_2_5 *>(context))->OnFailureResponse_1(status);
+        (static_cast<Test_TC_WNCV_2_5 *>(context))->OnFailureResponse_1(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_1(void * context, uint8_t endProductType)
@@ -22674,7 +22152,8 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeEndProductType(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::EndProductType::TypeInfo>(
+            this, OnSuccessCallback_0, OnFailureCallback_0);
     }
 
     void OnFailureResponse_0(uint8_t status) { ThrowFailureResponse(); }
@@ -22690,7 +22169,8 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeEndProductType(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::EndProductType::TypeInfo>(
+            this, OnSuccessCallback_1, OnFailureCallback_1);
     }
 
     void OnFailureResponse_1(uint8_t status) { ThrowFailureResponse(); }
@@ -22758,12 +22238,9 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 3;
 
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_2{ OnFailureCallback_2, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t operationalStatus)> mOnSuccessCallback_2{ OnSuccessCallback_2, this };
-
-    static void OnFailureCallback_2(void * context, uint8_t status)
+    static void OnFailureCallback_2(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_WNCV_3_1 *>(context))->OnFailureResponse_2(status);
+        (static_cast<Test_TC_WNCV_3_1 *>(context))->OnFailureResponse_2(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_2(void * context, uint8_t operationalStatus)
@@ -22828,7 +22305,8 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOperationalStatus(mOnSuccessCallback_2.Cancel(), mOnFailureCallback_2.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::OperationalStatus::TypeInfo>(
+            this, OnSuccessCallback_2, OnFailureCallback_2);
     }
 
     void OnFailureResponse_2(uint8_t status) { ThrowFailureResponse(); }
@@ -22895,12 +22373,9 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 3;
 
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_2{ OnFailureCallback_2, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t operationalStatus)> mOnSuccessCallback_2{ OnSuccessCallback_2, this };
-
-    static void OnFailureCallback_2(void * context, uint8_t status)
+    static void OnFailureCallback_2(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_WNCV_3_2 *>(context))->OnFailureResponse_2(status);
+        (static_cast<Test_TC_WNCV_3_2 *>(context))->OnFailureResponse_2(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_2(void * context, uint8_t operationalStatus)
@@ -22965,7 +22440,8 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOperationalStatus(mOnSuccessCallback_2.Cancel(), mOnFailureCallback_2.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::OperationalStatus::TypeInfo>(
+            this, OnSuccessCallback_2, OnFailureCallback_2);
     }
 
     void OnFailureResponse_2(uint8_t status) { ThrowFailureResponse(); }
@@ -23032,12 +22508,9 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 3;
 
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_2{ OnFailureCallback_2, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t operationalStatus)> mOnSuccessCallback_2{ OnSuccessCallback_2, this };
-
-    static void OnFailureCallback_2(void * context, uint8_t status)
+    static void OnFailureCallback_2(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_WNCV_3_3 *>(context))->OnFailureResponse_2(status);
+        (static_cast<Test_TC_WNCV_3_3 *>(context))->OnFailureResponse_2(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_2(void * context, uint8_t operationalStatus)
@@ -23102,7 +22575,8 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOperationalStatus(mOnSuccessCallback_2.Cancel(), mOnFailureCallback_2.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::WindowCovering::Attributes::OperationalStatus::TypeInfo>(
+            this, OnSuccessCallback_2, OnFailureCallback_2);
     }
 
     void OnFailureResponse_2(uint8_t status) { ThrowFailureResponse(); }
@@ -23165,16 +22639,9 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 2;
 
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_0{ OnFailureCallback_0, this };
-    chip::Callback::Callback<void (*)(
-        void * context,
-        const chip::app::DataModel::DecodableList<
-            chip::app::Clusters::TargetNavigator::Structs::NavigateTargetTargetInfo::DecodableType> & targetNavigatorList)>
-        mOnSuccessCallback_0{ OnSuccessCallback_0, this };
-
-    static void OnFailureCallback_0(void * context, uint8_t status)
+    static void OnFailureCallback_0(void * context, EmberAfStatus status)
     {
-        (static_cast<TV_TargetNavigatorCluster *>(context))->OnFailureResponse_0(status);
+        (static_cast<TV_TargetNavigatorCluster *>(context))->OnFailureResponse_0(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_0(
@@ -23194,7 +22661,8 @@ private:
         chip::Controller::TargetNavigatorClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeTargetNavigatorList(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TargetNavigator::Attributes::TargetNavigatorList::TypeInfo>(
+            this, OnSuccessCallback_0, OnFailureCallback_0);
     }
 
     void OnFailureResponse_0(uint8_t status) { ThrowFailureResponse(); }
@@ -23296,16 +22764,9 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 3;
 
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_0{ OnFailureCallback_0, this };
-    chip::Callback::Callback<void (*)(
-        void * context,
-        const chip::app::DataModel::DecodableList<chip::app::Clusters::AudioOutput::Structs::AudioOutputInfo::DecodableType> &
-            audioOutputList)>
-        mOnSuccessCallback_0{ OnSuccessCallback_0, this };
-
-    static void OnFailureCallback_0(void * context, uint8_t status)
+    static void OnFailureCallback_0(void * context, EmberAfStatus status)
     {
-        (static_cast<TV_AudioOutputCluster *>(context))->OnFailureResponse_0(status);
+        (static_cast<TV_AudioOutputCluster *>(context))->OnFailureResponse_0(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_0(
@@ -23325,7 +22786,8 @@ private:
         chip::Controller::AudioOutputClusterTest cluster;
         cluster.Associate(mDevice, 2);
 
-        return cluster.ReadAttributeAudioOutputList(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::AudioOutput::Attributes::AudioOutputList::TypeInfo>(
+            this, OnSuccessCallback_0, OnFailureCallback_0);
     }
 
     void OnFailureResponse_0(uint8_t status) { ThrowFailureResponse(); }
@@ -23462,18 +22924,9 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 4;
 
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_0{ OnFailureCallback_0, this };
-    chip::Callback::Callback<void (*)(void * context,
-                                      const chip::app::DataModel::DecodableList<uint16_t> & applicationLauncherList)>
-        mOnSuccessCallback_0{ OnSuccessCallback_0, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_2{ OnFailureCallback_2, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t catalogVendorId)> mOnSuccessCallback_2{ OnSuccessCallback_2, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_3{ OnFailureCallback_3, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t applicationId)> mOnSuccessCallback_3{ OnSuccessCallback_3, this };
-
-    static void OnFailureCallback_0(void * context, uint8_t status)
+    static void OnFailureCallback_0(void * context, EmberAfStatus status)
     {
-        (static_cast<TV_ApplicationLauncherCluster *>(context))->OnFailureResponse_0(status);
+        (static_cast<TV_ApplicationLauncherCluster *>(context))->OnFailureResponse_0(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_0(void * context, const chip::app::DataModel::DecodableList<uint16_t> & applicationLauncherList)
@@ -23481,9 +22934,9 @@ private:
         (static_cast<TV_ApplicationLauncherCluster *>(context))->OnSuccessResponse_0(applicationLauncherList);
     }
 
-    static void OnFailureCallback_2(void * context, uint8_t status)
+    static void OnFailureCallback_2(void * context, EmberAfStatus status)
     {
-        (static_cast<TV_ApplicationLauncherCluster *>(context))->OnFailureResponse_2(status);
+        (static_cast<TV_ApplicationLauncherCluster *>(context))->OnFailureResponse_2(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_2(void * context, uint8_t catalogVendorId)
@@ -23491,9 +22944,9 @@ private:
         (static_cast<TV_ApplicationLauncherCluster *>(context))->OnSuccessResponse_2(catalogVendorId);
     }
 
-    static void OnFailureCallback_3(void * context, uint8_t status)
+    static void OnFailureCallback_3(void * context, EmberAfStatus status)
     {
-        (static_cast<TV_ApplicationLauncherCluster *>(context))->OnFailureResponse_3(status);
+        (static_cast<TV_ApplicationLauncherCluster *>(context))->OnFailureResponse_3(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_3(void * context, uint8_t applicationId)
@@ -23510,7 +22963,8 @@ private:
         chip::Controller::ApplicationLauncherClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeApplicationLauncherList(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ApplicationLauncher::Attributes::ApplicationLauncherList::TypeInfo>(
+            this, OnSuccessCallback_0, OnFailureCallback_0);
     }
 
     void OnFailureResponse_0(uint8_t status) { ThrowFailureResponse(); }
@@ -23562,7 +23016,8 @@ private:
         chip::Controller::ApplicationLauncherClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeCatalogVendorId(mOnSuccessCallback_2.Cancel(), mOnFailureCallback_2.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ApplicationLauncher::Attributes::CatalogVendorId::TypeInfo>(
+            this, OnSuccessCallback_2, OnFailureCallback_2);
     }
 
     void OnFailureResponse_2(uint8_t status) { ThrowFailureResponse(); }
@@ -23578,7 +23033,8 @@ private:
         chip::Controller::ApplicationLauncherClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeApplicationId(mOnSuccessCallback_3.Cancel(), mOnFailureCallback_3.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ApplicationLauncher::Attributes::ApplicationId::TypeInfo>(
+            this, OnSuccessCallback_3, OnFailureCallback_3);
     }
 
     void OnFailureResponse_3(uint8_t status) { ThrowFailureResponse(); }
@@ -23821,14 +23277,9 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 1;
 
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_0{ OnFailureCallback_0, this };
-    chip::Callback::Callback<void (*)(void * context, chip::CharSpan wakeOnLanMacAddress)> mOnSuccessCallback_0{
-        OnSuccessCallback_0, this
-    };
-
-    static void OnFailureCallback_0(void * context, uint8_t status)
+    static void OnFailureCallback_0(void * context, EmberAfStatus status)
     {
-        (static_cast<TV_WakeOnLanCluster *>(context))->OnFailureResponse_0(status);
+        (static_cast<TV_WakeOnLanCluster *>(context))->OnFailureResponse_0(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_0(void * context, chip::CharSpan wakeOnLanMacAddress)
@@ -23845,7 +23296,8 @@ private:
         chip::Controller::WakeOnLanClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeWakeOnLanMacAddress(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::WakeOnLan::Attributes::WakeOnLanMacAddress::TypeInfo>(
+            this, OnSuccessCallback_0, OnFailureCallback_0);
     }
 
     void OnFailureResponse_0(uint8_t status) { ThrowFailureResponse(); }
@@ -23916,16 +23368,9 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 4;
 
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_1{ OnFailureCallback_1, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t vendorId)> mOnSuccessCallback_1{ OnSuccessCallback_1, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_2{ OnFailureCallback_2, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t productId)> mOnSuccessCallback_2{ OnSuccessCallback_2, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_3{ OnFailureCallback_3, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t catalogVendorId)> mOnSuccessCallback_3{ OnSuccessCallback_3, this };
-
-    static void OnFailureCallback_1(void * context, uint8_t status)
+    static void OnFailureCallback_1(void * context, EmberAfStatus status)
     {
-        (static_cast<TV_ApplicationBasicCluster *>(context))->OnFailureResponse_1(status);
+        (static_cast<TV_ApplicationBasicCluster *>(context))->OnFailureResponse_1(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_1(void * context, uint16_t vendorId)
@@ -23933,9 +23378,9 @@ private:
         (static_cast<TV_ApplicationBasicCluster *>(context))->OnSuccessResponse_1(vendorId);
     }
 
-    static void OnFailureCallback_2(void * context, uint8_t status)
+    static void OnFailureCallback_2(void * context, EmberAfStatus status)
     {
-        (static_cast<TV_ApplicationBasicCluster *>(context))->OnFailureResponse_2(status);
+        (static_cast<TV_ApplicationBasicCluster *>(context))->OnFailureResponse_2(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_2(void * context, uint16_t productId)
@@ -23943,9 +23388,9 @@ private:
         (static_cast<TV_ApplicationBasicCluster *>(context))->OnSuccessResponse_2(productId);
     }
 
-    static void OnFailureCallback_3(void * context, uint8_t status)
+    static void OnFailureCallback_3(void * context, EmberAfStatus status)
     {
-        (static_cast<TV_ApplicationBasicCluster *>(context))->OnFailureResponse_3(status);
+        (static_cast<TV_ApplicationBasicCluster *>(context))->OnFailureResponse_3(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_3(void * context, uint16_t catalogVendorId)
@@ -23987,7 +23432,8 @@ private:
         chip::Controller::ApplicationBasicClusterTest cluster;
         cluster.Associate(mDevice, 3);
 
-        return cluster.ReadAttributeVendorId(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ApplicationBasic::Attributes::VendorId::TypeInfo>(
+            this, OnSuccessCallback_1, OnFailureCallback_1);
     }
 
     void OnFailureResponse_1(uint8_t status) { ThrowFailureResponse(); }
@@ -24003,7 +23449,8 @@ private:
         chip::Controller::ApplicationBasicClusterTest cluster;
         cluster.Associate(mDevice, 3);
 
-        return cluster.ReadAttributeProductId(mOnSuccessCallback_2.Cancel(), mOnFailureCallback_2.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ApplicationBasic::Attributes::ProductId::TypeInfo>(
+            this, OnSuccessCallback_2, OnFailureCallback_2);
     }
 
     void OnFailureResponse_2(uint8_t status) { ThrowFailureResponse(); }
@@ -24019,7 +23466,8 @@ private:
         chip::Controller::ApplicationBasicClusterTest cluster;
         cluster.Associate(mDevice, 3);
 
-        return cluster.ReadAttributeCatalogVendorId(mOnSuccessCallback_3.Cancel(), mOnFailureCallback_3.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ApplicationBasic::Attributes::CatalogVendorId::TypeInfo>(
+            this, OnSuccessCallback_3, OnFailureCallback_3);
     }
 
     void OnFailureResponse_3(uint8_t status) { ThrowFailureResponse(); }
@@ -24489,15 +23937,9 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 3;
 
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_0{ OnFailureCallback_0, this };
-    chip::Callback::Callback<void (*)(void * context,
-                                      const chip::app::DataModel::DecodableList<
-                                          chip::app::Clusters::TvChannel::Structs::TvChannelInfo::DecodableType> & tvChannelList)>
-        mOnSuccessCallback_0{ OnSuccessCallback_0, this };
-
-    static void OnFailureCallback_0(void * context, uint8_t status)
+    static void OnFailureCallback_0(void * context, EmberAfStatus status)
     {
-        (static_cast<TV_TvChannelCluster *>(context))->OnFailureResponse_0(status);
+        (static_cast<TV_TvChannelCluster *>(context))->OnFailureResponse_0(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_0(
@@ -24517,7 +23959,8 @@ private:
         chip::Controller::TvChannelClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeTvChannelList(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TvChannel::Attributes::TvChannelList::TypeInfo>(this, OnSuccessCallback_0,
+                                                                                                          OnFailureCallback_0);
     }
 
     void OnFailureResponse_0(uint8_t status) { ThrowFailureResponse(); }
@@ -24738,18 +24181,9 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 6;
 
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_0{ OnFailureCallback_0, this };
-    chip::Callback::Callback<void (*)(
-        void * context,
-        const chip::app::DataModel::DecodableList<chip::app::Clusters::MediaInput::Structs::MediaInputInfo::DecodableType> &
-            mediaInputList)>
-        mOnSuccessCallback_0{ OnSuccessCallback_0, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_2{ OnFailureCallback_2, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t currentMediaInput)> mOnSuccessCallback_2{ OnSuccessCallback_2, this };
-
-    static void OnFailureCallback_0(void * context, uint8_t status)
+    static void OnFailureCallback_0(void * context, EmberAfStatus status)
     {
-        (static_cast<TV_MediaInputCluster *>(context))->OnFailureResponse_0(status);
+        (static_cast<TV_MediaInputCluster *>(context))->OnFailureResponse_0(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_0(
@@ -24760,9 +24194,9 @@ private:
         (static_cast<TV_MediaInputCluster *>(context))->OnSuccessResponse_0(mediaInputList);
     }
 
-    static void OnFailureCallback_2(void * context, uint8_t status)
+    static void OnFailureCallback_2(void * context, EmberAfStatus status)
     {
-        (static_cast<TV_MediaInputCluster *>(context))->OnFailureResponse_2(status);
+        (static_cast<TV_MediaInputCluster *>(context))->OnFailureResponse_2(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_2(void * context, uint8_t currentMediaInput)
@@ -24779,7 +24213,8 @@ private:
         chip::Controller::MediaInputClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeMediaInputList(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::MediaInput::Attributes::MediaInputList::TypeInfo>(
+            this, OnSuccessCallback_0, OnFailureCallback_0);
     }
 
     void OnFailureResponse_0(uint8_t status) { ThrowFailureResponse(); }
@@ -24833,7 +24268,8 @@ private:
         chip::Controller::MediaInputClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeCurrentMediaInput(mOnSuccessCallback_2.Cancel(), mOnFailureCallback_2.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::MediaInput::Attributes::CurrentMediaInput::TypeInfo>(
+            this, OnSuccessCallback_2, OnFailureCallback_2);
     }
 
     void OnFailureResponse_2(uint8_t status) { ThrowFailureResponse(); }
@@ -25470,164 +24906,9 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 127;
 
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_5{ OnFailureCallback_5, this };
-    chip::Callback::Callback<void (*)(void * context, bool boolean)> mOnSuccessCallback_5{ OnSuccessCallback_5, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_7{ OnFailureCallback_7, this };
-    chip::Callback::Callback<void (*)(void * context, bool boolean)> mOnSuccessCallback_7{ OnSuccessCallback_7, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_9{ OnFailureCallback_9, this };
-    chip::Callback::Callback<void (*)(void * context, bool boolean)> mOnSuccessCallback_9{ OnSuccessCallback_9, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_10{ OnFailureCallback_10, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t bitmap8)> mOnSuccessCallback_10{ OnSuccessCallback_10, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_12{ OnFailureCallback_12, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t bitmap8)> mOnSuccessCallback_12{ OnSuccessCallback_12, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_14{ OnFailureCallback_14, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t bitmap8)> mOnSuccessCallback_14{ OnSuccessCallback_14, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_15{ OnFailureCallback_15, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t bitmap16)> mOnSuccessCallback_15{ OnSuccessCallback_15, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_17{ OnFailureCallback_17, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t bitmap16)> mOnSuccessCallback_17{ OnSuccessCallback_17, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_19{ OnFailureCallback_19, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t bitmap16)> mOnSuccessCallback_19{ OnSuccessCallback_19, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_20{ OnFailureCallback_20, this };
-    chip::Callback::Callback<void (*)(void * context, uint32_t bitmap32)> mOnSuccessCallback_20{ OnSuccessCallback_20, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_22{ OnFailureCallback_22, this };
-    chip::Callback::Callback<void (*)(void * context, uint32_t bitmap32)> mOnSuccessCallback_22{ OnSuccessCallback_22, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_24{ OnFailureCallback_24, this };
-    chip::Callback::Callback<void (*)(void * context, uint32_t bitmap32)> mOnSuccessCallback_24{ OnSuccessCallback_24, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_25{ OnFailureCallback_25, this };
-    chip::Callback::Callback<void (*)(void * context, uint64_t bitmap64)> mOnSuccessCallback_25{ OnSuccessCallback_25, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_27{ OnFailureCallback_27, this };
-    chip::Callback::Callback<void (*)(void * context, uint64_t bitmap64)> mOnSuccessCallback_27{ OnSuccessCallback_27, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_29{ OnFailureCallback_29, this };
-    chip::Callback::Callback<void (*)(void * context, uint64_t bitmap64)> mOnSuccessCallback_29{ OnSuccessCallback_29, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_30{ OnFailureCallback_30, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t int8u)> mOnSuccessCallback_30{ OnSuccessCallback_30, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_32{ OnFailureCallback_32, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t int8u)> mOnSuccessCallback_32{ OnSuccessCallback_32, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_34{ OnFailureCallback_34, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t int8u)> mOnSuccessCallback_34{ OnSuccessCallback_34, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_35{ OnFailureCallback_35, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t int16u)> mOnSuccessCallback_35{ OnSuccessCallback_35, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_37{ OnFailureCallback_37, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t int16u)> mOnSuccessCallback_37{ OnSuccessCallback_37, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_39{ OnFailureCallback_39, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t int16u)> mOnSuccessCallback_39{ OnSuccessCallback_39, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_40{ OnFailureCallback_40, this };
-    chip::Callback::Callback<void (*)(void * context, uint32_t int32u)> mOnSuccessCallback_40{ OnSuccessCallback_40, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_42{ OnFailureCallback_42, this };
-    chip::Callback::Callback<void (*)(void * context, uint32_t int32u)> mOnSuccessCallback_42{ OnSuccessCallback_42, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_44{ OnFailureCallback_44, this };
-    chip::Callback::Callback<void (*)(void * context, uint32_t int32u)> mOnSuccessCallback_44{ OnSuccessCallback_44, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_45{ OnFailureCallback_45, this };
-    chip::Callback::Callback<void (*)(void * context, uint64_t int64u)> mOnSuccessCallback_45{ OnSuccessCallback_45, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_47{ OnFailureCallback_47, this };
-    chip::Callback::Callback<void (*)(void * context, uint64_t int64u)> mOnSuccessCallback_47{ OnSuccessCallback_47, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_49{ OnFailureCallback_49, this };
-    chip::Callback::Callback<void (*)(void * context, uint64_t int64u)> mOnSuccessCallback_49{ OnSuccessCallback_49, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_50{ OnFailureCallback_50, this };
-    chip::Callback::Callback<void (*)(void * context, int8_t int8s)> mOnSuccessCallback_50{ OnSuccessCallback_50, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_52{ OnFailureCallback_52, this };
-    chip::Callback::Callback<void (*)(void * context, int8_t int8s)> mOnSuccessCallback_52{ OnSuccessCallback_52, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_54{ OnFailureCallback_54, this };
-    chip::Callback::Callback<void (*)(void * context, int8_t int8s)> mOnSuccessCallback_54{ OnSuccessCallback_54, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_56{ OnFailureCallback_56, this };
-    chip::Callback::Callback<void (*)(void * context, int8_t int8s)> mOnSuccessCallback_56{ OnSuccessCallback_56, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_57{ OnFailureCallback_57, this };
-    chip::Callback::Callback<void (*)(void * context, int16_t int16s)> mOnSuccessCallback_57{ OnSuccessCallback_57, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_59{ OnFailureCallback_59, this };
-    chip::Callback::Callback<void (*)(void * context, int16_t int16s)> mOnSuccessCallback_59{ OnSuccessCallback_59, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_61{ OnFailureCallback_61, this };
-    chip::Callback::Callback<void (*)(void * context, int16_t int16s)> mOnSuccessCallback_61{ OnSuccessCallback_61, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_63{ OnFailureCallback_63, this };
-    chip::Callback::Callback<void (*)(void * context, int16_t int16s)> mOnSuccessCallback_63{ OnSuccessCallback_63, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_64{ OnFailureCallback_64, this };
-    chip::Callback::Callback<void (*)(void * context, int32_t int32s)> mOnSuccessCallback_64{ OnSuccessCallback_64, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_66{ OnFailureCallback_66, this };
-    chip::Callback::Callback<void (*)(void * context, int32_t int32s)> mOnSuccessCallback_66{ OnSuccessCallback_66, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_68{ OnFailureCallback_68, this };
-    chip::Callback::Callback<void (*)(void * context, int32_t int32s)> mOnSuccessCallback_68{ OnSuccessCallback_68, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_70{ OnFailureCallback_70, this };
-    chip::Callback::Callback<void (*)(void * context, int32_t int32s)> mOnSuccessCallback_70{ OnSuccessCallback_70, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_71{ OnFailureCallback_71, this };
-    chip::Callback::Callback<void (*)(void * context, int64_t int64s)> mOnSuccessCallback_71{ OnSuccessCallback_71, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_73{ OnFailureCallback_73, this };
-    chip::Callback::Callback<void (*)(void * context, int64_t int64s)> mOnSuccessCallback_73{ OnSuccessCallback_73, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_75{ OnFailureCallback_75, this };
-    chip::Callback::Callback<void (*)(void * context, int64_t int64s)> mOnSuccessCallback_75{ OnSuccessCallback_75, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_77{ OnFailureCallback_77, this };
-    chip::Callback::Callback<void (*)(void * context, int64_t int64s)> mOnSuccessCallback_77{ OnSuccessCallback_77, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_78{ OnFailureCallback_78, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t enum8)> mOnSuccessCallback_78{ OnSuccessCallback_78, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_80{ OnFailureCallback_80, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t enum8)> mOnSuccessCallback_80{ OnSuccessCallback_80, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_82{ OnFailureCallback_82, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t enum8)> mOnSuccessCallback_82{ OnSuccessCallback_82, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_83{ OnFailureCallback_83, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t enum16)> mOnSuccessCallback_83{ OnSuccessCallback_83, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_85{ OnFailureCallback_85, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t enum16)> mOnSuccessCallback_85{ OnSuccessCallback_85, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_87{ OnFailureCallback_87, this };
-    chip::Callback::Callback<void (*)(void * context, uint16_t enum16)> mOnSuccessCallback_87{ OnSuccessCallback_87, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_88{ OnFailureCallback_88, this };
-    chip::Callback::Callback<void (*)(void * context, chip::ByteSpan octetString)> mOnSuccessCallback_88{ OnSuccessCallback_88,
-                                                                                                          this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_90{ OnFailureCallback_90, this };
-    chip::Callback::Callback<void (*)(void * context, chip::ByteSpan octetString)> mOnSuccessCallback_90{ OnSuccessCallback_90,
-                                                                                                          this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_92{ OnFailureCallback_92, this };
-    chip::Callback::Callback<void (*)(void * context, chip::ByteSpan octetString)> mOnSuccessCallback_92{ OnSuccessCallback_92,
-                                                                                                          this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_94{ OnFailureCallback_94, this };
-    chip::Callback::Callback<void (*)(void * context, chip::ByteSpan longOctetString)> mOnSuccessCallback_94{ OnSuccessCallback_94,
-                                                                                                              this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_96{ OnFailureCallback_96, this };
-    chip::Callback::Callback<void (*)(void * context, chip::ByteSpan longOctetString)> mOnSuccessCallback_96{ OnSuccessCallback_96,
-                                                                                                              this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_98{ OnFailureCallback_98, this };
-    chip::Callback::Callback<void (*)(void * context, chip::CharSpan charString)> mOnSuccessCallback_98{ OnSuccessCallback_98,
-                                                                                                         this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_102{ OnFailureCallback_102, this };
-    chip::Callback::Callback<void (*)(void * context, chip::CharSpan longCharString)> mOnSuccessCallback_102{ OnSuccessCallback_102,
-                                                                                                              this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_104{ OnFailureCallback_104, this };
-    chip::Callback::Callback<void (*)(void * context, chip::CharSpan longCharString)> mOnSuccessCallback_104{ OnSuccessCallback_104,
-                                                                                                              this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_106{ OnFailureCallback_106, this };
-    chip::Callback::Callback<void (*)(void * context, const chip::app::DataModel::DecodableList<uint8_t> & listInt8u)>
-        mOnSuccessCallback_106{ OnSuccessCallback_106, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_107{ OnFailureCallback_107, this };
-    chip::Callback::Callback<void (*)(void * context, const chip::app::DataModel::DecodableList<chip::ByteSpan> & listOctetString)>
-        mOnSuccessCallback_107{ OnSuccessCallback_107, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_108{ OnFailureCallback_108, this };
-    chip::Callback::Callback<void (*)(
-        void * context,
-        const chip::app::DataModel::DecodableList<chip::app::Clusters::TestCluster::Structs::TestListStructOctet::DecodableType> &
-            listStructOctetString)>
-        mOnSuccessCallback_108{ OnSuccessCallback_108, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_109{ OnFailureCallback_109, this };
-    chip::Callback::Callback<void (*)(void * context, uint64_t epochUs)> mOnSuccessCallback_109{ OnSuccessCallback_109, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_111{ OnFailureCallback_111, this };
-    chip::Callback::Callback<void (*)(void * context, uint64_t epochUs)> mOnSuccessCallback_111{ OnSuccessCallback_111, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_113{ OnFailureCallback_113, this };
-    chip::Callback::Callback<void (*)(void * context, uint64_t epochUs)> mOnSuccessCallback_113{ OnSuccessCallback_113, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_114{ OnFailureCallback_114, this };
-    chip::Callback::Callback<void (*)(void * context, uint32_t epochS)> mOnSuccessCallback_114{ OnSuccessCallback_114, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_116{ OnFailureCallback_116, this };
-    chip::Callback::Callback<void (*)(void * context, uint32_t epochS)> mOnSuccessCallback_116{ OnSuccessCallback_116, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_118{ OnFailureCallback_118, this };
-    chip::Callback::Callback<void (*)(void * context, uint32_t epochS)> mOnSuccessCallback_118{ OnSuccessCallback_118, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_119{ OnFailureCallback_119, this };
-    chip::Callback::Callback<void (*)(void * context, bool unsupported)> mOnSuccessCallback_119{ OnSuccessCallback_119, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_122{ OnFailureCallback_122, this };
-    chip::Callback::Callback<void (*)(void * context, chip::VendorId vendorId)> mOnSuccessCallback_122{ OnSuccessCallback_122,
-                                                                                                        this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_124{ OnFailureCallback_124, this };
-    chip::Callback::Callback<void (*)(void * context, chip::VendorId vendorId)> mOnSuccessCallback_124{ OnSuccessCallback_124,
-                                                                                                        this };
-
-    static void OnFailureCallback_5(void * context, uint8_t status)
+    static void OnFailureCallback_5(void * context, EmberAfStatus status)
     {
-        (static_cast<TestCluster *>(context))->OnFailureResponse_5(status);
+        (static_cast<TestCluster *>(context))->OnFailureResponse_5(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_5(void * context, bool boolean)
@@ -25642,9 +24923,9 @@ private:
 
     static void OnSuccessCallback_6(void * context) { (static_cast<TestCluster *>(context))->OnSuccessResponse_6(); }
 
-    static void OnFailureCallback_7(void * context, uint8_t status)
+    static void OnFailureCallback_7(void * context, EmberAfStatus status)
     {
-        (static_cast<TestCluster *>(context))->OnFailureResponse_7(status);
+        (static_cast<TestCluster *>(context))->OnFailureResponse_7(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_7(void * context, bool boolean)
@@ -25659,9 +24940,9 @@ private:
 
     static void OnSuccessCallback_8(void * context) { (static_cast<TestCluster *>(context))->OnSuccessResponse_8(); }
 
-    static void OnFailureCallback_9(void * context, uint8_t status)
+    static void OnFailureCallback_9(void * context, EmberAfStatus status)
     {
-        (static_cast<TestCluster *>(context))->OnFailureResponse_9(status);
+        (static_cast<TestCluster *>(context))->OnFailureResponse_9(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_9(void * context, bool boolean)
@@ -25669,9 +24950,9 @@ private:
         (static_cast<TestCluster *>(context))->OnSuccessResponse_9(boolean);
     }
 
-    static void OnFailureCallback_10(void * context, uint8_t status)
+    static void OnFailureCallback_10(void * context, EmberAfStatus status)
     {
-        (static_cast<TestCluster *>(context))->OnFailureResponse_10(status);
+        (static_cast<TestCluster *>(context))->OnFailureResponse_10(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_10(void * context, uint8_t bitmap8)
@@ -25686,9 +24967,9 @@ private:
 
     static void OnSuccessCallback_11(void * context) { (static_cast<TestCluster *>(context))->OnSuccessResponse_11(); }
 
-    static void OnFailureCallback_12(void * context, uint8_t status)
+    static void OnFailureCallback_12(void * context, EmberAfStatus status)
     {
-        (static_cast<TestCluster *>(context))->OnFailureResponse_12(status);
+        (static_cast<TestCluster *>(context))->OnFailureResponse_12(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_12(void * context, uint8_t bitmap8)
@@ -25703,9 +24984,9 @@ private:
 
     static void OnSuccessCallback_13(void * context) { (static_cast<TestCluster *>(context))->OnSuccessResponse_13(); }
 
-    static void OnFailureCallback_14(void * context, uint8_t status)
+    static void OnFailureCallback_14(void * context, EmberAfStatus status)
     {
-        (static_cast<TestCluster *>(context))->OnFailureResponse_14(status);
+        (static_cast<TestCluster *>(context))->OnFailureResponse_14(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_14(void * context, uint8_t bitmap8)
@@ -25713,9 +24994,9 @@ private:
         (static_cast<TestCluster *>(context))->OnSuccessResponse_14(bitmap8);
     }
 
-    static void OnFailureCallback_15(void * context, uint8_t status)
+    static void OnFailureCallback_15(void * context, EmberAfStatus status)
     {
-        (static_cast<TestCluster *>(context))->OnFailureResponse_15(status);
+        (static_cast<TestCluster *>(context))->OnFailureResponse_15(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_15(void * context, uint16_t bitmap16)
@@ -25730,9 +25011,9 @@ private:
 
     static void OnSuccessCallback_16(void * context) { (static_cast<TestCluster *>(context))->OnSuccessResponse_16(); }
 
-    static void OnFailureCallback_17(void * context, uint8_t status)
+    static void OnFailureCallback_17(void * context, EmberAfStatus status)
     {
-        (static_cast<TestCluster *>(context))->OnFailureResponse_17(status);
+        (static_cast<TestCluster *>(context))->OnFailureResponse_17(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_17(void * context, uint16_t bitmap16)
@@ -25747,9 +25028,9 @@ private:
 
     static void OnSuccessCallback_18(void * context) { (static_cast<TestCluster *>(context))->OnSuccessResponse_18(); }
 
-    static void OnFailureCallback_19(void * context, uint8_t status)
+    static void OnFailureCallback_19(void * context, EmberAfStatus status)
     {
-        (static_cast<TestCluster *>(context))->OnFailureResponse_19(status);
+        (static_cast<TestCluster *>(context))->OnFailureResponse_19(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_19(void * context, uint16_t bitmap16)
@@ -25757,9 +25038,9 @@ private:
         (static_cast<TestCluster *>(context))->OnSuccessResponse_19(bitmap16);
     }
 
-    static void OnFailureCallback_20(void * context, uint8_t status)
+    static void OnFailureCallback_20(void * context, EmberAfStatus status)
     {
-        (static_cast<TestCluster *>(context))->OnFailureResponse_20(status);
+        (static_cast<TestCluster *>(context))->OnFailureResponse_20(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_20(void * context, uint32_t bitmap32)
@@ -25774,9 +25055,9 @@ private:
 
     static void OnSuccessCallback_21(void * context) { (static_cast<TestCluster *>(context))->OnSuccessResponse_21(); }
 
-    static void OnFailureCallback_22(void * context, uint8_t status)
+    static void OnFailureCallback_22(void * context, EmberAfStatus status)
     {
-        (static_cast<TestCluster *>(context))->OnFailureResponse_22(status);
+        (static_cast<TestCluster *>(context))->OnFailureResponse_22(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_22(void * context, uint32_t bitmap32)
@@ -25791,9 +25072,9 @@ private:
 
     static void OnSuccessCallback_23(void * context) { (static_cast<TestCluster *>(context))->OnSuccessResponse_23(); }
 
-    static void OnFailureCallback_24(void * context, uint8_t status)
+    static void OnFailureCallback_24(void * context, EmberAfStatus status)
     {
-        (static_cast<TestCluster *>(context))->OnFailureResponse_24(status);
+        (static_cast<TestCluster *>(context))->OnFailureResponse_24(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_24(void * context, uint32_t bitmap32)
@@ -25801,9 +25082,9 @@ private:
         (static_cast<TestCluster *>(context))->OnSuccessResponse_24(bitmap32);
     }
 
-    static void OnFailureCallback_25(void * context, uint8_t status)
+    static void OnFailureCallback_25(void * context, EmberAfStatus status)
     {
-        (static_cast<TestCluster *>(context))->OnFailureResponse_25(status);
+        (static_cast<TestCluster *>(context))->OnFailureResponse_25(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_25(void * context, uint64_t bitmap64)
@@ -25818,9 +25099,9 @@ private:
 
     static void OnSuccessCallback_26(void * context) { (static_cast<TestCluster *>(context))->OnSuccessResponse_26(); }
 
-    static void OnFailureCallback_27(void * context, uint8_t status)
+    static void OnFailureCallback_27(void * context, EmberAfStatus status)
     {
-        (static_cast<TestCluster *>(context))->OnFailureResponse_27(status);
+        (static_cast<TestCluster *>(context))->OnFailureResponse_27(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_27(void * context, uint64_t bitmap64)
@@ -25835,9 +25116,9 @@ private:
 
     static void OnSuccessCallback_28(void * context) { (static_cast<TestCluster *>(context))->OnSuccessResponse_28(); }
 
-    static void OnFailureCallback_29(void * context, uint8_t status)
+    static void OnFailureCallback_29(void * context, EmberAfStatus status)
     {
-        (static_cast<TestCluster *>(context))->OnFailureResponse_29(status);
+        (static_cast<TestCluster *>(context))->OnFailureResponse_29(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_29(void * context, uint64_t bitmap64)
@@ -25845,9 +25126,9 @@ private:
         (static_cast<TestCluster *>(context))->OnSuccessResponse_29(bitmap64);
     }
 
-    static void OnFailureCallback_30(void * context, uint8_t status)
+    static void OnFailureCallback_30(void * context, EmberAfStatus status)
     {
-        (static_cast<TestCluster *>(context))->OnFailureResponse_30(status);
+        (static_cast<TestCluster *>(context))->OnFailureResponse_30(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_30(void * context, uint8_t int8u)
@@ -25862,9 +25143,9 @@ private:
 
     static void OnSuccessCallback_31(void * context) { (static_cast<TestCluster *>(context))->OnSuccessResponse_31(); }
 
-    static void OnFailureCallback_32(void * context, uint8_t status)
+    static void OnFailureCallback_32(void * context, EmberAfStatus status)
     {
-        (static_cast<TestCluster *>(context))->OnFailureResponse_32(status);
+        (static_cast<TestCluster *>(context))->OnFailureResponse_32(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_32(void * context, uint8_t int8u)
@@ -25879,9 +25160,9 @@ private:
 
     static void OnSuccessCallback_33(void * context) { (static_cast<TestCluster *>(context))->OnSuccessResponse_33(); }
 
-    static void OnFailureCallback_34(void * context, uint8_t status)
+    static void OnFailureCallback_34(void * context, EmberAfStatus status)
     {
-        (static_cast<TestCluster *>(context))->OnFailureResponse_34(status);
+        (static_cast<TestCluster *>(context))->OnFailureResponse_34(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_34(void * context, uint8_t int8u)
@@ -25889,9 +25170,9 @@ private:
         (static_cast<TestCluster *>(context))->OnSuccessResponse_34(int8u);
     }
 
-    static void OnFailureCallback_35(void * context, uint8_t status)
+    static void OnFailureCallback_35(void * context, EmberAfStatus status)
     {
-        (static_cast<TestCluster *>(context))->OnFailureResponse_35(status);
+        (static_cast<TestCluster *>(context))->OnFailureResponse_35(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_35(void * context, uint16_t int16u)
@@ -25906,9 +25187,9 @@ private:
 
     static void OnSuccessCallback_36(void * context) { (static_cast<TestCluster *>(context))->OnSuccessResponse_36(); }
 
-    static void OnFailureCallback_37(void * context, uint8_t status)
+    static void OnFailureCallback_37(void * context, EmberAfStatus status)
     {
-        (static_cast<TestCluster *>(context))->OnFailureResponse_37(status);
+        (static_cast<TestCluster *>(context))->OnFailureResponse_37(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_37(void * context, uint16_t int16u)
@@ -25923,9 +25204,9 @@ private:
 
     static void OnSuccessCallback_38(void * context) { (static_cast<TestCluster *>(context))->OnSuccessResponse_38(); }
 
-    static void OnFailureCallback_39(void * context, uint8_t status)
+    static void OnFailureCallback_39(void * context, EmberAfStatus status)
     {
-        (static_cast<TestCluster *>(context))->OnFailureResponse_39(status);
+        (static_cast<TestCluster *>(context))->OnFailureResponse_39(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_39(void * context, uint16_t int16u)
@@ -25933,9 +25214,9 @@ private:
         (static_cast<TestCluster *>(context))->OnSuccessResponse_39(int16u);
     }
 
-    static void OnFailureCallback_40(void * context, uint8_t status)
+    static void OnFailureCallback_40(void * context, EmberAfStatus status)
     {
-        (static_cast<TestCluster *>(context))->OnFailureResponse_40(status);
+        (static_cast<TestCluster *>(context))->OnFailureResponse_40(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_40(void * context, uint32_t int32u)
@@ -25950,9 +25231,9 @@ private:
 
     static void OnSuccessCallback_41(void * context) { (static_cast<TestCluster *>(context))->OnSuccessResponse_41(); }
 
-    static void OnFailureCallback_42(void * context, uint8_t status)
+    static void OnFailureCallback_42(void * context, EmberAfStatus status)
     {
-        (static_cast<TestCluster *>(context))->OnFailureResponse_42(status);
+        (static_cast<TestCluster *>(context))->OnFailureResponse_42(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_42(void * context, uint32_t int32u)
@@ -25967,9 +25248,9 @@ private:
 
     static void OnSuccessCallback_43(void * context) { (static_cast<TestCluster *>(context))->OnSuccessResponse_43(); }
 
-    static void OnFailureCallback_44(void * context, uint8_t status)
+    static void OnFailureCallback_44(void * context, EmberAfStatus status)
     {
-        (static_cast<TestCluster *>(context))->OnFailureResponse_44(status);
+        (static_cast<TestCluster *>(context))->OnFailureResponse_44(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_44(void * context, uint32_t int32u)
@@ -25977,9 +25258,9 @@ private:
         (static_cast<TestCluster *>(context))->OnSuccessResponse_44(int32u);
     }
 
-    static void OnFailureCallback_45(void * context, uint8_t status)
+    static void OnFailureCallback_45(void * context, EmberAfStatus status)
     {
-        (static_cast<TestCluster *>(context))->OnFailureResponse_45(status);
+        (static_cast<TestCluster *>(context))->OnFailureResponse_45(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_45(void * context, uint64_t int64u)
@@ -25994,9 +25275,9 @@ private:
 
     static void OnSuccessCallback_46(void * context) { (static_cast<TestCluster *>(context))->OnSuccessResponse_46(); }
 
-    static void OnFailureCallback_47(void * context, uint8_t status)
+    static void OnFailureCallback_47(void * context, EmberAfStatus status)
     {
-        (static_cast<TestCluster *>(context))->OnFailureResponse_47(status);
+        (static_cast<TestCluster *>(context))->OnFailureResponse_47(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_47(void * context, uint64_t int64u)
@@ -26011,9 +25292,9 @@ private:
 
     static void OnSuccessCallback_48(void * context) { (static_cast<TestCluster *>(context))->OnSuccessResponse_48(); }
 
-    static void OnFailureCallback_49(void * context, uint8_t status)
+    static void OnFailureCallback_49(void * context, EmberAfStatus status)
     {
-        (static_cast<TestCluster *>(context))->OnFailureResponse_49(status);
+        (static_cast<TestCluster *>(context))->OnFailureResponse_49(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_49(void * context, uint64_t int64u)
@@ -26021,9 +25302,9 @@ private:
         (static_cast<TestCluster *>(context))->OnSuccessResponse_49(int64u);
     }
 
-    static void OnFailureCallback_50(void * context, uint8_t status)
+    static void OnFailureCallback_50(void * context, EmberAfStatus status)
     {
-        (static_cast<TestCluster *>(context))->OnFailureResponse_50(status);
+        (static_cast<TestCluster *>(context))->OnFailureResponse_50(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_50(void * context, int8_t int8s)
@@ -26038,9 +25319,9 @@ private:
 
     static void OnSuccessCallback_51(void * context) { (static_cast<TestCluster *>(context))->OnSuccessResponse_51(); }
 
-    static void OnFailureCallback_52(void * context, uint8_t status)
+    static void OnFailureCallback_52(void * context, EmberAfStatus status)
     {
-        (static_cast<TestCluster *>(context))->OnFailureResponse_52(status);
+        (static_cast<TestCluster *>(context))->OnFailureResponse_52(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_52(void * context, int8_t int8s)
@@ -26055,9 +25336,9 @@ private:
 
     static void OnSuccessCallback_53(void * context) { (static_cast<TestCluster *>(context))->OnSuccessResponse_53(); }
 
-    static void OnFailureCallback_54(void * context, uint8_t status)
+    static void OnFailureCallback_54(void * context, EmberAfStatus status)
     {
-        (static_cast<TestCluster *>(context))->OnFailureResponse_54(status);
+        (static_cast<TestCluster *>(context))->OnFailureResponse_54(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_54(void * context, int8_t int8s)
@@ -26072,9 +25353,9 @@ private:
 
     static void OnSuccessCallback_55(void * context) { (static_cast<TestCluster *>(context))->OnSuccessResponse_55(); }
 
-    static void OnFailureCallback_56(void * context, uint8_t status)
+    static void OnFailureCallback_56(void * context, EmberAfStatus status)
     {
-        (static_cast<TestCluster *>(context))->OnFailureResponse_56(status);
+        (static_cast<TestCluster *>(context))->OnFailureResponse_56(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_56(void * context, int8_t int8s)
@@ -26082,9 +25363,9 @@ private:
         (static_cast<TestCluster *>(context))->OnSuccessResponse_56(int8s);
     }
 
-    static void OnFailureCallback_57(void * context, uint8_t status)
+    static void OnFailureCallback_57(void * context, EmberAfStatus status)
     {
-        (static_cast<TestCluster *>(context))->OnFailureResponse_57(status);
+        (static_cast<TestCluster *>(context))->OnFailureResponse_57(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_57(void * context, int16_t int16s)
@@ -26099,9 +25380,9 @@ private:
 
     static void OnSuccessCallback_58(void * context) { (static_cast<TestCluster *>(context))->OnSuccessResponse_58(); }
 
-    static void OnFailureCallback_59(void * context, uint8_t status)
+    static void OnFailureCallback_59(void * context, EmberAfStatus status)
     {
-        (static_cast<TestCluster *>(context))->OnFailureResponse_59(status);
+        (static_cast<TestCluster *>(context))->OnFailureResponse_59(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_59(void * context, int16_t int16s)
@@ -26116,9 +25397,9 @@ private:
 
     static void OnSuccessCallback_60(void * context) { (static_cast<TestCluster *>(context))->OnSuccessResponse_60(); }
 
-    static void OnFailureCallback_61(void * context, uint8_t status)
+    static void OnFailureCallback_61(void * context, EmberAfStatus status)
     {
-        (static_cast<TestCluster *>(context))->OnFailureResponse_61(status);
+        (static_cast<TestCluster *>(context))->OnFailureResponse_61(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_61(void * context, int16_t int16s)
@@ -26133,9 +25414,9 @@ private:
 
     static void OnSuccessCallback_62(void * context) { (static_cast<TestCluster *>(context))->OnSuccessResponse_62(); }
 
-    static void OnFailureCallback_63(void * context, uint8_t status)
+    static void OnFailureCallback_63(void * context, EmberAfStatus status)
     {
-        (static_cast<TestCluster *>(context))->OnFailureResponse_63(status);
+        (static_cast<TestCluster *>(context))->OnFailureResponse_63(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_63(void * context, int16_t int16s)
@@ -26143,9 +25424,9 @@ private:
         (static_cast<TestCluster *>(context))->OnSuccessResponse_63(int16s);
     }
 
-    static void OnFailureCallback_64(void * context, uint8_t status)
+    static void OnFailureCallback_64(void * context, EmberAfStatus status)
     {
-        (static_cast<TestCluster *>(context))->OnFailureResponse_64(status);
+        (static_cast<TestCluster *>(context))->OnFailureResponse_64(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_64(void * context, int32_t int32s)
@@ -26160,9 +25441,9 @@ private:
 
     static void OnSuccessCallback_65(void * context) { (static_cast<TestCluster *>(context))->OnSuccessResponse_65(); }
 
-    static void OnFailureCallback_66(void * context, uint8_t status)
+    static void OnFailureCallback_66(void * context, EmberAfStatus status)
     {
-        (static_cast<TestCluster *>(context))->OnFailureResponse_66(status);
+        (static_cast<TestCluster *>(context))->OnFailureResponse_66(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_66(void * context, int32_t int32s)
@@ -26177,9 +25458,9 @@ private:
 
     static void OnSuccessCallback_67(void * context) { (static_cast<TestCluster *>(context))->OnSuccessResponse_67(); }
 
-    static void OnFailureCallback_68(void * context, uint8_t status)
+    static void OnFailureCallback_68(void * context, EmberAfStatus status)
     {
-        (static_cast<TestCluster *>(context))->OnFailureResponse_68(status);
+        (static_cast<TestCluster *>(context))->OnFailureResponse_68(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_68(void * context, int32_t int32s)
@@ -26194,9 +25475,9 @@ private:
 
     static void OnSuccessCallback_69(void * context) { (static_cast<TestCluster *>(context))->OnSuccessResponse_69(); }
 
-    static void OnFailureCallback_70(void * context, uint8_t status)
+    static void OnFailureCallback_70(void * context, EmberAfStatus status)
     {
-        (static_cast<TestCluster *>(context))->OnFailureResponse_70(status);
+        (static_cast<TestCluster *>(context))->OnFailureResponse_70(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_70(void * context, int32_t int32s)
@@ -26204,9 +25485,9 @@ private:
         (static_cast<TestCluster *>(context))->OnSuccessResponse_70(int32s);
     }
 
-    static void OnFailureCallback_71(void * context, uint8_t status)
+    static void OnFailureCallback_71(void * context, EmberAfStatus status)
     {
-        (static_cast<TestCluster *>(context))->OnFailureResponse_71(status);
+        (static_cast<TestCluster *>(context))->OnFailureResponse_71(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_71(void * context, int64_t int64s)
@@ -26221,9 +25502,9 @@ private:
 
     static void OnSuccessCallback_72(void * context) { (static_cast<TestCluster *>(context))->OnSuccessResponse_72(); }
 
-    static void OnFailureCallback_73(void * context, uint8_t status)
+    static void OnFailureCallback_73(void * context, EmberAfStatus status)
     {
-        (static_cast<TestCluster *>(context))->OnFailureResponse_73(status);
+        (static_cast<TestCluster *>(context))->OnFailureResponse_73(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_73(void * context, int64_t int64s)
@@ -26238,9 +25519,9 @@ private:
 
     static void OnSuccessCallback_74(void * context) { (static_cast<TestCluster *>(context))->OnSuccessResponse_74(); }
 
-    static void OnFailureCallback_75(void * context, uint8_t status)
+    static void OnFailureCallback_75(void * context, EmberAfStatus status)
     {
-        (static_cast<TestCluster *>(context))->OnFailureResponse_75(status);
+        (static_cast<TestCluster *>(context))->OnFailureResponse_75(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_75(void * context, int64_t int64s)
@@ -26255,9 +25536,9 @@ private:
 
     static void OnSuccessCallback_76(void * context) { (static_cast<TestCluster *>(context))->OnSuccessResponse_76(); }
 
-    static void OnFailureCallback_77(void * context, uint8_t status)
+    static void OnFailureCallback_77(void * context, EmberAfStatus status)
     {
-        (static_cast<TestCluster *>(context))->OnFailureResponse_77(status);
+        (static_cast<TestCluster *>(context))->OnFailureResponse_77(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_77(void * context, int64_t int64s)
@@ -26265,9 +25546,9 @@ private:
         (static_cast<TestCluster *>(context))->OnSuccessResponse_77(int64s);
     }
 
-    static void OnFailureCallback_78(void * context, uint8_t status)
+    static void OnFailureCallback_78(void * context, EmberAfStatus status)
     {
-        (static_cast<TestCluster *>(context))->OnFailureResponse_78(status);
+        (static_cast<TestCluster *>(context))->OnFailureResponse_78(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_78(void * context, uint8_t enum8)
@@ -26282,9 +25563,9 @@ private:
 
     static void OnSuccessCallback_79(void * context) { (static_cast<TestCluster *>(context))->OnSuccessResponse_79(); }
 
-    static void OnFailureCallback_80(void * context, uint8_t status)
+    static void OnFailureCallback_80(void * context, EmberAfStatus status)
     {
-        (static_cast<TestCluster *>(context))->OnFailureResponse_80(status);
+        (static_cast<TestCluster *>(context))->OnFailureResponse_80(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_80(void * context, uint8_t enum8)
@@ -26299,9 +25580,9 @@ private:
 
     static void OnSuccessCallback_81(void * context) { (static_cast<TestCluster *>(context))->OnSuccessResponse_81(); }
 
-    static void OnFailureCallback_82(void * context, uint8_t status)
+    static void OnFailureCallback_82(void * context, EmberAfStatus status)
     {
-        (static_cast<TestCluster *>(context))->OnFailureResponse_82(status);
+        (static_cast<TestCluster *>(context))->OnFailureResponse_82(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_82(void * context, uint8_t enum8)
@@ -26309,9 +25590,9 @@ private:
         (static_cast<TestCluster *>(context))->OnSuccessResponse_82(enum8);
     }
 
-    static void OnFailureCallback_83(void * context, uint8_t status)
+    static void OnFailureCallback_83(void * context, EmberAfStatus status)
     {
-        (static_cast<TestCluster *>(context))->OnFailureResponse_83(status);
+        (static_cast<TestCluster *>(context))->OnFailureResponse_83(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_83(void * context, uint16_t enum16)
@@ -26326,9 +25607,9 @@ private:
 
     static void OnSuccessCallback_84(void * context) { (static_cast<TestCluster *>(context))->OnSuccessResponse_84(); }
 
-    static void OnFailureCallback_85(void * context, uint8_t status)
+    static void OnFailureCallback_85(void * context, EmberAfStatus status)
     {
-        (static_cast<TestCluster *>(context))->OnFailureResponse_85(status);
+        (static_cast<TestCluster *>(context))->OnFailureResponse_85(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_85(void * context, uint16_t enum16)
@@ -26343,9 +25624,9 @@ private:
 
     static void OnSuccessCallback_86(void * context) { (static_cast<TestCluster *>(context))->OnSuccessResponse_86(); }
 
-    static void OnFailureCallback_87(void * context, uint8_t status)
+    static void OnFailureCallback_87(void * context, EmberAfStatus status)
     {
-        (static_cast<TestCluster *>(context))->OnFailureResponse_87(status);
+        (static_cast<TestCluster *>(context))->OnFailureResponse_87(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_87(void * context, uint16_t enum16)
@@ -26353,9 +25634,9 @@ private:
         (static_cast<TestCluster *>(context))->OnSuccessResponse_87(enum16);
     }
 
-    static void OnFailureCallback_88(void * context, uint8_t status)
+    static void OnFailureCallback_88(void * context, EmberAfStatus status)
     {
-        (static_cast<TestCluster *>(context))->OnFailureResponse_88(status);
+        (static_cast<TestCluster *>(context))->OnFailureResponse_88(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_88(void * context, chip::ByteSpan octetString)
@@ -26370,9 +25651,9 @@ private:
 
     static void OnSuccessCallback_89(void * context) { (static_cast<TestCluster *>(context))->OnSuccessResponse_89(); }
 
-    static void OnFailureCallback_90(void * context, uint8_t status)
+    static void OnFailureCallback_90(void * context, EmberAfStatus status)
     {
-        (static_cast<TestCluster *>(context))->OnFailureResponse_90(status);
+        (static_cast<TestCluster *>(context))->OnFailureResponse_90(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_90(void * context, chip::ByteSpan octetString)
@@ -26387,9 +25668,9 @@ private:
 
     static void OnSuccessCallback_91(void * context) { (static_cast<TestCluster *>(context))->OnSuccessResponse_91(); }
 
-    static void OnFailureCallback_92(void * context, uint8_t status)
+    static void OnFailureCallback_92(void * context, EmberAfStatus status)
     {
-        (static_cast<TestCluster *>(context))->OnFailureResponse_92(status);
+        (static_cast<TestCluster *>(context))->OnFailureResponse_92(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_92(void * context, chip::ByteSpan octetString)
@@ -26404,9 +25685,9 @@ private:
 
     static void OnSuccessCallback_93(void * context) { (static_cast<TestCluster *>(context))->OnSuccessResponse_93(); }
 
-    static void OnFailureCallback_94(void * context, uint8_t status)
+    static void OnFailureCallback_94(void * context, EmberAfStatus status)
     {
-        (static_cast<TestCluster *>(context))->OnFailureResponse_94(status);
+        (static_cast<TestCluster *>(context))->OnFailureResponse_94(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_94(void * context, chip::ByteSpan longOctetString)
@@ -26421,9 +25702,9 @@ private:
 
     static void OnSuccessCallback_95(void * context) { (static_cast<TestCluster *>(context))->OnSuccessResponse_95(); }
 
-    static void OnFailureCallback_96(void * context, uint8_t status)
+    static void OnFailureCallback_96(void * context, EmberAfStatus status)
     {
-        (static_cast<TestCluster *>(context))->OnFailureResponse_96(status);
+        (static_cast<TestCluster *>(context))->OnFailureResponse_96(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_96(void * context, chip::ByteSpan longOctetString)
@@ -26438,9 +25719,9 @@ private:
 
     static void OnSuccessCallback_97(void * context) { (static_cast<TestCluster *>(context))->OnSuccessResponse_97(); }
 
-    static void OnFailureCallback_98(void * context, uint8_t status)
+    static void OnFailureCallback_98(void * context, EmberAfStatus status)
     {
-        (static_cast<TestCluster *>(context))->OnFailureResponse_98(status);
+        (static_cast<TestCluster *>(context))->OnFailureResponse_98(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_98(void * context, chip::CharSpan charString)
@@ -26469,9 +25750,9 @@ private:
 
     static void OnSuccessCallback_101(void * context) { (static_cast<TestCluster *>(context))->OnSuccessResponse_101(); }
 
-    static void OnFailureCallback_102(void * context, uint8_t status)
+    static void OnFailureCallback_102(void * context, EmberAfStatus status)
     {
-        (static_cast<TestCluster *>(context))->OnFailureResponse_102(status);
+        (static_cast<TestCluster *>(context))->OnFailureResponse_102(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_102(void * context, chip::CharSpan longCharString)
@@ -26486,9 +25767,9 @@ private:
 
     static void OnSuccessCallback_103(void * context) { (static_cast<TestCluster *>(context))->OnSuccessResponse_103(); }
 
-    static void OnFailureCallback_104(void * context, uint8_t status)
+    static void OnFailureCallback_104(void * context, EmberAfStatus status)
     {
-        (static_cast<TestCluster *>(context))->OnFailureResponse_104(status);
+        (static_cast<TestCluster *>(context))->OnFailureResponse_104(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_104(void * context, chip::CharSpan longCharString)
@@ -26503,9 +25784,9 @@ private:
 
     static void OnSuccessCallback_105(void * context) { (static_cast<TestCluster *>(context))->OnSuccessResponse_105(); }
 
-    static void OnFailureCallback_106(void * context, uint8_t status)
+    static void OnFailureCallback_106(void * context, EmberAfStatus status)
     {
-        (static_cast<TestCluster *>(context))->OnFailureResponse_106(status);
+        (static_cast<TestCluster *>(context))->OnFailureResponse_106(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_106(void * context, const chip::app::DataModel::DecodableList<uint8_t> & listInt8u)
@@ -26513,9 +25794,9 @@ private:
         (static_cast<TestCluster *>(context))->OnSuccessResponse_106(listInt8u);
     }
 
-    static void OnFailureCallback_107(void * context, uint8_t status)
+    static void OnFailureCallback_107(void * context, EmberAfStatus status)
     {
-        (static_cast<TestCluster *>(context))->OnFailureResponse_107(status);
+        (static_cast<TestCluster *>(context))->OnFailureResponse_107(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_107(void * context, const chip::app::DataModel::DecodableList<chip::ByteSpan> & listOctetString)
@@ -26523,9 +25804,9 @@ private:
         (static_cast<TestCluster *>(context))->OnSuccessResponse_107(listOctetString);
     }
 
-    static void OnFailureCallback_108(void * context, uint8_t status)
+    static void OnFailureCallback_108(void * context, EmberAfStatus status)
     {
-        (static_cast<TestCluster *>(context))->OnFailureResponse_108(status);
+        (static_cast<TestCluster *>(context))->OnFailureResponse_108(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_108(
@@ -26536,9 +25817,9 @@ private:
         (static_cast<TestCluster *>(context))->OnSuccessResponse_108(listStructOctetString);
     }
 
-    static void OnFailureCallback_109(void * context, uint8_t status)
+    static void OnFailureCallback_109(void * context, EmberAfStatus status)
     {
-        (static_cast<TestCluster *>(context))->OnFailureResponse_109(status);
+        (static_cast<TestCluster *>(context))->OnFailureResponse_109(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_109(void * context, uint64_t epochUs)
@@ -26553,9 +25834,9 @@ private:
 
     static void OnSuccessCallback_110(void * context) { (static_cast<TestCluster *>(context))->OnSuccessResponse_110(); }
 
-    static void OnFailureCallback_111(void * context, uint8_t status)
+    static void OnFailureCallback_111(void * context, EmberAfStatus status)
     {
-        (static_cast<TestCluster *>(context))->OnFailureResponse_111(status);
+        (static_cast<TestCluster *>(context))->OnFailureResponse_111(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_111(void * context, uint64_t epochUs)
@@ -26570,9 +25851,9 @@ private:
 
     static void OnSuccessCallback_112(void * context) { (static_cast<TestCluster *>(context))->OnSuccessResponse_112(); }
 
-    static void OnFailureCallback_113(void * context, uint8_t status)
+    static void OnFailureCallback_113(void * context, EmberAfStatus status)
     {
-        (static_cast<TestCluster *>(context))->OnFailureResponse_113(status);
+        (static_cast<TestCluster *>(context))->OnFailureResponse_113(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_113(void * context, uint64_t epochUs)
@@ -26580,9 +25861,9 @@ private:
         (static_cast<TestCluster *>(context))->OnSuccessResponse_113(epochUs);
     }
 
-    static void OnFailureCallback_114(void * context, uint8_t status)
+    static void OnFailureCallback_114(void * context, EmberAfStatus status)
     {
-        (static_cast<TestCluster *>(context))->OnFailureResponse_114(status);
+        (static_cast<TestCluster *>(context))->OnFailureResponse_114(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_114(void * context, uint32_t epochS)
@@ -26597,9 +25878,9 @@ private:
 
     static void OnSuccessCallback_115(void * context) { (static_cast<TestCluster *>(context))->OnSuccessResponse_115(); }
 
-    static void OnFailureCallback_116(void * context, uint8_t status)
+    static void OnFailureCallback_116(void * context, EmberAfStatus status)
     {
-        (static_cast<TestCluster *>(context))->OnFailureResponse_116(status);
+        (static_cast<TestCluster *>(context))->OnFailureResponse_116(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_116(void * context, uint32_t epochS)
@@ -26614,9 +25895,9 @@ private:
 
     static void OnSuccessCallback_117(void * context) { (static_cast<TestCluster *>(context))->OnSuccessResponse_117(); }
 
-    static void OnFailureCallback_118(void * context, uint8_t status)
+    static void OnFailureCallback_118(void * context, EmberAfStatus status)
     {
-        (static_cast<TestCluster *>(context))->OnFailureResponse_118(status);
+        (static_cast<TestCluster *>(context))->OnFailureResponse_118(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_118(void * context, uint32_t epochS)
@@ -26624,9 +25905,9 @@ private:
         (static_cast<TestCluster *>(context))->OnSuccessResponse_118(epochS);
     }
 
-    static void OnFailureCallback_119(void * context, uint8_t status)
+    static void OnFailureCallback_119(void * context, EmberAfStatus status)
     {
-        (static_cast<TestCluster *>(context))->OnFailureResponse_119(status);
+        (static_cast<TestCluster *>(context))->OnFailureResponse_119(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_119(void * context, bool unsupported)
@@ -26641,9 +25922,9 @@ private:
 
     static void OnSuccessCallback_120(void * context) { (static_cast<TestCluster *>(context))->OnSuccessResponse_120(); }
 
-    static void OnFailureCallback_122(void * context, uint8_t status)
+    static void OnFailureCallback_122(void * context, EmberAfStatus status)
     {
-        (static_cast<TestCluster *>(context))->OnFailureResponse_122(status);
+        (static_cast<TestCluster *>(context))->OnFailureResponse_122(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_122(void * context, chip::VendorId vendorId)
@@ -26658,9 +25939,9 @@ private:
 
     static void OnSuccessCallback_123(void * context) { (static_cast<TestCluster *>(context))->OnSuccessResponse_123(); }
 
-    static void OnFailureCallback_124(void * context, uint8_t status)
+    static void OnFailureCallback_124(void * context, EmberAfStatus status)
     {
-        (static_cast<TestCluster *>(context))->OnFailureResponse_124(status);
+        (static_cast<TestCluster *>(context))->OnFailureResponse_124(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_124(void * context, chip::VendorId vendorId)
@@ -26816,7 +26097,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeBoolean(mOnSuccessCallback_5.Cancel(), mOnFailureCallback_5.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Boolean::TypeInfo>(this, OnSuccessCallback_5,
+                                                                                                      OnFailureCallback_5);
     }
 
     void OnFailureResponse_5(uint8_t status) { ThrowFailureResponse(); }
@@ -26848,7 +26130,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeBoolean(mOnSuccessCallback_7.Cancel(), mOnFailureCallback_7.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Boolean::TypeInfo>(this, OnSuccessCallback_7,
+                                                                                                      OnFailureCallback_7);
     }
 
     void OnFailureResponse_7(uint8_t status) { ThrowFailureResponse(); }
@@ -26880,7 +26163,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeBoolean(mOnSuccessCallback_9.Cancel(), mOnFailureCallback_9.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Boolean::TypeInfo>(this, OnSuccessCallback_9,
+                                                                                                      OnFailureCallback_9);
     }
 
     void OnFailureResponse_9(uint8_t status) { ThrowFailureResponse(); }
@@ -26896,7 +26180,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeBitmap8(mOnSuccessCallback_10.Cancel(), mOnFailureCallback_10.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Bitmap8::TypeInfo>(this, OnSuccessCallback_10,
+                                                                                                      OnFailureCallback_10);
     }
 
     void OnFailureResponse_10(uint8_t status) { ThrowFailureResponse(); }
@@ -26928,7 +26213,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeBitmap8(mOnSuccessCallback_12.Cancel(), mOnFailureCallback_12.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Bitmap8::TypeInfo>(this, OnSuccessCallback_12,
+                                                                                                      OnFailureCallback_12);
     }
 
     void OnFailureResponse_12(uint8_t status) { ThrowFailureResponse(); }
@@ -26960,7 +26246,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeBitmap8(mOnSuccessCallback_14.Cancel(), mOnFailureCallback_14.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Bitmap8::TypeInfo>(this, OnSuccessCallback_14,
+                                                                                                      OnFailureCallback_14);
     }
 
     void OnFailureResponse_14(uint8_t status) { ThrowFailureResponse(); }
@@ -26976,7 +26263,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeBitmap16(mOnSuccessCallback_15.Cancel(), mOnFailureCallback_15.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Bitmap16::TypeInfo>(this, OnSuccessCallback_15,
+                                                                                                       OnFailureCallback_15);
     }
 
     void OnFailureResponse_15(uint8_t status) { ThrowFailureResponse(); }
@@ -27008,7 +26296,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeBitmap16(mOnSuccessCallback_17.Cancel(), mOnFailureCallback_17.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Bitmap16::TypeInfo>(this, OnSuccessCallback_17,
+                                                                                                       OnFailureCallback_17);
     }
 
     void OnFailureResponse_17(uint8_t status) { ThrowFailureResponse(); }
@@ -27040,7 +26329,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeBitmap16(mOnSuccessCallback_19.Cancel(), mOnFailureCallback_19.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Bitmap16::TypeInfo>(this, OnSuccessCallback_19,
+                                                                                                       OnFailureCallback_19);
     }
 
     void OnFailureResponse_19(uint8_t status) { ThrowFailureResponse(); }
@@ -27056,7 +26346,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeBitmap32(mOnSuccessCallback_20.Cancel(), mOnFailureCallback_20.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Bitmap32::TypeInfo>(this, OnSuccessCallback_20,
+                                                                                                       OnFailureCallback_20);
     }
 
     void OnFailureResponse_20(uint8_t status) { ThrowFailureResponse(); }
@@ -27088,7 +26379,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeBitmap32(mOnSuccessCallback_22.Cancel(), mOnFailureCallback_22.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Bitmap32::TypeInfo>(this, OnSuccessCallback_22,
+                                                                                                       OnFailureCallback_22);
     }
 
     void OnFailureResponse_22(uint8_t status) { ThrowFailureResponse(); }
@@ -27120,7 +26412,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeBitmap32(mOnSuccessCallback_24.Cancel(), mOnFailureCallback_24.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Bitmap32::TypeInfo>(this, OnSuccessCallback_24,
+                                                                                                       OnFailureCallback_24);
     }
 
     void OnFailureResponse_24(uint8_t status) { ThrowFailureResponse(); }
@@ -27136,7 +26429,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeBitmap64(mOnSuccessCallback_25.Cancel(), mOnFailureCallback_25.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Bitmap64::TypeInfo>(this, OnSuccessCallback_25,
+                                                                                                       OnFailureCallback_25);
     }
 
     void OnFailureResponse_25(uint8_t status) { ThrowFailureResponse(); }
@@ -27168,7 +26462,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeBitmap64(mOnSuccessCallback_27.Cancel(), mOnFailureCallback_27.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Bitmap64::TypeInfo>(this, OnSuccessCallback_27,
+                                                                                                       OnFailureCallback_27);
     }
 
     void OnFailureResponse_27(uint8_t status) { ThrowFailureResponse(); }
@@ -27200,7 +26495,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeBitmap64(mOnSuccessCallback_29.Cancel(), mOnFailureCallback_29.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Bitmap64::TypeInfo>(this, OnSuccessCallback_29,
+                                                                                                       OnFailureCallback_29);
     }
 
     void OnFailureResponse_29(uint8_t status) { ThrowFailureResponse(); }
@@ -27216,7 +26512,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeInt8u(mOnSuccessCallback_30.Cancel(), mOnFailureCallback_30.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int8u::TypeInfo>(this, OnSuccessCallback_30,
+                                                                                                    OnFailureCallback_30);
     }
 
     void OnFailureResponse_30(uint8_t status) { ThrowFailureResponse(); }
@@ -27248,7 +26545,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeInt8u(mOnSuccessCallback_32.Cancel(), mOnFailureCallback_32.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int8u::TypeInfo>(this, OnSuccessCallback_32,
+                                                                                                    OnFailureCallback_32);
     }
 
     void OnFailureResponse_32(uint8_t status) { ThrowFailureResponse(); }
@@ -27280,7 +26578,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeInt8u(mOnSuccessCallback_34.Cancel(), mOnFailureCallback_34.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int8u::TypeInfo>(this, OnSuccessCallback_34,
+                                                                                                    OnFailureCallback_34);
     }
 
     void OnFailureResponse_34(uint8_t status) { ThrowFailureResponse(); }
@@ -27296,7 +26595,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeInt16u(mOnSuccessCallback_35.Cancel(), mOnFailureCallback_35.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int16u::TypeInfo>(this, OnSuccessCallback_35,
+                                                                                                     OnFailureCallback_35);
     }
 
     void OnFailureResponse_35(uint8_t status) { ThrowFailureResponse(); }
@@ -27328,7 +26628,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeInt16u(mOnSuccessCallback_37.Cancel(), mOnFailureCallback_37.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int16u::TypeInfo>(this, OnSuccessCallback_37,
+                                                                                                     OnFailureCallback_37);
     }
 
     void OnFailureResponse_37(uint8_t status) { ThrowFailureResponse(); }
@@ -27360,7 +26661,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeInt16u(mOnSuccessCallback_39.Cancel(), mOnFailureCallback_39.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int16u::TypeInfo>(this, OnSuccessCallback_39,
+                                                                                                     OnFailureCallback_39);
     }
 
     void OnFailureResponse_39(uint8_t status) { ThrowFailureResponse(); }
@@ -27376,7 +26678,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeInt32u(mOnSuccessCallback_40.Cancel(), mOnFailureCallback_40.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int32u::TypeInfo>(this, OnSuccessCallback_40,
+                                                                                                     OnFailureCallback_40);
     }
 
     void OnFailureResponse_40(uint8_t status) { ThrowFailureResponse(); }
@@ -27408,7 +26711,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeInt32u(mOnSuccessCallback_42.Cancel(), mOnFailureCallback_42.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int32u::TypeInfo>(this, OnSuccessCallback_42,
+                                                                                                     OnFailureCallback_42);
     }
 
     void OnFailureResponse_42(uint8_t status) { ThrowFailureResponse(); }
@@ -27440,7 +26744,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeInt32u(mOnSuccessCallback_44.Cancel(), mOnFailureCallback_44.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int32u::TypeInfo>(this, OnSuccessCallback_44,
+                                                                                                     OnFailureCallback_44);
     }
 
     void OnFailureResponse_44(uint8_t status) { ThrowFailureResponse(); }
@@ -27456,7 +26761,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeInt64u(mOnSuccessCallback_45.Cancel(), mOnFailureCallback_45.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int64u::TypeInfo>(this, OnSuccessCallback_45,
+                                                                                                     OnFailureCallback_45);
     }
 
     void OnFailureResponse_45(uint8_t status) { ThrowFailureResponse(); }
@@ -27488,7 +26794,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeInt64u(mOnSuccessCallback_47.Cancel(), mOnFailureCallback_47.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int64u::TypeInfo>(this, OnSuccessCallback_47,
+                                                                                                     OnFailureCallback_47);
     }
 
     void OnFailureResponse_47(uint8_t status) { ThrowFailureResponse(); }
@@ -27520,7 +26827,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeInt64u(mOnSuccessCallback_49.Cancel(), mOnFailureCallback_49.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int64u::TypeInfo>(this, OnSuccessCallback_49,
+                                                                                                     OnFailureCallback_49);
     }
 
     void OnFailureResponse_49(uint8_t status) { ThrowFailureResponse(); }
@@ -27536,7 +26844,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeInt8s(mOnSuccessCallback_50.Cancel(), mOnFailureCallback_50.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int8s::TypeInfo>(this, OnSuccessCallback_50,
+                                                                                                    OnFailureCallback_50);
     }
 
     void OnFailureResponse_50(uint8_t status) { ThrowFailureResponse(); }
@@ -27568,7 +26877,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeInt8s(mOnSuccessCallback_52.Cancel(), mOnFailureCallback_52.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int8s::TypeInfo>(this, OnSuccessCallback_52,
+                                                                                                    OnFailureCallback_52);
     }
 
     void OnFailureResponse_52(uint8_t status) { ThrowFailureResponse(); }
@@ -27600,7 +26910,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeInt8s(mOnSuccessCallback_54.Cancel(), mOnFailureCallback_54.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int8s::TypeInfo>(this, OnSuccessCallback_54,
+                                                                                                    OnFailureCallback_54);
     }
 
     void OnFailureResponse_54(uint8_t status) { ThrowFailureResponse(); }
@@ -27632,7 +26943,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeInt8s(mOnSuccessCallback_56.Cancel(), mOnFailureCallback_56.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int8s::TypeInfo>(this, OnSuccessCallback_56,
+                                                                                                    OnFailureCallback_56);
     }
 
     void OnFailureResponse_56(uint8_t status) { ThrowFailureResponse(); }
@@ -27648,7 +26960,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeInt16s(mOnSuccessCallback_57.Cancel(), mOnFailureCallback_57.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int16s::TypeInfo>(this, OnSuccessCallback_57,
+                                                                                                     OnFailureCallback_57);
     }
 
     void OnFailureResponse_57(uint8_t status) { ThrowFailureResponse(); }
@@ -27680,7 +26993,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeInt16s(mOnSuccessCallback_59.Cancel(), mOnFailureCallback_59.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int16s::TypeInfo>(this, OnSuccessCallback_59,
+                                                                                                     OnFailureCallback_59);
     }
 
     void OnFailureResponse_59(uint8_t status) { ThrowFailureResponse(); }
@@ -27712,7 +27026,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeInt16s(mOnSuccessCallback_61.Cancel(), mOnFailureCallback_61.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int16s::TypeInfo>(this, OnSuccessCallback_61,
+                                                                                                     OnFailureCallback_61);
     }
 
     void OnFailureResponse_61(uint8_t status) { ThrowFailureResponse(); }
@@ -27744,7 +27059,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeInt16s(mOnSuccessCallback_63.Cancel(), mOnFailureCallback_63.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int16s::TypeInfo>(this, OnSuccessCallback_63,
+                                                                                                     OnFailureCallback_63);
     }
 
     void OnFailureResponse_63(uint8_t status) { ThrowFailureResponse(); }
@@ -27760,7 +27076,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeInt32s(mOnSuccessCallback_64.Cancel(), mOnFailureCallback_64.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int32s::TypeInfo>(this, OnSuccessCallback_64,
+                                                                                                     OnFailureCallback_64);
     }
 
     void OnFailureResponse_64(uint8_t status) { ThrowFailureResponse(); }
@@ -27792,7 +27109,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeInt32s(mOnSuccessCallback_66.Cancel(), mOnFailureCallback_66.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int32s::TypeInfo>(this, OnSuccessCallback_66,
+                                                                                                     OnFailureCallback_66);
     }
 
     void OnFailureResponse_66(uint8_t status) { ThrowFailureResponse(); }
@@ -27824,7 +27142,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeInt32s(mOnSuccessCallback_68.Cancel(), mOnFailureCallback_68.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int32s::TypeInfo>(this, OnSuccessCallback_68,
+                                                                                                     OnFailureCallback_68);
     }
 
     void OnFailureResponse_68(uint8_t status) { ThrowFailureResponse(); }
@@ -27856,7 +27175,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeInt32s(mOnSuccessCallback_70.Cancel(), mOnFailureCallback_70.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int32s::TypeInfo>(this, OnSuccessCallback_70,
+                                                                                                     OnFailureCallback_70);
     }
 
     void OnFailureResponse_70(uint8_t status) { ThrowFailureResponse(); }
@@ -27872,7 +27192,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeInt64s(mOnSuccessCallback_71.Cancel(), mOnFailureCallback_71.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int64s::TypeInfo>(this, OnSuccessCallback_71,
+                                                                                                     OnFailureCallback_71);
     }
 
     void OnFailureResponse_71(uint8_t status) { ThrowFailureResponse(); }
@@ -27904,7 +27225,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeInt64s(mOnSuccessCallback_73.Cancel(), mOnFailureCallback_73.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int64s::TypeInfo>(this, OnSuccessCallback_73,
+                                                                                                     OnFailureCallback_73);
     }
 
     void OnFailureResponse_73(uint8_t status) { ThrowFailureResponse(); }
@@ -27936,7 +27258,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeInt64s(mOnSuccessCallback_75.Cancel(), mOnFailureCallback_75.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int64s::TypeInfo>(this, OnSuccessCallback_75,
+                                                                                                     OnFailureCallback_75);
     }
 
     void OnFailureResponse_75(uint8_t status) { ThrowFailureResponse(); }
@@ -27968,7 +27291,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeInt64s(mOnSuccessCallback_77.Cancel(), mOnFailureCallback_77.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int64s::TypeInfo>(this, OnSuccessCallback_77,
+                                                                                                     OnFailureCallback_77);
     }
 
     void OnFailureResponse_77(uint8_t status) { ThrowFailureResponse(); }
@@ -27984,7 +27308,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeEnum8(mOnSuccessCallback_78.Cancel(), mOnFailureCallback_78.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Enum8::TypeInfo>(this, OnSuccessCallback_78,
+                                                                                                    OnFailureCallback_78);
     }
 
     void OnFailureResponse_78(uint8_t status) { ThrowFailureResponse(); }
@@ -28016,7 +27341,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeEnum8(mOnSuccessCallback_80.Cancel(), mOnFailureCallback_80.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Enum8::TypeInfo>(this, OnSuccessCallback_80,
+                                                                                                    OnFailureCallback_80);
     }
 
     void OnFailureResponse_80(uint8_t status) { ThrowFailureResponse(); }
@@ -28048,7 +27374,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeEnum8(mOnSuccessCallback_82.Cancel(), mOnFailureCallback_82.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Enum8::TypeInfo>(this, OnSuccessCallback_82,
+                                                                                                    OnFailureCallback_82);
     }
 
     void OnFailureResponse_82(uint8_t status) { ThrowFailureResponse(); }
@@ -28064,7 +27391,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeEnum16(mOnSuccessCallback_83.Cancel(), mOnFailureCallback_83.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Enum16::TypeInfo>(this, OnSuccessCallback_83,
+                                                                                                     OnFailureCallback_83);
     }
 
     void OnFailureResponse_83(uint8_t status) { ThrowFailureResponse(); }
@@ -28096,7 +27424,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeEnum16(mOnSuccessCallback_85.Cancel(), mOnFailureCallback_85.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Enum16::TypeInfo>(this, OnSuccessCallback_85,
+                                                                                                     OnFailureCallback_85);
     }
 
     void OnFailureResponse_85(uint8_t status) { ThrowFailureResponse(); }
@@ -28128,7 +27457,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeEnum16(mOnSuccessCallback_87.Cancel(), mOnFailureCallback_87.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Enum16::TypeInfo>(this, OnSuccessCallback_87,
+                                                                                                     OnFailureCallback_87);
     }
 
     void OnFailureResponse_87(uint8_t status) { ThrowFailureResponse(); }
@@ -28144,7 +27474,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOctetString(mOnSuccessCallback_88.Cancel(), mOnFailureCallback_88.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::OctetString::TypeInfo>(
+            this, OnSuccessCallback_88, OnFailureCallback_88);
     }
 
     void OnFailureResponse_88(uint8_t status) { ThrowFailureResponse(); }
@@ -28176,7 +27507,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOctetString(mOnSuccessCallback_90.Cancel(), mOnFailureCallback_90.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::OctetString::TypeInfo>(
+            this, OnSuccessCallback_90, OnFailureCallback_90);
     }
 
     void OnFailureResponse_90(uint8_t status) { ThrowFailureResponse(); }
@@ -28209,7 +27541,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOctetString(mOnSuccessCallback_92.Cancel(), mOnFailureCallback_92.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::OctetString::TypeInfo>(
+            this, OnSuccessCallback_92, OnFailureCallback_92);
     }
 
     void OnFailureResponse_92(uint8_t status) { ThrowFailureResponse(); }
@@ -28241,7 +27574,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeLongOctetString(mOnSuccessCallback_94.Cancel(), mOnFailureCallback_94.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::LongOctetString::TypeInfo>(
+            this, OnSuccessCallback_94, OnFailureCallback_94);
     }
 
     void OnFailureResponse_94(uint8_t status) { ThrowFailureResponse(); }
@@ -28280,7 +27614,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeLongOctetString(mOnSuccessCallback_96.Cancel(), mOnFailureCallback_96.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::LongOctetString::TypeInfo>(
+            this, OnSuccessCallback_96, OnFailureCallback_96);
     }
 
     void OnFailureResponse_96(uint8_t status) { ThrowFailureResponse(); }
@@ -28316,7 +27651,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeCharString(mOnSuccessCallback_98.Cancel(), mOnFailureCallback_98.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::CharString::TypeInfo>(this, OnSuccessCallback_98,
+                                                                                                         OnFailureCallback_98);
     }
 
     void OnFailureResponse_98(uint8_t status) { ThrowFailureResponse(); }
@@ -28380,7 +27716,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeLongCharString(mOnSuccessCallback_102.Cancel(), mOnFailureCallback_102.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::LongCharString::TypeInfo>(
+            this, OnSuccessCallback_102, OnFailureCallback_102);
     }
 
     void OnFailureResponse_102(uint8_t status) { ThrowFailureResponse(); }
@@ -28418,7 +27755,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeLongCharString(mOnSuccessCallback_104.Cancel(), mOnFailureCallback_104.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::LongCharString::TypeInfo>(
+            this, OnSuccessCallback_104, OnFailureCallback_104);
     }
 
     void OnFailureResponse_104(uint8_t status) { ThrowFailureResponse(); }
@@ -28454,7 +27792,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeListInt8u(mOnSuccessCallback_106.Cancel(), mOnFailureCallback_106.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::ListInt8u::TypeInfo>(this, OnSuccessCallback_106,
+                                                                                                        OnFailureCallback_106);
     }
 
     void OnFailureResponse_106(uint8_t status) { ThrowFailureResponse(); }
@@ -28479,7 +27818,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeListOctetString(mOnSuccessCallback_107.Cancel(), mOnFailureCallback_107.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::ListOctetString::TypeInfo>(
+            this, OnSuccessCallback_107, OnFailureCallback_107);
     }
 
     void OnFailureResponse_107(uint8_t status) { ThrowFailureResponse(); }
@@ -28504,7 +27844,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeListStructOctetString(mOnSuccessCallback_108.Cancel(), mOnFailureCallback_108.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::ListStructOctetString::TypeInfo>(
+            this, OnSuccessCallback_108, OnFailureCallback_108);
     }
 
     void OnFailureResponse_108(uint8_t status) { ThrowFailureResponse(); }
@@ -28535,7 +27876,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeEpochUs(mOnSuccessCallback_109.Cancel(), mOnFailureCallback_109.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::EpochUs::TypeInfo>(this, OnSuccessCallback_109,
+                                                                                                      OnFailureCallback_109);
     }
 
     void OnFailureResponse_109(uint8_t status) { ThrowFailureResponse(); }
@@ -28567,7 +27909,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeEpochUs(mOnSuccessCallback_111.Cancel(), mOnFailureCallback_111.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::EpochUs::TypeInfo>(this, OnSuccessCallback_111,
+                                                                                                      OnFailureCallback_111);
     }
 
     void OnFailureResponse_111(uint8_t status) { ThrowFailureResponse(); }
@@ -28599,7 +27942,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeEpochUs(mOnSuccessCallback_113.Cancel(), mOnFailureCallback_113.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::EpochUs::TypeInfo>(this, OnSuccessCallback_113,
+                                                                                                      OnFailureCallback_113);
     }
 
     void OnFailureResponse_113(uint8_t status) { ThrowFailureResponse(); }
@@ -28615,7 +27959,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeEpochS(mOnSuccessCallback_114.Cancel(), mOnFailureCallback_114.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::EpochS::TypeInfo>(this, OnSuccessCallback_114,
+                                                                                                     OnFailureCallback_114);
     }
 
     void OnFailureResponse_114(uint8_t status) { ThrowFailureResponse(); }
@@ -28647,7 +27992,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeEpochS(mOnSuccessCallback_116.Cancel(), mOnFailureCallback_116.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::EpochS::TypeInfo>(this, OnSuccessCallback_116,
+                                                                                                     OnFailureCallback_116);
     }
 
     void OnFailureResponse_116(uint8_t status) { ThrowFailureResponse(); }
@@ -28679,7 +28025,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeEpochS(mOnSuccessCallback_118.Cancel(), mOnFailureCallback_118.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::EpochS::TypeInfo>(this, OnSuccessCallback_118,
+                                                                                                     OnFailureCallback_118);
     }
 
     void OnFailureResponse_118(uint8_t status) { ThrowFailureResponse(); }
@@ -28695,7 +28042,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeUnsupported(mOnSuccessCallback_119.Cancel(), mOnFailureCallback_119.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Unsupported::TypeInfo>(
+            this, OnSuccessCallback_119, OnFailureCallback_119);
     }
 
     void OnFailureResponse_119(uint8_t status)
@@ -28757,7 +28105,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeVendorId(mOnSuccessCallback_122.Cancel(), mOnFailureCallback_122.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::VendorId::TypeInfo>(this, OnSuccessCallback_122,
+                                                                                                       OnFailureCallback_122);
     }
 
     void OnFailureResponse_122(uint8_t status) { ThrowFailureResponse(); }
@@ -28789,7 +28138,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeVendorId(mOnSuccessCallback_124.Cancel(), mOnFailureCallback_124.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::VendorId::TypeInfo>(this, OnSuccessCallback_124,
+                                                                                                       OnFailureCallback_124);
     }
 
     void OnFailureResponse_124(uint8_t status) { ThrowFailureResponse(); }
@@ -29446,13 +28796,6 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 4;
 
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_1{ OnFailureCallback_1, this };
-    chip::Callback::Callback<void (*)(void * context, uint32_t int32u)> mOnSuccessCallback_1{ OnSuccessCallback_1, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_2{ OnFailureCallback_2, this };
-    chip::Callback::Callback<void (*)(void * context, uint32_t int32u)> mOnSuccessCallback_2{ OnSuccessCallback_2, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_3{ OnFailureCallback_3, this };
-    chip::Callback::Callback<void (*)(void * context, uint32_t int32u)> mOnSuccessCallback_3{ OnSuccessCallback_3, this };
-
     static void OnFailureCallback_0(void * context, EmberAfStatus status)
     {
         (static_cast<TestConstraints *>(context))->OnFailureResponse_0(chip::to_underlying(status));
@@ -29460,9 +28803,9 @@ private:
 
     static void OnSuccessCallback_0(void * context) { (static_cast<TestConstraints *>(context))->OnSuccessResponse_0(); }
 
-    static void OnFailureCallback_1(void * context, uint8_t status)
+    static void OnFailureCallback_1(void * context, EmberAfStatus status)
     {
-        (static_cast<TestConstraints *>(context))->OnFailureResponse_1(status);
+        (static_cast<TestConstraints *>(context))->OnFailureResponse_1(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_1(void * context, uint32_t int32u)
@@ -29470,9 +28813,9 @@ private:
         (static_cast<TestConstraints *>(context))->OnSuccessResponse_1(int32u);
     }
 
-    static void OnFailureCallback_2(void * context, uint8_t status)
+    static void OnFailureCallback_2(void * context, EmberAfStatus status)
     {
-        (static_cast<TestConstraints *>(context))->OnFailureResponse_2(status);
+        (static_cast<TestConstraints *>(context))->OnFailureResponse_2(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_2(void * context, uint32_t int32u)
@@ -29480,9 +28823,9 @@ private:
         (static_cast<TestConstraints *>(context))->OnSuccessResponse_2(int32u);
     }
 
-    static void OnFailureCallback_3(void * context, uint8_t status)
+    static void OnFailureCallback_3(void * context, EmberAfStatus status)
     {
-        (static_cast<TestConstraints *>(context))->OnFailureResponse_3(status);
+        (static_cast<TestConstraints *>(context))->OnFailureResponse_3(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_3(void * context, uint32_t int32u)
@@ -29515,7 +28858,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeInt32u(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int32u::TypeInfo>(this, OnSuccessCallback_1,
+                                                                                                     OnFailureCallback_1);
     }
 
     void OnFailureResponse_1(uint8_t status) { ThrowFailureResponse(); }
@@ -29531,7 +28875,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeInt32u(mOnSuccessCallback_2.Cancel(), mOnFailureCallback_2.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int32u::TypeInfo>(this, OnSuccessCallback_2,
+                                                                                                     OnFailureCallback_2);
     }
 
     void OnFailureResponse_2(uint8_t status) { ThrowFailureResponse(); }
@@ -29547,7 +28892,8 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeInt32u(mOnSuccessCallback_3.Cancel(), mOnFailureCallback_3.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int32u::TypeInfo>(this, OnSuccessCallback_3,
+                                                                                                     OnFailureCallback_3);
     }
 
     void OnFailureResponse_3(uint8_t status) { ThrowFailureResponse(); }
@@ -29726,24 +29072,9 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 4;
 
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_0{ OnFailureCallback_0, this };
-    chip::Callback::Callback<void (*)(void * context,
-                                      const chip::app::DataModel::DecodableList<
-                                          chip::app::Clusters::Descriptor::Structs::DeviceType::DecodableType> & deviceList)>
-        mOnSuccessCallback_0{ OnSuccessCallback_0, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_1{ OnFailureCallback_1, this };
-    chip::Callback::Callback<void (*)(void * context, const chip::app::DataModel::DecodableList<chip::ClusterId> & serverList)>
-        mOnSuccessCallback_1{ OnSuccessCallback_1, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_2{ OnFailureCallback_2, this };
-    chip::Callback::Callback<void (*)(void * context, const chip::app::DataModel::DecodableList<chip::ClusterId> & clientList)>
-        mOnSuccessCallback_2{ OnSuccessCallback_2, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_3{ OnFailureCallback_3, this };
-    chip::Callback::Callback<void (*)(void * context, const chip::app::DataModel::DecodableList<chip::EndpointId> & partsList)>
-        mOnSuccessCallback_3{ OnSuccessCallback_3, this };
-
-    static void OnFailureCallback_0(void * context, uint8_t status)
+    static void OnFailureCallback_0(void * context, EmberAfStatus status)
     {
-        (static_cast<TestDescriptorCluster *>(context))->OnFailureResponse_0(status);
+        (static_cast<TestDescriptorCluster *>(context))->OnFailureResponse_0(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_0(
@@ -29753,9 +29084,9 @@ private:
         (static_cast<TestDescriptorCluster *>(context))->OnSuccessResponse_0(deviceList);
     }
 
-    static void OnFailureCallback_1(void * context, uint8_t status)
+    static void OnFailureCallback_1(void * context, EmberAfStatus status)
     {
-        (static_cast<TestDescriptorCluster *>(context))->OnFailureResponse_1(status);
+        (static_cast<TestDescriptorCluster *>(context))->OnFailureResponse_1(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_1(void * context, const chip::app::DataModel::DecodableList<chip::ClusterId> & serverList)
@@ -29763,9 +29094,9 @@ private:
         (static_cast<TestDescriptorCluster *>(context))->OnSuccessResponse_1(serverList);
     }
 
-    static void OnFailureCallback_2(void * context, uint8_t status)
+    static void OnFailureCallback_2(void * context, EmberAfStatus status)
     {
-        (static_cast<TestDescriptorCluster *>(context))->OnFailureResponse_2(status);
+        (static_cast<TestDescriptorCluster *>(context))->OnFailureResponse_2(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_2(void * context, const chip::app::DataModel::DecodableList<chip::ClusterId> & clientList)
@@ -29773,9 +29104,9 @@ private:
         (static_cast<TestDescriptorCluster *>(context))->OnSuccessResponse_2(clientList);
     }
 
-    static void OnFailureCallback_3(void * context, uint8_t status)
+    static void OnFailureCallback_3(void * context, EmberAfStatus status)
     {
-        (static_cast<TestDescriptorCluster *>(context))->OnFailureResponse_3(status);
+        (static_cast<TestDescriptorCluster *>(context))->OnFailureResponse_3(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_3(void * context, const chip::app::DataModel::DecodableList<chip::EndpointId> & partsList)
@@ -29792,7 +29123,8 @@ private:
         chip::Controller::DescriptorClusterTest cluster;
         cluster.Associate(mDevice, 0);
 
-        return cluster.ReadAttributeDeviceList(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::Descriptor::Attributes::DeviceList::TypeInfo>(this, OnSuccessCallback_0,
+                                                                                                        OnFailureCallback_0);
     }
 
     void OnFailureResponse_0(uint8_t status) { ThrowFailureResponse(); }
@@ -29802,6 +29134,7 @@ private:
     {
         auto iter = deviceList.begin();
         VerifyOrReturn(CheckNextListItemDecodes<decltype(deviceList)>("deviceList", iter, 0));
+        VerifyOrReturn(CheckValue<>("deviceList[0].type", iter.GetValue().type, 0UL));
         VerifyOrReturn(CheckValue<>("deviceList[0].revision", iter.GetValue().revision, 1U));
         VerifyOrReturn(CheckNoMoreListItems<decltype(deviceList)>("deviceList", iter, 1));
         NextTest();
@@ -29812,7 +29145,8 @@ private:
         chip::Controller::DescriptorClusterTest cluster;
         cluster.Associate(mDevice, 0);
 
-        return cluster.ReadAttributeServerList(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::Descriptor::Attributes::ServerList::TypeInfo>(this, OnSuccessCallback_1,
+                                                                                                        OnFailureCallback_1);
     }
 
     void OnFailureResponse_1(uint8_t status) { ThrowFailureResponse(); }
@@ -29865,7 +29199,8 @@ private:
         chip::Controller::DescriptorClusterTest cluster;
         cluster.Associate(mDevice, 0);
 
-        return cluster.ReadAttributeClientList(mOnSuccessCallback_2.Cancel(), mOnFailureCallback_2.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::Descriptor::Attributes::ClientList::TypeInfo>(this, OnSuccessCallback_2,
+                                                                                                        OnFailureCallback_2);
     }
 
     void OnFailureResponse_2(uint8_t status) { ThrowFailureResponse(); }
@@ -29882,7 +29217,8 @@ private:
         chip::Controller::DescriptorClusterTest cluster;
         cluster.Associate(mDevice, 0);
 
-        return cluster.ReadAttributePartsList(mOnSuccessCallback_3.Cancel(), mOnFailureCallback_3.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::Descriptor::Attributes::PartsList::TypeInfo>(this, OnSuccessCallback_3,
+                                                                                                       OnFailureCallback_3);
     }
 
     void OnFailureResponse_3(uint8_t status) { ThrowFailureResponse(); }
@@ -29958,14 +29294,9 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 4;
 
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_0{ OnFailureCallback_0, this };
-    chip::Callback::Callback<void (*)(void * context, chip::CharSpan location)> mOnSuccessCallback_0{ OnSuccessCallback_0, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_2{ OnFailureCallback_2, this };
-    chip::Callback::Callback<void (*)(void * context, chip::CharSpan location)> mOnSuccessCallback_2{ OnSuccessCallback_2, this };
-
-    static void OnFailureCallback_0(void * context, uint8_t status)
+    static void OnFailureCallback_0(void * context, EmberAfStatus status)
     {
-        (static_cast<TestBasicInformation *>(context))->OnFailureResponse_0(status);
+        (static_cast<TestBasicInformation *>(context))->OnFailureResponse_0(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_0(void * context, chip::CharSpan location)
@@ -29980,9 +29311,9 @@ private:
 
     static void OnSuccessCallback_1(void * context) { (static_cast<TestBasicInformation *>(context))->OnSuccessResponse_1(); }
 
-    static void OnFailureCallback_2(void * context, uint8_t status)
+    static void OnFailureCallback_2(void * context, EmberAfStatus status)
     {
-        (static_cast<TestBasicInformation *>(context))->OnFailureResponse_2(status);
+        (static_cast<TestBasicInformation *>(context))->OnFailureResponse_2(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_2(void * context, chip::CharSpan location)
@@ -30006,7 +29337,8 @@ private:
         chip::Controller::BasicClusterTest cluster;
         cluster.Associate(mDevice, 0);
 
-        return cluster.ReadAttributeLocation(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::Basic::Attributes::Location::TypeInfo>(this, OnSuccessCallback_0,
+                                                                                                 OnFailureCallback_0);
     }
 
     void OnFailureResponse_0(uint8_t status) { ThrowFailureResponse(); }
@@ -30038,7 +29370,8 @@ private:
         chip::Controller::BasicClusterTest cluster;
         cluster.Associate(mDevice, 0);
 
-        return cluster.ReadAttributeLocation(mOnSuccessCallback_2.Cancel(), mOnFailureCallback_2.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::Basic::Attributes::Location::TypeInfo>(this, OnSuccessCallback_2,
+                                                                                                 OnFailureCallback_2);
     }
 
     void OnFailureResponse_2(uint8_t status) { ThrowFailureResponse(); }
@@ -30198,19 +29531,9 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 3;
 
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_0{ OnFailureCallback_0, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t supportedFabrics)> mOnSuccessCallback_0{ OnSuccessCallback_0, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_1{ OnFailureCallback_1, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t commissionedFabrics)> mOnSuccessCallback_1{ OnSuccessCallback_1,
-                                                                                                          this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_2{ OnFailureCallback_2, this };
-    chip::Callback::Callback<void (*)(void * context, chip::FabricIndex currentFabricIndex)> mOnSuccessCallback_2{
-        OnSuccessCallback_2, this
-    };
-
-    static void OnFailureCallback_0(void * context, uint8_t status)
+    static void OnFailureCallback_0(void * context, EmberAfStatus status)
     {
-        (static_cast<TestOperationalCredentialsCluster *>(context))->OnFailureResponse_0(status);
+        (static_cast<TestOperationalCredentialsCluster *>(context))->OnFailureResponse_0(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_0(void * context, uint8_t supportedFabrics)
@@ -30218,9 +29541,9 @@ private:
         (static_cast<TestOperationalCredentialsCluster *>(context))->OnSuccessResponse_0(supportedFabrics);
     }
 
-    static void OnFailureCallback_1(void * context, uint8_t status)
+    static void OnFailureCallback_1(void * context, EmberAfStatus status)
     {
-        (static_cast<TestOperationalCredentialsCluster *>(context))->OnFailureResponse_1(status);
+        (static_cast<TestOperationalCredentialsCluster *>(context))->OnFailureResponse_1(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_1(void * context, uint8_t commissionedFabrics)
@@ -30228,9 +29551,9 @@ private:
         (static_cast<TestOperationalCredentialsCluster *>(context))->OnSuccessResponse_1(commissionedFabrics);
     }
 
-    static void OnFailureCallback_2(void * context, uint8_t status)
+    static void OnFailureCallback_2(void * context, EmberAfStatus status)
     {
-        (static_cast<TestOperationalCredentialsCluster *>(context))->OnFailureResponse_2(status);
+        (static_cast<TestOperationalCredentialsCluster *>(context))->OnFailureResponse_2(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_2(void * context, chip::FabricIndex currentFabricIndex)
@@ -30247,7 +29570,8 @@ private:
         chip::Controller::OperationalCredentialsClusterTest cluster;
         cluster.Associate(mDevice, 0);
 
-        return cluster.ReadAttributeSupportedFabrics(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OperationalCredentials::Attributes::SupportedFabrics::TypeInfo>(
+            this, OnSuccessCallback_0, OnFailureCallback_0);
     }
 
     void OnFailureResponse_0(uint8_t status) { ThrowFailureResponse(); }
@@ -30264,7 +29588,8 @@ private:
         chip::Controller::OperationalCredentialsClusterTest cluster;
         cluster.Associate(mDevice, 0);
 
-        return cluster.ReadAttributeCommissionedFabrics(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OperationalCredentials::Attributes::CommissionedFabrics::TypeInfo>(
+            this, OnSuccessCallback_1, OnFailureCallback_1);
     }
 
     void OnFailureResponse_1(uint8_t status) { ThrowFailureResponse(); }
@@ -30281,7 +29606,8 @@ private:
         chip::Controller::OperationalCredentialsClusterTest cluster;
         cluster.Associate(mDevice, 0);
 
-        return cluster.ReadAttributeCurrentFabricIndex(mOnSuccessCallback_2.Cancel(), mOnFailureCallback_2.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::OperationalCredentials::Attributes::CurrentFabricIndex::TypeInfo>(
+            this, OnSuccessCallback_2, OnFailureCallback_2);
     }
 
     void OnFailureResponse_2(uint8_t status) { ThrowFailureResponse(); }
@@ -30369,27 +29695,9 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 8;
 
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_0{ OnFailureCallback_0, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t currentMode)> mOnSuccessCallback_0{ OnSuccessCallback_0, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_1{ OnFailureCallback_1, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t onMode)> mOnSuccessCallback_1{ OnSuccessCallback_1, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_2{ OnFailureCallback_2, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t startUpMode)> mOnSuccessCallback_2{ OnSuccessCallback_2, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_3{ OnFailureCallback_3, this };
-    chip::Callback::Callback<void (*)(void * context, chip::CharSpan description)> mOnSuccessCallback_3{ OnSuccessCallback_3,
-                                                                                                         this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_4{ OnFailureCallback_4, this };
-    chip::Callback::Callback<void (*)(
-        void * context,
-        const chip::app::DataModel::DecodableList<chip::app::Clusters::ModeSelect::Structs::ModeOptionStruct::DecodableType> &
-            supportedModes)>
-        mOnSuccessCallback_4{ OnSuccessCallback_4, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_6{ OnFailureCallback_6, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t currentMode)> mOnSuccessCallback_6{ OnSuccessCallback_6, this };
-
-    static void OnFailureCallback_0(void * context, uint8_t status)
+    static void OnFailureCallback_0(void * context, EmberAfStatus status)
     {
-        (static_cast<TestModeSelectCluster *>(context))->OnFailureResponse_0(status);
+        (static_cast<TestModeSelectCluster *>(context))->OnFailureResponse_0(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_0(void * context, uint8_t currentMode)
@@ -30397,9 +29705,9 @@ private:
         (static_cast<TestModeSelectCluster *>(context))->OnSuccessResponse_0(currentMode);
     }
 
-    static void OnFailureCallback_1(void * context, uint8_t status)
+    static void OnFailureCallback_1(void * context, EmberAfStatus status)
     {
-        (static_cast<TestModeSelectCluster *>(context))->OnFailureResponse_1(status);
+        (static_cast<TestModeSelectCluster *>(context))->OnFailureResponse_1(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_1(void * context, uint8_t onMode)
@@ -30407,9 +29715,9 @@ private:
         (static_cast<TestModeSelectCluster *>(context))->OnSuccessResponse_1(onMode);
     }
 
-    static void OnFailureCallback_2(void * context, uint8_t status)
+    static void OnFailureCallback_2(void * context, EmberAfStatus status)
     {
-        (static_cast<TestModeSelectCluster *>(context))->OnFailureResponse_2(status);
+        (static_cast<TestModeSelectCluster *>(context))->OnFailureResponse_2(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_2(void * context, uint8_t startUpMode)
@@ -30417,9 +29725,9 @@ private:
         (static_cast<TestModeSelectCluster *>(context))->OnSuccessResponse_2(startUpMode);
     }
 
-    static void OnFailureCallback_3(void * context, uint8_t status)
+    static void OnFailureCallback_3(void * context, EmberAfStatus status)
     {
-        (static_cast<TestModeSelectCluster *>(context))->OnFailureResponse_3(status);
+        (static_cast<TestModeSelectCluster *>(context))->OnFailureResponse_3(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_3(void * context, chip::CharSpan description)
@@ -30427,9 +29735,9 @@ private:
         (static_cast<TestModeSelectCluster *>(context))->OnSuccessResponse_3(description);
     }
 
-    static void OnFailureCallback_4(void * context, uint8_t status)
+    static void OnFailureCallback_4(void * context, EmberAfStatus status)
     {
-        (static_cast<TestModeSelectCluster *>(context))->OnFailureResponse_4(status);
+        (static_cast<TestModeSelectCluster *>(context))->OnFailureResponse_4(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_4(
@@ -30440,9 +29748,9 @@ private:
         (static_cast<TestModeSelectCluster *>(context))->OnSuccessResponse_4(supportedModes);
     }
 
-    static void OnFailureCallback_6(void * context, uint8_t status)
+    static void OnFailureCallback_6(void * context, EmberAfStatus status)
     {
-        (static_cast<TestModeSelectCluster *>(context))->OnFailureResponse_6(status);
+        (static_cast<TestModeSelectCluster *>(context))->OnFailureResponse_6(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_6(void * context, uint8_t currentMode)
@@ -30459,7 +29767,8 @@ private:
         chip::Controller::ModeSelectClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeCurrentMode(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ModeSelect::Attributes::CurrentMode::TypeInfo>(this, OnSuccessCallback_0,
+                                                                                                         OnFailureCallback_0);
     }
 
     void OnFailureResponse_0(uint8_t status) { ThrowFailureResponse(); }
@@ -30475,7 +29784,8 @@ private:
         chip::Controller::ModeSelectClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeOnMode(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ModeSelect::Attributes::OnMode::TypeInfo>(this, OnSuccessCallback_1,
+                                                                                                    OnFailureCallback_1);
     }
 
     void OnFailureResponse_1(uint8_t status) { ThrowFailureResponse(); }
@@ -30491,7 +29801,8 @@ private:
         chip::Controller::ModeSelectClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeStartUpMode(mOnSuccessCallback_2.Cancel(), mOnFailureCallback_2.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ModeSelect::Attributes::StartUpMode::TypeInfo>(this, OnSuccessCallback_2,
+                                                                                                         OnFailureCallback_2);
     }
 
     void OnFailureResponse_2(uint8_t status) { ThrowFailureResponse(); }
@@ -30507,7 +29818,8 @@ private:
         chip::Controller::ModeSelectClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeDescription(mOnSuccessCallback_3.Cancel(), mOnFailureCallback_3.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ModeSelect::Attributes::Description::TypeInfo>(this, OnSuccessCallback_3,
+                                                                                                         OnFailureCallback_3);
     }
 
     void OnFailureResponse_3(uint8_t status) { ThrowFailureResponse(); }
@@ -30523,7 +29835,8 @@ private:
         chip::Controller::ModeSelectClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeSupportedModes(mOnSuccessCallback_4.Cancel(), mOnFailureCallback_4.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ModeSelect::Attributes::SupportedModes::TypeInfo>(
+            this, OnSuccessCallback_4, OnFailureCallback_4);
     }
 
     void OnFailureResponse_4(uint8_t status) { ThrowFailureResponse(); }
@@ -30579,7 +29892,8 @@ private:
         chip::Controller::ModeSelectClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeCurrentMode(mOnSuccessCallback_6.Cancel(), mOnFailureCallback_6.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::ModeSelect::Attributes::CurrentMode::TypeInfo>(this, OnSuccessCallback_6,
+                                                                                                         OnFailureCallback_6);
     }
 
     void OnFailureResponse_6(uint8_t status) { ThrowFailureResponse(); }
@@ -30671,17 +29985,9 @@ private:
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = 3;
 
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_0{ OnFailureCallback_0, this };
-    chip::Callback::Callback<void (*)(void * context, uint64_t currentHeapFree)> mOnSuccessCallback_0{ OnSuccessCallback_0, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_1{ OnFailureCallback_1, this };
-    chip::Callback::Callback<void (*)(void * context, uint64_t currentHeapUsed)> mOnSuccessCallback_1{ OnSuccessCallback_1, this };
-    chip::Callback::Callback<void (*)(void * context, uint8_t status)> mOnFailureCallback_2{ OnFailureCallback_2, this };
-    chip::Callback::Callback<void (*)(void * context, uint64_t currentHeapHighWatermark)> mOnSuccessCallback_2{ OnSuccessCallback_2,
-                                                                                                                this };
-
-    static void OnFailureCallback_0(void * context, uint8_t status)
+    static void OnFailureCallback_0(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_DIAGSW_1_1 *>(context))->OnFailureResponse_0(status);
+        (static_cast<Test_TC_DIAGSW_1_1 *>(context))->OnFailureResponse_0(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_0(void * context, uint64_t currentHeapFree)
@@ -30689,9 +29995,9 @@ private:
         (static_cast<Test_TC_DIAGSW_1_1 *>(context))->OnSuccessResponse_0(currentHeapFree);
     }
 
-    static void OnFailureCallback_1(void * context, uint8_t status)
+    static void OnFailureCallback_1(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_DIAGSW_1_1 *>(context))->OnFailureResponse_1(status);
+        (static_cast<Test_TC_DIAGSW_1_1 *>(context))->OnFailureResponse_1(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_1(void * context, uint64_t currentHeapUsed)
@@ -30699,9 +30005,9 @@ private:
         (static_cast<Test_TC_DIAGSW_1_1 *>(context))->OnSuccessResponse_1(currentHeapUsed);
     }
 
-    static void OnFailureCallback_2(void * context, uint8_t status)
+    static void OnFailureCallback_2(void * context, EmberAfStatus status)
     {
-        (static_cast<Test_TC_DIAGSW_1_1 *>(context))->OnFailureResponse_2(status);
+        (static_cast<Test_TC_DIAGSW_1_1 *>(context))->OnFailureResponse_2(chip::to_underlying(status));
     }
 
     static void OnSuccessCallback_2(void * context, uint64_t currentHeapHighWatermark)
@@ -30718,7 +30024,8 @@ private:
         chip::Controller::SoftwareDiagnosticsClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeCurrentHeapFree(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::SoftwareDiagnostics::Attributes::CurrentHeapFree::TypeInfo>(
+            this, OnSuccessCallback_0, OnFailureCallback_0);
     }
 
     void OnFailureResponse_0(uint8_t status)
@@ -30737,7 +30044,8 @@ private:
         chip::Controller::SoftwareDiagnosticsClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeCurrentHeapUsed(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::SoftwareDiagnostics::Attributes::CurrentHeapUsed::TypeInfo>(
+            this, OnSuccessCallback_1, OnFailureCallback_1);
     }
 
     void OnFailureResponse_1(uint8_t status)
@@ -30756,7 +30064,8 @@ private:
         chip::Controller::SoftwareDiagnosticsClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttributeCurrentHeapHighWatermark(mOnSuccessCallback_2.Cancel(), mOnFailureCallback_2.Cancel());
+        return cluster.ReadAttribute<chip::app::Clusters::SoftwareDiagnostics::Attributes::CurrentHeapHighWatermark::TypeInfo>(
+            this, OnSuccessCallback_2, OnFailureCallback_2);
     }
 
     void OnFailureResponse_2(uint8_t status)


### PR DESCRIPTION
This will let us handle reading nullables (and structs once we can
have struct-typed attributes) propely.

#### Problem
YAML tests can't read interesting types (except for lists, which we have some special-case hacks for).

#### Change overview
Switch to using templated ReadAttribute to allow us to do that.

Also fixes the ReadAttribute templates to instantiate most of the work on a per-type basis, not per-attribute basis.

#### Testing
No behavior changes so far, but will be building on top of this to expand testing.