### PR TITLE
[Darwin] Use InvokeCommand instead of CHIPClusters.cpp for commands

### DIFF
--- a/src/darwin/Framework/CHIP.xcodeproj/project.pbxproj
+++ b/src/darwin/Framework/CHIP.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		1ED276E026C57CF000547A89 /* CHIPCallbackBridge.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1ED276DF26C57CF000547A89 /* CHIPCallbackBridge.mm */; };
 		1ED276E226C5812A00547A89 /* CHIPCluster.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1ED276E126C5812A00547A89 /* CHIPCluster.mm */; };
 		1ED276E426C5832500547A89 /* CHIPCluster.h in Headers */ = {isa = PBXBuildFile; fileRef = 1ED276E326C5832500547A89 /* CHIPCluster.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1EF900A0273AC39C006A4018 /* CHIPClustersInvoke.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1EF9009E273AC39C006A4018 /* CHIPClustersInvoke.cpp */; };
 		2C1B027A2641DB4E00780EF1 /* CHIPOperationalCredentialsDelegate.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2C1B02782641DB4E00780EF1 /* CHIPOperationalCredentialsDelegate.mm */; };
 		2C1B027B2641DB4E00780EF1 /* CHIPOperationalCredentialsDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 2C1B02792641DB4E00780EF1 /* CHIPOperationalCredentialsDelegate.h */; };
 		2C222AD0255C620600E446B9 /* CHIPDevice.h in Headers */ = {isa = PBXBuildFile; fileRef = 2C222ACE255C620600E446B9 /* CHIPDevice.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -124,6 +125,7 @@
 		1ED276DF26C57CF000547A89 /* CHIPCallbackBridge.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = CHIPCallbackBridge.mm; path = "zap-generated/CHIPCallbackBridge.mm"; sourceTree = "<group>"; };
 		1ED276E126C5812A00547A89 /* CHIPCluster.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CHIPCluster.mm; sourceTree = "<group>"; };
 		1ED276E326C5832500547A89 /* CHIPCluster.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CHIPCluster.h; sourceTree = "<group>"; };
+		1EF9009E273AC39C006A4018 /* CHIPClustersInvoke.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CHIPClustersInvoke.cpp; path = "../../../../zzz_generated/controller-clusters/zap-generated/CHIPClustersInvoke.cpp"; sourceTree = "<group>"; };
 		2C1B02782641DB4E00780EF1 /* CHIPOperationalCredentialsDelegate.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CHIPOperationalCredentialsDelegate.mm; sourceTree = "<group>"; };
 		2C1B02792641DB4E00780EF1 /* CHIPOperationalCredentialsDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CHIPOperationalCredentialsDelegate.h; sourceTree = "<group>"; };
 		2C222ACE255C620600E446B9 /* CHIPDevice.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CHIPDevice.h; sourceTree = "<group>"; };
@@ -222,6 +224,7 @@
 		1EC4CE5825CC26AB00D7304F /* CHIPGeneratedFiles */ = {
 			isa = PBXGroup;
 			children = (
+				1EF9009E273AC39C006A4018 /* CHIPClustersInvoke.cpp */,
 				1EC3238C271999E2002A8BF0 /* cluster-objects.cpp */,
 				1E16A8F926B9835600683C53 /* CHIPTestClustersObjc.h */,
 				1E16A8FA26B9835700683C53 /* CHIPTestClustersObjc.mm */,
@@ -517,6 +520,7 @@
 				B2E0D7B6245B0B5C003C5B48 /* CHIPManualSetupPayloadParser.mm in Sources */,
 				1E85732826551A490050A4D9 /* attribute-table.cpp in Sources */,
 				1E85732626551A490050A4D9 /* attribute-storage.cpp in Sources */,
+				1EF900A0273AC39C006A4018 /* CHIPClustersInvoke.cpp in Sources */,
 				1E85732C26551A490050A4D9 /* DataModelHandler.cpp in Sources */,
 				1E85733126551A490050A4D9 /* chip-message-send.cpp in Sources */,
 				1E85730F265519AE0050A4D9 /* attribute-size.cpp in Sources */,

--- a/src/darwin/Framework/CHIP/CHIPCallbackBridgeBase_internal.h
+++ b/src/darwin/Framework/CHIP/CHIPCallbackBridgeBase_internal.h
@@ -21,6 +21,7 @@
 #import "zap-generated/CHIPClientCallbacks.h"
 #import "zap-generated/CHIPClustersObjc.h"
 
+#include <app/data-model/NullObject.h>
 #include <platform/CHIPDeviceLayer.h>
 
 typedef CHIP_ERROR (^CHIPActionBlock)(chip::Callback::Cancelable * success, chip::Callback::Cancelable * failure);

--- a/src/darwin/Framework/CHIP/templates/CHIPCallbackBridge_internal.zapt
+++ b/src/darwin/Framework/CHIP/templates/CHIPCallbackBridge_internal.zapt
@@ -7,6 +7,15 @@
 #include <app/data-model/DecodableList.h>
 #include <app-common/zap-generated/cluster-objects.h>
 
+typedef void (*CHIPDefaultSuccessCallbackType)(void *, const chip::app::DataModel::NullObjectType &);
+typedef void (*CHIPDefaultFailureCallbackType)(void *, EmberAfStatus);
+
+{{#chip_client_clusters}}
+{{#chip_cluster_responses}}
+typedef void (*CHIP{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}CallbackType)(void *, const chip::app::Clusters::{{asUpperCamelCase parent.name}}::Commands::{{asUpperCamelCase name}}::DecodableType &);
+{{/chip_cluster_responses}}
+{{/chip_client_clusters}}
+
 {{#>CHIPCallbackBridge header="1" partial-type=""            }}DefaultSuccessCallback{{/CHIPCallbackBridge}}
 {{#>CHIPCallbackBridge header="1" partial-type="Octet_String"}}OctetStringAttributeCallback{{/CHIPCallbackBridge}}
 {{#>CHIPCallbackBridge header="1" partial-type="Char_String" }}CharStringAttributeCallback{{/CHIPCallbackBridge}}

--- a/src/darwin/Framework/CHIP/templates/CHIPClustersObjc-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/CHIPClustersObjc-src.zapt
@@ -9,10 +9,11 @@
 #import "CHIPDevice.h"
 #import "CHIPDevice_Internal.h"
 
+using chip::Callback::Callback;
 using chip::Callback::Cancelable;
+using namespace chip::app::Clusters;
 
 {{#chip_client_clusters}}
-
 @implementation CHIP{{asUpperCamelCase name}}
 
 - (chip::Controller::ClusterBase *)getCluster
@@ -22,25 +23,18 @@ using chip::Callback::Cancelable;
 
 {{#chip_cluster_commands}}
 {{#*inline "callbackName"}}{{#if hasSpecificResponse}}{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase responseName}}{{else}}DefaultSuccess{{/if}}{{/inline}}
-{{#*inline "callbackParams"}}{{#chip_cluster_command_arguments_with_structs_expanded}},
-  {{#if_chip_enum type}}
-    static_cast<{{chipType}}>({{asLowerCamelCase label}})
-  {{else if (isOctetString type)}}
-    [self asByteSpan:{{asLowerCamelCase label}}]
-  {{else if (isCharString type)}}
-    [self asCharSpan:{{asLowerCamelCase label}}]
-  {{else}}
-    {{asLowerCamelCase label}}
-  {{/if_chip_enum}}
-{{/chip_cluster_command_arguments_with_structs_expanded}}{{/inline}}
 {{#if (zcl_command_arguments_count this.id)}}
 - (void){{asLowerCamelCase name}}:{{#chip_cluster_command_arguments_with_structs_expanded}}{{#not_first}}{{asLowerCamelCase label}}:{{/not_first}}({{asObjectiveCBasicType type}}){{asLowerCamelCase label}} {{/chip_cluster_command_arguments_with_structs_expanded}}responseHandler:(ResponseHandler)responseHandler
 {{else}}
 - (void){{asLowerCamelCase name}}:(ResponseHandler)responseHandler
 {{/if}}
 {
+    {{>encode_command}}
+
     new CHIP{{>callbackName}}CallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.{{asUpperCamelCase name}}(success, failure{{>callbackParams}});
+        auto successFn = Callback<CHIP{{>callbackName}}CallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 {{/chip_cluster_commands}}

--- a/src/darwin/Framework/CHIP/templates/partials/CHIPCallbackBridge.zapt
+++ b/src/darwin/Framework/CHIP/templates/partials/CHIPCallbackBridge.zapt
@@ -1,14 +1,15 @@
 {{#if header}}
-class CHIP{{> @partial-block}}Bridge : public CHIPCallbackBridge<{{> @partial-block}}>
+{{#*inline "callbackType"}}{{#if (isStrEqual partial-type "Command")}}CHIP{{> @partial-block}}Type{{else}}{{> @partial-block}}{{/if}}{{/inline}}
+class CHIP{{> @partial-block}}Bridge : public CHIPCallbackBridge<{{>callbackType}}>
 {
 public:
     CHIP{{> @partial-block}}Bridge(dispatch_queue_t queue, ResponseHandler handler, CHIPActionBlock action, bool keepAlive = false)
-      : CHIPCallbackBridge<{{> @partial-block}}>(queue, handler, action, OnSuccessFn, keepAlive)
+      : CHIPCallbackBridge<{{>callbackType}}>(queue, handler, action, OnSuccessFn, keepAlive)
       {};
     
     static void OnSuccessFn(void * context
       {{#if (isStrEqual partial-type "Command")}}
-      {{#chip_cluster_response_arguments}}, {{asUnderlyingZclType type}} {{asSymbol label}}{{/chip_cluster_response_arguments}}
+      , const chip::app::Clusters::{{asUpperCamelCase parent.name}}::Commands::{{asUpperCamelCase name}}::DecodableType & data
       {{else if (isStrEqual partial-type "List")}}
       , {{zapTypeToDecodableClusterObjectType type ns=parent.name isArgument=true}} list
       {{else if partial-type}}
@@ -20,7 +21,7 @@ public:
 {{else}}
 void CHIP{{> @partial-block}}Bridge::OnSuccessFn(void * context
   {{#if (isStrEqual partial-type "Command")}}
-  {{#chip_cluster_response_arguments}}, {{asUnderlyingZclType type}} {{asSymbol label}}{{/chip_cluster_response_arguments}}
+  , const chip::app::Clusters::{{asUpperCamelCase parent.name}}::Commands::{{asUpperCamelCase name}}::DecodableType & data
   {{else if (isStrEqual partial-type "List")}}
   , {{zapTypeToDecodableClusterObjectType type ns=parent.name isArgument=true}} list
   {{else if partial-type}}
@@ -30,20 +31,8 @@ void CHIP{{> @partial-block}}Bridge::OnSuccessFn(void * context
 )
 {
     {{#if (isStrEqual partial-type "Command")}}
-    DispatchSuccess(context, @{
-      {{#chip_cluster_response_arguments}}
-      {{#if isArray}}
-      // {{asSymbol label}} : {{asUnderlyingZclType type}}
-      // Conversion from this type to Objc is not properly implemented yet
-      {{else if (isOctetString type)}}
-      @"{{asSymbol label}}" : [NSData dataWithBytes:{{asSymbol label}}.data() length:{{asSymbol label}}.size()],
-      {{else if (isCharString type)}}
-      @"{{asSymbol label}}" : [[NSString alloc] initWithBytes:{{asSymbol label}}.data() length:{{asSymbol label}}.size() encoding:NSUTF8StringEncoding],
-      {{else}}
-      @"{{asSymbol label}}" : [NSNumber numberWith{{asObjectiveCNumberType label type false}}:{{asSymbol label}}],
-      {{/if}}
-      {{/chip_cluster_response_arguments}}
-    });
+    {{>decode_response}}
+    DispatchSuccess(context, response);
     {{else if (isStrEqual partial-type "List")}}
     id array = [[NSMutableArray alloc] init];
     auto iter = list.begin();

--- a/src/darwin/Framework/CHIP/templates/partials/decode_response.zapt
+++ b/src/darwin/Framework/CHIP/templates/partials/decode_response.zapt
@@ -1,0 +1,15 @@
+id response = @{
+  {{#chip_cluster_response_arguments}}
+  @"{{asSymbol label}}": {{#if isOptional}}data.{{asLowerCamelCase label}}.HasValue() == false ? [NSNull null] : {{#if isNullable}}data.{{asLowerCamelCase label}}.Value().IsNull() ? [NSNull null] : {{/if}}{{/if}}
+    {{~#*inline "item"}}data.{{asLowerCamelCase name}}{{#if isOptional}}.Value(){{/if}}{{#if isNullable}}.Value(){{/if}}{{/inline}}
+    {{#if isArray}}
+    [NSNull null], /* Array - Conversion from this type to Objc is not properly implemented yet */
+    {{else if (isOctetString type)}}
+    [NSData dataWithBytes:{{>item}}.data() length:{{>item}}.size()],
+    {{else if (isCharString type)}}
+    [[NSString alloc] initWithBytes:{{>item}}.data() length:{{>item}}.size() encoding:NSUTF8StringEncoding],
+    {{else}}
+    [NSNumber numberWith{{asObjectiveCNumberType label type false}}:{{>item}}],
+    {{/if}}
+  {{/chip_cluster_response_arguments}}
+};

--- a/src/darwin/Framework/CHIP/templates/partials/encode_command.zapt
+++ b/src/darwin/Framework/CHIP/templates/partials/encode_command.zapt
@@ -1,0 +1,24 @@
+{{asUpperCamelCase parent.name}}::Commands::{{asUpperCamelCase name}}::Type request;
+{{#chip_cluster_command_arguments}}
+  {{#*inline "value"}}
+  {{! TODO Implement complex types parsing in order to properly set the request parameters }}
+  {{#if isArray}}
+  {{zapTypeToEncodableClusterObjectType type ns=parent.parent.name}}();
+  {{else if isStruct}}
+  {{zapTypeToEncodableClusterObjectType type ns=parent.parent.name}}();
+  {{else if (isOctetString type)}}
+  [self asByteSpan:{{asLowerCamelCase label}}]
+  {{else if (isCharString type)}}
+  [self asCharSpan:{{asLowerCamelCase label}}]
+  {{else if isBitmap}}
+  static_cast<decltype(request.{{asLowerCamelCase label}})>({{asLowerCamelCase label}})
+  {{else}}
+    {{#if_chip_enum type}}
+  static_cast<decltype(request.{{asLowerCamelCase label}})>({{asLowerCamelCase label}})
+    {{else}}
+  {{asLowerCamelCase label}}
+    {{/if_chip_enum}}
+  {{/if}}
+  {{/inline}}
+  request.{{asLowerCamelCase label}} = {{#if isOptional}}{{zapTypeToEncodableClusterObjectType type ns=parent.parent.name}}({{/if}}{{#if isNullable}}chip::app::DataModel::Nullable<{{chipType}}>({{/if}}{{>value}}{{#if isNullable}}){{/if}}{{#if isOptional}}){{/if}};
+{{/chip_cluster_command_arguments}}

--- a/src/darwin/Framework/CHIP/templates/templates.json
+++ b/src/darwin/Framework/CHIP/templates/templates.json
@@ -23,6 +23,14 @@
         {
             "name": "CHIPCallbackBridge",
             "path": "partials/CHIPCallbackBridge.zapt"
+        },
+        {
+            "name": "encode_command",
+            "path": "partials/encode_command.zapt"
+        },
+        {
+            "name": "decode_response",
+            "path": "partials/decode_response.zapt"
         }
     ],
     "templates": [

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPCallbackBridge.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPCallbackBridge.mm
@@ -762,670 +762,823 @@ void CHIPThreadNetworkDiagnosticsActiveNetworkFaultsListListAttributeCallbackBri
     DispatchSuccess(context, @ { @"value" : array });
 };
 
-void CHIPAccountLoginClusterGetSetupPINResponseCallbackBridge::OnSuccessFn(void * context, chip::CharSpan setupPIN)
+void CHIPAccountLoginClusterGetSetupPINResponseCallbackBridge::OnSuccessFn(
+    void * context, const chip::app::Clusters::AccountLogin::Commands::GetSetupPINResponse::DecodableType & data)
 {
-    DispatchSuccess(context, @ {
-        @"setupPIN" : [[NSString alloc] initWithBytes:setupPIN.data() length:setupPIN.size() encoding:NSUTF8StringEncoding],
-    });
+    id response = @ {
+        @"setupPIN" : [[NSString alloc] initWithBytes:data.setupPIN.data()
+                                               length:data.setupPIN.size()
+                                             encoding:NSUTF8StringEncoding],
+    };
+    DispatchSuccess(context, response);
 };
 
-void CHIPApplicationLauncherClusterLaunchAppResponseCallbackBridge::OnSuccessFn(void * context, uint8_t status, chip::CharSpan data)
+void CHIPApplicationLauncherClusterLaunchAppResponseCallbackBridge::OnSuccessFn(
+    void * context, const chip::app::Clusters::ApplicationLauncher::Commands::LaunchAppResponse::DecodableType & data)
 {
-    DispatchSuccess(context, @ {
-        @"status" : [NSNumber numberWithUnsignedChar:status],
-        @"data" : [[NSString alloc] initWithBytes:data.data() length:data.size() encoding:NSUTF8StringEncoding],
-    });
+    id response = @ {
+        @"status" : [NSNumber numberWithUnsignedChar:data.status],
+        @"data" : [[NSString alloc] initWithBytes:data.data.data() length:data.data.size() encoding:NSUTF8StringEncoding],
+    };
+    DispatchSuccess(context, response);
 };
 
 void CHIPContentLauncherClusterLaunchContentResponseCallbackBridge::OnSuccessFn(
-    void * context, chip::CharSpan data, uint8_t contentLaunchStatus)
+    void * context, const chip::app::Clusters::ContentLauncher::Commands::LaunchContentResponse::DecodableType & data)
 {
-    DispatchSuccess(context, @ {
-        @"data" : [[NSString alloc] initWithBytes:data.data() length:data.size() encoding:NSUTF8StringEncoding],
-        @"contentLaunchStatus" : [NSNumber numberWithUnsignedChar:contentLaunchStatus],
-    });
+    id response = @ {
+        @"data" : [[NSString alloc] initWithBytes:data.data.data() length:data.data.size() encoding:NSUTF8StringEncoding],
+        @"contentLaunchStatus" : [NSNumber numberWithUnsignedChar:data.contentLaunchStatus],
+    };
+    DispatchSuccess(context, response);
 };
 
 void CHIPContentLauncherClusterLaunchURLResponseCallbackBridge::OnSuccessFn(
-    void * context, chip::CharSpan data, uint8_t contentLaunchStatus)
+    void * context, const chip::app::Clusters::ContentLauncher::Commands::LaunchURLResponse::DecodableType & data)
 {
-    DispatchSuccess(context, @ {
-        @"data" : [[NSString alloc] initWithBytes:data.data() length:data.size() encoding:NSUTF8StringEncoding],
-        @"contentLaunchStatus" : [NSNumber numberWithUnsignedChar:contentLaunchStatus],
-    });
+    id response = @ {
+        @"data" : [[NSString alloc] initWithBytes:data.data.data() length:data.data.size() encoding:NSUTF8StringEncoding],
+        @"contentLaunchStatus" : [NSNumber numberWithUnsignedChar:data.contentLaunchStatus],
+    };
+    DispatchSuccess(context, response);
 };
 
 void CHIPDiagnosticLogsClusterRetrieveLogsResponseCallbackBridge::OnSuccessFn(
-    void * context, uint8_t status, chip::ByteSpan content, uint32_t timeStamp, uint32_t timeSinceBoot)
+    void * context, const chip::app::Clusters::DiagnosticLogs::Commands::RetrieveLogsResponse::DecodableType & data)
 {
-    DispatchSuccess(context, @ {
-        @"status" : [NSNumber numberWithUnsignedChar:status],
-        @"content" : [NSData dataWithBytes:content.data() length:content.size()],
-        @"timeStamp" : [NSNumber numberWithUnsignedLong:timeStamp],
-        @"timeSinceBoot" : [NSNumber numberWithUnsignedLong:timeSinceBoot],
-    });
+    id response = @ {
+        @"status" : [NSNumber numberWithUnsignedChar:data.status],
+        @"content" : [NSData dataWithBytes:data.content.data() length:data.content.size()],
+        @"timeStamp" : [NSNumber numberWithUnsignedLong:data.timeStamp],
+        @"timeSinceBoot" : [NSNumber numberWithUnsignedLong:data.timeSinceBoot],
+    };
+    DispatchSuccess(context, response);
 };
 
-void CHIPDoorLockClusterClearAllPinsResponseCallbackBridge::OnSuccessFn(void * context, uint8_t status)
+void CHIPDoorLockClusterClearAllPinsResponseCallbackBridge::OnSuccessFn(
+    void * context, const chip::app::Clusters::DoorLock::Commands::ClearAllPinsResponse::DecodableType & data)
 {
-    DispatchSuccess(context, @ {
-        @"status" : [NSNumber numberWithUnsignedChar:status],
-    });
+    id response = @ {
+        @"status" : [NSNumber numberWithUnsignedChar:data.status],
+    };
+    DispatchSuccess(context, response);
 };
 
-void CHIPDoorLockClusterClearAllRfidsResponseCallbackBridge::OnSuccessFn(void * context, uint8_t status)
+void CHIPDoorLockClusterClearAllRfidsResponseCallbackBridge::OnSuccessFn(
+    void * context, const chip::app::Clusters::DoorLock::Commands::ClearAllRfidsResponse::DecodableType & data)
 {
-    DispatchSuccess(context, @ {
-        @"status" : [NSNumber numberWithUnsignedChar:status],
-    });
+    id response = @ {
+        @"status" : [NSNumber numberWithUnsignedChar:data.status],
+    };
+    DispatchSuccess(context, response);
 };
 
-void CHIPDoorLockClusterClearHolidayScheduleResponseCallbackBridge::OnSuccessFn(void * context, uint8_t status)
+void CHIPDoorLockClusterClearHolidayScheduleResponseCallbackBridge::OnSuccessFn(
+    void * context, const chip::app::Clusters::DoorLock::Commands::ClearHolidayScheduleResponse::DecodableType & data)
 {
-    DispatchSuccess(context, @ {
-        @"status" : [NSNumber numberWithUnsignedChar:status],
-    });
+    id response = @ {
+        @"status" : [NSNumber numberWithUnsignedChar:data.status],
+    };
+    DispatchSuccess(context, response);
 };
 
-void CHIPDoorLockClusterClearPinResponseCallbackBridge::OnSuccessFn(void * context, uint8_t status)
+void CHIPDoorLockClusterClearPinResponseCallbackBridge::OnSuccessFn(
+    void * context, const chip::app::Clusters::DoorLock::Commands::ClearPinResponse::DecodableType & data)
 {
-    DispatchSuccess(context, @ {
-        @"status" : [NSNumber numberWithUnsignedChar:status],
-    });
+    id response = @ {
+        @"status" : [NSNumber numberWithUnsignedChar:data.status],
+    };
+    DispatchSuccess(context, response);
 };
 
-void CHIPDoorLockClusterClearRfidResponseCallbackBridge::OnSuccessFn(void * context, uint8_t status)
+void CHIPDoorLockClusterClearRfidResponseCallbackBridge::OnSuccessFn(
+    void * context, const chip::app::Clusters::DoorLock::Commands::ClearRfidResponse::DecodableType & data)
 {
-    DispatchSuccess(context, @ {
-        @"status" : [NSNumber numberWithUnsignedChar:status],
-    });
+    id response = @ {
+        @"status" : [NSNumber numberWithUnsignedChar:data.status],
+    };
+    DispatchSuccess(context, response);
 };
 
-void CHIPDoorLockClusterClearWeekdayScheduleResponseCallbackBridge::OnSuccessFn(void * context, uint8_t status)
+void CHIPDoorLockClusterClearWeekdayScheduleResponseCallbackBridge::OnSuccessFn(
+    void * context, const chip::app::Clusters::DoorLock::Commands::ClearWeekdayScheduleResponse::DecodableType & data)
 {
-    DispatchSuccess(context, @ {
-        @"status" : [NSNumber numberWithUnsignedChar:status],
-    });
+    id response = @ {
+        @"status" : [NSNumber numberWithUnsignedChar:data.status],
+    };
+    DispatchSuccess(context, response);
 };
 
-void CHIPDoorLockClusterClearYeardayScheduleResponseCallbackBridge::OnSuccessFn(void * context, uint8_t status)
+void CHIPDoorLockClusterClearYeardayScheduleResponseCallbackBridge::OnSuccessFn(
+    void * context, const chip::app::Clusters::DoorLock::Commands::ClearYeardayScheduleResponse::DecodableType & data)
 {
-    DispatchSuccess(context, @ {
-        @"status" : [NSNumber numberWithUnsignedChar:status],
-    });
+    id response = @ {
+        @"status" : [NSNumber numberWithUnsignedChar:data.status],
+    };
+    DispatchSuccess(context, response);
 };
 
-void CHIPDoorLockClusterGetHolidayScheduleResponseCallbackBridge::OnSuccessFn(void * context, uint8_t scheduleId, uint8_t status,
-    uint32_t localStartTime, uint32_t localEndTime, uint8_t operatingModeDuringHoliday)
+void CHIPDoorLockClusterGetHolidayScheduleResponseCallbackBridge::OnSuccessFn(
+    void * context, const chip::app::Clusters::DoorLock::Commands::GetHolidayScheduleResponse::DecodableType & data)
 {
-    DispatchSuccess(context, @ {
-        @"scheduleId" : [NSNumber numberWithUnsignedChar:scheduleId],
-        @"status" : [NSNumber numberWithUnsignedChar:status],
-        @"localStartTime" : [NSNumber numberWithUnsignedLong:localStartTime],
-        @"localEndTime" : [NSNumber numberWithUnsignedLong:localEndTime],
-        @"operatingModeDuringHoliday" : [NSNumber numberWithUnsignedChar:operatingModeDuringHoliday],
-    });
+    id response = @ {
+        @"scheduleId" : [NSNumber numberWithUnsignedChar:data.scheduleId],
+        @"status" : [NSNumber numberWithUnsignedChar:data.status],
+        @"localStartTime" : [NSNumber numberWithUnsignedLong:data.localStartTime],
+        @"localEndTime" : [NSNumber numberWithUnsignedLong:data.localEndTime],
+        @"operatingModeDuringHoliday" : [NSNumber numberWithUnsignedChar:data.operatingModeDuringHoliday],
+    };
+    DispatchSuccess(context, response);
 };
 
-void CHIPDoorLockClusterGetLogRecordResponseCallbackBridge::OnSuccessFn(void * context, uint16_t logEntryId, uint32_t timestamp,
-    uint8_t eventType, uint8_t source, uint8_t eventIdOrAlarmCode, uint16_t userId, chip::ByteSpan pin)
+void CHIPDoorLockClusterGetLogRecordResponseCallbackBridge::OnSuccessFn(
+    void * context, const chip::app::Clusters::DoorLock::Commands::GetLogRecordResponse::DecodableType & data)
 {
-    DispatchSuccess(context, @ {
-        @"logEntryId" : [NSNumber numberWithUnsignedShort:logEntryId],
-        @"timestamp" : [NSNumber numberWithUnsignedLong:timestamp],
-        @"eventType" : [NSNumber numberWithUnsignedChar:eventType],
-        @"source" : [NSNumber numberWithUnsignedChar:source],
-        @"eventIdOrAlarmCode" : [NSNumber numberWithUnsignedChar:eventIdOrAlarmCode],
-        @"userId" : [NSNumber numberWithUnsignedShort:userId],
-        @"pin" : [NSData dataWithBytes:pin.data() length:pin.size()],
-    });
+    id response = @ {
+        @"logEntryId" : [NSNumber numberWithUnsignedShort:data.logEntryId],
+        @"timestamp" : [NSNumber numberWithUnsignedLong:data.timestamp],
+        @"eventType" : [NSNumber numberWithUnsignedChar:data.eventType],
+        @"source" : [NSNumber numberWithUnsignedChar:data.source],
+        @"eventIdOrAlarmCode" : [NSNumber numberWithUnsignedChar:data.eventIdOrAlarmCode],
+        @"userId" : [NSNumber numberWithUnsignedShort:data.userId],
+        @"pin" : [NSData dataWithBytes:data.pin.data() length:data.pin.size()],
+    };
+    DispatchSuccess(context, response);
 };
 
 void CHIPDoorLockClusterGetPinResponseCallbackBridge::OnSuccessFn(
-    void * context, uint16_t userId, uint8_t userStatus, uint8_t userType, chip::ByteSpan pin)
+    void * context, const chip::app::Clusters::DoorLock::Commands::GetPinResponse::DecodableType & data)
 {
-    DispatchSuccess(context, @ {
-        @"userId" : [NSNumber numberWithUnsignedShort:userId],
-        @"userStatus" : [NSNumber numberWithUnsignedChar:userStatus],
-        @"userType" : [NSNumber numberWithUnsignedChar:userType],
-        @"pin" : [NSData dataWithBytes:pin.data() length:pin.size()],
-    });
+    id response = @ {
+        @"userId" : [NSNumber numberWithUnsignedShort:data.userId],
+        @"userStatus" : [NSNumber numberWithUnsignedChar:data.userStatus],
+        @"userType" : [NSNumber numberWithUnsignedChar:data.userType],
+        @"pin" : [NSData dataWithBytes:data.pin.data() length:data.pin.size()],
+    };
+    DispatchSuccess(context, response);
 };
 
 void CHIPDoorLockClusterGetRfidResponseCallbackBridge::OnSuccessFn(
-    void * context, uint16_t userId, uint8_t userStatus, uint8_t userType, chip::ByteSpan rfid)
+    void * context, const chip::app::Clusters::DoorLock::Commands::GetRfidResponse::DecodableType & data)
 {
-    DispatchSuccess(context, @ {
-        @"userId" : [NSNumber numberWithUnsignedShort:userId],
-        @"userStatus" : [NSNumber numberWithUnsignedChar:userStatus],
-        @"userType" : [NSNumber numberWithUnsignedChar:userType],
-        @"rfid" : [NSData dataWithBytes:rfid.data() length:rfid.size()],
-    });
+    id response = @ {
+        @"userId" : [NSNumber numberWithUnsignedShort:data.userId],
+        @"userStatus" : [NSNumber numberWithUnsignedChar:data.userStatus],
+        @"userType" : [NSNumber numberWithUnsignedChar:data.userType],
+        @"rfid" : [NSData dataWithBytes:data.rfid.data() length:data.rfid.size()],
+    };
+    DispatchSuccess(context, response);
 };
 
-void CHIPDoorLockClusterGetUserTypeResponseCallbackBridge::OnSuccessFn(void * context, uint16_t userId, uint8_t userType)
+void CHIPDoorLockClusterGetUserTypeResponseCallbackBridge::OnSuccessFn(
+    void * context, const chip::app::Clusters::DoorLock::Commands::GetUserTypeResponse::DecodableType & data)
 {
-    DispatchSuccess(context, @ {
-        @"userId" : [NSNumber numberWithUnsignedShort:userId],
-        @"userType" : [NSNumber numberWithUnsignedChar:userType],
-    });
+    id response = @ {
+        @"userId" : [NSNumber numberWithUnsignedShort:data.userId],
+        @"userType" : [NSNumber numberWithUnsignedChar:data.userType],
+    };
+    DispatchSuccess(context, response);
 };
 
-void CHIPDoorLockClusterGetWeekdayScheduleResponseCallbackBridge::OnSuccessFn(void * context, uint8_t scheduleId, uint16_t userId,
-    uint8_t status, uint8_t daysMask, uint8_t startHour, uint8_t startMinute, uint8_t endHour, uint8_t endMinute)
+void CHIPDoorLockClusterGetWeekdayScheduleResponseCallbackBridge::OnSuccessFn(
+    void * context, const chip::app::Clusters::DoorLock::Commands::GetWeekdayScheduleResponse::DecodableType & data)
 {
-    DispatchSuccess(context, @ {
-        @"scheduleId" : [NSNumber numberWithUnsignedChar:scheduleId],
-        @"userId" : [NSNumber numberWithUnsignedShort:userId],
-        @"status" : [NSNumber numberWithUnsignedChar:status],
-        @"daysMask" : [NSNumber numberWithUnsignedChar:daysMask],
-        @"startHour" : [NSNumber numberWithUnsignedChar:startHour],
-        @"startMinute" : [NSNumber numberWithUnsignedChar:startMinute],
-        @"endHour" : [NSNumber numberWithUnsignedChar:endHour],
-        @"endMinute" : [NSNumber numberWithUnsignedChar:endMinute],
-    });
+    id response = @ {
+        @"scheduleId" : [NSNumber numberWithUnsignedChar:data.scheduleId],
+        @"userId" : [NSNumber numberWithUnsignedShort:data.userId],
+        @"status" : [NSNumber numberWithUnsignedChar:data.status],
+        @"daysMask" : [NSNumber numberWithUnsignedChar:data.daysMask],
+        @"startHour" : [NSNumber numberWithUnsignedChar:data.startHour],
+        @"startMinute" : [NSNumber numberWithUnsignedChar:data.startMinute],
+        @"endHour" : [NSNumber numberWithUnsignedChar:data.endHour],
+        @"endMinute" : [NSNumber numberWithUnsignedChar:data.endMinute],
+    };
+    DispatchSuccess(context, response);
 };
 
 void CHIPDoorLockClusterGetYeardayScheduleResponseCallbackBridge::OnSuccessFn(
-    void * context, uint8_t scheduleId, uint16_t userId, uint8_t status, uint32_t localStartTime, uint32_t localEndTime)
+    void * context, const chip::app::Clusters::DoorLock::Commands::GetYeardayScheduleResponse::DecodableType & data)
 {
-    DispatchSuccess(context, @ {
-        @"scheduleId" : [NSNumber numberWithUnsignedChar:scheduleId],
-        @"userId" : [NSNumber numberWithUnsignedShort:userId],
-        @"status" : [NSNumber numberWithUnsignedChar:status],
-        @"localStartTime" : [NSNumber numberWithUnsignedLong:localStartTime],
-        @"localEndTime" : [NSNumber numberWithUnsignedLong:localEndTime],
-    });
+    id response = @ {
+        @"scheduleId" : [NSNumber numberWithUnsignedChar:data.scheduleId],
+        @"userId" : [NSNumber numberWithUnsignedShort:data.userId],
+        @"status" : [NSNumber numberWithUnsignedChar:data.status],
+        @"localStartTime" : [NSNumber numberWithUnsignedLong:data.localStartTime],
+        @"localEndTime" : [NSNumber numberWithUnsignedLong:data.localEndTime],
+    };
+    DispatchSuccess(context, response);
 };
 
-void CHIPDoorLockClusterLockDoorResponseCallbackBridge::OnSuccessFn(void * context, uint8_t status)
+void CHIPDoorLockClusterLockDoorResponseCallbackBridge::OnSuccessFn(
+    void * context, const chip::app::Clusters::DoorLock::Commands::LockDoorResponse::DecodableType & data)
 {
-    DispatchSuccess(context, @ {
-        @"status" : [NSNumber numberWithUnsignedChar:status],
-    });
+    id response = @ {
+        @"status" : [NSNumber numberWithUnsignedChar:data.status],
+    };
+    DispatchSuccess(context, response);
 };
 
-void CHIPDoorLockClusterSetHolidayScheduleResponseCallbackBridge::OnSuccessFn(void * context, uint8_t status)
+void CHIPDoorLockClusterSetHolidayScheduleResponseCallbackBridge::OnSuccessFn(
+    void * context, const chip::app::Clusters::DoorLock::Commands::SetHolidayScheduleResponse::DecodableType & data)
 {
-    DispatchSuccess(context, @ {
-        @"status" : [NSNumber numberWithUnsignedChar:status],
-    });
+    id response = @ {
+        @"status" : [NSNumber numberWithUnsignedChar:data.status],
+    };
+    DispatchSuccess(context, response);
 };
 
-void CHIPDoorLockClusterSetPinResponseCallbackBridge::OnSuccessFn(void * context, uint8_t status)
+void CHIPDoorLockClusterSetPinResponseCallbackBridge::OnSuccessFn(
+    void * context, const chip::app::Clusters::DoorLock::Commands::SetPinResponse::DecodableType & data)
 {
-    DispatchSuccess(context, @ {
-        @"status" : [NSNumber numberWithUnsignedChar:status],
-    });
+    id response = @ {
+        @"status" : [NSNumber numberWithUnsignedChar:data.status],
+    };
+    DispatchSuccess(context, response);
 };
 
-void CHIPDoorLockClusterSetRfidResponseCallbackBridge::OnSuccessFn(void * context, uint8_t status)
+void CHIPDoorLockClusterSetRfidResponseCallbackBridge::OnSuccessFn(
+    void * context, const chip::app::Clusters::DoorLock::Commands::SetRfidResponse::DecodableType & data)
 {
-    DispatchSuccess(context, @ {
-        @"status" : [NSNumber numberWithUnsignedChar:status],
-    });
+    id response = @ {
+        @"status" : [NSNumber numberWithUnsignedChar:data.status],
+    };
+    DispatchSuccess(context, response);
 };
 
-void CHIPDoorLockClusterSetUserTypeResponseCallbackBridge::OnSuccessFn(void * context, uint8_t status)
+void CHIPDoorLockClusterSetUserTypeResponseCallbackBridge::OnSuccessFn(
+    void * context, const chip::app::Clusters::DoorLock::Commands::SetUserTypeResponse::DecodableType & data)
 {
-    DispatchSuccess(context, @ {
-        @"status" : [NSNumber numberWithUnsignedChar:status],
-    });
+    id response = @ {
+        @"status" : [NSNumber numberWithUnsignedChar:data.status],
+    };
+    DispatchSuccess(context, response);
 };
 
-void CHIPDoorLockClusterSetWeekdayScheduleResponseCallbackBridge::OnSuccessFn(void * context, uint8_t status)
+void CHIPDoorLockClusterSetWeekdayScheduleResponseCallbackBridge::OnSuccessFn(
+    void * context, const chip::app::Clusters::DoorLock::Commands::SetWeekdayScheduleResponse::DecodableType & data)
 {
-    DispatchSuccess(context, @ {
-        @"status" : [NSNumber numberWithUnsignedChar:status],
-    });
+    id response = @ {
+        @"status" : [NSNumber numberWithUnsignedChar:data.status],
+    };
+    DispatchSuccess(context, response);
 };
 
-void CHIPDoorLockClusterSetYeardayScheduleResponseCallbackBridge::OnSuccessFn(void * context, uint8_t status)
+void CHIPDoorLockClusterSetYeardayScheduleResponseCallbackBridge::OnSuccessFn(
+    void * context, const chip::app::Clusters::DoorLock::Commands::SetYeardayScheduleResponse::DecodableType & data)
 {
-    DispatchSuccess(context, @ {
-        @"status" : [NSNumber numberWithUnsignedChar:status],
-    });
+    id response = @ {
+        @"status" : [NSNumber numberWithUnsignedChar:data.status],
+    };
+    DispatchSuccess(context, response);
 };
 
-void CHIPDoorLockClusterUnlockDoorResponseCallbackBridge::OnSuccessFn(void * context, uint8_t status)
+void CHIPDoorLockClusterUnlockDoorResponseCallbackBridge::OnSuccessFn(
+    void * context, const chip::app::Clusters::DoorLock::Commands::UnlockDoorResponse::DecodableType & data)
 {
-    DispatchSuccess(context, @ {
-        @"status" : [NSNumber numberWithUnsignedChar:status],
-    });
+    id response = @ {
+        @"status" : [NSNumber numberWithUnsignedChar:data.status],
+    };
+    DispatchSuccess(context, response);
 };
 
-void CHIPDoorLockClusterUnlockWithTimeoutResponseCallbackBridge::OnSuccessFn(void * context, uint8_t status)
+void CHIPDoorLockClusterUnlockWithTimeoutResponseCallbackBridge::OnSuccessFn(
+    void * context, const chip::app::Clusters::DoorLock::Commands::UnlockWithTimeoutResponse::DecodableType & data)
 {
-    DispatchSuccess(context, @ {
-        @"status" : [NSNumber numberWithUnsignedChar:status],
-    });
+    id response = @ {
+        @"status" : [NSNumber numberWithUnsignedChar:data.status],
+    };
+    DispatchSuccess(context, response);
 };
 
 void CHIPGeneralCommissioningClusterArmFailSafeResponseCallbackBridge::OnSuccessFn(
-    void * context, uint8_t errorCode, chip::CharSpan debugText)
+    void * context, const chip::app::Clusters::GeneralCommissioning::Commands::ArmFailSafeResponse::DecodableType & data)
 {
-    DispatchSuccess(context, @ {
-        @"errorCode" : [NSNumber numberWithUnsignedChar:errorCode],
-        @"debugText" : [[NSString alloc] initWithBytes:debugText.data() length:debugText.size() encoding:NSUTF8StringEncoding],
-    });
+    id response = @ {
+        @"errorCode" : [NSNumber numberWithUnsignedChar:data.errorCode],
+        @"debugText" : [[NSString alloc] initWithBytes:data.debugText.data()
+                                                length:data.debugText.size()
+                                              encoding:NSUTF8StringEncoding],
+    };
+    DispatchSuccess(context, response);
 };
 
 void CHIPGeneralCommissioningClusterCommissioningCompleteResponseCallbackBridge::OnSuccessFn(
-    void * context, uint8_t errorCode, chip::CharSpan debugText)
+    void * context, const chip::app::Clusters::GeneralCommissioning::Commands::CommissioningCompleteResponse::DecodableType & data)
 {
-    DispatchSuccess(context, @ {
-        @"errorCode" : [NSNumber numberWithUnsignedChar:errorCode],
-        @"debugText" : [[NSString alloc] initWithBytes:debugText.data() length:debugText.size() encoding:NSUTF8StringEncoding],
-    });
+    id response = @ {
+        @"errorCode" : [NSNumber numberWithUnsignedChar:data.errorCode],
+        @"debugText" : [[NSString alloc] initWithBytes:data.debugText.data()
+                                                length:data.debugText.size()
+                                              encoding:NSUTF8StringEncoding],
+    };
+    DispatchSuccess(context, response);
 };
 
 void CHIPGeneralCommissioningClusterSetRegulatoryConfigResponseCallbackBridge::OnSuccessFn(
-    void * context, uint8_t errorCode, chip::CharSpan debugText)
+    void * context, const chip::app::Clusters::GeneralCommissioning::Commands::SetRegulatoryConfigResponse::DecodableType & data)
 {
-    DispatchSuccess(context, @ {
-        @"errorCode" : [NSNumber numberWithUnsignedChar:errorCode],
-        @"debugText" : [[NSString alloc] initWithBytes:debugText.data() length:debugText.size() encoding:NSUTF8StringEncoding],
-    });
+    id response = @ {
+        @"errorCode" : [NSNumber numberWithUnsignedChar:data.errorCode],
+        @"debugText" : [[NSString alloc] initWithBytes:data.debugText.data()
+                                                length:data.debugText.size()
+                                              encoding:NSUTF8StringEncoding],
+    };
+    DispatchSuccess(context, response);
 };
 
-void CHIPGroupsClusterAddGroupResponseCallbackBridge::OnSuccessFn(void * context, uint8_t status, uint16_t groupId)
+void CHIPGroupsClusterAddGroupResponseCallbackBridge::OnSuccessFn(
+    void * context, const chip::app::Clusters::Groups::Commands::AddGroupResponse::DecodableType & data)
 {
-    DispatchSuccess(context, @ {
-        @"status" : [NSNumber numberWithUnsignedChar:status],
-        @"groupId" : [NSNumber numberWithUnsignedShort:groupId],
-    });
+    id response = @ {
+        @"status" : [NSNumber numberWithUnsignedChar:data.status],
+        @"groupId" : [NSNumber numberWithUnsignedShort:data.groupId],
+    };
+    DispatchSuccess(context, response);
 };
 
 void CHIPGroupsClusterGetGroupMembershipResponseCallbackBridge::OnSuccessFn(
-    void * context, uint8_t capacity, uint8_t groupCount, /* TYPE WARNING: array array defaults to */ uint8_t * groupList)
+    void * context, const chip::app::Clusters::Groups::Commands::GetGroupMembershipResponse::DecodableType & data)
 {
-    DispatchSuccess(context, @ {
-        @"capacity" : [NSNumber numberWithUnsignedChar:capacity],
-        @"groupCount" : [NSNumber numberWithUnsignedChar:groupCount],
-        // groupList : /* TYPE WARNING: array array defaults to */ uint8_t *
-        // Conversion from this type to Objc is not properly implemented yet
-    });
+    id response = @ {
+        @"capacity" : [NSNumber numberWithUnsignedChar:data.capacity],
+        @"groupCount" : [NSNumber numberWithUnsignedChar:data.groupCount],
+        @"groupList" : [NSNull null], /* Array - Conversion from this type to Objc is not properly implemented yet */
+    };
+    DispatchSuccess(context, response);
 };
 
-void CHIPGroupsClusterRemoveGroupResponseCallbackBridge::OnSuccessFn(void * context, uint8_t status, uint16_t groupId)
+void CHIPGroupsClusterRemoveGroupResponseCallbackBridge::OnSuccessFn(
+    void * context, const chip::app::Clusters::Groups::Commands::RemoveGroupResponse::DecodableType & data)
 {
-    DispatchSuccess(context, @ {
-        @"status" : [NSNumber numberWithUnsignedChar:status],
-        @"groupId" : [NSNumber numberWithUnsignedShort:groupId],
-    });
+    id response = @ {
+        @"status" : [NSNumber numberWithUnsignedChar:data.status],
+        @"groupId" : [NSNumber numberWithUnsignedShort:data.groupId],
+    };
+    DispatchSuccess(context, response);
 };
 
 void CHIPGroupsClusterViewGroupResponseCallbackBridge::OnSuccessFn(
-    void * context, uint8_t status, uint16_t groupId, chip::CharSpan groupName)
+    void * context, const chip::app::Clusters::Groups::Commands::ViewGroupResponse::DecodableType & data)
 {
-    DispatchSuccess(context, @ {
-        @"status" : [NSNumber numberWithUnsignedChar:status],
-        @"groupId" : [NSNumber numberWithUnsignedShort:groupId],
-        @"groupName" : [[NSString alloc] initWithBytes:groupName.data() length:groupName.size() encoding:NSUTF8StringEncoding],
-    });
+    id response = @ {
+        @"status" : [NSNumber numberWithUnsignedChar:data.status],
+        @"groupId" : [NSNumber numberWithUnsignedShort:data.groupId],
+        @"groupName" : [[NSString alloc] initWithBytes:data.groupName.data()
+                                                length:data.groupName.size()
+                                              encoding:NSUTF8StringEncoding],
+    };
+    DispatchSuccess(context, response);
 };
 
-void CHIPIdentifyClusterIdentifyQueryResponseCallbackBridge::OnSuccessFn(void * context, uint16_t timeout)
+void CHIPIdentifyClusterIdentifyQueryResponseCallbackBridge::OnSuccessFn(
+    void * context, const chip::app::Clusters::Identify::Commands::IdentifyQueryResponse::DecodableType & data)
 {
-    DispatchSuccess(context, @ {
-        @"timeout" : [NSNumber numberWithUnsignedShort:timeout],
-    });
+    id response = @ {
+        @"timeout" : [NSNumber numberWithUnsignedShort:data.timeout],
+    };
+    DispatchSuccess(context, response);
 };
 
-void CHIPKeypadInputClusterSendKeyResponseCallbackBridge::OnSuccessFn(void * context, uint8_t status)
+void CHIPKeypadInputClusterSendKeyResponseCallbackBridge::OnSuccessFn(
+    void * context, const chip::app::Clusters::KeypadInput::Commands::SendKeyResponse::DecodableType & data)
 {
-    DispatchSuccess(context, @ {
-        @"status" : [NSNumber numberWithUnsignedChar:status],
-    });
+    id response = @ {
+        @"status" : [NSNumber numberWithUnsignedChar:data.status],
+    };
+    DispatchSuccess(context, response);
 };
 
-void CHIPMediaPlaybackClusterMediaFastForwardResponseCallbackBridge::OnSuccessFn(void * context, uint8_t mediaPlaybackStatus)
+void CHIPMediaPlaybackClusterMediaFastForwardResponseCallbackBridge::OnSuccessFn(
+    void * context, const chip::app::Clusters::MediaPlayback::Commands::MediaFastForwardResponse::DecodableType & data)
 {
-    DispatchSuccess(context, @ {
-        @"mediaPlaybackStatus" : [NSNumber numberWithUnsignedChar:mediaPlaybackStatus],
-    });
+    id response = @ {
+        @"mediaPlaybackStatus" : [NSNumber numberWithUnsignedChar:data.mediaPlaybackStatus],
+    };
+    DispatchSuccess(context, response);
 };
 
-void CHIPMediaPlaybackClusterMediaNextResponseCallbackBridge::OnSuccessFn(void * context, uint8_t mediaPlaybackStatus)
+void CHIPMediaPlaybackClusterMediaNextResponseCallbackBridge::OnSuccessFn(
+    void * context, const chip::app::Clusters::MediaPlayback::Commands::MediaNextResponse::DecodableType & data)
 {
-    DispatchSuccess(context, @ {
-        @"mediaPlaybackStatus" : [NSNumber numberWithUnsignedChar:mediaPlaybackStatus],
-    });
+    id response = @ {
+        @"mediaPlaybackStatus" : [NSNumber numberWithUnsignedChar:data.mediaPlaybackStatus],
+    };
+    DispatchSuccess(context, response);
 };
 
-void CHIPMediaPlaybackClusterMediaPauseResponseCallbackBridge::OnSuccessFn(void * context, uint8_t mediaPlaybackStatus)
+void CHIPMediaPlaybackClusterMediaPauseResponseCallbackBridge::OnSuccessFn(
+    void * context, const chip::app::Clusters::MediaPlayback::Commands::MediaPauseResponse::DecodableType & data)
 {
-    DispatchSuccess(context, @ {
-        @"mediaPlaybackStatus" : [NSNumber numberWithUnsignedChar:mediaPlaybackStatus],
-    });
+    id response = @ {
+        @"mediaPlaybackStatus" : [NSNumber numberWithUnsignedChar:data.mediaPlaybackStatus],
+    };
+    DispatchSuccess(context, response);
 };
 
-void CHIPMediaPlaybackClusterMediaPlayResponseCallbackBridge::OnSuccessFn(void * context, uint8_t mediaPlaybackStatus)
+void CHIPMediaPlaybackClusterMediaPlayResponseCallbackBridge::OnSuccessFn(
+    void * context, const chip::app::Clusters::MediaPlayback::Commands::MediaPlayResponse::DecodableType & data)
 {
-    DispatchSuccess(context, @ {
-        @"mediaPlaybackStatus" : [NSNumber numberWithUnsignedChar:mediaPlaybackStatus],
-    });
+    id response = @ {
+        @"mediaPlaybackStatus" : [NSNumber numberWithUnsignedChar:data.mediaPlaybackStatus],
+    };
+    DispatchSuccess(context, response);
 };
 
-void CHIPMediaPlaybackClusterMediaPreviousResponseCallbackBridge::OnSuccessFn(void * context, uint8_t mediaPlaybackStatus)
+void CHIPMediaPlaybackClusterMediaPreviousResponseCallbackBridge::OnSuccessFn(
+    void * context, const chip::app::Clusters::MediaPlayback::Commands::MediaPreviousResponse::DecodableType & data)
 {
-    DispatchSuccess(context, @ {
-        @"mediaPlaybackStatus" : [NSNumber numberWithUnsignedChar:mediaPlaybackStatus],
-    });
+    id response = @ {
+        @"mediaPlaybackStatus" : [NSNumber numberWithUnsignedChar:data.mediaPlaybackStatus],
+    };
+    DispatchSuccess(context, response);
 };
 
-void CHIPMediaPlaybackClusterMediaRewindResponseCallbackBridge::OnSuccessFn(void * context, uint8_t mediaPlaybackStatus)
+void CHIPMediaPlaybackClusterMediaRewindResponseCallbackBridge::OnSuccessFn(
+    void * context, const chip::app::Clusters::MediaPlayback::Commands::MediaRewindResponse::DecodableType & data)
 {
-    DispatchSuccess(context, @ {
-        @"mediaPlaybackStatus" : [NSNumber numberWithUnsignedChar:mediaPlaybackStatus],
-    });
+    id response = @ {
+        @"mediaPlaybackStatus" : [NSNumber numberWithUnsignedChar:data.mediaPlaybackStatus],
+    };
+    DispatchSuccess(context, response);
 };
 
-void CHIPMediaPlaybackClusterMediaSeekResponseCallbackBridge::OnSuccessFn(void * context, uint8_t mediaPlaybackStatus)
+void CHIPMediaPlaybackClusterMediaSeekResponseCallbackBridge::OnSuccessFn(
+    void * context, const chip::app::Clusters::MediaPlayback::Commands::MediaSeekResponse::DecodableType & data)
 {
-    DispatchSuccess(context, @ {
-        @"mediaPlaybackStatus" : [NSNumber numberWithUnsignedChar:mediaPlaybackStatus],
-    });
+    id response = @ {
+        @"mediaPlaybackStatus" : [NSNumber numberWithUnsignedChar:data.mediaPlaybackStatus],
+    };
+    DispatchSuccess(context, response);
 };
 
-void CHIPMediaPlaybackClusterMediaSkipBackwardResponseCallbackBridge::OnSuccessFn(void * context, uint8_t mediaPlaybackStatus)
+void CHIPMediaPlaybackClusterMediaSkipBackwardResponseCallbackBridge::OnSuccessFn(
+    void * context, const chip::app::Clusters::MediaPlayback::Commands::MediaSkipBackwardResponse::DecodableType & data)
 {
-    DispatchSuccess(context, @ {
-        @"mediaPlaybackStatus" : [NSNumber numberWithUnsignedChar:mediaPlaybackStatus],
-    });
+    id response = @ {
+        @"mediaPlaybackStatus" : [NSNumber numberWithUnsignedChar:data.mediaPlaybackStatus],
+    };
+    DispatchSuccess(context, response);
 };
 
-void CHIPMediaPlaybackClusterMediaSkipForwardResponseCallbackBridge::OnSuccessFn(void * context, uint8_t mediaPlaybackStatus)
+void CHIPMediaPlaybackClusterMediaSkipForwardResponseCallbackBridge::OnSuccessFn(
+    void * context, const chip::app::Clusters::MediaPlayback::Commands::MediaSkipForwardResponse::DecodableType & data)
 {
-    DispatchSuccess(context, @ {
-        @"mediaPlaybackStatus" : [NSNumber numberWithUnsignedChar:mediaPlaybackStatus],
-    });
+    id response = @ {
+        @"mediaPlaybackStatus" : [NSNumber numberWithUnsignedChar:data.mediaPlaybackStatus],
+    };
+    DispatchSuccess(context, response);
 };
 
-void CHIPMediaPlaybackClusterMediaStartOverResponseCallbackBridge::OnSuccessFn(void * context, uint8_t mediaPlaybackStatus)
+void CHIPMediaPlaybackClusterMediaStartOverResponseCallbackBridge::OnSuccessFn(
+    void * context, const chip::app::Clusters::MediaPlayback::Commands::MediaStartOverResponse::DecodableType & data)
 {
-    DispatchSuccess(context, @ {
-        @"mediaPlaybackStatus" : [NSNumber numberWithUnsignedChar:mediaPlaybackStatus],
-    });
+    id response = @ {
+        @"mediaPlaybackStatus" : [NSNumber numberWithUnsignedChar:data.mediaPlaybackStatus],
+    };
+    DispatchSuccess(context, response);
 };
 
-void CHIPMediaPlaybackClusterMediaStopResponseCallbackBridge::OnSuccessFn(void * context, uint8_t mediaPlaybackStatus)
+void CHIPMediaPlaybackClusterMediaStopResponseCallbackBridge::OnSuccessFn(
+    void * context, const chip::app::Clusters::MediaPlayback::Commands::MediaStopResponse::DecodableType & data)
 {
-    DispatchSuccess(context, @ {
-        @"mediaPlaybackStatus" : [NSNumber numberWithUnsignedChar:mediaPlaybackStatus],
-    });
+    id response = @ {
+        @"mediaPlaybackStatus" : [NSNumber numberWithUnsignedChar:data.mediaPlaybackStatus],
+    };
+    DispatchSuccess(context, response);
 };
 
 void CHIPNetworkCommissioningClusterAddThreadNetworkResponseCallbackBridge::OnSuccessFn(
-    void * context, uint8_t errorCode, chip::CharSpan debugText)
+    void * context, const chip::app::Clusters::NetworkCommissioning::Commands::AddThreadNetworkResponse::DecodableType & data)
 {
-    DispatchSuccess(context, @ {
-        @"errorCode" : [NSNumber numberWithUnsignedChar:errorCode],
-        @"debugText" : [[NSString alloc] initWithBytes:debugText.data() length:debugText.size() encoding:NSUTF8StringEncoding],
-    });
+    id response = @ {
+        @"errorCode" : [NSNumber numberWithUnsignedChar:data.errorCode],
+        @"debugText" : [[NSString alloc] initWithBytes:data.debugText.data()
+                                                length:data.debugText.size()
+                                              encoding:NSUTF8StringEncoding],
+    };
+    DispatchSuccess(context, response);
 };
 
 void CHIPNetworkCommissioningClusterAddWiFiNetworkResponseCallbackBridge::OnSuccessFn(
-    void * context, uint8_t errorCode, chip::CharSpan debugText)
+    void * context, const chip::app::Clusters::NetworkCommissioning::Commands::AddWiFiNetworkResponse::DecodableType & data)
 {
-    DispatchSuccess(context, @ {
-        @"errorCode" : [NSNumber numberWithUnsignedChar:errorCode],
-        @"debugText" : [[NSString alloc] initWithBytes:debugText.data() length:debugText.size() encoding:NSUTF8StringEncoding],
-    });
+    id response = @ {
+        @"errorCode" : [NSNumber numberWithUnsignedChar:data.errorCode],
+        @"debugText" : [[NSString alloc] initWithBytes:data.debugText.data()
+                                                length:data.debugText.size()
+                                              encoding:NSUTF8StringEncoding],
+    };
+    DispatchSuccess(context, response);
 };
 
 void CHIPNetworkCommissioningClusterDisableNetworkResponseCallbackBridge::OnSuccessFn(
-    void * context, uint8_t errorCode, chip::CharSpan debugText)
+    void * context, const chip::app::Clusters::NetworkCommissioning::Commands::DisableNetworkResponse::DecodableType & data)
 {
-    DispatchSuccess(context, @ {
-        @"errorCode" : [NSNumber numberWithUnsignedChar:errorCode],
-        @"debugText" : [[NSString alloc] initWithBytes:debugText.data() length:debugText.size() encoding:NSUTF8StringEncoding],
-    });
+    id response = @ {
+        @"errorCode" : [NSNumber numberWithUnsignedChar:data.errorCode],
+        @"debugText" : [[NSString alloc] initWithBytes:data.debugText.data()
+                                                length:data.debugText.size()
+                                              encoding:NSUTF8StringEncoding],
+    };
+    DispatchSuccess(context, response);
 };
 
 void CHIPNetworkCommissioningClusterEnableNetworkResponseCallbackBridge::OnSuccessFn(
-    void * context, uint8_t errorCode, chip::CharSpan debugText)
+    void * context, const chip::app::Clusters::NetworkCommissioning::Commands::EnableNetworkResponse::DecodableType & data)
 {
-    DispatchSuccess(context, @ {
-        @"errorCode" : [NSNumber numberWithUnsignedChar:errorCode],
-        @"debugText" : [[NSString alloc] initWithBytes:debugText.data() length:debugText.size() encoding:NSUTF8StringEncoding],
-    });
+    id response = @ {
+        @"errorCode" : [NSNumber numberWithUnsignedChar:data.errorCode],
+        @"debugText" : [[NSString alloc] initWithBytes:data.debugText.data()
+                                                length:data.debugText.size()
+                                              encoding:NSUTF8StringEncoding],
+    };
+    DispatchSuccess(context, response);
 };
 
 void CHIPNetworkCommissioningClusterRemoveNetworkResponseCallbackBridge::OnSuccessFn(
-    void * context, uint8_t errorCode, chip::CharSpan debugText)
+    void * context, const chip::app::Clusters::NetworkCommissioning::Commands::RemoveNetworkResponse::DecodableType & data)
 {
-    DispatchSuccess(context, @ {
-        @"errorCode" : [NSNumber numberWithUnsignedChar:errorCode],
-        @"debugText" : [[NSString alloc] initWithBytes:debugText.data() length:debugText.size() encoding:NSUTF8StringEncoding],
-    });
+    id response = @ {
+        @"errorCode" : [NSNumber numberWithUnsignedChar:data.errorCode],
+        @"debugText" : [[NSString alloc] initWithBytes:data.debugText.data()
+                                                length:data.debugText.size()
+                                              encoding:NSUTF8StringEncoding],
+    };
+    DispatchSuccess(context, response);
 };
 
-void CHIPNetworkCommissioningClusterScanNetworksResponseCallbackBridge::OnSuccessFn(void * context, uint8_t errorCode,
-    chip::CharSpan debugText, /* TYPE WARNING: array array defaults to */ uint8_t * wifiScanResults,
-    /* TYPE WARNING: array array defaults to */ uint8_t * threadScanResults)
+void CHIPNetworkCommissioningClusterScanNetworksResponseCallbackBridge::OnSuccessFn(
+    void * context, const chip::app::Clusters::NetworkCommissioning::Commands::ScanNetworksResponse::DecodableType & data)
 {
-    DispatchSuccess(context, @ {
-        @"errorCode" : [NSNumber numberWithUnsignedChar:errorCode],
-        @"debugText" : [[NSString alloc] initWithBytes:debugText.data() length:debugText.size() encoding:NSUTF8StringEncoding],
-        // wifiScanResults : /* TYPE WARNING: array array defaults to */ uint8_t *
-        // Conversion from this type to Objc is not properly implemented yet
-        // threadScanResults : /* TYPE WARNING: array array defaults to */ uint8_t *
-        // Conversion from this type to Objc is not properly implemented yet
-    });
+    id response = @ {
+        @"errorCode" : [NSNumber numberWithUnsignedChar:data.errorCode],
+        @"debugText" : [[NSString alloc] initWithBytes:data.debugText.data()
+                                                length:data.debugText.size()
+                                              encoding:NSUTF8StringEncoding],
+        @"wifiScanResults" : [NSNull null], /* Array - Conversion from this type to Objc is not properly implemented yet */
+        @"threadScanResults" : [NSNull null], /* Array - Conversion from this type to Objc is not properly implemented yet */
+    };
+    DispatchSuccess(context, response);
 };
 
 void CHIPNetworkCommissioningClusterUpdateThreadNetworkResponseCallbackBridge::OnSuccessFn(
-    void * context, uint8_t errorCode, chip::CharSpan debugText)
+    void * context, const chip::app::Clusters::NetworkCommissioning::Commands::UpdateThreadNetworkResponse::DecodableType & data)
 {
-    DispatchSuccess(context, @ {
-        @"errorCode" : [NSNumber numberWithUnsignedChar:errorCode],
-        @"debugText" : [[NSString alloc] initWithBytes:debugText.data() length:debugText.size() encoding:NSUTF8StringEncoding],
-    });
+    id response = @ {
+        @"errorCode" : [NSNumber numberWithUnsignedChar:data.errorCode],
+        @"debugText" : [[NSString alloc] initWithBytes:data.debugText.data()
+                                                length:data.debugText.size()
+                                              encoding:NSUTF8StringEncoding],
+    };
+    DispatchSuccess(context, response);
 };
 
 void CHIPNetworkCommissioningClusterUpdateWiFiNetworkResponseCallbackBridge::OnSuccessFn(
-    void * context, uint8_t errorCode, chip::CharSpan debugText)
+    void * context, const chip::app::Clusters::NetworkCommissioning::Commands::UpdateWiFiNetworkResponse::DecodableType & data)
 {
-    DispatchSuccess(context, @ {
-        @"errorCode" : [NSNumber numberWithUnsignedChar:errorCode],
-        @"debugText" : [[NSString alloc] initWithBytes:debugText.data() length:debugText.size() encoding:NSUTF8StringEncoding],
-    });
+    id response = @ {
+        @"errorCode" : [NSNumber numberWithUnsignedChar:data.errorCode],
+        @"debugText" : [[NSString alloc] initWithBytes:data.debugText.data()
+                                                length:data.debugText.size()
+                                              encoding:NSUTF8StringEncoding],
+    };
+    DispatchSuccess(context, response);
 };
 
 void CHIPOtaSoftwareUpdateProviderClusterApplyUpdateResponseCallbackBridge::OnSuccessFn(
-    void * context, uint8_t action, uint32_t delayedActionTime)
+    void * context, const chip::app::Clusters::OtaSoftwareUpdateProvider::Commands::ApplyUpdateResponse::DecodableType & data)
 {
-    DispatchSuccess(context, @ {
-        @"action" : [NSNumber numberWithUnsignedChar:action],
-        @"delayedActionTime" : [NSNumber numberWithUnsignedLong:delayedActionTime],
-    });
+    id response = @ {
+        @"action" : [NSNumber numberWithUnsignedChar:data.action],
+        @"delayedActionTime" : [NSNumber numberWithUnsignedLong:data.delayedActionTime],
+    };
+    DispatchSuccess(context, response);
 };
 
-void CHIPOtaSoftwareUpdateProviderClusterQueryImageResponseCallbackBridge::OnSuccessFn(void * context, uint8_t status,
-    uint32_t delayedActionTime, chip::CharSpan imageURI, uint32_t softwareVersion, chip::CharSpan softwareVersionString,
-    chip::ByteSpan updateToken, bool userConsentNeeded, chip::ByteSpan metadataForRequestor)
+void CHIPOtaSoftwareUpdateProviderClusterQueryImageResponseCallbackBridge::OnSuccessFn(
+    void * context, const chip::app::Clusters::OtaSoftwareUpdateProvider::Commands::QueryImageResponse::DecodableType & data)
 {
-    DispatchSuccess(context, @ {
-        @"status" : [NSNumber numberWithUnsignedChar:status],
-        @"delayedActionTime" : [NSNumber numberWithUnsignedLong:delayedActionTime],
-        @"imageURI" : [[NSString alloc] initWithBytes:imageURI.data() length:imageURI.size() encoding:NSUTF8StringEncoding],
-        @"softwareVersion" : [NSNumber numberWithUnsignedLong:softwareVersion],
-        @"softwareVersionString" : [[NSString alloc] initWithBytes:softwareVersionString.data()
-                                                            length:softwareVersionString.size()
-                                                          encoding:NSUTF8StringEncoding],
-        @"updateToken" : [NSData dataWithBytes:updateToken.data() length:updateToken.size()],
-        @"userConsentNeeded" : [NSNumber numberWithBool:userConsentNeeded],
-        @"metadataForRequestor" : [NSData dataWithBytes:metadataForRequestor.data() length:metadataForRequestor.size()],
-    });
+    id response = @ {
+        @"status" : [NSNumber numberWithUnsignedChar:data.status],
+        @"delayedActionTime" : data.delayedActionTime.HasValue() == false
+            ? [NSNull null]
+            : [NSNumber numberWithUnsignedLong:data.delayedActionTime.Value()],
+        @"imageURI" : data.imageURI.HasValue() == false ? [NSNull null]
+                                                        : [[NSString alloc] initWithBytes:data.imageURI.Value().data()
+                                                                                   length:data.imageURI.Value().size()
+                                                                                 encoding:NSUTF8StringEncoding],
+        @"softwareVersion" : data.softwareVersion.HasValue() == false
+            ? [NSNull null]
+            : [NSNumber numberWithUnsignedLong:data.softwareVersion.Value()],
+        @"softwareVersionString" : data.softwareVersionString.HasValue() == false
+            ? [NSNull null]
+            : [[NSString alloc] initWithBytes:data.softwareVersionString.Value().data()
+                                       length:data.softwareVersionString.Value().size()
+                                     encoding:NSUTF8StringEncoding],
+        @"updateToken" : data.updateToken.HasValue() == false ? [NSNull null]
+                                                              : [NSData dataWithBytes:data.updateToken.Value().data()
+                                                                               length:data.updateToken.Value().size()],
+        @"userConsentNeeded" : data.userConsentNeeded.HasValue() == false
+            ? [NSNull null]
+            : [NSNumber numberWithBool:data.userConsentNeeded.Value()],
+        @"metadataForRequestor" : data.metadataForRequestor.HasValue() == false
+            ? [NSNull null]
+            : [NSData dataWithBytes:data.metadataForRequestor.Value().data() length:data.metadataForRequestor.Value().size()],
+    };
+    DispatchSuccess(context, response);
 };
 
 void CHIPOperationalCredentialsClusterAttestationResponseCallbackBridge::OnSuccessFn(
-    void * context, chip::ByteSpan AttestationElements, chip::ByteSpan Signature)
+    void * context, const chip::app::Clusters::OperationalCredentials::Commands::AttestationResponse::DecodableType & data)
 {
-    DispatchSuccess(context, @ {
-        @"AttestationElements" : [NSData dataWithBytes:AttestationElements.data() length:AttestationElements.size()],
-        @"Signature" : [NSData dataWithBytes:Signature.data() length:Signature.size()],
-    });
+    id response = @ {
+        @"AttestationElements" : [NSData dataWithBytes:data.attestationElements.data() length:data.attestationElements.size()],
+        @"Signature" : [NSData dataWithBytes:data.signature.data() length:data.signature.size()],
+    };
+    DispatchSuccess(context, response);
 };
 
 void CHIPOperationalCredentialsClusterCertificateChainResponseCallbackBridge::OnSuccessFn(
-    void * context, chip::ByteSpan Certificate)
+    void * context, const chip::app::Clusters::OperationalCredentials::Commands::CertificateChainResponse::DecodableType & data)
 {
-    DispatchSuccess(context, @ {
-        @"Certificate" : [NSData dataWithBytes:Certificate.data() length:Certificate.size()],
-    });
+    id response = @ {
+        @"Certificate" : [NSData dataWithBytes:data.certificate.data() length:data.certificate.size()],
+    };
+    DispatchSuccess(context, response);
 };
 
 void CHIPOperationalCredentialsClusterNOCResponseCallbackBridge::OnSuccessFn(
-    void * context, uint8_t StatusCode, uint8_t FabricIndex, chip::CharSpan DebugText)
+    void * context, const chip::app::Clusters::OperationalCredentials::Commands::NOCResponse::DecodableType & data)
 {
-    DispatchSuccess(context, @ {
-        @"StatusCode" : [NSNumber numberWithUnsignedChar:StatusCode],
-        @"FabricIndex" : [NSNumber numberWithUnsignedChar:FabricIndex],
-        @"DebugText" : [[NSString alloc] initWithBytes:DebugText.data() length:DebugText.size() encoding:NSUTF8StringEncoding],
-    });
+    id response = @ {
+        @"StatusCode" : [NSNumber numberWithUnsignedChar:data.statusCode],
+        @"FabricIndex" : [NSNumber numberWithUnsignedChar:data.fabricIndex],
+        @"DebugText" : [[NSString alloc] initWithBytes:data.debugText.data()
+                                                length:data.debugText.size()
+                                              encoding:NSUTF8StringEncoding],
+    };
+    DispatchSuccess(context, response);
 };
 
 void CHIPOperationalCredentialsClusterOpCSRResponseCallbackBridge::OnSuccessFn(
-    void * context, chip::ByteSpan NOCSRElements, chip::ByteSpan AttestationSignature)
+    void * context, const chip::app::Clusters::OperationalCredentials::Commands::OpCSRResponse::DecodableType & data)
 {
-    DispatchSuccess(context, @ {
-        @"NOCSRElements" : [NSData dataWithBytes:NOCSRElements.data() length:NOCSRElements.size()],
-        @"AttestationSignature" : [NSData dataWithBytes:AttestationSignature.data() length:AttestationSignature.size()],
-    });
+    id response = @ {
+        @"NOCSRElements" : [NSData dataWithBytes:data.NOCSRElements.data() length:data.NOCSRElements.size()],
+        @"AttestationSignature" : [NSData dataWithBytes:data.attestationSignature.data() length:data.attestationSignature.size()],
+    };
+    DispatchSuccess(context, response);
 };
 
-void CHIPScenesClusterAddSceneResponseCallbackBridge::OnSuccessFn(void * context, uint8_t status, uint16_t groupId, uint8_t sceneId)
+void CHIPScenesClusterAddSceneResponseCallbackBridge::OnSuccessFn(
+    void * context, const chip::app::Clusters::Scenes::Commands::AddSceneResponse::DecodableType & data)
 {
-    DispatchSuccess(context, @ {
-        @"status" : [NSNumber numberWithUnsignedChar:status],
-        @"groupId" : [NSNumber numberWithUnsignedShort:groupId],
-        @"sceneId" : [NSNumber numberWithUnsignedChar:sceneId],
-    });
+    id response = @ {
+        @"status" : [NSNumber numberWithUnsignedChar:data.status],
+        @"groupId" : [NSNumber numberWithUnsignedShort:data.groupId],
+        @"sceneId" : [NSNumber numberWithUnsignedChar:data.sceneId],
+    };
+    DispatchSuccess(context, response);
 };
 
-void CHIPScenesClusterGetSceneMembershipResponseCallbackBridge::OnSuccessFn(void * context, uint8_t status, uint8_t capacity,
-    uint16_t groupId, uint8_t sceneCount, /* TYPE WARNING: array array defaults to */ uint8_t * sceneList)
+void CHIPScenesClusterGetSceneMembershipResponseCallbackBridge::OnSuccessFn(
+    void * context, const chip::app::Clusters::Scenes::Commands::GetSceneMembershipResponse::DecodableType & data)
 {
-    DispatchSuccess(context, @ {
-        @"status" : [NSNumber numberWithUnsignedChar:status],
-        @"capacity" : [NSNumber numberWithUnsignedChar:capacity],
-        @"groupId" : [NSNumber numberWithUnsignedShort:groupId],
-        @"sceneCount" : [NSNumber numberWithUnsignedChar:sceneCount],
-        // sceneList : /* TYPE WARNING: array array defaults to */ uint8_t *
-        // Conversion from this type to Objc is not properly implemented yet
-    });
+    id response = @ {
+        @"status" : [NSNumber numberWithUnsignedChar:data.status],
+        @"capacity" : [NSNumber numberWithUnsignedChar:data.capacity],
+        @"groupId" : [NSNumber numberWithUnsignedShort:data.groupId],
+        @"sceneCount" : [NSNumber numberWithUnsignedChar:data.sceneCount],
+        @"sceneList" : [NSNull null], /* Array - Conversion from this type to Objc is not properly implemented yet */
+    };
+    DispatchSuccess(context, response);
 };
 
-void CHIPScenesClusterRemoveAllScenesResponseCallbackBridge::OnSuccessFn(void * context, uint8_t status, uint16_t groupId)
+void CHIPScenesClusterRemoveAllScenesResponseCallbackBridge::OnSuccessFn(
+    void * context, const chip::app::Clusters::Scenes::Commands::RemoveAllScenesResponse::DecodableType & data)
 {
-    DispatchSuccess(context, @ {
-        @"status" : [NSNumber numberWithUnsignedChar:status],
-        @"groupId" : [NSNumber numberWithUnsignedShort:groupId],
-    });
+    id response = @ {
+        @"status" : [NSNumber numberWithUnsignedChar:data.status],
+        @"groupId" : [NSNumber numberWithUnsignedShort:data.groupId],
+    };
+    DispatchSuccess(context, response);
 };
 
 void CHIPScenesClusterRemoveSceneResponseCallbackBridge::OnSuccessFn(
-    void * context, uint8_t status, uint16_t groupId, uint8_t sceneId)
+    void * context, const chip::app::Clusters::Scenes::Commands::RemoveSceneResponse::DecodableType & data)
 {
-    DispatchSuccess(context, @ {
-        @"status" : [NSNumber numberWithUnsignedChar:status],
-        @"groupId" : [NSNumber numberWithUnsignedShort:groupId],
-        @"sceneId" : [NSNumber numberWithUnsignedChar:sceneId],
-    });
+    id response = @ {
+        @"status" : [NSNumber numberWithUnsignedChar:data.status],
+        @"groupId" : [NSNumber numberWithUnsignedShort:data.groupId],
+        @"sceneId" : [NSNumber numberWithUnsignedChar:data.sceneId],
+    };
+    DispatchSuccess(context, response);
 };
 
 void CHIPScenesClusterStoreSceneResponseCallbackBridge::OnSuccessFn(
-    void * context, uint8_t status, uint16_t groupId, uint8_t sceneId)
+    void * context, const chip::app::Clusters::Scenes::Commands::StoreSceneResponse::DecodableType & data)
 {
-    DispatchSuccess(context, @ {
-        @"status" : [NSNumber numberWithUnsignedChar:status],
-        @"groupId" : [NSNumber numberWithUnsignedShort:groupId],
-        @"sceneId" : [NSNumber numberWithUnsignedChar:sceneId],
-    });
+    id response = @ {
+        @"status" : [NSNumber numberWithUnsignedChar:data.status],
+        @"groupId" : [NSNumber numberWithUnsignedShort:data.groupId],
+        @"sceneId" : [NSNumber numberWithUnsignedChar:data.sceneId],
+    };
+    DispatchSuccess(context, response);
 };
 
-void CHIPScenesClusterViewSceneResponseCallbackBridge::OnSuccessFn(void * context, uint8_t status, uint16_t groupId,
-    uint8_t sceneId, uint16_t transitionTime, chip::CharSpan sceneName,
-    /* TYPE WARNING: array array defaults to */ uint8_t * extensionFieldSets)
+void CHIPScenesClusterViewSceneResponseCallbackBridge::OnSuccessFn(
+    void * context, const chip::app::Clusters::Scenes::Commands::ViewSceneResponse::DecodableType & data)
 {
-    DispatchSuccess(context, @ {
-        @"status" : [NSNumber numberWithUnsignedChar:status],
-        @"groupId" : [NSNumber numberWithUnsignedShort:groupId],
-        @"sceneId" : [NSNumber numberWithUnsignedChar:sceneId],
-        @"transitionTime" : [NSNumber numberWithUnsignedShort:transitionTime],
-        @"sceneName" : [[NSString alloc] initWithBytes:sceneName.data() length:sceneName.size() encoding:NSUTF8StringEncoding],
-        // extensionFieldSets : /* TYPE WARNING: array array defaults to */ uint8_t *
-        // Conversion from this type to Objc is not properly implemented yet
-    });
+    id response = @ {
+        @"status" : [NSNumber numberWithUnsignedChar:data.status],
+        @"groupId" : [NSNumber numberWithUnsignedShort:data.groupId],
+        @"sceneId" : [NSNumber numberWithUnsignedChar:data.sceneId],
+        @"transitionTime" : [NSNumber numberWithUnsignedShort:data.transitionTime],
+        @"sceneName" : [[NSString alloc] initWithBytes:data.sceneName.data()
+                                                length:data.sceneName.size()
+                                              encoding:NSUTF8StringEncoding],
+        @"extensionFieldSets" : [NSNull null], /* Array - Conversion from this type to Objc is not properly implemented yet */
+    };
+    DispatchSuccess(context, response);
 };
 
 void CHIPTvChannelClusterChangeChannelResponseCallbackBridge::OnSuccessFn(
-    void * context, /* TYPE WARNING: array array defaults to */ uint8_t * ChannelMatch, uint8_t ErrorType)
+    void * context, const chip::app::Clusters::TvChannel::Commands::ChangeChannelResponse::DecodableType & data)
 {
-    DispatchSuccess(context, @ {
-        // ChannelMatch : /* TYPE WARNING: array array defaults to */ uint8_t *
-        // Conversion from this type to Objc is not properly implemented yet
-        @"ErrorType" : [NSNumber numberWithUnsignedChar:ErrorType],
-    });
+    id response = @ {
+        @"ChannelMatch" : [NSNull null], /* Array - Conversion from this type to Objc is not properly implemented yet */
+        @"ErrorType" : [NSNumber numberWithUnsignedChar:data.errorType],
+    };
+    DispatchSuccess(context, response);
 };
 
 void CHIPTargetNavigatorClusterNavigateTargetResponseCallbackBridge::OnSuccessFn(
-    void * context, uint8_t status, chip::CharSpan data)
+    void * context, const chip::app::Clusters::TargetNavigator::Commands::NavigateTargetResponse::DecodableType & data)
 {
-    DispatchSuccess(context, @ {
-        @"status" : [NSNumber numberWithUnsignedChar:status],
-        @"data" : [[NSString alloc] initWithBytes:data.data() length:data.size() encoding:NSUTF8StringEncoding],
-    });
+    id response = @ {
+        @"status" : [NSNumber numberWithUnsignedChar:data.status],
+        @"data" : [[NSString alloc] initWithBytes:data.data.data() length:data.data.size() encoding:NSUTF8StringEncoding],
+    };
+    DispatchSuccess(context, response);
 };
 
-void CHIPTestClusterClusterBooleanResponseCallbackBridge::OnSuccessFn(void * context, bool value)
+void CHIPTestClusterClusterBooleanResponseCallbackBridge::OnSuccessFn(
+    void * context, const chip::app::Clusters::TestCluster::Commands::BooleanResponse::DecodableType & data)
 {
-    DispatchSuccess(context, @ {
-        @"value" : [NSNumber numberWithBool:value],
-    });
+    id response = @ {
+        @"value" : [NSNumber numberWithBool:data.value],
+    };
+    DispatchSuccess(context, response);
 };
 
-void CHIPTestClusterClusterTestAddArgumentsResponseCallbackBridge::OnSuccessFn(void * context, uint8_t returnValue)
+void CHIPTestClusterClusterTestAddArgumentsResponseCallbackBridge::OnSuccessFn(
+    void * context, const chip::app::Clusters::TestCluster::Commands::TestAddArgumentsResponse::DecodableType & data)
 {
-    DispatchSuccess(context, @ {
-        @"returnValue" : [NSNumber numberWithUnsignedChar:returnValue],
-    });
+    id response = @ {
+        @"returnValue" : [NSNumber numberWithUnsignedChar:data.returnValue],
+    };
+    DispatchSuccess(context, response);
 };
 
-void CHIPTestClusterClusterTestEnumsResponseCallbackBridge::OnSuccessFn(void * context, chip::VendorId arg1, uint8_t arg2)
+void CHIPTestClusterClusterTestEnumsResponseCallbackBridge::OnSuccessFn(
+    void * context, const chip::app::Clusters::TestCluster::Commands::TestEnumsResponse::DecodableType & data)
 {
-    DispatchSuccess(context, @ {
-        @"arg1" : [NSNumber numberWithUnsignedShort:arg1],
-        @"arg2" : [NSNumber numberWithUnsignedChar:arg2],
-    });
+    id response = @ {
+        @"arg1" : [NSNumber numberWithUnsignedShort:data.arg1],
+        @"arg2" : [NSNumber numberWithUnsignedChar:data.arg2],
+    };
+    DispatchSuccess(context, response);
 };
 
 void CHIPTestClusterClusterTestListInt8UReverseResponseCallbackBridge::OnSuccessFn(
-    void * context, /* TYPE WARNING: array array defaults to */ uint8_t * arg1)
+    void * context, const chip::app::Clusters::TestCluster::Commands::TestListInt8UReverseResponse::DecodableType & data)
 {
-    DispatchSuccess(context,
-        @ {
-            // arg1 : /* TYPE WARNING: array array defaults to */ uint8_t *
-            // Conversion from this type to Objc is not properly implemented yet
-        });
+    id response = @ {
+        @"arg1" : [NSNull null], /* Array - Conversion from this type to Objc is not properly implemented yet */
+    };
+    DispatchSuccess(context, response);
 };
 
 void CHIPTestClusterClusterTestNullableOptionalResponseCallbackBridge::OnSuccessFn(
-    void * context, bool wasPresent, bool wasNull, uint8_t value, uint8_t originalValue)
+    void * context, const chip::app::Clusters::TestCluster::Commands::TestNullableOptionalResponse::DecodableType & data)
 {
-    DispatchSuccess(context, @ {
-        @"wasPresent" : [NSNumber numberWithBool:wasPresent],
-        @"wasNull" : [NSNumber numberWithBool:wasNull],
-        @"value" : [NSNumber numberWithUnsignedChar:value],
-        @"originalValue" : [NSNumber numberWithUnsignedChar:originalValue],
-    });
+    id response = @ {
+        @"wasPresent" : [NSNumber numberWithBool:data.wasPresent],
+        @"wasNull" : data.wasNull.HasValue() == false ? [NSNull null] : [NSNumber numberWithBool:data.wasNull.Value()],
+        @"value" : data.value.HasValue() == false ? [NSNull null] : [NSNumber numberWithUnsignedChar:data.value.Value()],
+        @"originalValue" : data.originalValue.HasValue() == false
+            ? [NSNull null]
+            : data.originalValue.Value().IsNull() ? [NSNull null]
+                                                  : [NSNumber numberWithUnsignedChar:data.originalValue.Value().Value()],
+    };
+    DispatchSuccess(context, response);
 };
 
-void CHIPTestClusterClusterTestSpecificResponseCallbackBridge::OnSuccessFn(void * context, uint8_t returnValue)
+void CHIPTestClusterClusterTestSpecificResponseCallbackBridge::OnSuccessFn(
+    void * context, const chip::app::Clusters::TestCluster::Commands::TestSpecificResponse::DecodableType & data)
 {
-    DispatchSuccess(context, @ {
-        @"returnValue" : [NSNumber numberWithUnsignedChar:returnValue],
-    });
+    id response = @ {
+        @"returnValue" : [NSNumber numberWithUnsignedChar:data.returnValue],
+    };
+    DispatchSuccess(context, response);
 };

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPCallbackBridge_internal.h
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPCallbackBridge_internal.h
@@ -23,6 +23,162 @@
 #include <app-common/zap-generated/cluster-objects.h>
 #include <app/data-model/DecodableList.h>
 
+typedef void (*CHIPDefaultSuccessCallbackType)(void *, const chip::app::DataModel::NullObjectType &);
+typedef void (*CHIPDefaultFailureCallbackType)(void *, EmberAfStatus);
+
+typedef void (*CHIPAccountLoginClusterGetSetupPINResponseCallbackType)(
+    void *, const chip::app::Clusters::AccountLogin::Commands::GetSetupPINResponse::DecodableType &);
+typedef void (*CHIPApplicationLauncherClusterLaunchAppResponseCallbackType)(
+    void *, const chip::app::Clusters::ApplicationLauncher::Commands::LaunchAppResponse::DecodableType &);
+typedef void (*CHIPContentLauncherClusterLaunchContentResponseCallbackType)(
+    void *, const chip::app::Clusters::ContentLauncher::Commands::LaunchContentResponse::DecodableType &);
+typedef void (*CHIPContentLauncherClusterLaunchURLResponseCallbackType)(
+    void *, const chip::app::Clusters::ContentLauncher::Commands::LaunchURLResponse::DecodableType &);
+typedef void (*CHIPDiagnosticLogsClusterRetrieveLogsResponseCallbackType)(
+    void *, const chip::app::Clusters::DiagnosticLogs::Commands::RetrieveLogsResponse::DecodableType &);
+typedef void (*CHIPDoorLockClusterClearAllPinsResponseCallbackType)(
+    void *, const chip::app::Clusters::DoorLock::Commands::ClearAllPinsResponse::DecodableType &);
+typedef void (*CHIPDoorLockClusterClearAllRfidsResponseCallbackType)(
+    void *, const chip::app::Clusters::DoorLock::Commands::ClearAllRfidsResponse::DecodableType &);
+typedef void (*CHIPDoorLockClusterClearHolidayScheduleResponseCallbackType)(
+    void *, const chip::app::Clusters::DoorLock::Commands::ClearHolidayScheduleResponse::DecodableType &);
+typedef void (*CHIPDoorLockClusterClearPinResponseCallbackType)(
+    void *, const chip::app::Clusters::DoorLock::Commands::ClearPinResponse::DecodableType &);
+typedef void (*CHIPDoorLockClusterClearRfidResponseCallbackType)(
+    void *, const chip::app::Clusters::DoorLock::Commands::ClearRfidResponse::DecodableType &);
+typedef void (*CHIPDoorLockClusterClearWeekdayScheduleResponseCallbackType)(
+    void *, const chip::app::Clusters::DoorLock::Commands::ClearWeekdayScheduleResponse::DecodableType &);
+typedef void (*CHIPDoorLockClusterClearYeardayScheduleResponseCallbackType)(
+    void *, const chip::app::Clusters::DoorLock::Commands::ClearYeardayScheduleResponse::DecodableType &);
+typedef void (*CHIPDoorLockClusterGetHolidayScheduleResponseCallbackType)(
+    void *, const chip::app::Clusters::DoorLock::Commands::GetHolidayScheduleResponse::DecodableType &);
+typedef void (*CHIPDoorLockClusterGetLogRecordResponseCallbackType)(
+    void *, const chip::app::Clusters::DoorLock::Commands::GetLogRecordResponse::DecodableType &);
+typedef void (*CHIPDoorLockClusterGetPinResponseCallbackType)(
+    void *, const chip::app::Clusters::DoorLock::Commands::GetPinResponse::DecodableType &);
+typedef void (*CHIPDoorLockClusterGetRfidResponseCallbackType)(
+    void *, const chip::app::Clusters::DoorLock::Commands::GetRfidResponse::DecodableType &);
+typedef void (*CHIPDoorLockClusterGetUserTypeResponseCallbackType)(
+    void *, const chip::app::Clusters::DoorLock::Commands::GetUserTypeResponse::DecodableType &);
+typedef void (*CHIPDoorLockClusterGetWeekdayScheduleResponseCallbackType)(
+    void *, const chip::app::Clusters::DoorLock::Commands::GetWeekdayScheduleResponse::DecodableType &);
+typedef void (*CHIPDoorLockClusterGetYeardayScheduleResponseCallbackType)(
+    void *, const chip::app::Clusters::DoorLock::Commands::GetYeardayScheduleResponse::DecodableType &);
+typedef void (*CHIPDoorLockClusterLockDoorResponseCallbackType)(
+    void *, const chip::app::Clusters::DoorLock::Commands::LockDoorResponse::DecodableType &);
+typedef void (*CHIPDoorLockClusterSetHolidayScheduleResponseCallbackType)(
+    void *, const chip::app::Clusters::DoorLock::Commands::SetHolidayScheduleResponse::DecodableType &);
+typedef void (*CHIPDoorLockClusterSetPinResponseCallbackType)(
+    void *, const chip::app::Clusters::DoorLock::Commands::SetPinResponse::DecodableType &);
+typedef void (*CHIPDoorLockClusterSetRfidResponseCallbackType)(
+    void *, const chip::app::Clusters::DoorLock::Commands::SetRfidResponse::DecodableType &);
+typedef void (*CHIPDoorLockClusterSetUserTypeResponseCallbackType)(
+    void *, const chip::app::Clusters::DoorLock::Commands::SetUserTypeResponse::DecodableType &);
+typedef void (*CHIPDoorLockClusterSetWeekdayScheduleResponseCallbackType)(
+    void *, const chip::app::Clusters::DoorLock::Commands::SetWeekdayScheduleResponse::DecodableType &);
+typedef void (*CHIPDoorLockClusterSetYeardayScheduleResponseCallbackType)(
+    void *, const chip::app::Clusters::DoorLock::Commands::SetYeardayScheduleResponse::DecodableType &);
+typedef void (*CHIPDoorLockClusterUnlockDoorResponseCallbackType)(
+    void *, const chip::app::Clusters::DoorLock::Commands::UnlockDoorResponse::DecodableType &);
+typedef void (*CHIPDoorLockClusterUnlockWithTimeoutResponseCallbackType)(
+    void *, const chip::app::Clusters::DoorLock::Commands::UnlockWithTimeoutResponse::DecodableType &);
+typedef void (*CHIPGeneralCommissioningClusterArmFailSafeResponseCallbackType)(
+    void *, const chip::app::Clusters::GeneralCommissioning::Commands::ArmFailSafeResponse::DecodableType &);
+typedef void (*CHIPGeneralCommissioningClusterCommissioningCompleteResponseCallbackType)(
+    void *, const chip::app::Clusters::GeneralCommissioning::Commands::CommissioningCompleteResponse::DecodableType &);
+typedef void (*CHIPGeneralCommissioningClusterSetRegulatoryConfigResponseCallbackType)(
+    void *, const chip::app::Clusters::GeneralCommissioning::Commands::SetRegulatoryConfigResponse::DecodableType &);
+typedef void (*CHIPGroupsClusterAddGroupResponseCallbackType)(
+    void *, const chip::app::Clusters::Groups::Commands::AddGroupResponse::DecodableType &);
+typedef void (*CHIPGroupsClusterGetGroupMembershipResponseCallbackType)(
+    void *, const chip::app::Clusters::Groups::Commands::GetGroupMembershipResponse::DecodableType &);
+typedef void (*CHIPGroupsClusterRemoveGroupResponseCallbackType)(
+    void *, const chip::app::Clusters::Groups::Commands::RemoveGroupResponse::DecodableType &);
+typedef void (*CHIPGroupsClusterViewGroupResponseCallbackType)(
+    void *, const chip::app::Clusters::Groups::Commands::ViewGroupResponse::DecodableType &);
+typedef void (*CHIPIdentifyClusterIdentifyQueryResponseCallbackType)(
+    void *, const chip::app::Clusters::Identify::Commands::IdentifyQueryResponse::DecodableType &);
+typedef void (*CHIPKeypadInputClusterSendKeyResponseCallbackType)(
+    void *, const chip::app::Clusters::KeypadInput::Commands::SendKeyResponse::DecodableType &);
+typedef void (*CHIPMediaPlaybackClusterMediaFastForwardResponseCallbackType)(
+    void *, const chip::app::Clusters::MediaPlayback::Commands::MediaFastForwardResponse::DecodableType &);
+typedef void (*CHIPMediaPlaybackClusterMediaNextResponseCallbackType)(
+    void *, const chip::app::Clusters::MediaPlayback::Commands::MediaNextResponse::DecodableType &);
+typedef void (*CHIPMediaPlaybackClusterMediaPauseResponseCallbackType)(
+    void *, const chip::app::Clusters::MediaPlayback::Commands::MediaPauseResponse::DecodableType &);
+typedef void (*CHIPMediaPlaybackClusterMediaPlayResponseCallbackType)(
+    void *, const chip::app::Clusters::MediaPlayback::Commands::MediaPlayResponse::DecodableType &);
+typedef void (*CHIPMediaPlaybackClusterMediaPreviousResponseCallbackType)(
+    void *, const chip::app::Clusters::MediaPlayback::Commands::MediaPreviousResponse::DecodableType &);
+typedef void (*CHIPMediaPlaybackClusterMediaRewindResponseCallbackType)(
+    void *, const chip::app::Clusters::MediaPlayback::Commands::MediaRewindResponse::DecodableType &);
+typedef void (*CHIPMediaPlaybackClusterMediaSeekResponseCallbackType)(
+    void *, const chip::app::Clusters::MediaPlayback::Commands::MediaSeekResponse::DecodableType &);
+typedef void (*CHIPMediaPlaybackClusterMediaSkipBackwardResponseCallbackType)(
+    void *, const chip::app::Clusters::MediaPlayback::Commands::MediaSkipBackwardResponse::DecodableType &);
+typedef void (*CHIPMediaPlaybackClusterMediaSkipForwardResponseCallbackType)(
+    void *, const chip::app::Clusters::MediaPlayback::Commands::MediaSkipForwardResponse::DecodableType &);
+typedef void (*CHIPMediaPlaybackClusterMediaStartOverResponseCallbackType)(
+    void *, const chip::app::Clusters::MediaPlayback::Commands::MediaStartOverResponse::DecodableType &);
+typedef void (*CHIPMediaPlaybackClusterMediaStopResponseCallbackType)(
+    void *, const chip::app::Clusters::MediaPlayback::Commands::MediaStopResponse::DecodableType &);
+typedef void (*CHIPNetworkCommissioningClusterAddThreadNetworkResponseCallbackType)(
+    void *, const chip::app::Clusters::NetworkCommissioning::Commands::AddThreadNetworkResponse::DecodableType &);
+typedef void (*CHIPNetworkCommissioningClusterAddWiFiNetworkResponseCallbackType)(
+    void *, const chip::app::Clusters::NetworkCommissioning::Commands::AddWiFiNetworkResponse::DecodableType &);
+typedef void (*CHIPNetworkCommissioningClusterDisableNetworkResponseCallbackType)(
+    void *, const chip::app::Clusters::NetworkCommissioning::Commands::DisableNetworkResponse::DecodableType &);
+typedef void (*CHIPNetworkCommissioningClusterEnableNetworkResponseCallbackType)(
+    void *, const chip::app::Clusters::NetworkCommissioning::Commands::EnableNetworkResponse::DecodableType &);
+typedef void (*CHIPNetworkCommissioningClusterRemoveNetworkResponseCallbackType)(
+    void *, const chip::app::Clusters::NetworkCommissioning::Commands::RemoveNetworkResponse::DecodableType &);
+typedef void (*CHIPNetworkCommissioningClusterScanNetworksResponseCallbackType)(
+    void *, const chip::app::Clusters::NetworkCommissioning::Commands::ScanNetworksResponse::DecodableType &);
+typedef void (*CHIPNetworkCommissioningClusterUpdateThreadNetworkResponseCallbackType)(
+    void *, const chip::app::Clusters::NetworkCommissioning::Commands::UpdateThreadNetworkResponse::DecodableType &);
+typedef void (*CHIPNetworkCommissioningClusterUpdateWiFiNetworkResponseCallbackType)(
+    void *, const chip::app::Clusters::NetworkCommissioning::Commands::UpdateWiFiNetworkResponse::DecodableType &);
+typedef void (*CHIPOtaSoftwareUpdateProviderClusterApplyUpdateResponseCallbackType)(
+    void *, const chip::app::Clusters::OtaSoftwareUpdateProvider::Commands::ApplyUpdateResponse::DecodableType &);
+typedef void (*CHIPOtaSoftwareUpdateProviderClusterQueryImageResponseCallbackType)(
+    void *, const chip::app::Clusters::OtaSoftwareUpdateProvider::Commands::QueryImageResponse::DecodableType &);
+typedef void (*CHIPOperationalCredentialsClusterAttestationResponseCallbackType)(
+    void *, const chip::app::Clusters::OperationalCredentials::Commands::AttestationResponse::DecodableType &);
+typedef void (*CHIPOperationalCredentialsClusterCertificateChainResponseCallbackType)(
+    void *, const chip::app::Clusters::OperationalCredentials::Commands::CertificateChainResponse::DecodableType &);
+typedef void (*CHIPOperationalCredentialsClusterNOCResponseCallbackType)(
+    void *, const chip::app::Clusters::OperationalCredentials::Commands::NOCResponse::DecodableType &);
+typedef void (*CHIPOperationalCredentialsClusterOpCSRResponseCallbackType)(
+    void *, const chip::app::Clusters::OperationalCredentials::Commands::OpCSRResponse::DecodableType &);
+typedef void (*CHIPScenesClusterAddSceneResponseCallbackType)(
+    void *, const chip::app::Clusters::Scenes::Commands::AddSceneResponse::DecodableType &);
+typedef void (*CHIPScenesClusterGetSceneMembershipResponseCallbackType)(
+    void *, const chip::app::Clusters::Scenes::Commands::GetSceneMembershipResponse::DecodableType &);
+typedef void (*CHIPScenesClusterRemoveAllScenesResponseCallbackType)(
+    void *, const chip::app::Clusters::Scenes::Commands::RemoveAllScenesResponse::DecodableType &);
+typedef void (*CHIPScenesClusterRemoveSceneResponseCallbackType)(
+    void *, const chip::app::Clusters::Scenes::Commands::RemoveSceneResponse::DecodableType &);
+typedef void (*CHIPScenesClusterStoreSceneResponseCallbackType)(
+    void *, const chip::app::Clusters::Scenes::Commands::StoreSceneResponse::DecodableType &);
+typedef void (*CHIPScenesClusterViewSceneResponseCallbackType)(
+    void *, const chip::app::Clusters::Scenes::Commands::ViewSceneResponse::DecodableType &);
+typedef void (*CHIPTvChannelClusterChangeChannelResponseCallbackType)(
+    void *, const chip::app::Clusters::TvChannel::Commands::ChangeChannelResponse::DecodableType &);
+typedef void (*CHIPTargetNavigatorClusterNavigateTargetResponseCallbackType)(
+    void *, const chip::app::Clusters::TargetNavigator::Commands::NavigateTargetResponse::DecodableType &);
+typedef void (*CHIPTestClusterClusterBooleanResponseCallbackType)(
+    void *, const chip::app::Clusters::TestCluster::Commands::BooleanResponse::DecodableType &);
+typedef void (*CHIPTestClusterClusterTestAddArgumentsResponseCallbackType)(
+    void *, const chip::app::Clusters::TestCluster::Commands::TestAddArgumentsResponse::DecodableType &);
+typedef void (*CHIPTestClusterClusterTestEnumsResponseCallbackType)(
+    void *, const chip::app::Clusters::TestCluster::Commands::TestEnumsResponse::DecodableType &);
+typedef void (*CHIPTestClusterClusterTestListInt8UReverseResponseCallbackType)(
+    void *, const chip::app::Clusters::TestCluster::Commands::TestListInt8UReverseResponse::DecodableType &);
+typedef void (*CHIPTestClusterClusterTestNullableOptionalResponseCallbackType)(
+    void *, const chip::app::Clusters::TestCluster::Commands::TestNullableOptionalResponse::DecodableType &);
+typedef void (*CHIPTestClusterClusterTestSpecificResponseCallbackType)(
+    void *, const chip::app::Clusters::TestCluster::Commands::TestSpecificResponse::DecodableType &);
+
 class CHIPDefaultSuccessCallbackBridge : public CHIPCallbackBridge<DefaultSuccessCallback>
 {
 public:
@@ -546,843 +702,944 @@ public:
 };
 
 class CHIPAccountLoginClusterGetSetupPINResponseCallbackBridge
-    : public CHIPCallbackBridge<AccountLoginClusterGetSetupPINResponseCallback>
+    : public CHIPCallbackBridge<CHIPAccountLoginClusterGetSetupPINResponseCallbackType>
 {
 public:
     CHIPAccountLoginClusterGetSetupPINResponseCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
                                                              CHIPActionBlock action, bool keepAlive = false) :
-        CHIPCallbackBridge<AccountLoginClusterGetSetupPINResponseCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
+        CHIPCallbackBridge<CHIPAccountLoginClusterGetSetupPINResponseCallbackType>(queue, handler, action, OnSuccessFn,
+                                                                                   keepAlive){};
 
-    static void OnSuccessFn(void * context, chip::CharSpan setupPIN);
+    static void OnSuccessFn(void * context,
+                            const chip::app::Clusters::AccountLogin::Commands::GetSetupPINResponse::DecodableType & data);
 };
 
 class CHIPApplicationLauncherClusterLaunchAppResponseCallbackBridge
-    : public CHIPCallbackBridge<ApplicationLauncherClusterLaunchAppResponseCallback>
+    : public CHIPCallbackBridge<CHIPApplicationLauncherClusterLaunchAppResponseCallbackType>
 {
 public:
     CHIPApplicationLauncherClusterLaunchAppResponseCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
                                                                   CHIPActionBlock action, bool keepAlive = false) :
-        CHIPCallbackBridge<ApplicationLauncherClusterLaunchAppResponseCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
+        CHIPCallbackBridge<CHIPApplicationLauncherClusterLaunchAppResponseCallbackType>(queue, handler, action, OnSuccessFn,
+                                                                                        keepAlive){};
 
-    static void OnSuccessFn(void * context, uint8_t status, chip::CharSpan data);
+    static void OnSuccessFn(void * context,
+                            const chip::app::Clusters::ApplicationLauncher::Commands::LaunchAppResponse::DecodableType & data);
 };
 
 class CHIPContentLauncherClusterLaunchContentResponseCallbackBridge
-    : public CHIPCallbackBridge<ContentLauncherClusterLaunchContentResponseCallback>
+    : public CHIPCallbackBridge<CHIPContentLauncherClusterLaunchContentResponseCallbackType>
 {
 public:
     CHIPContentLauncherClusterLaunchContentResponseCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
                                                                   CHIPActionBlock action, bool keepAlive = false) :
-        CHIPCallbackBridge<ContentLauncherClusterLaunchContentResponseCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
+        CHIPCallbackBridge<CHIPContentLauncherClusterLaunchContentResponseCallbackType>(queue, handler, action, OnSuccessFn,
+                                                                                        keepAlive){};
 
-    static void OnSuccessFn(void * context, chip::CharSpan data, uint8_t contentLaunchStatus);
+    static void OnSuccessFn(void * context,
+                            const chip::app::Clusters::ContentLauncher::Commands::LaunchContentResponse::DecodableType & data);
 };
 
 class CHIPContentLauncherClusterLaunchURLResponseCallbackBridge
-    : public CHIPCallbackBridge<ContentLauncherClusterLaunchURLResponseCallback>
+    : public CHIPCallbackBridge<CHIPContentLauncherClusterLaunchURLResponseCallbackType>
 {
 public:
     CHIPContentLauncherClusterLaunchURLResponseCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
                                                               CHIPActionBlock action, bool keepAlive = false) :
-        CHIPCallbackBridge<ContentLauncherClusterLaunchURLResponseCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
+        CHIPCallbackBridge<CHIPContentLauncherClusterLaunchURLResponseCallbackType>(queue, handler, action, OnSuccessFn,
+                                                                                    keepAlive){};
 
-    static void OnSuccessFn(void * context, chip::CharSpan data, uint8_t contentLaunchStatus);
+    static void OnSuccessFn(void * context,
+                            const chip::app::Clusters::ContentLauncher::Commands::LaunchURLResponse::DecodableType & data);
 };
 
 class CHIPDiagnosticLogsClusterRetrieveLogsResponseCallbackBridge
-    : public CHIPCallbackBridge<DiagnosticLogsClusterRetrieveLogsResponseCallback>
+    : public CHIPCallbackBridge<CHIPDiagnosticLogsClusterRetrieveLogsResponseCallbackType>
 {
 public:
     CHIPDiagnosticLogsClusterRetrieveLogsResponseCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
                                                                 CHIPActionBlock action, bool keepAlive = false) :
-        CHIPCallbackBridge<DiagnosticLogsClusterRetrieveLogsResponseCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
+        CHIPCallbackBridge<CHIPDiagnosticLogsClusterRetrieveLogsResponseCallbackType>(queue, handler, action, OnSuccessFn,
+                                                                                      keepAlive){};
 
-    static void OnSuccessFn(void * context, uint8_t status, chip::ByteSpan content, uint32_t timeStamp, uint32_t timeSinceBoot);
+    static void OnSuccessFn(void * context,
+                            const chip::app::Clusters::DiagnosticLogs::Commands::RetrieveLogsResponse::DecodableType & data);
 };
 
-class CHIPDoorLockClusterClearAllPinsResponseCallbackBridge : public CHIPCallbackBridge<DoorLockClusterClearAllPinsResponseCallback>
+class CHIPDoorLockClusterClearAllPinsResponseCallbackBridge
+    : public CHIPCallbackBridge<CHIPDoorLockClusterClearAllPinsResponseCallbackType>
 {
 public:
     CHIPDoorLockClusterClearAllPinsResponseCallbackBridge(dispatch_queue_t queue, ResponseHandler handler, CHIPActionBlock action,
                                                           bool keepAlive = false) :
-        CHIPCallbackBridge<DoorLockClusterClearAllPinsResponseCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
+        CHIPCallbackBridge<CHIPDoorLockClusterClearAllPinsResponseCallbackType>(queue, handler, action, OnSuccessFn, keepAlive){};
 
-    static void OnSuccessFn(void * context, uint8_t status);
+    static void OnSuccessFn(void * context,
+                            const chip::app::Clusters::DoorLock::Commands::ClearAllPinsResponse::DecodableType & data);
 };
 
 class CHIPDoorLockClusterClearAllRfidsResponseCallbackBridge
-    : public CHIPCallbackBridge<DoorLockClusterClearAllRfidsResponseCallback>
+    : public CHIPCallbackBridge<CHIPDoorLockClusterClearAllRfidsResponseCallbackType>
 {
 public:
     CHIPDoorLockClusterClearAllRfidsResponseCallbackBridge(dispatch_queue_t queue, ResponseHandler handler, CHIPActionBlock action,
                                                            bool keepAlive = false) :
-        CHIPCallbackBridge<DoorLockClusterClearAllRfidsResponseCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
+        CHIPCallbackBridge<CHIPDoorLockClusterClearAllRfidsResponseCallbackType>(queue, handler, action, OnSuccessFn, keepAlive){};
 
-    static void OnSuccessFn(void * context, uint8_t status);
+    static void OnSuccessFn(void * context,
+                            const chip::app::Clusters::DoorLock::Commands::ClearAllRfidsResponse::DecodableType & data);
 };
 
 class CHIPDoorLockClusterClearHolidayScheduleResponseCallbackBridge
-    : public CHIPCallbackBridge<DoorLockClusterClearHolidayScheduleResponseCallback>
+    : public CHIPCallbackBridge<CHIPDoorLockClusterClearHolidayScheduleResponseCallbackType>
 {
 public:
     CHIPDoorLockClusterClearHolidayScheduleResponseCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
                                                                   CHIPActionBlock action, bool keepAlive = false) :
-        CHIPCallbackBridge<DoorLockClusterClearHolidayScheduleResponseCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
+        CHIPCallbackBridge<CHIPDoorLockClusterClearHolidayScheduleResponseCallbackType>(queue, handler, action, OnSuccessFn,
+                                                                                        keepAlive){};
 
-    static void OnSuccessFn(void * context, uint8_t status);
+    static void OnSuccessFn(void * context,
+                            const chip::app::Clusters::DoorLock::Commands::ClearHolidayScheduleResponse::DecodableType & data);
 };
 
-class CHIPDoorLockClusterClearPinResponseCallbackBridge : public CHIPCallbackBridge<DoorLockClusterClearPinResponseCallback>
+class CHIPDoorLockClusterClearPinResponseCallbackBridge : public CHIPCallbackBridge<CHIPDoorLockClusterClearPinResponseCallbackType>
 {
 public:
     CHIPDoorLockClusterClearPinResponseCallbackBridge(dispatch_queue_t queue, ResponseHandler handler, CHIPActionBlock action,
                                                       bool keepAlive = false) :
-        CHIPCallbackBridge<DoorLockClusterClearPinResponseCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
+        CHIPCallbackBridge<CHIPDoorLockClusterClearPinResponseCallbackType>(queue, handler, action, OnSuccessFn, keepAlive){};
 
-    static void OnSuccessFn(void * context, uint8_t status);
+    static void OnSuccessFn(void * context, const chip::app::Clusters::DoorLock::Commands::ClearPinResponse::DecodableType & data);
 };
 
-class CHIPDoorLockClusterClearRfidResponseCallbackBridge : public CHIPCallbackBridge<DoorLockClusterClearRfidResponseCallback>
+class CHIPDoorLockClusterClearRfidResponseCallbackBridge
+    : public CHIPCallbackBridge<CHIPDoorLockClusterClearRfidResponseCallbackType>
 {
 public:
     CHIPDoorLockClusterClearRfidResponseCallbackBridge(dispatch_queue_t queue, ResponseHandler handler, CHIPActionBlock action,
                                                        bool keepAlive = false) :
-        CHIPCallbackBridge<DoorLockClusterClearRfidResponseCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
+        CHIPCallbackBridge<CHIPDoorLockClusterClearRfidResponseCallbackType>(queue, handler, action, OnSuccessFn, keepAlive){};
 
-    static void OnSuccessFn(void * context, uint8_t status);
+    static void OnSuccessFn(void * context, const chip::app::Clusters::DoorLock::Commands::ClearRfidResponse::DecodableType & data);
 };
 
 class CHIPDoorLockClusterClearWeekdayScheduleResponseCallbackBridge
-    : public CHIPCallbackBridge<DoorLockClusterClearWeekdayScheduleResponseCallback>
+    : public CHIPCallbackBridge<CHIPDoorLockClusterClearWeekdayScheduleResponseCallbackType>
 {
 public:
     CHIPDoorLockClusterClearWeekdayScheduleResponseCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
                                                                   CHIPActionBlock action, bool keepAlive = false) :
-        CHIPCallbackBridge<DoorLockClusterClearWeekdayScheduleResponseCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
+        CHIPCallbackBridge<CHIPDoorLockClusterClearWeekdayScheduleResponseCallbackType>(queue, handler, action, OnSuccessFn,
+                                                                                        keepAlive){};
 
-    static void OnSuccessFn(void * context, uint8_t status);
+    static void OnSuccessFn(void * context,
+                            const chip::app::Clusters::DoorLock::Commands::ClearWeekdayScheduleResponse::DecodableType & data);
 };
 
 class CHIPDoorLockClusterClearYeardayScheduleResponseCallbackBridge
-    : public CHIPCallbackBridge<DoorLockClusterClearYeardayScheduleResponseCallback>
+    : public CHIPCallbackBridge<CHIPDoorLockClusterClearYeardayScheduleResponseCallbackType>
 {
 public:
     CHIPDoorLockClusterClearYeardayScheduleResponseCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
                                                                   CHIPActionBlock action, bool keepAlive = false) :
-        CHIPCallbackBridge<DoorLockClusterClearYeardayScheduleResponseCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
+        CHIPCallbackBridge<CHIPDoorLockClusterClearYeardayScheduleResponseCallbackType>(queue, handler, action, OnSuccessFn,
+                                                                                        keepAlive){};
 
-    static void OnSuccessFn(void * context, uint8_t status);
+    static void OnSuccessFn(void * context,
+                            const chip::app::Clusters::DoorLock::Commands::ClearYeardayScheduleResponse::DecodableType & data);
 };
 
 class CHIPDoorLockClusterGetHolidayScheduleResponseCallbackBridge
-    : public CHIPCallbackBridge<DoorLockClusterGetHolidayScheduleResponseCallback>
+    : public CHIPCallbackBridge<CHIPDoorLockClusterGetHolidayScheduleResponseCallbackType>
 {
 public:
     CHIPDoorLockClusterGetHolidayScheduleResponseCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
                                                                 CHIPActionBlock action, bool keepAlive = false) :
-        CHIPCallbackBridge<DoorLockClusterGetHolidayScheduleResponseCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
+        CHIPCallbackBridge<CHIPDoorLockClusterGetHolidayScheduleResponseCallbackType>(queue, handler, action, OnSuccessFn,
+                                                                                      keepAlive){};
 
-    static void OnSuccessFn(void * context, uint8_t scheduleId, uint8_t status, uint32_t localStartTime, uint32_t localEndTime,
-                            uint8_t operatingModeDuringHoliday);
+    static void OnSuccessFn(void * context,
+                            const chip::app::Clusters::DoorLock::Commands::GetHolidayScheduleResponse::DecodableType & data);
 };
 
-class CHIPDoorLockClusterGetLogRecordResponseCallbackBridge : public CHIPCallbackBridge<DoorLockClusterGetLogRecordResponseCallback>
+class CHIPDoorLockClusterGetLogRecordResponseCallbackBridge
+    : public CHIPCallbackBridge<CHIPDoorLockClusterGetLogRecordResponseCallbackType>
 {
 public:
     CHIPDoorLockClusterGetLogRecordResponseCallbackBridge(dispatch_queue_t queue, ResponseHandler handler, CHIPActionBlock action,
                                                           bool keepAlive = false) :
-        CHIPCallbackBridge<DoorLockClusterGetLogRecordResponseCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
+        CHIPCallbackBridge<CHIPDoorLockClusterGetLogRecordResponseCallbackType>(queue, handler, action, OnSuccessFn, keepAlive){};
 
-    static void OnSuccessFn(void * context, uint16_t logEntryId, uint32_t timestamp, uint8_t eventType, uint8_t source,
-                            uint8_t eventIdOrAlarmCode, uint16_t userId, chip::ByteSpan pin);
+    static void OnSuccessFn(void * context,
+                            const chip::app::Clusters::DoorLock::Commands::GetLogRecordResponse::DecodableType & data);
 };
 
-class CHIPDoorLockClusterGetPinResponseCallbackBridge : public CHIPCallbackBridge<DoorLockClusterGetPinResponseCallback>
+class CHIPDoorLockClusterGetPinResponseCallbackBridge : public CHIPCallbackBridge<CHIPDoorLockClusterGetPinResponseCallbackType>
 {
 public:
     CHIPDoorLockClusterGetPinResponseCallbackBridge(dispatch_queue_t queue, ResponseHandler handler, CHIPActionBlock action,
                                                     bool keepAlive = false) :
-        CHIPCallbackBridge<DoorLockClusterGetPinResponseCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
+        CHIPCallbackBridge<CHIPDoorLockClusterGetPinResponseCallbackType>(queue, handler, action, OnSuccessFn, keepAlive){};
 
-    static void OnSuccessFn(void * context, uint16_t userId, uint8_t userStatus, uint8_t userType, chip::ByteSpan pin);
+    static void OnSuccessFn(void * context, const chip::app::Clusters::DoorLock::Commands::GetPinResponse::DecodableType & data);
 };
 
-class CHIPDoorLockClusterGetRfidResponseCallbackBridge : public CHIPCallbackBridge<DoorLockClusterGetRfidResponseCallback>
+class CHIPDoorLockClusterGetRfidResponseCallbackBridge : public CHIPCallbackBridge<CHIPDoorLockClusterGetRfidResponseCallbackType>
 {
 public:
     CHIPDoorLockClusterGetRfidResponseCallbackBridge(dispatch_queue_t queue, ResponseHandler handler, CHIPActionBlock action,
                                                      bool keepAlive = false) :
-        CHIPCallbackBridge<DoorLockClusterGetRfidResponseCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
+        CHIPCallbackBridge<CHIPDoorLockClusterGetRfidResponseCallbackType>(queue, handler, action, OnSuccessFn, keepAlive){};
 
-    static void OnSuccessFn(void * context, uint16_t userId, uint8_t userStatus, uint8_t userType, chip::ByteSpan rfid);
+    static void OnSuccessFn(void * context, const chip::app::Clusters::DoorLock::Commands::GetRfidResponse::DecodableType & data);
 };
 
-class CHIPDoorLockClusterGetUserTypeResponseCallbackBridge : public CHIPCallbackBridge<DoorLockClusterGetUserTypeResponseCallback>
+class CHIPDoorLockClusterGetUserTypeResponseCallbackBridge
+    : public CHIPCallbackBridge<CHIPDoorLockClusterGetUserTypeResponseCallbackType>
 {
 public:
     CHIPDoorLockClusterGetUserTypeResponseCallbackBridge(dispatch_queue_t queue, ResponseHandler handler, CHIPActionBlock action,
                                                          bool keepAlive = false) :
-        CHIPCallbackBridge<DoorLockClusterGetUserTypeResponseCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
+        CHIPCallbackBridge<CHIPDoorLockClusterGetUserTypeResponseCallbackType>(queue, handler, action, OnSuccessFn, keepAlive){};
 
-    static void OnSuccessFn(void * context, uint16_t userId, uint8_t userType);
+    static void OnSuccessFn(void * context,
+                            const chip::app::Clusters::DoorLock::Commands::GetUserTypeResponse::DecodableType & data);
 };
 
 class CHIPDoorLockClusterGetWeekdayScheduleResponseCallbackBridge
-    : public CHIPCallbackBridge<DoorLockClusterGetWeekdayScheduleResponseCallback>
+    : public CHIPCallbackBridge<CHIPDoorLockClusterGetWeekdayScheduleResponseCallbackType>
 {
 public:
     CHIPDoorLockClusterGetWeekdayScheduleResponseCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
                                                                 CHIPActionBlock action, bool keepAlive = false) :
-        CHIPCallbackBridge<DoorLockClusterGetWeekdayScheduleResponseCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
+        CHIPCallbackBridge<CHIPDoorLockClusterGetWeekdayScheduleResponseCallbackType>(queue, handler, action, OnSuccessFn,
+                                                                                      keepAlive){};
 
-    static void OnSuccessFn(void * context, uint8_t scheduleId, uint16_t userId, uint8_t status, uint8_t daysMask,
-                            uint8_t startHour, uint8_t startMinute, uint8_t endHour, uint8_t endMinute);
+    static void OnSuccessFn(void * context,
+                            const chip::app::Clusters::DoorLock::Commands::GetWeekdayScheduleResponse::DecodableType & data);
 };
 
 class CHIPDoorLockClusterGetYeardayScheduleResponseCallbackBridge
-    : public CHIPCallbackBridge<DoorLockClusterGetYeardayScheduleResponseCallback>
+    : public CHIPCallbackBridge<CHIPDoorLockClusterGetYeardayScheduleResponseCallbackType>
 {
 public:
     CHIPDoorLockClusterGetYeardayScheduleResponseCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
                                                                 CHIPActionBlock action, bool keepAlive = false) :
-        CHIPCallbackBridge<DoorLockClusterGetYeardayScheduleResponseCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
+        CHIPCallbackBridge<CHIPDoorLockClusterGetYeardayScheduleResponseCallbackType>(queue, handler, action, OnSuccessFn,
+                                                                                      keepAlive){};
 
-    static void OnSuccessFn(void * context, uint8_t scheduleId, uint16_t userId, uint8_t status, uint32_t localStartTime,
-                            uint32_t localEndTime);
+    static void OnSuccessFn(void * context,
+                            const chip::app::Clusters::DoorLock::Commands::GetYeardayScheduleResponse::DecodableType & data);
 };
 
-class CHIPDoorLockClusterLockDoorResponseCallbackBridge : public CHIPCallbackBridge<DoorLockClusterLockDoorResponseCallback>
+class CHIPDoorLockClusterLockDoorResponseCallbackBridge : public CHIPCallbackBridge<CHIPDoorLockClusterLockDoorResponseCallbackType>
 {
 public:
     CHIPDoorLockClusterLockDoorResponseCallbackBridge(dispatch_queue_t queue, ResponseHandler handler, CHIPActionBlock action,
                                                       bool keepAlive = false) :
-        CHIPCallbackBridge<DoorLockClusterLockDoorResponseCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
+        CHIPCallbackBridge<CHIPDoorLockClusterLockDoorResponseCallbackType>(queue, handler, action, OnSuccessFn, keepAlive){};
 
-    static void OnSuccessFn(void * context, uint8_t status);
+    static void OnSuccessFn(void * context, const chip::app::Clusters::DoorLock::Commands::LockDoorResponse::DecodableType & data);
 };
 
 class CHIPDoorLockClusterSetHolidayScheduleResponseCallbackBridge
-    : public CHIPCallbackBridge<DoorLockClusterSetHolidayScheduleResponseCallback>
+    : public CHIPCallbackBridge<CHIPDoorLockClusterSetHolidayScheduleResponseCallbackType>
 {
 public:
     CHIPDoorLockClusterSetHolidayScheduleResponseCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
                                                                 CHIPActionBlock action, bool keepAlive = false) :
-        CHIPCallbackBridge<DoorLockClusterSetHolidayScheduleResponseCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
+        CHIPCallbackBridge<CHIPDoorLockClusterSetHolidayScheduleResponseCallbackType>(queue, handler, action, OnSuccessFn,
+                                                                                      keepAlive){};
 
-    static void OnSuccessFn(void * context, uint8_t status);
+    static void OnSuccessFn(void * context,
+                            const chip::app::Clusters::DoorLock::Commands::SetHolidayScheduleResponse::DecodableType & data);
 };
 
-class CHIPDoorLockClusterSetPinResponseCallbackBridge : public CHIPCallbackBridge<DoorLockClusterSetPinResponseCallback>
+class CHIPDoorLockClusterSetPinResponseCallbackBridge : public CHIPCallbackBridge<CHIPDoorLockClusterSetPinResponseCallbackType>
 {
 public:
     CHIPDoorLockClusterSetPinResponseCallbackBridge(dispatch_queue_t queue, ResponseHandler handler, CHIPActionBlock action,
                                                     bool keepAlive = false) :
-        CHIPCallbackBridge<DoorLockClusterSetPinResponseCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
+        CHIPCallbackBridge<CHIPDoorLockClusterSetPinResponseCallbackType>(queue, handler, action, OnSuccessFn, keepAlive){};
 
-    static void OnSuccessFn(void * context, uint8_t status);
+    static void OnSuccessFn(void * context, const chip::app::Clusters::DoorLock::Commands::SetPinResponse::DecodableType & data);
 };
 
-class CHIPDoorLockClusterSetRfidResponseCallbackBridge : public CHIPCallbackBridge<DoorLockClusterSetRfidResponseCallback>
+class CHIPDoorLockClusterSetRfidResponseCallbackBridge : public CHIPCallbackBridge<CHIPDoorLockClusterSetRfidResponseCallbackType>
 {
 public:
     CHIPDoorLockClusterSetRfidResponseCallbackBridge(dispatch_queue_t queue, ResponseHandler handler, CHIPActionBlock action,
                                                      bool keepAlive = false) :
-        CHIPCallbackBridge<DoorLockClusterSetRfidResponseCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
+        CHIPCallbackBridge<CHIPDoorLockClusterSetRfidResponseCallbackType>(queue, handler, action, OnSuccessFn, keepAlive){};
 
-    static void OnSuccessFn(void * context, uint8_t status);
+    static void OnSuccessFn(void * context, const chip::app::Clusters::DoorLock::Commands::SetRfidResponse::DecodableType & data);
 };
 
-class CHIPDoorLockClusterSetUserTypeResponseCallbackBridge : public CHIPCallbackBridge<DoorLockClusterSetUserTypeResponseCallback>
+class CHIPDoorLockClusterSetUserTypeResponseCallbackBridge
+    : public CHIPCallbackBridge<CHIPDoorLockClusterSetUserTypeResponseCallbackType>
 {
 public:
     CHIPDoorLockClusterSetUserTypeResponseCallbackBridge(dispatch_queue_t queue, ResponseHandler handler, CHIPActionBlock action,
                                                          bool keepAlive = false) :
-        CHIPCallbackBridge<DoorLockClusterSetUserTypeResponseCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
+        CHIPCallbackBridge<CHIPDoorLockClusterSetUserTypeResponseCallbackType>(queue, handler, action, OnSuccessFn, keepAlive){};
 
-    static void OnSuccessFn(void * context, uint8_t status);
+    static void OnSuccessFn(void * context,
+                            const chip::app::Clusters::DoorLock::Commands::SetUserTypeResponse::DecodableType & data);
 };
 
 class CHIPDoorLockClusterSetWeekdayScheduleResponseCallbackBridge
-    : public CHIPCallbackBridge<DoorLockClusterSetWeekdayScheduleResponseCallback>
+    : public CHIPCallbackBridge<CHIPDoorLockClusterSetWeekdayScheduleResponseCallbackType>
 {
 public:
     CHIPDoorLockClusterSetWeekdayScheduleResponseCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
                                                                 CHIPActionBlock action, bool keepAlive = false) :
-        CHIPCallbackBridge<DoorLockClusterSetWeekdayScheduleResponseCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
+        CHIPCallbackBridge<CHIPDoorLockClusterSetWeekdayScheduleResponseCallbackType>(queue, handler, action, OnSuccessFn,
+                                                                                      keepAlive){};
 
-    static void OnSuccessFn(void * context, uint8_t status);
+    static void OnSuccessFn(void * context,
+                            const chip::app::Clusters::DoorLock::Commands::SetWeekdayScheduleResponse::DecodableType & data);
 };
 
 class CHIPDoorLockClusterSetYeardayScheduleResponseCallbackBridge
-    : public CHIPCallbackBridge<DoorLockClusterSetYeardayScheduleResponseCallback>
+    : public CHIPCallbackBridge<CHIPDoorLockClusterSetYeardayScheduleResponseCallbackType>
 {
 public:
     CHIPDoorLockClusterSetYeardayScheduleResponseCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
                                                                 CHIPActionBlock action, bool keepAlive = false) :
-        CHIPCallbackBridge<DoorLockClusterSetYeardayScheduleResponseCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
+        CHIPCallbackBridge<CHIPDoorLockClusterSetYeardayScheduleResponseCallbackType>(queue, handler, action, OnSuccessFn,
+                                                                                      keepAlive){};
 
-    static void OnSuccessFn(void * context, uint8_t status);
+    static void OnSuccessFn(void * context,
+                            const chip::app::Clusters::DoorLock::Commands::SetYeardayScheduleResponse::DecodableType & data);
 };
 
-class CHIPDoorLockClusterUnlockDoorResponseCallbackBridge : public CHIPCallbackBridge<DoorLockClusterUnlockDoorResponseCallback>
+class CHIPDoorLockClusterUnlockDoorResponseCallbackBridge
+    : public CHIPCallbackBridge<CHIPDoorLockClusterUnlockDoorResponseCallbackType>
 {
 public:
     CHIPDoorLockClusterUnlockDoorResponseCallbackBridge(dispatch_queue_t queue, ResponseHandler handler, CHIPActionBlock action,
                                                         bool keepAlive = false) :
-        CHIPCallbackBridge<DoorLockClusterUnlockDoorResponseCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
+        CHIPCallbackBridge<CHIPDoorLockClusterUnlockDoorResponseCallbackType>(queue, handler, action, OnSuccessFn, keepAlive){};
 
-    static void OnSuccessFn(void * context, uint8_t status);
+    static void OnSuccessFn(void * context,
+                            const chip::app::Clusters::DoorLock::Commands::UnlockDoorResponse::DecodableType & data);
 };
 
 class CHIPDoorLockClusterUnlockWithTimeoutResponseCallbackBridge
-    : public CHIPCallbackBridge<DoorLockClusterUnlockWithTimeoutResponseCallback>
+    : public CHIPCallbackBridge<CHIPDoorLockClusterUnlockWithTimeoutResponseCallbackType>
 {
 public:
     CHIPDoorLockClusterUnlockWithTimeoutResponseCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
                                                                CHIPActionBlock action, bool keepAlive = false) :
-        CHIPCallbackBridge<DoorLockClusterUnlockWithTimeoutResponseCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
+        CHIPCallbackBridge<CHIPDoorLockClusterUnlockWithTimeoutResponseCallbackType>(queue, handler, action, OnSuccessFn,
+                                                                                     keepAlive){};
 
-    static void OnSuccessFn(void * context, uint8_t status);
+    static void OnSuccessFn(void * context,
+                            const chip::app::Clusters::DoorLock::Commands::UnlockWithTimeoutResponse::DecodableType & data);
 };
 
 class CHIPGeneralCommissioningClusterArmFailSafeResponseCallbackBridge
-    : public CHIPCallbackBridge<GeneralCommissioningClusterArmFailSafeResponseCallback>
+    : public CHIPCallbackBridge<CHIPGeneralCommissioningClusterArmFailSafeResponseCallbackType>
 {
 public:
     CHIPGeneralCommissioningClusterArmFailSafeResponseCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
                                                                      CHIPActionBlock action, bool keepAlive = false) :
-        CHIPCallbackBridge<GeneralCommissioningClusterArmFailSafeResponseCallback>(queue, handler, action, OnSuccessFn,
-                                                                                   keepAlive){};
+        CHIPCallbackBridge<CHIPGeneralCommissioningClusterArmFailSafeResponseCallbackType>(queue, handler, action, OnSuccessFn,
+                                                                                           keepAlive){};
 
-    static void OnSuccessFn(void * context, uint8_t errorCode, chip::CharSpan debugText);
+    static void OnSuccessFn(void * context,
+                            const chip::app::Clusters::GeneralCommissioning::Commands::ArmFailSafeResponse::DecodableType & data);
 };
 
 class CHIPGeneralCommissioningClusterCommissioningCompleteResponseCallbackBridge
-    : public CHIPCallbackBridge<GeneralCommissioningClusterCommissioningCompleteResponseCallback>
+    : public CHIPCallbackBridge<CHIPGeneralCommissioningClusterCommissioningCompleteResponseCallbackType>
 {
 public:
     CHIPGeneralCommissioningClusterCommissioningCompleteResponseCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
                                                                                CHIPActionBlock action, bool keepAlive = false) :
-        CHIPCallbackBridge<GeneralCommissioningClusterCommissioningCompleteResponseCallback>(queue, handler, action, OnSuccessFn,
-                                                                                             keepAlive){};
+        CHIPCallbackBridge<CHIPGeneralCommissioningClusterCommissioningCompleteResponseCallbackType>(queue, handler, action,
+                                                                                                     OnSuccessFn, keepAlive){};
 
-    static void OnSuccessFn(void * context, uint8_t errorCode, chip::CharSpan debugText);
+    static void
+    OnSuccessFn(void * context,
+                const chip::app::Clusters::GeneralCommissioning::Commands::CommissioningCompleteResponse::DecodableType & data);
 };
 
 class CHIPGeneralCommissioningClusterSetRegulatoryConfigResponseCallbackBridge
-    : public CHIPCallbackBridge<GeneralCommissioningClusterSetRegulatoryConfigResponseCallback>
+    : public CHIPCallbackBridge<CHIPGeneralCommissioningClusterSetRegulatoryConfigResponseCallbackType>
 {
 public:
     CHIPGeneralCommissioningClusterSetRegulatoryConfigResponseCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
                                                                              CHIPActionBlock action, bool keepAlive = false) :
-        CHIPCallbackBridge<GeneralCommissioningClusterSetRegulatoryConfigResponseCallback>(queue, handler, action, OnSuccessFn,
-                                                                                           keepAlive){};
+        CHIPCallbackBridge<CHIPGeneralCommissioningClusterSetRegulatoryConfigResponseCallbackType>(queue, handler, action,
+                                                                                                   OnSuccessFn, keepAlive){};
 
-    static void OnSuccessFn(void * context, uint8_t errorCode, chip::CharSpan debugText);
+    static void
+    OnSuccessFn(void * context,
+                const chip::app::Clusters::GeneralCommissioning::Commands::SetRegulatoryConfigResponse::DecodableType & data);
 };
 
-class CHIPGroupsClusterAddGroupResponseCallbackBridge : public CHIPCallbackBridge<GroupsClusterAddGroupResponseCallback>
+class CHIPGroupsClusterAddGroupResponseCallbackBridge : public CHIPCallbackBridge<CHIPGroupsClusterAddGroupResponseCallbackType>
 {
 public:
     CHIPGroupsClusterAddGroupResponseCallbackBridge(dispatch_queue_t queue, ResponseHandler handler, CHIPActionBlock action,
                                                     bool keepAlive = false) :
-        CHIPCallbackBridge<GroupsClusterAddGroupResponseCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
+        CHIPCallbackBridge<CHIPGroupsClusterAddGroupResponseCallbackType>(queue, handler, action, OnSuccessFn, keepAlive){};
 
-    static void OnSuccessFn(void * context, uint8_t status, uint16_t groupId);
+    static void OnSuccessFn(void * context, const chip::app::Clusters::Groups::Commands::AddGroupResponse::DecodableType & data);
 };
 
 class CHIPGroupsClusterGetGroupMembershipResponseCallbackBridge
-    : public CHIPCallbackBridge<GroupsClusterGetGroupMembershipResponseCallback>
+    : public CHIPCallbackBridge<CHIPGroupsClusterGetGroupMembershipResponseCallbackType>
 {
 public:
     CHIPGroupsClusterGetGroupMembershipResponseCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
                                                               CHIPActionBlock action, bool keepAlive = false) :
-        CHIPCallbackBridge<GroupsClusterGetGroupMembershipResponseCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
+        CHIPCallbackBridge<CHIPGroupsClusterGetGroupMembershipResponseCallbackType>(queue, handler, action, OnSuccessFn,
+                                                                                    keepAlive){};
 
-    static void OnSuccessFn(void * context, uint8_t capacity, uint8_t groupCount,
-                            /* TYPE WARNING: array array defaults to */ uint8_t * groupList);
+    static void OnSuccessFn(void * context,
+                            const chip::app::Clusters::Groups::Commands::GetGroupMembershipResponse::DecodableType & data);
 };
 
-class CHIPGroupsClusterRemoveGroupResponseCallbackBridge : public CHIPCallbackBridge<GroupsClusterRemoveGroupResponseCallback>
+class CHIPGroupsClusterRemoveGroupResponseCallbackBridge
+    : public CHIPCallbackBridge<CHIPGroupsClusterRemoveGroupResponseCallbackType>
 {
 public:
     CHIPGroupsClusterRemoveGroupResponseCallbackBridge(dispatch_queue_t queue, ResponseHandler handler, CHIPActionBlock action,
                                                        bool keepAlive = false) :
-        CHIPCallbackBridge<GroupsClusterRemoveGroupResponseCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
+        CHIPCallbackBridge<CHIPGroupsClusterRemoveGroupResponseCallbackType>(queue, handler, action, OnSuccessFn, keepAlive){};
 
-    static void OnSuccessFn(void * context, uint8_t status, uint16_t groupId);
+    static void OnSuccessFn(void * context, const chip::app::Clusters::Groups::Commands::RemoveGroupResponse::DecodableType & data);
 };
 
-class CHIPGroupsClusterViewGroupResponseCallbackBridge : public CHIPCallbackBridge<GroupsClusterViewGroupResponseCallback>
+class CHIPGroupsClusterViewGroupResponseCallbackBridge : public CHIPCallbackBridge<CHIPGroupsClusterViewGroupResponseCallbackType>
 {
 public:
     CHIPGroupsClusterViewGroupResponseCallbackBridge(dispatch_queue_t queue, ResponseHandler handler, CHIPActionBlock action,
                                                      bool keepAlive = false) :
-        CHIPCallbackBridge<GroupsClusterViewGroupResponseCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
+        CHIPCallbackBridge<CHIPGroupsClusterViewGroupResponseCallbackType>(queue, handler, action, OnSuccessFn, keepAlive){};
 
-    static void OnSuccessFn(void * context, uint8_t status, uint16_t groupId, chip::CharSpan groupName);
+    static void OnSuccessFn(void * context, const chip::app::Clusters::Groups::Commands::ViewGroupResponse::DecodableType & data);
 };
 
 class CHIPIdentifyClusterIdentifyQueryResponseCallbackBridge
-    : public CHIPCallbackBridge<IdentifyClusterIdentifyQueryResponseCallback>
+    : public CHIPCallbackBridge<CHIPIdentifyClusterIdentifyQueryResponseCallbackType>
 {
 public:
     CHIPIdentifyClusterIdentifyQueryResponseCallbackBridge(dispatch_queue_t queue, ResponseHandler handler, CHIPActionBlock action,
                                                            bool keepAlive = false) :
-        CHIPCallbackBridge<IdentifyClusterIdentifyQueryResponseCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
+        CHIPCallbackBridge<CHIPIdentifyClusterIdentifyQueryResponseCallbackType>(queue, handler, action, OnSuccessFn, keepAlive){};
 
-    static void OnSuccessFn(void * context, uint16_t timeout);
+    static void OnSuccessFn(void * context,
+                            const chip::app::Clusters::Identify::Commands::IdentifyQueryResponse::DecodableType & data);
 };
 
-class CHIPKeypadInputClusterSendKeyResponseCallbackBridge : public CHIPCallbackBridge<KeypadInputClusterSendKeyResponseCallback>
+class CHIPKeypadInputClusterSendKeyResponseCallbackBridge
+    : public CHIPCallbackBridge<CHIPKeypadInputClusterSendKeyResponseCallbackType>
 {
 public:
     CHIPKeypadInputClusterSendKeyResponseCallbackBridge(dispatch_queue_t queue, ResponseHandler handler, CHIPActionBlock action,
                                                         bool keepAlive = false) :
-        CHIPCallbackBridge<KeypadInputClusterSendKeyResponseCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
+        CHIPCallbackBridge<CHIPKeypadInputClusterSendKeyResponseCallbackType>(queue, handler, action, OnSuccessFn, keepAlive){};
 
-    static void OnSuccessFn(void * context, uint8_t status);
+    static void OnSuccessFn(void * context,
+                            const chip::app::Clusters::KeypadInput::Commands::SendKeyResponse::DecodableType & data);
 };
 
 class CHIPMediaPlaybackClusterMediaFastForwardResponseCallbackBridge
-    : public CHIPCallbackBridge<MediaPlaybackClusterMediaFastForwardResponseCallback>
+    : public CHIPCallbackBridge<CHIPMediaPlaybackClusterMediaFastForwardResponseCallbackType>
 {
 public:
     CHIPMediaPlaybackClusterMediaFastForwardResponseCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
                                                                    CHIPActionBlock action, bool keepAlive = false) :
-        CHIPCallbackBridge<MediaPlaybackClusterMediaFastForwardResponseCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
+        CHIPCallbackBridge<CHIPMediaPlaybackClusterMediaFastForwardResponseCallbackType>(queue, handler, action, OnSuccessFn,
+                                                                                         keepAlive){};
 
-    static void OnSuccessFn(void * context, uint8_t mediaPlaybackStatus);
+    static void OnSuccessFn(void * context,
+                            const chip::app::Clusters::MediaPlayback::Commands::MediaFastForwardResponse::DecodableType & data);
 };
 
 class CHIPMediaPlaybackClusterMediaNextResponseCallbackBridge
-    : public CHIPCallbackBridge<MediaPlaybackClusterMediaNextResponseCallback>
+    : public CHIPCallbackBridge<CHIPMediaPlaybackClusterMediaNextResponseCallbackType>
 {
 public:
     CHIPMediaPlaybackClusterMediaNextResponseCallbackBridge(dispatch_queue_t queue, ResponseHandler handler, CHIPActionBlock action,
                                                             bool keepAlive = false) :
-        CHIPCallbackBridge<MediaPlaybackClusterMediaNextResponseCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
+        CHIPCallbackBridge<CHIPMediaPlaybackClusterMediaNextResponseCallbackType>(queue, handler, action, OnSuccessFn, keepAlive){};
 
-    static void OnSuccessFn(void * context, uint8_t mediaPlaybackStatus);
+    static void OnSuccessFn(void * context,
+                            const chip::app::Clusters::MediaPlayback::Commands::MediaNextResponse::DecodableType & data);
 };
 
 class CHIPMediaPlaybackClusterMediaPauseResponseCallbackBridge
-    : public CHIPCallbackBridge<MediaPlaybackClusterMediaPauseResponseCallback>
+    : public CHIPCallbackBridge<CHIPMediaPlaybackClusterMediaPauseResponseCallbackType>
 {
 public:
     CHIPMediaPlaybackClusterMediaPauseResponseCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
                                                              CHIPActionBlock action, bool keepAlive = false) :
-        CHIPCallbackBridge<MediaPlaybackClusterMediaPauseResponseCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
+        CHIPCallbackBridge<CHIPMediaPlaybackClusterMediaPauseResponseCallbackType>(queue, handler, action, OnSuccessFn,
+                                                                                   keepAlive){};
 
-    static void OnSuccessFn(void * context, uint8_t mediaPlaybackStatus);
+    static void OnSuccessFn(void * context,
+                            const chip::app::Clusters::MediaPlayback::Commands::MediaPauseResponse::DecodableType & data);
 };
 
 class CHIPMediaPlaybackClusterMediaPlayResponseCallbackBridge
-    : public CHIPCallbackBridge<MediaPlaybackClusterMediaPlayResponseCallback>
+    : public CHIPCallbackBridge<CHIPMediaPlaybackClusterMediaPlayResponseCallbackType>
 {
 public:
     CHIPMediaPlaybackClusterMediaPlayResponseCallbackBridge(dispatch_queue_t queue, ResponseHandler handler, CHIPActionBlock action,
                                                             bool keepAlive = false) :
-        CHIPCallbackBridge<MediaPlaybackClusterMediaPlayResponseCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
+        CHIPCallbackBridge<CHIPMediaPlaybackClusterMediaPlayResponseCallbackType>(queue, handler, action, OnSuccessFn, keepAlive){};
 
-    static void OnSuccessFn(void * context, uint8_t mediaPlaybackStatus);
+    static void OnSuccessFn(void * context,
+                            const chip::app::Clusters::MediaPlayback::Commands::MediaPlayResponse::DecodableType & data);
 };
 
 class CHIPMediaPlaybackClusterMediaPreviousResponseCallbackBridge
-    : public CHIPCallbackBridge<MediaPlaybackClusterMediaPreviousResponseCallback>
+    : public CHIPCallbackBridge<CHIPMediaPlaybackClusterMediaPreviousResponseCallbackType>
 {
 public:
     CHIPMediaPlaybackClusterMediaPreviousResponseCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
                                                                 CHIPActionBlock action, bool keepAlive = false) :
-        CHIPCallbackBridge<MediaPlaybackClusterMediaPreviousResponseCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
+        CHIPCallbackBridge<CHIPMediaPlaybackClusterMediaPreviousResponseCallbackType>(queue, handler, action, OnSuccessFn,
+                                                                                      keepAlive){};
 
-    static void OnSuccessFn(void * context, uint8_t mediaPlaybackStatus);
+    static void OnSuccessFn(void * context,
+                            const chip::app::Clusters::MediaPlayback::Commands::MediaPreviousResponse::DecodableType & data);
 };
 
 class CHIPMediaPlaybackClusterMediaRewindResponseCallbackBridge
-    : public CHIPCallbackBridge<MediaPlaybackClusterMediaRewindResponseCallback>
+    : public CHIPCallbackBridge<CHIPMediaPlaybackClusterMediaRewindResponseCallbackType>
 {
 public:
     CHIPMediaPlaybackClusterMediaRewindResponseCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
                                                               CHIPActionBlock action, bool keepAlive = false) :
-        CHIPCallbackBridge<MediaPlaybackClusterMediaRewindResponseCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
+        CHIPCallbackBridge<CHIPMediaPlaybackClusterMediaRewindResponseCallbackType>(queue, handler, action, OnSuccessFn,
+                                                                                    keepAlive){};
 
-    static void OnSuccessFn(void * context, uint8_t mediaPlaybackStatus);
+    static void OnSuccessFn(void * context,
+                            const chip::app::Clusters::MediaPlayback::Commands::MediaRewindResponse::DecodableType & data);
 };
 
 class CHIPMediaPlaybackClusterMediaSeekResponseCallbackBridge
-    : public CHIPCallbackBridge<MediaPlaybackClusterMediaSeekResponseCallback>
+    : public CHIPCallbackBridge<CHIPMediaPlaybackClusterMediaSeekResponseCallbackType>
 {
 public:
     CHIPMediaPlaybackClusterMediaSeekResponseCallbackBridge(dispatch_queue_t queue, ResponseHandler handler, CHIPActionBlock action,
                                                             bool keepAlive = false) :
-        CHIPCallbackBridge<MediaPlaybackClusterMediaSeekResponseCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
+        CHIPCallbackBridge<CHIPMediaPlaybackClusterMediaSeekResponseCallbackType>(queue, handler, action, OnSuccessFn, keepAlive){};
 
-    static void OnSuccessFn(void * context, uint8_t mediaPlaybackStatus);
+    static void OnSuccessFn(void * context,
+                            const chip::app::Clusters::MediaPlayback::Commands::MediaSeekResponse::DecodableType & data);
 };
 
 class CHIPMediaPlaybackClusterMediaSkipBackwardResponseCallbackBridge
-    : public CHIPCallbackBridge<MediaPlaybackClusterMediaSkipBackwardResponseCallback>
+    : public CHIPCallbackBridge<CHIPMediaPlaybackClusterMediaSkipBackwardResponseCallbackType>
 {
 public:
     CHIPMediaPlaybackClusterMediaSkipBackwardResponseCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
                                                                     CHIPActionBlock action, bool keepAlive = false) :
-        CHIPCallbackBridge<MediaPlaybackClusterMediaSkipBackwardResponseCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
+        CHIPCallbackBridge<CHIPMediaPlaybackClusterMediaSkipBackwardResponseCallbackType>(queue, handler, action, OnSuccessFn,
+                                                                                          keepAlive){};
 
-    static void OnSuccessFn(void * context, uint8_t mediaPlaybackStatus);
+    static void OnSuccessFn(void * context,
+                            const chip::app::Clusters::MediaPlayback::Commands::MediaSkipBackwardResponse::DecodableType & data);
 };
 
 class CHIPMediaPlaybackClusterMediaSkipForwardResponseCallbackBridge
-    : public CHIPCallbackBridge<MediaPlaybackClusterMediaSkipForwardResponseCallback>
+    : public CHIPCallbackBridge<CHIPMediaPlaybackClusterMediaSkipForwardResponseCallbackType>
 {
 public:
     CHIPMediaPlaybackClusterMediaSkipForwardResponseCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
                                                                    CHIPActionBlock action, bool keepAlive = false) :
-        CHIPCallbackBridge<MediaPlaybackClusterMediaSkipForwardResponseCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
+        CHIPCallbackBridge<CHIPMediaPlaybackClusterMediaSkipForwardResponseCallbackType>(queue, handler, action, OnSuccessFn,
+                                                                                         keepAlive){};
 
-    static void OnSuccessFn(void * context, uint8_t mediaPlaybackStatus);
+    static void OnSuccessFn(void * context,
+                            const chip::app::Clusters::MediaPlayback::Commands::MediaSkipForwardResponse::DecodableType & data);
 };
 
 class CHIPMediaPlaybackClusterMediaStartOverResponseCallbackBridge
-    : public CHIPCallbackBridge<MediaPlaybackClusterMediaStartOverResponseCallback>
+    : public CHIPCallbackBridge<CHIPMediaPlaybackClusterMediaStartOverResponseCallbackType>
 {
 public:
     CHIPMediaPlaybackClusterMediaStartOverResponseCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
                                                                  CHIPActionBlock action, bool keepAlive = false) :
-        CHIPCallbackBridge<MediaPlaybackClusterMediaStartOverResponseCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
+        CHIPCallbackBridge<CHIPMediaPlaybackClusterMediaStartOverResponseCallbackType>(queue, handler, action, OnSuccessFn,
+                                                                                       keepAlive){};
 
-    static void OnSuccessFn(void * context, uint8_t mediaPlaybackStatus);
+    static void OnSuccessFn(void * context,
+                            const chip::app::Clusters::MediaPlayback::Commands::MediaStartOverResponse::DecodableType & data);
 };
 
 class CHIPMediaPlaybackClusterMediaStopResponseCallbackBridge
-    : public CHIPCallbackBridge<MediaPlaybackClusterMediaStopResponseCallback>
+    : public CHIPCallbackBridge<CHIPMediaPlaybackClusterMediaStopResponseCallbackType>
 {
 public:
     CHIPMediaPlaybackClusterMediaStopResponseCallbackBridge(dispatch_queue_t queue, ResponseHandler handler, CHIPActionBlock action,
                                                             bool keepAlive = false) :
-        CHIPCallbackBridge<MediaPlaybackClusterMediaStopResponseCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
+        CHIPCallbackBridge<CHIPMediaPlaybackClusterMediaStopResponseCallbackType>(queue, handler, action, OnSuccessFn, keepAlive){};
 
-    static void OnSuccessFn(void * context, uint8_t mediaPlaybackStatus);
+    static void OnSuccessFn(void * context,
+                            const chip::app::Clusters::MediaPlayback::Commands::MediaStopResponse::DecodableType & data);
 };
 
 class CHIPNetworkCommissioningClusterAddThreadNetworkResponseCallbackBridge
-    : public CHIPCallbackBridge<NetworkCommissioningClusterAddThreadNetworkResponseCallback>
+    : public CHIPCallbackBridge<CHIPNetworkCommissioningClusterAddThreadNetworkResponseCallbackType>
 {
 public:
     CHIPNetworkCommissioningClusterAddThreadNetworkResponseCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
                                                                           CHIPActionBlock action, bool keepAlive = false) :
-        CHIPCallbackBridge<NetworkCommissioningClusterAddThreadNetworkResponseCallback>(queue, handler, action, OnSuccessFn,
-                                                                                        keepAlive){};
+        CHIPCallbackBridge<CHIPNetworkCommissioningClusterAddThreadNetworkResponseCallbackType>(queue, handler, action, OnSuccessFn,
+                                                                                                keepAlive){};
 
-    static void OnSuccessFn(void * context, uint8_t errorCode, chip::CharSpan debugText);
+    static void
+    OnSuccessFn(void * context,
+                const chip::app::Clusters::NetworkCommissioning::Commands::AddThreadNetworkResponse::DecodableType & data);
 };
 
 class CHIPNetworkCommissioningClusterAddWiFiNetworkResponseCallbackBridge
-    : public CHIPCallbackBridge<NetworkCommissioningClusterAddWiFiNetworkResponseCallback>
+    : public CHIPCallbackBridge<CHIPNetworkCommissioningClusterAddWiFiNetworkResponseCallbackType>
 {
 public:
     CHIPNetworkCommissioningClusterAddWiFiNetworkResponseCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
                                                                         CHIPActionBlock action, bool keepAlive = false) :
-        CHIPCallbackBridge<NetworkCommissioningClusterAddWiFiNetworkResponseCallback>(queue, handler, action, OnSuccessFn,
-                                                                                      keepAlive){};
+        CHIPCallbackBridge<CHIPNetworkCommissioningClusterAddWiFiNetworkResponseCallbackType>(queue, handler, action, OnSuccessFn,
+                                                                                              keepAlive){};
 
-    static void OnSuccessFn(void * context, uint8_t errorCode, chip::CharSpan debugText);
+    static void
+    OnSuccessFn(void * context,
+                const chip::app::Clusters::NetworkCommissioning::Commands::AddWiFiNetworkResponse::DecodableType & data);
 };
 
 class CHIPNetworkCommissioningClusterDisableNetworkResponseCallbackBridge
-    : public CHIPCallbackBridge<NetworkCommissioningClusterDisableNetworkResponseCallback>
+    : public CHIPCallbackBridge<CHIPNetworkCommissioningClusterDisableNetworkResponseCallbackType>
 {
 public:
     CHIPNetworkCommissioningClusterDisableNetworkResponseCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
                                                                         CHIPActionBlock action, bool keepAlive = false) :
-        CHIPCallbackBridge<NetworkCommissioningClusterDisableNetworkResponseCallback>(queue, handler, action, OnSuccessFn,
-                                                                                      keepAlive){};
+        CHIPCallbackBridge<CHIPNetworkCommissioningClusterDisableNetworkResponseCallbackType>(queue, handler, action, OnSuccessFn,
+                                                                                              keepAlive){};
 
-    static void OnSuccessFn(void * context, uint8_t errorCode, chip::CharSpan debugText);
+    static void
+    OnSuccessFn(void * context,
+                const chip::app::Clusters::NetworkCommissioning::Commands::DisableNetworkResponse::DecodableType & data);
 };
 
 class CHIPNetworkCommissioningClusterEnableNetworkResponseCallbackBridge
-    : public CHIPCallbackBridge<NetworkCommissioningClusterEnableNetworkResponseCallback>
+    : public CHIPCallbackBridge<CHIPNetworkCommissioningClusterEnableNetworkResponseCallbackType>
 {
 public:
     CHIPNetworkCommissioningClusterEnableNetworkResponseCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
                                                                        CHIPActionBlock action, bool keepAlive = false) :
-        CHIPCallbackBridge<NetworkCommissioningClusterEnableNetworkResponseCallback>(queue, handler, action, OnSuccessFn,
-                                                                                     keepAlive){};
+        CHIPCallbackBridge<CHIPNetworkCommissioningClusterEnableNetworkResponseCallbackType>(queue, handler, action, OnSuccessFn,
+                                                                                             keepAlive){};
 
-    static void OnSuccessFn(void * context, uint8_t errorCode, chip::CharSpan debugText);
+    static void OnSuccessFn(void * context,
+                            const chip::app::Clusters::NetworkCommissioning::Commands::EnableNetworkResponse::DecodableType & data);
 };
 
 class CHIPNetworkCommissioningClusterRemoveNetworkResponseCallbackBridge
-    : public CHIPCallbackBridge<NetworkCommissioningClusterRemoveNetworkResponseCallback>
+    : public CHIPCallbackBridge<CHIPNetworkCommissioningClusterRemoveNetworkResponseCallbackType>
 {
 public:
     CHIPNetworkCommissioningClusterRemoveNetworkResponseCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
                                                                        CHIPActionBlock action, bool keepAlive = false) :
-        CHIPCallbackBridge<NetworkCommissioningClusterRemoveNetworkResponseCallback>(queue, handler, action, OnSuccessFn,
-                                                                                     keepAlive){};
+        CHIPCallbackBridge<CHIPNetworkCommissioningClusterRemoveNetworkResponseCallbackType>(queue, handler, action, OnSuccessFn,
+                                                                                             keepAlive){};
 
-    static void OnSuccessFn(void * context, uint8_t errorCode, chip::CharSpan debugText);
+    static void OnSuccessFn(void * context,
+                            const chip::app::Clusters::NetworkCommissioning::Commands::RemoveNetworkResponse::DecodableType & data);
 };
 
 class CHIPNetworkCommissioningClusterScanNetworksResponseCallbackBridge
-    : public CHIPCallbackBridge<NetworkCommissioningClusterScanNetworksResponseCallback>
+    : public CHIPCallbackBridge<CHIPNetworkCommissioningClusterScanNetworksResponseCallbackType>
 {
 public:
     CHIPNetworkCommissioningClusterScanNetworksResponseCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
                                                                       CHIPActionBlock action, bool keepAlive = false) :
-        CHIPCallbackBridge<NetworkCommissioningClusterScanNetworksResponseCallback>(queue, handler, action, OnSuccessFn,
-                                                                                    keepAlive){};
+        CHIPCallbackBridge<CHIPNetworkCommissioningClusterScanNetworksResponseCallbackType>(queue, handler, action, OnSuccessFn,
+                                                                                            keepAlive){};
 
-    static void OnSuccessFn(void * context, uint8_t errorCode, chip::CharSpan debugText,
-                            /* TYPE WARNING: array array defaults to */ uint8_t * wifiScanResults,
-                            /* TYPE WARNING: array array defaults to */ uint8_t * threadScanResults);
+    static void OnSuccessFn(void * context,
+                            const chip::app::Clusters::NetworkCommissioning::Commands::ScanNetworksResponse::DecodableType & data);
 };
 
 class CHIPNetworkCommissioningClusterUpdateThreadNetworkResponseCallbackBridge
-    : public CHIPCallbackBridge<NetworkCommissioningClusterUpdateThreadNetworkResponseCallback>
+    : public CHIPCallbackBridge<CHIPNetworkCommissioningClusterUpdateThreadNetworkResponseCallbackType>
 {
 public:
     CHIPNetworkCommissioningClusterUpdateThreadNetworkResponseCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
                                                                              CHIPActionBlock action, bool keepAlive = false) :
-        CHIPCallbackBridge<NetworkCommissioningClusterUpdateThreadNetworkResponseCallback>(queue, handler, action, OnSuccessFn,
-                                                                                           keepAlive){};
+        CHIPCallbackBridge<CHIPNetworkCommissioningClusterUpdateThreadNetworkResponseCallbackType>(queue, handler, action,
+                                                                                                   OnSuccessFn, keepAlive){};
 
-    static void OnSuccessFn(void * context, uint8_t errorCode, chip::CharSpan debugText);
+    static void
+    OnSuccessFn(void * context,
+                const chip::app::Clusters::NetworkCommissioning::Commands::UpdateThreadNetworkResponse::DecodableType & data);
 };
 
 class CHIPNetworkCommissioningClusterUpdateWiFiNetworkResponseCallbackBridge
-    : public CHIPCallbackBridge<NetworkCommissioningClusterUpdateWiFiNetworkResponseCallback>
+    : public CHIPCallbackBridge<CHIPNetworkCommissioningClusterUpdateWiFiNetworkResponseCallbackType>
 {
 public:
     CHIPNetworkCommissioningClusterUpdateWiFiNetworkResponseCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
                                                                            CHIPActionBlock action, bool keepAlive = false) :
-        CHIPCallbackBridge<NetworkCommissioningClusterUpdateWiFiNetworkResponseCallback>(queue, handler, action, OnSuccessFn,
-                                                                                         keepAlive){};
+        CHIPCallbackBridge<CHIPNetworkCommissioningClusterUpdateWiFiNetworkResponseCallbackType>(queue, handler, action,
+                                                                                                 OnSuccessFn, keepAlive){};
 
-    static void OnSuccessFn(void * context, uint8_t errorCode, chip::CharSpan debugText);
+    static void
+    OnSuccessFn(void * context,
+                const chip::app::Clusters::NetworkCommissioning::Commands::UpdateWiFiNetworkResponse::DecodableType & data);
 };
 
 class CHIPOtaSoftwareUpdateProviderClusterApplyUpdateResponseCallbackBridge
-    : public CHIPCallbackBridge<OtaSoftwareUpdateProviderClusterApplyUpdateResponseCallback>
+    : public CHIPCallbackBridge<CHIPOtaSoftwareUpdateProviderClusterApplyUpdateResponseCallbackType>
 {
 public:
     CHIPOtaSoftwareUpdateProviderClusterApplyUpdateResponseCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
                                                                           CHIPActionBlock action, bool keepAlive = false) :
-        CHIPCallbackBridge<OtaSoftwareUpdateProviderClusterApplyUpdateResponseCallback>(queue, handler, action, OnSuccessFn,
-                                                                                        keepAlive){};
+        CHIPCallbackBridge<CHIPOtaSoftwareUpdateProviderClusterApplyUpdateResponseCallbackType>(queue, handler, action, OnSuccessFn,
+                                                                                                keepAlive){};
 
-    static void OnSuccessFn(void * context, uint8_t action, uint32_t delayedActionTime);
+    static void
+    OnSuccessFn(void * context,
+                const chip::app::Clusters::OtaSoftwareUpdateProvider::Commands::ApplyUpdateResponse::DecodableType & data);
 };
 
 class CHIPOtaSoftwareUpdateProviderClusterQueryImageResponseCallbackBridge
-    : public CHIPCallbackBridge<OtaSoftwareUpdateProviderClusterQueryImageResponseCallback>
+    : public CHIPCallbackBridge<CHIPOtaSoftwareUpdateProviderClusterQueryImageResponseCallbackType>
 {
 public:
     CHIPOtaSoftwareUpdateProviderClusterQueryImageResponseCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
                                                                          CHIPActionBlock action, bool keepAlive = false) :
-        CHIPCallbackBridge<OtaSoftwareUpdateProviderClusterQueryImageResponseCallback>(queue, handler, action, OnSuccessFn,
-                                                                                       keepAlive){};
+        CHIPCallbackBridge<CHIPOtaSoftwareUpdateProviderClusterQueryImageResponseCallbackType>(queue, handler, action, OnSuccessFn,
+                                                                                               keepAlive){};
 
-    static void OnSuccessFn(void * context, uint8_t status, uint32_t delayedActionTime, chip::CharSpan imageURI,
-                            uint32_t softwareVersion, chip::CharSpan softwareVersionString, chip::ByteSpan updateToken,
-                            bool userConsentNeeded, chip::ByteSpan metadataForRequestor);
+    static void
+    OnSuccessFn(void * context,
+                const chip::app::Clusters::OtaSoftwareUpdateProvider::Commands::QueryImageResponse::DecodableType & data);
 };
 
 class CHIPOperationalCredentialsClusterAttestationResponseCallbackBridge
-    : public CHIPCallbackBridge<OperationalCredentialsClusterAttestationResponseCallback>
+    : public CHIPCallbackBridge<CHIPOperationalCredentialsClusterAttestationResponseCallbackType>
 {
 public:
     CHIPOperationalCredentialsClusterAttestationResponseCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
                                                                        CHIPActionBlock action, bool keepAlive = false) :
-        CHIPCallbackBridge<OperationalCredentialsClusterAttestationResponseCallback>(queue, handler, action, OnSuccessFn,
-                                                                                     keepAlive){};
+        CHIPCallbackBridge<CHIPOperationalCredentialsClusterAttestationResponseCallbackType>(queue, handler, action, OnSuccessFn,
+                                                                                             keepAlive){};
 
-    static void OnSuccessFn(void * context, chip::ByteSpan AttestationElements, chip::ByteSpan Signature);
+    static void OnSuccessFn(void * context,
+                            const chip::app::Clusters::OperationalCredentials::Commands::AttestationResponse::DecodableType & data);
 };
 
 class CHIPOperationalCredentialsClusterCertificateChainResponseCallbackBridge
-    : public CHIPCallbackBridge<OperationalCredentialsClusterCertificateChainResponseCallback>
+    : public CHIPCallbackBridge<CHIPOperationalCredentialsClusterCertificateChainResponseCallbackType>
 {
 public:
     CHIPOperationalCredentialsClusterCertificateChainResponseCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
                                                                             CHIPActionBlock action, bool keepAlive = false) :
-        CHIPCallbackBridge<OperationalCredentialsClusterCertificateChainResponseCallback>(queue, handler, action, OnSuccessFn,
-                                                                                          keepAlive){};
+        CHIPCallbackBridge<CHIPOperationalCredentialsClusterCertificateChainResponseCallbackType>(queue, handler, action,
+                                                                                                  OnSuccessFn, keepAlive){};
 
-    static void OnSuccessFn(void * context, chip::ByteSpan Certificate);
+    static void
+    OnSuccessFn(void * context,
+                const chip::app::Clusters::OperationalCredentials::Commands::CertificateChainResponse::DecodableType & data);
 };
 
 class CHIPOperationalCredentialsClusterNOCResponseCallbackBridge
