### PR TITLE
Android build on Apple silicon 

### DIFF
--- a/.github/.wordlist.txt
+++ b/.github/.wordlist.txt
@@ -486,8 +486,11 @@ IPv
 ISCAN
 itemName
 iterable
+jdk
 jinja
 jlink
+jre
+JDK
 JLink
 JLinkExe
 JLinkRTTClient
@@ -669,6 +672,7 @@ Onboarding
 onboardingcodes
 oneshot
 onnetwork
+openjdk
 OnOff
 OnOffClusterTest
 OnPlatformEvent
@@ -970,6 +974,7 @@ unblur
 UNBLUR
 uncommissioned
 unfocus
+userguide
 Unicast
 UniFlash
 unpair

--- a/.github/.wordlist.txt
+++ b/.github/.wordlist.txt
@@ -486,7 +486,6 @@ IPv
 ISCAN
 itemName
 iterable
-jdk
 jinja
 jlink
 jre

--- a/build/toolchain/android/android_toolchain.gni
+++ b/build/toolchain/android/android_toolchain.gni
@@ -56,7 +56,7 @@ template("android_clang_toolchain") {
     if (host_cpu == "x64") {
       _ndk_host_cpu = "-x86_64"
     } else if (host_cpu == "arm64") {
-      # untils NDK 24.0.7856742-beta1, the host cpu on apple silicon is x86_64
+      # until NDK 24.0.7856742-beta1, the host cpu on apple silicon is x86_64
       _ndk_host_cpu = "-x86_64"
     }
 

--- a/build/toolchain/android/android_toolchain.gni
+++ b/build/toolchain/android/android_toolchain.gni
@@ -55,7 +55,7 @@ template("android_clang_toolchain") {
     _ndk_host_cpu = ""
     if (host_cpu == "x64") {
       _ndk_host_cpu = "-x86_64"
-    } else if(host_cpu == "arm64" ) {
+    } else if (host_cpu == "arm64") {
       # untils NDK 24.0.7856742-beta1, the host cpu on apple silicon is x86_64
       _ndk_host_cpu = "-x86_64"
     }

--- a/build/toolchain/android/android_toolchain.gni
+++ b/build/toolchain/android/android_toolchain.gni
@@ -55,6 +55,9 @@ template("android_clang_toolchain") {
     _ndk_host_cpu = ""
     if (host_cpu == "x64") {
       _ndk_host_cpu = "-x86_64"
+    } else if(host_cpu == "arm64" ) {
+      # untils NDK 24.0.7856742-beta1, the host cpu on apple silicon is x86_64
+      _ndk_host_cpu = "-x86_64"
     }
 
     _ndk_host = _ndk_host_os + _ndk_host_cpu

--- a/docs/guides/android_building.md
+++ b/docs/guides/android_building.md
@@ -64,7 +64,7 @@ architecture:
 
 We are using Gradle 7.1.1 for all android project which does not support Java 17
 (https://docs.gradle.org/current/userguide/compatibility.html) while the default
-JDK version on MacOS for Apple Silicon is openjdk 17.0.1 or above.
+JDK version on MacOS for Apple Silicon is 'openjdk 17.0.1' or above.
 
 Using JDK bundled with Android Studio will help on that.
 

--- a/docs/guides/android_building.md
+++ b/docs/guides/android_building.md
@@ -66,7 +66,7 @@ We are using Gradle 7.1.1 for all android project which does not support Java 17
 (https://docs.gradle.org/current/userguide/compatibility.html) while the default
 JDK version on MacOS for Apple Silicon is 'openjdk 17.0.1' or above.
 
-Using JDK bundled with Android Studio will help on that.
+Using JDK bundled with Android Studio will help with that.
 
 ```shell
 export JAVA_HOME=/Applications/Android\ Studio.app/Contents/jre/Contents/Home/

--- a/docs/guides/android_building.md
+++ b/docs/guides/android_building.md
@@ -62,14 +62,15 @@ architecture:
 
 ### Gradle & JDK Version
 
-We are using Gradle 7.1.1 for all android project which does not support Java 17 (https://docs.gradle.org/current/userguide/compatibility.html) while the default JDK version on MacOS for Apple Silicon is openjdk 17.0.1 or above. 
+We are using Gradle 7.1.1 for all android project which does not support Java 17
+(https://docs.gradle.org/current/userguide/compatibility.html) while the default
+JDK version on MacOS for Apple Silicon is openjdk 17.0.1 or above.
 
 Using JDK bundled with Android Studio will help on that.
 
 ```shell
 export JAVA_HOME=/Applications/Android\ Studio.app/Contents/jre/Contents/Home/
 ```
-
 
 <hr>
 

--- a/docs/guides/android_building.md
+++ b/docs/guides/android_building.md
@@ -18,6 +18,7 @@ There are following Apps on Android
 -   [Source files](#source)
 -   [Requirements for building](#requirements)
     -   [ABIs and TARGET_CPU](#abi)
+    -   [Gradle & JDK Version](#jdk)
 -   [Preparing for build](#preparing)
 -   [Building Android CHIPTool from scripts](#building-scripts)
 -   [Building Android CHIPTool from Android Studio](#building-studio)
@@ -56,6 +57,19 @@ architecture:
 | arm64-v8a   | arm64      |
 | x86         | x86        |
 | x86_64      | x64        |
+
+<a name="jdk"></a>
+
+### Gradle & JDK Version
+
+We are using Gradle 7.1.1 for all android project which does not support Java 17 (https://docs.gradle.org/current/userguide/compatibility.html) while the default JDK version on MacOS for Apple Silicon is openjdk 17.0.1 or above. 
+
+Using JDK bundled with Android Studio will help on that.
+
+```shell
+export JAVA_HOME=/Applications/Android\ Studio.app/Contents/jre/Contents/Home/
+```
+
 
 <hr>
 

--- a/scripts/build/builders/android.py
+++ b/scripts/build/builders/android.py
@@ -166,26 +166,24 @@ class AndroidBuilder(Builder):
 
             self._Execute(gn_gen, title='Generating ' + self.identifier)
 
-
             new_sdk_manager = os.path.join(os.environ['ANDROID_HOME'], 'cmdline-tools', 'latest',
-                                        'bin', 'sdkmanager')
+                                           'bin', 'sdkmanager')
             if (os.path.isfile(new_sdk_manager) and os.access(new_sdk_manager, os.X_OK)):
                 self._Execute([
                     'bash', '-c',
                     'yes | %s --licenses >/dev/null' %
                     new_sdk_manager
-                    ],
+                ],
                     title='Accepting NDK licenses @ cmdline-tools')
             else:
                 sdk_manager = os.path.join(os.environ['ANDROID_HOME'], 'tools', 'bin',
-                                   'sdkmanager')
+                                           'sdkmanager')
                 self._Execute([
                     'bash', '-c',
                     'yes | %s --licenses >/dev/null' %
                     sdk_manager
-                    ],
+                ],
                     title='Accepting NDK licenses @ tools')
-
 
     def _build(self):
         if self.board.IsIde():

--- a/scripts/build/builders/android.py
+++ b/scripts/build/builders/android.py
@@ -100,9 +100,13 @@ class AndroidBuilder(Builder):
         # SDK manager must be runnable to 'accept licenses'
         sdk_manager = os.path.join(os.environ['ANDROID_HOME'], 'tools', 'bin',
                                    'sdkmanager')
-        if not (os.path.isfile(sdk_manager) and os.access(sdk_manager, os.X_OK)):
-            raise Exception("'%s' is not executable by the current user" %
-                            sdk_manager)
+
+        # New SDK manager at cmdline-tools/latest/bin/
+        new_sdk_manager = os.path.join(os.environ['ANDROID_HOME'], 'cmdline-tools', 'latest',
+                                       'bin', 'sdkmanager')
+        if not (os.path.isfile(sdk_manager) and os.access(sdk_manager, os.X_OK)) and not (os.path.isfile(new_sdk_manager) and os.access(new_sdk_manager, os.X_OK)):
+            raise Exception("'%s' and '%s' is not executable by the current user" %
+                            (sdk_manager, new_sdk_manager))
 
         # In order to accept a license, the licenses folder is updated with the hash of the
         # accepted license
@@ -162,12 +166,26 @@ class AndroidBuilder(Builder):
 
             self._Execute(gn_gen, title='Generating ' + self.identifier)
 
-            self._Execute([
-                'bash', '-c',
-                'yes | %s/tools/bin/sdkmanager --licenses >/dev/null' %
-                os.environ['ANDROID_HOME']
-            ],
-                title='Accepting NDK licenses')
+
+            new_sdk_manager = os.path.join(os.environ['ANDROID_HOME'], 'cmdline-tools', 'latest',
+                                        'bin', 'sdkmanager')
+            if (os.path.isfile(new_sdk_manager) and os.access(new_sdk_manager, os.X_OK)):
+                self._Execute([
+                    'bash', '-c',
+                    'yes | %s --licenses >/dev/null' %
+                    new_sdk_manager
+                    ],
+                    title='Accepting NDK licenses @ cmdline-tools')
+            else:
+                sdk_manager = os.path.join(os.environ['ANDROID_HOME'], 'tools', 'bin',
+                                   'sdkmanager')
+                self._Execute([
+                    'bash', '-c',
+                    'yes | %s --licenses >/dev/null' %
+                    sdk_manager
+                    ],
+                    title='Accepting NDK licenses @ tools')
+
 
     def _build(self):
         if self.board.IsIde():

--- a/scripts/build/testdata/build_all_except_host.txt
+++ b/scripts/build/testdata/build_all_except_host.txt
@@ -13,7 +13,7 @@ python3 third_party/android_deps/set_up_android_deps.py
 # Generating android-androidstudio-arm-chip-tool
 gn gen --check --fail-on-unused-args {out}/android-androidstudio-arm-chip-tool '--args=target_os="android" target_cpu="arm" android_ndk_root="TEST_ANDROID_NDK_HOME" android_sdk_root="TEST_ANDROID_HOME" chip_use_clusters_for_ip_commissioning=true ' --ide=json --json-ide-script=//scripts/examples/gn_to_cmakelists.py
 
-# Accepting NDK licenses
+# Accepting NDK licenses @ tools
 bash -c 'yes | TEST_ANDROID_HOME/tools/bin/sdkmanager --licenses >/dev/null'
 
 # Generating JARs for Java build rules test
@@ -25,7 +25,7 @@ python3 third_party/android_deps/set_up_android_deps.py
 # Generating android-androidstudio-arm64-chip-tool
 gn gen --check --fail-on-unused-args {out}/android-androidstudio-arm64-chip-tool '--args=target_os="android" target_cpu="arm64" android_ndk_root="TEST_ANDROID_NDK_HOME" android_sdk_root="TEST_ANDROID_HOME" chip_use_clusters_for_ip_commissioning=true ' --ide=json --json-ide-script=//scripts/examples/gn_to_cmakelists.py
 
-# Accepting NDK licenses
+# Accepting NDK licenses @ tools
 bash -c 'yes | TEST_ANDROID_HOME/tools/bin/sdkmanager --licenses >/dev/null'
 
 # Generating JARs for Java build rules test
@@ -37,7 +37,7 @@ python3 third_party/android_deps/set_up_android_deps.py
 # Generating android-androidstudio-x64-chip-tool
 gn gen --check --fail-on-unused-args {out}/android-androidstudio-x64-chip-tool '--args=target_os="android" target_cpu="x64" android_ndk_root="TEST_ANDROID_NDK_HOME" android_sdk_root="TEST_ANDROID_HOME" chip_use_clusters_for_ip_commissioning=true ' --ide=json --json-ide-script=//scripts/examples/gn_to_cmakelists.py
 
-# Accepting NDK licenses
+# Accepting NDK licenses @ tools
 bash -c 'yes | TEST_ANDROID_HOME/tools/bin/sdkmanager --licenses >/dev/null'
 
 # Generating JARs for Java build rules test
@@ -49,7 +49,7 @@ python3 third_party/android_deps/set_up_android_deps.py
 # Generating android-androidstudio-x86-chip-tool
 gn gen --check --fail-on-unused-args {out}/android-androidstudio-x86-chip-tool '--args=target_os="android" target_cpu="x86" android_ndk_root="TEST_ANDROID_NDK_HOME" android_sdk_root="TEST_ANDROID_HOME" chip_use_clusters_for_ip_commissioning=true ' --ide=json --json-ide-script=//scripts/examples/gn_to_cmakelists.py
 
-# Accepting NDK licenses
+# Accepting NDK licenses @ tools
 bash -c 'yes | TEST_ANDROID_HOME/tools/bin/sdkmanager --licenses >/dev/null'
 
 # Generating JARs for Java build rules test
@@ -61,7 +61,7 @@ python3 third_party/android_deps/set_up_android_deps.py
 # Generating android-arm-chip-tool
 gn gen --check --fail-on-unused-args {out}/android-arm-chip-tool '--args=target_os="android" target_cpu="arm" android_ndk_root="TEST_ANDROID_NDK_HOME" android_sdk_root="TEST_ANDROID_HOME" chip_use_clusters_for_ip_commissioning=true '
 
-# Accepting NDK licenses
+# Accepting NDK licenses @ tools
 bash -c 'yes | TEST_ANDROID_HOME/tools/bin/sdkmanager --licenses >/dev/null'
 
 # Generating JARs for Java build rules test
@@ -73,7 +73,7 @@ python3 third_party/android_deps/set_up_android_deps.py
 # Generating android-arm64-chip-test
 gn gen --check --fail-on-unused-args {out}/android-arm64-chip-test '--args=target_os="android" target_cpu="arm64" android_ndk_root="TEST_ANDROID_NDK_HOME" android_sdk_root="TEST_ANDROID_HOME" chip_use_clusters_for_ip_commissioning=true '
 
-# Accepting NDK licenses
+# Accepting NDK licenses @ tools
 bash -c 'yes | TEST_ANDROID_HOME/tools/bin/sdkmanager --licenses >/dev/null'
 
 # Generating JARs for Java build rules test
@@ -85,7 +85,7 @@ python3 third_party/android_deps/set_up_android_deps.py
 # Generating android-arm64-chip-tool
 gn gen --check --fail-on-unused-args {out}/android-arm64-chip-tool '--args=target_os="android" target_cpu="arm64" android_ndk_root="TEST_ANDROID_NDK_HOME" android_sdk_root="TEST_ANDROID_HOME" chip_use_clusters_for_ip_commissioning=true '
 
-# Accepting NDK licenses
+# Accepting NDK licenses @ tools
 bash -c 'yes | TEST_ANDROID_HOME/tools/bin/sdkmanager --licenses >/dev/null'
 
 # Generating JARs for Java build rules test
@@ -97,7 +97,7 @@ python3 third_party/android_deps/set_up_android_deps.py
 # Generating android-arm64-chip-tvserver
 gn gen --check --fail-on-unused-args {out}/android-arm64-chip-tvserver '--args=target_os="android" target_cpu="arm64" android_ndk_root="TEST_ANDROID_NDK_HOME" android_sdk_root="TEST_ANDROID_HOME" chip_use_clusters_for_ip_commissioning=true chip_config_network_layer_ble=false '
 
-# Accepting NDK licenses
+# Accepting NDK licenses @ tools
 bash -c 'yes | TEST_ANDROID_HOME/tools/bin/sdkmanager --licenses >/dev/null'
 
 # Generating JARs for Java build rules test
@@ -109,7 +109,7 @@ python3 third_party/android_deps/set_up_android_deps.py
 # Generating android-x64-chip-tool
 gn gen --check --fail-on-unused-args {out}/android-x64-chip-tool '--args=target_os="android" target_cpu="x64" android_ndk_root="TEST_ANDROID_NDK_HOME" android_sdk_root="TEST_ANDROID_HOME" chip_use_clusters_for_ip_commissioning=true '
 
-# Accepting NDK licenses
+# Accepting NDK licenses @ tools
 bash -c 'yes | TEST_ANDROID_HOME/tools/bin/sdkmanager --licenses >/dev/null'
 
 # Generating JARs for Java build rules test
@@ -121,7 +121,7 @@ python3 third_party/android_deps/set_up_android_deps.py
 # Generating android-x86-chip-tool
 gn gen --check --fail-on-unused-args {out}/android-x86-chip-tool '--args=target_os="android" target_cpu="x86" android_ndk_root="TEST_ANDROID_NDK_HOME" android_sdk_root="TEST_ANDROID_HOME" chip_use_clusters_for_ip_commissioning=true '
 
-# Accepting NDK licenses
+# Accepting NDK licenses @ tools
 bash -c 'yes | TEST_ANDROID_HOME/tools/bin/sdkmanager --licenses >/dev/null'
 
 # Generating efr32-brd4161a-light


### PR DESCRIPTION
#### Problem
* Failed to build on macOS with Apple silicon 
* sdkmanager failed to start
* aarch64-linux-android24-clang: No such file or directory
* General error during conversion: Unsupported class file major version 61

#### Change overview
* using new sdkmanager at cmdline-tools if have
* added  ndk_host_cpu = "-x86_64" on arm64 mac
* added document to fix Gradle version mismatch version 

#### Testing
* './scripts/build/build_examples.py --target-glob "android-*" build' success to build on M1 with macOS 11.6.1, android 2020.3.1 Patch 3, and NDK 21.4.7075529 and SDK 31
