### PR TITLE
Rename SubSpan to subspan

### DIFF
--- a/src/credentials/DeviceAttestationConstructor.cpp
+++ b/src/credentials/DeviceAttestationConstructor.cpp
@@ -183,7 +183,7 @@ CHIP_ERROR ConstructAttestationElements(const ByteSpan & certificationDeclaratio
 
     ReturnErrorOnFailure(tlvWriter.EndContainer(outerContainerType));
     ReturnErrorOnFailure(tlvWriter.Finalize());
-    attestationElements = attestationElements.SubSpan(0, tlvWriter.GetLengthWritten());
+    attestationElements = attestationElements.subspan(0, tlvWriter.GetLengthWritten());
 
     return CHIP_NO_ERROR;
 }

--- a/src/crypto/CHIPCryptoPAL.cpp
+++ b/src/crypto/CHIPCryptoPAL.cpp
@@ -183,7 +183,7 @@ CHIP_ERROR ConvertIntegerRawToDerInternal(const ByteSpan & raw_integer, MutableB
         return CHIP_ERROR_BUFFER_TOO_SMALL;
     }
 
-    out_der_integer = out_der_integer.SubSpan(0, actually_written);
+    out_der_integer = out_der_integer.subspan(0, actually_written);
 
     return CHIP_NO_ERROR;
 }