-    : public CHIPCallbackBridge<OperationalCredentialsClusterNOCResponseCallback>
+    : public CHIPCallbackBridge<CHIPOperationalCredentialsClusterNOCResponseCallbackType>
 {
 public:
     CHIPOperationalCredentialsClusterNOCResponseCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
                                                                CHIPActionBlock action, bool keepAlive = false) :
-        CHIPCallbackBridge<OperationalCredentialsClusterNOCResponseCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
+        CHIPCallbackBridge<CHIPOperationalCredentialsClusterNOCResponseCallbackType>(queue, handler, action, OnSuccessFn,
+                                                                                     keepAlive){};
 
-    static void OnSuccessFn(void * context, uint8_t StatusCode, uint8_t FabricIndex, chip::CharSpan DebugText);
+    static void OnSuccessFn(void * context,
+                            const chip::app::Clusters::OperationalCredentials::Commands::NOCResponse::DecodableType & data);
 };
 
 class CHIPOperationalCredentialsClusterOpCSRResponseCallbackBridge
-    : public CHIPCallbackBridge<OperationalCredentialsClusterOpCSRResponseCallback>
+    : public CHIPCallbackBridge<CHIPOperationalCredentialsClusterOpCSRResponseCallbackType>
 {
 public:
     CHIPOperationalCredentialsClusterOpCSRResponseCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
                                                                  CHIPActionBlock action, bool keepAlive = false) :
