### PR TITLE
[SimulatedDevice] Add a test step to wait for commissioning complete

### DIFF
--- a/examples/placeholder/linux/main.cpp
+++ b/examples/placeholder/linux/main.cpp
@@ -17,35 +17,18 @@
  */
 
 #include "AppMain.h"
-#include "Options.h"
-
-#include <lib/support/CodeUtils.h>
-
 #include "MatterCallbacks.h"
-
-std::unique_ptr<TestCommand> RunTestCommand()
-{
-    const char * command = LinuxDeviceOptions::GetInstance().command;
-    if (command == nullptr)
-    {
-        return nullptr;
-    }
-
-    auto test = GetTestCommand(command);
-    if (test.get() == nullptr)
-    {
-        ChipLogError(chipTool, "Specified test command does not exists: %s", command);
-        return nullptr;
-    }
-
-    chip::DeviceLayer::PlatformMgr().AddEventHandler(OnPlatformEvent, reinterpret_cast<intptr_t>(test.get()));
-    return test;
-}
 
 int main(int argc, char * argv[])
 {
     VerifyOrDie(ChipLinuxAppInit(argc, argv) == 0);
-    auto test = RunTestCommand();
+
+    auto test = GetTargetTest();
+    if (test != nullptr)
+    {
+        test->NextTest();
+    }
+
     ChipLinuxAppMainLoop();
     return 0;
 }

--- a/src/app/tests/suites/certification/Test_TC_DM_1_3_Simulated.yaml
+++ b/src/app/tests/suites/certification/Test_TC_DM_1_3_Simulated.yaml
@@ -19,6 +19,10 @@ config:
     endpoint: 0
 
 tests:
+    - label: "Wait for the device to be commissioned"
+      cluster: "DelayCommands"
+      command: "WaitForCommissioning"
+
     - label: "Log OnOff Test Startup"
       cluster: "LogCommands"
       command: "Log"

--- a/src/app/zap-templates/common/simulated-clusters/TestDelayCommands.js
+++ b/src/app/zap-templates/common/simulated-clusters/TestDelayCommands.js
@@ -30,9 +30,15 @@ const WaitForMs = {
   response : { arguments : [] }
 };
 
+const WaitForCommissioning = {
+  name : 'WaitForCommissioning',
+  arguments : [],
+  response : { arguments : [] }
+};
+
 const DelayCommands = {
   name : 'DelayCommands',
-  commands : [ WaitForMs ],
+  commands : [ WaitForMs, WaitForCommissioning ],
 };
 
 //


### PR DESCRIPTION
#### Problem

For simulated node YAML tests, commissioning must complete before testing starts. Some controller certification tests will need to test their ability to walk through node commissioning flow. Therefore, weather commissioning should occur pre-test or not should be up to the script writer.

#### Change overview
 * Add a new command to wait for commissioning

#### Testing

I have manually verified that it works by removing/adding the new step of `Test_TC_DM_1_3_Simulated`

#fixes #11549
