### PR TITLE
Use correct node ID for requesting OTA updates

### DIFF
--- a/examples/ota-requestor-app/linux/main.cpp
+++ b/examples/ota-requestor-app/linux/main.cpp
@@ -255,7 +255,7 @@ bool HandleOptions(const char * aProgram, OptionSet * aOptions, int aIdentifier,
 void SendQueryImageCommand(chip::NodeId peerNodeId = providerNodeId, chip::FabricIndex peerFabricIndex = providerFabricIndex)
 {
     Server * server           = &(Server::GetInstance());
-    chip::FabricInfo * fabric = server->GetFabricTable().FindFabricWithIndex(providerFabricIndex);
+    chip::FabricInfo * fabric = server->GetFabricTable().FindFabricWithIndex(peerFabricIndex);
 
     chip::DeviceProxyInitParams initParams = {
         .sessionManager = &(server->GetSecureSessionManager()),

--- a/src/transport/FabricTable.h
+++ b/src/transport/FabricTable.h
@@ -139,6 +139,13 @@ public:
     }
 
     PeerId GetPeerId() const { return mOperationalId; }
+    PeerId GetPeerIdForNode(const NodeId node) const
+    {
+        PeerId peer = mOperationalId;
+        peer.SetNodeId(node);
+        return peer;
+    }
+
     FabricId GetFabricId() const { return mFabricId; }
     FabricIndex GetFabricIndex() const { return mFabric; }
     uint16_t GetVendorId() const { return mVendorId; }


### PR DESCRIPTION
#### Problem
OTA requestor app is unable to establish secure session with the provider app.

#### Change overview
The requestor app was using the default/global `providerNodeId` instead of provided `peerNodeId` as the destination node ID. Also, the PeerID didn't have the fabric ID set correctly.

#### Testing
Tested manually by running OTA provider, requestor and chip-tool commands.