-        CHIPCallbackBridge<OperationalCredentialsClusterOpCSRResponseCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
+        CHIPCallbackBridge<CHIPOperationalCredentialsClusterOpCSRResponseCallbackType>(queue, handler, action, OnSuccessFn,
+                                                                                       keepAlive){};
 
-    static void OnSuccessFn(void * context, chip::ByteSpan NOCSRElements, chip::ByteSpan AttestationSignature);
+    static void OnSuccessFn(void * context,
+                            const chip::app::Clusters::OperationalCredentials::Commands::OpCSRResponse::DecodableType & data);
 };
 
-class CHIPScenesClusterAddSceneResponseCallbackBridge : public CHIPCallbackBridge<ScenesClusterAddSceneResponseCallback>
+class CHIPScenesClusterAddSceneResponseCallbackBridge : public CHIPCallbackBridge<CHIPScenesClusterAddSceneResponseCallbackType>
 {
 public:
     CHIPScenesClusterAddSceneResponseCallbackBridge(dispatch_queue_t queue, ResponseHandler handler, CHIPActionBlock action,
                                                     bool keepAlive = false) :
-        CHIPCallbackBridge<ScenesClusterAddSceneResponseCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
+        CHIPCallbackBridge<CHIPScenesClusterAddSceneResponseCallbackType>(queue, handler, action, OnSuccessFn, keepAlive){};
 
-    static void OnSuccessFn(void * context, uint8_t status, uint16_t groupId, uint8_t sceneId);
+    static void OnSuccessFn(void * context, const chip::app::Clusters::Scenes::Commands::AddSceneResponse::DecodableType & data);
 };
 
 class CHIPScenesClusterGetSceneMembershipResponseCallbackBridge