@@ -528,7 +528,7 @@ CHIP_ERROR EcdsaRawSignatureToAsn1(size_t fe_length_bytes, const ByteSpan & raw_
     // Write R (first `fe_length_bytes` block of raw signature)
     {
         MutableByteSpan out_der_integer(cursor, remaining);
-        ReturnErrorOnFailure(ConvertIntegerRawToDer(raw_sig.SubSpan(0, fe_length_bytes), out_der_integer));
+        ReturnErrorOnFailure(ConvertIntegerRawToDer(raw_sig.subspan(0, fe_length_bytes), out_der_integer));
         VerifyOrReturnError(out_der_integer.size() <= remaining, CHIP_ERROR_INTERNAL);
 
         integers_length += out_der_integer.size();
@@ -539,7 +539,7 @@ CHIP_ERROR EcdsaRawSignatureToAsn1(size_t fe_length_bytes, const ByteSpan & raw_
     // Write S (second `fe_length_bytes` block of raw signature)
     {
         MutableByteSpan out_der_integer(cursor, remaining);
-        ReturnErrorOnFailure(ConvertIntegerRawToDer(raw_sig.SubSpan(fe_length_bytes, fe_length_bytes), out_der_integer));
+        ReturnErrorOnFailure(ConvertIntegerRawToDer(raw_sig.subspan(fe_length_bytes, fe_length_bytes), out_der_integer));
         VerifyOrReturnError(out_der_integer.size() <= remaining, CHIP_ERROR_INTERNAL);
         integers_length += out_der_integer.size();
     }
@@ -575,7 +575,7 @@ CHIP_ERROR EcdsaRawSignatureToAsn1(size_t fe_length_bytes, const ByteSpan & raw_
     size_t actually_written = 0;
     VerifyOrReturnError(writer.Fit(actually_written), CHIP_ERROR_BUFFER_TOO_SMALL);
 
-    out_asn1_sig = out_asn1_sig.SubSpan(0, actually_written);
+    out_asn1_sig = out_asn1_sig.subspan(0, actually_written);
     return CHIP_NO_ERROR;
 }
 
@@ -612,7 +612,7 @@ CHIP_ERROR EcdsaAsn1SignatureToRaw(size_t fe_length_bytes, const ByteSpan & asn1
     // Read S
     ReturnErrorOnFailure(ReadDerUnsignedIntegerIntoRaw(reader, MutableByteSpan{ raw_cursor, fe_length_bytes }));
 
-    out_raw_sig = out_raw_sig.SubSpan(0, (2u * fe_length_bytes));
+    out_raw_sig = out_raw_sig.subspan(0, (2u * fe_length_bytes));
 
     return CHIP_NO_ERROR;
 }
@@ -651,7 +651,7 @@ CHIP_ERROR GenerateCompressedFabricId(const Crypto::P256PublicKey & root_public_
     // Resize output to final bounds on success
     if (status == CHIP_NO_ERROR)
     {
-        out_compressed_fabric_id = out_compressed_fabric_id.SubSpan(0, kCompressedFabricIdentifierSize);
+        out_compressed_fabric_id = out_compressed_fabric_id.subspan(0, kCompressedFabricIdentifierSize);
     }
 
     return status;

--- a/src/crypto/CHIPCryptoPALOpenSSL.cpp
+++ b/src/crypto/CHIPCryptoPALOpenSSL.cpp
@@ -421,7 +421,7 @@ CHIP_ERROR Hash_SHA256_stream::Finish(MutableByteSpan & out_buffer)
     SHA256_CTX * const context = to_inner_hash_sha256_context(&mContext);
     const int result           = SHA256_Final(Uint8::to_uchar(out_buffer.data()), context);
     VerifyOrReturnError(result == 1, CHIP_ERROR_INTERNAL);
-    out_buffer = out_buffer.SubSpan(0, kSHA256_Hash_Length);
+    out_buffer = out_buffer.subspan(0, kSHA256_Hash_Length);
 
     return CHIP_NO_ERROR;
 }

--- a/src/crypto/CHIPCryptoPALmbedTLS.cpp
+++ b/src/crypto/CHIPCryptoPALmbedTLS.cpp
@@ -272,7 +272,7 @@ CHIP_ERROR Hash_SHA256_stream::Finish(MutableByteSpan & out_buffer)
 
     const int result = mbedtls_sha256_finish_ret(context, Uint8::to_uchar(out_buffer.data()));
     VerifyOrReturnError(result == 0, CHIP_ERROR_INTERNAL);
-    out_buffer = out_buffer.SubSpan(0, kSHA256_Hash_Length);
+    out_buffer = out_buffer.subspan(0, kSHA256_Hash_Length);
 
     return CHIP_NO_ERROR;
 }

--- a/src/lib/support/BytesCircularBuffer.cpp
+++ b/src/lib/support/BytesCircularBuffer.cpp
@@ -147,7 +147,7 @@ CHIP_ERROR BytesCircularBuffer::ReadFront(MutableByteSpan & dest) const
     if (dest.size() < length)
         return CHIP_ERROR_INVALID_ARGUMENT;
 
-    dest = dest.SubSpan(0, length);
+    dest = dest.subspan(0, length);
 
     Read(dest.data(), length, sizeof(SizeType) /* offset */);
     return CHIP_NO_ERROR;

--- a/src/lib/support/Span.h
+++ b/src/lib/support/Span.h
@@ -82,7 +82,7 @@ public:
     template <class U, size_t N, typename = std::enable_if_t<std::is_same<std::remove_const_t<T>, std::remove_const_t<U>>::value>>
     inline bool data_equal(const FixedSpan<U, N> & other) const;
 
-    Span SubSpan(size_t offset, size_t length) const
+    Span subspan(size_t offset, size_t length) const
     {
         VerifyOrDie(offset <= mDataLen);
         VerifyOrDie(length <= mDataLen - offset);

--- a/src/protocols/secure_channel/CASESession.cpp
+++ b/src/protocols/secure_channel/CASESession.cpp
@@ -1160,7 +1160,7 @@ CHIP_ERROR CASESession::ConstructSaltSigma2(const ByteSpan & rand, const Crypto:
 
     size_t saltWritten = 0;
     VerifyOrReturnError(bbuf.Fit(saltWritten), CHIP_ERROR_BUFFER_TOO_SMALL);
-    salt = salt.SubSpan(0, saltWritten);
+    salt = salt.subspan(0, saltWritten);
 
     return CHIP_NO_ERROR;
 }
@@ -1178,7 +1178,7 @@ CHIP_ERROR CASESession::ConstructSaltSigma3(const ByteSpan & ipk, MutableByteSpa
 
     size_t saltWritten = 0;
     VerifyOrReturnError(bbuf.Fit(saltWritten), CHIP_ERROR_BUFFER_TOO_SMALL);
-    salt = salt.SubSpan(0, saltWritten);
+    salt = salt.subspan(0, saltWritten);
 
     return CHIP_NO_ERROR;
 }

--- a/src/setup_payload/ManualSetupPayloadGenerator.cpp
+++ b/src/setup_payload/ManualSetupPayloadGenerator.cpp
@@ -132,25 +132,25 @@ CHIP_ERROR ManualSetupPayloadGenerator::payloadDecimalStringRepresentation(Mutab
     size_t offset = 0;
 
     // Add one to the length of each chunk, since snprintf writes a null terminator.
-    ReturnErrorOnFailure(decimalStringWithPadding(outBuffer.SubSpan(offset, kManualSetupCodeChunk1CharLength + 1), chunk1));
+    ReturnErrorOnFailure(decimalStringWithPadding(outBuffer.subspan(offset, kManualSetupCodeChunk1CharLength + 1), chunk1));
     offset += kManualSetupCodeChunk1CharLength;
-    ReturnErrorOnFailure(decimalStringWithPadding(outBuffer.SubSpan(offset, kManualSetupCodeChunk2CharLength + 1), chunk2));
+    ReturnErrorOnFailure(decimalStringWithPadding(outBuffer.subspan(offset, kManualSetupCodeChunk2CharLength + 1), chunk2));
     offset += kManualSetupCodeChunk2CharLength;
-    ReturnErrorOnFailure(decimalStringWithPadding(outBuffer.SubSpan(offset, kManualSetupCodeChunk3CharLength + 1), chunk3));
+    ReturnErrorOnFailure(decimalStringWithPadding(outBuffer.subspan(offset, kManualSetupCodeChunk3CharLength + 1), chunk3));
     offset += kManualSetupCodeChunk3CharLength;
 
     if (useLongCode)
     {
         ReturnErrorOnFailure(
-            decimalStringWithPadding(outBuffer.SubSpan(offset, kManualSetupVendorIdCharLength + 1), mPayloadContents.vendorID));
+            decimalStringWithPadding(outBuffer.subspan(offset, kManualSetupVendorIdCharLength + 1), mPayloadContents.vendorID));
         offset += kManualSetupVendorIdCharLength;
         ReturnErrorOnFailure(
-            decimalStringWithPadding(outBuffer.SubSpan(offset, kManualSetupProductIdCharLength + 1), mPayloadContents.productID));
+            decimalStringWithPadding(outBuffer.subspan(offset, kManualSetupProductIdCharLength + 1), mPayloadContents.productID));
         offset += kManualSetupProductIdCharLength;
     }
 
     int checkDigit = Verhoeff10::CharToVal(Verhoeff10::ComputeCheckChar(outBuffer.data()));
-    ReturnErrorOnFailure(decimalStringWithPadding(outBuffer.SubSpan(offset, 2), static_cast<uint32_t>(checkDigit)));
+    ReturnErrorOnFailure(decimalStringWithPadding(outBuffer.subspan(offset, 2), static_cast<uint32_t>(checkDigit)));
 
     return CHIP_NO_ERROR;
 }

--- a/src/setup_payload/QRCodeSetupPayloadGenerator.cpp
+++ b/src/setup_payload/QRCodeSetupPayloadGenerator.cpp
@@ -193,7 +193,7 @@ static CHIP_ERROR payloadBase38RepresentationWithTLV(PayloadContents & payload, 
     }
     else
     {
-        MutableCharSpan subSpan = outBuffer.SubSpan(prefixLen, outBuffer.size() - prefixLen);
+        MutableCharSpan subSpan = outBuffer.subspan(prefixLen, outBuffer.size() - prefixLen);
         memcpy(outBuffer.data(), kQRCodePrefix, prefixLen);
         err = base38Encode(bits, subSpan);
     }

--- a/src/setup_payload/tests/TestQRCode.cpp
+++ b/src/setup_payload/tests/TestQRCode.cpp
@@ -124,22 +124,22 @@ void TestBase38(nlTestSuite * inSuite, void * inContext)
     MutableCharSpan encodedSpan(encodedBuf);
 
     // basic stuff
-    base38Encode(inputSpan.SubSpan(0, 0), encodedSpan);
+    base38Encode(inputSpan.subspan(0, 0), encodedSpan);
     NL_TEST_ASSERT(inSuite, strlen(encodedBuf) == 0);
-    base38Encode(inputSpan.SubSpan(0, 1), encodedSpan);
+    base38Encode(inputSpan.subspan(0, 1), encodedSpan);
     NL_TEST_ASSERT(inSuite, strcmp(encodedBuf, "A0") == 0);
-    base38Encode(inputSpan.SubSpan(0, 2), encodedSpan);
+    base38Encode(inputSpan.subspan(0, 2), encodedSpan);
     NL_TEST_ASSERT(inSuite, strcmp(encodedBuf, "OT10") == 0);
     base38Encode(inputSpan, encodedSpan);
     NL_TEST_ASSERT(inSuite, strcmp(encodedBuf, "-N.B0") == 0);
 
     // test null termination of output buffer
-    MutableCharSpan subSpan = encodedSpan.SubSpan(0, 2);
-    NL_TEST_ASSERT(inSuite, base38Encode(inputSpan.SubSpan(0, 1), subSpan) == CHIP_ERROR_BUFFER_TOO_SMALL);
+    MutableCharSpan subSpan = encodedSpan.subspan(0, 2);
+    NL_TEST_ASSERT(inSuite, base38Encode(inputSpan.subspan(0, 1), subSpan) == CHIP_ERROR_BUFFER_TOO_SMALL);
     // Force no nulls in output buffer
     memset(encodedSpan.data(), '?', encodedSpan.size());
-    subSpan = encodedSpan.SubSpan(0, 3);
-    base38Encode(inputSpan.SubSpan(0, 1), subSpan);
+    subSpan = encodedSpan.subspan(0, 3);
+    base38Encode(inputSpan.subspan(0, 1), subSpan);
     size_t encodedLen = strnlen(encodedSpan.data(), ArraySize(encodedBuf));
     NL_TEST_ASSERT(inSuite, encodedLen == strlen("A0"));
     NL_TEST_ASSERT(inSuite, strcmp(encodedBuf, "A0") == 0);
@@ -168,12 +168,12 @@ void TestBase38(nlTestSuite * inSuite, void * inContext)
     // verify chunks of 1,2 and 3 bytes result in fixed-length strings padded with '0'
     // for 1 byte we need always 2 characters
     input[0] = 35;
-    base38Encode(inputSpan.SubSpan(0, 1), encodedSpan);
+    base38Encode(inputSpan.subspan(0, 1), encodedSpan);
     NL_TEST_ASSERT(inSuite, strcmp(encodedBuf, "Z0") == 0);
     // for 2 bytes we need always 4 characters
     input[0] = 255;
     input[1] = 0;
-    base38Encode(inputSpan.SubSpan(0, 2), encodedSpan);
+    base38Encode(inputSpan.subspan(0, 2), encodedSpan);
     NL_TEST_ASSERT(inSuite, strcmp(encodedBuf, "R600") == 0);
     // for 3 bytes we need always 5 characters
     input[0] = 46;
@@ -185,12 +185,12 @@ void TestBase38(nlTestSuite * inSuite, void * inContext)
     // verify maximum available values for each chunk size to check selecting proper characters number
     // for 1 byte we need 2 characters
     input[0] = 255;
-    base38Encode(inputSpan.SubSpan(0, 1), encodedSpan);
+    base38Encode(inputSpan.subspan(0, 1), encodedSpan);
     NL_TEST_ASSERT(inSuite, strcmp(encodedBuf, "R6") == 0);
     // for 2 bytes we need 4 characters
     input[0] = 255;
     input[1] = 255;
-    base38Encode(inputSpan.SubSpan(0, 2), encodedSpan);
+    base38Encode(inputSpan.subspan(0, 2), encodedSpan);
     NL_TEST_ASSERT(inSuite, strcmp(encodedBuf, "NE71") == 0);
     // for 3 bytes we need 5 characters
     input[0] = 255;


### PR DESCRIPTION
#### Problem
`Span`/`FixedSpan` is mimicking STL `std::span` APIs

#### Change overview
Rename `Span::SubSpan` to `subspan`

#### Testing
Running unit-tests