### PR TITLE
Codegen a ResponseType for command cluster objects and use it to simplify templates

### DIFF
--- a/examples/chip-tool/templates/partials/test_cluster.zapt
+++ b/examples/chip-tool/templates/partials/test_cluster.zapt
@@ -134,22 +134,21 @@ class {{filename}}: public TestCommand
         cluster.Associate(mDevice, {{endpoint}});
 
         {{#if isCommand}}
-        using requestType  = chip::app::Clusters::{{asUpperCamelCase cluster}}::Commands::{{asUpperCamelCase command}}::Type;
-        using responseType = chip::app::{{chip_tests_item_response_type}};
+        using RequestType = chip::app::Clusters::{{asUpperCamelCase cluster}}::Commands::{{asUpperCamelCase command}}::Type;
 
-        chip::app::Clusters::{{asUpperCamelCase cluster}}::Commands::{{asUpperCamelCase command}}::Type request;
+        RequestType request;
         {{#chip_tests_item_parameters}}
         {{>commandValue ns=parent.cluster container=(concat "request." (asLowerCamelCase label)) definedValue=definedValue}}
         {{/chip_tests_item_parameters}}
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<{{filename}} *>(context))->OnSuccessResponse_{{index}}({{#chip_tests_item_response_parameters}}{{#not_first}}, {{/not_first}}data.{{asLowerCamelCase name}}{{/chip_tests_item_response_parameters}});
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<{{filename}} *>(context))->OnFailureResponse_{{index}}(status);
         };
-        {{#if async}}ReturnErrorOnFailure({{else}}return {{/if}}cluster.InvokeCommand<requestType, responseType>(request, this, success, failure){{#if async}}){{/if}};
+        {{#if async}}ReturnErrorOnFailure({{else}}return {{/if}}cluster.InvokeCommand(request, this, success, failure){{#if async}}){{/if}};
         {{else}}
         {{#chip_tests_item_parameters}}
         {{zapTypeToEncodableClusterObjectType type ns=parent.cluster}} {{asLowerCamelCase name}}Argument;

--- a/src/app/zap-templates/common/ClusterTestGeneration.js
+++ b/src/app/zap-templates/common/ClusterTestGeneration.js
@@ -453,20 +453,6 @@ function isTestOnlyCluster(name)
   return testOnlyClusters.includes(name);
 }
 
-function chip_tests_item_response_type(options)
-{
-  const promise = assertCommandOrAttribute(this).then(item => {
-    if (item.hasSpecificResponse) {
-      return 'Clusters::' + asUpperCamelCase(this.cluster) + '::Commands::' + asUpperCamelCase(item.response.name)
-          + '::DecodableType';
-    }
-
-    return 'DataModel::NullObjectType';
-  });
-
-  return asPromise.call(this, promise, options);
-}
-
 // test_cluster_command_value and test_cluster_value-equals are recursive partials using #each. At some point the |global|
 // context is lost and it fails. Make sure to attach the global context as a property of the | value |
 // that is evaluated.
@@ -602,7 +588,6 @@ function expectedValueHasProp(value, name)
 exports.chip_tests                          = chip_tests;
 exports.chip_tests_items                    = chip_tests_items;
 exports.chip_tests_item_parameters          = chip_tests_item_parameters;
-exports.chip_tests_item_response_type       = chip_tests_item_response_type;
 exports.chip_tests_item_response_parameters = chip_tests_item_response_parameters;
 exports.chip_tests_pics                     = chip_tests_pics;
 exports.isTestOnlyCluster                   = isTestOnlyCluster;

--- a/src/app/zap-templates/templates/app/CHIPClustersInvoke-src.zapt
+++ b/src/app/zap-templates/templates/app/CHIPClustersInvoke-src.zapt
@@ -18,18 +18,17 @@ namespace Controller {
 
 {{#chip_cluster_commands}}
 {{#*inline "requestType"}}chip::app::Clusters::{{asUpperCamelCase parent.name}}::Commands::{{asUpperCamelCase name}}::Type{{/inline}}
-{{#*inline "responseType"}}chip::app::{{#if hasSpecificResponse}}Clusters::{{asUpperCamelCase parent.name}}::Commands::{{asUpperCamelCase response.name}}::DecodableType{{else}}DataModel::NullObjectType{{/if}}{{/inline}}
-template CHIP_ERROR ClusterBase::InvokeCommand<{{>requestType}}, {{>responseType}}>(const {{>requestType}} &, void *, CommandResponseSuccessCallback<{{>responseType}}>, CommandResponseFailureCallback);
+template CHIP_ERROR ClusterBase::InvokeCommand<{{>requestType}}>(const {{>requestType}} &, void *, CommandResponseSuccessCallback<typename {{>requestType}}::ResponseType>, CommandResponseFailureCallback);
 {{/chip_cluster_commands}}
 {{/chip_client_clusters}}
 
-template <typename RequestDataT, typename ResponseDataT>
+template <typename RequestDataT>
 CHIP_ERROR ClusterBase::InvokeCommand(const RequestDataT & requestData, void * context,
-                         CommandResponseSuccessCallback<ResponseDataT> successCb, CommandResponseFailureCallback failureCb)
+                         CommandResponseSuccessCallback<typename RequestDataT::ResponseType> successCb, CommandResponseFailureCallback failureCb)
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    auto onSuccessCb = [context, successCb](const app::ConcreteCommandPath & commandPath, const app::StatusIB & aStatus, const ResponseDataT & responseData) {
+    auto onSuccessCb = [context, successCb](const app::ConcreteCommandPath & commandPath, const app::StatusIB & aStatus, const typename RequestDataT::ResponseType & responseData) {
         successCb(context, responseData);
     };
 
@@ -37,8 +36,8 @@ CHIP_ERROR ClusterBase::InvokeCommand(const RequestDataT & requestData, void * c
         failureCb(context, app::ToEmberAfStatus(aStatus.mStatus));
     };
 
-    return InvokeCommandRequest<ResponseDataT>(mDevice->GetExchangeManager(), mDevice->GetSecureSession().Value(), mEndpoint,
-                                               requestData, onSuccessCb, onFailureCb);
+    return InvokeCommandRequest(mDevice->GetExchangeManager(), mDevice->GetSecureSession().Value(), mEndpoint,
+                                requestData, onSuccessCb, onFailureCb);
 };
 
 } // namespace Controller

--- a/src/app/zap-templates/templates/app/cluster-objects.zapt
+++ b/src/app/zap-templates/templates/app/cluster-objects.zapt
@@ -6,6 +6,7 @@
 #include <app/data-model/Decode.h>
 #include <app/data-model/Encode.h>
 #include <app/data-model/List.h>
+#include <app/data-model/NullObject.h>
 #include <app/EventLoggingTypes.h>
 #include <app/util/basic-types.h>
 #include <lib/support/BitFlags.h>
@@ -90,6 +91,22 @@ namespace {{asUpperCamelCase name}} {
 {{#zcl_commands}}
 {{#first}}
 namespace Commands {
+ // Forward-declarations so we can reference these later.
+{{/first}}
+
+namespace {{asUpperCamelCase name}} {
+ struct Type;
+ struct DecodableType;
+} // namespace {{asUpperCamelCase name}}
+{{#last}}
+
+} // namespace Commands
+{{/last}}
+{{/zcl_commands}}
+
+{{#zcl_commands}}
+{{#first}}
+namespace Commands {
 {{/first}}
 namespace {{asUpperCamelCase name}} {
 enum class Fields {
@@ -110,6 +127,13 @@ public:
     {{/zcl_command_arguments}}
 
     CHIP_ERROR Encode(TLV::TLVWriter &writer, TLV::Tag tag) const;
+
+    using ResponseType =
+    {{~#if responseRef}}
+      Clusters::{{asUpperCamelCase parent.name}}::Commands::{{getResponseCommandName responseRef}}::DecodableType;
+    {{else}}
+      DataModel::NullObjectType;
+    {{/if}}
 };
 
 struct DecodableType {

--- a/src/app/zap-templates/templates/app/helper.js
+++ b/src/app/zap-templates/templates/app/helper.js
@@ -19,6 +19,7 @@
 const zapPath      = '../../../../../third_party/zap/repo/dist/src-electron/';
 const templateUtil = require(zapPath + 'generator/template-util.js')
 const zclHelper    = require(zapPath + 'generator/helper-zcl.js')
+const queryCommand = require(zapPath + 'db/query-command.js')
 const zclQuery     = require(zapPath + 'db/query-zcl.js')
 const cHelper      = require(zapPath + 'generator/helper-c.js')
 const string       = require(zapPath + 'util/string.js')
@@ -476,6 +477,14 @@ function zapTypeToPythonClusterObjectType(type, options)
   return templateUtil.templatePromise(this.global, promise)
 }
 
+async function getResponseCommandName(responseRef, options)
+{
+  let pkgId = await templateUtil.ensureZclPackageId(this);
+
+  const { db, sessionId } = this.global;
+  return queryCommand.selectCommandById(db, responseRef, pkgId).then(response => asUpperCamelCase(response.name));
+}
+
 //
 // Module exports
 //
@@ -491,3 +500,4 @@ exports.asMEI                               = asMEI;
 exports.zapTypeToEncodableClusterObjectType = zapTypeToEncodableClusterObjectType;
 exports.zapTypeToDecodableClusterObjectType = zapTypeToDecodableClusterObjectType;
 exports.zapTypeToPythonClusterObjectType    = zapTypeToPythonClusterObjectType;
+exports.getResponseCommandName              = getResponseCommandName;

--- a/src/controller/CHIPCluster.h
+++ b/src/controller/CHIPCluster.h
@@ -58,9 +58,10 @@ public:
      * Success and Failure callbacks must be passed in through which the decoded response is provided as well as notification of any
      * failure.
      */
-    template <typename RequestDataT, typename ResponseDataT>
+    template <typename RequestDataT>
     CHIP_ERROR InvokeCommand(const RequestDataT & requestData, void * context,
-                             CommandResponseSuccessCallback<ResponseDataT> successCb, CommandResponseFailureCallback failureCb);
+                             CommandResponseSuccessCallback<typename RequestDataT::ResponseType> successCb,
+                             CommandResponseFailureCallback failureCb);
 
     /**
      * Functions for writing attributes.  We have lots of different

--- a/src/controller/InvokeInteraction.h
+++ b/src/controller/InvokeInteraction.h
@@ -30,21 +30,23 @@ namespace Controller {
  * the provided success callback or calls the provided failure callback.
  *
  * The RequestObjectT is generally expected to be a ClusterName::Commands::CommandName::Type struct, but any object
- * that can be encoded using the DataModel::Encode machinery and exposes the GetClusterId() and GetCommandId() functions
+ * that can be encoded using the DataModel::Encode machinery and exposes the
+ * GetClusterId() and GetCommandId() functions and a ResponseType type
  * is expected to work.
  *
- * The ResponseObjectT is expected to be one of two things:
+ * The ResponseType is expected to be one of two things:
  *
  *    - If a data response is expected on success, a struct type decodable via DataModel::Decode which has GetClusterId() and
  * GetCommandId() methods.  A ClusterName::Commands::ResponseCommandName::DecodableType is typically used.
- *    - If a status response is expected on success, a DataModel::NullObjectType.
+ *    - If a status response is expected on success, DataModel::NullObjectType.
  *
  */
-template <typename ResponseObjectT = app::DataModel::NullObjectType, typename RequestObjectT>
-CHIP_ERROR InvokeCommandRequest(Messaging::ExchangeManager * aExchangeMgr, SessionHandle sessionHandle, chip::EndpointId endpointId,
-                                const RequestObjectT & requestCommandData,
-                                typename TypedCommandCallback<ResponseObjectT>::OnSuccessCallbackType onSuccessCb,
-                                typename TypedCommandCallback<ResponseObjectT>::OnErrorCallbackType onErrorCb)
+template <typename RequestObjectT>
+CHIP_ERROR
+InvokeCommandRequest(Messaging::ExchangeManager * aExchangeMgr, SessionHandle sessionHandle, chip::EndpointId endpointId,
+                     const RequestObjectT & requestCommandData,
+                     typename TypedCommandCallback<typename RequestObjectT::ResponseType>::OnSuccessCallbackType onSuccessCb,
+                     typename TypedCommandCallback<typename RequestObjectT::ResponseType>::OnErrorCallbackType onErrorCb)
 {
     app::CommandPathParams commandPath = { endpointId, 0, RequestObjectT::GetClusterId(), RequestObjectT::GetCommandId(),
                                            (app::CommandPathFlags::kEndpointIdValid) };
@@ -52,7 +54,7 @@ CHIP_ERROR InvokeCommandRequest(Messaging::ExchangeManager * aExchangeMgr, Sessi
     //
     // Let's create a handle version of the decoder to ensure we do correct clean-up of it if things go south at any point below
     //
-    auto decoder = chip::Platform::MakeUnique<TypedCommandCallback<ResponseObjectT>>(onSuccessCb, onErrorCb);
+    auto decoder = chip::Platform::MakeUnique<TypedCommandCallback<typename RequestObjectT::ResponseType>>(onSuccessCb, onErrorCb);
     VerifyOrReturnError(decoder != nullptr, CHIP_ERROR_NO_MEMORY);
 
     //

--- a/src/controller/tests/TestServerCommandDispatch.cpp
+++ b/src/controller/tests/TestServerCommandDispatch.cpp
@@ -114,10 +114,18 @@ public:
 private:
 };
 
+// We want to send a TestSimpleArgumentRequest::Type, but get a
+// TestStructArrayArgumentResponse in return, so need to shadow the actual
+// ResponseType that TestSimpleArgumentRequest has.
+struct FakeRequest : public TestCluster::Commands::TestSimpleArgumentRequest::Type
+{
+    using ResponseType = TestCluster::Commands::TestStructArrayArgumentResponse::DecodableType;
+};
+
 void TestCommandInteraction::TestNoHandler(nlTestSuite * apSuite, void * apContext)
 {
     TestContext & ctx = *static_cast<TestContext *>(apContext);
-    TestCluster::Commands::TestSimpleArgumentRequest::Type request;
+    FakeRequest request;
     auto sessionHandle = ctx.GetSessionBobToAlice();
 
     request.arg1 = true;
@@ -142,8 +150,8 @@ void TestCommandInteraction::TestNoHandler(nlTestSuite * apSuite, void * apConte
 
     ctx.EnableAsyncDispatch();
 
-    chip::Controller::InvokeCommandRequest<TestCluster::Commands::TestStructArrayArgumentResponse::DecodableType>(
-        &ctx.GetExchangeManager(), sessionHandle, kTestEndpointId, request, onSuccessCb, onFailureCb);
+    chip::Controller::InvokeCommandRequest(&ctx.GetExchangeManager(), sessionHandle, kTestEndpointId, request, onSuccessCb,
+                                           onFailureCb);
 
     ctx.DrainAndServiceIO();
 
@@ -176,7 +184,7 @@ DECLARE_DYNAMIC_ENDPOINT(testEndpoint, testEndpointClusters);
 void TestCommandInteraction::TestDataResponse(nlTestSuite * apSuite, void * apContext)
 {
     TestContext & ctx = *static_cast<TestContext *>(apContext);
-    TestCluster::Commands::TestSimpleArgumentRequest::Type request;
+    FakeRequest request;
     auto sessionHandle = ctx.GetSessionBobToAlice();
     TestClusterCommandHandler commandHandler;
 
@@ -220,8 +228,8 @@ void TestCommandInteraction::TestDataResponse(nlTestSuite * apSuite, void * apCo
 
     responseDirective = kSendDataResponse;
 
-    chip::Controller::InvokeCommandRequest<TestCluster::Commands::TestStructArrayArgumentResponse::DecodableType>(
-        &ctx.GetExchangeManager(), sessionHandle, kTestEndpointId, request, onSuccessCb, onFailureCb);
+    chip::Controller::InvokeCommandRequest(&ctx.GetExchangeManager(), sessionHandle, kTestEndpointId, request, onSuccessCb,
+                                           onFailureCb);
 
     ctx.DrainAndServiceIO();
 

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
@@ -28,6 +28,7 @@
 #include <app/data-model/Decode.h>
 #include <app/data-model/Encode.h>
 #include <app/data-model/List.h>
+#include <app/data-model/NullObject.h>
 #include <app/util/basic-types.h>
 #include <lib/support/BitFlags.h>
 #include <protocols/interaction_model/Constants.h>
@@ -792,6 +793,31 @@ using IdentifyIdentifyType                 = EmberAfIdentifyIdentifyType;
 #endif
 
 namespace Commands {
+// Forward-declarations so we can reference these later.
+
+namespace Identify {
+struct Type;
+struct DecodableType;
+} // namespace Identify
+
+namespace IdentifyQueryResponse {
+struct Type;
+struct DecodableType;
+} // namespace IdentifyQueryResponse
+
+namespace IdentifyQuery {
+struct Type;
+struct DecodableType;
+} // namespace IdentifyQuery
+
+namespace TriggerEffect {
+struct Type;
+struct DecodableType;
+} // namespace TriggerEffect
+
+} // namespace Commands
+
+namespace Commands {
 namespace Identify {
 enum class Fields
 {
@@ -808,6 +834,8 @@ public:
     uint16_t identifyTime;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -836,6 +864,8 @@ public:
     uint16_t timeout;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -861,6 +891,8 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::Identify::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::Identify::Commands::IdentifyQueryResponse::DecodableType;
 };
 
 struct DecodableType
@@ -890,6 +922,8 @@ public:
     IdentifyEffectVariant effectVariant;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -951,6 +985,61 @@ struct TypeInfo
 namespace Groups {
 
 namespace Commands {
+// Forward-declarations so we can reference these later.
+
+namespace AddGroup {
+struct Type;
+struct DecodableType;
+} // namespace AddGroup
+
+namespace AddGroupResponse {
+struct Type;
+struct DecodableType;
+} // namespace AddGroupResponse
+
+namespace ViewGroup {
+struct Type;
+struct DecodableType;
+} // namespace ViewGroup
+
+namespace ViewGroupResponse {
+struct Type;
+struct DecodableType;
+} // namespace ViewGroupResponse
+
+namespace GetGroupMembership {
+struct Type;
+struct DecodableType;
+} // namespace GetGroupMembership
+
+namespace GetGroupMembershipResponse {
+struct Type;
+struct DecodableType;
+} // namespace GetGroupMembershipResponse
+
+namespace RemoveGroup {
+struct Type;
+struct DecodableType;
+} // namespace RemoveGroup
+
+namespace RemoveGroupResponse {
+struct Type;
+struct DecodableType;
+} // namespace RemoveGroupResponse
+
+namespace RemoveAllGroups {
+struct Type;
+struct DecodableType;
+} // namespace RemoveAllGroups
+
+namespace AddGroupIfIdentifying {
+struct Type;
+struct DecodableType;
+} // namespace AddGroupIfIdentifying
+
+} // namespace Commands
+
+namespace Commands {
 namespace AddGroup {
 enum class Fields
 {
@@ -969,6 +1058,8 @@ public:
     chip::CharSpan groupName;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::Groups::Commands::AddGroupResponse::DecodableType;
 };
 
 struct DecodableType
@@ -1000,6 +1091,8 @@ public:
     uint16_t groupId;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -1029,6 +1122,8 @@ public:
     uint16_t groupId;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::Groups::Commands::ViewGroupResponse::DecodableType;
 };
 
 struct DecodableType
@@ -1061,6 +1156,8 @@ public:
     chip::CharSpan groupName;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -1093,6 +1190,8 @@ public:
     DataModel::List<const uint16_t> groupList;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::Groups::Commands::GetGroupMembershipResponse::DecodableType;
 };
 
 struct DecodableType
@@ -1126,6 +1225,8 @@ public:
     DataModel::List<const uint16_t> groupList;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -1156,6 +1257,8 @@ public:
     uint16_t groupId;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::Groups::Commands::RemoveGroupResponse::DecodableType;
 };
 
 struct DecodableType
@@ -1186,6 +1289,8 @@ public:
     uint16_t groupId;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -1212,6 +1317,8 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::Groups::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -1241,6 +1348,8 @@ public:
     chip::CharSpan groupName;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -1323,6 +1432,106 @@ using DecodableType = Type;
 } // namespace Structs
 
 namespace Commands {
+// Forward-declarations so we can reference these later.
+
+namespace AddScene {
+struct Type;
+struct DecodableType;
+} // namespace AddScene
+
+namespace AddSceneResponse {
+struct Type;
+struct DecodableType;
+} // namespace AddSceneResponse
+
+namespace ViewScene {
+struct Type;
+struct DecodableType;
+} // namespace ViewScene
+
+namespace ViewSceneResponse {
+struct Type;
+struct DecodableType;
+} // namespace ViewSceneResponse
+
+namespace RemoveScene {
+struct Type;
+struct DecodableType;
+} // namespace RemoveScene
+
+namespace RemoveSceneResponse {
+struct Type;
+struct DecodableType;
+} // namespace RemoveSceneResponse
+
+namespace RemoveAllScenes {
+struct Type;
+struct DecodableType;
+} // namespace RemoveAllScenes
+
+namespace RemoveAllScenesResponse {
+struct Type;
+struct DecodableType;
+} // namespace RemoveAllScenesResponse
+
+namespace StoreScene {
+struct Type;
+struct DecodableType;
+} // namespace StoreScene
+
+namespace StoreSceneResponse {
+struct Type;
+struct DecodableType;
+} // namespace StoreSceneResponse
+
+namespace RecallScene {
+struct Type;
+struct DecodableType;
+} // namespace RecallScene
+
+namespace GetSceneMembership {
+struct Type;
+struct DecodableType;
+} // namespace GetSceneMembership
+
+namespace GetSceneMembershipResponse {
+struct Type;
+struct DecodableType;
+} // namespace GetSceneMembershipResponse
+
+namespace EnhancedAddScene {
+struct Type;
+struct DecodableType;
+} // namespace EnhancedAddScene
+
+namespace EnhancedAddSceneResponse {
+struct Type;
+struct DecodableType;
+} // namespace EnhancedAddSceneResponse
+
+namespace EnhancedViewScene {
+struct Type;
+struct DecodableType;
+} // namespace EnhancedViewScene
+
+namespace EnhancedViewSceneResponse {
+struct Type;
+struct DecodableType;
+} // namespace EnhancedViewSceneResponse
+
+namespace CopyScene {
+struct Type;
+struct DecodableType;
+} // namespace CopyScene
+
+namespace CopySceneResponse {
+struct Type;
+struct DecodableType;
+} // namespace CopySceneResponse
+
+} // namespace Commands
+
+namespace Commands {
 namespace AddScene {
 enum class Fields
 {
@@ -1347,6 +1556,8 @@ public:
     DataModel::List<const Structs::SceneExtensionFieldSet::Type> extensionFieldSets;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::Scenes::Commands::AddSceneResponse::DecodableType;
 };
 
 struct DecodableType
@@ -1383,6 +1594,8 @@ public:
     uint8_t sceneId;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -1415,6 +1628,8 @@ public:
     uint8_t sceneId;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::Scenes::Commands::ViewSceneResponse::DecodableType;
 };
 
 struct DecodableType
@@ -1454,6 +1669,8 @@ public:
     DataModel::List<const Structs::SceneExtensionFieldSet::Type> extensionFieldSets;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -1489,6 +1706,8 @@ public:
     uint8_t sceneId;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::Scenes::Commands::RemoveSceneResponse::DecodableType;
 };
 
 struct DecodableType
@@ -1522,6 +1741,8 @@ public:
     uint8_t sceneId;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -1552,6 +1773,8 @@ public:
     uint16_t groupId;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::Scenes::Commands::RemoveAllScenesResponse::DecodableType;
 };
 
 struct DecodableType
@@ -1582,6 +1805,8 @@ public:
     uint16_t groupId;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -1613,6 +1838,8 @@ public:
     uint8_t sceneId;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::Scenes::Commands::StoreSceneResponse::DecodableType;
 };
 
 struct DecodableType
@@ -1646,6 +1873,8 @@ public:
     uint8_t sceneId;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -1680,6 +1909,8 @@ public:
     uint16_t transitionTime;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -1710,6 +1941,8 @@ public:
     uint16_t groupId;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::Scenes::Commands::GetSceneMembershipResponse::DecodableType;
 };
 
 struct DecodableType
@@ -1746,6 +1979,8 @@ public:
     DataModel::List<const uint8_t> sceneList;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -1786,6 +2021,8 @@ public:
     DataModel::List<const Structs::SceneExtensionFieldSet::Type> extensionFieldSets;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::Scenes::Commands::EnhancedAddSceneResponse::DecodableType;
 };
 
 struct DecodableType
@@ -1822,6 +2059,8 @@ public:
     uint8_t sceneId;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -1854,6 +2093,8 @@ public:
     uint8_t sceneId;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::Scenes::Commands::EnhancedViewSceneResponse::DecodableType;
 };
 
 struct DecodableType
@@ -1893,6 +2134,8 @@ public:
     DataModel::List<const Structs::SceneExtensionFieldSet::Type> extensionFieldSets;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -1934,6 +2177,8 @@ public:
     uint8_t sceneIdTo;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::Scenes::Commands::CopySceneResponse::DecodableType;
 };
 
 struct DecodableType
@@ -1970,6 +2215,8 @@ public:
     uint8_t sceneIdFrom;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -2114,6 +2361,66 @@ enum class OnOffControl : uint8_t
 };
 
 namespace Commands {
+// Forward-declarations so we can reference these later.
+
+namespace Off {
+struct Type;
+struct DecodableType;
+} // namespace Off
+
+namespace SampleMfgSpecificOffWithTransition {
+struct Type;
+struct DecodableType;
+} // namespace SampleMfgSpecificOffWithTransition
+
+namespace On {
+struct Type;
+struct DecodableType;
+} // namespace On
+
+namespace SampleMfgSpecificOnWithTransition {
+struct Type;
+struct DecodableType;
+} // namespace SampleMfgSpecificOnWithTransition
+
+namespace SampleMfgSpecificOnWithTransition2 {
+struct Type;
+struct DecodableType;
+} // namespace SampleMfgSpecificOnWithTransition2
+
+namespace Toggle {
+struct Type;
+struct DecodableType;
+} // namespace Toggle
+
+namespace SampleMfgSpecificToggleWithTransition {
+struct Type;
+struct DecodableType;
+} // namespace SampleMfgSpecificToggleWithTransition
+
+namespace SampleMfgSpecificToggleWithTransition2 {
+struct Type;
+struct DecodableType;
+} // namespace SampleMfgSpecificToggleWithTransition2
+
+namespace OffWithEffect {
+struct Type;
+struct DecodableType;
+} // namespace OffWithEffect
+
+namespace OnWithRecallGlobalScene {
+struct Type;
+struct DecodableType;
+} // namespace OnWithRecallGlobalScene
+
+namespace OnWithTimedOff {
+struct Type;
+struct DecodableType;
+} // namespace OnWithTimedOff
+
+} // namespace Commands
+
+namespace Commands {
 namespace Off {
 enum class Fields
 {
@@ -2127,6 +2434,8 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::OnOff::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -2151,6 +2460,8 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::OnOff::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -2175,6 +2486,8 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::OnOff::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -2199,6 +2512,8 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::OnOff::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -2223,6 +2538,8 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::OnOff::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -2247,6 +2564,8 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::OnOff::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -2271,6 +2590,8 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::OnOff::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -2295,6 +2616,8 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::OnOff::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -2324,6 +2647,8 @@ public:
     OnOffDelayedAllOffEffectVariant effectVariant;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -2350,6 +2675,8 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::OnOff::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -2381,6 +2708,8 @@ public:
     uint16_t offWaitTime;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -2582,6 +2911,51 @@ using StepMode                             = EmberAfStepMode;
 #endif
 
 namespace Commands {
+// Forward-declarations so we can reference these later.
+
+namespace MoveToLevel {
+struct Type;
+struct DecodableType;
+} // namespace MoveToLevel
+
+namespace Move {
+struct Type;
+struct DecodableType;
+} // namespace Move
+
+namespace Step {
+struct Type;
+struct DecodableType;
+} // namespace Step
+
+namespace Stop {
+struct Type;
+struct DecodableType;
+} // namespace Stop
+
+namespace MoveToLevelWithOnOff {
+struct Type;
+struct DecodableType;
+} // namespace MoveToLevelWithOnOff
+
+namespace MoveWithOnOff {
+struct Type;
+struct DecodableType;
+} // namespace MoveWithOnOff
+
+namespace StepWithOnOff {
+struct Type;
+struct DecodableType;
+} // namespace StepWithOnOff
+
+namespace StopWithOnOff {
+struct Type;
+struct DecodableType;
+} // namespace StopWithOnOff
+
+} // namespace Commands
+
+namespace Commands {
 namespace MoveToLevel {
 enum class Fields
 {
@@ -2604,6 +2978,8 @@ public:
     uint8_t optionOverride;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -2641,6 +3017,8 @@ public:
     uint8_t optionOverride;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -2680,6 +3058,8 @@ public:
     uint8_t optionOverride;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -2714,6 +3094,8 @@ public:
     uint8_t optionOverride;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -2745,6 +3127,8 @@ public:
     uint16_t transitionTime;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -2776,6 +3160,8 @@ public:
     uint8_t rate;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -2809,6 +3195,8 @@ public:
     uint16_t transitionTime;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -2836,6 +3224,8 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::LevelControl::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -3015,6 +3405,41 @@ struct TypeInfo
 namespace Alarms {
 
 namespace Commands {
+// Forward-declarations so we can reference these later.
+
+namespace ResetAlarm {
+struct Type;
+struct DecodableType;
+} // namespace ResetAlarm
+
+namespace Alarm {
+struct Type;
+struct DecodableType;
+} // namespace Alarm
+
+namespace ResetAllAlarms {
+struct Type;
+struct DecodableType;
+} // namespace ResetAllAlarms
+
+namespace GetAlarmResponse {
+struct Type;
+struct DecodableType;
+} // namespace GetAlarmResponse
+
+namespace GetAlarm {
+struct Type;
+struct DecodableType;
+} // namespace GetAlarm
+
+namespace ResetAlarmLog {
+struct Type;
+struct DecodableType;
+} // namespace ResetAlarmLog
+
+} // namespace Commands
+
+namespace Commands {
 namespace ResetAlarm {
 enum class Fields
 {
@@ -3033,6 +3458,8 @@ public:
     chip::ClusterId clusterId;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -3064,6 +3491,8 @@ public:
     chip::ClusterId clusterId;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -3090,6 +3519,8 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::Alarms::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -3123,6 +3554,8 @@ public:
     uint32_t timeStamp;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -3151,6 +3584,8 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::Alarms::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::Alarms::Commands::GetAlarmResponse::DecodableType;
 };
 
 struct DecodableType
@@ -3175,6 +3610,8 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::Alarms::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -3539,6 +3976,116 @@ using DecodableType = Type;
 } // namespace Structs
 
 namespace Commands {
+// Forward-declarations so we can reference these later.
+
+namespace PowerProfileRequest {
+struct Type;
+struct DecodableType;
+} // namespace PowerProfileRequest
+
+namespace PowerProfileNotification {
+struct Type;
+struct DecodableType;
+} // namespace PowerProfileNotification
+
+namespace PowerProfileStateRequest {
+struct Type;
+struct DecodableType;
+} // namespace PowerProfileStateRequest
+
+namespace PowerProfileResponse {
+struct Type;
+struct DecodableType;
+} // namespace PowerProfileResponse
+
+namespace GetPowerProfilePriceResponse {
+struct Type;
+struct DecodableType;
+} // namespace GetPowerProfilePriceResponse
+
+namespace PowerProfileStateResponse {
+struct Type;
+struct DecodableType;
+} // namespace PowerProfileStateResponse
+
+namespace GetOverallSchedulePriceResponse {
+struct Type;
+struct DecodableType;
+} // namespace GetOverallSchedulePriceResponse
+
+namespace GetPowerProfilePrice {
+struct Type;
+struct DecodableType;
+} // namespace GetPowerProfilePrice
+
+namespace EnergyPhasesScheduleNotification {
+struct Type;
+struct DecodableType;
+} // namespace EnergyPhasesScheduleNotification
+
+namespace PowerProfilesStateNotification {
+struct Type;
+struct DecodableType;
+} // namespace PowerProfilesStateNotification
+
+namespace EnergyPhasesScheduleResponse {
+struct Type;
+struct DecodableType;
+} // namespace EnergyPhasesScheduleResponse
+
+namespace GetOverallSchedulePrice {
+struct Type;
+struct DecodableType;
+} // namespace GetOverallSchedulePrice
+
+namespace PowerProfileScheduleConstraintsRequest {
+struct Type;
+struct DecodableType;
+} // namespace PowerProfileScheduleConstraintsRequest
+
+namespace EnergyPhasesScheduleRequest {
+struct Type;
+struct DecodableType;
+} // namespace EnergyPhasesScheduleRequest
+
+namespace EnergyPhasesScheduleStateRequest {
+struct Type;
+struct DecodableType;
+} // namespace EnergyPhasesScheduleStateRequest
+
+namespace EnergyPhasesScheduleStateResponse {
+struct Type;
+struct DecodableType;
+} // namespace EnergyPhasesScheduleStateResponse
+
+namespace GetPowerProfilePriceExtendedResponse {
+struct Type;
+struct DecodableType;
+} // namespace GetPowerProfilePriceExtendedResponse
+
+namespace EnergyPhasesScheduleStateNotification {
+struct Type;
+struct DecodableType;
+} // namespace EnergyPhasesScheduleStateNotification
+
+namespace PowerProfileScheduleConstraintsNotification {
+struct Type;
+struct DecodableType;
+} // namespace PowerProfileScheduleConstraintsNotification
+
+namespace PowerProfileScheduleConstraintsResponse {
+struct Type;
+struct DecodableType;
+} // namespace PowerProfileScheduleConstraintsResponse
+
+namespace GetPowerProfilePriceExtended {
+struct Type;
+struct DecodableType;
+} // namespace GetPowerProfilePriceExtended
+
+} // namespace Commands
+
+namespace Commands {
 namespace PowerProfileRequest {
 enum class Fields
 {
@@ -3555,6 +4102,8 @@ public:
     uint8_t powerProfileId;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::PowerProfile::Commands::PowerProfileResponse::DecodableType;
 };
 
 struct DecodableType
@@ -3589,6 +4138,8 @@ public:
     DataModel::List<const Structs::TransferredPhase::Type> transferredPhases;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -3617,6 +4168,8 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::PowerProfile::Commands::PowerProfileStateResponse::DecodableType;
 };
 
 struct DecodableType
@@ -3650,6 +4203,8 @@ public:
     DataModel::List<const Structs::TransferredPhase::Type> transferredPhases;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -3687,6 +4242,8 @@ public:
     uint8_t priceTrailingDigit;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -3720,6 +4277,8 @@ public:
     DataModel::List<const Structs::PowerProfileRecord::Type> powerProfileRecords;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -3753,6 +4312,8 @@ public:
     uint8_t priceTrailingDigit;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -3783,6 +4344,8 @@ public:
     uint8_t powerProfileId;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::PowerProfile::Commands::GetPowerProfilePriceResponse::DecodableType;
 };
 
 struct DecodableType
@@ -3815,6 +4378,8 @@ public:
     DataModel::List<const Structs::ScheduledPhase::Type> scheduledPhases;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -3847,6 +4412,8 @@ public:
     DataModel::List<const Structs::PowerProfileRecord::Type> powerProfileRecords;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -3880,6 +4447,8 @@ public:
     DataModel::List<const Structs::ScheduledPhase::Type> scheduledPhases;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -3907,6 +4476,8 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::PowerProfile::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::PowerProfile::Commands::GetOverallSchedulePriceResponse::DecodableType;
 };
 
 struct DecodableType
@@ -3934,6 +4505,8 @@ public:
     uint8_t powerProfileId;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::PowerProfile::Commands::PowerProfileScheduleConstraintsResponse::DecodableType;
 };
 
 struct DecodableType
@@ -3962,6 +4535,8 @@ public:
     uint8_t powerProfileId;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::PowerProfile::Commands::EnergyPhasesScheduleResponse::DecodableType;
 };
 
 struct DecodableType
@@ -3990,6 +4565,8 @@ public:
     uint8_t powerProfileId;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::PowerProfile::Commands::EnergyPhasesScheduleStateResponse::DecodableType;
 };
 
 struct DecodableType
@@ -4022,6 +4599,8 @@ public:
     DataModel::List<const Structs::ScheduledPhase::Type> scheduledPhases;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -4058,6 +4637,8 @@ public:
     uint8_t priceTrailingDigit;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -4093,6 +4674,8 @@ public:
     DataModel::List<const Structs::ScheduledPhase::Type> scheduledPhases;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -4127,6 +4710,8 @@ public:
     uint16_t stopBefore;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -4161,6 +4746,8 @@ public:
     uint16_t stopBefore;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -4195,6 +4782,8 @@ public:
     uint16_t powerProfileStartTime;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::PowerProfile::Commands::GetPowerProfilePriceExtendedResponse::DecodableType;
 };
 
 struct DecodableType
@@ -4355,6 +4944,51 @@ enum class RemoteEnableFlagsAndDeviceStatus2 : uint8_t
 };
 
 namespace Commands {
+// Forward-declarations so we can reference these later.
+
+namespace ExecutionOfACommand {
+struct Type;
+struct DecodableType;
+} // namespace ExecutionOfACommand
+
+namespace SignalStateResponse {
+struct Type;
+struct DecodableType;
+} // namespace SignalStateResponse
+
+namespace SignalState {
+struct Type;
+struct DecodableType;
+} // namespace SignalState
+
+namespace SignalStateNotification {
+struct Type;
+struct DecodableType;
+} // namespace SignalStateNotification
+
+namespace WriteFunctions {
+struct Type;
+struct DecodableType;
+} // namespace WriteFunctions
+
+namespace OverloadPauseResume {
+struct Type;
+struct DecodableType;
+} // namespace OverloadPauseResume
+
+namespace OverloadPause {
+struct Type;
+struct DecodableType;
+} // namespace OverloadPause
+
+namespace OverloadWarning {
+struct Type;
+struct DecodableType;
+} // namespace OverloadWarning
+
+} // namespace Commands
+
+namespace Commands {
 namespace ExecutionOfACommand {
 enum class Fields
 {
@@ -4371,6 +5005,8 @@ public:
     CommandIdentification commandId;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -4403,6 +5039,8 @@ public:
     ApplianceStatus applianceStatus2;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -4430,6 +5068,8 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::ApplianceControl::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::ApplianceControl::Commands::SignalStateResponse::DecodableType;
 };
 
 struct DecodableType
@@ -4461,6 +5101,8 @@ public:
     ApplianceStatus applianceStatus2;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -4495,6 +5137,8 @@ public:
     DataModel::List<const uint8_t> functionData;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -4522,6 +5166,8 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::ApplianceControl::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -4546,6 +5192,8 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::ApplianceControl::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -4573,6 +5221,8 @@ public:
     WarningEvent warningEvent;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -4731,6 +5381,36 @@ struct TypeInfo
 namespace PollControl {
 
 namespace Commands {
+// Forward-declarations so we can reference these later.
+
+namespace CheckIn {
+struct Type;
+struct DecodableType;
+} // namespace CheckIn
+
+namespace CheckInResponse {
+struct Type;
+struct DecodableType;
+} // namespace CheckInResponse
+
+namespace FastPollStop {
+struct Type;
+struct DecodableType;
+} // namespace FastPollStop
+
+namespace SetLongPollInterval {
+struct Type;
+struct DecodableType;
+} // namespace SetLongPollInterval
+
+namespace SetShortPollInterval {
+struct Type;
+struct DecodableType;
+} // namespace SetShortPollInterval
+
+} // namespace Commands
+
+namespace Commands {
 namespace CheckIn {
 enum class Fields
 {
@@ -4744,6 +5424,8 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::PollControl::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::PollControl::Commands::CheckInResponse::DecodableType;
 };
 
 struct DecodableType
@@ -4773,6 +5455,8 @@ public:
     uint16_t fastPollTimeout;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -4799,6 +5483,8 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::PollControl::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -4826,6 +5512,8 @@ public:
     uint32_t newLongPollInterval;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -4854,6 +5542,8 @@ public:
     uint16_t newShortPollInterval;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -5092,6 +5782,71 @@ using DecodableType = Type;
 } // namespace Structs
 
 namespace Commands {
+// Forward-declarations so we can reference these later.
+
+namespace InstantAction {
+struct Type;
+struct DecodableType;
+} // namespace InstantAction
+
+namespace InstantActionWithTransition {
+struct Type;
+struct DecodableType;
+} // namespace InstantActionWithTransition
+
+namespace StartAction {
+struct Type;
+struct DecodableType;
+} // namespace StartAction
+
+namespace StartActionWithDuration {
+struct Type;
+struct DecodableType;
+} // namespace StartActionWithDuration
+
+namespace StopAction {
+struct Type;
+struct DecodableType;
+} // namespace StopAction
+
+namespace PauseAction {
+struct Type;
+struct DecodableType;
+} // namespace PauseAction
+
+namespace PauseActionWithDuration {
+struct Type;
+struct DecodableType;
+} // namespace PauseActionWithDuration
+
+namespace ResumeAction {
+struct Type;
+struct DecodableType;
+} // namespace ResumeAction
+
+namespace EnableAction {
+struct Type;
+struct DecodableType;
+} // namespace EnableAction
+
+namespace EnableActionWithDuration {
+struct Type;
+struct DecodableType;
+} // namespace EnableActionWithDuration
+
+namespace DisableAction {
+struct Type;
+struct DecodableType;
+} // namespace DisableAction
+
+namespace DisableActionWithDuration {
+struct Type;
+struct DecodableType;
+} // namespace DisableActionWithDuration
+
+} // namespace Commands
+
+namespace Commands {
 namespace InstantAction {
 enum class Fields
 {
@@ -5110,6 +5865,8 @@ public:
     Optional<uint32_t> invokeID;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -5143,6 +5900,8 @@ public:
     uint16_t transitionTime;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -5175,6 +5934,8 @@ public:
     Optional<uint32_t> invokeID;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -5208,6 +5969,8 @@ public:
     uint32_t duration;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -5240,6 +6003,8 @@ public:
     Optional<uint32_t> invokeID;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -5271,6 +6036,8 @@ public:
     Optional<uint32_t> invokeID;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -5304,6 +6071,8 @@ public:
     uint32_t duration;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -5336,6 +6105,8 @@ public:
     Optional<uint32_t> invokeID;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -5367,6 +6138,8 @@ public:
     Optional<uint32_t> invokeID;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -5400,6 +6173,8 @@ public:
     uint32_t duration;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -5432,6 +6207,8 @@ public:
     Optional<uint32_t> invokeID;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -5465,6 +6242,8 @@ public:
     uint32_t duration;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -5537,6 +6316,31 @@ struct TypeInfo
 namespace Basic {
 
 namespace Commands {
+// Forward-declarations so we can reference these later.
+
+namespace StartUp {
+struct Type;
+struct DecodableType;
+} // namespace StartUp
+
+namespace MfgSpecificPing {
+struct Type;
+struct DecodableType;
+} // namespace MfgSpecificPing
+
+namespace ShutDown {
+struct Type;
+struct DecodableType;
+} // namespace ShutDown
+
+namespace Leave {
+struct Type;
+struct DecodableType;
+} // namespace Leave
+
+} // namespace Commands
+
+namespace Commands {
 namespace StartUp {
 enum class Fields
 {
@@ -5550,6 +6354,8 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::Basic::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -5574,6 +6380,8 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::Basic::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -5598,6 +6406,8 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::Basic::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -5622,6 +6432,8 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::Basic::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -5881,6 +6693,36 @@ using OTAQueryStatus                       = EmberAfOTAQueryStatus;
 #endif
 
 namespace Commands {
+// Forward-declarations so we can reference these later.
+
+namespace QueryImage {
+struct Type;
+struct DecodableType;
+} // namespace QueryImage
+
+namespace ApplyUpdateRequest {
+struct Type;
+struct DecodableType;
+} // namespace ApplyUpdateRequest
+
+namespace NotifyUpdateApplied {
+struct Type;
+struct DecodableType;
+} // namespace NotifyUpdateApplied
+
+namespace QueryImageResponse {
+struct Type;
+struct DecodableType;
+} // namespace QueryImageResponse
+
+namespace ApplyUpdateResponse {
+struct Type;
+struct DecodableType;
+} // namespace ApplyUpdateResponse
+
+} // namespace Commands
+
+namespace Commands {
 namespace QueryImage {
 enum class Fields
 {
@@ -5911,6 +6753,8 @@ public:
     Optional<chip::ByteSpan> metadataForProvider;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::OtaSoftwareUpdateProvider::Commands::QueryImageResponse::DecodableType;
 };
 
 struct DecodableType
@@ -5948,6 +6792,8 @@ public:
     uint32_t newVersion;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::OtaSoftwareUpdateProvider::Commands::ApplyUpdateResponse::DecodableType;
 };
 
 struct DecodableType
@@ -5979,6 +6825,8 @@ public:
     uint32_t softwareVersion;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -6022,6 +6870,8 @@ public:
     Optional<chip::ByteSpan> metadataForRequestor;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -6059,6 +6909,8 @@ public:
     uint32_t delayedActionTime;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -6113,6 +6965,16 @@ using OTAAnnouncementReason                = EmberAfOTAAnnouncementReason;
 #endif
 
 namespace Commands {
+// Forward-declarations so we can reference these later.
+
+namespace AnnounceOtaProvider {
+struct Type;
+struct DecodableType;
+} // namespace AnnounceOtaProvider
+
+} // namespace Commands
+
+namespace Commands {
 namespace AnnounceOtaProvider {
 enum class Fields
 {
@@ -6135,6 +6997,8 @@ public:
     Optional<chip::ByteSpan> metadataForNode;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -6580,6 +7444,41 @@ using DecodableType = Type;
 } // namespace Structs
 
 namespace Commands {
+// Forward-declarations so we can reference these later.
+
+namespace ArmFailSafe {
+struct Type;
+struct DecodableType;
+} // namespace ArmFailSafe
+
+namespace ArmFailSafeResponse {
+struct Type;
+struct DecodableType;
+} // namespace ArmFailSafeResponse
+
+namespace SetRegulatoryConfig {
+struct Type;
+struct DecodableType;
+} // namespace SetRegulatoryConfig
+
+namespace SetRegulatoryConfigResponse {
+struct Type;
+struct DecodableType;
+} // namespace SetRegulatoryConfigResponse
+
+namespace CommissioningComplete {
+struct Type;
+struct DecodableType;
+} // namespace CommissioningComplete
+
+namespace CommissioningCompleteResponse {
+struct Type;
+struct DecodableType;
+} // namespace CommissioningCompleteResponse
+
+} // namespace Commands
+
+namespace Commands {
 namespace ArmFailSafe {
 enum class Fields
 {
@@ -6600,6 +7499,8 @@ public:
     uint32_t timeoutMs;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::GeneralCommissioning::Commands::ArmFailSafeResponse::DecodableType;
 };
 
 struct DecodableType
@@ -6632,6 +7533,8 @@ public:
     chip::CharSpan debugText;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -6667,6 +7570,8 @@ public:
     uint32_t timeoutMs;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::GeneralCommissioning::Commands::SetRegulatoryConfigResponse::DecodableType;
 };
 
 struct DecodableType
@@ -6700,6 +7605,8 @@ public:
     chip::CharSpan debugText;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -6726,6 +7633,8 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::GeneralCommissioning::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::GeneralCommissioning::Commands::CommissioningCompleteResponse::DecodableType;
 };
 
 struct DecodableType
@@ -6755,6 +7664,8 @@ public:
     chip::CharSpan debugText;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -6913,6 +7824,91 @@ using DecodableType = Type;
 } // namespace Structs
 
 namespace Commands {
+// Forward-declarations so we can reference these later.
+
+namespace ScanNetworks {
+struct Type;
+struct DecodableType;
+} // namespace ScanNetworks
+
+namespace ScanNetworksResponse {
+struct Type;
+struct DecodableType;
+} // namespace ScanNetworksResponse
+
+namespace AddWiFiNetwork {
+struct Type;
+struct DecodableType;
+} // namespace AddWiFiNetwork
+
+namespace AddWiFiNetworkResponse {
+struct Type;
+struct DecodableType;
+} // namespace AddWiFiNetworkResponse
+
+namespace UpdateWiFiNetwork {
+struct Type;
+struct DecodableType;
+} // namespace UpdateWiFiNetwork
+
+namespace UpdateWiFiNetworkResponse {
+struct Type;
+struct DecodableType;
+} // namespace UpdateWiFiNetworkResponse
+
+namespace AddThreadNetwork {
+struct Type;
+struct DecodableType;
+} // namespace AddThreadNetwork
+
+namespace AddThreadNetworkResponse {
+struct Type;
+struct DecodableType;
+} // namespace AddThreadNetworkResponse
+
+namespace UpdateThreadNetwork {
+struct Type;
+struct DecodableType;
+} // namespace UpdateThreadNetwork
+
+namespace UpdateThreadNetworkResponse {
+struct Type;
+struct DecodableType;
+} // namespace UpdateThreadNetworkResponse
+
+namespace RemoveNetwork {
+struct Type;
+struct DecodableType;
+} // namespace RemoveNetwork
+
+namespace RemoveNetworkResponse {
+struct Type;
+struct DecodableType;
+} // namespace RemoveNetworkResponse
+
+namespace EnableNetwork {
+struct Type;
+struct DecodableType;
+} // namespace EnableNetwork
+
+namespace EnableNetworkResponse {
+struct Type;
+struct DecodableType;
+} // namespace EnableNetworkResponse
+
+namespace DisableNetwork {
+struct Type;
+struct DecodableType;
+} // namespace DisableNetwork
+
+namespace DisableNetworkResponse {
+struct Type;
+struct DecodableType;
+} // namespace DisableNetworkResponse
+
+} // namespace Commands
+
+namespace Commands {
 namespace ScanNetworks {
 enum class Fields
 {
@@ -6933,6 +7929,8 @@ public:
     uint32_t timeoutMs;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::NetworkCommissioning::Commands::ScanNetworksResponse::DecodableType;
 };
 
 struct DecodableType
@@ -6969,6 +7967,8 @@ public:
     DataModel::List<const Structs::ThreadInterfaceScanResult::Type> threadScanResults;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -7006,6 +8006,8 @@ public:
     uint32_t timeoutMs;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::NetworkCommissioning::Commands::AddWiFiNetworkResponse::DecodableType;
 };
 
 struct DecodableType
@@ -7039,6 +8041,8 @@ public:
     chip::CharSpan debugText;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -7074,6 +8078,8 @@ public:
     uint32_t timeoutMs;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::NetworkCommissioning::Commands::UpdateWiFiNetworkResponse::DecodableType;
 };
 
 struct DecodableType
@@ -7107,6 +8113,8 @@ public:
     chip::CharSpan debugText;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -7140,6 +8148,8 @@ public:
     uint32_t timeoutMs;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::NetworkCommissioning::Commands::AddThreadNetworkResponse::DecodableType;
 };
 
 struct DecodableType
@@ -7172,6 +8182,8 @@ public:
     chip::CharSpan debugText;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -7205,6 +8217,8 @@ public:
     uint32_t timeoutMs;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::NetworkCommissioning::Commands::UpdateThreadNetworkResponse::DecodableType;
 };
 
 struct DecodableType
@@ -7237,6 +8251,8 @@ public:
     chip::CharSpan debugText;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -7270,6 +8286,8 @@ public:
     uint32_t timeoutMs;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::NetworkCommissioning::Commands::RemoveNetworkResponse::DecodableType;
 };
 
 struct DecodableType
@@ -7302,6 +8320,8 @@ public:
     chip::CharSpan debugText;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -7335,6 +8355,8 @@ public:
     uint32_t timeoutMs;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::NetworkCommissioning::Commands::EnableNetworkResponse::DecodableType;
 };
 
 struct DecodableType
@@ -7367,6 +8389,8 @@ public:
     chip::CharSpan debugText;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -7400,6 +8424,8 @@ public:
     uint32_t timeoutMs;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::NetworkCommissioning::Commands::DisableNetworkResponse::DecodableType;
 };
 
 struct DecodableType
@@ -7432,6 +8458,8 @@ public:
     chip::CharSpan debugText;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -7513,6 +8541,21 @@ using LogsTransferProtocol                 = EmberAfLogsTransferProtocol;
 #endif
 
 namespace Commands {
+// Forward-declarations so we can reference these later.
+
+namespace RetrieveLogsRequest {
+struct Type;
+struct DecodableType;
+} // namespace RetrieveLogsRequest
+
+namespace RetrieveLogsResponse {
+struct Type;
+struct DecodableType;
+} // namespace RetrieveLogsResponse
+
+} // namespace Commands
+
+namespace Commands {
 namespace RetrieveLogsRequest {
 enum class Fields
 {
@@ -7533,6 +8576,8 @@ public:
     chip::ByteSpan transferFileDesignator;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::DiagnosticLogs::Commands::RetrieveLogsResponse::DecodableType;
 };
 
 struct DecodableType
@@ -7569,6 +8614,8 @@ public:
     uint32_t timeSinceBoot;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -7861,6 +8908,16 @@ using DecodableType = Type;
 } // namespace Structs
 
 namespace Commands {
+// Forward-declarations so we can reference these later.
+
+namespace ResetWatermarks {
+struct Type;
+struct DecodableType;
+} // namespace ResetWatermarks
+
+} // namespace Commands
+
+namespace Commands {
 namespace ResetWatermarks {
 enum class Fields
 {
@@ -7874,6 +8931,8 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::SoftwareDiagnostics::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -8127,6 +9186,16 @@ using DecodableType = Type;
 } // namespace Structs
 
 namespace Commands {
+// Forward-declarations so we can reference these later.
+
+namespace ResetCounts {
+struct Type;
+struct DecodableType;
+} // namespace ResetCounts
+
+} // namespace Commands
+
+namespace Commands {
 namespace ResetCounts {
 enum class Fields
 {
@@ -8140,6 +9209,8 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::ThreadNetworkDiagnostics::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -8841,6 +9912,16 @@ using WiFiVersionType                      = EmberAfWiFiVersionType;
 #endif
 
 namespace Commands {
+// Forward-declarations so we can reference these later.
+
+namespace ResetCounts {
+struct Type;
+struct DecodableType;
+} // namespace ResetCounts
+
+} // namespace Commands
+
+namespace Commands {
 namespace ResetCounts {
 enum class Fields
 {
@@ -8854,6 +9935,8 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::WiFiNetworkDiagnostics::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -9043,6 +10126,16 @@ using PHYRateType                          = EmberAfPHYRateType;
 #endif
 
 namespace Commands {
+// Forward-declarations so we can reference these later.
+
+namespace ResetCounts {
+struct Type;
+struct DecodableType;
+} // namespace ResetCounts
+
+} // namespace Commands
+
+namespace Commands {
 namespace ResetCounts {
 enum class Fields
 {
@@ -9056,6 +10149,8 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::EthernetNetworkDiagnostics::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -9185,6 +10280,31 @@ struct TypeInfo
 namespace BridgedDeviceBasic {
 
 namespace Commands {
+// Forward-declarations so we can reference these later.
+
+namespace StartUp {
+struct Type;
+struct DecodableType;
+} // namespace StartUp
+
+namespace ShutDown {
+struct Type;
+struct DecodableType;
+} // namespace ShutDown
+
+namespace Leave {
+struct Type;
+struct DecodableType;
+} // namespace Leave
+
+namespace ReachableChanged {
+struct Type;
+struct DecodableType;
+} // namespace ReachableChanged
+
+} // namespace Commands
+
+namespace Commands {
 namespace StartUp {
 enum class Fields
 {
@@ -9198,6 +10318,8 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::BridgedDeviceBasic::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -9222,6 +10344,8 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::BridgedDeviceBasic::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -9246,6 +10370,8 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::BridgedDeviceBasic::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -9270,6 +10396,8 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::BridgedDeviceBasic::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -9517,6 +10645,26 @@ using StatusCode                           = EmberAfStatusCode;
 #endif
 
 namespace Commands {
+// Forward-declarations so we can reference these later.
+
+namespace OpenCommissioningWindow {
+struct Type;
+struct DecodableType;
+} // namespace OpenCommissioningWindow
+
+namespace OpenBasicCommissioningWindow {
+struct Type;
+struct DecodableType;
+} // namespace OpenBasicCommissioningWindow
+
+namespace RevokeCommissioning {
+struct Type;
+struct DecodableType;
+} // namespace RevokeCommissioning
+
+} // namespace Commands
+
+namespace Commands {
 namespace OpenCommissioningWindow {
 enum class Fields
 {
@@ -9543,6 +10691,8 @@ public:
     uint16_t passcodeID;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -9576,6 +10726,8 @@ public:
     uint16_t commissioningTimeout;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -9601,6 +10753,8 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::AdministratorCommissioning::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -9711,6 +10865,76 @@ using DecodableType = Type;
 } // namespace Structs
 
 namespace Commands {
+// Forward-declarations so we can reference these later.
+
+namespace AttestationRequest {
+struct Type;
+struct DecodableType;
+} // namespace AttestationRequest
+
+namespace AttestationResponse {
+struct Type;
+struct DecodableType;
+} // namespace AttestationResponse
+
+namespace CertificateChainRequest {
+struct Type;
+struct DecodableType;
+} // namespace CertificateChainRequest
+
+namespace CertificateChainResponse {
+struct Type;
+struct DecodableType;
+} // namespace CertificateChainResponse
+
+namespace OpCSRRequest {
+struct Type;
+struct DecodableType;
+} // namespace OpCSRRequest
+
+namespace OpCSRResponse {
+struct Type;
+struct DecodableType;
+} // namespace OpCSRResponse
+
+namespace AddNOC {
+struct Type;
+struct DecodableType;
+} // namespace AddNOC
+
+namespace UpdateNOC {
+struct Type;
+struct DecodableType;
+} // namespace UpdateNOC
+
+namespace NOCResponse {
+struct Type;
+struct DecodableType;
+} // namespace NOCResponse
+
+namespace UpdateFabricLabel {
+struct Type;
+struct DecodableType;
+} // namespace UpdateFabricLabel
+
+namespace RemoveFabric {
+struct Type;
+struct DecodableType;
+} // namespace RemoveFabric
+
+namespace AddTrustedRootCertificate {
+struct Type;
+struct DecodableType;
+} // namespace AddTrustedRootCertificate
+
+namespace RemoveTrustedRootCertificate {
+struct Type;
+struct DecodableType;
+} // namespace RemoveTrustedRootCertificate
+
+} // namespace Commands
+
+namespace Commands {
 namespace AttestationRequest {
 enum class Fields
 {
@@ -9727,6 +10951,8 @@ public:
     chip::ByteSpan attestationNonce;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::OperationalCredentials::Commands::AttestationResponse::DecodableType;
 };
 
 struct DecodableType
@@ -9757,6 +10983,8 @@ public:
     chip::ByteSpan signature;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -9786,6 +11014,8 @@ public:
     uint8_t certificateType;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::OperationalCredentials::Commands::CertificateChainResponse::DecodableType;
 };
 
 struct DecodableType
@@ -9814,6 +11044,8 @@ public:
     chip::ByteSpan certificate;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -9842,6 +11074,8 @@ public:
     chip::ByteSpan CSRNonce;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::OperationalCredentials::Commands::OpCSRResponse::DecodableType;
 };
 
 struct DecodableType
@@ -9872,6 +11106,8 @@ public:
     chip::ByteSpan attestationSignature;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -9909,6 +11145,8 @@ public:
     uint16_t adminVendorId;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::OperationalCredentials::Commands::NOCResponse::DecodableType;
 };
 
 struct DecodableType
@@ -9943,6 +11181,8 @@ public:
     Optional<chip::ByteSpan> ICACValue;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::OperationalCredentials::Commands::NOCResponse::DecodableType;
 };
 
 struct DecodableType
@@ -9976,6 +11216,8 @@ public:
     chip::CharSpan debugText;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -10006,6 +11248,8 @@ public:
     chip::CharSpan label;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::OperationalCredentials::Commands::NOCResponse::DecodableType;
 };
 
 struct DecodableType
@@ -10034,6 +11278,8 @@ public:
     uint8_t fabricIndex;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::OperationalCredentials::Commands::NOCResponse::DecodableType;
 };
 
 struct DecodableType
@@ -10062,6 +11308,8 @@ public:
     chip::ByteSpan rootCertificate;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -10090,6 +11338,8 @@ public:
     chip::ByteSpan trustedRootIdentifier;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -10353,6 +11603,16 @@ using DecodableType = Type;
 } // namespace Structs
 
 namespace Commands {
+// Forward-declarations so we can reference these later.
+
+namespace ChangeToMode {
+struct Type;
+struct DecodableType;
+} // namespace ChangeToMode
+
+} // namespace Commands
+
+namespace Commands {
 namespace ChangeToMode {
 enum class Fields
 {
@@ -10369,6 +11629,8 @@ public:
     uint8_t newMode;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -10632,6 +11894,281 @@ enum class DoorLockDayOfWeek : uint8_t
 };
 
 namespace Commands {
+// Forward-declarations so we can reference these later.
+
+namespace LockDoor {
+struct Type;
+struct DecodableType;
+} // namespace LockDoor
+
+namespace LockDoorResponse {
+struct Type;
+struct DecodableType;
+} // namespace LockDoorResponse
+
+namespace UnlockDoor {
+struct Type;
+struct DecodableType;
+} // namespace UnlockDoor
+
+namespace UnlockDoorResponse {
+struct Type;
+struct DecodableType;
+} // namespace UnlockDoorResponse
+
+namespace Toggle {
+struct Type;
+struct DecodableType;
+} // namespace Toggle
+
+namespace ToggleResponse {
+struct Type;
+struct DecodableType;
+} // namespace ToggleResponse
+
+namespace UnlockWithTimeout {
+struct Type;
+struct DecodableType;
+} // namespace UnlockWithTimeout
+
+namespace UnlockWithTimeoutResponse {
+struct Type;
+struct DecodableType;
+} // namespace UnlockWithTimeoutResponse
+
+namespace GetLogRecord {
+struct Type;
+struct DecodableType;
+} // namespace GetLogRecord
+
+namespace GetLogRecordResponse {
+struct Type;
+struct DecodableType;
+} // namespace GetLogRecordResponse
+
+namespace SetPin {
+struct Type;
+struct DecodableType;
+} // namespace SetPin
+
+namespace SetPinResponse {
+struct Type;
+struct DecodableType;
+} // namespace SetPinResponse
+
+namespace GetPin {
+struct Type;
+struct DecodableType;
+} // namespace GetPin
+
+namespace GetPinResponse {
+struct Type;
+struct DecodableType;
+} // namespace GetPinResponse
+
+namespace ClearPin {
+struct Type;
+struct DecodableType;
+} // namespace ClearPin
+
+namespace ClearPinResponse {
+struct Type;
+struct DecodableType;
+} // namespace ClearPinResponse
+
+namespace ClearAllPins {
+struct Type;
+struct DecodableType;
+} // namespace ClearAllPins
+
+namespace ClearAllPinsResponse {
+struct Type;
+struct DecodableType;
+} // namespace ClearAllPinsResponse
+
+namespace SetUserStatus {
+struct Type;
+struct DecodableType;
+} // namespace SetUserStatus
+
+namespace SetUserStatusResponse {
+struct Type;
+struct DecodableType;
+} // namespace SetUserStatusResponse
+
+namespace GetUserStatus {
+struct Type;
+struct DecodableType;
+} // namespace GetUserStatus
+
+namespace GetUserStatusResponse {
+struct Type;
+struct DecodableType;
+} // namespace GetUserStatusResponse
+
+namespace SetWeekdaySchedule {
+struct Type;
+struct DecodableType;
+} // namespace SetWeekdaySchedule
+
+namespace SetWeekdayScheduleResponse {
+struct Type;
+struct DecodableType;
+} // namespace SetWeekdayScheduleResponse
+
+namespace GetWeekdaySchedule {
+struct Type;
+struct DecodableType;
+} // namespace GetWeekdaySchedule
+
+namespace GetWeekdayScheduleResponse {
+struct Type;
+struct DecodableType;
+} // namespace GetWeekdayScheduleResponse
+
+namespace ClearWeekdaySchedule {
+struct Type;
+struct DecodableType;
+} // namespace ClearWeekdaySchedule
+
+namespace ClearWeekdayScheduleResponse {
+struct Type;
+struct DecodableType;
+} // namespace ClearWeekdayScheduleResponse
+
+namespace SetYeardaySchedule {
+struct Type;
+struct DecodableType;
+} // namespace SetYeardaySchedule
+
+namespace SetYeardayScheduleResponse {
+struct Type;
+struct DecodableType;
+} // namespace SetYeardayScheduleResponse
+
+namespace GetYeardaySchedule {
+struct Type;
+struct DecodableType;
+} // namespace GetYeardaySchedule
+
+namespace GetYeardayScheduleResponse {
+struct Type;
+struct DecodableType;
+} // namespace GetYeardayScheduleResponse
+
+namespace ClearYeardaySchedule {
+struct Type;
+struct DecodableType;
+} // namespace ClearYeardaySchedule
+
+namespace ClearYeardayScheduleResponse {
+struct Type;
+struct DecodableType;
+} // namespace ClearYeardayScheduleResponse
+
+namespace SetHolidaySchedule {
+struct Type;
+struct DecodableType;
+} // namespace SetHolidaySchedule
+
+namespace SetHolidayScheduleResponse {
+struct Type;
+struct DecodableType;
+} // namespace SetHolidayScheduleResponse
+
+namespace GetHolidaySchedule {
+struct Type;
+struct DecodableType;
+} // namespace GetHolidaySchedule
+
+namespace GetHolidayScheduleResponse {
+struct Type;
+struct DecodableType;
+} // namespace GetHolidayScheduleResponse
+
+namespace ClearHolidaySchedule {
+struct Type;
+struct DecodableType;
+} // namespace ClearHolidaySchedule
+
+namespace ClearHolidayScheduleResponse {
+struct Type;
+struct DecodableType;
+} // namespace ClearHolidayScheduleResponse
+
+namespace SetUserType {
+struct Type;
+struct DecodableType;
+} // namespace SetUserType
+
+namespace SetUserTypeResponse {
+struct Type;
+struct DecodableType;
+} // namespace SetUserTypeResponse
+
+namespace GetUserType {
+struct Type;
+struct DecodableType;
+} // namespace GetUserType
+
+namespace GetUserTypeResponse {
+struct Type;
+struct DecodableType;
+} // namespace GetUserTypeResponse
+
+namespace SetRfid {
+struct Type;
+struct DecodableType;
+} // namespace SetRfid
+
+namespace SetRfidResponse {
+struct Type;
+struct DecodableType;
+} // namespace SetRfidResponse
+
+namespace GetRfid {
+struct Type;
+struct DecodableType;
+} // namespace GetRfid
+
+namespace GetRfidResponse {
+struct Type;
+struct DecodableType;
+} // namespace GetRfidResponse
+
+namespace ClearRfid {
+struct Type;
+struct DecodableType;
+} // namespace ClearRfid
+
+namespace ClearRfidResponse {
+struct Type;
+struct DecodableType;
+} // namespace ClearRfidResponse
+
+namespace ClearAllRfids {
+struct Type;
+struct DecodableType;
+} // namespace ClearAllRfids
+
+namespace ClearAllRfidsResponse {
+struct Type;
+struct DecodableType;
+} // namespace ClearAllRfidsResponse
+
+namespace OperationEventNotification {
+struct Type;
+struct DecodableType;
+} // namespace OperationEventNotification
+
+namespace ProgrammingEventNotification {
+struct Type;
+struct DecodableType;
+} // namespace ProgrammingEventNotification
+
+} // namespace Commands
+
+namespace Commands {
 namespace LockDoor {
 enum class Fields
 {
@@ -10648,6 +12185,8 @@ public:
     chip::ByteSpan pin;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::DoorLock::Commands::LockDoorResponse::DecodableType;
 };
 
 struct DecodableType
@@ -10676,6 +12215,8 @@ public:
     uint8_t status;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -10704,6 +12245,8 @@ public:
     chip::ByteSpan pin;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::DoorLock::Commands::UnlockDoorResponse::DecodableType;
 };
 
 struct DecodableType
@@ -10732,6 +12275,8 @@ public:
     uint8_t status;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -10760,6 +12305,8 @@ public:
     chip::CharSpan pin;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::DoorLock::Commands::ToggleResponse::DecodableType;
 };
 
 struct DecodableType
@@ -10788,6 +12335,8 @@ public:
     uint8_t status;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -10818,6 +12367,8 @@ public:
     chip::ByteSpan pin;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::DoorLock::Commands::UnlockWithTimeoutResponse::DecodableType;
 };
 
 struct DecodableType
@@ -10847,6 +12398,8 @@ public:
     uint8_t status;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -10875,6 +12428,8 @@ public:
     uint16_t logIndex;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::DoorLock::Commands::GetLogRecordResponse::DecodableType;
 };
 
 struct DecodableType
@@ -10915,6 +12470,8 @@ public:
     chip::ByteSpan pin;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -10955,6 +12512,8 @@ public:
     chip::ByteSpan pin;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::DoorLock::Commands::SetPinResponse::DecodableType;
 };
 
 struct DecodableType
@@ -10986,6 +12545,8 @@ public:
     DoorLockSetPinOrIdStatus status;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -11014,6 +12575,8 @@ public:
     uint16_t userId;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::DoorLock::Commands::GetPinResponse::DecodableType;
 };
 
 struct DecodableType
@@ -11048,6 +12611,8 @@ public:
     chip::ByteSpan pin;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -11079,6 +12644,8 @@ public:
     uint16_t userId;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::DoorLock::Commands::ClearPinResponse::DecodableType;
 };
 
 struct DecodableType
@@ -11107,6 +12674,8 @@ public:
     uint8_t status;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -11132,6 +12701,8 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::DoorLock::Commands::ClearAllPinsResponse::DecodableType;
 };
 
 struct DecodableType
@@ -11159,6 +12730,8 @@ public:
     uint8_t status;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -11189,6 +12762,8 @@ public:
     uint8_t userStatus;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::DoorLock::Commands::SetUserStatusResponse::DecodableType;
 };
 
 struct DecodableType
@@ -11218,6 +12793,8 @@ public:
     uint8_t status;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -11246,6 +12823,8 @@ public:
     uint16_t userId;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::DoorLock::Commands::GetUserStatusResponse::DecodableType;
 };
 
 struct DecodableType
@@ -11276,6 +12855,8 @@ public:
     uint8_t status;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -11317,6 +12898,8 @@ public:
     uint8_t endMinute;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::DoorLock::Commands::SetWeekdayScheduleResponse::DecodableType;
 };
 
 struct DecodableType
@@ -11351,6 +12934,8 @@ public:
     uint8_t status;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -11381,6 +12966,8 @@ public:
     uint16_t userId;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::DoorLock::Commands::GetWeekdayScheduleResponse::DecodableType;
 };
 
 struct DecodableType
@@ -11424,6 +13011,8 @@ public:
     uint8_t endMinute;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -11461,6 +13050,8 @@ public:
     uint16_t userId;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::DoorLock::Commands::ClearWeekdayScheduleResponse::DecodableType;
 };
 
 struct DecodableType
@@ -11490,6 +13081,8 @@ public:
     uint8_t status;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -11524,6 +13117,8 @@ public:
     uint32_t localEndTime;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::DoorLock::Commands::SetYeardayScheduleResponse::DecodableType;
 };
 
 struct DecodableType
@@ -11555,6 +13150,8 @@ public:
     uint8_t status;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -11585,6 +13182,8 @@ public:
     uint16_t userId;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::DoorLock::Commands::GetYeardayScheduleResponse::DecodableType;
 };
 
 struct DecodableType
@@ -11622,6 +13221,8 @@ public:
     uint32_t localEndTime;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -11656,6 +13257,8 @@ public:
     uint16_t userId;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::DoorLock::Commands::ClearYeardayScheduleResponse::DecodableType;
 };
 
 struct DecodableType
@@ -11685,6 +13288,8 @@ public:
     uint8_t status;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -11719,6 +13324,8 @@ public:
     uint8_t operatingModeDuringHoliday;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::DoorLock::Commands::SetHolidayScheduleResponse::DecodableType;
 };
 
 struct DecodableType
@@ -11750,6 +13357,8 @@ public:
     uint8_t status;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -11778,6 +13387,8 @@ public:
     uint8_t scheduleId;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::DoorLock::Commands::GetHolidayScheduleResponse::DecodableType;
 };
 
 struct DecodableType
@@ -11814,6 +13425,8 @@ public:
     uint8_t operatingModeDuringHoliday;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -11846,6 +13459,8 @@ public:
     uint8_t scheduleId;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::DoorLock::Commands::ClearHolidayScheduleResponse::DecodableType;
 };
 
 struct DecodableType
@@ -11874,6 +13489,8 @@ public:
     uint8_t status;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -11904,6 +13521,8 @@ public:
     DoorLockUserType userType;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::DoorLock::Commands::SetUserTypeResponse::DecodableType;
 };
 
 struct DecodableType
@@ -11933,6 +13552,8 @@ public:
     uint8_t status;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -11961,6 +13582,8 @@ public:
     uint16_t userId;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::DoorLock::Commands::GetUserTypeResponse::DecodableType;
 };
 
 struct DecodableType
@@ -11991,6 +13614,8 @@ public:
     DoorLockUserType userType;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -12026,6 +13651,8 @@ public:
     chip::ByteSpan id;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::DoorLock::Commands::SetRfidResponse::DecodableType;
 };
 
 struct DecodableType
@@ -12057,6 +13684,8 @@ public:
     DoorLockSetPinOrIdStatus status;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -12085,6 +13714,8 @@ public:
     uint16_t userId;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::DoorLock::Commands::GetRfidResponse::DecodableType;
 };
 
 struct DecodableType
@@ -12119,6 +13750,8 @@ public:
     chip::ByteSpan rfid;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -12150,6 +13783,8 @@ public:
     uint16_t userId;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::DoorLock::Commands::ClearRfidResponse::DecodableType;
 };
 
 struct DecodableType
@@ -12178,6 +13813,8 @@ public:
     uint8_t status;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -12203,6 +13840,8 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::DoorLock::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::DoorLock::Commands::ClearAllRfidsResponse::DecodableType;
 };
 
 struct DecodableType
@@ -12230,6 +13869,8 @@ public:
     uint8_t status;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -12268,6 +13909,8 @@ public:
     chip::CharSpan data;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -12315,6 +13958,8 @@ public:
     chip::CharSpan data;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -12838,6 +14483,46 @@ enum class WcSafetyStatus : uint16_t
 };
 
 namespace Commands {
+// Forward-declarations so we can reference these later.
+
+namespace UpOrOpen {
+struct Type;
+struct DecodableType;
+} // namespace UpOrOpen
+
+namespace DownOrClose {
+struct Type;
+struct DecodableType;
+} // namespace DownOrClose
+
+namespace StopMotion {
+struct Type;
+struct DecodableType;
+} // namespace StopMotion
+
+namespace GoToLiftValue {
+struct Type;
+struct DecodableType;
+} // namespace GoToLiftValue
+
+namespace GoToLiftPercentage {
+struct Type;
+struct DecodableType;
+} // namespace GoToLiftPercentage
+
+namespace GoToTiltValue {
+struct Type;
+struct DecodableType;
+} // namespace GoToTiltValue
+
+namespace GoToTiltPercentage {
+struct Type;
+struct DecodableType;
+} // namespace GoToTiltPercentage
+
+} // namespace Commands
+
+namespace Commands {
 namespace UpOrOpen {
 enum class Fields
 {
@@ -12851,6 +14536,8 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::WindowCovering::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -12875,6 +14562,8 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::WindowCovering::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -12899,6 +14588,8 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::WindowCovering::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -12926,6 +14617,8 @@ public:
     uint16_t liftValue;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -12956,6 +14649,8 @@ public:
     uint16_t liftPercent100thsValue;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -12985,6 +14680,8 @@ public:
     uint16_t tiltValue;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -13015,6 +14712,8 @@ public:
     uint16_t tiltPercent100thsValue;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -13326,6 +15025,21 @@ struct TypeInfo
 namespace BarrierControl {
 
 namespace Commands {
+// Forward-declarations so we can reference these later.
+
+namespace BarrierControlGoToPercent {
+struct Type;
+struct DecodableType;
+} // namespace BarrierControlGoToPercent
+
+namespace BarrierControlStop {
+struct Type;
+struct DecodableType;
+} // namespace BarrierControlStop
+
+} // namespace Commands
+
+namespace Commands {
 namespace BarrierControlGoToPercent {
 enum class Fields
 {
@@ -13342,6 +15056,8 @@ public:
     uint8_t percentOpen;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -13367,6 +15083,8 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::BarrierControl::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -14326,6 +16044,46 @@ enum class ModeForSequence : uint8_t
 };
 
 namespace Commands {
+// Forward-declarations so we can reference these later.
+
+namespace SetpointRaiseLower {
+struct Type;
+struct DecodableType;
+} // namespace SetpointRaiseLower
+
+namespace CurrentWeeklySchedule {
+struct Type;
+struct DecodableType;
+} // namespace CurrentWeeklySchedule
+
+namespace SetWeeklySchedule {
+struct Type;
+struct DecodableType;
+} // namespace SetWeeklySchedule
+
+namespace RelayStatusLog {
+struct Type;
+struct DecodableType;
+} // namespace RelayStatusLog
+
+namespace GetWeeklySchedule {
+struct Type;
+struct DecodableType;
+} // namespace GetWeeklySchedule
+
+namespace ClearWeeklySchedule {
+struct Type;
+struct DecodableType;
+} // namespace ClearWeeklySchedule
+
+namespace GetRelayStatusLog {
+struct Type;
+struct DecodableType;
+} // namespace GetRelayStatusLog
+
+} // namespace Commands
+
+namespace Commands {
 namespace SetpointRaiseLower {
 enum class Fields
 {
@@ -14344,6 +16102,8 @@ public:
     int8_t amount;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -14379,6 +16139,8 @@ public:
     DataModel::List<const uint8_t> payload;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -14416,6 +16178,8 @@ public:
     DataModel::List<const uint8_t> payload;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -14457,6 +16221,8 @@ public:
     uint16_t unreadEntries;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -14492,6 +16258,8 @@ public:
     chip::BitFlags<ModeForSequence> modeToReturn;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -14518,6 +16286,8 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::Thermostat::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -14542,6 +16312,8 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::Thermostat::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -15337,6 +17109,106 @@ enum class ColorLoopUpdateFlags : uint8_t
 };
 
 namespace Commands {
+// Forward-declarations so we can reference these later.
+
+namespace MoveToHue {
+struct Type;
+struct DecodableType;
+} // namespace MoveToHue
+
+namespace MoveHue {
+struct Type;
+struct DecodableType;
+} // namespace MoveHue
+
+namespace StepHue {
+struct Type;
+struct DecodableType;
+} // namespace StepHue
+
+namespace MoveToSaturation {
+struct Type;
+struct DecodableType;
+} // namespace MoveToSaturation
+
+namespace MoveSaturation {
+struct Type;
+struct DecodableType;
+} // namespace MoveSaturation
+
+namespace StepSaturation {
+struct Type;
+struct DecodableType;
+} // namespace StepSaturation
+
+namespace MoveToHueAndSaturation {
+struct Type;
+struct DecodableType;
+} // namespace MoveToHueAndSaturation
+
+namespace MoveToColor {
+struct Type;
+struct DecodableType;
+} // namespace MoveToColor
+
+namespace MoveColor {
+struct Type;
+struct DecodableType;
+} // namespace MoveColor
+
+namespace StepColor {
+struct Type;
+struct DecodableType;
+} // namespace StepColor
+
+namespace MoveToColorTemperature {
+struct Type;
+struct DecodableType;
+} // namespace MoveToColorTemperature
+
+namespace EnhancedMoveToHue {
+struct Type;
+struct DecodableType;
+} // namespace EnhancedMoveToHue
+
+namespace EnhancedMoveHue {
+struct Type;
+struct DecodableType;
+} // namespace EnhancedMoveHue
+
+namespace EnhancedStepHue {
+struct Type;
+struct DecodableType;
+} // namespace EnhancedStepHue
+
+namespace EnhancedMoveToHueAndSaturation {
+struct Type;
+struct DecodableType;
+} // namespace EnhancedMoveToHueAndSaturation
+
+namespace ColorLoopSet {
+struct Type;
+struct DecodableType;
+} // namespace ColorLoopSet
+
+namespace StopMoveStep {
+struct Type;
+struct DecodableType;
+} // namespace StopMoveStep
+
+namespace MoveColorTemperature {
+struct Type;
+struct DecodableType;
+} // namespace MoveColorTemperature
+
+namespace StepColorTemperature {
+struct Type;
+struct DecodableType;
+} // namespace StepColorTemperature
+
+} // namespace Commands
+
+namespace Commands {
 namespace MoveToHue {
 enum class Fields
 {
@@ -15361,6 +17233,8 @@ public:
     uint8_t optionsOverride;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -15399,6 +17273,8 @@ public:
     uint8_t optionsOverride;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -15438,6 +17314,8 @@ public:
     uint8_t optionsOverride;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -15476,6 +17354,8 @@ public:
     uint8_t optionsOverride;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -15513,6 +17393,8 @@ public:
     uint8_t optionsOverride;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -15552,6 +17434,8 @@ public:
     uint8_t optionsOverride;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -15592,6 +17476,8 @@ public:
     uint8_t optionsOverride;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -15632,6 +17518,8 @@ public:
     uint8_t optionsOverride;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -15670,6 +17558,8 @@ public:
     uint8_t optionsOverride;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -15709,6 +17599,8 @@ public:
     uint8_t optionsOverride;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -15747,6 +17639,8 @@ public:
     uint8_t optionsOverride;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -15786,6 +17680,8 @@ public:
     uint8_t optionsOverride;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -15824,6 +17720,8 @@ public:
     uint8_t optionsOverride;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -15863,6 +17761,8 @@ public:
     uint8_t optionsOverride;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -15903,6 +17803,8 @@ public:
     uint8_t optionsOverride;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -15947,6 +17849,8 @@ public:
     uint8_t optionsOverride;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -15983,6 +17887,8 @@ public:
     uint8_t optionsOverride;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -16022,6 +17928,8 @@ public:
     uint8_t optionsOverride;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -16067,6 +17975,8 @@ public:
     uint8_t optionsOverride;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -19365,6 +21275,46 @@ enum class IasZoneStatus : uint16_t
 };
 
 namespace Commands {
+// Forward-declarations so we can reference these later.
+
+namespace ZoneEnrollResponse {
+struct Type;
+struct DecodableType;
+} // namespace ZoneEnrollResponse
+
+namespace ZoneStatusChangeNotification {
+struct Type;
+struct DecodableType;
+} // namespace ZoneStatusChangeNotification
+
+namespace InitiateNormalOperationMode {
+struct Type;
+struct DecodableType;
+} // namespace InitiateNormalOperationMode
+
+namespace ZoneEnrollRequest {
+struct Type;
+struct DecodableType;
+} // namespace ZoneEnrollRequest
+
+namespace InitiateTestMode {
+struct Type;
+struct DecodableType;
+} // namespace InitiateTestMode
+
+namespace InitiateNormalOperationModeResponse {
+struct Type;
+struct DecodableType;
+} // namespace InitiateNormalOperationModeResponse
+
+namespace InitiateTestModeResponse {
+struct Type;
+struct DecodableType;
+} // namespace InitiateTestModeResponse
+
+} // namespace Commands
+
+namespace Commands {
 namespace ZoneEnrollResponse {
 enum class Fields
 {
@@ -19383,6 +21333,8 @@ public:
     uint8_t zoneId;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -19418,6 +21370,8 @@ public:
     uint16_t delay;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -19446,6 +21400,8 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::IasZone::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::IasZone::Commands::InitiateNormalOperationModeResponse::DecodableType;
 };
 
 struct DecodableType
@@ -19475,6 +21431,8 @@ public:
     uint16_t manufacturerCode;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::IasZone::Commands::ZoneEnrollResponse::DecodableType;
 };
 
 struct DecodableType
@@ -19506,6 +21464,8 @@ public:
     uint8_t currentZoneSensitivityLevel;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::IasZone::Commands::InitiateTestModeResponse::DecodableType;
 };
 
 struct DecodableType
@@ -19532,6 +21492,8 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::IasZone::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -19556,6 +21518,8 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::IasZone::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -19826,6 +21790,106 @@ using DecodableType = Type;
 } // namespace Structs
 
 namespace Commands {
+// Forward-declarations so we can reference these later.
+
+namespace Arm {
+struct Type;
+struct DecodableType;
+} // namespace Arm
+
+namespace ArmResponse {
+struct Type;
+struct DecodableType;
+} // namespace ArmResponse
+
+namespace Bypass {
+struct Type;
+struct DecodableType;
+} // namespace Bypass
+
+namespace GetZoneIdMapResponse {
+struct Type;
+struct DecodableType;
+} // namespace GetZoneIdMapResponse
+
+namespace Emergency {
+struct Type;
+struct DecodableType;
+} // namespace Emergency
+
+namespace GetZoneInformationResponse {
+struct Type;
+struct DecodableType;
+} // namespace GetZoneInformationResponse
+
+namespace Fire {
+struct Type;
+struct DecodableType;
+} // namespace Fire
+
+namespace ZoneStatusChanged {
+struct Type;
+struct DecodableType;
+} // namespace ZoneStatusChanged
+
+namespace Panic {
+struct Type;
+struct DecodableType;
+} // namespace Panic
+
+namespace PanelStatusChanged {
+struct Type;
+struct DecodableType;
+} // namespace PanelStatusChanged
+
+namespace GetZoneIdMap {
+struct Type;
+struct DecodableType;
+} // namespace GetZoneIdMap
+
+namespace GetPanelStatusResponse {
+struct Type;
+struct DecodableType;
+} // namespace GetPanelStatusResponse
+
+namespace GetZoneInformation {
+struct Type;
+struct DecodableType;
+} // namespace GetZoneInformation
+
+namespace SetBypassedZoneList {
+struct Type;
+struct DecodableType;
+} // namespace SetBypassedZoneList
+
+namespace GetPanelStatus {
+struct Type;
+struct DecodableType;
+} // namespace GetPanelStatus
+
+namespace BypassResponse {
+struct Type;
+struct DecodableType;
+} // namespace BypassResponse
+
+namespace GetBypassedZoneList {
+struct Type;
+struct DecodableType;
+} // namespace GetBypassedZoneList
+
+namespace GetZoneStatusResponse {
+struct Type;
+struct DecodableType;
+} // namespace GetZoneStatusResponse
+
+namespace GetZoneStatus {
+struct Type;
+struct DecodableType;
+} // namespace GetZoneStatus
+
+} // namespace Commands
+
+namespace Commands {
 namespace Arm {
 enum class Fields
 {
@@ -19846,6 +21910,8 @@ public:
     uint8_t zoneId;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::IasAce::Commands::ArmResponse::DecodableType;
 };
 
 struct DecodableType
@@ -19876,6 +21942,8 @@ public:
     IasAceArmNotification armNotification;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -19908,6 +21976,8 @@ public:
     chip::CharSpan armDisarmCode;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::IasAce::Commands::BypassResponse::DecodableType;
 };
 
 struct DecodableType
@@ -19968,6 +22038,8 @@ public:
     uint16_t section15;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -20008,6 +22080,8 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::IasAce::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -20041,6 +22115,8 @@ public:
     chip::CharSpan zoneLabel;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -20069,6 +22145,8 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::IasAce::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -20102,6 +22180,8 @@ public:
     chip::CharSpan zoneLabel;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -20130,6 +22210,8 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::IasAce::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -20163,6 +22245,8 @@ public:
     IasAceAlarmStatus alarmStatus;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -20191,6 +22275,8 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::IasAce::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::IasAce::Commands::GetZoneIdMapResponse::DecodableType;
 };
 
 struct DecodableType
@@ -20224,6 +22310,8 @@ public:
     IasAceAlarmStatus alarmStatus;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -20255,6 +22343,8 @@ public:
     uint8_t zoneId;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::IasAce::Commands::GetZoneInformationResponse::DecodableType;
 };
 
 struct DecodableType
@@ -20285,6 +22375,8 @@ public:
     DataModel::List<const uint8_t> zoneIds;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -20311,6 +22403,8 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::IasAce::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::IasAce::Commands::GetPanelStatusResponse::DecodableType;
 };
 
 struct DecodableType
@@ -20340,6 +22434,8 @@ public:
     DataModel::List<const IasAceBypassResult> bypassResult;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -20366,6 +22462,8 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::IasAce::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -20397,6 +22495,8 @@ public:
     DataModel::List<const Structs::IasAceZoneStatusResult::Type> zoneStatusResult;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -20433,6 +22533,8 @@ public:
     uint16_t zoneStatusMask;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::IasAce::Commands::GetZoneStatusResponse::DecodableType;
 };
 
 struct DecodableType
@@ -20492,6 +22594,21 @@ enum class WarningInfo : uint8_t
 };
 
 namespace Commands {
+// Forward-declarations so we can reference these later.
+
+namespace StartWarning {
+struct Type;
+struct DecodableType;
+} // namespace StartWarning
+
+namespace Squawk {
+struct Type;
+struct DecodableType;
+} // namespace Squawk
+
+} // namespace Commands
+
+namespace Commands {
 namespace StartWarning {
 enum class Fields
 {
@@ -20514,6 +22631,8 @@ public:
     uint8_t strobeLevel;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -20545,6 +22664,8 @@ public:
     chip::BitFlags<SquawkInfo> squawkInfo;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -20706,6 +22827,31 @@ using DecodableType = Type;
 } // namespace Structs
 
 namespace Commands {
+// Forward-declarations so we can reference these later.
+
+namespace ChangeChannel {
+struct Type;
+struct DecodableType;
+} // namespace ChangeChannel
+
+namespace ChangeChannelResponse {
+struct Type;
+struct DecodableType;
+} // namespace ChangeChannelResponse
+
+namespace ChangeChannelByNumber {
+struct Type;
+struct DecodableType;
+} // namespace ChangeChannelByNumber
+
+namespace SkipChannel {
+struct Type;
+struct DecodableType;
+} // namespace SkipChannel
+
+} // namespace Commands
+
+namespace Commands {
 namespace ChangeChannel {
 enum class Fields
 {
@@ -20722,6 +22868,8 @@ public:
     chip::CharSpan match;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::TvChannel::Commands::ChangeChannelResponse::DecodableType;
 };
 
 struct DecodableType
@@ -20752,6 +22900,8 @@ public:
     TvChannelErrorType errorType;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -20783,6 +22933,8 @@ public:
     uint16_t minorNumber;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -20812,6 +22964,8 @@ public:
     uint16_t count;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -20918,6 +23072,21 @@ using DecodableType = Type;
 } // namespace Structs
 
 namespace Commands {
+// Forward-declarations so we can reference these later.
+
+namespace NavigateTarget {
+struct Type;
+struct DecodableType;
+} // namespace NavigateTarget
+
+namespace NavigateTargetResponse {
+struct Type;
+struct DecodableType;
+} // namespace NavigateTargetResponse
+
+} // namespace Commands
+
+namespace Commands {
 namespace NavigateTarget {
 enum class Fields
 {
@@ -20936,6 +23105,8 @@ public:
     chip::CharSpan data;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::TargetNavigator::Commands::NavigateTargetResponse::DecodableType;
 };
 
 struct DecodableType
@@ -20967,6 +23138,8 @@ public:
     chip::CharSpan data;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -21081,6 +23254,121 @@ using DecodableType = Type;
 } // namespace Structs
 
 namespace Commands {
+// Forward-declarations so we can reference these later.
+
+namespace MediaPlay {
+struct Type;
+struct DecodableType;
+} // namespace MediaPlay
+
+namespace MediaPlayResponse {
+struct Type;
+struct DecodableType;
+} // namespace MediaPlayResponse
+
+namespace MediaPause {
+struct Type;
+struct DecodableType;
+} // namespace MediaPause
+
+namespace MediaPauseResponse {
+struct Type;
+struct DecodableType;
+} // namespace MediaPauseResponse
+
+namespace MediaStop {
+struct Type;
+struct DecodableType;
+} // namespace MediaStop
+
+namespace MediaStopResponse {
+struct Type;
+struct DecodableType;
+} // namespace MediaStopResponse
+
+namespace MediaStartOver {
+struct Type;
+struct DecodableType;
+} // namespace MediaStartOver
+
+namespace MediaStartOverResponse {
+struct Type;
+struct DecodableType;
+} // namespace MediaStartOverResponse
+
+namespace MediaPrevious {
+struct Type;
+struct DecodableType;
+} // namespace MediaPrevious
+
+namespace MediaPreviousResponse {
+struct Type;
+struct DecodableType;
+} // namespace MediaPreviousResponse
+
+namespace MediaNext {
+struct Type;
+struct DecodableType;
+} // namespace MediaNext
+
+namespace MediaNextResponse {
+struct Type;
+struct DecodableType;
+} // namespace MediaNextResponse
+
+namespace MediaRewind {
+struct Type;
+struct DecodableType;
+} // namespace MediaRewind
+
+namespace MediaRewindResponse {
+struct Type;
+struct DecodableType;
+} // namespace MediaRewindResponse
+
+namespace MediaFastForward {
+struct Type;
+struct DecodableType;
+} // namespace MediaFastForward
+
+namespace MediaFastForwardResponse {
+struct Type;
+struct DecodableType;
+} // namespace MediaFastForwardResponse
+
+namespace MediaSkipForward {
+struct Type;
+struct DecodableType;
+} // namespace MediaSkipForward
+
+namespace MediaSkipForwardResponse {
+struct Type;
+struct DecodableType;
+} // namespace MediaSkipForwardResponse
+
+namespace MediaSkipBackward {
+struct Type;
+struct DecodableType;
+} // namespace MediaSkipBackward
+
+namespace MediaSkipBackwardResponse {
+struct Type;
+struct DecodableType;
+} // namespace MediaSkipBackwardResponse
+
+namespace MediaSeek {
+struct Type;
+struct DecodableType;
+} // namespace MediaSeek
+
+namespace MediaSeekResponse {
+struct Type;
+struct DecodableType;
+} // namespace MediaSeekResponse
+
+} // namespace Commands
+
+namespace Commands {
 namespace MediaPlay {
 enum class Fields
 {
@@ -21094,6 +23382,8 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::MediaPlayback::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::MediaPlayback::Commands::MediaPlayResponse::DecodableType;
 };
 
 struct DecodableType
@@ -21121,6 +23411,8 @@ public:
     MediaPlaybackStatus mediaPlaybackStatus;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -21146,6 +23438,8 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::MediaPlayback::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::MediaPlayback::Commands::MediaPauseResponse::DecodableType;
 };
 
 struct DecodableType
@@ -21173,6 +23467,8 @@ public:
     MediaPlaybackStatus mediaPlaybackStatus;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -21198,6 +23494,8 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::MediaPlayback::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::MediaPlayback::Commands::MediaStopResponse::DecodableType;
 };
 
 struct DecodableType
@@ -21225,6 +23523,8 @@ public:
     MediaPlaybackStatus mediaPlaybackStatus;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -21250,6 +23550,8 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::MediaPlayback::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::MediaPlayback::Commands::MediaStartOverResponse::DecodableType;
 };
 
 struct DecodableType
@@ -21277,6 +23579,8 @@ public:
     MediaPlaybackStatus mediaPlaybackStatus;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -21302,6 +23606,8 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::MediaPlayback::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::MediaPlayback::Commands::MediaPreviousResponse::DecodableType;
 };
 
 struct DecodableType
@@ -21329,6 +23635,8 @@ public:
     MediaPlaybackStatus mediaPlaybackStatus;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -21354,6 +23662,8 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::MediaPlayback::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::MediaPlayback::Commands::MediaNextResponse::DecodableType;
 };
 
 struct DecodableType
@@ -21381,6 +23691,8 @@ public:
     MediaPlaybackStatus mediaPlaybackStatus;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -21406,6 +23718,8 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::MediaPlayback::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::MediaPlayback::Commands::MediaRewindResponse::DecodableType;
 };
 
 struct DecodableType
@@ -21433,6 +23747,8 @@ public:
     MediaPlaybackStatus mediaPlaybackStatus;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -21458,6 +23774,8 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::MediaPlayback::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::MediaPlayback::Commands::MediaFastForwardResponse::DecodableType;
 };
 
 struct DecodableType
@@ -21485,6 +23803,8 @@ public:
     MediaPlaybackStatus mediaPlaybackStatus;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -21513,6 +23833,8 @@ public:
     uint64_t deltaPositionMilliseconds;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::MediaPlayback::Commands::MediaSkipForwardResponse::DecodableType;
 };
 
 struct DecodableType
@@ -21541,6 +23863,8 @@ public:
     MediaPlaybackStatus mediaPlaybackStatus;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -21569,6 +23893,8 @@ public:
     uint64_t deltaPositionMilliseconds;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::MediaPlayback::Commands::MediaSkipBackwardResponse::DecodableType;
 };
 
 struct DecodableType
@@ -21597,6 +23923,8 @@ public:
     MediaPlaybackStatus mediaPlaybackStatus;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -21625,6 +23953,8 @@ public:
     uint64_t position;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::MediaPlayback::Commands::MediaSeekResponse::DecodableType;
 };
 
 struct DecodableType
@@ -21653,6 +23983,8 @@ public:
     MediaPlaybackStatus mediaPlaybackStatus;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -21822,6 +24154,31 @@ using DecodableType = Type;
 } // namespace Structs
 
 namespace Commands {
+// Forward-declarations so we can reference these later.
+
+namespace SelectInput {
+struct Type;
+struct DecodableType;
+} // namespace SelectInput
+
+namespace ShowInputStatus {
+struct Type;
+struct DecodableType;
+} // namespace ShowInputStatus
+
+namespace HideInputStatus {
+struct Type;
+struct DecodableType;
+} // namespace HideInputStatus
+
+namespace RenameInput {
+struct Type;
+struct DecodableType;
+} // namespace RenameInput
+
+} // namespace Commands
+
+namespace Commands {
 namespace SelectInput {
 enum class Fields
 {
@@ -21838,6 +24195,8 @@ public:
     uint8_t index;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -21863,6 +24222,8 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::MediaInput::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -21887,6 +24248,8 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::MediaInput::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -21916,6 +24279,8 @@ public:
     chip::CharSpan name;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -21977,6 +24342,16 @@ struct TypeInfo
 namespace LowPower {
 
 namespace Commands {
+// Forward-declarations so we can reference these later.
+
+namespace Sleep {
+struct Type;
+struct DecodableType;
+} // namespace Sleep
+
+} // namespace Commands
+
+namespace Commands {
 namespace Sleep {
 enum class Fields
 {
@@ -21990,6 +24365,8 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::LowPower::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -22138,6 +24515,21 @@ using KeypadInputStatus                    = EmberAfKeypadInputStatus;
 #endif
 
 namespace Commands {
+// Forward-declarations so we can reference these later.
+
+namespace SendKey {
+struct Type;
+struct DecodableType;
+} // namespace SendKey
+
+namespace SendKeyResponse {
+struct Type;
+struct DecodableType;
+} // namespace SendKeyResponse
+
+} // namespace Commands
+
+namespace Commands {
 namespace SendKey {
 enum class Fields
 {
@@ -22154,6 +24546,8 @@ public:
     KeypadInputCecKeyCode keyCode;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::KeypadInput::Commands::SendKeyResponse::DecodableType;
 };
 
 struct DecodableType
@@ -22182,6 +24576,8 @@ public:
     KeypadInputStatus status;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -22403,6 +24799,31 @@ using DecodableType = Type;
 } // namespace Structs
 
 namespace Commands {
+// Forward-declarations so we can reference these later.
+
+namespace LaunchContent {
+struct Type;
+struct DecodableType;
+} // namespace LaunchContent
+
+namespace LaunchContentResponse {
+struct Type;
+struct DecodableType;
+} // namespace LaunchContentResponse
+
+namespace LaunchURL {
+struct Type;
+struct DecodableType;
+} // namespace LaunchURL
+
+namespace LaunchURLResponse {
+struct Type;
+struct DecodableType;
+} // namespace LaunchURLResponse
+
+} // namespace Commands
+
+namespace Commands {
 namespace LaunchContent {
 enum class Fields
 {
@@ -22421,6 +24842,8 @@ public:
     chip::CharSpan data;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::ContentLauncher::Commands::LaunchContentResponse::DecodableType;
 };
 
 struct DecodableType
@@ -22452,6 +24875,8 @@ public:
     ContentLaunchStatus contentLaunchStatus;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -22483,6 +24908,8 @@ public:
     chip::CharSpan displayString;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::ContentLauncher::Commands::LaunchURLResponse::DecodableType;
 };
 
 struct DecodableType
@@ -22514,6 +24941,8 @@ public:
     ContentLaunchStatus contentLaunchStatus;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -22616,6 +25045,21 @@ using DecodableType = Type;
 } // namespace Structs
 
 namespace Commands {
+// Forward-declarations so we can reference these later.
+
+namespace SelectOutput {
+struct Type;
+struct DecodableType;
+} // namespace SelectOutput
+
+namespace RenameOutput {
+struct Type;
+struct DecodableType;
+} // namespace RenameOutput
+
+} // namespace Commands
+
+namespace Commands {
 namespace SelectOutput {
 enum class Fields
 {
@@ -22632,6 +25076,8 @@ public:
     uint8_t index;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -22662,6 +25108,8 @@ public:
     chip::CharSpan name;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -22759,6 +25207,21 @@ using DecodableType = Type;
 } // namespace Structs
 
 namespace Commands {
+// Forward-declarations so we can reference these later.
+
+namespace LaunchApp {
+struct Type;
+struct DecodableType;
+} // namespace LaunchApp
+
+namespace LaunchAppResponse {
+struct Type;
+struct DecodableType;
+} // namespace LaunchAppResponse
+
+} // namespace Commands
+
+namespace Commands {
 namespace LaunchApp {
 enum class Fields
 {
@@ -22779,6 +25242,8 @@ public:
     chip::CharSpan applicationId;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::ApplicationLauncher::Commands::LaunchAppResponse::DecodableType;
 };
 
 struct DecodableType
@@ -22811,6 +25276,8 @@ public:
     chip::CharSpan data;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -22896,6 +25363,16 @@ using ApplicationBasicStatus               = EmberAfApplicationBasicStatus;
 #endif
 
 namespace Commands {
+// Forward-declarations so we can reference these later.
+
+namespace ChangeStatus {
+struct Type;
+struct DecodableType;
+} // namespace ChangeStatus
+
+} // namespace Commands
+
+namespace Commands {
 namespace ChangeStatus {
 enum class Fields
 {
@@ -22912,6 +25389,8 @@ public:
     ApplicationBasicStatus status;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -23022,6 +25501,26 @@ struct TypeInfo
 namespace AccountLogin {
 
 namespace Commands {
+// Forward-declarations so we can reference these later.
+
+namespace GetSetupPIN {
+struct Type;
+struct DecodableType;
+} // namespace GetSetupPIN
+
+namespace GetSetupPINResponse {
+struct Type;
+struct DecodableType;
+} // namespace GetSetupPINResponse
+
+namespace Login {
+struct Type;
+struct DecodableType;
+} // namespace Login
+
+} // namespace Commands
+
+namespace Commands {
 namespace GetSetupPIN {
 enum class Fields
 {
@@ -23038,6 +25537,8 @@ public:
     chip::CharSpan tempAccountIdentifier;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::AccountLogin::Commands::GetSetupPINResponse::DecodableType;
 };
 
 struct DecodableType
@@ -23066,6 +25567,8 @@ public:
     chip::CharSpan setupPIN;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -23096,6 +25599,8 @@ public:
     chip::CharSpan setupPIN;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -23349,6 +25854,141 @@ using DecodableType = Type;
 } // namespace Structs
 
 namespace Commands {
+// Forward-declarations so we can reference these later.
+
+namespace Test {
+struct Type;
+struct DecodableType;
+} // namespace Test
+
+namespace TestSpecificResponse {
+struct Type;
+struct DecodableType;
+} // namespace TestSpecificResponse
+
+namespace TestNotHandled {
+struct Type;
+struct DecodableType;
+} // namespace TestNotHandled
+
+namespace TestAddArgumentsResponse {
+struct Type;
+struct DecodableType;
+} // namespace TestAddArgumentsResponse
+
+namespace TestSpecific {
+struct Type;
+struct DecodableType;
+} // namespace TestSpecific
+
+namespace TestSimpleArgumentResponse {
+struct Type;
+struct DecodableType;
+} // namespace TestSimpleArgumentResponse
+
+namespace TestUnknownCommand {
+struct Type;
+struct DecodableType;
+} // namespace TestUnknownCommand
+
+namespace TestStructArrayArgumentResponse {
+struct Type;
+struct DecodableType;
+} // namespace TestStructArrayArgumentResponse
+
+namespace TestAddArguments {
+struct Type;
+struct DecodableType;
+} // namespace TestAddArguments
+
+namespace TestListInt8UReverseResponse {
+struct Type;
+struct DecodableType;
+} // namespace TestListInt8UReverseResponse
+
+namespace TestSimpleArgumentRequest {
+struct Type;
+struct DecodableType;
+} // namespace TestSimpleArgumentRequest
+
+namespace TestEnumsResponse {
+struct Type;
+struct DecodableType;
+} // namespace TestEnumsResponse
+
+namespace TestStructArrayArgumentRequest {
+struct Type;
+struct DecodableType;
+} // namespace TestStructArrayArgumentRequest
+
+namespace TestNullableOptionalResponse {
+struct Type;
+struct DecodableType;
+} // namespace TestNullableOptionalResponse
+
+namespace TestStructArgumentRequest {
+struct Type;
+struct DecodableType;
+} // namespace TestStructArgumentRequest
+
+namespace TestComplexNullableOptionalResponse {
+struct Type;
+struct DecodableType;
+} // namespace TestComplexNullableOptionalResponse
+
+namespace TestNestedStructArgumentRequest {
+struct Type;
+struct DecodableType;
+} // namespace TestNestedStructArgumentRequest
+
+namespace BooleanResponse {
+struct Type;
+struct DecodableType;
+} // namespace BooleanResponse
+
+namespace TestListStructArgumentRequest {
+struct Type;
+struct DecodableType;
+} // namespace TestListStructArgumentRequest
+
+namespace TestListInt8UArgumentRequest {
+struct Type;
+struct DecodableType;
+} // namespace TestListInt8UArgumentRequest
+
+namespace TestNestedStructListArgumentRequest {
+struct Type;
+struct DecodableType;
+} // namespace TestNestedStructListArgumentRequest
+
+namespace TestListNestedStructListArgumentRequest {
+struct Type;
+struct DecodableType;
+} // namespace TestListNestedStructListArgumentRequest
+
+namespace TestListInt8UReverseRequest {
+struct Type;
+struct DecodableType;
+} // namespace TestListInt8UReverseRequest
+
+namespace TestEnumsRequest {
+struct Type;
+struct DecodableType;
+} // namespace TestEnumsRequest
+
+namespace TestNullableOptionalRequest {
+struct Type;
+struct DecodableType;
+} // namespace TestNullableOptionalRequest
+
+namespace TestComplexNullableOptionalRequest {
+struct Type;
+struct DecodableType;
+} // namespace TestComplexNullableOptionalRequest
+
+} // namespace Commands
+
+namespace Commands {
 namespace Test {
 enum class Fields
 {
@@ -23362,6 +26002,8 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -23389,6 +26031,8 @@ public:
     uint8_t returnValue;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -23414,6 +26058,8 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -23441,6 +26087,8 @@ public:
     uint8_t returnValue;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -23466,6 +26114,8 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::TestCluster::Commands::TestSpecificResponse::DecodableType;
 };
 
 struct DecodableType
@@ -23493,6 +26143,8 @@ public:
     bool returnValue;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -23518,6 +26170,8 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -23555,6 +26209,8 @@ public:
     bool arg6;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -23590,6 +26246,8 @@ public:
     uint8_t arg2;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::TestCluster::Commands::TestAddArgumentsResponse::DecodableType;
 };
 
 struct DecodableType
@@ -23619,6 +26277,8 @@ public:
     DataModel::List<const uint8_t> arg1;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -23647,6 +26307,8 @@ public:
     bool arg1;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::TestCluster::Commands::TestSimpleArgumentResponse::DecodableType;
 };
 
 struct DecodableType
@@ -23677,6 +26339,8 @@ public:
     SimpleEnum arg2;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -23716,6 +26380,8 @@ public:
     bool arg6;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::TestCluster::Commands::TestStructArrayArgumentResponse::DecodableType;
 };
 
 struct DecodableType
@@ -23755,6 +26421,8 @@ public:
     Optional<DataModel::Nullable<uint8_t>> originalValue;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -23786,6 +26454,8 @@ public:
     Structs::SimpleStruct::Type arg1;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::TestCluster::Commands::BooleanResponse::DecodableType;
 };
 
 struct DecodableType
@@ -23868,6 +26538,8 @@ public:
     Optional<DataModel::List<const SimpleEnum>> nullableOptionalListValue;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -23923,6 +26595,8 @@ public:
     Structs::NestedStruct::Type arg1;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::TestCluster::Commands::BooleanResponse::DecodableType;
 };
 
 struct DecodableType
@@ -23951,6 +26625,8 @@ public:
     bool value;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -23979,6 +26655,8 @@ public:
     DataModel::List<const Structs::SimpleStruct::Type> arg1;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::TestCluster::Commands::BooleanResponse::DecodableType;
 };
 
 struct DecodableType
@@ -24007,6 +26685,8 @@ public:
     DataModel::List<const uint8_t> arg1;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::TestCluster::Commands::BooleanResponse::DecodableType;
 };
 
 struct DecodableType
@@ -24035,6 +26715,8 @@ public:
     Structs::NestedStructList::Type arg1;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::TestCluster::Commands::BooleanResponse::DecodableType;
 };
 
 struct DecodableType
@@ -24063,6 +26745,8 @@ public:
     DataModel::List<const Structs::NestedStructList::Type> arg1;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -24091,6 +26775,8 @@ public:
     DataModel::List<const uint8_t> arg1;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::TestCluster::Commands::TestListInt8UReverseResponse::DecodableType;
 };
 
 struct DecodableType
@@ -24121,6 +26807,8 @@ public:
     SimpleEnum arg2;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::TestCluster::Commands::TestEnumsResponse::DecodableType;
 };
 
 struct DecodableType
@@ -24150,6 +26838,8 @@ public:
     Optional<DataModel::Nullable<uint8_t>> arg1;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::TestCluster::Commands::TestNullableOptionalResponse::DecodableType;
 };
 
 struct DecodableType
@@ -24200,6 +26890,8 @@ public:
     Optional<DataModel::Nullable<DataModel::List<const SimpleEnum>>> nullableOptionalList;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::TestCluster::Commands::TestComplexNullableOptionalResponse::DecodableType;
 };
 
 struct DecodableType
@@ -24736,6 +27428,46 @@ enum class MessagingExtendedControlMask : uint8_t
 };
 
 namespace Commands {
+// Forward-declarations so we can reference these later.
+
+namespace DisplayMessage {
+struct Type;
+struct DecodableType;
+} // namespace DisplayMessage
+
+namespace GetLastMessage {
+struct Type;
+struct DecodableType;
+} // namespace GetLastMessage
+
+namespace CancelMessage {
+struct Type;
+struct DecodableType;
+} // namespace CancelMessage
+
+namespace MessageConfirmation {
+struct Type;
+struct DecodableType;
+} // namespace MessageConfirmation
+
+namespace DisplayProtectedMessage {
+struct Type;
+struct DecodableType;
+} // namespace DisplayProtectedMessage
+
+namespace GetMessageCancellation {
+struct Type;
+struct DecodableType;
+} // namespace GetMessageCancellation
+
+namespace CancelAllMessages {
+struct Type;
+struct DecodableType;
+} // namespace CancelAllMessages
+
+} // namespace Commands
+
+namespace Commands {
 namespace DisplayMessage {
 enum class Fields
 {
@@ -24762,6 +27494,8 @@ public:
     chip::BitFlags<MessagingExtendedControlMask> optionalExtendedMessageControl;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -24792,6 +27526,8 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::Messaging::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -24821,6 +27557,8 @@ public:
     chip::BitFlags<MessagingControlMask> messageControl;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -24856,6 +27594,8 @@ public:
     chip::ByteSpan messageResponse;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -24897,6 +27637,8 @@ public:
     chip::BitFlags<MessagingExtendedControlMask> optionalExtendedMessageControl;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -24930,6 +27672,8 @@ public:
     uint32_t earliestImplementationTime;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -24958,6 +27702,8 @@ public:
     uint32_t implementationDateTime;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -25318,6 +28064,31 @@ enum class AlertStructure : uint32_t
 };
 
 namespace Commands {
+// Forward-declarations so we can reference these later.
+
+namespace GetAlerts {
+struct Type;
+struct DecodableType;
+} // namespace GetAlerts
+
+namespace GetAlertsResponse {
+struct Type;
+struct DecodableType;
+} // namespace GetAlertsResponse
+
+namespace AlertsNotification {
+struct Type;
+struct DecodableType;
+} // namespace AlertsNotification
+
+namespace EventsNotification {
+struct Type;
+struct DecodableType;
+} // namespace EventsNotification
+
+} // namespace Commands
+
+namespace Commands {
 namespace GetAlerts {
 enum class Fields
 {
@@ -25331,6 +28102,8 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::ApplianceEventsAndAlert::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::ApplianceEventsAndAlert::Commands::GetAlertsResponse::DecodableType;
 };
 
 struct DecodableType
@@ -25360,6 +28133,8 @@ public:
     DataModel::List<const chip::BitFlags<AlertStructure>> alertStructures;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -25391,6 +28166,8 @@ public:
     DataModel::List<const chip::BitFlags<AlertStructure>> alertStructures;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -25422,6 +28199,8 @@ public:
     EventIdentification eventId;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -25463,6 +28242,41 @@ struct TypeInfo
 namespace ApplianceStatistics {
 
 namespace Commands {
+// Forward-declarations so we can reference these later.
+
+namespace LogNotification {
+struct Type;
+struct DecodableType;
+} // namespace LogNotification
+
+namespace LogRequest {
+struct Type;
+struct DecodableType;
+} // namespace LogRequest
+
+namespace LogResponse {
+struct Type;
+struct DecodableType;
+} // namespace LogResponse
+
+namespace LogQueueRequest {
+struct Type;
+struct DecodableType;
+} // namespace LogQueueRequest
+
+namespace LogQueueResponse {
+struct Type;
+struct DecodableType;
+} // namespace LogQueueResponse
+
+namespace StatisticsAvailable {
+struct Type;
+struct DecodableType;
+} // namespace StatisticsAvailable
+
+} // namespace Commands
+
+namespace Commands {
 namespace LogNotification {
 enum class Fields
 {
@@ -25485,6 +28299,8 @@ public:
     DataModel::List<const uint8_t> logPayload;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -25516,6 +28332,8 @@ public:
     uint32_t logId;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::ApplianceStatistics::Commands::LogResponse::DecodableType;
 };
 
 struct DecodableType
@@ -25550,6 +28368,8 @@ public:
     DataModel::List<const uint8_t> logPayload;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -25578,6 +28398,8 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::ApplianceStatistics::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = Clusters::ApplianceStatistics::Commands::LogQueueResponse::DecodableType;
 };
 
 struct DecodableType
@@ -25607,6 +28429,8 @@ public:
     DataModel::List<const uint32_t> logIds;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -25638,6 +28462,8 @@ public:
     DataModel::List<const uint32_t> logIds;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -25699,6 +28525,31 @@ struct TypeInfo
 namespace ElectricalMeasurement {
 
 namespace Commands {
+// Forward-declarations so we can reference these later.
+
+namespace GetProfileInfoResponseCommand {
+struct Type;
+struct DecodableType;
+} // namespace GetProfileInfoResponseCommand
+
+namespace GetProfileInfoCommand {
+struct Type;
+struct DecodableType;
+} // namespace GetProfileInfoCommand
+
+namespace GetMeasurementProfileResponseCommand {
+struct Type;
+struct DecodableType;
+} // namespace GetMeasurementProfileResponseCommand
+
+namespace GetMeasurementProfileCommand {
+struct Type;
+struct DecodableType;
+} // namespace GetMeasurementProfileCommand
+
+} // namespace Commands
+
+namespace Commands {
 namespace GetProfileInfoResponseCommand {
 enum class Fields
 {
@@ -25721,6 +28572,8 @@ public:
     DataModel::List<const uint16_t> listOfAttributes;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -25749,6 +28602,8 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::ElectricalMeasurement::Id; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -25786,6 +28641,8 @@ public:
     DataModel::List<const uint8_t> intervals;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -25823,6 +28680,8 @@ public:
     uint8_t numberOfIntervals;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -27145,6 +30004,21 @@ struct TypeInfo
 namespace Binding {
 
 namespace Commands {
+// Forward-declarations so we can reference these later.
+
+namespace Bind {
+struct Type;
+struct DecodableType;
+} // namespace Bind
+
+namespace Unbind {
+struct Type;
+struct DecodableType;
+} // namespace Unbind
+
+} // namespace Commands
+
+namespace Commands {
 namespace Bind {
 enum class Fields
 {
@@ -27167,6 +30041,8 @@ public:
     chip::ClusterId clusterId;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -27204,6 +30080,8 @@ public:
     chip::ClusterId clusterId;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -27355,6 +30233,16 @@ struct TypeInfo
 namespace SampleMfgSpecificCluster {
 
 namespace Commands {
+// Forward-declarations so we can reference these later.
+
+namespace CommandOne {
+struct Type;
+struct DecodableType;
+} // namespace CommandOne
+
+} // namespace Commands
+
+namespace Commands {
 namespace CommandOne {
 enum class Fields
 {
@@ -27371,6 +30259,8 @@ public:
     uint8_t argOne;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType
@@ -27431,6 +30321,16 @@ struct TypeInfo
 namespace SampleMfgSpecificCluster2 {
 
 namespace Commands {
+// Forward-declarations so we can reference these later.
+
+namespace CommandTwo {
+struct Type;
+struct DecodableType;
+} // namespace CommandTwo
+
+} // namespace Commands
+
+namespace Commands {
 namespace CommandTwo {
 enum class Fields
 {
@@ -27447,6 +30347,8 @@ public:
     uint8_t argOne;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
 };
 
 struct DecodableType

--- a/zzz_generated/chip-tool/zap-generated/test/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/test/Commands.h
@@ -5947,19 +5947,18 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::OnOff::Commands::On::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::OnOff::Commands::On::Type;
 
-        chip::app::Clusters::OnOff::Commands::On::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_3_1 *>(context))->OnSuccessResponse_0();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_3_1 *>(context))->OnFailureResponse_0(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_0(uint8_t status) { ThrowFailureResponse(); }
@@ -5987,24 +5986,23 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::ColorControl::Commands::MoveToHue::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::ColorControl::Commands::MoveToHue::Type;
 
-        chip::app::Clusters::ColorControl::Commands::MoveToHue::Type request;
+        RequestType request;
         request.hue             = 150;
         request.direction       = static_cast<chip::app::Clusters::ColorControl::HueDirection>(0);
         request.transitionTime  = 100U;
         request.optionsMask     = 0;
         request.optionsOverride = 0;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_3_1 *>(context))->OnSuccessResponse_2();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_3_1 *>(context))->OnFailureResponse_2(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_2(uint8_t status) { ThrowFailureResponse(); }
@@ -6016,24 +6014,23 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::ColorControl::Commands::MoveToHue::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::ColorControl::Commands::MoveToHue::Type;
 
-        chip::app::Clusters::ColorControl::Commands::MoveToHue::Type request;
+        RequestType request;
         request.hue             = 200;
         request.direction       = static_cast<chip::app::Clusters::ColorControl::HueDirection>(1);
         request.transitionTime  = 100U;
         request.optionsMask     = 0;
         request.optionsOverride = 0;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_3_1 *>(context))->OnSuccessResponse_3();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_3_1 *>(context))->OnFailureResponse_3(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_3(uint8_t status) { ThrowFailureResponse(); }
@@ -6045,24 +6042,23 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::ColorControl::Commands::MoveToHue::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::ColorControl::Commands::MoveToHue::Type;
 
-        chip::app::Clusters::ColorControl::Commands::MoveToHue::Type request;
+        RequestType request;
         request.hue             = 250;
         request.direction       = static_cast<chip::app::Clusters::ColorControl::HueDirection>(2);
         request.transitionTime  = 100U;
         request.optionsMask     = 0;
         request.optionsOverride = 0;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_3_1 *>(context))->OnSuccessResponse_4();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_3_1 *>(context))->OnFailureResponse_4(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_4(uint8_t status) { ThrowFailureResponse(); }
@@ -6074,24 +6070,23 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::ColorControl::Commands::MoveToHue::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::ColorControl::Commands::MoveToHue::Type;
 
-        chip::app::Clusters::ColorControl::Commands::MoveToHue::Type request;
+        RequestType request;
         request.hue             = 225;
         request.direction       = static_cast<chip::app::Clusters::ColorControl::HueDirection>(3);
         request.transitionTime  = 100U;
         request.optionsMask     = 0;
         request.optionsOverride = 0;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_3_1 *>(context))->OnSuccessResponse_5();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_3_1 *>(context))->OnFailureResponse_5(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_5(uint8_t status) { ThrowFailureResponse(); }
@@ -6103,19 +6098,18 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::OnOff::Commands::Off::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::OnOff::Commands::Off::Type;
 
-        chip::app::Clusters::OnOff::Commands::Off::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_3_1 *>(context))->OnSuccessResponse_6();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_3_1 *>(context))->OnFailureResponse_6(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_6(uint8_t status) { ThrowFailureResponse(); }
@@ -6248,19 +6242,18 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::OnOff::Commands::On::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::OnOff::Commands::On::Type;
 
-        chip::app::Clusters::OnOff::Commands::On::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_3_2 *>(context))->OnSuccessResponse_0();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_3_2 *>(context))->OnFailureResponse_0(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_0(uint8_t status) { ThrowFailureResponse(); }
@@ -6288,23 +6281,22 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::ColorControl::Commands::MoveHue::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::ColorControl::Commands::MoveHue::Type;
 
-        chip::app::Clusters::ColorControl::Commands::MoveHue::Type request;
+        RequestType request;
         request.moveMode        = static_cast<chip::app::Clusters::ColorControl::HueMoveMode>(1);
         request.rate            = 50;
         request.optionsMask     = 0;
         request.optionsOverride = 0;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_3_2 *>(context))->OnSuccessResponse_2();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_3_2 *>(context))->OnFailureResponse_2(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_2(uint8_t status) { ThrowFailureResponse(); }
@@ -6316,23 +6308,22 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::ColorControl::Commands::MoveHue::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::ColorControl::Commands::MoveHue::Type;
 
-        chip::app::Clusters::ColorControl::Commands::MoveHue::Type request;
+        RequestType request;
         request.moveMode        = static_cast<chip::app::Clusters::ColorControl::HueMoveMode>(0);
         request.rate            = 50;
         request.optionsMask     = 0;
         request.optionsOverride = 0;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_3_2 *>(context))->OnSuccessResponse_3();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_3_2 *>(context))->OnFailureResponse_3(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_3(uint8_t status) { ThrowFailureResponse(); }
@@ -6344,23 +6335,22 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::ColorControl::Commands::MoveHue::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::ColorControl::Commands::MoveHue::Type;
 
-        chip::app::Clusters::ColorControl::Commands::MoveHue::Type request;
+        RequestType request;
         request.moveMode        = static_cast<chip::app::Clusters::ColorControl::HueMoveMode>(3);
         request.rate            = 50;
         request.optionsMask     = 0;
         request.optionsOverride = 0;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_3_2 *>(context))->OnSuccessResponse_4();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_3_2 *>(context))->OnFailureResponse_4(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_4(uint8_t status) { ThrowFailureResponse(); }
@@ -6372,23 +6362,22 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::ColorControl::Commands::MoveHue::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::ColorControl::Commands::MoveHue::Type;
 
-        chip::app::Clusters::ColorControl::Commands::MoveHue::Type request;
+        RequestType request;
         request.moveMode        = static_cast<chip::app::Clusters::ColorControl::HueMoveMode>(0);
         request.rate            = 50;
         request.optionsMask     = 0;
         request.optionsOverride = 0;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_3_2 *>(context))->OnSuccessResponse_5();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_3_2 *>(context))->OnFailureResponse_5(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_5(uint8_t status) { ThrowFailureResponse(); }
@@ -6400,19 +6389,18 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::OnOff::Commands::Off::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::OnOff::Commands::Off::Type;
 
-        chip::app::Clusters::OnOff::Commands::Off::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_3_2 *>(context))->OnSuccessResponse_6();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_3_2 *>(context))->OnFailureResponse_6(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_6(uint8_t status) { ThrowFailureResponse(); }
@@ -6537,19 +6525,18 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::OnOff::Commands::On::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::OnOff::Commands::On::Type;
 
-        chip::app::Clusters::OnOff::Commands::On::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_3_3 *>(context))->OnSuccessResponse_0();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_3_3 *>(context))->OnFailureResponse_0(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_0(uint8_t status) { ThrowFailureResponse(); }
@@ -6577,24 +6564,23 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::ColorControl::Commands::StepHue::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::ColorControl::Commands::StepHue::Type;
 
-        chip::app::Clusters::ColorControl::Commands::StepHue::Type request;
+        RequestType request;
         request.stepMode        = static_cast<chip::app::Clusters::ColorControl::HueStepMode>(1);
         request.stepSize        = 5;
         request.transitionTime  = 25;
         request.optionsMask     = 0;
         request.optionsOverride = 0;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_3_3 *>(context))->OnSuccessResponse_2();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_3_3 *>(context))->OnFailureResponse_2(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_2(uint8_t status) { ThrowFailureResponse(); }
@@ -6606,24 +6592,23 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::ColorControl::Commands::StepHue::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::ColorControl::Commands::StepHue::Type;
 
-        chip::app::Clusters::ColorControl::Commands::StepHue::Type request;
+        RequestType request;
         request.stepMode        = static_cast<chip::app::Clusters::ColorControl::HueStepMode>(3);
         request.stepSize        = 5;
         request.transitionTime  = 25;
         request.optionsMask     = 0;
         request.optionsOverride = 0;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_3_3 *>(context))->OnSuccessResponse_3();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_3_3 *>(context))->OnFailureResponse_3(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_3(uint8_t status) { ThrowFailureResponse(); }
@@ -6635,19 +6620,18 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::OnOff::Commands::Off::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::OnOff::Commands::Off::Type;
 
-        chip::app::Clusters::OnOff::Commands::Off::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_3_3 *>(context))->OnSuccessResponse_4();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_3_3 *>(context))->OnFailureResponse_4(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_4(uint8_t status) { ThrowFailureResponse(); }
@@ -6768,19 +6752,18 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::OnOff::Commands::On::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::OnOff::Commands::On::Type;
 
-        chip::app::Clusters::OnOff::Commands::On::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_4_1 *>(context))->OnSuccessResponse_0();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_4_1 *>(context))->OnFailureResponse_0(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_0(uint8_t status) { ThrowFailureResponse(); }
@@ -6808,23 +6791,22 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::ColorControl::Commands::MoveToSaturation::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::ColorControl::Commands::MoveToSaturation::Type;
 
-        chip::app::Clusters::ColorControl::Commands::MoveToSaturation::Type request;
+        RequestType request;
         request.saturation      = 90;
         request.transitionTime  = 10U;
         request.optionsMask     = 0;
         request.optionsOverride = 0;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_4_1 *>(context))->OnSuccessResponse_2();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_4_1 *>(context))->OnFailureResponse_2(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_2(uint8_t status) { ThrowFailureResponse(); }
@@ -6836,19 +6818,18 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::OnOff::Commands::Off::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::OnOff::Commands::Off::Type;
 
-        chip::app::Clusters::OnOff::Commands::Off::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_4_1 *>(context))->OnSuccessResponse_3();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_4_1 *>(context))->OnFailureResponse_3(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_3(uint8_t status) { ThrowFailureResponse(); }
@@ -6973,19 +6954,18 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::OnOff::Commands::On::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::OnOff::Commands::On::Type;
 
-        chip::app::Clusters::OnOff::Commands::On::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_4_2 *>(context))->OnSuccessResponse_0();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_4_2 *>(context))->OnFailureResponse_0(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_0(uint8_t status) { ThrowFailureResponse(); }
@@ -7013,23 +6993,22 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::ColorControl::Commands::MoveSaturation::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::ColorControl::Commands::MoveSaturation::Type;
 
-        chip::app::Clusters::ColorControl::Commands::MoveSaturation::Type request;
+        RequestType request;
         request.moveMode        = static_cast<chip::app::Clusters::ColorControl::SaturationMoveMode>(1);
         request.rate            = 5;
         request.optionsMask     = 0;
         request.optionsOverride = 0;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_4_2 *>(context))->OnSuccessResponse_2();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_4_2 *>(context))->OnFailureResponse_2(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_2(uint8_t status) { ThrowFailureResponse(); }
@@ -7041,23 +7020,22 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::ColorControl::Commands::MoveSaturation::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::ColorControl::Commands::MoveSaturation::Type;
 
-        chip::app::Clusters::ColorControl::Commands::MoveSaturation::Type request;
+        RequestType request;
         request.moveMode        = static_cast<chip::app::Clusters::ColorControl::SaturationMoveMode>(3);
         request.rate            = 5;
         request.optionsMask     = 0;
         request.optionsOverride = 0;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_4_2 *>(context))->OnSuccessResponse_3();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_4_2 *>(context))->OnFailureResponse_3(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_3(uint8_t status) { ThrowFailureResponse(); }
@@ -7069,19 +7047,18 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::OnOff::Commands::Off::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::OnOff::Commands::Off::Type;
 
-        chip::app::Clusters::OnOff::Commands::Off::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_4_2 *>(context))->OnSuccessResponse_4();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_4_2 *>(context))->OnFailureResponse_4(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_4(uint8_t status) { ThrowFailureResponse(); }
@@ -7206,19 +7183,18 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::OnOff::Commands::On::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::OnOff::Commands::On::Type;
 
-        chip::app::Clusters::OnOff::Commands::On::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_4_3 *>(context))->OnSuccessResponse_0();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_4_3 *>(context))->OnFailureResponse_0(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_0(uint8_t status) { ThrowFailureResponse(); }
@@ -7246,24 +7222,23 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::ColorControl::Commands::StepSaturation::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::ColorControl::Commands::StepSaturation::Type;
 
-        chip::app::Clusters::ColorControl::Commands::StepSaturation::Type request;
+        RequestType request;
         request.stepMode        = static_cast<chip::app::Clusters::ColorControl::SaturationStepMode>(1);
         request.stepSize        = 15;
         request.transitionTime  = 10;
         request.optionsMask     = 0;
         request.optionsOverride = 0;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_4_3 *>(context))->OnSuccessResponse_2();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_4_3 *>(context))->OnFailureResponse_2(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_2(uint8_t status) { ThrowFailureResponse(); }
@@ -7275,24 +7250,23 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::ColorControl::Commands::StepSaturation::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::ColorControl::Commands::StepSaturation::Type;
 
-        chip::app::Clusters::ColorControl::Commands::StepSaturation::Type request;
+        RequestType request;
         request.stepMode        = static_cast<chip::app::Clusters::ColorControl::SaturationStepMode>(3);
         request.stepSize        = 20;
         request.transitionTime  = 10;
         request.optionsMask     = 0;
         request.optionsOverride = 0;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_4_3 *>(context))->OnSuccessResponse_3();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_4_3 *>(context))->OnFailureResponse_3(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_3(uint8_t status) { ThrowFailureResponse(); }
@@ -7304,19 +7278,18 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::OnOff::Commands::Off::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::OnOff::Commands::Off::Type;
 
-        chip::app::Clusters::OnOff::Commands::Off::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_4_3 *>(context))->OnSuccessResponse_4();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_4_3 *>(context))->OnFailureResponse_4(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_4(uint8_t status) { ThrowFailureResponse(); }
@@ -7437,19 +7410,18 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::OnOff::Commands::On::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::OnOff::Commands::On::Type;
 
-        chip::app::Clusters::OnOff::Commands::On::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_4_4 *>(context))->OnSuccessResponse_0();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_4_4 *>(context))->OnFailureResponse_0(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_0(uint8_t status) { ThrowFailureResponse(); }
@@ -7477,24 +7449,23 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::ColorControl::Commands::MoveToHueAndSaturation::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::ColorControl::Commands::MoveToHueAndSaturation::Type;
 
-        chip::app::Clusters::ColorControl::Commands::MoveToHueAndSaturation::Type request;
+        RequestType request;
         request.hue             = 40;
         request.saturation      = 160;
         request.transitionTime  = 10U;
         request.optionsMask     = 0;
         request.optionsOverride = 0;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_4_4 *>(context))->OnSuccessResponse_2();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_4_4 *>(context))->OnFailureResponse_2(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_2(uint8_t status) { ThrowFailureResponse(); }
@@ -7506,19 +7477,18 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::OnOff::Commands::Off::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::OnOff::Commands::Off::Type;
 
-        chip::app::Clusters::OnOff::Commands::Off::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_4_4 *>(context))->OnSuccessResponse_3();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_4_4 *>(context))->OnFailureResponse_3(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_3(uint8_t status) { ThrowFailureResponse(); }
@@ -7639,19 +7609,18 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::OnOff::Commands::On::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::OnOff::Commands::On::Type;
 
-        chip::app::Clusters::OnOff::Commands::On::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_5_1 *>(context))->OnSuccessResponse_0();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_5_1 *>(context))->OnFailureResponse_0(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_0(uint8_t status) { ThrowFailureResponse(); }
@@ -7679,24 +7648,23 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::ColorControl::Commands::MoveToColor::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::ColorControl::Commands::MoveToColor::Type;
 
-        chip::app::Clusters::ColorControl::Commands::MoveToColor::Type request;
+        RequestType request;
         request.colorX          = 200U;
         request.colorY          = 300U;
         request.transitionTime  = 20U;
         request.optionsMask     = 0;
         request.optionsOverride = 0;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_5_1 *>(context))->OnSuccessResponse_2();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_5_1 *>(context))->OnFailureResponse_2(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_2(uint8_t status) { ThrowFailureResponse(); }
@@ -7708,19 +7676,18 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::OnOff::Commands::Off::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::OnOff::Commands::Off::Type;
 
-        chip::app::Clusters::OnOff::Commands::Off::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_5_1 *>(context))->OnSuccessResponse_3();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_5_1 *>(context))->OnFailureResponse_3(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_3(uint8_t status) { ThrowFailureResponse(); }
@@ -7845,19 +7812,18 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::OnOff::Commands::On::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::OnOff::Commands::On::Type;
 
-        chip::app::Clusters::OnOff::Commands::On::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_5_2 *>(context))->OnSuccessResponse_0();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_5_2 *>(context))->OnFailureResponse_0(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_0(uint8_t status) { ThrowFailureResponse(); }
@@ -7885,23 +7851,22 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::ColorControl::Commands::MoveColor::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::ColorControl::Commands::MoveColor::Type;
 
-        chip::app::Clusters::ColorControl::Commands::MoveColor::Type request;
+        RequestType request;
         request.rateX           = 15;
         request.rateY           = 20;
         request.optionsMask     = 0;
         request.optionsOverride = 0;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_5_2 *>(context))->OnSuccessResponse_2();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_5_2 *>(context))->OnFailureResponse_2(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_2(uint8_t status) { ThrowFailureResponse(); }
@@ -7913,21 +7878,20 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::ColorControl::Commands::StopMoveStep::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::ColorControl::Commands::StopMoveStep::Type;
 
-        chip::app::Clusters::ColorControl::Commands::StopMoveStep::Type request;
+        RequestType request;
         request.optionsMask     = 0;
         request.optionsOverride = 0;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_5_2 *>(context))->OnSuccessResponse_3();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_5_2 *>(context))->OnFailureResponse_3(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_3(uint8_t status) { ThrowFailureResponse(); }
@@ -7939,19 +7903,18 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::OnOff::Commands::Off::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::OnOff::Commands::Off::Type;
 
-        chip::app::Clusters::OnOff::Commands::Off::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_5_2 *>(context))->OnSuccessResponse_4();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_5_2 *>(context))->OnFailureResponse_4(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_4(uint8_t status) { ThrowFailureResponse(); }
@@ -8072,19 +8035,18 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::OnOff::Commands::On::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::OnOff::Commands::On::Type;
 
-        chip::app::Clusters::OnOff::Commands::On::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_5_3 *>(context))->OnSuccessResponse_0();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_5_3 *>(context))->OnFailureResponse_0(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_0(uint8_t status) { ThrowFailureResponse(); }
@@ -8112,24 +8074,23 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::ColorControl::Commands::StepColor::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::ColorControl::Commands::StepColor::Type;
 
-        chip::app::Clusters::ColorControl::Commands::StepColor::Type request;
+        RequestType request;
         request.stepX           = 15;
         request.stepY           = 20;
         request.transitionTime  = 50U;
         request.optionsMask     = 0;
         request.optionsOverride = 0;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_5_3 *>(context))->OnSuccessResponse_2();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_5_3 *>(context))->OnFailureResponse_2(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_2(uint8_t status) { ThrowFailureResponse(); }
@@ -8141,19 +8102,18 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::OnOff::Commands::Off::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::OnOff::Commands::Off::Type;
 
-        chip::app::Clusters::OnOff::Commands::Off::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_5_3 *>(context))->OnSuccessResponse_3();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_5_3 *>(context))->OnFailureResponse_3(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_3(uint8_t status) { ThrowFailureResponse(); }
@@ -8274,19 +8234,18 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::OnOff::Commands::On::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::OnOff::Commands::On::Type;
 
-        chip::app::Clusters::OnOff::Commands::On::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_6_1 *>(context))->OnSuccessResponse_0();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_6_1 *>(context))->OnFailureResponse_0(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_0(uint8_t status) { ThrowFailureResponse(); }
@@ -8314,23 +8273,22 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::ColorControl::Commands::MoveToColorTemperature::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::ColorControl::Commands::MoveToColorTemperature::Type;
 
-        chip::app::Clusters::ColorControl::Commands::MoveToColorTemperature::Type request;
+        RequestType request;
         request.colorTemperature = 100U;
         request.transitionTime   = 10U;
         request.optionsMask      = 0;
         request.optionsOverride  = 0;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_6_1 *>(context))->OnSuccessResponse_2();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_6_1 *>(context))->OnFailureResponse_2(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_2(uint8_t status) { ThrowFailureResponse(); }
@@ -8342,19 +8300,18 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::OnOff::Commands::Off::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::OnOff::Commands::Off::Type;
 
-        chip::app::Clusters::OnOff::Commands::Off::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_6_1 *>(context))->OnSuccessResponse_3();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_6_1 *>(context))->OnFailureResponse_3(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_3(uint8_t status) { ThrowFailureResponse(); }
@@ -8483,19 +8440,18 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::OnOff::Commands::On::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::OnOff::Commands::On::Type;
 
-        chip::app::Clusters::OnOff::Commands::On::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_6_2 *>(context))->OnSuccessResponse_0();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_6_2 *>(context))->OnFailureResponse_0(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_0(uint8_t status) { ThrowFailureResponse(); }
@@ -8523,10 +8479,9 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::ColorControl::Commands::MoveColorTemperature::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::ColorControl::Commands::MoveColorTemperature::Type;
 
-        chip::app::Clusters::ColorControl::Commands::MoveColorTemperature::Type request;
+        RequestType request;
         request.moveMode                = static_cast<chip::app::Clusters::ColorControl::HueMoveMode>(1);
         request.rate                    = 10U;
         request.colorTemperatureMinimum = 1U;
@@ -8534,14 +8489,14 @@ private:
         request.optionsMask             = 0;
         request.optionsOverride         = 0;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_6_2 *>(context))->OnSuccessResponse_2();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_6_2 *>(context))->OnFailureResponse_2(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_2(uint8_t status) { ThrowFailureResponse(); }
@@ -8553,10 +8508,9 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::ColorControl::Commands::MoveColorTemperature::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::ColorControl::Commands::MoveColorTemperature::Type;
 
-        chip::app::Clusters::ColorControl::Commands::MoveColorTemperature::Type request;
+        RequestType request;
         request.moveMode                = static_cast<chip::app::Clusters::ColorControl::HueMoveMode>(0);
         request.rate                    = 10U;
         request.colorTemperatureMinimum = 1U;
@@ -8564,14 +8518,14 @@ private:
         request.optionsMask             = 0;
         request.optionsOverride         = 0;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_6_2 *>(context))->OnSuccessResponse_3();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_6_2 *>(context))->OnFailureResponse_3(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_3(uint8_t status) { ThrowFailureResponse(); }
@@ -8583,10 +8537,9 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::ColorControl::Commands::MoveColorTemperature::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::ColorControl::Commands::MoveColorTemperature::Type;
 
-        chip::app::Clusters::ColorControl::Commands::MoveColorTemperature::Type request;
+        RequestType request;
         request.moveMode                = static_cast<chip::app::Clusters::ColorControl::HueMoveMode>(3);
         request.rate                    = 20U;
         request.colorTemperatureMinimum = 1U;
@@ -8594,14 +8547,14 @@ private:
         request.optionsMask             = 0;
         request.optionsOverride         = 0;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_6_2 *>(context))->OnSuccessResponse_4();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_6_2 *>(context))->OnFailureResponse_4(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_4(uint8_t status) { ThrowFailureResponse(); }
@@ -8613,19 +8566,18 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::OnOff::Commands::Off::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::OnOff::Commands::Off::Type;
 
-        chip::app::Clusters::OnOff::Commands::Off::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_6_2 *>(context))->OnSuccessResponse_5();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_6_2 *>(context))->OnFailureResponse_5(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_5(uint8_t status) { ThrowFailureResponse(); }
@@ -8750,19 +8702,18 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::OnOff::Commands::On::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::OnOff::Commands::On::Type;
 
-        chip::app::Clusters::OnOff::Commands::On::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_6_3 *>(context))->OnSuccessResponse_0();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_6_3 *>(context))->OnFailureResponse_0(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_0(uint8_t status) { ThrowFailureResponse(); }
@@ -8790,10 +8741,9 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::ColorControl::Commands::StepColorTemperature::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::ColorControl::Commands::StepColorTemperature::Type;
 
-        chip::app::Clusters::ColorControl::Commands::StepColorTemperature::Type request;
+        RequestType request;
         request.stepMode                = static_cast<chip::app::Clusters::ColorControl::HueStepMode>(1);
         request.stepSize                = 5U;
         request.transitionTime          = 50U;
@@ -8802,14 +8752,14 @@ private:
         request.optionsMask             = 0;
         request.optionsOverride         = 0;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_6_3 *>(context))->OnSuccessResponse_2();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_6_3 *>(context))->OnFailureResponse_2(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_2(uint8_t status) { ThrowFailureResponse(); }
@@ -8821,10 +8771,9 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::ColorControl::Commands::StepColorTemperature::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::ColorControl::Commands::StepColorTemperature::Type;
 
-        chip::app::Clusters::ColorControl::Commands::StepColorTemperature::Type request;
+        RequestType request;
         request.stepMode                = static_cast<chip::app::Clusters::ColorControl::HueStepMode>(3);
         request.stepSize                = 5U;
         request.transitionTime          = 50U;
@@ -8833,14 +8782,14 @@ private:
         request.optionsMask             = 0;
         request.optionsOverride         = 0;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_6_3 *>(context))->OnSuccessResponse_3();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_6_3 *>(context))->OnFailureResponse_3(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_3(uint8_t status) { ThrowFailureResponse(); }
@@ -8852,19 +8801,18 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::OnOff::Commands::Off::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::OnOff::Commands::Off::Type;
 
-        chip::app::Clusters::OnOff::Commands::Off::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_6_3 *>(context))->OnSuccessResponse_4();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_6_3 *>(context))->OnFailureResponse_4(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_4(uint8_t status) { ThrowFailureResponse(); }
@@ -9002,19 +8950,18 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::OnOff::Commands::On::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::OnOff::Commands::On::Type;
 
-        chip::app::Clusters::OnOff::Commands::On::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_7_1 *>(context))->OnSuccessResponse_0();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_7_1 *>(context))->OnFailureResponse_0(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_0(uint8_t status) { ThrowFailureResponse(); }
@@ -9042,24 +8989,23 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::ColorControl::Commands::EnhancedMoveToHue::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::ColorControl::Commands::EnhancedMoveToHue::Type;
 
-        chip::app::Clusters::ColorControl::Commands::EnhancedMoveToHue::Type request;
+        RequestType request;
         request.enhancedHue     = 1025U;
         request.direction       = static_cast<chip::app::Clusters::ColorControl::HueDirection>(0);
         request.transitionTime  = 1U;
         request.optionsMask     = 0;
         request.optionsOverride = 0;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_7_1 *>(context))->OnSuccessResponse_2();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_7_1 *>(context))->OnFailureResponse_2(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_2(uint8_t status) { ThrowFailureResponse(); }
@@ -9087,19 +9033,18 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::OnOff::Commands::Off::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::OnOff::Commands::Off::Type;
 
-        chip::app::Clusters::OnOff::Commands::Off::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_7_1 *>(context))->OnSuccessResponse_4();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_7_1 *>(context))->OnFailureResponse_4(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_4(uint8_t status) { ThrowFailureResponse(); }
@@ -9232,19 +9177,18 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::OnOff::Commands::On::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::OnOff::Commands::On::Type;
 
-        chip::app::Clusters::OnOff::Commands::On::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_7_2 *>(context))->OnSuccessResponse_0();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_7_2 *>(context))->OnFailureResponse_0(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_0(uint8_t status) { ThrowFailureResponse(); }
@@ -9272,23 +9216,22 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::ColorControl::Commands::EnhancedMoveHue::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::ColorControl::Commands::EnhancedMoveHue::Type;
 
-        chip::app::Clusters::ColorControl::Commands::EnhancedMoveHue::Type request;
+        RequestType request;
         request.moveMode        = static_cast<chip::app::Clusters::ColorControl::HueMoveMode>(3);
         request.rate            = 5U;
         request.optionsMask     = 0;
         request.optionsOverride = 0;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_7_2 *>(context))->OnSuccessResponse_2();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_7_2 *>(context))->OnFailureResponse_2(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_2(uint8_t status) { ThrowFailureResponse(); }
@@ -9300,23 +9243,22 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::ColorControl::Commands::EnhancedMoveHue::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::ColorControl::Commands::EnhancedMoveHue::Type;
 
-        chip::app::Clusters::ColorControl::Commands::EnhancedMoveHue::Type request;
+        RequestType request;
         request.moveMode        = static_cast<chip::app::Clusters::ColorControl::HueMoveMode>(0);
         request.rate            = 0U;
         request.optionsMask     = 0;
         request.optionsOverride = 0;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_7_2 *>(context))->OnSuccessResponse_3();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_7_2 *>(context))->OnFailureResponse_3(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_3(uint8_t status) { ThrowFailureResponse(); }
@@ -9328,23 +9270,22 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::ColorControl::Commands::EnhancedMoveHue::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::ColorControl::Commands::EnhancedMoveHue::Type;
 
-        chip::app::Clusters::ColorControl::Commands::EnhancedMoveHue::Type request;
+        RequestType request;
         request.moveMode        = static_cast<chip::app::Clusters::ColorControl::HueMoveMode>(1);
         request.rate            = 50U;
         request.optionsMask     = 0;
         request.optionsOverride = 0;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_7_2 *>(context))->OnSuccessResponse_4();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_7_2 *>(context))->OnFailureResponse_4(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_4(uint8_t status) { ThrowFailureResponse(); }
@@ -9356,23 +9297,22 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::ColorControl::Commands::EnhancedMoveHue::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::ColorControl::Commands::EnhancedMoveHue::Type;
 
-        chip::app::Clusters::ColorControl::Commands::EnhancedMoveHue::Type request;
+        RequestType request;
         request.moveMode        = static_cast<chip::app::Clusters::ColorControl::HueMoveMode>(0);
         request.rate            = 0U;
         request.optionsMask     = 0;
         request.optionsOverride = 0;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_7_2 *>(context))->OnSuccessResponse_5();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_7_2 *>(context))->OnFailureResponse_5(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_5(uint8_t status) { ThrowFailureResponse(); }
@@ -9384,19 +9324,18 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::OnOff::Commands::Off::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::OnOff::Commands::Off::Type;
 
-        chip::app::Clusters::OnOff::Commands::Off::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_7_2 *>(context))->OnSuccessResponse_6();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_7_2 *>(context))->OnFailureResponse_6(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_6(uint8_t status) { ThrowFailureResponse(); }
@@ -9521,19 +9460,18 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::OnOff::Commands::On::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::OnOff::Commands::On::Type;
 
-        chip::app::Clusters::OnOff::Commands::On::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_7_3 *>(context))->OnSuccessResponse_0();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_7_3 *>(context))->OnFailureResponse_0(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_0(uint8_t status) { ThrowFailureResponse(); }
@@ -9561,24 +9499,23 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::ColorControl::Commands::EnhancedStepHue::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::ColorControl::Commands::EnhancedStepHue::Type;
 
-        chip::app::Clusters::ColorControl::Commands::EnhancedStepHue::Type request;
+        RequestType request;
         request.stepMode        = static_cast<chip::app::Clusters::ColorControl::HueStepMode>(0);
         request.stepSize        = 50U;
         request.transitionTime  = 1U;
         request.optionsMask     = 0;
         request.optionsOverride = 0;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_7_3 *>(context))->OnSuccessResponse_2();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_7_3 *>(context))->OnFailureResponse_2(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_2(uint8_t status) { ThrowFailureResponse(); }
@@ -9590,24 +9527,23 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::ColorControl::Commands::EnhancedStepHue::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::ColorControl::Commands::EnhancedStepHue::Type;
 
-        chip::app::Clusters::ColorControl::Commands::EnhancedStepHue::Type request;
+        RequestType request;
         request.stepMode        = static_cast<chip::app::Clusters::ColorControl::HueStepMode>(1);
         request.stepSize        = 75U;
         request.transitionTime  = 1U;
         request.optionsMask     = 0;
         request.optionsOverride = 0;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_7_3 *>(context))->OnSuccessResponse_3();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_7_3 *>(context))->OnFailureResponse_3(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_3(uint8_t status) { ThrowFailureResponse(); }
@@ -9619,19 +9555,18 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::OnOff::Commands::Off::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::OnOff::Commands::Off::Type;
 
-        chip::app::Clusters::OnOff::Commands::Off::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_7_3 *>(context))->OnSuccessResponse_4();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_7_3 *>(context))->OnFailureResponse_4(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_4(uint8_t status) { ThrowFailureResponse(); }
@@ -9752,19 +9687,18 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::OnOff::Commands::On::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::OnOff::Commands::On::Type;
 
-        chip::app::Clusters::OnOff::Commands::On::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_7_4 *>(context))->OnSuccessResponse_0();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_7_4 *>(context))->OnFailureResponse_0(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_0(uint8_t status) { ThrowFailureResponse(); }
@@ -9792,24 +9726,23 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::ColorControl::Commands::EnhancedMoveToHueAndSaturation::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::ColorControl::Commands::EnhancedMoveToHueAndSaturation::Type;
 
-        chip::app::Clusters::ColorControl::Commands::EnhancedMoveToHueAndSaturation::Type request;
+        RequestType request;
         request.enhancedHue     = 1200U;
         request.saturation      = 90;
         request.transitionTime  = 10U;
         request.optionsMask     = 0;
         request.optionsOverride = 0;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_7_4 *>(context))->OnSuccessResponse_2();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_7_4 *>(context))->OnFailureResponse_2(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_2(uint8_t status) { ThrowFailureResponse(); }
@@ -9821,19 +9754,18 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::OnOff::Commands::Off::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::OnOff::Commands::Off::Type;
 
-        chip::app::Clusters::OnOff::Commands::Off::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_7_4 *>(context))->OnSuccessResponse_3();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_7_4 *>(context))->OnFailureResponse_3(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_3(uint8_t status) { ThrowFailureResponse(); }
@@ -10099,19 +10031,18 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::OnOff::Commands::On::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::OnOff::Commands::On::Type;
 
-        chip::app::Clusters::OnOff::Commands::On::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_8_1 *>(context))->OnSuccessResponse_0();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_8_1 *>(context))->OnFailureResponse_0(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_0(uint8_t status) { ThrowFailureResponse(); }
@@ -10139,10 +10070,9 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
 
-        chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type request;
+        RequestType request;
         request.updateFlags     = static_cast<chip::BitFlags<chip::app::Clusters::ColorControl::ColorLoopUpdateFlags>>(14);
         request.action          = static_cast<chip::app::Clusters::ColorControl::ColorLoopAction>(0);
         request.direction       = static_cast<chip::app::Clusters::ColorControl::ColorLoopDirection>(1);
@@ -10151,14 +10081,14 @@ private:
         request.optionsMask     = 0;
         request.optionsOverride = 0;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_8_1 *>(context))->OnSuccessResponse_2();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_8_1 *>(context))->OnFailureResponse_2(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_2(uint8_t status) { ThrowFailureResponse(); }
@@ -10234,10 +10164,9 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
 
-        chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type request;
+        RequestType request;
         request.updateFlags     = static_cast<chip::BitFlags<chip::app::Clusters::ColorControl::ColorLoopUpdateFlags>>(1);
         request.action          = static_cast<chip::app::Clusters::ColorControl::ColorLoopAction>(1);
         request.direction       = static_cast<chip::app::Clusters::ColorControl::ColorLoopDirection>(0);
@@ -10246,14 +10175,14 @@ private:
         request.optionsMask     = 0;
         request.optionsOverride = 0;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_8_1 *>(context))->OnSuccessResponse_7();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_8_1 *>(context))->OnFailureResponse_7(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_7(uint8_t status) { ThrowFailureResponse(); }
@@ -10281,10 +10210,9 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
 
-        chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type request;
+        RequestType request;
         request.updateFlags     = static_cast<chip::BitFlags<chip::app::Clusters::ColorControl::ColorLoopUpdateFlags>>(6);
         request.action          = static_cast<chip::app::Clusters::ColorControl::ColorLoopAction>(0);
         request.direction       = static_cast<chip::app::Clusters::ColorControl::ColorLoopDirection>(0);
@@ -10293,14 +10221,14 @@ private:
         request.optionsMask     = 0;
         request.optionsOverride = 0;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_8_1 *>(context))->OnSuccessResponse_9();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_8_1 *>(context))->OnFailureResponse_9(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_9(uint8_t status) { ThrowFailureResponse(); }
@@ -10344,10 +10272,9 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
 
-        chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type request;
+        RequestType request;
         request.updateFlags     = static_cast<chip::BitFlags<chip::app::Clusters::ColorControl::ColorLoopUpdateFlags>>(2);
         request.action          = static_cast<chip::app::Clusters::ColorControl::ColorLoopAction>(0);
         request.direction       = static_cast<chip::app::Clusters::ColorControl::ColorLoopDirection>(1);
@@ -10356,14 +10283,14 @@ private:
         request.optionsMask     = 0;
         request.optionsOverride = 0;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_8_1 *>(context))->OnSuccessResponse_12();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_8_1 *>(context))->OnFailureResponse_12(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_12(uint8_t status) { ThrowFailureResponse(); }
@@ -10391,19 +10318,18 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::OnOff::Commands::Off::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::OnOff::Commands::Off::Type;
 
-        chip::app::Clusters::OnOff::Commands::Off::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_8_1 *>(context))->OnSuccessResponse_14();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_8_1 *>(context))->OnFailureResponse_14(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_14(uint8_t status) { ThrowFailureResponse(); }
@@ -10835,19 +10761,18 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::OnOff::Commands::On::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::OnOff::Commands::On::Type;
 
-        chip::app::Clusters::OnOff::Commands::On::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_9_1 *>(context))->OnSuccessResponse_0();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_9_1 *>(context))->OnFailureResponse_0(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_0(uint8_t status) { ThrowFailureResponse(); }
@@ -10875,10 +10800,9 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
 
-        chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type request;
+        RequestType request;
         request.updateFlags     = static_cast<chip::BitFlags<chip::app::Clusters::ColorControl::ColorLoopUpdateFlags>>(1);
         request.action          = static_cast<chip::app::Clusters::ColorControl::ColorLoopAction>(0);
         request.direction       = static_cast<chip::app::Clusters::ColorControl::ColorLoopDirection>(0);
@@ -10887,14 +10811,14 @@ private:
         request.optionsMask     = 0;
         request.optionsOverride = 0;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_9_1 *>(context))->OnSuccessResponse_2();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_9_1 *>(context))->OnFailureResponse_2(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_2(uint8_t status) { ThrowFailureResponse(); }
@@ -10922,10 +10846,9 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
 
-        chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type request;
+        RequestType request;
         request.updateFlags     = static_cast<chip::BitFlags<chip::app::Clusters::ColorControl::ColorLoopUpdateFlags>>(2);
         request.action          = static_cast<chip::app::Clusters::ColorControl::ColorLoopAction>(0);
         request.direction       = static_cast<chip::app::Clusters::ColorControl::ColorLoopDirection>(0);
@@ -10934,14 +10857,14 @@ private:
         request.optionsMask     = 0;
         request.optionsOverride = 0;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_9_1 *>(context))->OnSuccessResponse_4();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_9_1 *>(context))->OnFailureResponse_4(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_4(uint8_t status) { ThrowFailureResponse(); }
@@ -10969,10 +10892,9 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
 
-        chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type request;
+        RequestType request;
         request.updateFlags     = static_cast<chip::BitFlags<chip::app::Clusters::ColorControl::ColorLoopUpdateFlags>>(4);
         request.action          = static_cast<chip::app::Clusters::ColorControl::ColorLoopAction>(0);
         request.direction       = static_cast<chip::app::Clusters::ColorControl::ColorLoopDirection>(0);
@@ -10981,14 +10903,14 @@ private:
         request.optionsMask     = 0;
         request.optionsOverride = 0;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_9_1 *>(context))->OnSuccessResponse_6();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_9_1 *>(context))->OnFailureResponse_6(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_6(uint8_t status) { ThrowFailureResponse(); }
@@ -11016,10 +10938,9 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
 
-        chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type request;
+        RequestType request;
         request.updateFlags     = static_cast<chip::BitFlags<chip::app::Clusters::ColorControl::ColorLoopUpdateFlags>>(8);
         request.action          = static_cast<chip::app::Clusters::ColorControl::ColorLoopAction>(0);
         request.direction       = static_cast<chip::app::Clusters::ColorControl::ColorLoopDirection>(0);
@@ -11028,14 +10949,14 @@ private:
         request.optionsMask     = 0;
         request.optionsOverride = 0;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_9_1 *>(context))->OnSuccessResponse_8();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_9_1 *>(context))->OnFailureResponse_8(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_8(uint8_t status) { ThrowFailureResponse(); }
@@ -11063,10 +10984,9 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
 
-        chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type request;
+        RequestType request;
         request.updateFlags     = static_cast<chip::BitFlags<chip::app::Clusters::ColorControl::ColorLoopUpdateFlags>>(1);
         request.action          = static_cast<chip::app::Clusters::ColorControl::ColorLoopAction>(1);
         request.direction       = static_cast<chip::app::Clusters::ColorControl::ColorLoopDirection>(0);
@@ -11075,14 +10995,14 @@ private:
         request.optionsMask     = 0;
         request.optionsOverride = 0;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_9_1 *>(context))->OnSuccessResponse_10();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_9_1 *>(context))->OnFailureResponse_10(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_10(uint8_t status) { ThrowFailureResponse(); }
@@ -11110,10 +11030,9 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
 
-        chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type request;
+        RequestType request;
         request.updateFlags     = static_cast<chip::BitFlags<chip::app::Clusters::ColorControl::ColorLoopUpdateFlags>>(1);
         request.action          = static_cast<chip::app::Clusters::ColorControl::ColorLoopAction>(0);
         request.direction       = static_cast<chip::app::Clusters::ColorControl::ColorLoopDirection>(0);
@@ -11122,14 +11041,14 @@ private:
         request.optionsMask     = 0;
         request.optionsOverride = 0;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_9_1 *>(context))->OnSuccessResponse_12();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_9_1 *>(context))->OnFailureResponse_12(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_12(uint8_t status) { ThrowFailureResponse(); }
@@ -11157,10 +11076,9 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
 
-        chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type request;
+        RequestType request;
         request.updateFlags     = static_cast<chip::BitFlags<chip::app::Clusters::ColorControl::ColorLoopUpdateFlags>>(2);
         request.action          = static_cast<chip::app::Clusters::ColorControl::ColorLoopAction>(0);
         request.direction       = static_cast<chip::app::Clusters::ColorControl::ColorLoopDirection>(1);
@@ -11169,14 +11087,14 @@ private:
         request.optionsMask     = 0;
         request.optionsOverride = 0;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_9_1 *>(context))->OnSuccessResponse_14();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_9_1 *>(context))->OnFailureResponse_14(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_14(uint8_t status) { ThrowFailureResponse(); }
@@ -11204,10 +11122,9 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
 
-        chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type request;
+        RequestType request;
         request.updateFlags     = static_cast<chip::BitFlags<chip::app::Clusters::ColorControl::ColorLoopUpdateFlags>>(1);
         request.action          = static_cast<chip::app::Clusters::ColorControl::ColorLoopAction>(1);
         request.direction       = static_cast<chip::app::Clusters::ColorControl::ColorLoopDirection>(0);
@@ -11216,14 +11133,14 @@ private:
         request.optionsMask     = 0;
         request.optionsOverride = 0;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_9_1 *>(context))->OnSuccessResponse_16();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_9_1 *>(context))->OnFailureResponse_16(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_16(uint8_t status) { ThrowFailureResponse(); }
@@ -11251,10 +11168,9 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
 
-        chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type request;
+        RequestType request;
         request.updateFlags     = static_cast<chip::BitFlags<chip::app::Clusters::ColorControl::ColorLoopUpdateFlags>>(1);
         request.action          = static_cast<chip::app::Clusters::ColorControl::ColorLoopAction>(0);
         request.direction       = static_cast<chip::app::Clusters::ColorControl::ColorLoopDirection>(0);
@@ -11263,14 +11179,14 @@ private:
         request.optionsMask     = 0;
         request.optionsOverride = 0;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_9_1 *>(context))->OnSuccessResponse_18();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_9_1 *>(context))->OnFailureResponse_18(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_18(uint8_t status) { ThrowFailureResponse(); }
@@ -11298,24 +11214,23 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::ColorControl::Commands::EnhancedMoveToHue::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::ColorControl::Commands::EnhancedMoveToHue::Type;
 
-        chip::app::Clusters::ColorControl::Commands::EnhancedMoveToHue::Type request;
+        RequestType request;
         request.enhancedHue     = 40960U;
         request.direction       = static_cast<chip::app::Clusters::ColorControl::HueDirection>(0);
         request.transitionTime  = 0U;
         request.optionsMask     = 0;
         request.optionsOverride = 0;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_9_1 *>(context))->OnSuccessResponse_20();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_9_1 *>(context))->OnFailureResponse_20(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_20(uint8_t status) { ThrowFailureResponse(); }
@@ -11345,10 +11260,9 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
 
-        chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type request;
+        RequestType request;
         request.updateFlags     = static_cast<chip::BitFlags<chip::app::Clusters::ColorControl::ColorLoopUpdateFlags>>(2);
         request.action          = static_cast<chip::app::Clusters::ColorControl::ColorLoopAction>(0);
         request.direction       = static_cast<chip::app::Clusters::ColorControl::ColorLoopDirection>(0);
@@ -11357,14 +11271,14 @@ private:
         request.optionsMask     = 0;
         request.optionsOverride = 0;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_9_1 *>(context))->OnSuccessResponse_23();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_9_1 *>(context))->OnFailureResponse_23(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_23(uint8_t status) { ThrowFailureResponse(); }
@@ -11392,10 +11306,9 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
 
-        chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type request;
+        RequestType request;
         request.updateFlags     = static_cast<chip::BitFlags<chip::app::Clusters::ColorControl::ColorLoopUpdateFlags>>(1);
         request.action          = static_cast<chip::app::Clusters::ColorControl::ColorLoopAction>(2);
         request.direction       = static_cast<chip::app::Clusters::ColorControl::ColorLoopDirection>(0);
@@ -11404,14 +11317,14 @@ private:
         request.optionsMask     = 0;
         request.optionsOverride = 0;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_9_1 *>(context))->OnSuccessResponse_25();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_9_1 *>(context))->OnFailureResponse_25(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_25(uint8_t status) { ThrowFailureResponse(); }
@@ -11439,10 +11352,9 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
 
-        chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type request;
+        RequestType request;
         request.updateFlags     = static_cast<chip::BitFlags<chip::app::Clusters::ColorControl::ColorLoopUpdateFlags>>(1);
         request.action          = static_cast<chip::app::Clusters::ColorControl::ColorLoopAction>(0);
         request.direction       = static_cast<chip::app::Clusters::ColorControl::ColorLoopDirection>(0);
@@ -11451,14 +11363,14 @@ private:
         request.optionsMask     = 0;
         request.optionsOverride = 0;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_9_1 *>(context))->OnSuccessResponse_27();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_9_1 *>(context))->OnFailureResponse_27(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_27(uint8_t status) { ThrowFailureResponse(); }
@@ -11486,10 +11398,9 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
 
-        chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type request;
+        RequestType request;
         request.updateFlags     = static_cast<chip::BitFlags<chip::app::Clusters::ColorControl::ColorLoopUpdateFlags>>(2);
         request.action          = static_cast<chip::app::Clusters::ColorControl::ColorLoopAction>(0);
         request.direction       = static_cast<chip::app::Clusters::ColorControl::ColorLoopDirection>(1);
@@ -11498,14 +11409,14 @@ private:
         request.optionsMask     = 0;
         request.optionsOverride = 0;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_9_1 *>(context))->OnSuccessResponse_29();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_9_1 *>(context))->OnFailureResponse_29(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_29(uint8_t status) { ThrowFailureResponse(); }
@@ -11533,10 +11444,9 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
 
-        chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type request;
+        RequestType request;
         request.updateFlags     = static_cast<chip::BitFlags<chip::app::Clusters::ColorControl::ColorLoopUpdateFlags>>(1);
         request.action          = static_cast<chip::app::Clusters::ColorControl::ColorLoopAction>(2);
         request.direction       = static_cast<chip::app::Clusters::ColorControl::ColorLoopDirection>(0);
@@ -11545,14 +11455,14 @@ private:
         request.optionsMask     = 0;
         request.optionsOverride = 0;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_9_1 *>(context))->OnSuccessResponse_31();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_9_1 *>(context))->OnFailureResponse_31(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_31(uint8_t status) { ThrowFailureResponse(); }
@@ -11580,10 +11490,9 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
 
-        chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type request;
+        RequestType request;
         request.updateFlags     = static_cast<chip::BitFlags<chip::app::Clusters::ColorControl::ColorLoopUpdateFlags>>(1);
         request.action          = static_cast<chip::app::Clusters::ColorControl::ColorLoopAction>(0);
         request.direction       = static_cast<chip::app::Clusters::ColorControl::ColorLoopDirection>(0);
@@ -11592,14 +11501,14 @@ private:
         request.optionsMask     = 0;
         request.optionsOverride = 0;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_9_1 *>(context))->OnSuccessResponse_33();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_9_1 *>(context))->OnFailureResponse_33(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_33(uint8_t status) { ThrowFailureResponse(); }
@@ -11627,19 +11536,18 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::OnOff::Commands::Off::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::OnOff::Commands::Off::Type;
 
-        chip::app::Clusters::OnOff::Commands::Off::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_9_1 *>(context))->OnSuccessResponse_35();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_9_1 *>(context))->OnFailureResponse_35(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_35(uint8_t status) { ThrowFailureResponse(); }
@@ -11856,19 +11764,18 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::OnOff::Commands::On::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::OnOff::Commands::On::Type;
 
-        chip::app::Clusters::OnOff::Commands::On::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_9_2 *>(context))->OnSuccessResponse_0();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_9_2 *>(context))->OnFailureResponse_0(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_0(uint8_t status) { ThrowFailureResponse(); }
@@ -11896,10 +11803,9 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
 
-        chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type request;
+        RequestType request;
         request.updateFlags     = static_cast<chip::BitFlags<chip::app::Clusters::ColorControl::ColorLoopUpdateFlags>>(15);
         request.action          = static_cast<chip::app::Clusters::ColorControl::ColorLoopAction>(0);
         request.direction       = static_cast<chip::app::Clusters::ColorControl::ColorLoopDirection>(0);
@@ -11908,14 +11814,14 @@ private:
         request.optionsMask     = 0;
         request.optionsOverride = 0;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_9_2 *>(context))->OnSuccessResponse_2();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_9_2 *>(context))->OnFailureResponse_2(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_2(uint8_t status) { ThrowFailureResponse(); }
@@ -11991,10 +11897,9 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
 
-        chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type request;
+        RequestType request;
         request.updateFlags     = static_cast<chip::BitFlags<chip::app::Clusters::ColorControl::ColorLoopUpdateFlags>>(1);
         request.action          = static_cast<chip::app::Clusters::ColorControl::ColorLoopAction>(1);
         request.direction       = static_cast<chip::app::Clusters::ColorControl::ColorLoopDirection>(0);
@@ -12003,14 +11908,14 @@ private:
         request.optionsMask     = 0;
         request.optionsOverride = 0;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_9_2 *>(context))->OnSuccessResponse_7();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_9_2 *>(context))->OnFailureResponse_7(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_7(uint8_t status) { ThrowFailureResponse(); }
@@ -12038,10 +11943,9 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
 
-        chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type request;
+        RequestType request;
         request.updateFlags     = static_cast<chip::BitFlags<chip::app::Clusters::ColorControl::ColorLoopUpdateFlags>>(2);
         request.action          = static_cast<chip::app::Clusters::ColorControl::ColorLoopAction>(0);
         request.direction       = static_cast<chip::app::Clusters::ColorControl::ColorLoopDirection>(1);
@@ -12050,14 +11954,14 @@ private:
         request.optionsMask     = 0;
         request.optionsOverride = 0;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_9_2 *>(context))->OnSuccessResponse_9();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_9_2 *>(context))->OnFailureResponse_9(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_9(uint8_t status) { ThrowFailureResponse(); }
@@ -12085,10 +11989,9 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
 
-        chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type request;
+        RequestType request;
         request.updateFlags     = static_cast<chip::BitFlags<chip::app::Clusters::ColorControl::ColorLoopUpdateFlags>>(1);
         request.action          = static_cast<chip::app::Clusters::ColorControl::ColorLoopAction>(0);
         request.direction       = static_cast<chip::app::Clusters::ColorControl::ColorLoopDirection>(0);
@@ -12097,14 +12000,14 @@ private:
         request.optionsMask     = 0;
         request.optionsOverride = 0;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_9_2 *>(context))->OnSuccessResponse_11();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_9_2 *>(context))->OnFailureResponse_11(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_11(uint8_t status) { ThrowFailureResponse(); }
@@ -12132,19 +12035,18 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::OnOff::Commands::Off::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::OnOff::Commands::Off::Type;
 
-        chip::app::Clusters::OnOff::Commands::Off::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_9_2 *>(context))->OnSuccessResponse_13();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_9_2 *>(context))->OnFailureResponse_13(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_13(uint8_t status) { ThrowFailureResponse(); }
@@ -12360,19 +12262,18 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::OnOff::Commands::On::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::OnOff::Commands::On::Type;
 
-        chip::app::Clusters::OnOff::Commands::On::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_9_3 *>(context))->OnSuccessResponse_0();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_9_3 *>(context))->OnFailureResponse_0(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_0(uint8_t status) { ThrowFailureResponse(); }
@@ -12400,10 +12301,9 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
 
-        chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type request;
+        RequestType request;
         request.updateFlags     = static_cast<chip::BitFlags<chip::app::Clusters::ColorControl::ColorLoopUpdateFlags>>(15);
         request.action          = static_cast<chip::app::Clusters::ColorControl::ColorLoopAction>(0);
         request.direction       = static_cast<chip::app::Clusters::ColorControl::ColorLoopDirection>(0);
@@ -12412,14 +12312,14 @@ private:
         request.optionsMask     = 0;
         request.optionsOverride = 0;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_9_3 *>(context))->OnSuccessResponse_2();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_9_3 *>(context))->OnFailureResponse_2(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_2(uint8_t status) { ThrowFailureResponse(); }
@@ -12495,10 +12395,9 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
 
-        chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type request;
+        RequestType request;
         request.updateFlags     = static_cast<chip::BitFlags<chip::app::Clusters::ColorControl::ColorLoopUpdateFlags>>(1);
         request.action          = static_cast<chip::app::Clusters::ColorControl::ColorLoopAction>(1);
         request.direction       = static_cast<chip::app::Clusters::ColorControl::ColorLoopDirection>(0);
@@ -12507,14 +12406,14 @@ private:
         request.optionsMask     = 0;
         request.optionsOverride = 0;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_9_3 *>(context))->OnSuccessResponse_7();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_9_3 *>(context))->OnFailureResponse_7(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_7(uint8_t status) { ThrowFailureResponse(); }
@@ -12542,10 +12441,9 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
 
-        chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type request;
+        RequestType request;
         request.updateFlags     = static_cast<chip::BitFlags<chip::app::Clusters::ColorControl::ColorLoopUpdateFlags>>(4);
         request.action          = static_cast<chip::app::Clusters::ColorControl::ColorLoopAction>(0);
         request.direction       = static_cast<chip::app::Clusters::ColorControl::ColorLoopDirection>(0);
@@ -12554,14 +12452,14 @@ private:
         request.optionsMask     = 0;
         request.optionsOverride = 0;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_9_3 *>(context))->OnSuccessResponse_9();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_9_3 *>(context))->OnFailureResponse_9(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_9(uint8_t status) { ThrowFailureResponse(); }
@@ -12589,10 +12487,9 @@ private:
         chip::Controller::ColorControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
 
-        chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type request;
+        RequestType request;
         request.updateFlags     = static_cast<chip::BitFlags<chip::app::Clusters::ColorControl::ColorLoopUpdateFlags>>(1);
         request.action          = static_cast<chip::app::Clusters::ColorControl::ColorLoopAction>(0);
         request.direction       = static_cast<chip::app::Clusters::ColorControl::ColorLoopDirection>(0);
@@ -12601,14 +12498,14 @@ private:
         request.optionsMask     = 0;
         request.optionsOverride = 0;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_9_3 *>(context))->OnSuccessResponse_11();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_9_3 *>(context))->OnFailureResponse_11(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_11(uint8_t status) { ThrowFailureResponse(); }
@@ -12636,19 +12533,18 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::OnOff::Commands::Off::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::OnOff::Commands::Off::Type;
 
-        chip::app::Clusters::OnOff::Commands::Off::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_CC_9_3 *>(context))->OnSuccessResponse_13();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_CC_9_3 *>(context))->OnFailureResponse_13(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_13(uint8_t status) { ThrowFailureResponse(); }
@@ -14455,23 +14351,22 @@ private:
         chip::Controller::LevelControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::LevelControl::Commands::MoveToLevel::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::LevelControl::Commands::MoveToLevel::Type;
 
-        chip::app::Clusters::LevelControl::Commands::MoveToLevel::Type request;
+        RequestType request;
         request.level          = 64;
         request.transitionTime = 0U;
         request.optionMask     = 1;
         request.optionOverride = 1;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_LVL_2_1 *>(context))->OnSuccessResponse_1();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_LVL_2_1 *>(context))->OnFailureResponse_1(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_1(uint8_t status) { ThrowFailureResponse(); }
@@ -14501,23 +14396,22 @@ private:
         chip::Controller::LevelControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::LevelControl::Commands::MoveToLevel::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::LevelControl::Commands::MoveToLevel::Type;
 
-        chip::app::Clusters::LevelControl::Commands::MoveToLevel::Type request;
+        RequestType request;
         request.level          = 128;
         request.transitionTime = 1U;
         request.optionMask     = 1;
         request.optionOverride = 1;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_LVL_2_1 *>(context))->OnSuccessResponse_4();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_LVL_2_1 *>(context))->OnFailureResponse_4(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_4(uint8_t status) { ThrowFailureResponse(); }
@@ -14563,23 +14457,22 @@ private:
         chip::Controller::LevelControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::LevelControl::Commands::MoveToLevel::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::LevelControl::Commands::MoveToLevel::Type;
 
-        chip::app::Clusters::LevelControl::Commands::MoveToLevel::Type request;
+        RequestType request;
         request.level          = 254;
         request.transitionTime = 65535U;
         request.optionMask     = 1;
         request.optionOverride = 1;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_LVL_2_1 *>(context))->OnSuccessResponse_8();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_LVL_2_1 *>(context))->OnFailureResponse_8(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_8(uint8_t status) { ThrowFailureResponse(); }
@@ -14609,23 +14502,22 @@ private:
         chip::Controller::LevelControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::LevelControl::Commands::MoveToLevel::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::LevelControl::Commands::MoveToLevel::Type;
 
-        chip::app::Clusters::LevelControl::Commands::MoveToLevel::Type request;
+        RequestType request;
         request.level          = 0;
         request.transitionTime = 0U;
         request.optionMask     = 1;
         request.optionOverride = 1;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_LVL_2_1 *>(context))->OnSuccessResponse_11();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_LVL_2_1 *>(context))->OnFailureResponse_11(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_11(uint8_t status) { ThrowFailureResponse(); }
@@ -14867,23 +14759,22 @@ private:
         chip::Controller::LevelControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::LevelControl::Commands::Move::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::LevelControl::Commands::Move::Type;
 
-        chip::app::Clusters::LevelControl::Commands::Move::Type request;
+        RequestType request;
         request.moveMode       = static_cast<chip::app::Clusters::LevelControl::MoveMode>(0);
         request.rate           = 200;
         request.optionMask     = 1;
         request.optionOverride = 1;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_LVL_3_1 *>(context))->OnSuccessResponse_2();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_LVL_3_1 *>(context))->OnFailureResponse_2(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_2(uint8_t status) { ThrowFailureResponse(); }
@@ -14929,23 +14820,22 @@ private:
         chip::Controller::LevelControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::LevelControl::Commands::Move::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::LevelControl::Commands::Move::Type;
 
-        chip::app::Clusters::LevelControl::Commands::Move::Type request;
+        RequestType request;
         request.moveMode       = static_cast<chip::app::Clusters::LevelControl::MoveMode>(1);
         request.rate           = 250;
         request.optionMask     = 1;
         request.optionOverride = 1;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_LVL_3_1 *>(context))->OnSuccessResponse_6();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_LVL_3_1 *>(context))->OnFailureResponse_6(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_6(uint8_t status) { ThrowFailureResponse(); }
@@ -15007,23 +14897,22 @@ private:
         chip::Controller::LevelControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::LevelControl::Commands::Move::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::LevelControl::Commands::Move::Type;
 
-        chip::app::Clusters::LevelControl::Commands::Move::Type request;
+        RequestType request;
         request.moveMode       = static_cast<chip::app::Clusters::LevelControl::MoveMode>(1);
         request.rate           = 255;
         request.optionMask     = 1;
         request.optionOverride = 1;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_LVL_3_1 *>(context))->OnSuccessResponse_11();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_LVL_3_1 *>(context))->OnFailureResponse_11(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_11(uint8_t status) { ThrowFailureResponse(); }
@@ -15182,19 +15071,18 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::OnOff::Commands::On::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::OnOff::Commands::On::Type;
 
-        chip::app::Clusters::OnOff::Commands::On::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_LVL_4_1 *>(context))->OnSuccessResponse_0();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_LVL_4_1 *>(context))->OnFailureResponse_0(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_0(uint8_t status) { ThrowFailureResponse(); }
@@ -15206,24 +15094,23 @@ private:
         chip::Controller::LevelControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::LevelControl::Commands::Step::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::LevelControl::Commands::Step::Type;
 
-        chip::app::Clusters::LevelControl::Commands::Step::Type request;
+        RequestType request;
         request.stepMode       = static_cast<chip::app::Clusters::LevelControl::StepMode>(0);
         request.stepSize       = 128;
         request.transitionTime = 20U;
         request.optionMask     = 0;
         request.optionOverride = 0;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_LVL_4_1 *>(context))->OnSuccessResponse_1();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_LVL_4_1 *>(context))->OnFailureResponse_1(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_1(uint8_t status) { ThrowFailureResponse(); }
@@ -15253,24 +15140,23 @@ private:
         chip::Controller::LevelControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::LevelControl::Commands::Step::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::LevelControl::Commands::Step::Type;
 
-        chip::app::Clusters::LevelControl::Commands::Step::Type request;
+        RequestType request;
         request.stepMode       = static_cast<chip::app::Clusters::LevelControl::StepMode>(1);
         request.stepSize       = 64;
         request.transitionTime = 20U;
         request.optionMask     = 0;
         request.optionOverride = 0;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_LVL_4_1 *>(context))->OnSuccessResponse_4();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_LVL_4_1 *>(context))->OnFailureResponse_4(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_4(uint8_t status) { ThrowFailureResponse(); }
@@ -15300,24 +15186,23 @@ private:
         chip::Controller::LevelControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::LevelControl::Commands::Step::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::LevelControl::Commands::Step::Type;
 
-        chip::app::Clusters::LevelControl::Commands::Step::Type request;
+        RequestType request;
         request.stepMode       = static_cast<chip::app::Clusters::LevelControl::StepMode>(0);
         request.stepSize       = 64;
         request.transitionTime = 20U;
         request.optionMask     = 0;
         request.optionOverride = 0;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_LVL_4_1 *>(context))->OnSuccessResponse_7();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_LVL_4_1 *>(context))->OnFailureResponse_7(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_7(uint8_t status) { ThrowFailureResponse(); }
@@ -15347,19 +15232,18 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::OnOff::Commands::Off::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::OnOff::Commands::Off::Type;
 
-        chip::app::Clusters::OnOff::Commands::Off::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_LVL_4_1 *>(context))->OnSuccessResponse_10();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_LVL_4_1 *>(context))->OnFailureResponse_10(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_10(uint8_t status) { ThrowFailureResponse(); }
@@ -15447,19 +15331,18 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::OnOff::Commands::On::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::OnOff::Commands::On::Type;
 
-        chip::app::Clusters::OnOff::Commands::On::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_LVL_5_1 *>(context))->OnSuccessResponse_0();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_LVL_5_1 *>(context))->OnFailureResponse_0(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_0(uint8_t status) { ThrowFailureResponse(); }
@@ -15471,24 +15354,23 @@ private:
         chip::Controller::LevelControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::LevelControl::Commands::Step::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::LevelControl::Commands::Step::Type;
 
-        chip::app::Clusters::LevelControl::Commands::Step::Type request;
+        RequestType request;
         request.stepMode       = static_cast<chip::app::Clusters::LevelControl::StepMode>(0);
         request.stepSize       = 128;
         request.transitionTime = 20U;
         request.optionMask     = 0;
         request.optionOverride = 0;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_LVL_5_1 *>(context))->OnSuccessResponse_1();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_LVL_5_1 *>(context))->OnFailureResponse_1(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_1(uint8_t status) { ThrowFailureResponse(); }
@@ -15502,23 +15384,22 @@ private:
         chip::Controller::LevelControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::LevelControl::Commands::Move::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::LevelControl::Commands::Move::Type;
 
-        chip::app::Clusters::LevelControl::Commands::Move::Type request;
+        RequestType request;
         request.moveMode       = static_cast<chip::app::Clusters::LevelControl::MoveMode>(0);
         request.rate           = 1;
         request.optionMask     = 1;
         request.optionOverride = 1;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_LVL_5_1 *>(context))->OnSuccessResponse_3();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_LVL_5_1 *>(context))->OnFailureResponse_3(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_3(uint8_t status) { ThrowFailureResponse(); }
@@ -15532,21 +15413,20 @@ private:
         chip::Controller::LevelControlClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::LevelControl::Commands::Stop::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::LevelControl::Commands::Stop::Type;
 
-        chip::app::Clusters::LevelControl::Commands::Stop::Type request;
+        RequestType request;
         request.optionMask     = 0;
         request.optionOverride = 0;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_LVL_5_1 *>(context))->OnSuccessResponse_5();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_LVL_5_1 *>(context))->OnFailureResponse_5(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_5(uint8_t status) { ThrowFailureResponse(); }
@@ -15558,19 +15438,18 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::OnOff::Commands::Off::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::OnOff::Commands::Off::Type;
 
-        chip::app::Clusters::OnOff::Commands::Off::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_LVL_5_1 *>(context))->OnSuccessResponse_6();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_LVL_5_1 *>(context))->OnFailureResponse_6(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_6(uint8_t status) { ThrowFailureResponse(); }
@@ -15710,19 +15589,18 @@ private:
         chip::Controller::LowPowerClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::LowPower::Commands::Sleep::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::LowPower::Commands::Sleep::Type;
 
-        chip::app::Clusters::LowPower::Commands::Sleep::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_MC_2_1 *>(context))->OnSuccessResponse_0();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_MC_2_1 *>(context))->OnFailureResponse_0(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_0(uint8_t status) { ThrowFailureResponse(); }
@@ -17657,19 +17535,18 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::OnOff::Commands::Off::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::OnOff::Commands::Off::Type;
 
-        chip::app::Clusters::OnOff::Commands::Off::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_OO_2_2 *>(context))->OnSuccessResponse_0();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_OO_2_2 *>(context))->OnFailureResponse_0(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_0(uint8_t status) { ThrowFailureResponse(); }
@@ -17697,19 +17574,18 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::OnOff::Commands::On::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::OnOff::Commands::On::Type;
 
-        chip::app::Clusters::OnOff::Commands::On::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_OO_2_2 *>(context))->OnSuccessResponse_2();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_OO_2_2 *>(context))->OnFailureResponse_2(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_2(uint8_t status) { ThrowFailureResponse(); }
@@ -17737,19 +17613,18 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::OnOff::Commands::Off::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::OnOff::Commands::Off::Type;
 
-        chip::app::Clusters::OnOff::Commands::Off::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_OO_2_2 *>(context))->OnSuccessResponse_4();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_OO_2_2 *>(context))->OnFailureResponse_4(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_4(uint8_t status) { ThrowFailureResponse(); }
@@ -17777,19 +17652,18 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::OnOff::Commands::Toggle::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::OnOff::Commands::Toggle::Type;
 
-        chip::app::Clusters::OnOff::Commands::Toggle::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_OO_2_2 *>(context))->OnSuccessResponse_6();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_OO_2_2 *>(context))->OnFailureResponse_6(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_6(uint8_t status) { ThrowFailureResponse(); }
@@ -17817,19 +17691,18 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::OnOff::Commands::Toggle::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::OnOff::Commands::Toggle::Type;
 
-        chip::app::Clusters::OnOff::Commands::Toggle::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_OO_2_2 *>(context))->OnSuccessResponse_8();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_OO_2_2 *>(context))->OnFailureResponse_8(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_8(uint8_t status) { ThrowFailureResponse(); }
@@ -17857,19 +17730,18 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::OnOff::Commands::On::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::OnOff::Commands::On::Type;
 
-        chip::app::Clusters::OnOff::Commands::On::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_OO_2_2 *>(context))->OnSuccessResponse_10();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_OO_2_2 *>(context))->OnFailureResponse_10(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_10(uint8_t status) { ThrowFailureResponse(); }
@@ -17897,19 +17769,18 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::OnOff::Commands::Off::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::OnOff::Commands::Off::Type;
 
-        chip::app::Clusters::OnOff::Commands::Off::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_OO_2_2 *>(context))->OnSuccessResponse_12();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_OO_2_2 *>(context))->OnFailureResponse_12(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_12(uint8_t status) { ThrowFailureResponse(); }
@@ -18566,19 +18437,18 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::OnOff::Commands::On::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::OnOff::Commands::On::Type;
 
-        chip::app::Clusters::OnOff::Commands::On::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_OO_2_3 *>(context))->OnSuccessResponse_0();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_OO_2_3 *>(context))->OnFailureResponse_0(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_0(uint8_t status) { ThrowFailureResponse(); }
@@ -18624,19 +18494,18 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::OnOff::Commands::On::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::OnOff::Commands::On::Type;
 
-        chip::app::Clusters::OnOff::Commands::On::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_OO_2_3 *>(context))->OnSuccessResponse_4();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_OO_2_3 *>(context))->OnFailureResponse_4(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_4(uint8_t status) { ThrowFailureResponse(); }
@@ -18682,19 +18551,18 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::OnOff::Commands::On::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::OnOff::Commands::On::Type;
 
-        chip::app::Clusters::OnOff::Commands::On::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_OO_2_3 *>(context))->OnSuccessResponse_8();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_OO_2_3 *>(context))->OnFailureResponse_8(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_8(uint8_t status) { ThrowFailureResponse(); }
@@ -18772,19 +18640,18 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::OnOff::Commands::On::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::OnOff::Commands::On::Type;
 
-        chip::app::Clusters::OnOff::Commands::On::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_OO_2_3 *>(context))->OnSuccessResponse_14();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_OO_2_3 *>(context))->OnFailureResponse_14(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_14(uint8_t status) { ThrowFailureResponse(); }
@@ -18844,19 +18711,18 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::OnOff::Commands::Off::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::OnOff::Commands::Off::Type;
 
-        chip::app::Clusters::OnOff::Commands::Off::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_OO_2_3 *>(context))->OnSuccessResponse_18();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_OO_2_3 *>(context))->OnFailureResponse_18(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_18(uint8_t status) { ThrowFailureResponse(); }
@@ -18948,19 +18814,18 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::OnOff::Commands::On::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::OnOff::Commands::On::Type;
 
-        chip::app::Clusters::OnOff::Commands::On::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_OO_2_3 *>(context))->OnSuccessResponse_24();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_OO_2_3 *>(context))->OnFailureResponse_24(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_24(uint8_t status) { ThrowFailureResponse(); }
@@ -19004,19 +18869,18 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::OnOff::Commands::Off::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::OnOff::Commands::Off::Type;
 
-        chip::app::Clusters::OnOff::Commands::Off::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_OO_2_3 *>(context))->OnSuccessResponse_27();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_OO_2_3 *>(context))->OnFailureResponse_27(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_27(uint8_t status) { ThrowFailureResponse(); }
@@ -19092,19 +18956,18 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::OnOff::Commands::On::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::OnOff::Commands::On::Type;
 
-        chip::app::Clusters::OnOff::Commands::On::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_OO_2_3 *>(context))->OnSuccessResponse_32();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_OO_2_3 *>(context))->OnFailureResponse_32(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_32(uint8_t status) { ThrowFailureResponse(); }
@@ -19164,19 +19027,18 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::OnOff::Commands::Off::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::OnOff::Commands::Off::Type;
 
-        chip::app::Clusters::OnOff::Commands::Off::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_OO_2_3 *>(context))->OnSuccessResponse_36();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_OO_2_3 *>(context))->OnFailureResponse_36(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_36(uint8_t status) { ThrowFailureResponse(); }
@@ -19316,19 +19178,18 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::OnOff::Commands::Off::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::OnOff::Commands::Off::Type;
 
-        chip::app::Clusters::OnOff::Commands::Off::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_OO_2_3 *>(context))->OnSuccessResponse_45();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_OO_2_3 *>(context))->OnFailureResponse_45(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_45(uint8_t status) { ThrowFailureResponse(); }
@@ -25135,19 +24996,18 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::WindowCovering::Commands::DownOrClose::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::WindowCovering::Commands::DownOrClose::Type;
 
-        chip::app::Clusters::WindowCovering::Commands::DownOrClose::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_WNCV_3_1 *>(context))->OnSuccessResponse_0();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_WNCV_3_1 *>(context))->OnFailureResponse_0(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_0(uint8_t status) { ThrowFailureResponse(); }
@@ -25159,19 +25019,18 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::WindowCovering::Commands::UpOrOpen::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::WindowCovering::Commands::UpOrOpen::Type;
 
-        chip::app::Clusters::WindowCovering::Commands::UpOrOpen::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_WNCV_3_1 *>(context))->OnSuccessResponse_1();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_WNCV_3_1 *>(context))->OnFailureResponse_1(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_1(uint8_t status) { ThrowFailureResponse(); }
@@ -25272,19 +25131,18 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::WindowCovering::Commands::UpOrOpen::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::WindowCovering::Commands::UpOrOpen::Type;
 
-        chip::app::Clusters::WindowCovering::Commands::UpOrOpen::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_WNCV_3_2 *>(context))->OnSuccessResponse_0();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_WNCV_3_2 *>(context))->OnFailureResponse_0(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_0(uint8_t status) { ThrowFailureResponse(); }
@@ -25296,19 +25154,18 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::WindowCovering::Commands::DownOrClose::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::WindowCovering::Commands::DownOrClose::Type;
 
-        chip::app::Clusters::WindowCovering::Commands::DownOrClose::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_WNCV_3_2 *>(context))->OnSuccessResponse_1();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_WNCV_3_2 *>(context))->OnFailureResponse_1(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_1(uint8_t status) { ThrowFailureResponse(); }
@@ -25409,19 +25266,18 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::WindowCovering::Commands::UpOrOpen::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::WindowCovering::Commands::UpOrOpen::Type;
 
-        chip::app::Clusters::WindowCovering::Commands::UpOrOpen::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_WNCV_3_3 *>(context))->OnSuccessResponse_0();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_WNCV_3_3 *>(context))->OnFailureResponse_0(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_0(uint8_t status) { ThrowFailureResponse(); }
@@ -25433,19 +25289,18 @@ private:
         chip::Controller::WindowCoveringClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::WindowCovering::Commands::StopMotion::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::WindowCovering::Commands::StopMotion::Type;
 
-        chip::app::Clusters::WindowCovering::Commands::StopMotion::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<Test_TC_WNCV_3_3 *>(context))->OnSuccessResponse_1();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<Test_TC_WNCV_3_3 *>(context))->OnFailureResponse_1(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_1(uint8_t status) { ThrowFailureResponse(); }
@@ -25574,21 +25429,20 @@ private:
         chip::Controller::TargetNavigatorClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::TargetNavigator::Commands::NavigateTarget::Type;
-        using responseType = chip::app::Clusters::TargetNavigator::Commands::NavigateTargetResponse::DecodableType;
+        using RequestType = chip::app::Clusters::TargetNavigator::Commands::NavigateTarget::Type;
 
-        chip::app::Clusters::TargetNavigator::Commands::NavigateTarget::Type request;
+        RequestType request;
         request.target = 1;
         request.data   = chip::Span<const char>("1", strlen("1"));
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<TV_TargetNavigatorCluster *>(context))->OnSuccessResponse_1(data.status, data.data);
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<TV_TargetNavigatorCluster *>(context))->OnFailureResponse_1(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_1(uint8_t status) { ThrowFailureResponse(); }
@@ -25711,20 +25565,19 @@ private:
         chip::Controller::AudioOutputClusterTest cluster;
         cluster.Associate(mDevice, 2);
 
-        using requestType  = chip::app::Clusters::AudioOutput::Commands::SelectOutput::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::AudioOutput::Commands::SelectOutput::Type;
 
-        chip::app::Clusters::AudioOutput::Commands::SelectOutput::Type request;
+        RequestType request;
         request.index = 1;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<TV_AudioOutputCluster *>(context))->OnSuccessResponse_1();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<TV_AudioOutputCluster *>(context))->OnFailureResponse_1(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_1(uint8_t status) { ThrowFailureResponse(); }
@@ -25736,21 +25589,20 @@ private:
         chip::Controller::AudioOutputClusterTest cluster;
         cluster.Associate(mDevice, 2);
 
-        using requestType  = chip::app::Clusters::AudioOutput::Commands::RenameOutput::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::AudioOutput::Commands::RenameOutput::Type;
 
-        chip::app::Clusters::AudioOutput::Commands::RenameOutput::Type request;
+        RequestType request;
         request.index = 1;
         request.name  = chip::Span<const char>("exampleName", strlen("exampleName"));
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<TV_AudioOutputCluster *>(context))->OnSuccessResponse_2();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<TV_AudioOutputCluster *>(context))->OnFailureResponse_2(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_2(uint8_t status) { ThrowFailureResponse(); }
@@ -25886,22 +25738,21 @@ private:
         chip::Controller::ApplicationLauncherClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::ApplicationLauncher::Commands::LaunchApp::Type;
-        using responseType = chip::app::Clusters::ApplicationLauncher::Commands::LaunchAppResponse::DecodableType;
+        using RequestType = chip::app::Clusters::ApplicationLauncher::Commands::LaunchApp::Type;
 
-        chip::app::Clusters::ApplicationLauncher::Commands::LaunchApp::Type request;
+        RequestType request;
         request.data            = chip::Span<const char>("exampleData", strlen("exampleData"));
         request.catalogVendorId = 1U;
         request.applicationId   = chip::Span<const char>("appId", strlen("appId"));
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<TV_ApplicationLauncherCluster *>(context))->OnSuccessResponse_1(data.status, data.data);
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<TV_ApplicationLauncherCluster *>(context))->OnFailureResponse_1(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_1(uint8_t status) { ThrowFailureResponse(); }
@@ -26001,20 +25852,19 @@ private:
         chip::Controller::KeypadInputClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::KeypadInput::Commands::SendKey::Type;
-        using responseType = chip::app::Clusters::KeypadInput::Commands::SendKeyResponse::DecodableType;
+        using RequestType = chip::app::Clusters::KeypadInput::Commands::SendKey::Type;
 
-        chip::app::Clusters::KeypadInput::Commands::SendKey::Type request;
+        RequestType request;
         request.keyCode = static_cast<chip::app::Clusters::KeypadInput::KeypadInputCecKeyCode>(3);
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<TV_KeypadInputCluster *>(context))->OnSuccessResponse_0(data.status);
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<TV_KeypadInputCluster *>(context))->OnFailureResponse_0(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_0(uint8_t status) { ThrowFailureResponse(); }
@@ -26082,20 +25932,19 @@ private:
         chip::Controller::AccountLoginClusterTest cluster;
         cluster.Associate(mDevice, 3);
 
-        using requestType  = chip::app::Clusters::AccountLogin::Commands::GetSetupPIN::Type;
-        using responseType = chip::app::Clusters::AccountLogin::Commands::GetSetupPINResponse::DecodableType;
+        using RequestType = chip::app::Clusters::AccountLogin::Commands::GetSetupPIN::Type;
 
-        chip::app::Clusters::AccountLogin::Commands::GetSetupPIN::Type request;
+        RequestType request;
         request.tempAccountIdentifier = chip::Span<const char>("asdf", strlen("asdf"));
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<TV_AccountLoginCluster *>(context))->OnSuccessResponse_0(data.setupPIN);
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<TV_AccountLoginCluster *>(context))->OnFailureResponse_0(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_0(uint8_t status) { ThrowFailureResponse(); }
@@ -26107,21 +25956,20 @@ private:
         chip::Controller::AccountLoginClusterTest cluster;
         cluster.Associate(mDevice, 3);
 
-        using requestType  = chip::app::Clusters::AccountLogin::Commands::Login::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::AccountLogin::Commands::Login::Type;
 
-        chip::app::Clusters::AccountLogin::Commands::Login::Type request;
+        RequestType request;
         request.tempAccountIdentifier = chip::Span<const char>("asdf", strlen("asdf"));
         request.setupPIN              = chip::Span<const char>("tempPin123", strlen("tempPin123"));
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<TV_AccountLoginCluster *>(context))->OnSuccessResponse_1();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<TV_AccountLoginCluster *>(context))->OnFailureResponse_1(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_1(uint8_t status) { ThrowFailureResponse(); }
@@ -26317,20 +26165,19 @@ private:
         chip::Controller::ApplicationBasicClusterTest cluster;
         cluster.Associate(mDevice, 3);
 
-        using requestType  = chip::app::Clusters::ApplicationBasic::Commands::ChangeStatus::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::ApplicationBasic::Commands::ChangeStatus::Type;
 
-        chip::app::Clusters::ApplicationBasic::Commands::ChangeStatus::Type request;
+        RequestType request;
         request.status = static_cast<chip::app::Clusters::ApplicationBasic::ApplicationBasicStatus>(1);
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<TV_ApplicationBasicCluster *>(context))->OnSuccessResponse_0();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<TV_ApplicationBasicCluster *>(context))->OnFailureResponse_0(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_0(uint8_t status) { ThrowFailureResponse(); }
@@ -26482,19 +26329,18 @@ private:
         chip::Controller::MediaPlaybackClusterTest cluster;
         cluster.Associate(mDevice, 3);
 
-        using requestType  = chip::app::Clusters::MediaPlayback::Commands::MediaPlay::Type;
-        using responseType = chip::app::Clusters::MediaPlayback::Commands::MediaPlayResponse::DecodableType;
+        using RequestType = chip::app::Clusters::MediaPlayback::Commands::MediaPlay::Type;
 
-        chip::app::Clusters::MediaPlayback::Commands::MediaPlay::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<TV_MediaPlaybackCluster *>(context))->OnSuccessResponse_0(data.mediaPlaybackStatus);
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<TV_MediaPlaybackCluster *>(context))->OnFailureResponse_0(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_0(uint8_t status) { ThrowFailureResponse(); }
@@ -26510,19 +26356,18 @@ private:
         chip::Controller::MediaPlaybackClusterTest cluster;
         cluster.Associate(mDevice, 3);
 
-        using requestType  = chip::app::Clusters::MediaPlayback::Commands::MediaPause::Type;
-        using responseType = chip::app::Clusters::MediaPlayback::Commands::MediaPauseResponse::DecodableType;
+        using RequestType = chip::app::Clusters::MediaPlayback::Commands::MediaPause::Type;
 
-        chip::app::Clusters::MediaPlayback::Commands::MediaPause::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<TV_MediaPlaybackCluster *>(context))->OnSuccessResponse_1(data.mediaPlaybackStatus);
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<TV_MediaPlaybackCluster *>(context))->OnFailureResponse_1(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_1(uint8_t status) { ThrowFailureResponse(); }
@@ -26538,19 +26383,18 @@ private:
         chip::Controller::MediaPlaybackClusterTest cluster;
         cluster.Associate(mDevice, 3);
 
-        using requestType  = chip::app::Clusters::MediaPlayback::Commands::MediaStop::Type;
-        using responseType = chip::app::Clusters::MediaPlayback::Commands::MediaStopResponse::DecodableType;
+        using RequestType = chip::app::Clusters::MediaPlayback::Commands::MediaStop::Type;
 
-        chip::app::Clusters::MediaPlayback::Commands::MediaStop::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<TV_MediaPlaybackCluster *>(context))->OnSuccessResponse_2(data.mediaPlaybackStatus);
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<TV_MediaPlaybackCluster *>(context))->OnFailureResponse_2(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_2(uint8_t status) { ThrowFailureResponse(); }
@@ -26566,19 +26410,18 @@ private:
         chip::Controller::MediaPlaybackClusterTest cluster;
         cluster.Associate(mDevice, 3);
 
-        using requestType  = chip::app::Clusters::MediaPlayback::Commands::MediaStartOver::Type;
-        using responseType = chip::app::Clusters::MediaPlayback::Commands::MediaStartOverResponse::DecodableType;
+        using RequestType = chip::app::Clusters::MediaPlayback::Commands::MediaStartOver::Type;
 
-        chip::app::Clusters::MediaPlayback::Commands::MediaStartOver::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<TV_MediaPlaybackCluster *>(context))->OnSuccessResponse_3(data.mediaPlaybackStatus);
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<TV_MediaPlaybackCluster *>(context))->OnFailureResponse_3(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_3(uint8_t status) { ThrowFailureResponse(); }
@@ -26594,19 +26437,18 @@ private:
         chip::Controller::MediaPlaybackClusterTest cluster;
         cluster.Associate(mDevice, 3);
 
-        using requestType  = chip::app::Clusters::MediaPlayback::Commands::MediaPrevious::Type;
-        using responseType = chip::app::Clusters::MediaPlayback::Commands::MediaPreviousResponse::DecodableType;
+        using RequestType = chip::app::Clusters::MediaPlayback::Commands::MediaPrevious::Type;
 
-        chip::app::Clusters::MediaPlayback::Commands::MediaPrevious::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<TV_MediaPlaybackCluster *>(context))->OnSuccessResponse_4(data.mediaPlaybackStatus);
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<TV_MediaPlaybackCluster *>(context))->OnFailureResponse_4(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_4(uint8_t status) { ThrowFailureResponse(); }
@@ -26622,19 +26464,18 @@ private:
         chip::Controller::MediaPlaybackClusterTest cluster;
         cluster.Associate(mDevice, 3);
 
-        using requestType  = chip::app::Clusters::MediaPlayback::Commands::MediaNext::Type;
-        using responseType = chip::app::Clusters::MediaPlayback::Commands::MediaNextResponse::DecodableType;
+        using RequestType = chip::app::Clusters::MediaPlayback::Commands::MediaNext::Type;
 
-        chip::app::Clusters::MediaPlayback::Commands::MediaNext::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<TV_MediaPlaybackCluster *>(context))->OnSuccessResponse_5(data.mediaPlaybackStatus);
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<TV_MediaPlaybackCluster *>(context))->OnFailureResponse_5(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_5(uint8_t status) { ThrowFailureResponse(); }
@@ -26650,19 +26491,18 @@ private:
         chip::Controller::MediaPlaybackClusterTest cluster;
         cluster.Associate(mDevice, 3);
 
-        using requestType  = chip::app::Clusters::MediaPlayback::Commands::MediaRewind::Type;
-        using responseType = chip::app::Clusters::MediaPlayback::Commands::MediaRewindResponse::DecodableType;
+        using RequestType = chip::app::Clusters::MediaPlayback::Commands::MediaRewind::Type;
 
-        chip::app::Clusters::MediaPlayback::Commands::MediaRewind::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<TV_MediaPlaybackCluster *>(context))->OnSuccessResponse_6(data.mediaPlaybackStatus);
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<TV_MediaPlaybackCluster *>(context))->OnFailureResponse_6(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_6(uint8_t status) { ThrowFailureResponse(); }
@@ -26678,19 +26518,18 @@ private:
         chip::Controller::MediaPlaybackClusterTest cluster;
         cluster.Associate(mDevice, 3);
 
-        using requestType  = chip::app::Clusters::MediaPlayback::Commands::MediaFastForward::Type;
-        using responseType = chip::app::Clusters::MediaPlayback::Commands::MediaFastForwardResponse::DecodableType;
+        using RequestType = chip::app::Clusters::MediaPlayback::Commands::MediaFastForward::Type;
 
-        chip::app::Clusters::MediaPlayback::Commands::MediaFastForward::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<TV_MediaPlaybackCluster *>(context))->OnSuccessResponse_7(data.mediaPlaybackStatus);
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<TV_MediaPlaybackCluster *>(context))->OnFailureResponse_7(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_7(uint8_t status) { ThrowFailureResponse(); }
@@ -26706,20 +26545,19 @@ private:
         chip::Controller::MediaPlaybackClusterTest cluster;
         cluster.Associate(mDevice, 3);
 
-        using requestType  = chip::app::Clusters::MediaPlayback::Commands::MediaSkipForward::Type;
-        using responseType = chip::app::Clusters::MediaPlayback::Commands::MediaSkipForwardResponse::DecodableType;
+        using RequestType = chip::app::Clusters::MediaPlayback::Commands::MediaSkipForward::Type;
 
-        chip::app::Clusters::MediaPlayback::Commands::MediaSkipForward::Type request;
+        RequestType request;
         request.deltaPositionMilliseconds = 100ULL;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<TV_MediaPlaybackCluster *>(context))->OnSuccessResponse_8(data.mediaPlaybackStatus);
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<TV_MediaPlaybackCluster *>(context))->OnFailureResponse_8(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_8(uint8_t status) { ThrowFailureResponse(); }
@@ -26735,20 +26573,19 @@ private:
         chip::Controller::MediaPlaybackClusterTest cluster;
         cluster.Associate(mDevice, 3);
 
-        using requestType  = chip::app::Clusters::MediaPlayback::Commands::MediaSkipBackward::Type;
-        using responseType = chip::app::Clusters::MediaPlayback::Commands::MediaSkipBackwardResponse::DecodableType;
+        using RequestType = chip::app::Clusters::MediaPlayback::Commands::MediaSkipBackward::Type;
 
-        chip::app::Clusters::MediaPlayback::Commands::MediaSkipBackward::Type request;
+        RequestType request;
         request.deltaPositionMilliseconds = 100ULL;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<TV_MediaPlaybackCluster *>(context))->OnSuccessResponse_9(data.mediaPlaybackStatus);
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<TV_MediaPlaybackCluster *>(context))->OnFailureResponse_9(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_9(uint8_t status) { ThrowFailureResponse(); }
@@ -26764,20 +26601,19 @@ private:
         chip::Controller::MediaPlaybackClusterTest cluster;
         cluster.Associate(mDevice, 3);
 
-        using requestType  = chip::app::Clusters::MediaPlayback::Commands::MediaSeek::Type;
-        using responseType = chip::app::Clusters::MediaPlayback::Commands::MediaSeekResponse::DecodableType;
+        using RequestType = chip::app::Clusters::MediaPlayback::Commands::MediaSeek::Type;
 
-        chip::app::Clusters::MediaPlayback::Commands::MediaSeek::Type request;
+        RequestType request;
         request.position = 100ULL;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<TV_MediaPlaybackCluster *>(context))->OnSuccessResponse_10(data.mediaPlaybackStatus);
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<TV_MediaPlaybackCluster *>(context))->OnFailureResponse_10(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_10(uint8_t status) { ThrowFailureResponse(); }
@@ -26903,21 +26739,20 @@ private:
         chip::Controller::TvChannelClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::TvChannel::Commands::ChangeChannelByNumber::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::TvChannel::Commands::ChangeChannelByNumber::Type;
 
-        chip::app::Clusters::TvChannel::Commands::ChangeChannelByNumber::Type request;
+        RequestType request;
         request.majorNumber = 1U;
         request.minorNumber = 2U;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<TV_TvChannelCluster *>(context))->OnSuccessResponse_1();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<TV_TvChannelCluster *>(context))->OnFailureResponse_1(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_1(uint8_t status) { ThrowFailureResponse(); }
@@ -26929,20 +26764,19 @@ private:
         chip::Controller::TvChannelClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::TvChannel::Commands::SkipChannel::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::TvChannel::Commands::SkipChannel::Type;
 
-        chip::app::Clusters::TvChannel::Commands::SkipChannel::Type request;
+        RequestType request;
         request.count = 1U;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<TV_TvChannelCluster *>(context))->OnSuccessResponse_2();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<TV_TvChannelCluster *>(context))->OnFailureResponse_2(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_2(uint8_t status) { ThrowFailureResponse(); }
@@ -27006,19 +26840,18 @@ private:
         chip::Controller::LowPowerClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::LowPower::Commands::Sleep::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::LowPower::Commands::Sleep::Type;
 
-        chip::app::Clusters::LowPower::Commands::Sleep::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<TV_LowPowerCluster *>(context))->OnSuccessResponse_0();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<TV_LowPowerCluster *>(context))->OnFailureResponse_0(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_0(uint8_t status) { ThrowFailureResponse(); }
@@ -27163,20 +26996,19 @@ private:
         chip::Controller::MediaInputClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::MediaInput::Commands::SelectInput::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::MediaInput::Commands::SelectInput::Type;
 
-        chip::app::Clusters::MediaInput::Commands::SelectInput::Type request;
+        RequestType request;
         request.index = 1;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<TV_MediaInputCluster *>(context))->OnSuccessResponse_1();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<TV_MediaInputCluster *>(context))->OnFailureResponse_1(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_1(uint8_t status) { ThrowFailureResponse(); }
@@ -27204,19 +27036,18 @@ private:
         chip::Controller::MediaInputClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::MediaInput::Commands::HideInputStatus::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::MediaInput::Commands::HideInputStatus::Type;
 
-        chip::app::Clusters::MediaInput::Commands::HideInputStatus::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<TV_MediaInputCluster *>(context))->OnSuccessResponse_3();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<TV_MediaInputCluster *>(context))->OnFailureResponse_3(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_3(uint8_t status) { ThrowFailureResponse(); }
@@ -27228,19 +27059,18 @@ private:
         chip::Controller::MediaInputClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::MediaInput::Commands::ShowInputStatus::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::MediaInput::Commands::ShowInputStatus::Type;
 
-        chip::app::Clusters::MediaInput::Commands::ShowInputStatus::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<TV_MediaInputCluster *>(context))->OnSuccessResponse_4();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<TV_MediaInputCluster *>(context))->OnFailureResponse_4(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_4(uint8_t status) { ThrowFailureResponse(); }
@@ -27252,21 +27082,20 @@ private:
         chip::Controller::MediaInputClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::MediaInput::Commands::RenameInput::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::MediaInput::Commands::RenameInput::Type;
 
-        chip::app::Clusters::MediaInput::Commands::RenameInput::Type request;
+        RequestType request;
         request.index = 1;
         request.name  = chip::Span<const char>("newName", strlen("newName"));
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<TV_MediaInputCluster *>(context))->OnSuccessResponse_5();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<TV_MediaInputCluster *>(context))->OnFailureResponse_5(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_5(uint8_t status) { ThrowFailureResponse(); }
@@ -29039,19 +28868,18 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::TestCluster::Commands::Test::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::TestCluster::Commands::Test::Type;
 
-        chip::app::Clusters::TestCluster::Commands::Test::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<TestCluster *>(context))->OnSuccessResponse_0();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<TestCluster *>(context))->OnFailureResponse_0(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_0(uint8_t status) { ThrowFailureResponse(); }
@@ -29063,19 +28891,18 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::TestCluster::Commands::TestNotHandled::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::TestCluster::Commands::TestNotHandled::Type;
 
-        chip::app::Clusters::TestCluster::Commands::TestNotHandled::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<TestCluster *>(context))->OnSuccessResponse_1();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<TestCluster *>(context))->OnFailureResponse_1(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_1(uint8_t status) { NextTest(); }
@@ -29087,19 +28914,18 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::TestCluster::Commands::TestSpecific::Type;
-        using responseType = chip::app::Clusters::TestCluster::Commands::TestSpecificResponse::DecodableType;
+        using RequestType = chip::app::Clusters::TestCluster::Commands::TestSpecific::Type;
 
-        chip::app::Clusters::TestCluster::Commands::TestSpecific::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<TestCluster *>(context))->OnSuccessResponse_2(data.returnValue);
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<TestCluster *>(context))->OnFailureResponse_2(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_2(uint8_t status) { ThrowFailureResponse(); }
@@ -29115,21 +28941,20 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::TestCluster::Commands::TestAddArguments::Type;
-        using responseType = chip::app::Clusters::TestCluster::Commands::TestAddArgumentsResponse::DecodableType;
+        using RequestType = chip::app::Clusters::TestCluster::Commands::TestAddArguments::Type;
 
-        chip::app::Clusters::TestCluster::Commands::TestAddArguments::Type request;
+        RequestType request;
         request.arg1 = 3;
         request.arg2 = 17;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<TestCluster *>(context))->OnSuccessResponse_3(data.returnValue);
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<TestCluster *>(context))->OnFailureResponse_3(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_3(uint8_t status) { ThrowFailureResponse(); }
@@ -29145,21 +28970,20 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::TestCluster::Commands::TestAddArguments::Type;
-        using responseType = chip::app::Clusters::TestCluster::Commands::TestAddArgumentsResponse::DecodableType;
+        using RequestType = chip::app::Clusters::TestCluster::Commands::TestAddArguments::Type;
 
-        chip::app::Clusters::TestCluster::Commands::TestAddArguments::Type request;
+        RequestType request;
         request.arg1 = 250;
         request.arg2 = 6;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<TestCluster *>(context))->OnSuccessResponse_4(data.returnValue);
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<TestCluster *>(context))->OnFailureResponse_4(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_4(uint8_t status) { NextTest(); }
@@ -31088,19 +30912,18 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 200);
 
-        using requestType  = chip::app::Clusters::TestCluster::Commands::Test::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::TestCluster::Commands::Test::Type;
 
-        chip::app::Clusters::TestCluster::Commands::Test::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<TestCluster *>(context))->OnSuccessResponse_121();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<TestCluster *>(context))->OnFailureResponse_121(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_121(uint8_t status) { NextTest(); }
@@ -31176,21 +30999,20 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::TestCluster::Commands::TestEnumsRequest::Type;
-        using responseType = chip::app::Clusters::TestCluster::Commands::TestEnumsResponse::DecodableType;
+        using RequestType = chip::app::Clusters::TestCluster::Commands::TestEnumsRequest::Type;
 
-        chip::app::Clusters::TestCluster::Commands::TestEnumsRequest::Type request;
+        RequestType request;
         request.arg1 = static_cast<chip::VendorId>(20003);
         request.arg2 = static_cast<chip::app::Clusters::TestCluster::SimpleEnum>(101);
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<TestCluster *>(context))->OnSuccessResponse_126(data.arg1, data.arg2);
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<TestCluster *>(context))->OnFailureResponse_126(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_126(uint8_t status) { ThrowFailureResponse(); }
@@ -31304,10 +31126,9 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::TestCluster::Commands::TestStructArgumentRequest::Type;
-        using responseType = chip::app::Clusters::TestCluster::Commands::BooleanResponse::DecodableType;
+        using RequestType = chip::app::Clusters::TestCluster::Commands::TestStructArgumentRequest::Type;
 
-        chip::app::Clusters::TestCluster::Commands::TestStructArgumentRequest::Type request;
+        RequestType request;
 
         request.arg1.a = 0;
         request.arg1.b = true;
@@ -31316,14 +31137,14 @@ private:
         request.arg1.e = chip::Span<const char>("char_string", strlen("char_string"));
         request.arg1.f = static_cast<chip::BitFlags<chip::app::Clusters::TestCluster::SimpleBitmap>>(1);
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<TestClusterComplexTypes *>(context))->OnSuccessResponse_0(data.value);
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<TestClusterComplexTypes *>(context))->OnFailureResponse_0(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_0(uint8_t status) { ThrowFailureResponse(); }
@@ -31339,10 +31160,9 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::TestCluster::Commands::TestStructArgumentRequest::Type;
-        using responseType = chip::app::Clusters::TestCluster::Commands::BooleanResponse::DecodableType;
+        using RequestType = chip::app::Clusters::TestCluster::Commands::TestStructArgumentRequest::Type;
 
-        chip::app::Clusters::TestCluster::Commands::TestStructArgumentRequest::Type request;
+        RequestType request;
 
         request.arg1.a = 0;
         request.arg1.b = false;
@@ -31351,14 +31171,14 @@ private:
         request.arg1.e = chip::Span<const char>("char_string", strlen("char_string"));
         request.arg1.f = static_cast<chip::BitFlags<chip::app::Clusters::TestCluster::SimpleBitmap>>(1);
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<TestClusterComplexTypes *>(context))->OnSuccessResponse_1(data.value);
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<TestClusterComplexTypes *>(context))->OnFailureResponse_1(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_1(uint8_t status) { ThrowFailureResponse(); }
@@ -31374,10 +31194,9 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::TestCluster::Commands::TestListInt8UArgumentRequest::Type;
-        using responseType = chip::app::Clusters::TestCluster::Commands::BooleanResponse::DecodableType;
+        using RequestType = chip::app::Clusters::TestCluster::Commands::TestListInt8UArgumentRequest::Type;
 
-        chip::app::Clusters::TestCluster::Commands::TestListInt8UArgumentRequest::Type request;
+        RequestType request;
 
         uint8_t arg1List[9];
         arg1List[0]  = 1;
@@ -31391,14 +31210,14 @@ private:
         arg1List[8]  = 9;
         request.arg1 = arg1List;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<TestClusterComplexTypes *>(context))->OnSuccessResponse_2(data.value);
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<TestClusterComplexTypes *>(context))->OnFailureResponse_2(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_2(uint8_t status) { ThrowFailureResponse(); }
@@ -31414,10 +31233,9 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::TestCluster::Commands::TestListInt8UArgumentRequest::Type;
-        using responseType = chip::app::Clusters::TestCluster::Commands::BooleanResponse::DecodableType;
+        using RequestType = chip::app::Clusters::TestCluster::Commands::TestListInt8UArgumentRequest::Type;
 
-        chip::app::Clusters::TestCluster::Commands::TestListInt8UArgumentRequest::Type request;
+        RequestType request;
 
         uint8_t arg1List[10];
         arg1List[0]  = 1;
@@ -31432,14 +31250,14 @@ private:
         arg1List[9]  = 0;
         request.arg1 = arg1List;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<TestClusterComplexTypes *>(context))->OnSuccessResponse_3(data.value);
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<TestClusterComplexTypes *>(context))->OnFailureResponse_3(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_3(uint8_t status) { ThrowFailureResponse(); }
@@ -31455,10 +31273,9 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::TestCluster::Commands::TestListInt8UReverseRequest::Type;
-        using responseType = chip::app::Clusters::TestCluster::Commands::TestListInt8UReverseResponse::DecodableType;
+        using RequestType = chip::app::Clusters::TestCluster::Commands::TestListInt8UReverseRequest::Type;
 
-        chip::app::Clusters::TestCluster::Commands::TestListInt8UReverseRequest::Type request;
+        RequestType request;
 
         uint8_t arg1List[9];
         arg1List[0]  = 1;
@@ -31472,14 +31289,14 @@ private:
         arg1List[8]  = 9;
         request.arg1 = arg1List;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<TestClusterComplexTypes *>(context))->OnSuccessResponse_4(data.arg1);
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<TestClusterComplexTypes *>(context))->OnFailureResponse_4(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_4(uint8_t status) { ThrowFailureResponse(); }
@@ -31514,21 +31331,20 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::TestCluster::Commands::TestListInt8UReverseRequest::Type;
-        using responseType = chip::app::Clusters::TestCluster::Commands::TestListInt8UReverseResponse::DecodableType;
+        using RequestType = chip::app::Clusters::TestCluster::Commands::TestListInt8UReverseRequest::Type;
 
-        chip::app::Clusters::TestCluster::Commands::TestListInt8UReverseRequest::Type request;
+        RequestType request;
 
         request.arg1 = chip::app::DataModel::List<uint8_t>();
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<TestClusterComplexTypes *>(context))->OnSuccessResponse_5(data.arg1);
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<TestClusterComplexTypes *>(context))->OnFailureResponse_5(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_5(uint8_t status) { ThrowFailureResponse(); }
@@ -31545,10 +31361,9 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::TestCluster::Commands::TestListStructArgumentRequest::Type;
-        using responseType = chip::app::Clusters::TestCluster::Commands::BooleanResponse::DecodableType;
+        using RequestType = chip::app::Clusters::TestCluster::Commands::TestListStructArgumentRequest::Type;
 
-        chip::app::Clusters::TestCluster::Commands::TestListStructArgumentRequest::Type request;
+        RequestType request;
 
         chip::app::Clusters::TestCluster::Structs::SimpleStruct::Type arg1List[2];
 
@@ -31568,14 +31383,14 @@ private:
 
         request.arg1 = arg1List;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<TestClusterComplexTypes *>(context))->OnSuccessResponse_6(data.value);
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<TestClusterComplexTypes *>(context))->OnFailureResponse_6(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_6(uint8_t status) { ThrowFailureResponse(); }
@@ -31591,10 +31406,9 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::TestCluster::Commands::TestListStructArgumentRequest::Type;
-        using responseType = chip::app::Clusters::TestCluster::Commands::BooleanResponse::DecodableType;
+        using RequestType = chip::app::Clusters::TestCluster::Commands::TestListStructArgumentRequest::Type;
 
-        chip::app::Clusters::TestCluster::Commands::TestListStructArgumentRequest::Type request;
+        RequestType request;
 
         chip::app::Clusters::TestCluster::Structs::SimpleStruct::Type arg1List[2];
 
@@ -31614,14 +31428,14 @@ private:
 
         request.arg1 = arg1List;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<TestClusterComplexTypes *>(context))->OnSuccessResponse_7(data.value);
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<TestClusterComplexTypes *>(context))->OnFailureResponse_7(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_7(uint8_t status) { ThrowFailureResponse(); }
@@ -31637,13 +31451,12 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::TestCluster::Commands::TestNullableOptionalRequest::Type;
-        using responseType = chip::app::Clusters::TestCluster::Commands::TestNullableOptionalResponse::DecodableType;
+        using RequestType = chip::app::Clusters::TestCluster::Commands::TestNullableOptionalRequest::Type;
 
-        chip::app::Clusters::TestCluster::Commands::TestNullableOptionalRequest::Type request;
+        RequestType request;
         request.arg1.Emplace().SetNonNull() = 5;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<TestClusterComplexTypes *>(context))
                 ->OnSuccessResponse_8(data.wasPresent, data.wasNull, data.value, data.originalValue);
         };
@@ -31651,7 +31464,7 @@ private:
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<TestClusterComplexTypes *>(context))->OnFailureResponse_8(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_8(uint8_t status) { ThrowFailureResponse(); }
@@ -31678,12 +31491,11 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::TestCluster::Commands::TestNullableOptionalRequest::Type;
-        using responseType = chip::app::Clusters::TestCluster::Commands::TestNullableOptionalResponse::DecodableType;
+        using RequestType = chip::app::Clusters::TestCluster::Commands::TestNullableOptionalRequest::Type;
 
-        chip::app::Clusters::TestCluster::Commands::TestNullableOptionalRequest::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<TestClusterComplexTypes *>(context))
                 ->OnSuccessResponse_9(data.wasPresent, data.wasNull, data.value, data.originalValue);
         };
@@ -31691,7 +31503,7 @@ private:
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<TestClusterComplexTypes *>(context))->OnFailureResponse_9(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_9(uint8_t status) { ThrowFailureResponse(); }
@@ -31709,13 +31521,12 @@ private:
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::TestCluster::Commands::TestNullableOptionalRequest::Type;
-        using responseType = chip::app::Clusters::TestCluster::Commands::TestNullableOptionalResponse::DecodableType;
+        using RequestType = chip::app::Clusters::TestCluster::Commands::TestNullableOptionalRequest::Type;
 
-        chip::app::Clusters::TestCluster::Commands::TestNullableOptionalRequest::Type request;
+        RequestType request;
         request.arg1.Emplace().SetNull();
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<TestClusterComplexTypes *>(context))
                 ->OnSuccessResponse_10(data.wasPresent, data.wasNull, data.value, data.originalValue);
         };
@@ -31723,7 +31534,7 @@ private:
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<TestClusterComplexTypes *>(context))->OnFailureResponse_10(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_10(uint8_t status) { ThrowFailureResponse(); }
@@ -32477,20 +32288,19 @@ private:
         chip::Controller::IdentifyClusterTest cluster;
         cluster.Associate(mDevice, 0);
 
-        using requestType  = chip::app::Clusters::Identify::Commands::Identify::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::Identify::Commands::Identify::Type;
 
-        chip::app::Clusters::Identify::Commands::Identify::Type request;
+        RequestType request;
         request.identifyTime = 0U;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<TestIdentifyCluster *>(context))->OnSuccessResponse_0();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<TestIdentifyCluster *>(context))->OnFailureResponse_0(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_0(uint8_t status) { ThrowFailureResponse(); }
@@ -32909,20 +32719,19 @@ private:
         chip::Controller::ModeSelectClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::ModeSelect::Commands::ChangeToMode::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::ModeSelect::Commands::ChangeToMode::Type;
 
-        chip::app::Clusters::ModeSelect::Commands::ChangeToMode::Type request;
+        RequestType request;
         request.newMode = 4;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<TestModeSelectCluster *>(context))->OnSuccessResponse_5();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<TestModeSelectCluster *>(context))->OnFailureResponse_5(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_5(uint8_t status) { ThrowFailureResponse(); }
@@ -32950,20 +32759,19 @@ private:
         chip::Controller::ModeSelectClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::ModeSelect::Commands::ChangeToMode::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::ModeSelect::Commands::ChangeToMode::Type;
 
-        chip::app::Clusters::ModeSelect::Commands::ChangeToMode::Type request;
+        RequestType request;
         request.newMode = 2;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<TestModeSelectCluster *>(context))->OnSuccessResponse_7();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<TestModeSelectCluster *>(context))->OnFailureResponse_7(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_7(uint8_t status) { NextTest(); }
@@ -33261,19 +33069,18 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::OnOff::Commands::Off::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::OnOff::Commands::Off::Type;
 
-        chip::app::Clusters::OnOff::Commands::Off::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<TestSubscribe_OnOff *>(context))->OnSuccessResponse_0();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<TestSubscribe_OnOff *>(context))->OnFailureResponse_0(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_0(uint8_t status) { ThrowFailureResponse(); }
@@ -33328,19 +33135,18 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::OnOff::Commands::On::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::OnOff::Commands::On::Type;
 
-        chip::app::Clusters::OnOff::Commands::On::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<TestSubscribe_OnOff *>(context))->OnSuccessResponse_3();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<TestSubscribe_OnOff *>(context))->OnFailureResponse_3(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_3(uint8_t status) { ThrowFailureResponse(); }
@@ -33371,19 +33177,18 @@ private:
         chip::Controller::OnOffClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        using requestType  = chip::app::Clusters::OnOff::Commands::Off::Type;
-        using responseType = chip::app::DataModel::NullObjectType;
+        using RequestType = chip::app::Clusters::OnOff::Commands::Off::Type;
 
-        chip::app::Clusters::OnOff::Commands::Off::Type request;
+        RequestType request;
 
-        auto success = [](void * context, const responseType & data) {
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<TestSubscribe_OnOff *>(context))->OnSuccessResponse_5();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
             (static_cast<TestSubscribe_OnOff *>(context))->OnFailureResponse_5(status);
         };
-        return cluster.InvokeCommand<requestType, responseType>(request, this, success, failure);
+        return cluster.InvokeCommand(request, this, success, failure);
     }
 
     void OnFailureResponse_5(uint8_t status) { ThrowFailureResponse(); }

--- a/zzz_generated/controller-clusters/zap-generated/CHIPClustersInvoke.cpp
+++ b/zzz_generated/controller-clusters/zap-generated/CHIPClustersInvoke.cpp
@@ -30,1004 +30,939 @@ using namespace Encoding::LittleEndian;
 
 namespace Controller {
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::AccountLogin::Commands::GetSetupPIN::Type,
-                                               chip::app::Clusters::AccountLogin::Commands::GetSetupPINResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::AccountLogin::Commands::GetSetupPIN::Type>(
     const chip::app::Clusters::AccountLogin::Commands::GetSetupPIN::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::AccountLogin::Commands::GetSetupPINResponse::DecodableType>,
+    CommandResponseSuccessCallback<typename chip::app::Clusters::AccountLogin::Commands::GetSetupPIN::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::AccountLogin::Commands::Login::Type, chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::AccountLogin::Commands::Login::Type>(
     const chip::app::Clusters::AccountLogin::Commands::Login::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<typename chip::app::Clusters::AccountLogin::Commands::Login::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
 template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::AdministratorCommissioning::Commands::OpenBasicCommissioningWindow::Type,
-                           chip::app::DataModel::NullObjectType>(
+ClusterBase::InvokeCommand<chip::app::Clusters::AdministratorCommissioning::Commands::OpenBasicCommissioningWindow::Type>(
     const chip::app::Clusters::AdministratorCommissioning::Commands::OpenBasicCommissioningWindow::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<
+        typename chip::app::Clusters::AdministratorCommissioning::Commands::OpenBasicCommissioningWindow::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
 template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::AdministratorCommissioning::Commands::OpenCommissioningWindow::Type,
-                           chip::app::DataModel::NullObjectType>(
+ClusterBase::InvokeCommand<chip::app::Clusters::AdministratorCommissioning::Commands::OpenCommissioningWindow::Type>(
     const chip::app::Clusters::AdministratorCommissioning::Commands::OpenCommissioningWindow::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<
+        typename chip::app::Clusters::AdministratorCommissioning::Commands::OpenCommissioningWindow::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::AdministratorCommissioning::Commands::RevokeCommissioning::Type,
-                                               chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR
+ClusterBase::InvokeCommand<chip::app::Clusters::AdministratorCommissioning::Commands::RevokeCommissioning::Type>(
     const chip::app::Clusters::AdministratorCommissioning::Commands::RevokeCommissioning::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<
+        typename chip::app::Clusters::AdministratorCommissioning::Commands::RevokeCommissioning::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::ApplicationBasic::Commands::ChangeStatus::Type,
-                                               chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::ApplicationBasic::Commands::ChangeStatus::Type>(
     const chip::app::Clusters::ApplicationBasic::Commands::ChangeStatus::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<typename chip::app::Clusters::ApplicationBasic::Commands::ChangeStatus::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::ApplicationLauncher::Commands::LaunchApp::Type,
-                           chip::app::Clusters::ApplicationLauncher::Commands::LaunchAppResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::ApplicationLauncher::Commands::LaunchApp::Type>(
     const chip::app::Clusters::ApplicationLauncher::Commands::LaunchApp::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::ApplicationLauncher::Commands::LaunchAppResponse::DecodableType>,
+    CommandResponseSuccessCallback<typename chip::app::Clusters::ApplicationLauncher::Commands::LaunchApp::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::AudioOutput::Commands::RenameOutput::Type, chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::AudioOutput::Commands::RenameOutput::Type>(
     const chip::app::Clusters::AudioOutput::Commands::RenameOutput::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<typename chip::app::Clusters::AudioOutput::Commands::RenameOutput::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::AudioOutput::Commands::SelectOutput::Type, chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::AudioOutput::Commands::SelectOutput::Type>(
     const chip::app::Clusters::AudioOutput::Commands::SelectOutput::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<typename chip::app::Clusters::AudioOutput::Commands::SelectOutput::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::BarrierControl::Commands::BarrierControlGoToPercent::Type,
-                                               chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::BarrierControl::Commands::BarrierControlGoToPercent::Type>(
     const chip::app::Clusters::BarrierControl::Commands::BarrierControlGoToPercent::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<
+        typename chip::app::Clusters::BarrierControl::Commands::BarrierControlGoToPercent::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::BarrierControl::Commands::BarrierControlStop::Type,
-                                               chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::BarrierControl::Commands::BarrierControlStop::Type>(
     const chip::app::Clusters::BarrierControl::Commands::BarrierControlStop::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<typename chip::app::Clusters::BarrierControl::Commands::BarrierControlStop::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::Basic::Commands::MfgSpecificPing::Type, chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::Basic::Commands::MfgSpecificPing::Type>(
     const chip::app::Clusters::Basic::Commands::MfgSpecificPing::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<typename chip::app::Clusters::Basic::Commands::MfgSpecificPing::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::Binding::Commands::Bind::Type, chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::Binding::Commands::Bind::Type>(
     const chip::app::Clusters::Binding::Commands::Bind::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<typename chip::app::Clusters::Binding::Commands::Bind::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::Binding::Commands::Unbind::Type, chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::Binding::Commands::Unbind::Type>(
     const chip::app::Clusters::Binding::Commands::Unbind::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<typename chip::app::Clusters::Binding::Commands::Unbind::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::BridgedActions::Commands::DisableAction::Type,
-                                               chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::BridgedActions::Commands::DisableAction::Type>(
     const chip::app::Clusters::BridgedActions::Commands::DisableAction::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<typename chip::app::Clusters::BridgedActions::Commands::DisableAction::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::BridgedActions::Commands::DisableActionWithDuration::Type,
-                                               chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::BridgedActions::Commands::DisableActionWithDuration::Type>(
     const chip::app::Clusters::BridgedActions::Commands::DisableActionWithDuration::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<
+        typename chip::app::Clusters::BridgedActions::Commands::DisableActionWithDuration::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::BridgedActions::Commands::EnableAction::Type, chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::BridgedActions::Commands::EnableAction::Type>(
     const chip::app::Clusters::BridgedActions::Commands::EnableAction::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<typename chip::app::Clusters::BridgedActions::Commands::EnableAction::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::BridgedActions::Commands::EnableActionWithDuration::Type,
-                                               chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::BridgedActions::Commands::EnableActionWithDuration::Type>(
     const chip::app::Clusters::BridgedActions::Commands::EnableActionWithDuration::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<
+        typename chip::app::Clusters::BridgedActions::Commands::EnableActionWithDuration::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::BridgedActions::Commands::InstantAction::Type,
-                                               chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::BridgedActions::Commands::InstantAction::Type>(
     const chip::app::Clusters::BridgedActions::Commands::InstantAction::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<typename chip::app::Clusters::BridgedActions::Commands::InstantAction::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::BridgedActions::Commands::InstantActionWithTransition::Type,
-                                               chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::BridgedActions::Commands::InstantActionWithTransition::Type>(
     const chip::app::Clusters::BridgedActions::Commands::InstantActionWithTransition::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<
+        typename chip::app::Clusters::BridgedActions::Commands::InstantActionWithTransition::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::BridgedActions::Commands::PauseAction::Type, chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::BridgedActions::Commands::PauseAction::Type>(
     const chip::app::Clusters::BridgedActions::Commands::PauseAction::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<typename chip::app::Clusters::BridgedActions::Commands::PauseAction::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::BridgedActions::Commands::PauseActionWithDuration::Type,
-                                               chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::BridgedActions::Commands::PauseActionWithDuration::Type>(
     const chip::app::Clusters::BridgedActions::Commands::PauseActionWithDuration::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<
+        typename chip::app::Clusters::BridgedActions::Commands::PauseActionWithDuration::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::BridgedActions::Commands::ResumeAction::Type, chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::BridgedActions::Commands::ResumeAction::Type>(
     const chip::app::Clusters::BridgedActions::Commands::ResumeAction::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<typename chip::app::Clusters::BridgedActions::Commands::ResumeAction::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::BridgedActions::Commands::StartAction::Type, chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::BridgedActions::Commands::StartAction::Type>(
     const chip::app::Clusters::BridgedActions::Commands::StartAction::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<typename chip::app::Clusters::BridgedActions::Commands::StartAction::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::BridgedActions::Commands::StartActionWithDuration::Type,
-                                               chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::BridgedActions::Commands::StartActionWithDuration::Type>(
     const chip::app::Clusters::BridgedActions::Commands::StartActionWithDuration::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<
+        typename chip::app::Clusters::BridgedActions::Commands::StartActionWithDuration::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::BridgedActions::Commands::StopAction::Type, chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::BridgedActions::Commands::StopAction::Type>(
     const chip::app::Clusters::BridgedActions::Commands::StopAction::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<typename chip::app::Clusters::BridgedActions::Commands::StopAction::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type, chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type>(
     const chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<typename chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::ColorControl::Commands::EnhancedMoveHue::Type,
-                                               chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::ColorControl::Commands::EnhancedMoveHue::Type>(
     const chip::app::Clusters::ColorControl::Commands::EnhancedMoveHue::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<typename chip::app::Clusters::ColorControl::Commands::EnhancedMoveHue::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::ColorControl::Commands::EnhancedMoveToHue::Type,
-                                               chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::ColorControl::Commands::EnhancedMoveToHue::Type>(
     const chip::app::Clusters::ColorControl::Commands::EnhancedMoveToHue::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<typename chip::app::Clusters::ColorControl::Commands::EnhancedMoveToHue::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::ColorControl::Commands::EnhancedMoveToHueAndSaturation::Type,
-                                               chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::ColorControl::Commands::EnhancedMoveToHueAndSaturation::Type>(
     const chip::app::Clusters::ColorControl::Commands::EnhancedMoveToHueAndSaturation::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<
+        typename chip::app::Clusters::ColorControl::Commands::EnhancedMoveToHueAndSaturation::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::ColorControl::Commands::EnhancedStepHue::Type,
-                                               chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::ColorControl::Commands::EnhancedStepHue::Type>(
     const chip::app::Clusters::ColorControl::Commands::EnhancedStepHue::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<typename chip::app::Clusters::ColorControl::Commands::EnhancedStepHue::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::ColorControl::Commands::MoveColor::Type, chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::ColorControl::Commands::MoveColor::Type>(
     const chip::app::Clusters::ColorControl::Commands::MoveColor::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<typename chip::app::Clusters::ColorControl::Commands::MoveColor::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::ColorControl::Commands::MoveColorTemperature::Type,
-                                               chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::ColorControl::Commands::MoveColorTemperature::Type>(
     const chip::app::Clusters::ColorControl::Commands::MoveColorTemperature::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<typename chip::app::Clusters::ColorControl::Commands::MoveColorTemperature::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::ColorControl::Commands::MoveHue::Type, chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::ColorControl::Commands::MoveHue::Type>(
     const chip::app::Clusters::ColorControl::Commands::MoveHue::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<typename chip::app::Clusters::ColorControl::Commands::MoveHue::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::ColorControl::Commands::MoveSaturation::Type, chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::ColorControl::Commands::MoveSaturation::Type>(
     const chip::app::Clusters::ColorControl::Commands::MoveSaturation::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<typename chip::app::Clusters::ColorControl::Commands::MoveSaturation::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::ColorControl::Commands::MoveToColor::Type, chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::ColorControl::Commands::MoveToColor::Type>(
     const chip::app::Clusters::ColorControl::Commands::MoveToColor::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<typename chip::app::Clusters::ColorControl::Commands::MoveToColor::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::ColorControl::Commands::MoveToColorTemperature::Type,
-                                               chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::ColorControl::Commands::MoveToColorTemperature::Type>(
     const chip::app::Clusters::ColorControl::Commands::MoveToColorTemperature::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<
+        typename chip::app::Clusters::ColorControl::Commands::MoveToColorTemperature::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::ColorControl::Commands::MoveToHue::Type, chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::ColorControl::Commands::MoveToHue::Type>(
     const chip::app::Clusters::ColorControl::Commands::MoveToHue::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<typename chip::app::Clusters::ColorControl::Commands::MoveToHue::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::ColorControl::Commands::MoveToHueAndSaturation::Type,
-                                               chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::ColorControl::Commands::MoveToHueAndSaturation::Type>(
     const chip::app::Clusters::ColorControl::Commands::MoveToHueAndSaturation::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<
+        typename chip::app::Clusters::ColorControl::Commands::MoveToHueAndSaturation::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::ColorControl::Commands::MoveToSaturation::Type,
-                                               chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::ColorControl::Commands::MoveToSaturation::Type>(
     const chip::app::Clusters::ColorControl::Commands::MoveToSaturation::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<typename chip::app::Clusters::ColorControl::Commands::MoveToSaturation::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::ColorControl::Commands::StepColor::Type, chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::ColorControl::Commands::StepColor::Type>(
     const chip::app::Clusters::ColorControl::Commands::StepColor::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<typename chip::app::Clusters::ColorControl::Commands::StepColor::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::ColorControl::Commands::StepColorTemperature::Type,
-                                               chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::ColorControl::Commands::StepColorTemperature::Type>(
     const chip::app::Clusters::ColorControl::Commands::StepColorTemperature::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<typename chip::app::Clusters::ColorControl::Commands::StepColorTemperature::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::ColorControl::Commands::StepHue::Type, chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::ColorControl::Commands::StepHue::Type>(
     const chip::app::Clusters::ColorControl::Commands::StepHue::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<typename chip::app::Clusters::ColorControl::Commands::StepHue::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::ColorControl::Commands::StepSaturation::Type, chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::ColorControl::Commands::StepSaturation::Type>(
     const chip::app::Clusters::ColorControl::Commands::StepSaturation::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<typename chip::app::Clusters::ColorControl::Commands::StepSaturation::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::ColorControl::Commands::StopMoveStep::Type, chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::ColorControl::Commands::StopMoveStep::Type>(
     const chip::app::Clusters::ColorControl::Commands::StopMoveStep::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<typename chip::app::Clusters::ColorControl::Commands::StopMoveStep::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::ContentLauncher::Commands::LaunchContent::Type,
-                           chip::app::Clusters::ContentLauncher::Commands::LaunchContentResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::ContentLauncher::Commands::LaunchContent::Type>(
     const chip::app::Clusters::ContentLauncher::Commands::LaunchContent::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::ContentLauncher::Commands::LaunchContentResponse::DecodableType>,
+    CommandResponseSuccessCallback<typename chip::app::Clusters::ContentLauncher::Commands::LaunchContent::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::ContentLauncher::Commands::LaunchURL::Type,
-                                               chip::app::Clusters::ContentLauncher::Commands::LaunchURLResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::ContentLauncher::Commands::LaunchURL::Type>(
     const chip::app::Clusters::ContentLauncher::Commands::LaunchURL::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::ContentLauncher::Commands::LaunchURLResponse::DecodableType>,
+    CommandResponseSuccessCallback<typename chip::app::Clusters::ContentLauncher::Commands::LaunchURL::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::DiagnosticLogs::Commands::RetrieveLogsRequest::Type,
-                                               chip::app::Clusters::DiagnosticLogs::Commands::RetrieveLogsResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::DiagnosticLogs::Commands::RetrieveLogsRequest::Type>(
     const chip::app::Clusters::DiagnosticLogs::Commands::RetrieveLogsRequest::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::DiagnosticLogs::Commands::RetrieveLogsResponse::DecodableType>,
+    CommandResponseSuccessCallback<typename chip::app::Clusters::DiagnosticLogs::Commands::RetrieveLogsRequest::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::DoorLock::Commands::ClearAllPins::Type,
-                                               chip::app::Clusters::DoorLock::Commands::ClearAllPinsResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::DoorLock::Commands::ClearAllPins::Type>(
     const chip::app::Clusters::DoorLock::Commands::ClearAllPins::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::DoorLock::Commands::ClearAllPinsResponse::DecodableType>,
+    CommandResponseSuccessCallback<typename chip::app::Clusters::DoorLock::Commands::ClearAllPins::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::DoorLock::Commands::ClearAllRfids::Type,
-                                               chip::app::Clusters::DoorLock::Commands::ClearAllRfidsResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::DoorLock::Commands::ClearAllRfids::Type>(
     const chip::app::Clusters::DoorLock::Commands::ClearAllRfids::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::DoorLock::Commands::ClearAllRfidsResponse::DecodableType>,
+    CommandResponseSuccessCallback<typename chip::app::Clusters::DoorLock::Commands::ClearAllRfids::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::DoorLock::Commands::ClearHolidaySchedule::Type,
-                           chip::app::Clusters::DoorLock::Commands::ClearHolidayScheduleResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::DoorLock::Commands::ClearHolidaySchedule::Type>(
     const chip::app::Clusters::DoorLock::Commands::ClearHolidaySchedule::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::DoorLock::Commands::ClearHolidayScheduleResponse::DecodableType>,
+    CommandResponseSuccessCallback<typename chip::app::Clusters::DoorLock::Commands::ClearHolidaySchedule::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::DoorLock::Commands::ClearPin::Type,
-                                               chip::app::Clusters::DoorLock::Commands::ClearPinResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::DoorLock::Commands::ClearPin::Type>(
     const chip::app::Clusters::DoorLock::Commands::ClearPin::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::DoorLock::Commands::ClearPinResponse::DecodableType>,
+    CommandResponseSuccessCallback<typename chip::app::Clusters::DoorLock::Commands::ClearPin::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::DoorLock::Commands::ClearRfid::Type,
-                                               chip::app::Clusters::DoorLock::Commands::ClearRfidResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::DoorLock::Commands::ClearRfid::Type>(
     const chip::app::Clusters::DoorLock::Commands::ClearRfid::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::DoorLock::Commands::ClearRfidResponse::DecodableType>,
+    CommandResponseSuccessCallback<typename chip::app::Clusters::DoorLock::Commands::ClearRfid::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::DoorLock::Commands::ClearWeekdaySchedule::Type,
-                           chip::app::Clusters::DoorLock::Commands::ClearWeekdayScheduleResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::DoorLock::Commands::ClearWeekdaySchedule::Type>(
     const chip::app::Clusters::DoorLock::Commands::ClearWeekdaySchedule::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::DoorLock::Commands::ClearWeekdayScheduleResponse::DecodableType>,
+    CommandResponseSuccessCallback<typename chip::app::Clusters::DoorLock::Commands::ClearWeekdaySchedule::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::DoorLock::Commands::ClearYeardaySchedule::Type,
-                           chip::app::Clusters::DoorLock::Commands::ClearYeardayScheduleResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::DoorLock::Commands::ClearYeardaySchedule::Type>(
     const chip::app::Clusters::DoorLock::Commands::ClearYeardaySchedule::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::DoorLock::Commands::ClearYeardayScheduleResponse::DecodableType>,
+    CommandResponseSuccessCallback<typename chip::app::Clusters::DoorLock::Commands::ClearYeardaySchedule::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::DoorLock::Commands::GetHolidaySchedule::Type,
-                                               chip::app::Clusters::DoorLock::Commands::GetHolidayScheduleResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::DoorLock::Commands::GetHolidaySchedule::Type>(
     const chip::app::Clusters::DoorLock::Commands::GetHolidaySchedule::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::DoorLock::Commands::GetHolidayScheduleResponse::DecodableType>,
+    CommandResponseSuccessCallback<typename chip::app::Clusters::DoorLock::Commands::GetHolidaySchedule::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::DoorLock::Commands::GetLogRecord::Type,
-                                               chip::app::Clusters::DoorLock::Commands::GetLogRecordResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::DoorLock::Commands::GetLogRecord::Type>(
     const chip::app::Clusters::DoorLock::Commands::GetLogRecord::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::DoorLock::Commands::GetLogRecordResponse::DecodableType>,
+    CommandResponseSuccessCallback<typename chip::app::Clusters::DoorLock::Commands::GetLogRecord::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::DoorLock::Commands::GetPin::Type,
-                                               chip::app::Clusters::DoorLock::Commands::GetPinResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::DoorLock::Commands::GetPin::Type>(
     const chip::app::Clusters::DoorLock::Commands::GetPin::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::DoorLock::Commands::GetPinResponse::DecodableType>,
+    CommandResponseSuccessCallback<typename chip::app::Clusters::DoorLock::Commands::GetPin::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::DoorLock::Commands::GetRfid::Type,
-                                               chip::app::Clusters::DoorLock::Commands::GetRfidResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::DoorLock::Commands::GetRfid::Type>(
     const chip::app::Clusters::DoorLock::Commands::GetRfid::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::DoorLock::Commands::GetRfidResponse::DecodableType>,
+    CommandResponseSuccessCallback<typename chip::app::Clusters::DoorLock::Commands::GetRfid::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::DoorLock::Commands::GetUserType::Type,
-                                               chip::app::Clusters::DoorLock::Commands::GetUserTypeResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::DoorLock::Commands::GetUserType::Type>(
     const chip::app::Clusters::DoorLock::Commands::GetUserType::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::DoorLock::Commands::GetUserTypeResponse::DecodableType>,
+    CommandResponseSuccessCallback<typename chip::app::Clusters::DoorLock::Commands::GetUserType::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::DoorLock::Commands::GetWeekdaySchedule::Type,
-                                               chip::app::Clusters::DoorLock::Commands::GetWeekdayScheduleResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::DoorLock::Commands::GetWeekdaySchedule::Type>(
     const chip::app::Clusters::DoorLock::Commands::GetWeekdaySchedule::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::DoorLock::Commands::GetWeekdayScheduleResponse::DecodableType>,
+    CommandResponseSuccessCallback<typename chip::app::Clusters::DoorLock::Commands::GetWeekdaySchedule::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::DoorLock::Commands::GetYeardaySchedule::Type,
-                                               chip::app::Clusters::DoorLock::Commands::GetYeardayScheduleResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::DoorLock::Commands::GetYeardaySchedule::Type>(
     const chip::app::Clusters::DoorLock::Commands::GetYeardaySchedule::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::DoorLock::Commands::GetYeardayScheduleResponse::DecodableType>,
+    CommandResponseSuccessCallback<typename chip::app::Clusters::DoorLock::Commands::GetYeardaySchedule::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::DoorLock::Commands::LockDoor::Type,
-                                               chip::app::Clusters::DoorLock::Commands::LockDoorResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::DoorLock::Commands::LockDoor::Type>(
     const chip::app::Clusters::DoorLock::Commands::LockDoor::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::DoorLock::Commands::LockDoorResponse::DecodableType>,
+    CommandResponseSuccessCallback<typename chip::app::Clusters::DoorLock::Commands::LockDoor::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::DoorLock::Commands::SetHolidaySchedule::Type,
-                                               chip::app::Clusters::DoorLock::Commands::SetHolidayScheduleResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::DoorLock::Commands::SetHolidaySchedule::Type>(
     const chip::app::Clusters::DoorLock::Commands::SetHolidaySchedule::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::DoorLock::Commands::SetHolidayScheduleResponse::DecodableType>,
+    CommandResponseSuccessCallback<typename chip::app::Clusters::DoorLock::Commands::SetHolidaySchedule::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::DoorLock::Commands::SetPin::Type,
-                                               chip::app::Clusters::DoorLock::Commands::SetPinResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::DoorLock::Commands::SetPin::Type>(
     const chip::app::Clusters::DoorLock::Commands::SetPin::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::DoorLock::Commands::SetPinResponse::DecodableType>,
+    CommandResponseSuccessCallback<typename chip::app::Clusters::DoorLock::Commands::SetPin::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::DoorLock::Commands::SetRfid::Type,
-                                               chip::app::Clusters::DoorLock::Commands::SetRfidResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::DoorLock::Commands::SetRfid::Type>(
     const chip::app::Clusters::DoorLock::Commands::SetRfid::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::DoorLock::Commands::SetRfidResponse::DecodableType>,
+    CommandResponseSuccessCallback<typename chip::app::Clusters::DoorLock::Commands::SetRfid::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::DoorLock::Commands::SetUserType::Type,
-                                               chip::app::Clusters::DoorLock::Commands::SetUserTypeResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::DoorLock::Commands::SetUserType::Type>(
     const chip::app::Clusters::DoorLock::Commands::SetUserType::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::DoorLock::Commands::SetUserTypeResponse::DecodableType>,
+    CommandResponseSuccessCallback<typename chip::app::Clusters::DoorLock::Commands::SetUserType::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::DoorLock::Commands::SetWeekdaySchedule::Type,
-                                               chip::app::Clusters::DoorLock::Commands::SetWeekdayScheduleResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::DoorLock::Commands::SetWeekdaySchedule::Type>(
     const chip::app::Clusters::DoorLock::Commands::SetWeekdaySchedule::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::DoorLock::Commands::SetWeekdayScheduleResponse::DecodableType>,
+    CommandResponseSuccessCallback<typename chip::app::Clusters::DoorLock::Commands::SetWeekdaySchedule::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::DoorLock::Commands::SetYeardaySchedule::Type,
-                                               chip::app::Clusters::DoorLock::Commands::SetYeardayScheduleResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::DoorLock::Commands::SetYeardaySchedule::Type>(
     const chip::app::Clusters::DoorLock::Commands::SetYeardaySchedule::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::DoorLock::Commands::SetYeardayScheduleResponse::DecodableType>,
+    CommandResponseSuccessCallback<typename chip::app::Clusters::DoorLock::Commands::SetYeardaySchedule::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::DoorLock::Commands::UnlockDoor::Type,
-                                               chip::app::Clusters::DoorLock::Commands::UnlockDoorResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::DoorLock::Commands::UnlockDoor::Type>(
     const chip::app::Clusters::DoorLock::Commands::UnlockDoor::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::DoorLock::Commands::UnlockDoorResponse::DecodableType>,
+    CommandResponseSuccessCallback<typename chip::app::Clusters::DoorLock::Commands::UnlockDoor::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::DoorLock::Commands::UnlockWithTimeout::Type,
-                                               chip::app::Clusters::DoorLock::Commands::UnlockWithTimeoutResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::DoorLock::Commands::UnlockWithTimeout::Type>(
     const chip::app::Clusters::DoorLock::Commands::UnlockWithTimeout::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::DoorLock::Commands::UnlockWithTimeoutResponse::DecodableType>,
+    CommandResponseSuccessCallback<typename chip::app::Clusters::DoorLock::Commands::UnlockWithTimeout::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::EthernetNetworkDiagnostics::Commands::ResetCounts::Type,
-                                               chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::EthernetNetworkDiagnostics::Commands::ResetCounts::Type>(
     const chip::app::Clusters::EthernetNetworkDiagnostics::Commands::ResetCounts::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
-
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::GeneralCommissioning::Commands::ArmFailSafe::Type,
-                           chip::app::Clusters::GeneralCommissioning::Commands::ArmFailSafeResponse::DecodableType>(
-    const chip::app::Clusters::GeneralCommissioning::Commands::ArmFailSafe::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::GeneralCommissioning::Commands::ArmFailSafeResponse::DecodableType>,
+    CommandResponseSuccessCallback<
+        typename chip::app::Clusters::EthernetNetworkDiagnostics::Commands::ResetCounts::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::GeneralCommissioning::Commands::CommissioningComplete::Type,
-                           chip::app::Clusters::GeneralCommissioning::Commands::CommissioningCompleteResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::GeneralCommissioning::Commands::ArmFailSafe::Type>(
+    const chip::app::Clusters::GeneralCommissioning::Commands::ArmFailSafe::Type &, void *,
+    CommandResponseSuccessCallback<typename chip::app::Clusters::GeneralCommissioning::Commands::ArmFailSafe::Type::ResponseType>,
+    CommandResponseFailureCallback);
+
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::GeneralCommissioning::Commands::CommissioningComplete::Type>(
     const chip::app::Clusters::GeneralCommissioning::Commands::CommissioningComplete::Type &, void *,
     CommandResponseSuccessCallback<
-        chip::app::Clusters::GeneralCommissioning::Commands::CommissioningCompleteResponse::DecodableType>,
+        typename chip::app::Clusters::GeneralCommissioning::Commands::CommissioningComplete::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::GeneralCommissioning::Commands::SetRegulatoryConfig::Type,
-                           chip::app::Clusters::GeneralCommissioning::Commands::SetRegulatoryConfigResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::GeneralCommissioning::Commands::SetRegulatoryConfig::Type>(
     const chip::app::Clusters::GeneralCommissioning::Commands::SetRegulatoryConfig::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::GeneralCommissioning::Commands::SetRegulatoryConfigResponse::DecodableType>,
+    CommandResponseSuccessCallback<
+        typename chip::app::Clusters::GeneralCommissioning::Commands::SetRegulatoryConfig::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::Groups::Commands::AddGroup::Type,
-                                               chip::app::Clusters::Groups::Commands::AddGroupResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::Groups::Commands::AddGroup::Type>(
     const chip::app::Clusters::Groups::Commands::AddGroup::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::Groups::Commands::AddGroupResponse::DecodableType>,
+    CommandResponseSuccessCallback<typename chip::app::Clusters::Groups::Commands::AddGroup::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::Groups::Commands::AddGroupIfIdentifying::Type,
-                                               chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::Groups::Commands::AddGroupIfIdentifying::Type>(
     const chip::app::Clusters::Groups::Commands::AddGroupIfIdentifying::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<typename chip::app::Clusters::Groups::Commands::AddGroupIfIdentifying::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::Groups::Commands::GetGroupMembership::Type,
-                                               chip::app::Clusters::Groups::Commands::GetGroupMembershipResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::Groups::Commands::GetGroupMembership::Type>(
     const chip::app::Clusters::Groups::Commands::GetGroupMembership::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::Groups::Commands::GetGroupMembershipResponse::DecodableType>,
+    CommandResponseSuccessCallback<typename chip::app::Clusters::Groups::Commands::GetGroupMembership::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::Groups::Commands::RemoveAllGroups::Type, chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::Groups::Commands::RemoveAllGroups::Type>(
     const chip::app::Clusters::Groups::Commands::RemoveAllGroups::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<typename chip::app::Clusters::Groups::Commands::RemoveAllGroups::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::Groups::Commands::RemoveGroup::Type,
-                                               chip::app::Clusters::Groups::Commands::RemoveGroupResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::Groups::Commands::RemoveGroup::Type>(
     const chip::app::Clusters::Groups::Commands::RemoveGroup::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::Groups::Commands::RemoveGroupResponse::DecodableType>,
+    CommandResponseSuccessCallback<typename chip::app::Clusters::Groups::Commands::RemoveGroup::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::Groups::Commands::ViewGroup::Type,
-                                               chip::app::Clusters::Groups::Commands::ViewGroupResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::Groups::Commands::ViewGroup::Type>(
     const chip::app::Clusters::Groups::Commands::ViewGroup::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::Groups::Commands::ViewGroupResponse::DecodableType>,
+    CommandResponseSuccessCallback<typename chip::app::Clusters::Groups::Commands::ViewGroup::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::Identify::Commands::Identify::Type, chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::Identify::Commands::Identify::Type>(
     const chip::app::Clusters::Identify::Commands::Identify::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<typename chip::app::Clusters::Identify::Commands::Identify::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::Identify::Commands::IdentifyQuery::Type,
-                                               chip::app::Clusters::Identify::Commands::IdentifyQueryResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::Identify::Commands::IdentifyQuery::Type>(
     const chip::app::Clusters::Identify::Commands::IdentifyQuery::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::Identify::Commands::IdentifyQueryResponse::DecodableType>,
+    CommandResponseSuccessCallback<typename chip::app::Clusters::Identify::Commands::IdentifyQuery::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::Identify::Commands::TriggerEffect::Type, chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::Identify::Commands::TriggerEffect::Type>(
     const chip::app::Clusters::Identify::Commands::TriggerEffect::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<typename chip::app::Clusters::Identify::Commands::TriggerEffect::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::KeypadInput::Commands::SendKey::Type,
-                                               chip::app::Clusters::KeypadInput::Commands::SendKeyResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::KeypadInput::Commands::SendKey::Type>(
     const chip::app::Clusters::KeypadInput::Commands::SendKey::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::KeypadInput::Commands::SendKeyResponse::DecodableType>,
+    CommandResponseSuccessCallback<typename chip::app::Clusters::KeypadInput::Commands::SendKey::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::LevelControl::Commands::Move::Type, chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::LevelControl::Commands::Move::Type>(
     const chip::app::Clusters::LevelControl::Commands::Move::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<typename chip::app::Clusters::LevelControl::Commands::Move::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::LevelControl::Commands::MoveToLevel::Type, chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::LevelControl::Commands::MoveToLevel::Type>(
     const chip::app::Clusters::LevelControl::Commands::MoveToLevel::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<typename chip::app::Clusters::LevelControl::Commands::MoveToLevel::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::LevelControl::Commands::MoveToLevelWithOnOff::Type,
-                                               chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::LevelControl::Commands::MoveToLevelWithOnOff::Type>(
     const chip::app::Clusters::LevelControl::Commands::MoveToLevelWithOnOff::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<typename chip::app::Clusters::LevelControl::Commands::MoveToLevelWithOnOff::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::LevelControl::Commands::MoveWithOnOff::Type, chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::LevelControl::Commands::MoveWithOnOff::Type>(
     const chip::app::Clusters::LevelControl::Commands::MoveWithOnOff::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<typename chip::app::Clusters::LevelControl::Commands::MoveWithOnOff::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::LevelControl::Commands::Step::Type, chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::LevelControl::Commands::Step::Type>(
     const chip::app::Clusters::LevelControl::Commands::Step::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<typename chip::app::Clusters::LevelControl::Commands::Step::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::LevelControl::Commands::StepWithOnOff::Type, chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::LevelControl::Commands::StepWithOnOff::Type>(
     const chip::app::Clusters::LevelControl::Commands::StepWithOnOff::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<typename chip::app::Clusters::LevelControl::Commands::StepWithOnOff::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::LevelControl::Commands::Stop::Type, chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::LevelControl::Commands::Stop::Type>(
     const chip::app::Clusters::LevelControl::Commands::Stop::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<typename chip::app::Clusters::LevelControl::Commands::Stop::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::LevelControl::Commands::StopWithOnOff::Type, chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::LevelControl::Commands::StopWithOnOff::Type>(
     const chip::app::Clusters::LevelControl::Commands::StopWithOnOff::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<typename chip::app::Clusters::LevelControl::Commands::StopWithOnOff::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::LowPower::Commands::Sleep::Type, chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::LowPower::Commands::Sleep::Type>(
     const chip::app::Clusters::LowPower::Commands::Sleep::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<typename chip::app::Clusters::LowPower::Commands::Sleep::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::MediaInput::Commands::HideInputStatus::Type, chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::MediaInput::Commands::HideInputStatus::Type>(
     const chip::app::Clusters::MediaInput::Commands::HideInputStatus::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<typename chip::app::Clusters::MediaInput::Commands::HideInputStatus::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::MediaInput::Commands::RenameInput::Type, chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::MediaInput::Commands::RenameInput::Type>(
     const chip::app::Clusters::MediaInput::Commands::RenameInput::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<typename chip::app::Clusters::MediaInput::Commands::RenameInput::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::MediaInput::Commands::SelectInput::Type, chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::MediaInput::Commands::SelectInput::Type>(
     const chip::app::Clusters::MediaInput::Commands::SelectInput::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<typename chip::app::Clusters::MediaInput::Commands::SelectInput::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::MediaInput::Commands::ShowInputStatus::Type, chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::MediaInput::Commands::ShowInputStatus::Type>(
     const chip::app::Clusters::MediaInput::Commands::ShowInputStatus::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<typename chip::app::Clusters::MediaInput::Commands::ShowInputStatus::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::MediaPlayback::Commands::MediaFastForward::Type,
-                           chip::app::Clusters::MediaPlayback::Commands::MediaFastForwardResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::MediaPlayback::Commands::MediaFastForward::Type>(
     const chip::app::Clusters::MediaPlayback::Commands::MediaFastForward::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::MediaPlayback::Commands::MediaFastForwardResponse::DecodableType>,
+    CommandResponseSuccessCallback<typename chip::app::Clusters::MediaPlayback::Commands::MediaFastForward::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::MediaPlayback::Commands::MediaNext::Type,
-                                               chip::app::Clusters::MediaPlayback::Commands::MediaNextResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::MediaPlayback::Commands::MediaNext::Type>(
     const chip::app::Clusters::MediaPlayback::Commands::MediaNext::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::MediaPlayback::Commands::MediaNextResponse::DecodableType>,
+    CommandResponseSuccessCallback<typename chip::app::Clusters::MediaPlayback::Commands::MediaNext::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::MediaPlayback::Commands::MediaPause::Type,
-                                               chip::app::Clusters::MediaPlayback::Commands::MediaPauseResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::MediaPlayback::Commands::MediaPause::Type>(
     const chip::app::Clusters::MediaPlayback::Commands::MediaPause::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::MediaPlayback::Commands::MediaPauseResponse::DecodableType>,
+    CommandResponseSuccessCallback<typename chip::app::Clusters::MediaPlayback::Commands::MediaPause::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::MediaPlayback::Commands::MediaPlay::Type,
-                                               chip::app::Clusters::MediaPlayback::Commands::MediaPlayResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::MediaPlayback::Commands::MediaPlay::Type>(
     const chip::app::Clusters::MediaPlayback::Commands::MediaPlay::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::MediaPlayback::Commands::MediaPlayResponse::DecodableType>,
+    CommandResponseSuccessCallback<typename chip::app::Clusters::MediaPlayback::Commands::MediaPlay::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::MediaPlayback::Commands::MediaPrevious::Type,
-                                               chip::app::Clusters::MediaPlayback::Commands::MediaPreviousResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::MediaPlayback::Commands::MediaPrevious::Type>(
     const chip::app::Clusters::MediaPlayback::Commands::MediaPrevious::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::MediaPlayback::Commands::MediaPreviousResponse::DecodableType>,
+    CommandResponseSuccessCallback<typename chip::app::Clusters::MediaPlayback::Commands::MediaPrevious::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::MediaPlayback::Commands::MediaRewind::Type,
-                                               chip::app::Clusters::MediaPlayback::Commands::MediaRewindResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::MediaPlayback::Commands::MediaRewind::Type>(
     const chip::app::Clusters::MediaPlayback::Commands::MediaRewind::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::MediaPlayback::Commands::MediaRewindResponse::DecodableType>,
+    CommandResponseSuccessCallback<typename chip::app::Clusters::MediaPlayback::Commands::MediaRewind::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::MediaPlayback::Commands::MediaSeek::Type,
-                                               chip::app::Clusters::MediaPlayback::Commands::MediaSeekResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::MediaPlayback::Commands::MediaSeek::Type>(
     const chip::app::Clusters::MediaPlayback::Commands::MediaSeek::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::MediaPlayback::Commands::MediaSeekResponse::DecodableType>,
+    CommandResponseSuccessCallback<typename chip::app::Clusters::MediaPlayback::Commands::MediaSeek::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::MediaPlayback::Commands::MediaSkipBackward::Type,
-                           chip::app::Clusters::MediaPlayback::Commands::MediaSkipBackwardResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::MediaPlayback::Commands::MediaSkipBackward::Type>(
     const chip::app::Clusters::MediaPlayback::Commands::MediaSkipBackward::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::MediaPlayback::Commands::MediaSkipBackwardResponse::DecodableType>,
+    CommandResponseSuccessCallback<typename chip::app::Clusters::MediaPlayback::Commands::MediaSkipBackward::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::MediaPlayback::Commands::MediaSkipForward::Type,
-                           chip::app::Clusters::MediaPlayback::Commands::MediaSkipForwardResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::MediaPlayback::Commands::MediaSkipForward::Type>(
     const chip::app::Clusters::MediaPlayback::Commands::MediaSkipForward::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::MediaPlayback::Commands::MediaSkipForwardResponse::DecodableType>,
+    CommandResponseSuccessCallback<typename chip::app::Clusters::MediaPlayback::Commands::MediaSkipForward::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::MediaPlayback::Commands::MediaStartOver::Type,
-                                               chip::app::Clusters::MediaPlayback::Commands::MediaStartOverResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::MediaPlayback::Commands::MediaStartOver::Type>(
     const chip::app::Clusters::MediaPlayback::Commands::MediaStartOver::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::MediaPlayback::Commands::MediaStartOverResponse::DecodableType>,
+    CommandResponseSuccessCallback<typename chip::app::Clusters::MediaPlayback::Commands::MediaStartOver::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::MediaPlayback::Commands::MediaStop::Type,
-                                               chip::app::Clusters::MediaPlayback::Commands::MediaStopResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::MediaPlayback::Commands::MediaStop::Type>(
     const chip::app::Clusters::MediaPlayback::Commands::MediaStop::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::MediaPlayback::Commands::MediaStopResponse::DecodableType>,
+    CommandResponseSuccessCallback<typename chip::app::Clusters::MediaPlayback::Commands::MediaStop::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::ModeSelect::Commands::ChangeToMode::Type, chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::ModeSelect::Commands::ChangeToMode::Type>(
     const chip::app::Clusters::ModeSelect::Commands::ChangeToMode::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<typename chip::app::Clusters::ModeSelect::Commands::ChangeToMode::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::NetworkCommissioning::Commands::AddThreadNetwork::Type,
-                           chip::app::Clusters::NetworkCommissioning::Commands::AddThreadNetworkResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::NetworkCommissioning::Commands::AddThreadNetwork::Type>(
     const chip::app::Clusters::NetworkCommissioning::Commands::AddThreadNetwork::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::NetworkCommissioning::Commands::AddThreadNetworkResponse::DecodableType>,
+    CommandResponseSuccessCallback<
+        typename chip::app::Clusters::NetworkCommissioning::Commands::AddThreadNetwork::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::NetworkCommissioning::Commands::AddWiFiNetwork::Type,
-                           chip::app::Clusters::NetworkCommissioning::Commands::AddWiFiNetworkResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::NetworkCommissioning::Commands::AddWiFiNetwork::Type>(
     const chip::app::Clusters::NetworkCommissioning::Commands::AddWiFiNetwork::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::NetworkCommissioning::Commands::AddWiFiNetworkResponse::DecodableType>,
+    CommandResponseSuccessCallback<
+        typename chip::app::Clusters::NetworkCommissioning::Commands::AddWiFiNetwork::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::NetworkCommissioning::Commands::DisableNetwork::Type,
-                           chip::app::Clusters::NetworkCommissioning::Commands::DisableNetworkResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::NetworkCommissioning::Commands::DisableNetwork::Type>(
     const chip::app::Clusters::NetworkCommissioning::Commands::DisableNetwork::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::NetworkCommissioning::Commands::DisableNetworkResponse::DecodableType>,
+    CommandResponseSuccessCallback<
+        typename chip::app::Clusters::NetworkCommissioning::Commands::DisableNetwork::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::NetworkCommissioning::Commands::EnableNetwork::Type,
-                           chip::app::Clusters::NetworkCommissioning::Commands::EnableNetworkResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::NetworkCommissioning::Commands::EnableNetwork::Type>(
     const chip::app::Clusters::NetworkCommissioning::Commands::EnableNetwork::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::NetworkCommissioning::Commands::EnableNetworkResponse::DecodableType>,
+    CommandResponseSuccessCallback<typename chip::app::Clusters::NetworkCommissioning::Commands::EnableNetwork::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::NetworkCommissioning::Commands::RemoveNetwork::Type,
-                           chip::app::Clusters::NetworkCommissioning::Commands::RemoveNetworkResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::NetworkCommissioning::Commands::RemoveNetwork::Type>(
     const chip::app::Clusters::NetworkCommissioning::Commands::RemoveNetwork::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::NetworkCommissioning::Commands::RemoveNetworkResponse::DecodableType>,
+    CommandResponseSuccessCallback<typename chip::app::Clusters::NetworkCommissioning::Commands::RemoveNetwork::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::NetworkCommissioning::Commands::ScanNetworks::Type,
-                           chip::app::Clusters::NetworkCommissioning::Commands::ScanNetworksResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::NetworkCommissioning::Commands::ScanNetworks::Type>(
     const chip::app::Clusters::NetworkCommissioning::Commands::ScanNetworks::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::NetworkCommissioning::Commands::ScanNetworksResponse::DecodableType>,
+    CommandResponseSuccessCallback<typename chip::app::Clusters::NetworkCommissioning::Commands::ScanNetworks::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::NetworkCommissioning::Commands::UpdateThreadNetwork::Type,
-                           chip::app::Clusters::NetworkCommissioning::Commands::UpdateThreadNetworkResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::NetworkCommissioning::Commands::UpdateThreadNetwork::Type>(
     const chip::app::Clusters::NetworkCommissioning::Commands::UpdateThreadNetwork::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::NetworkCommissioning::Commands::UpdateThreadNetworkResponse::DecodableType>,
+    CommandResponseSuccessCallback<
+        typename chip::app::Clusters::NetworkCommissioning::Commands::UpdateThreadNetwork::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::NetworkCommissioning::Commands::UpdateWiFiNetwork::Type,
-                           chip::app::Clusters::NetworkCommissioning::Commands::UpdateWiFiNetworkResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::NetworkCommissioning::Commands::UpdateWiFiNetwork::Type>(
     const chip::app::Clusters::NetworkCommissioning::Commands::UpdateWiFiNetwork::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::NetworkCommissioning::Commands::UpdateWiFiNetworkResponse::DecodableType>,
+    CommandResponseSuccessCallback<
+        typename chip::app::Clusters::NetworkCommissioning::Commands::UpdateWiFiNetwork::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::OtaSoftwareUpdateProvider::Commands::ApplyUpdateRequest::Type,
-                           chip::app::Clusters::OtaSoftwareUpdateProvider::Commands::ApplyUpdateResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::OtaSoftwareUpdateProvider::Commands::ApplyUpdateRequest::Type>(
     const chip::app::Clusters::OtaSoftwareUpdateProvider::Commands::ApplyUpdateRequest::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::OtaSoftwareUpdateProvider::Commands::ApplyUpdateResponse::DecodableType>,
+    CommandResponseSuccessCallback<
+        typename chip::app::Clusters::OtaSoftwareUpdateProvider::Commands::ApplyUpdateRequest::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::OtaSoftwareUpdateProvider::Commands::NotifyUpdateApplied::Type,
-                                               chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::OtaSoftwareUpdateProvider::Commands::NotifyUpdateApplied::Type>(
     const chip::app::Clusters::OtaSoftwareUpdateProvider::Commands::NotifyUpdateApplied::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<
+        typename chip::app::Clusters::OtaSoftwareUpdateProvider::Commands::NotifyUpdateApplied::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::OtaSoftwareUpdateProvider::Commands::QueryImage::Type,
-                           chip::app::Clusters::OtaSoftwareUpdateProvider::Commands::QueryImageResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::OtaSoftwareUpdateProvider::Commands::QueryImage::Type>(
     const chip::app::Clusters::OtaSoftwareUpdateProvider::Commands::QueryImage::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::OtaSoftwareUpdateProvider::Commands::QueryImageResponse::DecodableType>,
+    CommandResponseSuccessCallback<
+        typename chip::app::Clusters::OtaSoftwareUpdateProvider::Commands::QueryImage::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::OtaSoftwareUpdateRequestor::Commands::AnnounceOtaProvider::Type,
-                                               chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR
+ClusterBase::InvokeCommand<chip::app::Clusters::OtaSoftwareUpdateRequestor::Commands::AnnounceOtaProvider::Type>(
     const chip::app::Clusters::OtaSoftwareUpdateRequestor::Commands::AnnounceOtaProvider::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<
+        typename chip::app::Clusters::OtaSoftwareUpdateRequestor::Commands::AnnounceOtaProvider::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::OnOff::Commands::Off::Type, chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::OnOff::Commands::Off::Type>(
     const chip::app::Clusters::OnOff::Commands::Off::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<typename chip::app::Clusters::OnOff::Commands::Off::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::OnOff::Commands::OffWithEffect::Type, chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::OnOff::Commands::OffWithEffect::Type>(
     const chip::app::Clusters::OnOff::Commands::OffWithEffect::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<typename chip::app::Clusters::OnOff::Commands::OffWithEffect::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::OnOff::Commands::On::Type, chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::OnOff::Commands::On::Type>(
     const chip::app::Clusters::OnOff::Commands::On::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<typename chip::app::Clusters::OnOff::Commands::On::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::OnOff::Commands::OnWithRecallGlobalScene::Type,
-                                               chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::OnOff::Commands::OnWithRecallGlobalScene::Type>(
     const chip::app::Clusters::OnOff::Commands::OnWithRecallGlobalScene::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<typename chip::app::Clusters::OnOff::Commands::OnWithRecallGlobalScene::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::OnOff::Commands::OnWithTimedOff::Type, chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::OnOff::Commands::OnWithTimedOff::Type>(
     const chip::app::Clusters::OnOff::Commands::OnWithTimedOff::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<typename chip::app::Clusters::OnOff::Commands::OnWithTimedOff::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::OnOff::Commands::Toggle::Type, chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::OnOff::Commands::Toggle::Type>(
     const chip::app::Clusters::OnOff::Commands::Toggle::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<typename chip::app::Clusters::OnOff::Commands::Toggle::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::OperationalCredentials::Commands::AddNOC::Type,
-                                               chip::app::Clusters::OperationalCredentials::Commands::NOCResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::OperationalCredentials::Commands::AddNOC::Type>(
     const chip::app::Clusters::OperationalCredentials::Commands::AddNOC::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::OperationalCredentials::Commands::NOCResponse::DecodableType>,
+    CommandResponseSuccessCallback<typename chip::app::Clusters::OperationalCredentials::Commands::AddNOC::Type::ResponseType>,
     CommandResponseFailureCallback);
 
 template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::OperationalCredentials::Commands::AddTrustedRootCertificate::Type,
-                           chip::app::DataModel::NullObjectType>(
+ClusterBase::InvokeCommand<chip::app::Clusters::OperationalCredentials::Commands::AddTrustedRootCertificate::Type>(
     const chip::app::Clusters::OperationalCredentials::Commands::AddTrustedRootCertificate::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<
+        typename chip::app::Clusters::OperationalCredentials::Commands::AddTrustedRootCertificate::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::OperationalCredentials::Commands::AttestationRequest::Type,
-                           chip::app::Clusters::OperationalCredentials::Commands::AttestationResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::OperationalCredentials::Commands::AttestationRequest::Type>(
     const chip::app::Clusters::OperationalCredentials::Commands::AttestationRequest::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::OperationalCredentials::Commands::AttestationResponse::DecodableType>,
+    CommandResponseSuccessCallback<
+        typename chip::app::Clusters::OperationalCredentials::Commands::AttestationRequest::Type::ResponseType>,
     CommandResponseFailureCallback);
 
 template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::OperationalCredentials::Commands::CertificateChainRequest::Type,
-                           chip::app::Clusters::OperationalCredentials::Commands::CertificateChainResponse::DecodableType>(
+ClusterBase::InvokeCommand<chip::app::Clusters::OperationalCredentials::Commands::CertificateChainRequest::Type>(
     const chip::app::Clusters::OperationalCredentials::Commands::CertificateChainRequest::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::OperationalCredentials::Commands::CertificateChainResponse::DecodableType>,
+    CommandResponseSuccessCallback<
+        typename chip::app::Clusters::OperationalCredentials::Commands::CertificateChainRequest::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::OperationalCredentials::Commands::OpCSRRequest::Type,
-                                               chip::app::Clusters::OperationalCredentials::Commands::OpCSRResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::OperationalCredentials::Commands::OpCSRRequest::Type>(
     const chip::app::Clusters::OperationalCredentials::Commands::OpCSRRequest::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::OperationalCredentials::Commands::OpCSRResponse::DecodableType>,
+    CommandResponseSuccessCallback<
+        typename chip::app::Clusters::OperationalCredentials::Commands::OpCSRRequest::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::OperationalCredentials::Commands::RemoveFabric::Type,
-                                               chip::app::Clusters::OperationalCredentials::Commands::NOCResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::OperationalCredentials::Commands::RemoveFabric::Type>(
     const chip::app::Clusters::OperationalCredentials::Commands::RemoveFabric::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::OperationalCredentials::Commands::NOCResponse::DecodableType>,
+    CommandResponseSuccessCallback<
+        typename chip::app::Clusters::OperationalCredentials::Commands::RemoveFabric::Type::ResponseType>,
     CommandResponseFailureCallback);
 
 template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::OperationalCredentials::Commands::RemoveTrustedRootCertificate::Type,
-                           chip::app::DataModel::NullObjectType>(
+ClusterBase::InvokeCommand<chip::app::Clusters::OperationalCredentials::Commands::RemoveTrustedRootCertificate::Type>(
     const chip::app::Clusters::OperationalCredentials::Commands::RemoveTrustedRootCertificate::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<
+        typename chip::app::Clusters::OperationalCredentials::Commands::RemoveTrustedRootCertificate::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::OperationalCredentials::Commands::UpdateFabricLabel::Type,
-                                               chip::app::Clusters::OperationalCredentials::Commands::NOCResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::OperationalCredentials::Commands::UpdateFabricLabel::Type>(
     const chip::app::Clusters::OperationalCredentials::Commands::UpdateFabricLabel::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::OperationalCredentials::Commands::NOCResponse::DecodableType>,
+    CommandResponseSuccessCallback<
+        typename chip::app::Clusters::OperationalCredentials::Commands::UpdateFabricLabel::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::OperationalCredentials::Commands::UpdateNOC::Type,
-                                               chip::app::Clusters::OperationalCredentials::Commands::NOCResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::OperationalCredentials::Commands::UpdateNOC::Type>(
     const chip::app::Clusters::OperationalCredentials::Commands::UpdateNOC::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::OperationalCredentials::Commands::NOCResponse::DecodableType>,
+    CommandResponseSuccessCallback<typename chip::app::Clusters::OperationalCredentials::Commands::UpdateNOC::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::Scenes::Commands::AddScene::Type,
-                                               chip::app::Clusters::Scenes::Commands::AddSceneResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::Scenes::Commands::AddScene::Type>(
     const chip::app::Clusters::Scenes::Commands::AddScene::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::Scenes::Commands::AddSceneResponse::DecodableType>,
+    CommandResponseSuccessCallback<typename chip::app::Clusters::Scenes::Commands::AddScene::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::Scenes::Commands::GetSceneMembership::Type,
-                                               chip::app::Clusters::Scenes::Commands::GetSceneMembershipResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::Scenes::Commands::GetSceneMembership::Type>(
     const chip::app::Clusters::Scenes::Commands::GetSceneMembership::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::Scenes::Commands::GetSceneMembershipResponse::DecodableType>,
+    CommandResponseSuccessCallback<typename chip::app::Clusters::Scenes::Commands::GetSceneMembership::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::Scenes::Commands::RecallScene::Type, chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::Scenes::Commands::RecallScene::Type>(
     const chip::app::Clusters::Scenes::Commands::RecallScene::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<typename chip::app::Clusters::Scenes::Commands::RecallScene::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::Scenes::Commands::RemoveAllScenes::Type,
-                                               chip::app::Clusters::Scenes::Commands::RemoveAllScenesResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::Scenes::Commands::RemoveAllScenes::Type>(
     const chip::app::Clusters::Scenes::Commands::RemoveAllScenes::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::Scenes::Commands::RemoveAllScenesResponse::DecodableType>,
+    CommandResponseSuccessCallback<typename chip::app::Clusters::Scenes::Commands::RemoveAllScenes::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::Scenes::Commands::RemoveScene::Type,
-                                               chip::app::Clusters::Scenes::Commands::RemoveSceneResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::Scenes::Commands::RemoveScene::Type>(
     const chip::app::Clusters::Scenes::Commands::RemoveScene::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::Scenes::Commands::RemoveSceneResponse::DecodableType>,
+    CommandResponseSuccessCallback<typename chip::app::Clusters::Scenes::Commands::RemoveScene::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::Scenes::Commands::StoreScene::Type,
-                                               chip::app::Clusters::Scenes::Commands::StoreSceneResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::Scenes::Commands::StoreScene::Type>(
     const chip::app::Clusters::Scenes::Commands::StoreScene::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::Scenes::Commands::StoreSceneResponse::DecodableType>,
+    CommandResponseSuccessCallback<typename chip::app::Clusters::Scenes::Commands::StoreScene::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::Scenes::Commands::ViewScene::Type,
-                                               chip::app::Clusters::Scenes::Commands::ViewSceneResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::Scenes::Commands::ViewScene::Type>(
     const chip::app::Clusters::Scenes::Commands::ViewScene::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::Scenes::Commands::ViewSceneResponse::DecodableType>,
+    CommandResponseSuccessCallback<typename chip::app::Clusters::Scenes::Commands::ViewScene::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::SoftwareDiagnostics::Commands::ResetWatermarks::Type,
-                                               chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::SoftwareDiagnostics::Commands::ResetWatermarks::Type>(
     const chip::app::Clusters::SoftwareDiagnostics::Commands::ResetWatermarks::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<
+        typename chip::app::Clusters::SoftwareDiagnostics::Commands::ResetWatermarks::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::TvChannel::Commands::ChangeChannel::Type,
-                                               chip::app::Clusters::TvChannel::Commands::ChangeChannelResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::TvChannel::Commands::ChangeChannel::Type>(
     const chip::app::Clusters::TvChannel::Commands::ChangeChannel::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::TvChannel::Commands::ChangeChannelResponse::DecodableType>,
+    CommandResponseSuccessCallback<typename chip::app::Clusters::TvChannel::Commands::ChangeChannel::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::TvChannel::Commands::ChangeChannelByNumber::Type,
-                                               chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::TvChannel::Commands::ChangeChannelByNumber::Type>(
     const chip::app::Clusters::TvChannel::Commands::ChangeChannelByNumber::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<typename chip::app::Clusters::TvChannel::Commands::ChangeChannelByNumber::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::TvChannel::Commands::SkipChannel::Type, chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::TvChannel::Commands::SkipChannel::Type>(
     const chip::app::Clusters::TvChannel::Commands::SkipChannel::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<typename chip::app::Clusters::TvChannel::Commands::SkipChannel::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::TargetNavigator::Commands::NavigateTarget::Type,
-                           chip::app::Clusters::TargetNavigator::Commands::NavigateTargetResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::TargetNavigator::Commands::NavigateTarget::Type>(
     const chip::app::Clusters::TargetNavigator::Commands::NavigateTarget::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::TargetNavigator::Commands::NavigateTargetResponse::DecodableType>,
+    CommandResponseSuccessCallback<typename chip::app::Clusters::TargetNavigator::Commands::NavigateTarget::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::TestCluster::Commands::Test::Type, chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::TestCluster::Commands::Test::Type>(
     const chip::app::Clusters::TestCluster::Commands::Test::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<typename chip::app::Clusters::TestCluster::Commands::Test::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::TestCluster::Commands::TestAddArguments::Type,
-                                               chip::app::Clusters::TestCluster::Commands::TestAddArgumentsResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::TestCluster::Commands::TestAddArguments::Type>(
     const chip::app::Clusters::TestCluster::Commands::TestAddArguments::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::TestCluster::Commands::TestAddArgumentsResponse::DecodableType>,
+    CommandResponseSuccessCallback<typename chip::app::Clusters::TestCluster::Commands::TestAddArguments::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::TestCluster::Commands::TestEnumsRequest::Type,
-                                               chip::app::Clusters::TestCluster::Commands::TestEnumsResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::TestCluster::Commands::TestEnumsRequest::Type>(
     const chip::app::Clusters::TestCluster::Commands::TestEnumsRequest::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::TestCluster::Commands::TestEnumsResponse::DecodableType>,
+    CommandResponseSuccessCallback<typename chip::app::Clusters::TestCluster::Commands::TestEnumsRequest::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::TestCluster::Commands::TestListInt8UArgumentRequest::Type,
-                                               chip::app::Clusters::TestCluster::Commands::BooleanResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::TestCluster::Commands::TestListInt8UArgumentRequest::Type>(
     const chip::app::Clusters::TestCluster::Commands::TestListInt8UArgumentRequest::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::TestCluster::Commands::BooleanResponse::DecodableType>,
+    CommandResponseSuccessCallback<
+        typename chip::app::Clusters::TestCluster::Commands::TestListInt8UArgumentRequest::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::TestCluster::Commands::TestListInt8UReverseRequest::Type,
-                           chip::app::Clusters::TestCluster::Commands::TestListInt8UReverseResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::TestCluster::Commands::TestListInt8UReverseRequest::Type>(
     const chip::app::Clusters::TestCluster::Commands::TestListInt8UReverseRequest::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::TestCluster::Commands::TestListInt8UReverseResponse::DecodableType>,
+    CommandResponseSuccessCallback<
+        typename chip::app::Clusters::TestCluster::Commands::TestListInt8UReverseRequest::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::TestCluster::Commands::TestListStructArgumentRequest::Type,
-                                               chip::app::Clusters::TestCluster::Commands::BooleanResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::TestCluster::Commands::TestListStructArgumentRequest::Type>(
     const chip::app::Clusters::TestCluster::Commands::TestListStructArgumentRequest::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::TestCluster::Commands::BooleanResponse::DecodableType>,
+    CommandResponseSuccessCallback<
+        typename chip::app::Clusters::TestCluster::Commands::TestListStructArgumentRequest::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::TestCluster::Commands::TestNotHandled::Type, chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::TestCluster::Commands::TestNotHandled::Type>(
     const chip::app::Clusters::TestCluster::Commands::TestNotHandled::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<typename chip::app::Clusters::TestCluster::Commands::TestNotHandled::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::TestCluster::Commands::TestNullableOptionalRequest::Type,
-                           chip::app::Clusters::TestCluster::Commands::TestNullableOptionalResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::TestCluster::Commands::TestNullableOptionalRequest::Type>(
     const chip::app::Clusters::TestCluster::Commands::TestNullableOptionalRequest::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::TestCluster::Commands::TestNullableOptionalResponse::DecodableType>,
+    CommandResponseSuccessCallback<
+        typename chip::app::Clusters::TestCluster::Commands::TestNullableOptionalRequest::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::TestCluster::Commands::TestSpecific::Type,
-                                               chip::app::Clusters::TestCluster::Commands::TestSpecificResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::TestCluster::Commands::TestSpecific::Type>(
     const chip::app::Clusters::TestCluster::Commands::TestSpecific::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::TestCluster::Commands::TestSpecificResponse::DecodableType>,
+    CommandResponseSuccessCallback<typename chip::app::Clusters::TestCluster::Commands::TestSpecific::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::TestCluster::Commands::TestStructArgumentRequest::Type,
-                                               chip::app::Clusters::TestCluster::Commands::BooleanResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::TestCluster::Commands::TestStructArgumentRequest::Type>(
     const chip::app::Clusters::TestCluster::Commands::TestStructArgumentRequest::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::TestCluster::Commands::BooleanResponse::DecodableType>,
+    CommandResponseSuccessCallback<
+        typename chip::app::Clusters::TestCluster::Commands::TestStructArgumentRequest::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::TestCluster::Commands::TestUnknownCommand::Type,
-                                               chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::TestCluster::Commands::TestUnknownCommand::Type>(
     const chip::app::Clusters::TestCluster::Commands::TestUnknownCommand::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<typename chip::app::Clusters::TestCluster::Commands::TestUnknownCommand::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::Thermostat::Commands::ClearWeeklySchedule::Type,
-                                               chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::Thermostat::Commands::ClearWeeklySchedule::Type>(
     const chip::app::Clusters::Thermostat::Commands::ClearWeeklySchedule::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<typename chip::app::Clusters::Thermostat::Commands::ClearWeeklySchedule::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::Thermostat::Commands::GetRelayStatusLog::Type,
-                                               chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::Thermostat::Commands::GetRelayStatusLog::Type>(
     const chip::app::Clusters::Thermostat::Commands::GetRelayStatusLog::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<typename chip::app::Clusters::Thermostat::Commands::GetRelayStatusLog::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::Thermostat::Commands::GetWeeklySchedule::Type,
-                                               chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::Thermostat::Commands::GetWeeklySchedule::Type>(
     const chip::app::Clusters::Thermostat::Commands::GetWeeklySchedule::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<typename chip::app::Clusters::Thermostat::Commands::GetWeeklySchedule::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::Thermostat::Commands::SetWeeklySchedule::Type,
-                                               chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::Thermostat::Commands::SetWeeklySchedule::Type>(
     const chip::app::Clusters::Thermostat::Commands::SetWeeklySchedule::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<typename chip::app::Clusters::Thermostat::Commands::SetWeeklySchedule::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::Thermostat::Commands::SetpointRaiseLower::Type,
-                                               chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::Thermostat::Commands::SetpointRaiseLower::Type>(
     const chip::app::Clusters::Thermostat::Commands::SetpointRaiseLower::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<typename chip::app::Clusters::Thermostat::Commands::SetpointRaiseLower::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::ThreadNetworkDiagnostics::Commands::ResetCounts::Type,
-                                               chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::ThreadNetworkDiagnostics::Commands::ResetCounts::Type>(
     const chip::app::Clusters::ThreadNetworkDiagnostics::Commands::ResetCounts::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<
+        typename chip::app::Clusters::ThreadNetworkDiagnostics::Commands::ResetCounts::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::WiFiNetworkDiagnostics::Commands::ResetCounts::Type,
-                                               chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::WiFiNetworkDiagnostics::Commands::ResetCounts::Type>(
     const chip::app::Clusters::WiFiNetworkDiagnostics::Commands::ResetCounts::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<typename chip::app::Clusters::WiFiNetworkDiagnostics::Commands::ResetCounts::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::WindowCovering::Commands::DownOrClose::Type, chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::WindowCovering::Commands::DownOrClose::Type>(
     const chip::app::Clusters::WindowCovering::Commands::DownOrClose::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<typename chip::app::Clusters::WindowCovering::Commands::DownOrClose::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::WindowCovering::Commands::GoToLiftPercentage::Type,
-                                               chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::WindowCovering::Commands::GoToLiftPercentage::Type>(
     const chip::app::Clusters::WindowCovering::Commands::GoToLiftPercentage::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<typename chip::app::Clusters::WindowCovering::Commands::GoToLiftPercentage::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::WindowCovering::Commands::GoToLiftValue::Type,
-                                               chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::WindowCovering::Commands::GoToLiftValue::Type>(
     const chip::app::Clusters::WindowCovering::Commands::GoToLiftValue::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<typename chip::app::Clusters::WindowCovering::Commands::GoToLiftValue::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::WindowCovering::Commands::GoToTiltPercentage::Type,
-                                               chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::WindowCovering::Commands::GoToTiltPercentage::Type>(
     const chip::app::Clusters::WindowCovering::Commands::GoToTiltPercentage::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<typename chip::app::Clusters::WindowCovering::Commands::GoToTiltPercentage::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::WindowCovering::Commands::GoToTiltValue::Type,
-                                               chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::WindowCovering::Commands::GoToTiltValue::Type>(
     const chip::app::Clusters::WindowCovering::Commands::GoToTiltValue::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<typename chip::app::Clusters::WindowCovering::Commands::GoToTiltValue::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::WindowCovering::Commands::StopMotion::Type, chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::WindowCovering::Commands::StopMotion::Type>(
     const chip::app::Clusters::WindowCovering::Commands::StopMotion::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<typename chip::app::Clusters::WindowCovering::Commands::StopMotion::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::WindowCovering::Commands::UpOrOpen::Type, chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::WindowCovering::Commands::UpOrOpen::Type>(
     const chip::app::Clusters::WindowCovering::Commands::UpOrOpen::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<typename chip::app::Clusters::WindowCovering::Commands::UpOrOpen::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template <typename RequestDataT, typename ResponseDataT>
+template <typename RequestDataT>
 CHIP_ERROR ClusterBase::InvokeCommand(const RequestDataT & requestData, void * context,
-                                      CommandResponseSuccessCallback<ResponseDataT> successCb,
+                                      CommandResponseSuccessCallback<typename RequestDataT::ResponseType> successCb,
                                       CommandResponseFailureCallback failureCb)
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
     auto onSuccessCb = [context, successCb](const app::ConcreteCommandPath & commandPath, const app::StatusIB & aStatus,
-                                            const ResponseDataT & responseData) { successCb(context, responseData); };
+                                            const typename RequestDataT::ResponseType & responseData) {
+        successCb(context, responseData);
+    };
 
     auto onFailureCb = [context, failureCb](const app::StatusIB & aStatus, CHIP_ERROR aError) {
         failureCb(context, app::ToEmberAfStatus(aStatus.mStatus));
     };
 
-    return InvokeCommandRequest<ResponseDataT>(mDevice->GetExchangeManager(), mDevice->GetSecureSession().Value(), mEndpoint,
-                                               requestData, onSuccessCb, onFailureCb);
+    return InvokeCommandRequest(mDevice->GetExchangeManager(), mDevice->GetSecureSession().Value(), mEndpoint, requestData,
+                                onSuccessCb, onFailureCb);
 };
 
 } // namespace Controller

--- a/zzz_generated/lighting-app/zap-generated/CHIPClustersInvoke.cpp
+++ b/zzz_generated/lighting-app/zap-generated/CHIPClustersInvoke.cpp
@@ -30,22 +30,24 @@ using namespace Encoding::LittleEndian;
 
 namespace Controller {
 
-template <typename RequestDataT, typename ResponseDataT>
+template <typename RequestDataT>
 CHIP_ERROR ClusterBase::InvokeCommand(const RequestDataT & requestData, void * context,
-                                      CommandResponseSuccessCallback<ResponseDataT> successCb,
+                                      CommandResponseSuccessCallback<typename RequestDataT::ResponseType> successCb,
                                       CommandResponseFailureCallback failureCb)
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
     auto onSuccessCb = [context, successCb](const app::ConcreteCommandPath & commandPath, const app::StatusIB & aStatus,
-                                            const ResponseDataT & responseData) { successCb(context, responseData); };
+                                            const typename RequestDataT::ResponseType & responseData) {
+        successCb(context, responseData);
+    };
 
     auto onFailureCb = [context, failureCb](const app::StatusIB & aStatus, CHIP_ERROR aError) {
         failureCb(context, app::ToEmberAfStatus(aStatus.mStatus));
     };
 
-    return InvokeCommandRequest<ResponseDataT>(mDevice->GetExchangeManager(), mDevice->GetSecureSession().Value(), mEndpoint,
-                                               requestData, onSuccessCb, onFailureCb);
+    return InvokeCommandRequest(mDevice->GetExchangeManager(), mDevice->GetSecureSession().Value(), mEndpoint, requestData,
+                                onSuccessCb, onFailureCb);
 };
 
 } // namespace Controller

--- a/zzz_generated/ota-requestor-app/zap-generated/CHIPClustersInvoke.cpp
+++ b/zzz_generated/ota-requestor-app/zap-generated/CHIPClustersInvoke.cpp
@@ -30,41 +30,42 @@ using namespace Encoding::LittleEndian;
 
 namespace Controller {
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::OtaSoftwareUpdateProvider::Commands::ApplyUpdateRequest::Type,
-                           chip::app::Clusters::OtaSoftwareUpdateProvider::Commands::ApplyUpdateResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::OtaSoftwareUpdateProvider::Commands::ApplyUpdateRequest::Type>(
     const chip::app::Clusters::OtaSoftwareUpdateProvider::Commands::ApplyUpdateRequest::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::OtaSoftwareUpdateProvider::Commands::ApplyUpdateResponse::DecodableType>,
+    CommandResponseSuccessCallback<
+        typename chip::app::Clusters::OtaSoftwareUpdateProvider::Commands::ApplyUpdateRequest::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::OtaSoftwareUpdateProvider::Commands::NotifyUpdateApplied::Type,
-                                               chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::OtaSoftwareUpdateProvider::Commands::NotifyUpdateApplied::Type>(
     const chip::app::Clusters::OtaSoftwareUpdateProvider::Commands::NotifyUpdateApplied::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
-
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::OtaSoftwareUpdateProvider::Commands::QueryImage::Type,
-                           chip::app::Clusters::OtaSoftwareUpdateProvider::Commands::QueryImageResponse::DecodableType>(
-    const chip::app::Clusters::OtaSoftwareUpdateProvider::Commands::QueryImage::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::OtaSoftwareUpdateProvider::Commands::QueryImageResponse::DecodableType>,
+    CommandResponseSuccessCallback<
+        typename chip::app::Clusters::OtaSoftwareUpdateProvider::Commands::NotifyUpdateApplied::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template <typename RequestDataT, typename ResponseDataT>
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::OtaSoftwareUpdateProvider::Commands::QueryImage::Type>(
+    const chip::app::Clusters::OtaSoftwareUpdateProvider::Commands::QueryImage::Type &, void *,
+    CommandResponseSuccessCallback<
+        typename chip::app::Clusters::OtaSoftwareUpdateProvider::Commands::QueryImage::Type::ResponseType>,
+    CommandResponseFailureCallback);
+
+template <typename RequestDataT>
 CHIP_ERROR ClusterBase::InvokeCommand(const RequestDataT & requestData, void * context,
-                                      CommandResponseSuccessCallback<ResponseDataT> successCb,
+                                      CommandResponseSuccessCallback<typename RequestDataT::ResponseType> successCb,
                                       CommandResponseFailureCallback failureCb)
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
     auto onSuccessCb = [context, successCb](const app::ConcreteCommandPath & commandPath, const app::StatusIB & aStatus,
-                                            const ResponseDataT & responseData) { successCb(context, responseData); };
+                                            const typename RequestDataT::ResponseType & responseData) {
+        successCb(context, responseData);
+    };
 
     auto onFailureCb = [context, failureCb](const app::StatusIB & aStatus, CHIP_ERROR aError) {
         failureCb(context, app::ToEmberAfStatus(aStatus.mStatus));
     };
 
-    return InvokeCommandRequest<ResponseDataT>(mDevice->GetExchangeManager(), mDevice->GetSecureSession().Value(), mEndpoint,
-                                               requestData, onSuccessCb, onFailureCb);
+    return InvokeCommandRequest(mDevice->GetExchangeManager(), mDevice->GetSecureSession().Value(), mEndpoint, requestData,
+                                onSuccessCb, onFailureCb);
 };
 
 } // namespace Controller

--- a/zzz_generated/pump-app/zap-generated/CHIPClustersInvoke.cpp
+++ b/zzz_generated/pump-app/zap-generated/CHIPClustersInvoke.cpp
@@ -30,22 +30,24 @@ using namespace Encoding::LittleEndian;
 
 namespace Controller {
 
-template <typename RequestDataT, typename ResponseDataT>
+template <typename RequestDataT>
 CHIP_ERROR ClusterBase::InvokeCommand(const RequestDataT & requestData, void * context,
-                                      CommandResponseSuccessCallback<ResponseDataT> successCb,
+                                      CommandResponseSuccessCallback<typename RequestDataT::ResponseType> successCb,
                                       CommandResponseFailureCallback failureCb)
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
     auto onSuccessCb = [context, successCb](const app::ConcreteCommandPath & commandPath, const app::StatusIB & aStatus,
-                                            const ResponseDataT & responseData) { successCb(context, responseData); };
+                                            const typename RequestDataT::ResponseType & responseData) {
+        successCb(context, responseData);
+    };
 
     auto onFailureCb = [context, failureCb](const app::StatusIB & aStatus, CHIP_ERROR aError) {
         failureCb(context, app::ToEmberAfStatus(aStatus.mStatus));
     };
 
-    return InvokeCommandRequest<ResponseDataT>(mDevice->GetExchangeManager(), mDevice->GetSecureSession().Value(), mEndpoint,
-                                               requestData, onSuccessCb, onFailureCb);
+    return InvokeCommandRequest(mDevice->GetExchangeManager(), mDevice->GetSecureSession().Value(), mEndpoint, requestData,
+                                onSuccessCb, onFailureCb);
 };
 
 } // namespace Controller

--- a/zzz_generated/pump-controller-app/zap-generated/CHIPClustersInvoke.cpp
+++ b/zzz_generated/pump-controller-app/zap-generated/CHIPClustersInvoke.cpp
@@ -30,77 +30,79 @@ using namespace Encoding::LittleEndian;
 
 namespace Controller {
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::LevelControl::Commands::Move::Type, chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::LevelControl::Commands::Move::Type>(
     const chip::app::Clusters::LevelControl::Commands::Move::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<typename chip::app::Clusters::LevelControl::Commands::Move::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::LevelControl::Commands::MoveToLevel::Type, chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::LevelControl::Commands::MoveToLevel::Type>(
     const chip::app::Clusters::LevelControl::Commands::MoveToLevel::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<typename chip::app::Clusters::LevelControl::Commands::MoveToLevel::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::LevelControl::Commands::MoveToLevelWithOnOff::Type,
-                                               chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::LevelControl::Commands::MoveToLevelWithOnOff::Type>(
     const chip::app::Clusters::LevelControl::Commands::MoveToLevelWithOnOff::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<typename chip::app::Clusters::LevelControl::Commands::MoveToLevelWithOnOff::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::LevelControl::Commands::MoveWithOnOff::Type, chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::LevelControl::Commands::MoveWithOnOff::Type>(
     const chip::app::Clusters::LevelControl::Commands::MoveWithOnOff::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<typename chip::app::Clusters::LevelControl::Commands::MoveWithOnOff::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::LevelControl::Commands::Step::Type, chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::LevelControl::Commands::Step::Type>(
     const chip::app::Clusters::LevelControl::Commands::Step::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<typename chip::app::Clusters::LevelControl::Commands::Step::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::LevelControl::Commands::StepWithOnOff::Type, chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::LevelControl::Commands::StepWithOnOff::Type>(
     const chip::app::Clusters::LevelControl::Commands::StepWithOnOff::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<typename chip::app::Clusters::LevelControl::Commands::StepWithOnOff::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::LevelControl::Commands::Stop::Type, chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::LevelControl::Commands::Stop::Type>(
     const chip::app::Clusters::LevelControl::Commands::Stop::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<typename chip::app::Clusters::LevelControl::Commands::Stop::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::LevelControl::Commands::StopWithOnOff::Type, chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::LevelControl::Commands::StopWithOnOff::Type>(
     const chip::app::Clusters::LevelControl::Commands::StopWithOnOff::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<typename chip::app::Clusters::LevelControl::Commands::StopWithOnOff::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::OnOff::Commands::Off::Type, chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::OnOff::Commands::Off::Type>(
     const chip::app::Clusters::OnOff::Commands::Off::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<typename chip::app::Clusters::OnOff::Commands::Off::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::OnOff::Commands::On::Type, chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::OnOff::Commands::On::Type>(
     const chip::app::Clusters::OnOff::Commands::On::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<typename chip::app::Clusters::OnOff::Commands::On::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::OnOff::Commands::Toggle::Type, chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::OnOff::Commands::Toggle::Type>(
     const chip::app::Clusters::OnOff::Commands::Toggle::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<typename chip::app::Clusters::OnOff::Commands::Toggle::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template <typename RequestDataT, typename ResponseDataT>
+template <typename RequestDataT>
 CHIP_ERROR ClusterBase::InvokeCommand(const RequestDataT & requestData, void * context,
-                                      CommandResponseSuccessCallback<ResponseDataT> successCb,
+                                      CommandResponseSuccessCallback<typename RequestDataT::ResponseType> successCb,
                                       CommandResponseFailureCallback failureCb)
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
     auto onSuccessCb = [context, successCb](const app::ConcreteCommandPath & commandPath, const app::StatusIB & aStatus,
-                                            const ResponseDataT & responseData) { successCb(context, responseData); };
+                                            const typename RequestDataT::ResponseType & responseData) {
+        successCb(context, responseData);
+    };
 
     auto onFailureCb = [context, failureCb](const app::StatusIB & aStatus, CHIP_ERROR aError) {
         failureCb(context, app::ToEmberAfStatus(aStatus.mStatus));
     };
 
-    return InvokeCommandRequest<ResponseDataT>(mDevice->GetExchangeManager(), mDevice->GetSecureSession().Value(), mEndpoint,
-                                               requestData, onSuccessCb, onFailureCb);
+    return InvokeCommandRequest(mDevice->GetExchangeManager(), mDevice->GetSecureSession().Value(), mEndpoint, requestData,
+                                onSuccessCb, onFailureCb);
 };
 
 } // namespace Controller

--- a/zzz_generated/thermostat/zap-generated/CHIPClustersInvoke.cpp
+++ b/zzz_generated/thermostat/zap-generated/CHIPClustersInvoke.cpp
@@ -30,33 +30,34 @@ using namespace Encoding::LittleEndian;
 
 namespace Controller {
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::Identify::Commands::Identify::Type, chip::app::DataModel::NullObjectType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::Identify::Commands::Identify::Type>(
     const chip::app::Clusters::Identify::Commands::Identify::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
-
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::Identify::Commands::IdentifyQuery::Type,
-                                               chip::app::Clusters::Identify::Commands::IdentifyQueryResponse::DecodableType>(
-    const chip::app::Clusters::Identify::Commands::IdentifyQuery::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::Identify::Commands::IdentifyQueryResponse::DecodableType>,
+    CommandResponseSuccessCallback<typename chip::app::Clusters::Identify::Commands::Identify::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template <typename RequestDataT, typename ResponseDataT>
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::Identify::Commands::IdentifyQuery::Type>(
+    const chip::app::Clusters::Identify::Commands::IdentifyQuery::Type &, void *,
+    CommandResponseSuccessCallback<typename chip::app::Clusters::Identify::Commands::IdentifyQuery::Type::ResponseType>,
+    CommandResponseFailureCallback);
+
+template <typename RequestDataT>
 CHIP_ERROR ClusterBase::InvokeCommand(const RequestDataT & requestData, void * context,
-                                      CommandResponseSuccessCallback<ResponseDataT> successCb,
+                                      CommandResponseSuccessCallback<typename RequestDataT::ResponseType> successCb,
                                       CommandResponseFailureCallback failureCb)
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
     auto onSuccessCb = [context, successCb](const app::ConcreteCommandPath & commandPath, const app::StatusIB & aStatus,
-                                            const ResponseDataT & responseData) { successCb(context, responseData); };
+                                            const typename RequestDataT::ResponseType & responseData) {
+        successCb(context, responseData);
+    };
 
     auto onFailureCb = [context, failureCb](const app::StatusIB & aStatus, CHIP_ERROR aError) {
         failureCb(context, app::ToEmberAfStatus(aStatus.mStatus));
     };
 
-    return InvokeCommandRequest<ResponseDataT>(mDevice->GetExchangeManager(), mDevice->GetSecureSession().Value(), mEndpoint,
-                                               requestData, onSuccessCb, onFailureCb);
+    return InvokeCommandRequest(mDevice->GetExchangeManager(), mDevice->GetSecureSession().Value(), mEndpoint, requestData,
+                                onSuccessCb, onFailureCb);
 };
 
 } // namespace Controller

--- a/zzz_generated/tv-app/zap-generated/CHIPClustersInvoke.cpp
+++ b/zzz_generated/tv-app/zap-generated/CHIPClustersInvoke.cpp
@@ -30,116 +30,105 @@ using namespace Encoding::LittleEndian;
 
 namespace Controller {
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::GeneralCommissioning::Commands::ArmFailSafe::Type,
-                           chip::app::Clusters::GeneralCommissioning::Commands::ArmFailSafeResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::GeneralCommissioning::Commands::ArmFailSafe::Type>(
     const chip::app::Clusters::GeneralCommissioning::Commands::ArmFailSafe::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::GeneralCommissioning::Commands::ArmFailSafeResponse::DecodableType>,
+    CommandResponseSuccessCallback<typename chip::app::Clusters::GeneralCommissioning::Commands::ArmFailSafe::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::GeneralCommissioning::Commands::CommissioningComplete::Type,
-                           chip::app::Clusters::GeneralCommissioning::Commands::CommissioningCompleteResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::GeneralCommissioning::Commands::CommissioningComplete::Type>(
     const chip::app::Clusters::GeneralCommissioning::Commands::CommissioningComplete::Type &, void *,
     CommandResponseSuccessCallback<
-        chip::app::Clusters::GeneralCommissioning::Commands::CommissioningCompleteResponse::DecodableType>,
+        typename chip::app::Clusters::GeneralCommissioning::Commands::CommissioningComplete::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::GeneralCommissioning::Commands::SetRegulatoryConfig::Type,
-                           chip::app::Clusters::GeneralCommissioning::Commands::SetRegulatoryConfigResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::GeneralCommissioning::Commands::SetRegulatoryConfig::Type>(
     const chip::app::Clusters::GeneralCommissioning::Commands::SetRegulatoryConfig::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::GeneralCommissioning::Commands::SetRegulatoryConfigResponse::DecodableType>,
+    CommandResponseSuccessCallback<
+        typename chip::app::Clusters::GeneralCommissioning::Commands::SetRegulatoryConfig::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::NetworkCommissioning::Commands::DisableNetwork::Type,
-                           chip::app::Clusters::NetworkCommissioning::Commands::DisableNetworkResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::NetworkCommissioning::Commands::DisableNetwork::Type>(
     const chip::app::Clusters::NetworkCommissioning::Commands::DisableNetwork::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::NetworkCommissioning::Commands::DisableNetworkResponse::DecodableType>,
+    CommandResponseSuccessCallback<
+        typename chip::app::Clusters::NetworkCommissioning::Commands::DisableNetwork::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::NetworkCommissioning::Commands::EnableNetwork::Type,
-                           chip::app::Clusters::NetworkCommissioning::Commands::EnableNetworkResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::NetworkCommissioning::Commands::EnableNetwork::Type>(
     const chip::app::Clusters::NetworkCommissioning::Commands::EnableNetwork::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::NetworkCommissioning::Commands::EnableNetworkResponse::DecodableType>,
+    CommandResponseSuccessCallback<typename chip::app::Clusters::NetworkCommissioning::Commands::EnableNetwork::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::NetworkCommissioning::Commands::RemoveNetwork::Type,
-                           chip::app::Clusters::NetworkCommissioning::Commands::RemoveNetworkResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::NetworkCommissioning::Commands::RemoveNetwork::Type>(
     const chip::app::Clusters::NetworkCommissioning::Commands::RemoveNetwork::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::NetworkCommissioning::Commands::RemoveNetworkResponse::DecodableType>,
+    CommandResponseSuccessCallback<typename chip::app::Clusters::NetworkCommissioning::Commands::RemoveNetwork::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::NetworkCommissioning::Commands::ScanNetworks::Type,
-                           chip::app::Clusters::NetworkCommissioning::Commands::ScanNetworksResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::NetworkCommissioning::Commands::ScanNetworks::Type>(
     const chip::app::Clusters::NetworkCommissioning::Commands::ScanNetworks::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::NetworkCommissioning::Commands::ScanNetworksResponse::DecodableType>,
+    CommandResponseSuccessCallback<typename chip::app::Clusters::NetworkCommissioning::Commands::ScanNetworks::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::OperationalCredentials::Commands::AddNOC::Type,
-                                               chip::app::Clusters::OperationalCredentials::Commands::NOCResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::OperationalCredentials::Commands::AddNOC::Type>(
     const chip::app::Clusters::OperationalCredentials::Commands::AddNOC::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::OperationalCredentials::Commands::NOCResponse::DecodableType>,
+    CommandResponseSuccessCallback<typename chip::app::Clusters::OperationalCredentials::Commands::AddNOC::Type::ResponseType>,
     CommandResponseFailureCallback);
 
 template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::OperationalCredentials::Commands::AddTrustedRootCertificate::Type,
-                           chip::app::DataModel::NullObjectType>(
+ClusterBase::InvokeCommand<chip::app::Clusters::OperationalCredentials::Commands::AddTrustedRootCertificate::Type>(
     const chip::app::Clusters::OperationalCredentials::Commands::AddTrustedRootCertificate::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::DataModel::NullObjectType>, CommandResponseFailureCallback);
+    CommandResponseSuccessCallback<
+        typename chip::app::Clusters::OperationalCredentials::Commands::AddTrustedRootCertificate::Type::ResponseType>,
+    CommandResponseFailureCallback);
 
-template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::OperationalCredentials::Commands::AttestationRequest::Type,
-                           chip::app::Clusters::OperationalCredentials::Commands::AttestationResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::OperationalCredentials::Commands::AttestationRequest::Type>(
     const chip::app::Clusters::OperationalCredentials::Commands::AttestationRequest::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::OperationalCredentials::Commands::AttestationResponse::DecodableType>,
+    CommandResponseSuccessCallback<
+        typename chip::app::Clusters::OperationalCredentials::Commands::AttestationRequest::Type::ResponseType>,
     CommandResponseFailureCallback);
 
 template CHIP_ERROR
-ClusterBase::InvokeCommand<chip::app::Clusters::OperationalCredentials::Commands::CertificateChainRequest::Type,
-                           chip::app::Clusters::OperationalCredentials::Commands::CertificateChainResponse::DecodableType>(
+ClusterBase::InvokeCommand<chip::app::Clusters::OperationalCredentials::Commands::CertificateChainRequest::Type>(
     const chip::app::Clusters::OperationalCredentials::Commands::CertificateChainRequest::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::OperationalCredentials::Commands::CertificateChainResponse::DecodableType>,
+    CommandResponseSuccessCallback<
+        typename chip::app::Clusters::OperationalCredentials::Commands::CertificateChainRequest::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::OperationalCredentials::Commands::OpCSRRequest::Type,
-                                               chip::app::Clusters::OperationalCredentials::Commands::OpCSRResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::OperationalCredentials::Commands::OpCSRRequest::Type>(
     const chip::app::Clusters::OperationalCredentials::Commands::OpCSRRequest::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::OperationalCredentials::Commands::OpCSRResponse::DecodableType>,
+    CommandResponseSuccessCallback<
+        typename chip::app::Clusters::OperationalCredentials::Commands::OpCSRRequest::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::OperationalCredentials::Commands::RemoveFabric::Type,
-                                               chip::app::Clusters::OperationalCredentials::Commands::NOCResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::OperationalCredentials::Commands::RemoveFabric::Type>(
     const chip::app::Clusters::OperationalCredentials::Commands::RemoveFabric::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::OperationalCredentials::Commands::NOCResponse::DecodableType>,
+    CommandResponseSuccessCallback<
+        typename chip::app::Clusters::OperationalCredentials::Commands::RemoveFabric::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::OperationalCredentials::Commands::UpdateFabricLabel::Type,
-                                               chip::app::Clusters::OperationalCredentials::Commands::NOCResponse::DecodableType>(
+template CHIP_ERROR ClusterBase::InvokeCommand<chip::app::Clusters::OperationalCredentials::Commands::UpdateFabricLabel::Type>(
     const chip::app::Clusters::OperationalCredentials::Commands::UpdateFabricLabel::Type &, void *,
-    CommandResponseSuccessCallback<chip::app::Clusters::OperationalCredentials::Commands::NOCResponse::DecodableType>,
+    CommandResponseSuccessCallback<
+        typename chip::app::Clusters::OperationalCredentials::Commands::UpdateFabricLabel::Type::ResponseType>,
     CommandResponseFailureCallback);
 
-template <typename RequestDataT, typename ResponseDataT>
+template <typename RequestDataT>
 CHIP_ERROR ClusterBase::InvokeCommand(const RequestDataT & requestData, void * context,
-                                      CommandResponseSuccessCallback<ResponseDataT> successCb,
+                                      CommandResponseSuccessCallback<typename RequestDataT::ResponseType> successCb,
                                       CommandResponseFailureCallback failureCb)
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
     auto onSuccessCb = [context, successCb](const app::ConcreteCommandPath & commandPath, const app::StatusIB & aStatus,
-                                            const ResponseDataT & responseData) { successCb(context, responseData); };
+                                            const typename RequestDataT::ResponseType & responseData) {
+        successCb(context, responseData);
+    };
 
     auto onFailureCb = [context, failureCb](const app::StatusIB & aStatus, CHIP_ERROR aError) {
         failureCb(context, app::ToEmberAfStatus(aStatus.mStatus));
     };
 
-    return InvokeCommandRequest<ResponseDataT>(mDevice->GetExchangeManager(), mDevice->GetSecureSession().Value(), mEndpoint,
-                                               requestData, onSuccessCb, onFailureCb);
+    return InvokeCommandRequest(mDevice->GetExchangeManager(), mDevice->GetSecureSession().Value(), mEndpoint, requestData,
+                                onSuccessCb, onFailureCb);
 };
 
 } // namespace Controller


### PR DESCRIPTION
#### Problem
It's possible to mess up sending a command by saying you are sending command X and expecting response Y, when Y is not the response to command X.

#### Change overview
Hang the response type off the command type.

#### Testing
No behavior changes, just simpler code (outside the cluster-objects file, at least).