-    : public CHIPCallbackBridge<ScenesClusterGetSceneMembershipResponseCallback>
+    : public CHIPCallbackBridge<CHIPScenesClusterGetSceneMembershipResponseCallbackType>
 {
 public:
     CHIPScenesClusterGetSceneMembershipResponseCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
                                                               CHIPActionBlock action, bool keepAlive = false) :
-        CHIPCallbackBridge<ScenesClusterGetSceneMembershipResponseCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
+        CHIPCallbackBridge<CHIPScenesClusterGetSceneMembershipResponseCallbackType>(queue, handler, action, OnSuccessFn,
+                                                                                    keepAlive){};
 
-    static void OnSuccessFn(void * context, uint8_t status, uint8_t capacity, uint16_t groupId, uint8_t sceneCount,
-                            /* TYPE WARNING: array array defaults to */ uint8_t * sceneList);
+    static void OnSuccessFn(void * context,
+                            const chip::app::Clusters::Scenes::Commands::GetSceneMembershipResponse::DecodableType & data);
 };
 
 class CHIPScenesClusterRemoveAllScenesResponseCallbackBridge
-    : public CHIPCallbackBridge<ScenesClusterRemoveAllScenesResponseCallback>
+    : public CHIPCallbackBridge<CHIPScenesClusterRemoveAllScenesResponseCallbackType>
 {
 public:
     CHIPScenesClusterRemoveAllScenesResponseCallbackBridge(dispatch_queue_t queue, ResponseHandler handler, CHIPActionBlock action,
                                                            bool keepAlive = false) :
-        CHIPCallbackBridge<ScenesClusterRemoveAllScenesResponseCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
+        CHIPCallbackBridge<CHIPScenesClusterRemoveAllScenesResponseCallbackType>(queue, handler, action, OnSuccessFn, keepAlive){};
 
-    static void OnSuccessFn(void * context, uint8_t status, uint16_t groupId);
+    static void OnSuccessFn(void * context,
+                            const chip::app::Clusters::Scenes::Commands::RemoveAllScenesResponse::DecodableType & data);
 };
 
