### PR TITLE
[linux]: Implement the optional attributes for WiFi diagnostic cluster

### DIFF
--- a/examples/platform/linux/Options.h
+++ b/examples/platform/linux/Options.h
@@ -33,7 +33,7 @@ struct LinuxDeviceOptions
 {
     chip::SetupPayload payload;
     uint32_t mBleDevice                = 0;
-    bool mWiFi                         = false;
+    bool mWiFi                         = true;
     bool mThread                       = false;
     uint32_t securedDevicePort         = CHIP_PORT;
     uint32_t securedCommissionerPort   = CHIP_PORT + 2;

--- a/src/app/clusters/wifi_network_diagnostics_server/wifi_network_diagnostics_server.cpp
+++ b/src/app/clusters/wifi_network_diagnostics_server/wifi_network_diagnostics_server.cpp
@@ -72,7 +72,8 @@ CHIP_ERROR WiFiDiagosticsAttrAccess::ReadIfSupported(CHIP_ERROR (ConnectivityMan
 
 CHIP_ERROR WiFiDiagosticsAttrAccess::ReadWiFiBssId(AttributeValueEncoder & aEncoder)
 {
-    ByteSpan bssid;
+    // TODO: Use Nullable<ByteSpan> after we get darwin converted over to the new APIs.
+    Bssid::TypeInfo::Type bssid;
 
     if (ConnectivityMgr().GetWiFiBssId(bssid) == CHIP_NO_ERROR)
     {

--- a/src/include/platform/ConnectivityManager.h
+++ b/src/include/platform/ConnectivityManager.h
@@ -248,6 +248,7 @@ public:
     CHIP_ERROR ResetEthNetworkDiagnosticsCounts();
 
     // WiFi network diagnostics methods
+    CHIP_ERROR GetWiFiBssId(ByteSpan & value);
     CHIP_ERROR GetWiFiSecurityType(uint8_t & securityType);
     CHIP_ERROR GetWiFiVersion(uint8_t & wiFiVersion);
     CHIP_ERROR GetWiFiChannelNumber(uint16_t & channelNumber);
@@ -518,6 +519,11 @@ inline CHIP_ERROR ConnectivityManager::GetEthOverrunCount(uint64_t & overrunCoun
 inline CHIP_ERROR ConnectivityManager::ResetEthNetworkDiagnosticsCounts()
 {
     return static_cast<ImplClass *>(this)->_ResetEthNetworkDiagnosticsCounts();
+}
+
+inline CHIP_ERROR ConnectivityManager::GetWiFiBssId(ByteSpan & value)
+{
+    return static_cast<ImplClass *>(this)->_GetWiFiBssId(value);
 }
 
 inline CHIP_ERROR ConnectivityManager::GetWiFiSecurityType(uint8_t & securityType)

--- a/src/include/platform/internal/GenericConnectivityManagerImpl_NoWiFi.h
+++ b/src/include/platform/internal/GenericConnectivityManagerImpl_NoWiFi.h
@@ -71,6 +71,7 @@ public:
     System::Clock::Timeout _GetWiFiAPIdleTimeout(void);
     void _SetWiFiAPIdleTimeout(System::Clock::Timeout val);
     CHIP_ERROR _GetAndLogWifiStatsCounters(void);
+    CHIP_ERROR _GetWiFiBssId(ByteSpan & value);
     CHIP_ERROR _GetWiFiSecurityType(uint8_t & securityType);
     CHIP_ERROR _GetWiFiVersion(uint8_t & wiFiVersion);
     CHIP_ERROR _GetWiFiChannelNumber(uint16_t & channelNumber);
@@ -232,6 +233,12 @@ template <class ImplClass>
 inline const char * GenericConnectivityManagerImpl_NoWiFi<ImplClass>::_WiFiAPStateToStr(ConnectivityManager::WiFiAPState state)
 {
     return NULL;
+}
+
+template <class ImplClass>
+inline CHIP_ERROR GenericConnectivityManagerImpl_NoWiFi<ImplClass>::_GetWiFiBssId(ByteSpan & value)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 }
 
 template <class ImplClass>

--- a/src/include/platform/internal/GenericConnectivityManagerImpl_WiFi.h
+++ b/src/include/platform/internal/GenericConnectivityManagerImpl_WiFi.h
@@ -73,6 +73,7 @@ public:
     System::Clock::Timeout _GetWiFiAPIdleTimeout();
     void _SetWiFiAPIdleTimeout(System::Clock::Timeout val);
     CHIP_ERROR _GetAndLogWifiStatsCounters();
+    CHIP_ERROR _GetWiFiBssId(ByteSpan & value);
     CHIP_ERROR _GetWiFiSecurityType(uint8_t & securityType);
     CHIP_ERROR _GetWiFiVersion(uint8_t & wiFiVersion);
     CHIP_ERROR _GetWiFiChannelNumber(uint16_t & channelNumber);
@@ -193,6 +194,12 @@ inline void GenericConnectivityManagerImpl_WiFi<ImplClass>::_OnWiFiScanDone()
 template <class ImplClass>
 inline void GenericConnectivityManagerImpl_WiFi<ImplClass>::_OnWiFiStationProvisionChange()
 {}
+
+template <class ImplClass>
+inline CHIP_ERROR GenericConnectivityManagerImpl_WiFi<ImplClass>::_GetWiFiBssId(ByteSpan & value)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
 
 template <class ImplClass>
 inline CHIP_ERROR GenericConnectivityManagerImpl_WiFi<ImplClass>::_GetWiFiSecurityType(uint8_t & securityType)

--- a/src/platform/Linux/ConnectivityManagerImpl.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl.cpp
@@ -91,8 +91,7 @@ CHIP_ERROR GetEthernetStatsCount(EthernetStatsCountType type, uint64_t & count)
     {
         struct ifaddrs * ifa = nullptr;
 
-        /* Walk through linked list, maintaining head pointer so we
-          can free list later */
+        // Walk through linked list, maintaining head pointer so we can free list later.
         for (ifa = ifaddr; ifa != nullptr; ifa = ifa->ifa_next)
         {
             if (ConnectivityUtils::GetInterfaceConnectionType(ifa->ifa_name) == InterfaceType::EMBER_ZCL_INTERFACE_TYPE_ETHERNET)
@@ -156,8 +155,7 @@ CHIP_ERROR GetWiFiStatsCount(WiFiStatsCountType type, uint64_t & count)
     {
         struct ifaddrs * ifa = nullptr;
 
-        /* Walk through linked list, maintaining head pointer so we
-          can free list later */
+        // Walk through linked list, maintaining head pointer so we can free list later.
         for (ifa = ifaddr; ifa != nullptr; ifa = ifa->ifa_next)
         {
             if (ConnectivityUtils::GetInterfaceConnectionType(ifa->ifa_name) == InterfaceType::EMBER_ZCL_INTERFACE_TYPE_WI_FI)
@@ -431,6 +429,104 @@ CHIP_ERROR ConnectivityManagerImpl::_SetWiFiAPMode(WiFiAPMode val)
 
 exit:
     return err;
+}
+
+CHIP_ERROR ConnectivityManagerImpl::_GetWiFiBssId(ByteSpan & value)
+{
+    CHIP_ERROR err          = CHIP_ERROR_READ_FAILED;
+    struct ifaddrs * ifaddr = nullptr;
+
+    // On Linux simulation, we don't have the DBus API to get the BSSID of connected AP. Use mac address
+    // of local WiFi network card instead.
+    if (getifaddrs(&ifaddr) == -1)
+    {
+        ChipLogError(DeviceLayer, "Failed to get network interfaces");
+    }
+    else
+    {
+        // Walk through linked list, maintaining head pointer so we can free list later.
+        for (struct ifaddrs * ifa = ifaddr; ifa != nullptr; ifa = ifa->ifa_next)
+        {
+            if (ConnectivityUtils::GetInterfaceConnectionType(ifa->ifa_name) == InterfaceType::EMBER_ZCL_INTERFACE_TYPE_WI_FI)
+            {
+                if (ConnectivityUtils::GetInterfaceHardwareAddrs(ifa->ifa_name, mWiFiMacAddress, kMaxHardwareAddrSize) !=
+                    CHIP_NO_ERROR)
+                {
+                    ChipLogError(DeviceLayer, "Failed to get WiFi network hardware address");
+                }
+                else
+                {
+                    // Set 48-bit IEEE MAC Address
+                    value = ByteSpan(mWiFiMacAddress, 6);
+                    err   = CHIP_NO_ERROR;
+                    break;
+                }
+            }
+        }
+
+        freeifaddrs(ifaddr);
+    }
+
+    return err;
+}
+
+CHIP_ERROR ConnectivityManagerImpl::_GetWiFiSecurityType(uint8_t & securityType)
+{
+    const gchar * mode = nullptr;
+
+    std::lock_guard<std::mutex> lock(mWpaSupplicantMutex);
+
+    if (mWpaSupplicant.state != GDBusWpaSupplicant::WPA_INTERFACE_CONNECTED)
+    {
+        ChipLogError(DeviceLayer, "wpa_supplicant: _GetWiFiSecurityType: interface proxy not connected");
+        return CHIP_ERROR_INCORRECT_STATE;
+    }
+
+    mode = wpa_fi_w1_wpa_supplicant1_interface_get_current_auth_mode(mWpaSupplicant.iface);
+    ChipLogProgress(DeviceLayer, "wpa_supplicant: current Wi-Fi security type: %s", mode);
+
+    if (strncmp(mode, "WPA-PSK", 7) == 0)
+    {
+        securityType = EMBER_ZCL_SECURITY_TYPE_WPA;
+    }
+    else if (strncmp(mode, "WPA2-PSK", 8) == 0)
+    {
+        securityType = EMBER_ZCL_SECURITY_TYPE_WPA2;
+    }
+    else if (strncmp(mode, "WPA2-EAP", 8) == 0)
+    {
+        securityType = EMBER_ZCL_SECURITY_TYPE_WPA2;
+    }
+    else if (strncmp(mode, "WPA3-PSK", 8) == 0)
+    {
+        securityType = EMBER_ZCL_SECURITY_TYPE_WPA3;
+    }
+    else if (strncmp(mode, "WEP", 3) == 0)
+    {
+        securityType = EMBER_ZCL_SECURITY_TYPE_WEP;
+    }
+    else if (strncmp(mode, "NONE", 4) == 0)
+    {
+        securityType = EMBER_ZCL_SECURITY_TYPE_NONE;
+    }
+    else if (strncmp(mode, "WPA-NONE", 8) == 0)
+    {
+        securityType = EMBER_ZCL_SECURITY_TYPE_NONE;
+    }
+    else
+    {
+        securityType = EMBER_ZCL_SECURITY_TYPE_UNSPECIFIED;
+    }
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR ConnectivityManagerImpl::_GetWiFiVersion(uint8_t & wiFiVersion)
+{
+    // We don't have driect API to get the WiFi version yet, retrun 802.11n on Linux simulation.
+    wiFiVersion = EMBER_ZCL_WI_FI_VERSION_TYPE_802__11N;
+
+    return CHIP_NO_ERROR;
 }
 
 void ConnectivityManagerImpl::_DemandStartWiFiAP()
@@ -1105,8 +1201,7 @@ CHIP_ERROR ConnectivityManagerImpl::_GetNetworkInterfaces(NetworkInterface ** ne
     {
         NetworkInterface * head = nullptr;
 
-        /* Walk through linked list, maintaining head pointer so we
-          can free list later */
+        // Walk through linked list, maintaining head pointer so we can free list later.
         for (struct ifaddrs * ifa = ifaddr; ifa != nullptr; ifa = ifa->ifa_next)
         {
             if (ifa->ifa_addr && ifa->ifa_addr->sa_family == AF_PACKET)
@@ -1250,8 +1345,7 @@ CHIP_ERROR ConnectivityManagerImpl::ResetEthernetStatsCount()
     {
         struct ifaddrs * ifa = nullptr;
 
-        /* Walk through linked list, maintaining head pointer so we
-          can free list later */
+        // Walk through linked list, maintaining head pointer so we can free list later.
         for (ifa = ifaddr; ifa != nullptr; ifa = ifa->ifa_next)
         {
             if (ConnectivityUtils::GetInterfaceConnectionType(ifa->ifa_name) == InterfaceType::EMBER_ZCL_INTERFACE_TYPE_ETHERNET)
@@ -1421,8 +1515,7 @@ CHIP_ERROR ConnectivityManagerImpl::ResetWiFiStatsCount()
     {
         struct ifaddrs * ifa = nullptr;
 
-        /* Walk through linked list, maintaining head pointer so we
-          can free list later */
+        // Walk through linked list, maintaining head pointer so we can free list later.
         for (ifa = ifaddr; ifa != nullptr; ifa = ifa->ifa_next)
         {
             if (ConnectivityUtils::GetInterfaceConnectionType(ifa->ifa_name) == InterfaceType::EMBER_ZCL_INTERFACE_TYPE_WI_FI)

--- a/src/platform/Linux/ConnectivityManagerImpl.h
+++ b/src/platform/Linux/ConnectivityManagerImpl.h
@@ -136,6 +136,9 @@ private:
 
     WiFiAPMode _GetWiFiAPMode();
     CHIP_ERROR _SetWiFiAPMode(WiFiAPMode val);
+    CHIP_ERROR _GetWiFiBssId(ByteSpan & value);
+    CHIP_ERROR _GetWiFiSecurityType(uint8_t & securityType);
+    CHIP_ERROR _GetWiFiVersion(uint8_t & wiFiVersion);
     bool _IsWiFiAPActive();
     bool _IsWiFiAPApplicationControlled();
     void _DemandStartWiFiAP();
@@ -220,6 +223,7 @@ private:
     System::Clock::Timestamp mLastAPDemandTime;
     System::Clock::Timeout mWiFiStationReconnectInterval;
     System::Clock::Timeout mWiFiAPIdleTimeout;
+    uint8_t mWiFiMacAddress[kMaxHardwareAddrSize];
 #endif
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* There are still several optional attributes missing in wiFi diagnostic cluster.

#### Change overview
Implement the optional attributes for WiFi diagnostic cluster

#### Testing
How was this tested? (at least one bullet point required)
```
yufengw@yufengw-SEi:~/connectedhomeip/out/debug/standalone$ ./chip-tool wifinetworkdiagnostics read bssid 12344321 0
......
[1636521181.437964][56908:56913] CHIP:DMG: ReportDataMessage =
[1636521181.437970][56908:56913] CHIP:DMG: {
[1636521181.437975][56908:56913] CHIP:DMG:  AttributeReportIBs =
[1636521181.437981][56908:56913] CHIP:DMG:  [
[1636521181.437986][56908:56913] CHIP:DMG:    AttributeReportIB =
[1636521181.437992][56908:56913] CHIP:DMG:    {
[1636521181.437997][56908:56913] CHIP:DMG:      AttributeDataIB =
[1636521181.438005][56908:56913] CHIP:DMG:      {
[1636521181.438012][56908:56913] CHIP:DMG:        AttributePathIB =
[1636521181.438023][56908:56913] CHIP:DMG:        {
[1636521181.438031][56908:56913] CHIP:DMG:          Endpoint = 0x0,
[1636521181.438040][56908:56913] CHIP:DMG:          Cluster = 0x36,
[1636521181.438050][56908:56913] CHIP:DMG:          Attribute = 0x0000_0000,
[1636521181.438058][56908:56913] CHIP:DMG:        }
[1636521181.438067][56908:56913] CHIP:DMG:          
[1636521181.438075][56908:56913] CHIP:DMG:          Data = [
[1636521181.438085][56908:56913] CHIP:DMG:            0xb0, 0xa4, 0x60, 0xe, 0xcf, 0xae, 
[1636521181.438093][56908:56913] CHIP:DMG:          ]
[1636521181.438100][56908:56913] CHIP:DMG:        DataVersion = 0x0,
[1636521181.438106][56908:56913] CHIP:DMG:      },
[1636521181.438114][56908:56913] CHIP:DMG:      
[1636521181.438120][56908:56913] CHIP:DMG:    },
[1636521181.438128][56908:56913] CHIP:DMG:    
[1636521181.438133][56908:56913] CHIP:DMG:  ],
[1636521181.438143][56908:56913] CHIP:DMG:  
[1636521181.438148][56908:56913] CHIP:DMG: }
[1636521181.438178][56908:56913] CHIP:ZCL: ReadAttributesResponse:
[1636521181.438183][56908:56913] CHIP:ZCL:   ClusterId: 0x0000_0036
[1636521181.438190][56908:56913] CHIP:ZCL:   attributeId: 0x0000_0000
[1636521181.438196][56908:56913] CHIP:ZCL:   status: Success                (0x0000)
[1636521181.438202][56908:56913] CHIP:ZCL:   attribute TLV Type: 0x10
[1636521181.438210][56908:56913] CHIP:TOO: OctetString attribute Response: B0A4600ECFAE


yufengw@yufengw-SEi:~/connectedhomeip/out/debug/standalone$ ./chip-tool wifinetworkdiagnostics read wi-fi-version 12344321 0
......
[1636521256.424450][56941:56946] CHIP:DMG: ReportDataMessage =
[1636521256.424456][56941:56946] CHIP:DMG: {
[1636521256.424460][56941:56946] CHIP:DMG:  AttributeReportIBs =
[1636521256.424467][56941:56946] CHIP:DMG:  [
[1636521256.424480][56941:56946] CHIP:DMG:    AttributeReportIB =
[1636521256.424500][56941:56946] CHIP:DMG:    {
[1636521256.424516][56941:56946] CHIP:DMG:      AttributeDataIB =
[1636521256.424524][56941:56946] CHIP:DMG:      {
[1636521256.424529][56941:56946] CHIP:DMG:        AttributePathIB =
[1636521256.424535][56941:56946] CHIP:DMG:        {
[1636521256.424542][56941:56946] CHIP:DMG:          Endpoint = 0x0,
[1636521256.424547][56941:56946] CHIP:DMG:          Cluster = 0x36,
[1636521256.424553][56941:56946] CHIP:DMG:          Attribute = 0x0000_0002,
[1636521256.424559][56941:56946] CHIP:DMG:        }
[1636521256.424566][56941:56946] CHIP:DMG:          
[1636521256.424572][56941:56946] CHIP:DMG:          Data = 3, 
[1636521256.424577][56941:56946] CHIP:DMG:        DataVersion = 0x0,
[1636521256.424583][56941:56946] CHIP:DMG:      },
[1636521256.424590][56941:56946] CHIP:DMG:      
[1636521256.424594][56941:56946] CHIP:DMG:    },
[1636521256.424601][56941:56946] CHIP:DMG:    
[1636521256.424605][56941:56946] CHIP:DMG:  ],
[1636521256.424611][56941:56946] CHIP:DMG:  
[1636521256.424616][56941:56946] CHIP:DMG: }
[1636521256.424643][56941:56946] CHIP:ZCL: ReadAttributesResponse:
[1636521256.424648][56941:56946] CHIP:ZCL:   ClusterId: 0x0000_0036
[1636521256.424654][56941:56946] CHIP:ZCL:   attributeId: 0x0000_0002
[1636521256.424658][56941:56946] CHIP:ZCL:   status: Success                (0x0000)
[1636521256.424663][56941:56946] CHIP:ZCL:   attribute TLV Type: 0x04
[1636521256.424670][56941:56946] CHIP:TOO: Int8u attribute Response: 3


yufengw@yufengw-SEi:~/connectedhomeip/out/debug/standalone$ ./chip-tool wifinetworkdiagnostics read security-type 12344321 0
......
[1636525123.341307][65613:65618] CHIP:DMG: ReportDataMessage =
[1636525123.341312][65613:65618] CHIP:DMG: {
[1636525123.341316][65613:65618] CHIP:DMG:  AttributeReportIBs =
[1636525123.341321][65613:65618] CHIP:DMG:  [
[1636525123.341326][65613:65618] CHIP:DMG:    AttributeReportIB =
[1636525123.341331][65613:65618] CHIP:DMG:    {
[1636525123.341335][65613:65618] CHIP:DMG:      AttributeDataIB =
[1636525123.341341][65613:65618] CHIP:DMG:      {
[1636525123.341346][65613:65618] CHIP:DMG:        AttributePathIB =
[1636525123.341354][65613:65618] CHIP:DMG:        {
[1636525123.341359][65613:65618] CHIP:DMG:          Endpoint = 0x0,
[1636525123.341366][65613:65618] CHIP:DMG:          Cluster = 0x36,
[1636525123.341372][65613:65618] CHIP:DMG:          Attribute = 0x0000_0001,
[1636525123.341378][65613:65618] CHIP:DMG:        }
[1636525123.341384][65613:65618] CHIP:DMG:          
[1636525123.341390][65613:65618] CHIP:DMG:          Data = 4, 
[1636525123.341397][65613:65618] CHIP:DMG:        DataVersion = 0x0,
[1636525123.341402][65613:65618] CHIP:DMG:      },
[1636525123.341409][65613:65618] CHIP:DMG:      
[1636525123.341413][65613:65618] CHIP:DMG:    },
[1636525123.341420][65613:65618] CHIP:DMG:    
[1636525123.341424][65613:65618] CHIP:DMG:  ],
[1636525123.341430][65613:65618] CHIP:DMG:  
[1636525123.341435][65613:65618] CHIP:DMG: }
[1636525123.341464][65613:65618] CHIP:ZCL: ReadAttributesResponse:
[1636525123.341468][65613:65618] CHIP:ZCL:   ClusterId: 0x0000_0036
[1636525123.341473][65613:65618] CHIP:ZCL:   attributeId: 0x0000_0001
[1636525123.341478][65613:65618] CHIP:ZCL:   status: Success                (0x0000)
[1636525123.341483][65613:65618] CHIP:ZCL:   attribute TLV Type: 0x04
[1636525123.341487][65613:65618] CHIP:TOO: Int8u attribute Response: 4
```