-class CHIPScenesClusterRemoveSceneResponseCallbackBridge : public CHIPCallbackBridge<ScenesClusterRemoveSceneResponseCallback>
+class CHIPScenesClusterRemoveSceneResponseCallbackBridge
+    : public CHIPCallbackBridge<CHIPScenesClusterRemoveSceneResponseCallbackType>
 {
 public:
     CHIPScenesClusterRemoveSceneResponseCallbackBridge(dispatch_queue_t queue, ResponseHandler handler, CHIPActionBlock action,
                                                        bool keepAlive = false) :
-        CHIPCallbackBridge<ScenesClusterRemoveSceneResponseCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
+        CHIPCallbackBridge<CHIPScenesClusterRemoveSceneResponseCallbackType>(queue, handler, action, OnSuccessFn, keepAlive){};
 
-    static void OnSuccessFn(void * context, uint8_t status, uint16_t groupId, uint8_t sceneId);
+    static void OnSuccessFn(void * context, const chip::app::Clusters::Scenes::Commands::RemoveSceneResponse::DecodableType & data);
 };
 
-class CHIPScenesClusterStoreSceneResponseCallbackBridge : public CHIPCallbackBridge<ScenesClusterStoreSceneResponseCallback>
+class CHIPScenesClusterStoreSceneResponseCallbackBridge : public CHIPCallbackBridge<CHIPScenesClusterStoreSceneResponseCallbackType>
 {
 public:
     CHIPScenesClusterStoreSceneResponseCallbackBridge(dispatch_queue_t queue, ResponseHandler handler, CHIPActionBlock action,
                                                       bool keepAlive = false) :
-        CHIPCallbackBridge<ScenesClusterStoreSceneResponseCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
+        CHIPCallbackBridge<CHIPScenesClusterStoreSceneResponseCallbackType>(queue, handler, action, OnSuccessFn, keepAlive){};
 
-    static void OnSuccessFn(void * context, uint8_t status, uint16_t groupId, uint8_t sceneId);
+    static void OnSuccessFn(void * context, const chip::app::Clusters::Scenes::Commands::StoreSceneResponse::DecodableType & data);
 };
 
-class CHIPScenesClusterViewSceneResponseCallbackBridge : public CHIPCallbackBridge<ScenesClusterViewSceneResponseCallback>
+class CHIPScenesClusterViewSceneResponseCallbackBridge : public CHIPCallbackBridge<CHIPScenesClusterViewSceneResponseCallbackType>
 {
 public:
     CHIPScenesClusterViewSceneResponseCallbackBridge(dispatch_queue_t queue, ResponseHandler handler, CHIPActionBlock action,
                                                      bool keepAlive = false) :
-        CHIPCallbackBridge<ScenesClusterViewSceneResponseCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
+        CHIPCallbackBridge<CHIPScenesClusterViewSceneResponseCallbackType>(queue, handler, action, OnSuccessFn, keepAlive){};
 
-    static void OnSuccessFn(void * context, uint8_t status, uint16_t groupId, uint8_t sceneId, uint16_t transitionTime,
-                            chip::CharSpan sceneName, /* TYPE WARNING: array array defaults to */ uint8_t * extensionFieldSets);
+    static void OnSuccessFn(void * context, const chip::app::Clusters::Scenes::Commands::ViewSceneResponse::DecodableType & data);
 };
 
 class CHIPTvChannelClusterChangeChannelResponseCallbackBridge
-    : public CHIPCallbackBridge<TvChannelClusterChangeChannelResponseCallback>
+    : public CHIPCallbackBridge<CHIPTvChannelClusterChangeChannelResponseCallbackType>
 {
 public:
     CHIPTvChannelClusterChangeChannelResponseCallbackBridge(dispatch_queue_t queue, ResponseHandler handler, CHIPActionBlock action,
                                                             bool keepAlive = false) :
-        CHIPCallbackBridge<TvChannelClusterChangeChannelResponseCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
+        CHIPCallbackBridge<CHIPTvChannelClusterChangeChannelResponseCallbackType>(queue, handler, action, OnSuccessFn, keepAlive){};
 
-    static void OnSuccessFn(void * context, /* TYPE WARNING: array array defaults to */ uint8_t * ChannelMatch, uint8_t ErrorType);
+    static void OnSuccessFn(void * context,
+                            const chip::app::Clusters::TvChannel::Commands::ChangeChannelResponse::DecodableType & data);
 };
 
 class CHIPTargetNavigatorClusterNavigateTargetResponseCallbackBridge
-    : public CHIPCallbackBridge<TargetNavigatorClusterNavigateTargetResponseCallback>
+    : public CHIPCallbackBridge<CHIPTargetNavigatorClusterNavigateTargetResponseCallbackType>
 {
 public:
     CHIPTargetNavigatorClusterNavigateTargetResponseCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
                                                                    CHIPActionBlock action, bool keepAlive = false) :
-        CHIPCallbackBridge<TargetNavigatorClusterNavigateTargetResponseCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
+        CHIPCallbackBridge<CHIPTargetNavigatorClusterNavigateTargetResponseCallbackType>(queue, handler, action, OnSuccessFn,
+                                                                                         keepAlive){};
 
-    static void OnSuccessFn(void * context, uint8_t status, chip::CharSpan data);
+    static void OnSuccessFn(void * context,
+                            const chip::app::Clusters::TargetNavigator::Commands::NavigateTargetResponse::DecodableType & data);
 };
 
-class CHIPTestClusterClusterBooleanResponseCallbackBridge : public CHIPCallbackBridge<TestClusterClusterBooleanResponseCallback>
+class CHIPTestClusterClusterBooleanResponseCallbackBridge
+    : public CHIPCallbackBridge<CHIPTestClusterClusterBooleanResponseCallbackType>
 {
 public:
     CHIPTestClusterClusterBooleanResponseCallbackBridge(dispatch_queue_t queue, ResponseHandler handler, CHIPActionBlock action,
                                                         bool keepAlive = false) :
-        CHIPCallbackBridge<TestClusterClusterBooleanResponseCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
+        CHIPCallbackBridge<CHIPTestClusterClusterBooleanResponseCallbackType>(queue, handler, action, OnSuccessFn, keepAlive){};
 
-    static void OnSuccessFn(void * context, bool value);
+    static void OnSuccessFn(void * context,
+                            const chip::app::Clusters::TestCluster::Commands::BooleanResponse::DecodableType & data);
 };
 
 class CHIPTestClusterClusterTestAddArgumentsResponseCallbackBridge
-    : public CHIPCallbackBridge<TestClusterClusterTestAddArgumentsResponseCallback>
+    : public CHIPCallbackBridge<CHIPTestClusterClusterTestAddArgumentsResponseCallbackType>
 {
 public:
     CHIPTestClusterClusterTestAddArgumentsResponseCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
                                                                  CHIPActionBlock action, bool keepAlive = false) :
-        CHIPCallbackBridge<TestClusterClusterTestAddArgumentsResponseCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
+        CHIPCallbackBridge<CHIPTestClusterClusterTestAddArgumentsResponseCallbackType>(queue, handler, action, OnSuccessFn,
+                                                                                       keepAlive){};
 
-    static void OnSuccessFn(void * context, uint8_t returnValue);
+    static void OnSuccessFn(void * context,
+                            const chip::app::Clusters::TestCluster::Commands::TestAddArgumentsResponse::DecodableType & data);
 };
 
-class CHIPTestClusterClusterTestEnumsResponseCallbackBridge : public CHIPCallbackBridge<TestClusterClusterTestEnumsResponseCallback>
+class CHIPTestClusterClusterTestEnumsResponseCallbackBridge
+    : public CHIPCallbackBridge<CHIPTestClusterClusterTestEnumsResponseCallbackType>
 {
 public:
     CHIPTestClusterClusterTestEnumsResponseCallbackBridge(dispatch_queue_t queue, ResponseHandler handler, CHIPActionBlock action,
                                                           bool keepAlive = false) :
-        CHIPCallbackBridge<TestClusterClusterTestEnumsResponseCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
+        CHIPCallbackBridge<CHIPTestClusterClusterTestEnumsResponseCallbackType>(queue, handler, action, OnSuccessFn, keepAlive){};
 
-    static void OnSuccessFn(void * context, chip::VendorId arg1, uint8_t arg2);
+    static void OnSuccessFn(void * context,
+                            const chip::app::Clusters::TestCluster::Commands::TestEnumsResponse::DecodableType & data);
 };
 
 class CHIPTestClusterClusterTestListInt8UReverseResponseCallbackBridge
-    : public CHIPCallbackBridge<TestClusterClusterTestListInt8UReverseResponseCallback>
+    : public CHIPCallbackBridge<CHIPTestClusterClusterTestListInt8UReverseResponseCallbackType>
 {
 public:
     CHIPTestClusterClusterTestListInt8UReverseResponseCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
                                                                      CHIPActionBlock action, bool keepAlive = false) :
-        CHIPCallbackBridge<TestClusterClusterTestListInt8UReverseResponseCallback>(queue, handler, action, OnSuccessFn,
-                                                                                   keepAlive){};
+        CHIPCallbackBridge<CHIPTestClusterClusterTestListInt8UReverseResponseCallbackType>(queue, handler, action, OnSuccessFn,
+                                                                                           keepAlive){};
 
-    static void OnSuccessFn(void * context, /* TYPE WARNING: array array defaults to */ uint8_t * arg1);
+    static void OnSuccessFn(void * context,
+                            const chip::app::Clusters::TestCluster::Commands::TestListInt8UReverseResponse::DecodableType & data);
 };
 
 class CHIPTestClusterClusterTestNullableOptionalResponseCallbackBridge
-    : public CHIPCallbackBridge<TestClusterClusterTestNullableOptionalResponseCallback>
+    : public CHIPCallbackBridge<CHIPTestClusterClusterTestNullableOptionalResponseCallbackType>
 {
 public:
     CHIPTestClusterClusterTestNullableOptionalResponseCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
                                                                      CHIPActionBlock action, bool keepAlive = false) :
-        CHIPCallbackBridge<TestClusterClusterTestNullableOptionalResponseCallback>(queue, handler, action, OnSuccessFn,
-                                                                                   keepAlive){};
+        CHIPCallbackBridge<CHIPTestClusterClusterTestNullableOptionalResponseCallbackType>(queue, handler, action, OnSuccessFn,
+                                                                                           keepAlive){};
 
-    static void OnSuccessFn(void * context, bool wasPresent, bool wasNull, uint8_t value, uint8_t originalValue);
+    static void OnSuccessFn(void * context,
+                            const chip::app::Clusters::TestCluster::Commands::TestNullableOptionalResponse::DecodableType & data);
 };
 
 class CHIPTestClusterClusterTestSpecificResponseCallbackBridge
-    : public CHIPCallbackBridge<TestClusterClusterTestSpecificResponseCallback>
+    : public CHIPCallbackBridge<CHIPTestClusterClusterTestSpecificResponseCallbackType>
 {
 public:
     CHIPTestClusterClusterTestSpecificResponseCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
                                                              CHIPActionBlock action, bool keepAlive = false) :
-        CHIPCallbackBridge<TestClusterClusterTestSpecificResponseCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
+        CHIPCallbackBridge<CHIPTestClusterClusterTestSpecificResponseCallbackType>(queue, handler, action, OnSuccessFn,
+                                                                                   keepAlive){};
 
-    static void OnSuccessFn(void * context, uint8_t returnValue);
+    static void OnSuccessFn(void * context,
+                            const chip::app::Clusters::TestCluster::Commands::TestSpecificResponse::DecodableType & data);
 };

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPClustersObjc.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPClustersObjc.mm
@@ -25,7 +25,9 @@
 #import "CHIPDevice.h"
 #import "CHIPDevice_Internal.h"
 
+using chip::Callback::Callback;
 using chip::Callback::Cancelable;
+using namespace chip::app::Clusters;
 
 @implementation CHIPAccountLogin
 
@@ -36,16 +38,27 @@ using chip::Callback::Cancelable;
 
 - (void)getSetupPIN:(NSString *)tempAccountIdentifier responseHandler:(ResponseHandler)responseHandler
 {
+    AccountLogin::Commands::GetSetupPIN::Type request;
+    request.tempAccountIdentifier = [self asCharSpan:tempAccountIdentifier];
+
     new CHIPAccountLoginClusterGetSetupPINResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.GetSetupPIN(success, failure, [self asCharSpan:tempAccountIdentifier]);
+            auto successFn = Callback<CHIPAccountLoginClusterGetSetupPINResponseCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
 - (void)login:(NSString *)tempAccountIdentifier setupPIN:(NSString *)setupPIN responseHandler:(ResponseHandler)responseHandler
 {
+    AccountLogin::Commands::Login::Type request;
+    request.tempAccountIdentifier = [self asCharSpan:tempAccountIdentifier];
+    request.setupPIN = [self asCharSpan:setupPIN];
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.Login(success, failure, [self asCharSpan:tempAccountIdentifier], [self asCharSpan:setupPIN]);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -67,8 +80,13 @@ using chip::Callback::Cancelable;
 
 - (void)openBasicCommissioningWindow:(uint16_t)commissioningTimeout responseHandler:(ResponseHandler)responseHandler
 {
+    AdministratorCommissioning::Commands::OpenBasicCommissioningWindow::Type request;
+    request.commissioningTimeout = commissioningTimeout;
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.OpenBasicCommissioningWindow(success, failure, commissioningTimeout);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -80,16 +98,29 @@ using chip::Callback::Cancelable;
                      passcodeID:(uint16_t)passcodeID
                 responseHandler:(ResponseHandler)responseHandler
 {
+    AdministratorCommissioning::Commands::OpenCommissioningWindow::Type request;
+    request.commissioningTimeout = commissioningTimeout;
+    request.PAKEVerifier = [self asByteSpan:PAKEVerifier];
+    request.discriminator = discriminator;
+    request.iterations = iterations;
+    request.salt = [self asByteSpan:salt];
+    request.passcodeID = passcodeID;
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.OpenCommissioningWindow(success, failure, commissioningTimeout, [self asByteSpan:PAKEVerifier],
-            discriminator, iterations, [self asByteSpan:salt], passcodeID);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
 - (void)revokeCommissioning:(ResponseHandler)responseHandler
 {
+    AdministratorCommissioning::Commands::RevokeCommissioning::Type request;
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.RevokeCommissioning(success, failure);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -111,8 +142,13 @@ using chip::Callback::Cancelable;
 
 - (void)changeStatus:(uint8_t)status responseHandler:(ResponseHandler)responseHandler
 {
+    ApplicationBasic::Commands::ChangeStatus::Type request;
+    request.status = static_cast<decltype(request.status)>(status);
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.ChangeStatus(success, failure, static_cast<uint8_t>(status));
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -186,10 +222,16 @@ using chip::Callback::Cancelable;
       applicationId:(NSString *)applicationId
     responseHandler:(ResponseHandler)responseHandler
 {
+    ApplicationLauncher::Commands::LaunchApp::Type request;
+    request.data = [self asCharSpan:data];
+    request.catalogVendorId = catalogVendorId;
+    request.applicationId = [self asCharSpan:applicationId];
+
     new CHIPApplicationLauncherClusterLaunchAppResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.LaunchApp(
-                success, failure, [self asCharSpan:data], catalogVendorId, [self asCharSpan:applicationId]);
+            auto successFn = Callback<CHIPApplicationLauncherClusterLaunchAppResponseCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
@@ -233,15 +275,26 @@ using chip::Callback::Cancelable;
 
 - (void)renameOutput:(uint8_t)index name:(NSString *)name responseHandler:(ResponseHandler)responseHandler
 {
+    AudioOutput::Commands::RenameOutput::Type request;
+    request.index = index;
+    request.name = [self asCharSpan:name];
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.RenameOutput(success, failure, index, [self asCharSpan:name]);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
 - (void)selectOutput:(uint8_t)index responseHandler:(ResponseHandler)responseHandler
 {
+    AudioOutput::Commands::SelectOutput::Type request;
+    request.index = index;
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.SelectOutput(success, failure, index);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -278,15 +331,24 @@ using chip::Callback::Cancelable;
 
 - (void)barrierControlGoToPercent:(uint8_t)percentOpen responseHandler:(ResponseHandler)responseHandler
 {
+    BarrierControl::Commands::BarrierControlGoToPercent::Type request;
+    request.percentOpen = percentOpen;
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.BarrierControlGoToPercent(success, failure, percentOpen);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
 - (void)barrierControlStop:(ResponseHandler)responseHandler
 {
+    BarrierControl::Commands::BarrierControlStop::Type request;
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.BarrierControlStop(success, failure);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -336,8 +398,12 @@ using chip::Callback::Cancelable;
 
 - (void)mfgSpecificPing:(ResponseHandler)responseHandler
 {
+    Basic::Commands::MfgSpecificPing::Type request;
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.MfgSpecificPing(success, failure);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -599,8 +665,16 @@ using chip::Callback::Cancelable;
           clusterId:(uint32_t)clusterId
     responseHandler:(ResponseHandler)responseHandler
 {
+    Binding::Commands::Bind::Type request;
+    request.nodeId = nodeId;
+    request.groupId = groupId;
+    request.endpointId = endpointId;
+    request.clusterId = clusterId;
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.Bind(success, failure, nodeId, groupId, endpointId, clusterId);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -610,8 +684,16 @@ using chip::Callback::Cancelable;
           clusterId:(uint32_t)clusterId
     responseHandler:(ResponseHandler)responseHandler
 {
+    Binding::Commands::Unbind::Type request;
+    request.nodeId = nodeId;
+    request.groupId = groupId;
+    request.endpointId = endpointId;
+    request.clusterId = clusterId;
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.Unbind(success, failure, nodeId, groupId, endpointId, clusterId);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -675,8 +757,14 @@ using chip::Callback::Cancelable;
 
 - (void)disableAction:(uint16_t)actionID invokeID:(uint32_t)invokeID responseHandler:(ResponseHandler)responseHandler
 {
+    BridgedActions::Commands::DisableAction::Type request;
+    request.actionID = actionID;
+    request.invokeID = chip::Optional<uint32_t>(invokeID);
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.DisableAction(success, failure, actionID, invokeID);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -685,15 +773,28 @@ using chip::Callback::Cancelable;
                          duration:(uint32_t)duration
                   responseHandler:(ResponseHandler)responseHandler
 {
+    BridgedActions::Commands::DisableActionWithDuration::Type request;
+    request.actionID = actionID;
+    request.invokeID = chip::Optional<uint32_t>(invokeID);
+    request.duration = duration;
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.DisableActionWithDuration(success, failure, actionID, invokeID, duration);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
 - (void)enableAction:(uint16_t)actionID invokeID:(uint32_t)invokeID responseHandler:(ResponseHandler)responseHandler
 {
+    BridgedActions::Commands::EnableAction::Type request;
+    request.actionID = actionID;
+    request.invokeID = chip::Optional<uint32_t>(invokeID);
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.EnableAction(success, failure, actionID, invokeID);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -702,15 +803,28 @@ using chip::Callback::Cancelable;
                         duration:(uint32_t)duration
                  responseHandler:(ResponseHandler)responseHandler
 {
+    BridgedActions::Commands::EnableActionWithDuration::Type request;
+    request.actionID = actionID;
+    request.invokeID = chip::Optional<uint32_t>(invokeID);
+    request.duration = duration;
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.EnableActionWithDuration(success, failure, actionID, invokeID, duration);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
 - (void)instantAction:(uint16_t)actionID invokeID:(uint32_t)invokeID responseHandler:(ResponseHandler)responseHandler
 {
+    BridgedActions::Commands::InstantAction::Type request;
+    request.actionID = actionID;
+    request.invokeID = chip::Optional<uint32_t>(invokeID);
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.InstantAction(success, failure, actionID, invokeID);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -719,15 +833,28 @@ using chip::Callback::Cancelable;
                      transitionTime:(uint16_t)transitionTime
                     responseHandler:(ResponseHandler)responseHandler
 {
+    BridgedActions::Commands::InstantActionWithTransition::Type request;
+    request.actionID = actionID;
+    request.invokeID = chip::Optional<uint32_t>(invokeID);
+    request.transitionTime = transitionTime;
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.InstantActionWithTransition(success, failure, actionID, invokeID, transitionTime);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
 - (void)pauseAction:(uint16_t)actionID invokeID:(uint32_t)invokeID responseHandler:(ResponseHandler)responseHandler
 {
+    BridgedActions::Commands::PauseAction::Type request;
+    request.actionID = actionID;
+    request.invokeID = chip::Optional<uint32_t>(invokeID);
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.PauseAction(success, failure, actionID, invokeID);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -736,22 +863,41 @@ using chip::Callback::Cancelable;
                        duration:(uint32_t)duration
                 responseHandler:(ResponseHandler)responseHandler
 {
+    BridgedActions::Commands::PauseActionWithDuration::Type request;
+    request.actionID = actionID;
+    request.invokeID = chip::Optional<uint32_t>(invokeID);
+    request.duration = duration;
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.PauseActionWithDuration(success, failure, actionID, invokeID, duration);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
 - (void)resumeAction:(uint16_t)actionID invokeID:(uint32_t)invokeID responseHandler:(ResponseHandler)responseHandler
 {
+    BridgedActions::Commands::ResumeAction::Type request;
+    request.actionID = actionID;
+    request.invokeID = chip::Optional<uint32_t>(invokeID);
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.ResumeAction(success, failure, actionID, invokeID);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
 - (void)startAction:(uint16_t)actionID invokeID:(uint32_t)invokeID responseHandler:(ResponseHandler)responseHandler
 {
+    BridgedActions::Commands::StartAction::Type request;
+    request.actionID = actionID;
+    request.invokeID = chip::Optional<uint32_t>(invokeID);
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.StartAction(success, failure, actionID, invokeID);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -760,15 +906,28 @@ using chip::Callback::Cancelable;
                        duration:(uint32_t)duration
                 responseHandler:(ResponseHandler)responseHandler
 {
+    BridgedActions::Commands::StartActionWithDuration::Type request;
+    request.actionID = actionID;
+    request.invokeID = chip::Optional<uint32_t>(invokeID);
+    request.duration = duration;
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.StartActionWithDuration(success, failure, actionID, invokeID, duration);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
 - (void)stopAction:(uint16_t)actionID invokeID:(uint32_t)invokeID responseHandler:(ResponseHandler)responseHandler
 {
+    BridgedActions::Commands::StopAction::Type request;
+    request.actionID = actionID;
+    request.invokeID = chip::Optional<uint32_t>(invokeID);
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.StopAction(success, failure, actionID, invokeID);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -941,9 +1100,19 @@ using chip::Callback::Cancelable;
      optionsOverride:(uint8_t)optionsOverride
      responseHandler:(ResponseHandler)responseHandler
 {
+    ColorControl::Commands::ColorLoopSet::Type request;
+    request.updateFlags = static_cast<decltype(request.updateFlags)>(updateFlags);
+    request.action = static_cast<decltype(request.action)>(action);
+    request.direction = static_cast<decltype(request.direction)>(direction);
+    request.time = time;
+    request.startHue = startHue;
+    request.optionsMask = optionsMask;
+    request.optionsOverride = optionsOverride;
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.ColorLoopSet(success, failure, updateFlags, static_cast<uint8_t>(action),
-            static_cast<uint8_t>(direction), time, startHue, optionsMask, optionsOverride);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -953,9 +1122,16 @@ using chip::Callback::Cancelable;
         optionsOverride:(uint8_t)optionsOverride
         responseHandler:(ResponseHandler)responseHandler
 {
+    ColorControl::Commands::EnhancedMoveHue::Type request;
+    request.moveMode = static_cast<decltype(request.moveMode)>(moveMode);
+    request.rate = rate;
+    request.optionsMask = optionsMask;
+    request.optionsOverride = optionsOverride;
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.EnhancedMoveHue(
-            success, failure, static_cast<uint8_t>(moveMode), rate, optionsMask, optionsOverride);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -966,9 +1142,17 @@ using chip::Callback::Cancelable;
           optionsOverride:(uint8_t)optionsOverride
           responseHandler:(ResponseHandler)responseHandler
 {
+    ColorControl::Commands::EnhancedMoveToHue::Type request;
+    request.enhancedHue = enhancedHue;
+    request.direction = static_cast<decltype(request.direction)>(direction);
+    request.transitionTime = transitionTime;
+    request.optionsMask = optionsMask;
+    request.optionsOverride = optionsOverride;
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.EnhancedMoveToHue(
-            success, failure, enhancedHue, static_cast<uint8_t>(direction), transitionTime, optionsMask, optionsOverride);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -979,9 +1163,17 @@ using chip::Callback::Cancelable;
                        optionsOverride:(uint8_t)optionsOverride
                        responseHandler:(ResponseHandler)responseHandler
 {
+    ColorControl::Commands::EnhancedMoveToHueAndSaturation::Type request;
+    request.enhancedHue = enhancedHue;
+    request.saturation = saturation;
+    request.transitionTime = transitionTime;
+    request.optionsMask = optionsMask;
+    request.optionsOverride = optionsOverride;
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.EnhancedMoveToHueAndSaturation(
-            success, failure, enhancedHue, saturation, transitionTime, optionsMask, optionsOverride);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -992,9 +1184,17 @@ using chip::Callback::Cancelable;
         optionsOverride:(uint8_t)optionsOverride
         responseHandler:(ResponseHandler)responseHandler
 {
+    ColorControl::Commands::EnhancedStepHue::Type request;
+    request.stepMode = static_cast<decltype(request.stepMode)>(stepMode);
+    request.stepSize = stepSize;
+    request.transitionTime = transitionTime;
+    request.optionsMask = optionsMask;
+    request.optionsOverride = optionsOverride;
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.EnhancedStepHue(
-            success, failure, static_cast<uint8_t>(stepMode), stepSize, transitionTime, optionsMask, optionsOverride);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -1004,8 +1204,16 @@ using chip::Callback::Cancelable;
     optionsOverride:(uint8_t)optionsOverride
     responseHandler:(ResponseHandler)responseHandler
 {
+    ColorControl::Commands::MoveColor::Type request;
+    request.rateX = rateX;
+    request.rateY = rateY;
+    request.optionsMask = optionsMask;
+    request.optionsOverride = optionsOverride;
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.MoveColor(success, failure, rateX, rateY, optionsMask, optionsOverride);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -1017,9 +1225,18 @@ using chip::Callback::Cancelable;
              optionsOverride:(uint8_t)optionsOverride
              responseHandler:(ResponseHandler)responseHandler
 {
+    ColorControl::Commands::MoveColorTemperature::Type request;
+    request.moveMode = static_cast<decltype(request.moveMode)>(moveMode);
+    request.rate = rate;
+    request.colorTemperatureMinimum = colorTemperatureMinimum;
+    request.colorTemperatureMaximum = colorTemperatureMaximum;
+    request.optionsMask = optionsMask;
+    request.optionsOverride = optionsOverride;
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.MoveColorTemperature(success, failure, static_cast<uint8_t>(moveMode), rate, colorTemperatureMinimum,
-            colorTemperatureMaximum, optionsMask, optionsOverride);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -1029,8 +1246,16 @@ using chip::Callback::Cancelable;
     optionsOverride:(uint8_t)optionsOverride
     responseHandler:(ResponseHandler)responseHandler
 {
+    ColorControl::Commands::MoveHue::Type request;
+    request.moveMode = static_cast<decltype(request.moveMode)>(moveMode);
+    request.rate = rate;
+    request.optionsMask = optionsMask;
+    request.optionsOverride = optionsOverride;
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.MoveHue(success, failure, static_cast<uint8_t>(moveMode), rate, optionsMask, optionsOverride);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -1040,8 +1265,16 @@ using chip::Callback::Cancelable;
        optionsOverride:(uint8_t)optionsOverride
        responseHandler:(ResponseHandler)responseHandler
 {
+    ColorControl::Commands::MoveSaturation::Type request;
+    request.moveMode = static_cast<decltype(request.moveMode)>(moveMode);
+    request.rate = rate;
+    request.optionsMask = optionsMask;
+    request.optionsOverride = optionsOverride;
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.MoveSaturation(success, failure, static_cast<uint8_t>(moveMode), rate, optionsMask, optionsOverride);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -1052,8 +1285,17 @@ using chip::Callback::Cancelable;
     optionsOverride:(uint8_t)optionsOverride
     responseHandler:(ResponseHandler)responseHandler
 {
+    ColorControl::Commands::MoveToColor::Type request;
+    request.colorX = colorX;
+    request.colorY = colorY;
+    request.transitionTime = transitionTime;
+    request.optionsMask = optionsMask;
+    request.optionsOverride = optionsOverride;
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.MoveToColor(success, failure, colorX, colorY, transitionTime, optionsMask, optionsOverride);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -1063,9 +1305,16 @@ using chip::Callback::Cancelable;
                optionsOverride:(uint8_t)optionsOverride
                responseHandler:(ResponseHandler)responseHandler
 {
+    ColorControl::Commands::MoveToColorTemperature::Type request;
+    request.colorTemperature = colorTemperature;
+    request.transitionTime = transitionTime;
+    request.optionsMask = optionsMask;
+    request.optionsOverride = optionsOverride;
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.MoveToColorTemperature(
-            success, failure, colorTemperature, transitionTime, optionsMask, optionsOverride);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -1076,9 +1325,17 @@ using chip::Callback::Cancelable;
     optionsOverride:(uint8_t)optionsOverride
     responseHandler:(ResponseHandler)responseHandler
 {
+    ColorControl::Commands::MoveToHue::Type request;
+    request.hue = hue;
+    request.direction = static_cast<decltype(request.direction)>(direction);
+    request.transitionTime = transitionTime;
+    request.optionsMask = optionsMask;
+    request.optionsOverride = optionsOverride;
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.MoveToHue(
-            success, failure, hue, static_cast<uint8_t>(direction), transitionTime, optionsMask, optionsOverride);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -1089,9 +1346,17 @@ using chip::Callback::Cancelable;
                optionsOverride:(uint8_t)optionsOverride
                responseHandler:(ResponseHandler)responseHandler
 {
+    ColorControl::Commands::MoveToHueAndSaturation::Type request;
+    request.hue = hue;
+    request.saturation = saturation;
+    request.transitionTime = transitionTime;
+    request.optionsMask = optionsMask;
+    request.optionsOverride = optionsOverride;
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.MoveToHueAndSaturation(
-            success, failure, hue, saturation, transitionTime, optionsMask, optionsOverride);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -1101,8 +1366,16 @@ using chip::Callback::Cancelable;
          optionsOverride:(uint8_t)optionsOverride
          responseHandler:(ResponseHandler)responseHandler
 {
+    ColorControl::Commands::MoveToSaturation::Type request;
+    request.saturation = saturation;
+    request.transitionTime = transitionTime;
+    request.optionsMask = optionsMask;
+    request.optionsOverride = optionsOverride;
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.MoveToSaturation(success, failure, saturation, transitionTime, optionsMask, optionsOverride);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -1113,8 +1386,17 @@ using chip::Callback::Cancelable;
     optionsOverride:(uint8_t)optionsOverride
     responseHandler:(ResponseHandler)responseHandler
 {
+    ColorControl::Commands::StepColor::Type request;
+    request.stepX = stepX;
+    request.stepY = stepY;
+    request.transitionTime = transitionTime;
+    request.optionsMask = optionsMask;
+    request.optionsOverride = optionsOverride;
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.StepColor(success, failure, stepX, stepY, transitionTime, optionsMask, optionsOverride);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -1127,9 +1409,19 @@ using chip::Callback::Cancelable;
              optionsOverride:(uint8_t)optionsOverride
              responseHandler:(ResponseHandler)responseHandler
 {
+    ColorControl::Commands::StepColorTemperature::Type request;
+    request.stepMode = static_cast<decltype(request.stepMode)>(stepMode);
+    request.stepSize = stepSize;
+    request.transitionTime = transitionTime;
+    request.colorTemperatureMinimum = colorTemperatureMinimum;
+    request.colorTemperatureMaximum = colorTemperatureMaximum;
+    request.optionsMask = optionsMask;
+    request.optionsOverride = optionsOverride;
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.StepColorTemperature(success, failure, static_cast<uint8_t>(stepMode), stepSize, transitionTime,
-            colorTemperatureMinimum, colorTemperatureMaximum, optionsMask, optionsOverride);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -1140,9 +1432,17 @@ using chip::Callback::Cancelable;
     optionsOverride:(uint8_t)optionsOverride
     responseHandler:(ResponseHandler)responseHandler
 {
+    ColorControl::Commands::StepHue::Type request;
+    request.stepMode = static_cast<decltype(request.stepMode)>(stepMode);
+    request.stepSize = stepSize;
+    request.transitionTime = transitionTime;
+    request.optionsMask = optionsMask;
+    request.optionsOverride = optionsOverride;
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.StepHue(
-            success, failure, static_cast<uint8_t>(stepMode), stepSize, transitionTime, optionsMask, optionsOverride);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -1153,16 +1453,30 @@ using chip::Callback::Cancelable;
        optionsOverride:(uint8_t)optionsOverride
        responseHandler:(ResponseHandler)responseHandler
 {
+    ColorControl::Commands::StepSaturation::Type request;
+    request.stepMode = static_cast<decltype(request.stepMode)>(stepMode);
+    request.stepSize = stepSize;
+    request.transitionTime = transitionTime;
+    request.optionsMask = optionsMask;
+    request.optionsOverride = optionsOverride;
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.StepSaturation(
-            success, failure, static_cast<uint8_t>(stepMode), stepSize, transitionTime, optionsMask, optionsOverride);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
 - (void)stopMoveStep:(uint8_t)optionsMask optionsOverride:(uint8_t)optionsOverride responseHandler:(ResponseHandler)responseHandler
 {
+    ColorControl::Commands::StopMoveStep::Type request;
+    request.optionsMask = optionsMask;
+    request.optionsOverride = optionsOverride;
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.StopMoveStep(success, failure, optionsMask, optionsOverride);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -1734,17 +2048,29 @@ using chip::Callback::Cancelable;
 
 - (void)launchContent:(bool)autoPlay data:(NSString *)data responseHandler:(ResponseHandler)responseHandler
 {
+    ContentLauncher::Commands::LaunchContent::Type request;
+    request.autoPlay = autoPlay;
+    request.data = [self asCharSpan:data];
+
     new CHIPContentLauncherClusterLaunchContentResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.LaunchContent(success, failure, autoPlay, [self asCharSpan:data]);
+            auto successFn = Callback<CHIPContentLauncherClusterLaunchContentResponseCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
 - (void)launchURL:(NSString *)contentURL displayString:(NSString *)displayString responseHandler:(ResponseHandler)responseHandler
 {
+    ContentLauncher::Commands::LaunchURL::Type request;
+    request.contentURL = [self asCharSpan:contentURL];
+    request.displayString = [self asCharSpan:displayString];
+
     new CHIPContentLauncherClusterLaunchURLResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.LaunchURL(success, failure, [self asCharSpan:contentURL], [self asCharSpan:displayString]);
+            auto successFn = Callback<CHIPContentLauncherClusterLaunchURLResponseCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
@@ -1833,10 +2159,16 @@ using chip::Callback::Cancelable;
      transferFileDesignator:(NSData *)transferFileDesignator
             responseHandler:(ResponseHandler)responseHandler
 {
+    DiagnosticLogs::Commands::RetrieveLogsRequest::Type request;
+    request.intent = static_cast<decltype(request.intent)>(intent);
+    request.requestedProtocol = static_cast<decltype(request.requestedProtocol)>(requestedProtocol);
+    request.transferFileDesignator = [self asByteSpan:transferFileDesignator];
+
     new CHIPDiagnosticLogsClusterRetrieveLogsResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.RetrieveLogsRequest(success, failure, static_cast<uint8_t>(intent),
-                static_cast<uint8_t>(requestedProtocol), [self asByteSpan:transferFileDesignator]);
+            auto successFn = Callback<CHIPDiagnosticLogsClusterRetrieveLogsResponseCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
@@ -1851,121 +2183,198 @@ using chip::Callback::Cancelable;
 
 - (void)clearAllPins:(ResponseHandler)responseHandler
 {
+    DoorLock::Commands::ClearAllPins::Type request;
+
     new CHIPDoorLockClusterClearAllPinsResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.ClearAllPins(success, failure);
+            auto successFn = Callback<CHIPDoorLockClusterClearAllPinsResponseCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
 - (void)clearAllRfids:(ResponseHandler)responseHandler
 {
+    DoorLock::Commands::ClearAllRfids::Type request;
+
     new CHIPDoorLockClusterClearAllRfidsResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.ClearAllRfids(success, failure);
+            auto successFn = Callback<CHIPDoorLockClusterClearAllRfidsResponseCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
 - (void)clearHolidaySchedule:(uint8_t)scheduleId responseHandler:(ResponseHandler)responseHandler
 {
+    DoorLock::Commands::ClearHolidaySchedule::Type request;
+    request.scheduleId = scheduleId;
+
     new CHIPDoorLockClusterClearHolidayScheduleResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.ClearHolidaySchedule(success, failure, scheduleId);
+            auto successFn = Callback<CHIPDoorLockClusterClearHolidayScheduleResponseCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
 - (void)clearPin:(uint16_t)userId responseHandler:(ResponseHandler)responseHandler
 {
+    DoorLock::Commands::ClearPin::Type request;
+    request.userId = userId;
+
     new CHIPDoorLockClusterClearPinResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.ClearPin(success, failure, userId);
+            auto successFn = Callback<CHIPDoorLockClusterClearPinResponseCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
 - (void)clearRfid:(uint16_t)userId responseHandler:(ResponseHandler)responseHandler
 {
+    DoorLock::Commands::ClearRfid::Type request;
+    request.userId = userId;
+
     new CHIPDoorLockClusterClearRfidResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.ClearRfid(success, failure, userId);
+            auto successFn = Callback<CHIPDoorLockClusterClearRfidResponseCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
 - (void)clearWeekdaySchedule:(uint8_t)scheduleId userId:(uint16_t)userId responseHandler:(ResponseHandler)responseHandler
 {
+    DoorLock::Commands::ClearWeekdaySchedule::Type request;
+    request.scheduleId = scheduleId;
+    request.userId = userId;
+
     new CHIPDoorLockClusterClearWeekdayScheduleResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.ClearWeekdaySchedule(success, failure, scheduleId, userId);
+            auto successFn = Callback<CHIPDoorLockClusterClearWeekdayScheduleResponseCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
 - (void)clearYeardaySchedule:(uint8_t)scheduleId userId:(uint16_t)userId responseHandler:(ResponseHandler)responseHandler
 {
+    DoorLock::Commands::ClearYeardaySchedule::Type request;
+    request.scheduleId = scheduleId;
+    request.userId = userId;
+
     new CHIPDoorLockClusterClearYeardayScheduleResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.ClearYeardaySchedule(success, failure, scheduleId, userId);
+            auto successFn = Callback<CHIPDoorLockClusterClearYeardayScheduleResponseCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
 - (void)getHolidaySchedule:(uint8_t)scheduleId responseHandler:(ResponseHandler)responseHandler
 {
+    DoorLock::Commands::GetHolidaySchedule::Type request;
+    request.scheduleId = scheduleId;
+
     new CHIPDoorLockClusterGetHolidayScheduleResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.GetHolidaySchedule(success, failure, scheduleId);
+            auto successFn = Callback<CHIPDoorLockClusterGetHolidayScheduleResponseCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
 - (void)getLogRecord:(uint16_t)logIndex responseHandler:(ResponseHandler)responseHandler
 {
+    DoorLock::Commands::GetLogRecord::Type request;
+    request.logIndex = logIndex;
+
     new CHIPDoorLockClusterGetLogRecordResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.GetLogRecord(success, failure, logIndex);
+            auto successFn = Callback<CHIPDoorLockClusterGetLogRecordResponseCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
 - (void)getPin:(uint16_t)userId responseHandler:(ResponseHandler)responseHandler
 {
+    DoorLock::Commands::GetPin::Type request;
+    request.userId = userId;
+
     new CHIPDoorLockClusterGetPinResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.GetPin(success, failure, userId);
+            auto successFn = Callback<CHIPDoorLockClusterGetPinResponseCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
 - (void)getRfid:(uint16_t)userId responseHandler:(ResponseHandler)responseHandler
 {
+    DoorLock::Commands::GetRfid::Type request;
+    request.userId = userId;
+
     new CHIPDoorLockClusterGetRfidResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.GetRfid(success, failure, userId);
+            auto successFn = Callback<CHIPDoorLockClusterGetRfidResponseCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
 - (void)getUserType:(uint16_t)userId responseHandler:(ResponseHandler)responseHandler
 {
+    DoorLock::Commands::GetUserType::Type request;
+    request.userId = userId;
+
     new CHIPDoorLockClusterGetUserTypeResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.GetUserType(success, failure, userId);
+            auto successFn = Callback<CHIPDoorLockClusterGetUserTypeResponseCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
 - (void)getWeekdaySchedule:(uint8_t)scheduleId userId:(uint16_t)userId responseHandler:(ResponseHandler)responseHandler
 {
+    DoorLock::Commands::GetWeekdaySchedule::Type request;
+    request.scheduleId = scheduleId;
+    request.userId = userId;
+
     new CHIPDoorLockClusterGetWeekdayScheduleResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.GetWeekdaySchedule(success, failure, scheduleId, userId);
+            auto successFn = Callback<CHIPDoorLockClusterGetWeekdayScheduleResponseCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
 - (void)getYeardaySchedule:(uint8_t)scheduleId userId:(uint16_t)userId responseHandler:(ResponseHandler)responseHandler
 {
+    DoorLock::Commands::GetYeardaySchedule::Type request;
+    request.scheduleId = scheduleId;
+    request.userId = userId;
+
     new CHIPDoorLockClusterGetYeardayScheduleResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.GetYeardaySchedule(success, failure, scheduleId, userId);
+            auto successFn = Callback<CHIPDoorLockClusterGetYeardayScheduleResponseCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
 - (void)lockDoor:(NSData *)pin responseHandler:(ResponseHandler)responseHandler
 {
+    DoorLock::Commands::LockDoor::Type request;
+    request.pin = [self asByteSpan:pin];
+
     new CHIPDoorLockClusterLockDoorResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.LockDoor(success, failure, [self asByteSpan:pin]);
+            auto successFn = Callback<CHIPDoorLockClusterLockDoorResponseCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
@@ -1975,10 +2384,17 @@ using chip::Callback::Cancelable;
     operatingModeDuringHoliday:(uint8_t)operatingModeDuringHoliday
                responseHandler:(ResponseHandler)responseHandler
 {
+    DoorLock::Commands::SetHolidaySchedule::Type request;
+    request.scheduleId = scheduleId;
+    request.localStartTime = localStartTime;
+    request.localEndTime = localEndTime;
+    request.operatingModeDuringHoliday = operatingModeDuringHoliday;
+
     new CHIPDoorLockClusterSetHolidayScheduleResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.SetHolidaySchedule(
-                success, failure, scheduleId, localStartTime, localEndTime, operatingModeDuringHoliday);
+            auto successFn = Callback<CHIPDoorLockClusterSetHolidayScheduleResponseCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
@@ -1988,10 +2404,17 @@ using chip::Callback::Cancelable;
                 pin:(NSData *)pin
     responseHandler:(ResponseHandler)responseHandler
 {
+    DoorLock::Commands::SetPin::Type request;
+    request.userId = userId;
+    request.userStatus = static_cast<decltype(request.userStatus)>(userStatus);
+    request.userType = static_cast<decltype(request.userType)>(userType);
+    request.pin = [self asByteSpan:pin];
+
     new CHIPDoorLockClusterSetPinResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.SetPin(
-                success, failure, userId, static_cast<uint8_t>(userStatus), static_cast<uint8_t>(userType), [self asByteSpan:pin]);
+            auto successFn = Callback<CHIPDoorLockClusterSetPinResponseCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
@@ -2001,18 +2424,31 @@ using chip::Callback::Cancelable;
                  id:(NSData *)id
     responseHandler:(ResponseHandler)responseHandler
 {
+    DoorLock::Commands::SetRfid::Type request;
+    request.userId = userId;
+    request.userStatus = static_cast<decltype(request.userStatus)>(userStatus);
+    request.userType = static_cast<decltype(request.userType)>(userType);
+    request.id = [self asByteSpan:id];
+
     new CHIPDoorLockClusterSetRfidResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.SetRfid(
-                success, failure, userId, static_cast<uint8_t>(userStatus), static_cast<uint8_t>(userType), [self asByteSpan:id]);
+            auto successFn = Callback<CHIPDoorLockClusterSetRfidResponseCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
 - (void)setUserType:(uint16_t)userId userType:(uint8_t)userType responseHandler:(ResponseHandler)responseHandler
 {
+    DoorLock::Commands::SetUserType::Type request;
+    request.userId = userId;
+    request.userType = static_cast<decltype(request.userType)>(userType);
+
     new CHIPDoorLockClusterSetUserTypeResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.SetUserType(success, failure, userId, static_cast<uint8_t>(userType));
+            auto successFn = Callback<CHIPDoorLockClusterSetUserTypeResponseCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
@@ -2025,10 +2461,20 @@ using chip::Callback::Cancelable;
                  endMinute:(uint8_t)endMinute
            responseHandler:(ResponseHandler)responseHandler
 {
+    DoorLock::Commands::SetWeekdaySchedule::Type request;
+    request.scheduleId = scheduleId;
+    request.userId = userId;
+    request.daysMask = static_cast<decltype(request.daysMask)>(daysMask);
+    request.startHour = startHour;
+    request.startMinute = startMinute;
+    request.endHour = endHour;
+    request.endMinute = endMinute;
+
     new CHIPDoorLockClusterSetWeekdayScheduleResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.SetWeekdaySchedule(
-                success, failure, scheduleId, userId, daysMask, startHour, startMinute, endHour, endMinute);
+            auto successFn = Callback<CHIPDoorLockClusterSetWeekdayScheduleResponseCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
@@ -2038,25 +2484,44 @@ using chip::Callback::Cancelable;
               localEndTime:(uint32_t)localEndTime
            responseHandler:(ResponseHandler)responseHandler
 {
+    DoorLock::Commands::SetYeardaySchedule::Type request;
+    request.scheduleId = scheduleId;
+    request.userId = userId;
+    request.localStartTime = localStartTime;
+    request.localEndTime = localEndTime;
+
     new CHIPDoorLockClusterSetYeardayScheduleResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.SetYeardaySchedule(success, failure, scheduleId, userId, localStartTime, localEndTime);
+            auto successFn = Callback<CHIPDoorLockClusterSetYeardayScheduleResponseCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
 - (void)unlockDoor:(NSData *)pin responseHandler:(ResponseHandler)responseHandler
 {
+    DoorLock::Commands::UnlockDoor::Type request;
+    request.pin = [self asByteSpan:pin];
+
     new CHIPDoorLockClusterUnlockDoorResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.UnlockDoor(success, failure, [self asByteSpan:pin]);
+            auto successFn = Callback<CHIPDoorLockClusterUnlockDoorResponseCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
 - (void)unlockWithTimeout:(uint16_t)timeoutInSeconds pin:(NSData *)pin responseHandler:(ResponseHandler)responseHandler
 {
+    DoorLock::Commands::UnlockWithTimeout::Type request;
+    request.timeoutInSeconds = timeoutInSeconds;
+    request.pin = [self asByteSpan:pin];
+
     new CHIPDoorLockClusterUnlockWithTimeoutResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.UnlockWithTimeout(success, failure, timeoutInSeconds, [self asByteSpan:pin]);
+            auto successFn = Callback<CHIPDoorLockClusterUnlockWithTimeoutResponseCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
@@ -2211,8 +2676,12 @@ using chip::Callback::Cancelable;
 
 - (void)resetCounts:(ResponseHandler)responseHandler
 {
+    EthernetNetworkDiagnostics::Commands::ResetCounts::Type request;
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.ResetCounts(success, failure);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -2368,17 +2837,29 @@ using chip::Callback::Cancelable;
           timeoutMs:(uint32_t)timeoutMs
     responseHandler:(ResponseHandler)responseHandler
 {
+    GeneralCommissioning::Commands::ArmFailSafe::Type request;
+    request.expiryLengthSeconds = expiryLengthSeconds;
+    request.breadcrumb = breadcrumb;
+    request.timeoutMs = timeoutMs;
+
     new CHIPGeneralCommissioningClusterArmFailSafeResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.ArmFailSafe(success, failure, expiryLengthSeconds, breadcrumb, timeoutMs);
+            auto successFn = Callback<CHIPGeneralCommissioningClusterArmFailSafeResponseCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
 - (void)commissioningComplete:(ResponseHandler)responseHandler
 {
+    GeneralCommissioning::Commands::CommissioningComplete::Type request;
+
     new CHIPGeneralCommissioningClusterCommissioningCompleteResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.CommissioningComplete(success, failure);
+            auto successFn
+                = Callback<CHIPGeneralCommissioningClusterCommissioningCompleteResponseCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
@@ -2388,10 +2869,18 @@ using chip::Callback::Cancelable;
                   timeoutMs:(uint32_t)timeoutMs
             responseHandler:(ResponseHandler)responseHandler
 {
+    GeneralCommissioning::Commands::SetRegulatoryConfig::Type request;
+    request.location = static_cast<decltype(request.location)>(location);
+    request.countryCode = [self asCharSpan:countryCode];
+    request.breadcrumb = breadcrumb;
+    request.timeoutMs = timeoutMs;
+
     new CHIPGeneralCommissioningClusterSetRegulatoryConfigResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.SetRegulatoryConfig(
-                success, failure, static_cast<uint8_t>(location), [self asCharSpan:countryCode], breadcrumb, timeoutMs);
+            auto successFn
+                = Callback<CHIPGeneralCommissioningClusterSetRegulatoryConfigResponseCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
@@ -2519,47 +3008,80 @@ using chip::Callback::Cancelable;
 
 - (void)addGroup:(uint16_t)groupId groupName:(NSString *)groupName responseHandler:(ResponseHandler)responseHandler
 {
+    Groups::Commands::AddGroup::Type request;
+    request.groupId = groupId;
+    request.groupName = [self asCharSpan:groupName];
+
     new CHIPGroupsClusterAddGroupResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.AddGroup(success, failure, groupId, [self asCharSpan:groupName]);
+            auto successFn = Callback<CHIPGroupsClusterAddGroupResponseCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
 - (void)addGroupIfIdentifying:(uint16_t)groupId groupName:(NSString *)groupName responseHandler:(ResponseHandler)responseHandler
 {
+    Groups::Commands::AddGroupIfIdentifying::Type request;
+    request.groupId = groupId;
+    request.groupName = [self asCharSpan:groupName];
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.AddGroupIfIdentifying(success, failure, groupId, [self asCharSpan:groupName]);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
 - (void)getGroupMembership:(uint8_t)groupCount groupList:(uint16_t)groupList responseHandler:(ResponseHandler)responseHandler
 {
+    Groups::Commands::GetGroupMembership::Type request;
+    request.groupCount = groupCount;
+    request.groupList = chip::app::DataModel::List<const uint16_t>();
+    ;
+
     new CHIPGroupsClusterGetGroupMembershipResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.GetGroupMembership(success, failure, groupCount, groupList);
+            auto successFn = Callback<CHIPGroupsClusterGetGroupMembershipResponseCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
 - (void)removeAllGroups:(ResponseHandler)responseHandler
 {
+    Groups::Commands::RemoveAllGroups::Type request;
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.RemoveAllGroups(success, failure);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
 - (void)removeGroup:(uint16_t)groupId responseHandler:(ResponseHandler)responseHandler
 {
+    Groups::Commands::RemoveGroup::Type request;
+    request.groupId = groupId;
+
     new CHIPGroupsClusterRemoveGroupResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.RemoveGroup(success, failure, groupId);
+            auto successFn = Callback<CHIPGroupsClusterRemoveGroupResponseCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
 - (void)viewGroup:(uint16_t)groupId responseHandler:(ResponseHandler)responseHandler
 {
+    Groups::Commands::ViewGroup::Type request;
+    request.groupId = groupId;
+
     new CHIPGroupsClusterViewGroupResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.ViewGroup(success, failure, groupId);
+            auto successFn = Callback<CHIPGroupsClusterViewGroupResponseCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
@@ -2588,16 +3110,25 @@ using chip::Callback::Cancelable;
 
 - (void)identify:(uint16_t)identifyTime responseHandler:(ResponseHandler)responseHandler
 {
+    Identify::Commands::Identify::Type request;
+    request.identifyTime = identifyTime;
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.Identify(success, failure, identifyTime);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
 - (void)identifyQuery:(ResponseHandler)responseHandler
 {
+    Identify::Commands::IdentifyQuery::Type request;
+
     new CHIPIdentifyClusterIdentifyQueryResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.IdentifyQuery(success, failure);
+            auto successFn = Callback<CHIPIdentifyClusterIdentifyQueryResponseCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
@@ -2605,9 +3136,14 @@ using chip::Callback::Cancelable;
         effectVariant:(uint8_t)effectVariant
       responseHandler:(ResponseHandler)responseHandler
 {
+    Identify::Commands::TriggerEffect::Type request;
+    request.effectIdentifier = static_cast<decltype(request.effectIdentifier)>(effectIdentifier);
+    request.effectVariant = static_cast<decltype(request.effectVariant)>(effectVariant);
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.TriggerEffect(
-            success, failure, static_cast<uint8_t>(effectIdentifier), static_cast<uint8_t>(effectVariant));
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -2720,9 +3256,14 @@ using chip::Callback::Cancelable;
 
 - (void)sendKey:(uint8_t)keyCode responseHandler:(ResponseHandler)responseHandler
 {
+    KeypadInput::Commands::SendKey::Type request;
+    request.keyCode = static_cast<decltype(request.keyCode)>(keyCode);
+
     new CHIPKeypadInputClusterSendKeyResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.SendKey(success, failure, static_cast<uint8_t>(keyCode));
+            auto successFn = Callback<CHIPKeypadInputClusterSendKeyResponseCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
@@ -2748,8 +3289,16 @@ using chip::Callback::Cancelable;
      optionOverride:(uint8_t)optionOverride
     responseHandler:(ResponseHandler)responseHandler
 {
+    LevelControl::Commands::Move::Type request;
+    request.moveMode = static_cast<decltype(request.moveMode)>(moveMode);
+    request.rate = rate;
+    request.optionMask = optionMask;
+    request.optionOverride = optionOverride;
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.Move(success, failure, static_cast<uint8_t>(moveMode), rate, optionMask, optionOverride);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -2759,22 +3308,42 @@ using chip::Callback::Cancelable;
      optionOverride:(uint8_t)optionOverride
     responseHandler:(ResponseHandler)responseHandler
 {
+    LevelControl::Commands::MoveToLevel::Type request;
+    request.level = level;
+    request.transitionTime = transitionTime;
+    request.optionMask = optionMask;
+    request.optionOverride = optionOverride;
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.MoveToLevel(success, failure, level, transitionTime, optionMask, optionOverride);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
 - (void)moveToLevelWithOnOff:(uint8_t)level transitionTime:(uint16_t)transitionTime responseHandler:(ResponseHandler)responseHandler
 {
+    LevelControl::Commands::MoveToLevelWithOnOff::Type request;
+    request.level = level;
+    request.transitionTime = transitionTime;
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.MoveToLevelWithOnOff(success, failure, level, transitionTime);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
 - (void)moveWithOnOff:(uint8_t)moveMode rate:(uint8_t)rate responseHandler:(ResponseHandler)responseHandler
 {
+    LevelControl::Commands::MoveWithOnOff::Type request;
+    request.moveMode = static_cast<decltype(request.moveMode)>(moveMode);
+    request.rate = rate;
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.MoveWithOnOff(success, failure, static_cast<uint8_t>(moveMode), rate);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -2785,9 +3354,17 @@ using chip::Callback::Cancelable;
      optionOverride:(uint8_t)optionOverride
     responseHandler:(ResponseHandler)responseHandler
 {
+    LevelControl::Commands::Step::Type request;
+    request.stepMode = static_cast<decltype(request.stepMode)>(stepMode);
+    request.stepSize = stepSize;
+    request.transitionTime = transitionTime;
+    request.optionMask = optionMask;
+    request.optionOverride = optionOverride;
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.Step(
-            success, failure, static_cast<uint8_t>(stepMode), stepSize, transitionTime, optionMask, optionOverride);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -2796,22 +3373,39 @@ using chip::Callback::Cancelable;
        transitionTime:(uint16_t)transitionTime
       responseHandler:(ResponseHandler)responseHandler
 {
+    LevelControl::Commands::StepWithOnOff::Type request;
+    request.stepMode = static_cast<decltype(request.stepMode)>(stepMode);
+    request.stepSize = stepSize;
+    request.transitionTime = transitionTime;
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.StepWithOnOff(success, failure, static_cast<uint8_t>(stepMode), stepSize, transitionTime);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
 - (void)stop:(uint8_t)optionMask optionOverride:(uint8_t)optionOverride responseHandler:(ResponseHandler)responseHandler
 {
+    LevelControl::Commands::Stop::Type request;
+    request.optionMask = optionMask;
+    request.optionOverride = optionOverride;
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.Stop(success, failure, optionMask, optionOverride);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
 - (void)stopWithOnOff:(ResponseHandler)responseHandler
 {
+    LevelControl::Commands::StopWithOnOff::Type request;
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.StopWithOnOff(success, failure);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -2999,8 +3593,12 @@ using chip::Callback::Cancelable;
 
 - (void)sleep:(ResponseHandler)responseHandler
 {
+    LowPower::Commands::Sleep::Type request;
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.Sleep(success, failure);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -3022,29 +3620,48 @@ using chip::Callback::Cancelable;
 
 - (void)hideInputStatus:(ResponseHandler)responseHandler
 {
+    MediaInput::Commands::HideInputStatus::Type request;
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.HideInputStatus(success, failure);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
 - (void)renameInput:(uint8_t)index name:(NSString *)name responseHandler:(ResponseHandler)responseHandler
 {
+    MediaInput::Commands::RenameInput::Type request;
+    request.index = index;
+    request.name = [self asCharSpan:name];
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.RenameInput(success, failure, index, [self asCharSpan:name]);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
 - (void)selectInput:(uint8_t)index responseHandler:(ResponseHandler)responseHandler
 {
+    MediaInput::Commands::SelectInput::Type request;
+    request.index = index;
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.SelectInput(success, failure, index);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
 - (void)showInputStatus:(ResponseHandler)responseHandler
 {
+    MediaInput::Commands::ShowInputStatus::Type request;
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.ShowInputStatus(success, failure);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -3081,89 +3698,136 @@ using chip::Callback::Cancelable;
 
 - (void)mediaFastForward:(ResponseHandler)responseHandler
 {
+    MediaPlayback::Commands::MediaFastForward::Type request;
+
     new CHIPMediaPlaybackClusterMediaFastForwardResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.MediaFastForward(success, failure);
+            auto successFn = Callback<CHIPMediaPlaybackClusterMediaFastForwardResponseCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
 - (void)mediaNext:(ResponseHandler)responseHandler
 {
+    MediaPlayback::Commands::MediaNext::Type request;
+
     new CHIPMediaPlaybackClusterMediaNextResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.MediaNext(success, failure);
+            auto successFn = Callback<CHIPMediaPlaybackClusterMediaNextResponseCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
 - (void)mediaPause:(ResponseHandler)responseHandler
 {
+    MediaPlayback::Commands::MediaPause::Type request;
+
     new CHIPMediaPlaybackClusterMediaPauseResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.MediaPause(success, failure);
+            auto successFn = Callback<CHIPMediaPlaybackClusterMediaPauseResponseCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
 - (void)mediaPlay:(ResponseHandler)responseHandler
 {
+    MediaPlayback::Commands::MediaPlay::Type request;
+
     new CHIPMediaPlaybackClusterMediaPlayResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.MediaPlay(success, failure);
+            auto successFn = Callback<CHIPMediaPlaybackClusterMediaPlayResponseCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
 - (void)mediaPrevious:(ResponseHandler)responseHandler
 {
+    MediaPlayback::Commands::MediaPrevious::Type request;
+
     new CHIPMediaPlaybackClusterMediaPreviousResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.MediaPrevious(success, failure);
+            auto successFn = Callback<CHIPMediaPlaybackClusterMediaPreviousResponseCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
 - (void)mediaRewind:(ResponseHandler)responseHandler
 {
+    MediaPlayback::Commands::MediaRewind::Type request;
+
     new CHIPMediaPlaybackClusterMediaRewindResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.MediaRewind(success, failure);
+            auto successFn = Callback<CHIPMediaPlaybackClusterMediaRewindResponseCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
 - (void)mediaSeek:(uint64_t)position responseHandler:(ResponseHandler)responseHandler
 {
+    MediaPlayback::Commands::MediaSeek::Type request;
+    request.position = position;
+
     new CHIPMediaPlaybackClusterMediaSeekResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.MediaSeek(success, failure, position);
+            auto successFn = Callback<CHIPMediaPlaybackClusterMediaSeekResponseCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
 - (void)mediaSkipBackward:(uint64_t)deltaPositionMilliseconds responseHandler:(ResponseHandler)responseHandler
 {
+    MediaPlayback::Commands::MediaSkipBackward::Type request;
+    request.deltaPositionMilliseconds = deltaPositionMilliseconds;
+
     new CHIPMediaPlaybackClusterMediaSkipBackwardResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.MediaSkipBackward(success, failure, deltaPositionMilliseconds);
+            auto successFn = Callback<CHIPMediaPlaybackClusterMediaSkipBackwardResponseCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
 - (void)mediaSkipForward:(uint64_t)deltaPositionMilliseconds responseHandler:(ResponseHandler)responseHandler
 {
+    MediaPlayback::Commands::MediaSkipForward::Type request;
+    request.deltaPositionMilliseconds = deltaPositionMilliseconds;
+
     new CHIPMediaPlaybackClusterMediaSkipForwardResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.MediaSkipForward(success, failure, deltaPositionMilliseconds);
+            auto successFn = Callback<CHIPMediaPlaybackClusterMediaSkipForwardResponseCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
 - (void)mediaStartOver:(ResponseHandler)responseHandler
 {
+    MediaPlayback::Commands::MediaStartOver::Type request;
+
     new CHIPMediaPlaybackClusterMediaStartOverResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.MediaStartOver(success, failure);
+            auto successFn = Callback<CHIPMediaPlaybackClusterMediaStartOverResponseCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
 - (void)mediaStop:(ResponseHandler)responseHandler
 {
+    MediaPlayback::Commands::MediaStop::Type request;
+
     new CHIPMediaPlaybackClusterMediaStopResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.MediaStop(success, failure);
+            auto successFn = Callback<CHIPMediaPlaybackClusterMediaStopResponseCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
@@ -3241,8 +3905,13 @@ using chip::Callback::Cancelable;
 
 - (void)changeToMode:(uint8_t)newMode responseHandler:(ResponseHandler)responseHandler
 {
+    ModeSelect::Commands::ChangeToMode::Type request;
+    request.newMode = newMode;
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.ChangeToMode(success, failure, newMode);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -3329,9 +3998,16 @@ using chip::Callback::Cancelable;
                timeoutMs:(uint32_t)timeoutMs
          responseHandler:(ResponseHandler)responseHandler
 {
+    NetworkCommissioning::Commands::AddThreadNetwork::Type request;
+    request.operationalDataset = [self asByteSpan:operationalDataset];
+    request.breadcrumb = breadcrumb;
+    request.timeoutMs = timeoutMs;
+
     new CHIPNetworkCommissioningClusterAddThreadNetworkResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.AddThreadNetwork(success, failure, [self asByteSpan:operationalDataset], breadcrumb, timeoutMs);
+            auto successFn = Callback<CHIPNetworkCommissioningClusterAddThreadNetworkResponseCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
@@ -3341,10 +4017,17 @@ using chip::Callback::Cancelable;
              timeoutMs:(uint32_t)timeoutMs
        responseHandler:(ResponseHandler)responseHandler
 {
+    NetworkCommissioning::Commands::AddWiFiNetwork::Type request;
+    request.ssid = [self asByteSpan:ssid];
+    request.credentials = [self asByteSpan:credentials];
+    request.breadcrumb = breadcrumb;
+    request.timeoutMs = timeoutMs;
+
     new CHIPNetworkCommissioningClusterAddWiFiNetworkResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.AddWiFiNetwork(
-                success, failure, [self asByteSpan:ssid], [self asByteSpan:credentials], breadcrumb, timeoutMs);
+            auto successFn = Callback<CHIPNetworkCommissioningClusterAddWiFiNetworkResponseCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
@@ -3353,9 +4036,16 @@ using chip::Callback::Cancelable;
              timeoutMs:(uint32_t)timeoutMs
        responseHandler:(ResponseHandler)responseHandler
 {
+    NetworkCommissioning::Commands::DisableNetwork::Type request;
+    request.networkID = [self asByteSpan:networkID];
+    request.breadcrumb = breadcrumb;
+    request.timeoutMs = timeoutMs;
+
     new CHIPNetworkCommissioningClusterDisableNetworkResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.DisableNetwork(success, failure, [self asByteSpan:networkID], breadcrumb, timeoutMs);
+            auto successFn = Callback<CHIPNetworkCommissioningClusterDisableNetworkResponseCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
@@ -3364,9 +4054,16 @@ using chip::Callback::Cancelable;
             timeoutMs:(uint32_t)timeoutMs
       responseHandler:(ResponseHandler)responseHandler
 {
+    NetworkCommissioning::Commands::EnableNetwork::Type request;
+    request.networkID = [self asByteSpan:networkID];
+    request.breadcrumb = breadcrumb;
+    request.timeoutMs = timeoutMs;
+
     new CHIPNetworkCommissioningClusterEnableNetworkResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.EnableNetwork(success, failure, [self asByteSpan:networkID], breadcrumb, timeoutMs);
+            auto successFn = Callback<CHIPNetworkCommissioningClusterEnableNetworkResponseCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
@@ -3375,9 +4072,16 @@ using chip::Callback::Cancelable;
             timeoutMs:(uint32_t)timeoutMs
       responseHandler:(ResponseHandler)responseHandler
 {
+    NetworkCommissioning::Commands::RemoveNetwork::Type request;
+    request.networkID = [self asByteSpan:networkID];
+    request.breadcrumb = breadcrumb;
+    request.timeoutMs = timeoutMs;
+
     new CHIPNetworkCommissioningClusterRemoveNetworkResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.RemoveNetwork(success, failure, [self asByteSpan:networkID], breadcrumb, timeoutMs);
+            auto successFn = Callback<CHIPNetworkCommissioningClusterRemoveNetworkResponseCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
@@ -3386,9 +4090,16 @@ using chip::Callback::Cancelable;
            timeoutMs:(uint32_t)timeoutMs
      responseHandler:(ResponseHandler)responseHandler
 {
+    NetworkCommissioning::Commands::ScanNetworks::Type request;
+    request.ssid = [self asByteSpan:ssid];
+    request.breadcrumb = breadcrumb;
+    request.timeoutMs = timeoutMs;
+
     new CHIPNetworkCommissioningClusterScanNetworksResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.ScanNetworks(success, failure, [self asByteSpan:ssid], breadcrumb, timeoutMs);
+            auto successFn = Callback<CHIPNetworkCommissioningClusterScanNetworksResponseCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
@@ -3397,10 +4108,17 @@ using chip::Callback::Cancelable;
                   timeoutMs:(uint32_t)timeoutMs
             responseHandler:(ResponseHandler)responseHandler
 {
+    NetworkCommissioning::Commands::UpdateThreadNetwork::Type request;
+    request.operationalDataset = [self asByteSpan:operationalDataset];
+    request.breadcrumb = breadcrumb;
+    request.timeoutMs = timeoutMs;
+
     new CHIPNetworkCommissioningClusterUpdateThreadNetworkResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.UpdateThreadNetwork(
-                success, failure, [self asByteSpan:operationalDataset], breadcrumb, timeoutMs);
+            auto successFn
+                = Callback<CHIPNetworkCommissioningClusterUpdateThreadNetworkResponseCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
@@ -3410,10 +4128,18 @@ using chip::Callback::Cancelable;
                 timeoutMs:(uint32_t)timeoutMs
           responseHandler:(ResponseHandler)responseHandler
 {
+    NetworkCommissioning::Commands::UpdateWiFiNetwork::Type request;
+    request.ssid = [self asByteSpan:ssid];
+    request.credentials = [self asByteSpan:credentials];
+    request.breadcrumb = breadcrumb;
+    request.timeoutMs = timeoutMs;
+
     new CHIPNetworkCommissioningClusterUpdateWiFiNetworkResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.UpdateWiFiNetwork(
-                success, failure, [self asByteSpan:ssid], [self asByteSpan:credentials], breadcrumb, timeoutMs);
+            auto successFn
+                = Callback<CHIPNetworkCommissioningClusterUpdateWiFiNetworkResponseCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
@@ -3442,9 +4168,15 @@ using chip::Callback::Cancelable;
 
 - (void)applyUpdateRequest:(NSData *)updateToken newVersion:(uint32_t)newVersion responseHandler:(ResponseHandler)responseHandler
 {
+    OtaSoftwareUpdateProvider::Commands::ApplyUpdateRequest::Type request;
+    request.updateToken = [self asByteSpan:updateToken];
+    request.newVersion = newVersion;
+
     new CHIPOtaSoftwareUpdateProviderClusterApplyUpdateResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.ApplyUpdateRequest(success, failure, [self asByteSpan:updateToken], newVersion);
+            auto successFn = Callback<CHIPOtaSoftwareUpdateProviderClusterApplyUpdateResponseCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
@@ -3452,8 +4184,14 @@ using chip::Callback::Cancelable;
             softwareVersion:(uint32_t)softwareVersion
             responseHandler:(ResponseHandler)responseHandler
 {
+    OtaSoftwareUpdateProvider::Commands::NotifyUpdateApplied::Type request;
+    request.updateToken = [self asByteSpan:updateToken];
+    request.softwareVersion = softwareVersion;
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.NotifyUpdateApplied(success, failure, [self asByteSpan:updateToken], softwareVersion);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -3467,11 +4205,23 @@ using chip::Callback::Cancelable;
     metadataForProvider:(NSData *)metadataForProvider
         responseHandler:(ResponseHandler)responseHandler
 {
+    OtaSoftwareUpdateProvider::Commands::QueryImage::Type request;
+    request.vendorId = static_cast<decltype(request.vendorId)>(vendorId);
+    request.productId = productId;
+    request.softwareVersion = softwareVersion;
+    request.protocolsSupported
+        = chip::app::DataModel::List<const chip::app::Clusters::OtaSoftwareUpdateProvider::OTADownloadProtocol>();
+    ;
+    request.hardwareVersion = chip::Optional<uint16_t>(hardwareVersion);
+    request.location = chip::Optional<chip::CharSpan>([self asCharSpan:location]);
+    request.requestorCanConsent = chip::Optional<bool>(requestorCanConsent);
+    request.metadataForProvider = chip::Optional<chip::ByteSpan>([self asByteSpan:metadataForProvider]);
+
     new CHIPOtaSoftwareUpdateProviderClusterQueryImageResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.QueryImage(success, failure, static_cast<chip::VendorId>(vendorId), productId, softwareVersion,
-                static_cast<uint8_t>(protocolsSupported), hardwareVersion, [self asCharSpan:location], requestorCanConsent,
-                [self asByteSpan:metadataForProvider]);
+            auto successFn = Callback<CHIPOtaSoftwareUpdateProviderClusterQueryImageResponseCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
@@ -3497,9 +4247,16 @@ using chip::Callback::Cancelable;
             metadataForNode:(NSData *)metadataForNode
             responseHandler:(ResponseHandler)responseHandler
 {
+    OtaSoftwareUpdateRequestor::Commands::AnnounceOtaProvider::Type request;
+    request.providerLocation = providerLocation;
+    request.vendorId = static_cast<decltype(request.vendorId)>(vendorId);
+    request.announcementReason = static_cast<decltype(request.announcementReason)>(announcementReason);
+    request.metadataForNode = chip::Optional<chip::ByteSpan>([self asByteSpan:metadataForNode]);
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.AnnounceOtaProvider(success, failure, providerLocation, static_cast<chip::VendorId>(vendorId),
-            static_cast<uint8_t>(announcementReason), [self asByteSpan:metadataForNode]);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -3598,29 +4355,47 @@ using chip::Callback::Cancelable;
 
 - (void)off:(ResponseHandler)responseHandler
 {
+    OnOff::Commands::Off::Type request;
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.Off(success, failure);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
 - (void)offWithEffect:(uint8_t)effectId effectVariant:(uint8_t)effectVariant responseHandler:(ResponseHandler)responseHandler
 {
+    OnOff::Commands::OffWithEffect::Type request;
+    request.effectId = static_cast<decltype(request.effectId)>(effectId);
+    request.effectVariant = static_cast<decltype(request.effectVariant)>(effectVariant);
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.OffWithEffect(success, failure, static_cast<uint8_t>(effectId), static_cast<uint8_t>(effectVariant));
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
 - (void)on:(ResponseHandler)responseHandler
 {
+    OnOff::Commands::On::Type request;
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.On(success, failure);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
 - (void)onWithRecallGlobalScene:(ResponseHandler)responseHandler
 {
+    OnOff::Commands::OnWithRecallGlobalScene::Type request;
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.OnWithRecallGlobalScene(success, failure);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -3629,15 +4404,26 @@ using chip::Callback::Cancelable;
            offWaitTime:(uint16_t)offWaitTime
        responseHandler:(ResponseHandler)responseHandler
 {
+    OnOff::Commands::OnWithTimedOff::Type request;
+    request.onOffControl = static_cast<decltype(request.onOffControl)>(onOffControl);
+    request.onTime = onTime;
+    request.offWaitTime = offWaitTime;
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.OnWithTimedOff(success, failure, onOffControl, onTime, offWaitTime);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
 - (void)toggle:(ResponseHandler)responseHandler
 {
+    OnOff::Commands::Toggle::Type request;
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.Toggle(success, failure);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -3783,72 +4569,122 @@ using chip::Callback::Cancelable;
       adminVendorId:(uint16_t)adminVendorId
     responseHandler:(ResponseHandler)responseHandler
 {
+    OperationalCredentials::Commands::AddNOC::Type request;
+    request.NOCValue = [self asByteSpan:NOCValue];
+    request.ICACValue = chip::Optional<chip::ByteSpan>([self asByteSpan:ICACValue]);
+    request.IPKValue = [self asByteSpan:IPKValue];
+    request.caseAdminNode = caseAdminNode;
+    request.adminVendorId = adminVendorId;
+
     new CHIPOperationalCredentialsClusterNOCResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.AddNOC(success, failure, [self asByteSpan:NOCValue], [self asByteSpan:ICACValue],
-                [self asByteSpan:IPKValue], caseAdminNode, adminVendorId);
+            auto successFn = Callback<CHIPOperationalCredentialsClusterNOCResponseCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
 - (void)addTrustedRootCertificate:(NSData *)rootCertificate responseHandler:(ResponseHandler)responseHandler
 {
+    OperationalCredentials::Commands::AddTrustedRootCertificate::Type request;
+    request.rootCertificate = [self asByteSpan:rootCertificate];
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.AddTrustedRootCertificate(success, failure, [self asByteSpan:rootCertificate]);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
 - (void)attestationRequest:(NSData *)attestationNonce responseHandler:(ResponseHandler)responseHandler
 {
+    OperationalCredentials::Commands::AttestationRequest::Type request;
+    request.attestationNonce = [self asByteSpan:attestationNonce];
+
     new CHIPOperationalCredentialsClusterAttestationResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.AttestationRequest(success, failure, [self asByteSpan:attestationNonce]);
+            auto successFn = Callback<CHIPOperationalCredentialsClusterAttestationResponseCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
 - (void)certificateChainRequest:(uint8_t)certificateType responseHandler:(ResponseHandler)responseHandler
 {
+    OperationalCredentials::Commands::CertificateChainRequest::Type request;
+    request.certificateType = certificateType;
+
     new CHIPOperationalCredentialsClusterCertificateChainResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.CertificateChainRequest(success, failure, certificateType);
+            auto successFn
+                = Callback<CHIPOperationalCredentialsClusterCertificateChainResponseCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
 - (void)opCSRRequest:(NSData *)CSRNonce responseHandler:(ResponseHandler)responseHandler
 {
+    OperationalCredentials::Commands::OpCSRRequest::Type request;
+    request.CSRNonce = [self asByteSpan:CSRNonce];
+
     new CHIPOperationalCredentialsClusterOpCSRResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.OpCSRRequest(success, failure, [self asByteSpan:CSRNonce]);
+            auto successFn = Callback<CHIPOperationalCredentialsClusterOpCSRResponseCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
 - (void)removeFabric:(uint8_t)fabricIndex responseHandler:(ResponseHandler)responseHandler
 {
+    OperationalCredentials::Commands::RemoveFabric::Type request;
+    request.fabricIndex = fabricIndex;
+
     new CHIPOperationalCredentialsClusterNOCResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.RemoveFabric(success, failure, fabricIndex);
+            auto successFn = Callback<CHIPOperationalCredentialsClusterNOCResponseCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
 - (void)removeTrustedRootCertificate:(NSData *)trustedRootIdentifier responseHandler:(ResponseHandler)responseHandler
 {
+    OperationalCredentials::Commands::RemoveTrustedRootCertificate::Type request;
+    request.trustedRootIdentifier = [self asByteSpan:trustedRootIdentifier];
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.RemoveTrustedRootCertificate(success, failure, [self asByteSpan:trustedRootIdentifier]);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
 - (void)updateFabricLabel:(NSString *)label responseHandler:(ResponseHandler)responseHandler
 {
+    OperationalCredentials::Commands::UpdateFabricLabel::Type request;
+    request.label = [self asCharSpan:label];
+
     new CHIPOperationalCredentialsClusterNOCResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.UpdateFabricLabel(success, failure, [self asCharSpan:label]);
+            auto successFn = Callback<CHIPOperationalCredentialsClusterNOCResponseCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
 - (void)updateNOC:(NSData *)NOCValue ICACValue:(NSData *)ICACValue responseHandler:(ResponseHandler)responseHandler
 {
+    OperationalCredentials::Commands::UpdateNOC::Type request;
+    request.NOCValue = [self asByteSpan:NOCValue];
+    request.ICACValue = chip::Optional<chip::ByteSpan>([self asByteSpan:ICACValue]);
+
     new CHIPOperationalCredentialsClusterNOCResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.UpdateNOC(success, failure, [self asByteSpan:NOCValue], [self asByteSpan:ICACValue]);
+            auto successFn = Callback<CHIPOperationalCredentialsClusterNOCResponseCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
@@ -4368,18 +5204,33 @@ using chip::Callback::Cancelable;
               value:(uint8_t)value
     responseHandler:(ResponseHandler)responseHandler
 {
+    Scenes::Commands::AddScene::Type request;
+    request.groupId = groupId;
+    request.sceneId = sceneId;
+    request.transitionTime = transitionTime;
+    request.sceneName = [self asCharSpan:sceneName];
+    request.extensionFieldSets
+        = chip::app::DataModel::List<const chip::app::Clusters::Scenes::Structs::SceneExtensionFieldSet::Type>();
+    ;
+
     new CHIPScenesClusterAddSceneResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.AddScene(
-                success, failure, groupId, sceneId, transitionTime, [self asCharSpan:sceneName], clusterId, length, value);
+            auto successFn = Callback<CHIPScenesClusterAddSceneResponseCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
 - (void)getSceneMembership:(uint16_t)groupId responseHandler:(ResponseHandler)responseHandler
 {
+    Scenes::Commands::GetSceneMembership::Type request;
+    request.groupId = groupId;
+
     new CHIPScenesClusterGetSceneMembershipResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.GetSceneMembership(success, failure, groupId);
+            auto successFn = Callback<CHIPScenesClusterGetSceneMembershipResponseCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
@@ -4388,40 +5239,70 @@ using chip::Callback::Cancelable;
      transitionTime:(uint16_t)transitionTime
     responseHandler:(ResponseHandler)responseHandler
 {
+    Scenes::Commands::RecallScene::Type request;
+    request.groupId = groupId;
+    request.sceneId = sceneId;
+    request.transitionTime = transitionTime;
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.RecallScene(success, failure, groupId, sceneId, transitionTime);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
 - (void)removeAllScenes:(uint16_t)groupId responseHandler:(ResponseHandler)responseHandler
 {
+    Scenes::Commands::RemoveAllScenes::Type request;
+    request.groupId = groupId;
+
     new CHIPScenesClusterRemoveAllScenesResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.RemoveAllScenes(success, failure, groupId);
+            auto successFn = Callback<CHIPScenesClusterRemoveAllScenesResponseCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
 - (void)removeScene:(uint16_t)groupId sceneId:(uint8_t)sceneId responseHandler:(ResponseHandler)responseHandler
 {
+    Scenes::Commands::RemoveScene::Type request;
+    request.groupId = groupId;
+    request.sceneId = sceneId;
+
     new CHIPScenesClusterRemoveSceneResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.RemoveScene(success, failure, groupId, sceneId);
+            auto successFn = Callback<CHIPScenesClusterRemoveSceneResponseCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
 - (void)storeScene:(uint16_t)groupId sceneId:(uint8_t)sceneId responseHandler:(ResponseHandler)responseHandler
 {
+    Scenes::Commands::StoreScene::Type request;
+    request.groupId = groupId;
+    request.sceneId = sceneId;
+
     new CHIPScenesClusterStoreSceneResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.StoreScene(success, failure, groupId, sceneId);
+            auto successFn = Callback<CHIPScenesClusterStoreSceneResponseCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
 - (void)viewScene:(uint16_t)groupId sceneId:(uint8_t)sceneId responseHandler:(ResponseHandler)responseHandler
 {
+    Scenes::Commands::ViewScene::Type request;
+    request.groupId = groupId;
+    request.sceneId = sceneId;
+
     new CHIPScenesClusterViewSceneResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.ViewScene(success, failure, groupId, sceneId);
+            auto successFn = Callback<CHIPScenesClusterViewSceneResponseCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
@@ -4478,8 +5359,12 @@ using chip::Callback::Cancelable;
 
 - (void)resetWatermarks:(ResponseHandler)responseHandler
 {
+    SoftwareDiagnostics::Commands::ResetWatermarks::Type request;
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.ResetWatermarks(success, failure);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -4585,9 +5470,14 @@ using chip::Callback::Cancelable;
 
 - (void)changeChannel:(NSString *)match responseHandler:(ResponseHandler)responseHandler
 {
+    TvChannel::Commands::ChangeChannel::Type request;
+    request.match = [self asCharSpan:match];
+
     new CHIPTvChannelClusterChangeChannelResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.ChangeChannel(success, failure, [self asCharSpan:match]);
+            auto successFn = Callback<CHIPTvChannelClusterChangeChannelResponseCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
@@ -4595,15 +5485,26 @@ using chip::Callback::Cancelable;
                   minorNumber:(uint16_t)minorNumber
               responseHandler:(ResponseHandler)responseHandler
 {
+    TvChannel::Commands::ChangeChannelByNumber::Type request;
+    request.majorNumber = majorNumber;
+    request.minorNumber = minorNumber;
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.ChangeChannelByNumber(success, failure, majorNumber, minorNumber);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
 - (void)skipChannel:(uint16_t)count responseHandler:(ResponseHandler)responseHandler
 {
+    TvChannel::Commands::SkipChannel::Type request;
+    request.count = count;
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.SkipChannel(success, failure, count);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -4647,9 +5548,15 @@ using chip::Callback::Cancelable;
 
 - (void)navigateTarget:(uint8_t)target data:(NSString *)data responseHandler:(ResponseHandler)responseHandler
 {
+    TargetNavigator::Commands::NavigateTarget::Type request;
+    request.target = target;
+    request.data = [self asCharSpan:data];
+
     new CHIPTargetNavigatorClusterNavigateTargetResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.NavigateTarget(success, failure, target, [self asCharSpan:data]);
+            auto successFn = Callback<CHIPTargetNavigatorClusterNavigateTargetResponseCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
@@ -4761,41 +5668,68 @@ using chip::Callback::Cancelable;
 
 - (void)test:(ResponseHandler)responseHandler
 {
+    TestCluster::Commands::Test::Type request;
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.Test(success, failure);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
 - (void)testAddArguments:(uint8_t)arg1 arg2:(uint8_t)arg2 responseHandler:(ResponseHandler)responseHandler
 {
+    TestCluster::Commands::TestAddArguments::Type request;
+    request.arg1 = arg1;
+    request.arg2 = arg2;
+
     new CHIPTestClusterClusterTestAddArgumentsResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.TestAddArguments(success, failure, arg1, arg2);
+            auto successFn = Callback<CHIPTestClusterClusterTestAddArgumentsResponseCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
 - (void)testEnumsRequest:(uint16_t)arg1 arg2:(uint8_t)arg2 responseHandler:(ResponseHandler)responseHandler
 {
+    TestCluster::Commands::TestEnumsRequest::Type request;
+    request.arg1 = static_cast<decltype(request.arg1)>(arg1);
+    request.arg2 = static_cast<decltype(request.arg2)>(arg2);
+
     new CHIPTestClusterClusterTestEnumsResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.TestEnumsRequest(
-                success, failure, static_cast<chip::VendorId>(arg1), static_cast<uint8_t>(arg2));
+            auto successFn = Callback<CHIPTestClusterClusterTestEnumsResponseCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
 - (void)testListInt8UArgumentRequest:(uint8_t)arg1 responseHandler:(ResponseHandler)responseHandler
 {
+    TestCluster::Commands::TestListInt8UArgumentRequest::Type request;
+    request.arg1 = chip::app::DataModel::List<const uint8_t>();
+    ;
+
     new CHIPTestClusterClusterBooleanResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.TestListInt8UArgumentRequest(success, failure, arg1);
+            auto successFn = Callback<CHIPTestClusterClusterBooleanResponseCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
 - (void)testListInt8UReverseRequest:(uint8_t)arg1 responseHandler:(ResponseHandler)responseHandler
 {
+    TestCluster::Commands::TestListInt8UReverseRequest::Type request;
+    request.arg1 = chip::app::DataModel::List<const uint8_t>();
+    ;
+
     new CHIPTestClusterClusterTestListInt8UReverseResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.TestListInt8UReverseRequest(success, failure, arg1);
+            auto successFn = Callback<CHIPTestClusterClusterTestListInt8UReverseResponseCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
@@ -4807,33 +5741,51 @@ using chip::Callback::Cancelable;
                                     f:(uint8_t)f
                       responseHandler:(ResponseHandler)responseHandler
 {
+    TestCluster::Commands::TestListStructArgumentRequest::Type request;
+    request.arg1 = chip::app::DataModel::List<const chip::app::Clusters::TestCluster::Structs::SimpleStruct::Type>();
+    ;
+
     new CHIPTestClusterClusterBooleanResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.TestListStructArgumentRequest(
-                success, failure, a, b, static_cast<uint8_t>(c), [self asByteSpan:d], [self asCharSpan:e], f);
+            auto successFn = Callback<CHIPTestClusterClusterBooleanResponseCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
 - (void)testNotHandled:(ResponseHandler)responseHandler
 {
+    TestCluster::Commands::TestNotHandled::Type request;
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.TestNotHandled(success, failure);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
 - (void)testNullableOptionalRequest:(uint8_t)arg1 responseHandler:(ResponseHandler)responseHandler
 {
+    TestCluster::Commands::TestNullableOptionalRequest::Type request;
+    request.arg1 = chip::Optional<chip::app::DataModel::Nullable<uint8_t>>(chip::app::DataModel::Nullable<uint8_t>(arg1));
+
     new CHIPTestClusterClusterTestNullableOptionalResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.TestNullableOptionalRequest(success, failure, arg1);
+            auto successFn = Callback<CHIPTestClusterClusterTestNullableOptionalResponseCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
 - (void)testSpecific:(ResponseHandler)responseHandler
 {
+    TestCluster::Commands::TestSpecific::Type request;
+
     new CHIPTestClusterClusterTestSpecificResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.TestSpecific(success, failure);
+            auto successFn = Callback<CHIPTestClusterClusterTestSpecificResponseCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
@@ -4845,17 +5797,26 @@ using chip::Callback::Cancelable;
                                 f:(uint8_t)f
                   responseHandler:(ResponseHandler)responseHandler
 {
+    TestCluster::Commands::TestStructArgumentRequest::Type request;
+    request.arg1 = chip::app::Clusters::TestCluster::Structs::SimpleStruct::Type();
+    ;
+
     new CHIPTestClusterClusterBooleanResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-            return self.cppCluster.TestStructArgumentRequest(
-                success, failure, a, b, static_cast<uint8_t>(c), [self asByteSpan:d], [self asCharSpan:e], f);
+            auto successFn = Callback<CHIPTestClusterClusterBooleanResponseCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
 - (void)testUnknownCommand:(ResponseHandler)responseHandler
 {
+    TestCluster::Commands::TestUnknownCommand::Type request;
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.TestUnknownCommand(success, failure);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -5231,22 +6192,36 @@ using chip::Callback::Cancelable;
 
 - (void)clearWeeklySchedule:(ResponseHandler)responseHandler
 {
+    Thermostat::Commands::ClearWeeklySchedule::Type request;
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.ClearWeeklySchedule(success, failure);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
 - (void)getRelayStatusLog:(ResponseHandler)responseHandler
 {
+    Thermostat::Commands::GetRelayStatusLog::Type request;
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.GetRelayStatusLog(success, failure);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
 - (void)getWeeklySchedule:(uint8_t)daysToReturn modeToReturn:(uint8_t)modeToReturn responseHandler:(ResponseHandler)responseHandler
 {
+    Thermostat::Commands::GetWeeklySchedule::Type request;
+    request.daysToReturn = static_cast<decltype(request.daysToReturn)>(daysToReturn);
+    request.modeToReturn = static_cast<decltype(request.modeToReturn)>(modeToReturn);
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.GetWeeklySchedule(success, failure, daysToReturn, modeToReturn);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -5256,16 +6231,30 @@ using chip::Callback::Cancelable;
                   payload:(uint8_t)payload
           responseHandler:(ResponseHandler)responseHandler
 {
+    Thermostat::Commands::SetWeeklySchedule::Type request;
+    request.numberOfTransitionsForSequence = numberOfTransitionsForSequence;
+    request.dayOfWeekForSequence = static_cast<decltype(request.dayOfWeekForSequence)>(dayOfWeekForSequence);
+    request.modeForSequence = static_cast<decltype(request.modeForSequence)>(modeForSequence);
+    request.payload = chip::app::DataModel::List<const uint8_t>();
+    ;
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.SetWeeklySchedule(
-            success, failure, numberOfTransitionsForSequence, dayOfWeekForSequence, modeForSequence, payload);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
 - (void)setpointRaiseLower:(uint8_t)mode amount:(int8_t)amount responseHandler:(ResponseHandler)responseHandler
 {
+    Thermostat::Commands::SetpointRaiseLower::Type request;
+    request.mode = static_cast<decltype(request.mode)>(mode);
+    request.amount = amount;
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.SetpointRaiseLower(success, failure, static_cast<uint8_t>(mode), amount);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -5553,8 +6542,12 @@ using chip::Callback::Cancelable;
 
 - (void)resetCounts:(ResponseHandler)responseHandler
 {
+    ThreadNetworkDiagnostics::Commands::ResetCounts::Type request;
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.ResetCounts(success, failure);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -6045,8 +7038,12 @@ using chip::Callback::Cancelable;
 
 - (void)resetCounts:(ResponseHandler)responseHandler
 {
+    WiFiNetworkDiagnostics::Commands::ResetCounts::Type request;
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.ResetCounts(success, failure);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -6159,8 +7156,12 @@ using chip::Callback::Cancelable;
 
 - (void)downOrClose:(ResponseHandler)responseHandler
 {
+    WindowCovering::Commands::DownOrClose::Type request;
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.DownOrClose(success, failure);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -6168,15 +7169,26 @@ using chip::Callback::Cancelable;
     liftPercent100thsValue:(uint16_t)liftPercent100thsValue
            responseHandler:(ResponseHandler)responseHandler
 {
+    WindowCovering::Commands::GoToLiftPercentage::Type request;
+    request.liftPercentageValue = liftPercentageValue;
+    request.liftPercent100thsValue = liftPercent100thsValue;
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.GoToLiftPercentage(success, failure, liftPercentageValue, liftPercent100thsValue);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
 - (void)goToLiftValue:(uint16_t)liftValue responseHandler:(ResponseHandler)responseHandler
 {
+    WindowCovering::Commands::GoToLiftValue::Type request;
+    request.liftValue = liftValue;
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.GoToLiftValue(success, failure, liftValue);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -6184,29 +7196,48 @@ using chip::Callback::Cancelable;
     tiltPercent100thsValue:(uint16_t)tiltPercent100thsValue
            responseHandler:(ResponseHandler)responseHandler
 {
+    WindowCovering::Commands::GoToTiltPercentage::Type request;
+    request.tiltPercentageValue = tiltPercentageValue;
+    request.tiltPercent100thsValue = tiltPercent100thsValue;
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.GoToTiltPercentage(success, failure, tiltPercentageValue, tiltPercent100thsValue);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
 - (void)goToTiltValue:(uint16_t)tiltValue responseHandler:(ResponseHandler)responseHandler
 {
+    WindowCovering::Commands::GoToTiltValue::Type request;
+    request.tiltValue = tiltValue;
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.GoToTiltValue(success, failure, tiltValue);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
 - (void)stopMotion:(ResponseHandler)responseHandler
 {
+    WindowCovering::Commands::StopMotion::Type request;
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.StopMotion(success, failure);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
 - (void)upOrOpen:(ResponseHandler)responseHandler
 {
+    WindowCovering::Commands::UpOrOpen::Type request;
+
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.UpOrOpen(success, failure);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 


### PR DESCRIPTION
#### Problem

Darwin API relies on `CHIPClusters` which makes it hard to support optional and nullable attributes.

#### Change overview
* Update Darwin's internal to use `InvokeCommand` instead.

#### Testing
I have verified that the darwin tests still runs.
