### PR TITLE
Add optional args in chip-tool and end point optional arg

### DIFF
--- a/examples/chip-tool/commands/clusters/ModelCommand.h
+++ b/examples/chip-tool/commands/clusters/ModelCommand.h
@@ -40,8 +40,8 @@ public:
 
     void AddArguments()
     {
-        AddArgument("node-id", 0, UINT64_MAX, &mNodeId);
-        AddArgument("endpoint-id", CHIP_ZCL_ENDPOINT_MIN, CHIP_ZCL_ENDPOINT_MAX, &mEndPointId);
+        AddArgument("node-id", 0, UINT64_MAX, &mNodeId, false);
+        AddArgument("endpoint-id", CHIP_ZCL_ENDPOINT_MIN, CHIP_ZCL_ENDPOINT_MAX, &mEndPointId, false);
     }
 
     /////////// CHIPCommand Interface /////////

--- a/examples/chip-tool/commands/common/Command.h
+++ b/examples/chip-tool/commands/common/Command.h
@@ -74,6 +74,8 @@ struct Argument
     int64_t min;
     uint64_t max;
     void * value;
+    bool isOptional = false;
+    bool isProvided = false;
 };
 
 class Command
@@ -91,10 +93,13 @@ public:
     const char * GetName(void) const { return mName; }
     const char * GetAttribute(void) const;
     const char * GetArgumentName(size_t index) const;
+    const char * GetOptionalArgumentName(size_t index) const;
     size_t GetArgumentsCount(void) const { return mArgs.size(); }
+    size_t GetOptionalArgumentsCount(void) const { return mOptionalArgs.size(); }
 
     bool InitArguments(int argc, char ** argv);
-    size_t AddArgument(const char * name, const char * value);
+    bool InitOptionalArguments(int & argc, char ** argv);
+    size_t AddArgument(const char * name, const char * value, bool optional);
     /**
      * @brief
      *   Add a char string command argument
@@ -103,90 +108,91 @@ public:
      * @param value A pointer to a `char *` where the argv value will be stored
      * @returns The number of arguments currently added to the command
      */
-    size_t AddArgument(const char * name, char ** value);
+    size_t AddArgument(const char * name, char ** value, bool optional);
     /**
      * Add an octet string command argument
      */
-    size_t AddArgument(const char * name, chip::ByteSpan * value);
-    size_t AddArgument(const char * name, chip::Span<const char> * value);
-    size_t AddArgument(const char * name, AddressWithInterface * out);
-    size_t AddArgument(const char * name, int64_t min, uint64_t max, bool * out)
+    size_t AddArgument(const char * name, chip::ByteSpan * value, bool optional);
+    size_t AddArgument(const char * name, chip::Span<const char> * value, bool optional);
+    size_t AddArgument(const char * name, AddressWithInterface * out, bool optional);
+    size_t AddArgument(const char * name, int64_t min, uint64_t max, bool * out, bool optional)
     {
-        return AddArgument(name, min, max, reinterpret_cast<void *>(out), Boolean);
+        return AddArgument(name, min, max, reinterpret_cast<void *>(out), Boolean, optional);
     }
-    size_t AddArgument(const char * name, int64_t min, uint64_t max, int8_t * out)
+    size_t AddArgument(const char * name, int64_t min, uint64_t max, int8_t * out, bool optional)
     {
-        return AddArgument(name, min, max, reinterpret_cast<void *>(out), Number_int8);
+        return AddArgument(name, min, max, reinterpret_cast<void *>(out), Number_int8, optional);
     }
-    size_t AddArgument(const char * name, int64_t min, uint64_t max, int16_t * out)
+    size_t AddArgument(const char * name, int64_t min, uint64_t max, int16_t * out, bool optional)
     {
-        return AddArgument(name, min, max, reinterpret_cast<void *>(out), Number_int16);
+        return AddArgument(name, min, max, reinterpret_cast<void *>(out), Number_int16, optional);
     }
-    size_t AddArgument(const char * name, int64_t min, uint64_t max, int32_t * out)
+    size_t AddArgument(const char * name, int64_t min, uint64_t max, int32_t * out, bool optional)
     {
-        return AddArgument(name, min, max, reinterpret_cast<void *>(out), Number_int32);
+        return AddArgument(name, min, max, reinterpret_cast<void *>(out), Number_int32, optional);
     }
-    size_t AddArgument(const char * name, int64_t min, uint64_t max, int64_t * out)
+    size_t AddArgument(const char * name, int64_t min, uint64_t max, int64_t * out, bool optional)
     {
-        return AddArgument(name, min, max, reinterpret_cast<void *>(out), Number_int64);
+        return AddArgument(name, min, max, reinterpret_cast<void *>(out), Number_int64, optional);
     }
-    size_t AddArgument(const char * name, int64_t min, uint64_t max, uint8_t * out)
+    size_t AddArgument(const char * name, int64_t min, uint64_t max, uint8_t * out, bool optional)
     {
-        return AddArgument(name, min, max, reinterpret_cast<void *>(out), Number_uint8);
+        return AddArgument(name, min, max, reinterpret_cast<void *>(out), Number_uint8, optional);
     }
-    size_t AddArgument(const char * name, int64_t min, uint64_t max, uint16_t * out)
+    size_t AddArgument(const char * name, int64_t min, uint64_t max, uint16_t * out, bool optional)
     {
-        return AddArgument(name, min, max, reinterpret_cast<void *>(out), Number_uint16);
+        return AddArgument(name, min, max, reinterpret_cast<void *>(out), Number_uint16, optional);
     }
-    size_t AddArgument(const char * name, int64_t min, uint64_t max, uint32_t * out)
+    size_t AddArgument(const char * name, int64_t min, uint64_t max, uint32_t * out, bool optional)
     {
-        return AddArgument(name, min, max, reinterpret_cast<void *>(out), Number_uint32);
+        return AddArgument(name, min, max, reinterpret_cast<void *>(out), Number_uint32, optional);
     }
-    size_t AddArgument(const char * name, int64_t min, uint64_t max, uint64_t * out)
+    size_t AddArgument(const char * name, int64_t min, uint64_t max, uint64_t * out, bool optional)
     {
-        return AddArgument(name, min, max, reinterpret_cast<void *>(out), Number_uint64);
+        return AddArgument(name, min, max, reinterpret_cast<void *>(out), Number_uint64, optional);
     }
 
     template <typename T, typename = std::enable_if_t<std::is_enum<T>::value>>
-    size_t AddArgument(const char * name, int64_t min, uint64_t max, T * out)
+    size_t AddArgument(const char * name, int64_t min, uint64_t max, T * out, bool optional)
     {
-        return AddArgument(name, min, max, reinterpret_cast<std::underlying_type_t<T> *>(out));
+        return AddArgument(name, min, max, reinterpret_cast<std::underlying_type_t<T> *>(out), optional);
     }
 
     template <typename T>
-    size_t AddArgument(const char * name, chip::Optional<T> * value)
+    size_t AddArgument(const char * name, chip::Optional<T> * value, bool optional)
     {
         // We always require our args to be provided for the moment.
-        return AddArgument(name, &value->Emplace());
+        return AddArgument(name, &value->Emplace(), optional);
     }
 
     template <typename T>
-    size_t AddArgument(const char * name, int64_t min, uint64_t max, chip::Optional<T> * value)
+    size_t AddArgument(const char * name, int64_t min, uint64_t max, chip::Optional<T> * value, bool optional)
     {
         // We always require our args to be provided for the moment.
-        return AddArgument(name, min, max, &value->Emplace());
+        return AddArgument(name, min, max, &value->Emplace(), optional);
     }
 
     template <typename T>
-    size_t AddArgument(const char * name, chip::app::DataModel::Nullable<T> * value)
+    size_t AddArgument(const char * name, chip::app::DataModel::Nullable<T> * value, bool optional)
     {
         // We always require our args to be provided for the moment.
-        return AddArgument(name, &value->SetNonNull());
+        return AddArgument(name, &value->SetNonNull(), optional);
     }
 
     template <typename T>
-    size_t AddArgument(const char * name, int64_t min, uint64_t max, chip::app::DataModel::Nullable<T> * value)
+    size_t AddArgument(const char * name, int64_t min, uint64_t max, chip::app::DataModel::Nullable<T> * value, bool optional)
     {
         // We always require our args to be provided for the moment.
-        return AddArgument(name, min, max, &value->SetNonNull());
+        return AddArgument(name, min, max, &value->SetNonNull(), optional);
     }
 
     virtual CHIP_ERROR Run() = 0;
+    std::vector<Argument> mOptionalArgs;
 
 private:
-    bool InitArgument(size_t argIndex, char * argValue);
-    size_t AddArgument(const char * name, int64_t min, uint64_t max, void * out, ArgumentType type);
-    size_t AddArgument(const char * name, int64_t min, uint64_t max, void * out);
+    bool InitArgument(size_t argIndex, char * argValue, bool optional);
+    size_t AddArgument(const char * name, int64_t min, uint64_t max, void * out, ArgumentType type, bool optional);
+    size_t AddArgument(const char * name, int64_t min, uint64_t max, void * out, bool optional);
 
     const char * mName = nullptr;
     std::vector<Argument> mArgs;

--- a/examples/chip-tool/commands/common/Commands.cpp
+++ b/examples/chip-tool/commands/common/Commands.cpp
@@ -107,8 +107,14 @@ CHIP_ERROR Commands::RunCommand(int argc, char ** argv)
             return CHIP_ERROR_INVALID_ARGUMENT;
         }
     }
+    argc -= 3;
+    if (!command->InitOptionalArguments(argc, &argv[3]))
+    {
+        ShowCommand(argv[0], argv[1], command);
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    }
 
-    if (!command->InitArguments(argc - 3, &argv[3]))
+    if (!command->InitArguments(argc, &argv[3]))
     {
         ShowCommand(argv[0], argv[1], command);
         return CHIP_ERROR_INVALID_ARGUMENT;
@@ -256,6 +262,13 @@ void Commands::ShowCommand(std::string executable, std::string clusterName, Comm
     {
         arguments += " ";
         arguments += command->GetArgumentName(i);
+    }
+    argumentsCount = command->GetOptionalArgumentsCount();
+    for (size_t i = 0; i < argumentsCount; i++)
+    {
+        arguments += " [";
+        arguments += command->GetOptionalArgumentName(i);
+        arguments += " {value}]";
     }
     fprintf(stderr, "  %s %s %s\n", executable.c_str(), clusterName.c_str(), arguments.c_str());
 }

--- a/examples/chip-tool/commands/discover/DiscoverCommand.h
+++ b/examples/chip-tool/commands/discover/DiscoverCommand.h
@@ -27,8 +27,8 @@ class DiscoverCommand : public CHIPCommand, public chip::Controller::DeviceAddre
 public:
     DiscoverCommand(const char * commandName) : CHIPCommand(commandName)
     {
-        AddArgument("nodeid", 0, UINT64_MAX, &mNodeId);
-        AddArgument("fabricid", 0, UINT64_MAX, &mFabricId);
+        AddArgument("nodeid", 0, UINT64_MAX, &mNodeId, false);
+        AddArgument("fabricid", 0, UINT64_MAX, &mFabricId, false);
     }
 
     /////////// DeviceAddressUpdateDelegate Interface /////////

--- a/examples/chip-tool/commands/pairing/ConfigureFabricCommand.h
+++ b/examples/chip-tool/commands/pairing/ConfigureFabricCommand.h
@@ -24,7 +24,7 @@
 class ConfigureFabricCommand : public Command
 {
 public:
-    ConfigureFabricCommand() : Command("configure-fabric") { AddArgument("name", &mFabricName); }
+    ConfigureFabricCommand() : Command("configure-fabric") { AddArgument("name", &mFabricName, false); }
     CHIP_ERROR Run() override;
 
 private:

--- a/examples/chip-tool/commands/pairing/PairingCommand.h
+++ b/examples/chip-tool/commands/pairing/PairingCommand.h
@@ -63,7 +63,7 @@ public:
         mOnDeviceConnectionFailureCallback(OnDeviceConnectionFailureFn, this),
         mOnOpenCommissioningWindowCallback(OnOpenCommissioningWindowResponse, this)
     {
-        AddArgument("node-id", 0, UINT64_MAX, &mNodeId);
+        AddArgument("node-id", 0, UINT64_MAX, &mNodeId, false);
 
         switch (networkType)
         {
@@ -71,11 +71,11 @@ public:
         case PairingNetworkType::Ethernet:
             break;
         case PairingNetworkType::WiFi:
-            AddArgument("ssid", &mSSID);
-            AddArgument("password", &mPassword);
+            AddArgument("ssid", &mSSID, false);
+            AddArgument("password", &mPassword, false);
             break;
         case PairingNetworkType::Thread:
-            AddArgument("operationalDataset", &mOperationalDataset);
+            AddArgument("operationalDataset", &mOperationalDataset, false);
             break;
         }
 
@@ -85,34 +85,34 @@ public:
             break;
         case PairingMode::QRCode:
         case PairingMode::ManualCode:
-            AddArgument("payload", &mOnboardingPayload);
+            AddArgument("payload", &mOnboardingPayload, false);
             break;
         case PairingMode::Ble:
-            AddArgument("fabric-id", 0, UINT64_MAX, &mFabricId);
-            AddArgument("setup-pin-code", 0, 134217727, &mSetupPINCode);
-            AddArgument("discriminator", 0, 4096, &mDiscriminator);
+            AddArgument("fabric-id", 0, UINT64_MAX, &mFabricId, false);
+            AddArgument("setup-pin-code", 0, 134217727, &mSetupPINCode, false);
+            AddArgument("discriminator", 0, 4096, &mDiscriminator, false);
             break;
         case PairingMode::OnNetwork:
-            AddArgument("setup-pin-code", 0, 134217727, &mSetupPINCode);
+            AddArgument("setup-pin-code", 0, 134217727, &mSetupPINCode, false);
             break;
         case PairingMode::SoftAP:
-            AddArgument("fabric-id", 0, UINT64_MAX, &mFabricId);
-            AddArgument("setup-pin-code", 0, 134217727, &mSetupPINCode);
-            AddArgument("discriminator", 0, 4096, &mDiscriminator);
-            AddArgument("device-remote-ip", &mRemoteAddr);
-            AddArgument("device-remote-port", 0, UINT16_MAX, &mRemotePort);
+            AddArgument("fabric-id", 0, UINT64_MAX, &mFabricId, false);
+            AddArgument("setup-pin-code", 0, 134217727, &mSetupPINCode, false);
+            AddArgument("discriminator", 0, 4096, &mDiscriminator, false);
+            AddArgument("device-remote-ip", &mRemoteAddr, false);
+            AddArgument("device-remote-port", 0, UINT16_MAX, &mRemotePort, false);
             break;
         case PairingMode::Ethernet:
-            AddArgument("setup-pin-code", 0, 134217727, &mSetupPINCode);
-            AddArgument("discriminator", 0, 4096, &mDiscriminator);
-            AddArgument("device-remote-ip", &mRemoteAddr);
-            AddArgument("device-remote-port", 0, UINT16_MAX, &mRemotePort);
+            AddArgument("setup-pin-code", 0, 134217727, &mSetupPINCode, false);
+            AddArgument("discriminator", 0, 4096, &mDiscriminator, false);
+            AddArgument("device-remote-ip", &mRemoteAddr, false);
+            AddArgument("device-remote-port", 0, UINT16_MAX, &mRemotePort, false);
             break;
         case PairingMode::OpenCommissioningWindow:
-            AddArgument("option", 0, UINT8_MAX, &mCommissioningWindowOption);
-            AddArgument("timeout", 0, UINT16_MAX, &mTimeout);
-            AddArgument("iteration", 0, UINT16_MAX, &mIteration);
-            AddArgument("discriminator", 0, 4096, &mDiscriminator);
+            AddArgument("option", 0, UINT8_MAX, &mCommissioningWindowOption, false);
+            AddArgument("timeout", 0, UINT16_MAX, &mTimeout, false);
+            AddArgument("iteration", 0, UINT16_MAX, &mIteration, false);
+            AddArgument("discriminator", 0, 4096, &mDiscriminator, false);
             break;
         }
 
@@ -121,25 +121,25 @@ public:
         case chip::Dnssd::DiscoveryFilterType::kNone:
             break;
         case chip::Dnssd::DiscoveryFilterType::kShort:
-            AddArgument("discriminator", 0, 15, &mDiscoveryFilterCode);
+            AddArgument("discriminator", 0, 15, &mDiscoveryFilterCode, false);
             break;
         case chip::Dnssd::DiscoveryFilterType::kLong:
-            AddArgument("discriminator", 0, 4096, &mDiscoveryFilterCode);
+            AddArgument("discriminator", 0, 4096, &mDiscoveryFilterCode, false);
             break;
         case chip::Dnssd::DiscoveryFilterType::kVendor:
-            AddArgument("vendor-id", 0, UINT16_MAX, &mDiscoveryFilterCode);
+            AddArgument("vendor-id", 0, UINT16_MAX, &mDiscoveryFilterCode, false);
             break;
         case chip::Dnssd::DiscoveryFilterType::kCompressedFabricId:
-            AddArgument("fabric-id", 0, UINT64_MAX, &mDiscoveryFilterCode);
+            AddArgument("fabric-id", 0, UINT64_MAX, &mDiscoveryFilterCode, false);
             break;
         case chip::Dnssd::DiscoveryFilterType::kCommissioningMode:
         case chip::Dnssd::DiscoveryFilterType::kCommissioner:
             break;
         case chip::Dnssd::DiscoveryFilterType::kDeviceType:
-            AddArgument("device-type", 0, UINT16_MAX, &mDiscoveryFilterCode);
+            AddArgument("device-type", 0, UINT16_MAX, &mDiscoveryFilterCode, false);
             break;
         case chip::Dnssd::DiscoveryFilterType::kInstanceName:
-            AddArgument("name", &mDiscoveryFilterInstanceName);
+            AddArgument("name", &mDiscoveryFilterInstanceName, false);
             break;
         }
     }

--- a/examples/chip-tool/commands/payload/AdditionalDataParseCommand.h
+++ b/examples/chip-tool/commands/payload/AdditionalDataParseCommand.h
@@ -23,7 +23,7 @@
 class AdditionalDataParseCommand : public Command
 {
 public:
-    AdditionalDataParseCommand() : Command("parse-additional-data-payload") { AddArgument("payload", &mPayload); }
+    AdditionalDataParseCommand() : Command("parse-additional-data-payload") { AddArgument("payload", &mPayload, false); }
     CHIP_ERROR Run() override;
 
 private:

--- a/examples/chip-tool/commands/payload/SetupPayloadParseCommand.h
+++ b/examples/chip-tool/commands/payload/SetupPayloadParseCommand.h
@@ -24,7 +24,7 @@
 class SetupPayloadParseCommand : public Command
 {
 public:
-    SetupPayloadParseCommand() : Command("parse-setup-payload") { AddArgument("payload", &mCode); }
+    SetupPayloadParseCommand() : Command("parse-setup-payload") { AddArgument("payload", &mCode, false); }
     CHIP_ERROR Run() override;
 
 private:

--- a/examples/chip-tool/commands/reporting/ReportingCommand.h
+++ b/examples/chip-tool/commands/reporting/ReportingCommand.h
@@ -34,8 +34,8 @@ public:
         CHIPCommand(commandName), mOnDeviceConnectedCallback(OnDeviceConnectedFn, this),
         mOnDeviceConnectionFailureCallback(OnDeviceConnectionFailureFn, this)
     {
-        AddArgument("node-id", 0, UINT64_MAX, &mNodeId);
-        AddArgument("endpoint-id", CHIP_ZCL_ENDPOINT_MIN, CHIP_ZCL_ENDPOINT_MAX, &mEndPointId);
+        AddArgument("node-id", 0, UINT64_MAX, &mNodeId, false);
+        AddArgument("endpoint-id", CHIP_ZCL_ENDPOINT_MIN, CHIP_ZCL_ENDPOINT_MAX, &mEndPointId, false);
     }
 
     /////////// CHIPCommand Interface /////////

--- a/examples/chip-tool/commands/tests/TestCommand.h
+++ b/examples/chip-tool/commands/tests/TestCommand.h
@@ -27,6 +27,9 @@
 #include <type_traits>
 #include <zap-generated/tests/CHIPClustersTest.h>
 
+// Limits on endpoint values.
+#define CHIP_ZCL_ENDPOINT_MIN 0x00
+#define CHIP_ZCL_ENDPOINT_MAX 0xF0
 class TestCommand : public CHIPCommand
 {
 public:
@@ -34,8 +37,9 @@ public:
         CHIPCommand(commandName), mOnDeviceConnectedCallback(OnDeviceConnectedFn, this),
         mOnDeviceConnectionFailureCallback(OnDeviceConnectionFailureFn, this)
     {
-        AddArgument("node-id", 0, UINT64_MAX, &mNodeId);
-        AddArgument("delayInMs", 0, UINT64_MAX, &mDelayInMs);
+        AddArgument("node-id", 0, UINT64_MAX, &mNodeId, false);
+        AddArgument("delayInMs", 0, UINT64_MAX, &mDelayInMs, false);
+        AddArgument("--endpoint-id", CHIP_ZCL_ENDPOINT_MIN, CHIP_ZCL_ENDPOINT_MAX, &mEndPointId, true);
     }
 
     /////////// CHIPCommand Interface /////////
@@ -52,6 +56,7 @@ public:
 protected:
     ChipDevice * mDevice;
     chip::NodeId mNodeId;
+    uint8_t mEndPointId;
 
     static void OnDeviceConnectedFn(void * context, chip::DeviceProxy * device);
     static void OnDeviceConnectionFailureFn(void * context, NodeId deviceId, CHIP_ERROR error);

--- a/examples/chip-tool/templates/commands.zapt
+++ b/examples/chip-tool/templates/commands.zapt
@@ -387,13 +387,13 @@ public:
         {{else if isStruct}}
         // {{label}} Struct parsing is not supported yet
         {{else if (isString type)}}
-        AddArgument("{{asUpperCamelCase label}}", &{{>field}});
+        AddArgument("{{asUpperCamelCase label}}", &{{>field}}, false);
         {{else}}
         AddArgument("{{asUpperCamelCase label}}", {{asTypeMinValue type}}, {{asTypeMaxValue type}},
           {{~#if ./isEnum}}reinterpret_cast<std::underlying_type_t<decltype({{>field}})> *>(&{{>field}})
           {{else ./isBitmap}}reinterpret_cast<std::underlying_type_t<chip::app::Clusters::{{asUpperCamelCase parent.clusterName}}::{{asUpperCamelCase type}}> *>(&{{>field}})
           {{else}}&{{>field}}
-          {{/if~}}
+          {{/if~}}, false
         );
         {{/if}}
         {{/chip_cluster_command_arguments}}
@@ -431,7 +431,7 @@ class Read{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}: public Mode
 public:
     Read{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}(): ModelCommand("read")
     {
-        AddArgument("attr-name", "{{asDelimitedCommand (asUpperCamelCase name)}}");
+        AddArgument("attr-name", "{{asDelimitedCommand (asUpperCamelCase name)}}", false);
         ModelCommand::AddArguments();
     }
 
@@ -465,11 +465,11 @@ class Write{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}: public Mod
 public:
     Write{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}(): ModelCommand("write")
     {
-        AddArgument("attr-name", "{{asDelimitedCommand (asUpperCamelCase name)}}");
+        AddArgument("attr-name", "{{asDelimitedCommand (asUpperCamelCase name)}}", false);
         {{#if (isString type)}}
-        AddArgument("attr-value", &mValue);
+        AddArgument("attr-value", &mValue, false);
         {{else}}
-        AddArgument("attr-value", {{asTypeMinValue type}}, {{asTypeMaxValue type}}, &mValue);
+        AddArgument("attr-value", {{asTypeMinValue type}}, {{asTypeMaxValue type}}, &mValue, false);
         {{/if}}
         ModelCommand::AddArguments();
     }
@@ -502,10 +502,10 @@ class Report{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}: public Mo
 public:
     Report{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}(): ModelCommand("report")
     {
-        AddArgument("attr-name", "{{asDelimitedCommand (asUpperCamelCase name)}}");
-        AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
-        AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval);
-        AddArgument("wait", 0, 1, &mWait);
+        AddArgument("attr-name", "{{asDelimitedCommand (asUpperCamelCase name)}}", false);
+        AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval, false);
+        AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval, false);
+        AddArgument("wait", 0, 1, &mWait, false);
         ModelCommand::AddArguments();
     }
 

--- a/examples/chip-tool/templates/partials/test_cluster.zapt
+++ b/examples/chip-tool/templates/partials/test_cluster.zapt
@@ -115,7 +115,13 @@ class {{filename}}: public TestCommand
     {{else if isWait}}
     CHIP_ERROR {{>testCommand}}()
     {
-      ChipLogError(chipTool, "[Endpoint: {{endpoint}} Cluster: {{cluster}} {{#if isAttribute}}Attribute: {{attribute}}{{else}}Command: {{wait}}{{/if}}] {{label}}");
+      uint8_t endPoint = {{endpoint}};
+      Argument arg     = mOptionalArgs.at((size_t) 0);
+      if (arg.isProvided)
+      {
+        endPoint = mEndPointId;
+      }
+      ChipLogError(chipTool, "[Endpoint: %d Cluster: {{cluster}} {{#if isAttribute}}Attribute: {{attribute}}{{else}}Command: {{wait}}{{/if}}] {{label}}", endPoint);
       {{#*inline "waitForTypeName"}}{{#if isAttribute}}Attribute{{else}}Command{{/if}}{{/inline}}
       {{#*inline "waitForTypeId"}}chip::app::Clusters::{{asUpperCamelCase cluster}}::{{#if isAttribute}}Attributes::{{attribute}}{{else}}Commands::{{wait}}{{/if}}::Id{{/inline}}
       ClearAttributeAndCommandPaths();
@@ -131,7 +137,14 @@ class {{filename}}: public TestCommand
     CHIP_ERROR {{>testCommand}}()
     {
         chip::Controller::{{asUpperCamelCase cluster}}ClusterTest cluster;
-        cluster.Associate(mDevice, {{endpoint}});
+        uint8_t endPoint = {{endpoint}};
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+          endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         {{#if isCommand}}
         using requestType  = chip::app::Clusters::{{asUpperCamelCase cluster}}::Commands::{{asUpperCamelCase command}}::Type;

--- a/zzz_generated/chip-tool/zap-generated/cluster/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/cluster/Commands.h
@@ -4004,7 +4004,7 @@ class AccountLoginGetSetupPIN : public ModelCommand
 public:
     AccountLoginGetSetupPIN() : ModelCommand("get-setup-pin")
     {
-        AddArgument("TempAccountIdentifier", &mRequest.tempAccountIdentifier);
+        AddArgument("TempAccountIdentifier", &mRequest.tempAccountIdentifier, false);
         ModelCommand::AddArguments();
     }
 
@@ -4029,8 +4029,8 @@ class AccountLoginLogin : public ModelCommand
 public:
     AccountLoginLogin() : ModelCommand("login")
     {
-        AddArgument("TempAccountIdentifier", &mRequest.tempAccountIdentifier);
-        AddArgument("SetupPIN", &mRequest.setupPIN);
+        AddArgument("TempAccountIdentifier", &mRequest.tempAccountIdentifier, false);
+        AddArgument("SetupPIN", &mRequest.setupPIN, false);
         ModelCommand::AddArguments();
     }
 
@@ -4055,7 +4055,7 @@ class ReadAccountLoginClusterRevision : public ModelCommand
 public:
     ReadAccountLoginClusterRevision() : ModelCommand("read")
     {
-        AddArgument("attr-name", "cluster-revision");
+        AddArgument("attr-name", "cluster-revision", false);
         ModelCommand::AddArguments();
     }
 
@@ -4101,7 +4101,7 @@ class AdministratorCommissioningOpenBasicCommissioningWindow : public ModelComma
 public:
     AdministratorCommissioningOpenBasicCommissioningWindow() : ModelCommand("open-basic-commissioning-window")
     {
-        AddArgument("CommissioningTimeout", 0, UINT16_MAX, &mRequest.commissioningTimeout);
+        AddArgument("CommissioningTimeout", 0, UINT16_MAX, &mRequest.commissioningTimeout, false);
         ModelCommand::AddArguments();
     }
 
@@ -4126,12 +4126,12 @@ class AdministratorCommissioningOpenCommissioningWindow : public ModelCommand
 public:
     AdministratorCommissioningOpenCommissioningWindow() : ModelCommand("open-commissioning-window")
     {
-        AddArgument("CommissioningTimeout", 0, UINT16_MAX, &mRequest.commissioningTimeout);
-        AddArgument("PAKEVerifier", &mRequest.PAKEVerifier);
-        AddArgument("Discriminator", 0, UINT16_MAX, &mRequest.discriminator);
-        AddArgument("Iterations", 0, UINT32_MAX, &mRequest.iterations);
-        AddArgument("Salt", &mRequest.salt);
-        AddArgument("PasscodeID", 0, UINT16_MAX, &mRequest.passcodeID);
+        AddArgument("CommissioningTimeout", 0, UINT16_MAX, &mRequest.commissioningTimeout, false);
+        AddArgument("PAKEVerifier", &mRequest.PAKEVerifier, false);
+        AddArgument("Discriminator", 0, UINT16_MAX, &mRequest.discriminator, false);
+        AddArgument("Iterations", 0, UINT32_MAX, &mRequest.iterations, false);
+        AddArgument("Salt", &mRequest.salt, false);
+        AddArgument("PasscodeID", 0, UINT16_MAX, &mRequest.passcodeID, false);
         ModelCommand::AddArguments();
     }
 
@@ -4177,7 +4177,7 @@ class ReadAdministratorCommissioningClusterRevision : public ModelCommand
 public:
     ReadAdministratorCommissioningClusterRevision() : ModelCommand("read")
     {
-        AddArgument("attr-name", "cluster-revision");
+        AddArgument("attr-name", "cluster-revision", false);
         ModelCommand::AddArguments();
     }
 
@@ -4228,8 +4228,8 @@ class ApplicationBasicChangeStatus : public ModelCommand
 public:
     ApplicationBasicChangeStatus() : ModelCommand("change-status")
     {
-        AddArgument("Status", 0, UINT8_MAX,
-                    reinterpret_cast<std::underlying_type_t<decltype(mRequest.status)> *>(&mRequest.status));
+        AddArgument("Status", 0, UINT8_MAX, reinterpret_cast<std::underlying_type_t<decltype(mRequest.status)> *>(&mRequest.status),
+                    false);
         ModelCommand::AddArguments();
     }
 
@@ -4254,7 +4254,7 @@ class ReadApplicationBasicVendorName : public ModelCommand
 public:
     ReadApplicationBasicVendorName() : ModelCommand("read")
     {
-        AddArgument("attr-name", "vendor-name");
+        AddArgument("attr-name", "vendor-name", false);
         ModelCommand::AddArguments();
     }
 
@@ -4288,7 +4288,7 @@ class ReadApplicationBasicVendorId : public ModelCommand
 public:
     ReadApplicationBasicVendorId() : ModelCommand("read")
     {
-        AddArgument("attr-name", "vendor-id");
+        AddArgument("attr-name", "vendor-id", false);
         ModelCommand::AddArguments();
     }
 
@@ -4322,7 +4322,7 @@ class ReadApplicationBasicApplicationName : public ModelCommand
 public:
     ReadApplicationBasicApplicationName() : ModelCommand("read")
     {
-        AddArgument("attr-name", "application-name");
+        AddArgument("attr-name", "application-name", false);
         ModelCommand::AddArguments();
     }
 
@@ -4356,7 +4356,7 @@ class ReadApplicationBasicProductId : public ModelCommand
 public:
     ReadApplicationBasicProductId() : ModelCommand("read")
     {
-        AddArgument("attr-name", "product-id");
+        AddArgument("attr-name", "product-id", false);
         ModelCommand::AddArguments();
     }
 
@@ -4390,7 +4390,7 @@ class ReadApplicationBasicApplicationId : public ModelCommand
 public:
     ReadApplicationBasicApplicationId() : ModelCommand("read")
     {
-        AddArgument("attr-name", "application-id");
+        AddArgument("attr-name", "application-id", false);
         ModelCommand::AddArguments();
     }
 
@@ -4424,7 +4424,7 @@ class ReadApplicationBasicCatalogVendorId : public ModelCommand
 public:
     ReadApplicationBasicCatalogVendorId() : ModelCommand("read")
     {
-        AddArgument("attr-name", "catalog-vendor-id");
+        AddArgument("attr-name", "catalog-vendor-id", false);
         ModelCommand::AddArguments();
     }
 
@@ -4458,7 +4458,7 @@ class ReadApplicationBasicApplicationStatus : public ModelCommand
 public:
     ReadApplicationBasicApplicationStatus() : ModelCommand("read")
     {
-        AddArgument("attr-name", "application-status");
+        AddArgument("attr-name", "application-status", false);
         ModelCommand::AddArguments();
     }
 
@@ -4492,7 +4492,7 @@ class ReadApplicationBasicClusterRevision : public ModelCommand
 public:
     ReadApplicationBasicClusterRevision() : ModelCommand("read")
     {
-        AddArgument("attr-name", "cluster-revision");
+        AddArgument("attr-name", "cluster-revision", false);
         ModelCommand::AddArguments();
     }
 
@@ -4539,9 +4539,9 @@ class ApplicationLauncherLaunchApp : public ModelCommand
 public:
     ApplicationLauncherLaunchApp() : ModelCommand("launch-app")
     {
-        AddArgument("Data", &mRequest.data);
-        AddArgument("CatalogVendorId", 0, UINT16_MAX, &mRequest.catalogVendorId);
-        AddArgument("ApplicationId", &mRequest.applicationId);
+        AddArgument("Data", &mRequest.data, false);
+        AddArgument("CatalogVendorId", 0, UINT16_MAX, &mRequest.catalogVendorId, false);
+        AddArgument("ApplicationId", &mRequest.applicationId, false);
         ModelCommand::AddArguments();
     }
 
@@ -4566,7 +4566,7 @@ class ReadApplicationLauncherApplicationLauncherList : public ModelCommand
 public:
     ReadApplicationLauncherApplicationLauncherList() : ModelCommand("read")
     {
-        AddArgument("attr-name", "application-launcher-list");
+        AddArgument("attr-name", "application-launcher-list", false);
         ModelCommand::AddArguments();
     }
 
@@ -4601,7 +4601,7 @@ class ReadApplicationLauncherCatalogVendorId : public ModelCommand
 public:
     ReadApplicationLauncherCatalogVendorId() : ModelCommand("read")
     {
-        AddArgument("attr-name", "catalog-vendor-id");
+        AddArgument("attr-name", "catalog-vendor-id", false);
         ModelCommand::AddArguments();
     }
 
@@ -4635,7 +4635,7 @@ class ReadApplicationLauncherApplicationId : public ModelCommand
 public:
     ReadApplicationLauncherApplicationId() : ModelCommand("read")
     {
-        AddArgument("attr-name", "application-id");
+        AddArgument("attr-name", "application-id", false);
         ModelCommand::AddArguments();
     }
 
@@ -4669,7 +4669,7 @@ class ReadApplicationLauncherClusterRevision : public ModelCommand
 public:
     ReadApplicationLauncherClusterRevision() : ModelCommand("read")
     {
-        AddArgument("attr-name", "cluster-revision");
+        AddArgument("attr-name", "cluster-revision", false);
         ModelCommand::AddArguments();
     }
 
@@ -4716,8 +4716,8 @@ class AudioOutputRenameOutput : public ModelCommand
 public:
     AudioOutputRenameOutput() : ModelCommand("rename-output")
     {
-        AddArgument("Index", 0, UINT8_MAX, &mRequest.index);
-        AddArgument("Name", &mRequest.name);
+        AddArgument("Index", 0, UINT8_MAX, &mRequest.index, false);
+        AddArgument("Name", &mRequest.name, false);
         ModelCommand::AddArguments();
     }
 
@@ -4742,7 +4742,7 @@ class AudioOutputSelectOutput : public ModelCommand
 public:
     AudioOutputSelectOutput() : ModelCommand("select-output")
     {
-        AddArgument("Index", 0, UINT8_MAX, &mRequest.index);
+        AddArgument("Index", 0, UINT8_MAX, &mRequest.index, false);
         ModelCommand::AddArguments();
     }
 
@@ -4767,7 +4767,7 @@ class ReadAudioOutputAudioOutputList : public ModelCommand
 public:
     ReadAudioOutputAudioOutputList() : ModelCommand("read")
     {
-        AddArgument("attr-name", "audio-output-list");
+        AddArgument("attr-name", "audio-output-list", false);
         ModelCommand::AddArguments();
     }
 
@@ -4802,7 +4802,7 @@ class ReadAudioOutputCurrentAudioOutput : public ModelCommand
 public:
     ReadAudioOutputCurrentAudioOutput() : ModelCommand("read")
     {
-        AddArgument("attr-name", "current-audio-output");
+        AddArgument("attr-name", "current-audio-output", false);
         ModelCommand::AddArguments();
     }
 
@@ -4836,7 +4836,7 @@ class ReadAudioOutputClusterRevision : public ModelCommand
 public:
     ReadAudioOutputClusterRevision() : ModelCommand("read")
     {
-        AddArgument("attr-name", "cluster-revision");
+        AddArgument("attr-name", "cluster-revision", false);
         ModelCommand::AddArguments();
     }
 
@@ -4885,7 +4885,7 @@ class BarrierControlBarrierControlGoToPercent : public ModelCommand
 public:
     BarrierControlBarrierControlGoToPercent() : ModelCommand("barrier-control-go-to-percent")
     {
-        AddArgument("PercentOpen", 0, UINT8_MAX, &mRequest.percentOpen);
+        AddArgument("PercentOpen", 0, UINT8_MAX, &mRequest.percentOpen, false);
         ModelCommand::AddArguments();
     }
 
@@ -4931,7 +4931,7 @@ class ReadBarrierControlBarrierMovingState : public ModelCommand
 public:
     ReadBarrierControlBarrierMovingState() : ModelCommand("read")
     {
-        AddArgument("attr-name", "barrier-moving-state");
+        AddArgument("attr-name", "barrier-moving-state", false);
         ModelCommand::AddArguments();
     }
 
@@ -4965,7 +4965,7 @@ class ReadBarrierControlBarrierSafetyStatus : public ModelCommand
 public:
     ReadBarrierControlBarrierSafetyStatus() : ModelCommand("read")
     {
-        AddArgument("attr-name", "barrier-safety-status");
+        AddArgument("attr-name", "barrier-safety-status", false);
         ModelCommand::AddArguments();
     }
 
@@ -4999,7 +4999,7 @@ class ReadBarrierControlBarrierCapabilities : public ModelCommand
 public:
     ReadBarrierControlBarrierCapabilities() : ModelCommand("read")
     {
-        AddArgument("attr-name", "barrier-capabilities");
+        AddArgument("attr-name", "barrier-capabilities", false);
         ModelCommand::AddArguments();
     }
 
@@ -5033,7 +5033,7 @@ class ReadBarrierControlBarrierPosition : public ModelCommand
 public:
     ReadBarrierControlBarrierPosition() : ModelCommand("read")
     {
-        AddArgument("attr-name", "barrier-position");
+        AddArgument("attr-name", "barrier-position", false);
         ModelCommand::AddArguments();
     }
 
@@ -5067,7 +5067,7 @@ class ReadBarrierControlClusterRevision : public ModelCommand
 public:
     ReadBarrierControlClusterRevision() : ModelCommand("read")
     {
-        AddArgument("attr-name", "cluster-revision");
+        AddArgument("attr-name", "cluster-revision", false);
         ModelCommand::AddArguments();
     }
 
@@ -5150,7 +5150,7 @@ class ReadBasicInteractionModelVersion : public ModelCommand
 public:
     ReadBasicInteractionModelVersion() : ModelCommand("read")
     {
-        AddArgument("attr-name", "interaction-model-version");
+        AddArgument("attr-name", "interaction-model-version", false);
         ModelCommand::AddArguments();
     }
 
@@ -5184,7 +5184,7 @@ class ReadBasicVendorName : public ModelCommand
 public:
     ReadBasicVendorName() : ModelCommand("read")
     {
-        AddArgument("attr-name", "vendor-name");
+        AddArgument("attr-name", "vendor-name", false);
         ModelCommand::AddArguments();
     }
 
@@ -5218,7 +5218,7 @@ class ReadBasicVendorID : public ModelCommand
 public:
     ReadBasicVendorID() : ModelCommand("read")
     {
-        AddArgument("attr-name", "vendor-id");
+        AddArgument("attr-name", "vendor-id", false);
         ModelCommand::AddArguments();
     }
 
@@ -5252,7 +5252,7 @@ class ReadBasicProductName : public ModelCommand
 public:
     ReadBasicProductName() : ModelCommand("read")
     {
-        AddArgument("attr-name", "product-name");
+        AddArgument("attr-name", "product-name", false);
         ModelCommand::AddArguments();
     }
 
@@ -5286,7 +5286,7 @@ class ReadBasicProductID : public ModelCommand
 public:
     ReadBasicProductID() : ModelCommand("read")
     {
-        AddArgument("attr-name", "product-id");
+        AddArgument("attr-name", "product-id", false);
         ModelCommand::AddArguments();
     }
 
@@ -5320,7 +5320,7 @@ class ReadBasicUserLabel : public ModelCommand
 public:
     ReadBasicUserLabel() : ModelCommand("read")
     {
-        AddArgument("attr-name", "user-label");
+        AddArgument("attr-name", "user-label", false);
         ModelCommand::AddArguments();
     }
 
@@ -5351,8 +5351,8 @@ class WriteBasicUserLabel : public ModelCommand
 public:
     WriteBasicUserLabel() : ModelCommand("write")
     {
-        AddArgument("attr-name", "user-label");
-        AddArgument("attr-value", &mValue);
+        AddArgument("attr-name", "user-label", false);
+        AddArgument("attr-value", &mValue, false);
         ModelCommand::AddArguments();
     }
 
@@ -5387,7 +5387,7 @@ class ReadBasicLocation : public ModelCommand
 public:
     ReadBasicLocation() : ModelCommand("read")
     {
-        AddArgument("attr-name", "location");
+        AddArgument("attr-name", "location", false);
         ModelCommand::AddArguments();
     }
 
@@ -5418,8 +5418,8 @@ class WriteBasicLocation : public ModelCommand
 public:
     WriteBasicLocation() : ModelCommand("write")
     {
-        AddArgument("attr-name", "location");
-        AddArgument("attr-value", &mValue);
+        AddArgument("attr-name", "location", false);
+        AddArgument("attr-value", &mValue, false);
         ModelCommand::AddArguments();
     }
 
@@ -5454,7 +5454,7 @@ class ReadBasicHardwareVersion : public ModelCommand
 public:
     ReadBasicHardwareVersion() : ModelCommand("read")
     {
-        AddArgument("attr-name", "hardware-version");
+        AddArgument("attr-name", "hardware-version", false);
         ModelCommand::AddArguments();
     }
 
@@ -5488,7 +5488,7 @@ class ReadBasicHardwareVersionString : public ModelCommand
 public:
     ReadBasicHardwareVersionString() : ModelCommand("read")
     {
-        AddArgument("attr-name", "hardware-version-string");
+        AddArgument("attr-name", "hardware-version-string", false);
         ModelCommand::AddArguments();
     }
 
@@ -5522,7 +5522,7 @@ class ReadBasicSoftwareVersion : public ModelCommand
 public:
     ReadBasicSoftwareVersion() : ModelCommand("read")
     {
-        AddArgument("attr-name", "software-version");
+        AddArgument("attr-name", "software-version", false);
         ModelCommand::AddArguments();
     }
 
@@ -5556,7 +5556,7 @@ class ReadBasicSoftwareVersionString : public ModelCommand
 public:
     ReadBasicSoftwareVersionString() : ModelCommand("read")
     {
-        AddArgument("attr-name", "software-version-string");
+        AddArgument("attr-name", "software-version-string", false);
         ModelCommand::AddArguments();
     }
 
@@ -5590,7 +5590,7 @@ class ReadBasicManufacturingDate : public ModelCommand
 public:
     ReadBasicManufacturingDate() : ModelCommand("read")
     {
-        AddArgument("attr-name", "manufacturing-date");
+        AddArgument("attr-name", "manufacturing-date", false);
         ModelCommand::AddArguments();
     }
 
@@ -5624,7 +5624,7 @@ class ReadBasicPartNumber : public ModelCommand
 public:
     ReadBasicPartNumber() : ModelCommand("read")
     {
-        AddArgument("attr-name", "part-number");
+        AddArgument("attr-name", "part-number", false);
         ModelCommand::AddArguments();
     }
 
@@ -5658,7 +5658,7 @@ class ReadBasicProductURL : public ModelCommand
 public:
     ReadBasicProductURL() : ModelCommand("read")
     {
-        AddArgument("attr-name", "product-url");
+        AddArgument("attr-name", "product-url", false);
         ModelCommand::AddArguments();
     }
 
@@ -5692,7 +5692,7 @@ class ReadBasicProductLabel : public ModelCommand
 public:
     ReadBasicProductLabel() : ModelCommand("read")
     {
-        AddArgument("attr-name", "product-label");
+        AddArgument("attr-name", "product-label", false);
         ModelCommand::AddArguments();
     }
 
@@ -5726,7 +5726,7 @@ class ReadBasicSerialNumber : public ModelCommand
 public:
     ReadBasicSerialNumber() : ModelCommand("read")
     {
-        AddArgument("attr-name", "serial-number");
+        AddArgument("attr-name", "serial-number", false);
         ModelCommand::AddArguments();
     }
 
@@ -5760,7 +5760,7 @@ class ReadBasicLocalConfigDisabled : public ModelCommand
 public:
     ReadBasicLocalConfigDisabled() : ModelCommand("read")
     {
-        AddArgument("attr-name", "local-config-disabled");
+        AddArgument("attr-name", "local-config-disabled", false);
         ModelCommand::AddArguments();
     }
 
@@ -5791,8 +5791,8 @@ class WriteBasicLocalConfigDisabled : public ModelCommand
 public:
     WriteBasicLocalConfigDisabled() : ModelCommand("write")
     {
-        AddArgument("attr-name", "local-config-disabled");
-        AddArgument("attr-value", 0, 1, &mValue);
+        AddArgument("attr-name", "local-config-disabled", false);
+        AddArgument("attr-value", 0, 1, &mValue, false);
         ModelCommand::AddArguments();
     }
 
@@ -5827,7 +5827,7 @@ class ReadBasicReachable : public ModelCommand
 public:
     ReadBasicReachable() : ModelCommand("read")
     {
-        AddArgument("attr-name", "reachable");
+        AddArgument("attr-name", "reachable", false);
         ModelCommand::AddArguments();
     }
 
@@ -5861,7 +5861,7 @@ class ReadBasicClusterRevision : public ModelCommand
 public:
     ReadBasicClusterRevision() : ModelCommand("read")
     {
-        AddArgument("attr-name", "cluster-revision");
+        AddArgument("attr-name", "cluster-revision", false);
         ModelCommand::AddArguments();
     }
 
@@ -5907,7 +5907,7 @@ class ReadBinaryInputBasicOutOfService : public ModelCommand
 public:
     ReadBinaryInputBasicOutOfService() : ModelCommand("read")
     {
-        AddArgument("attr-name", "out-of-service");
+        AddArgument("attr-name", "out-of-service", false);
         ModelCommand::AddArguments();
     }
 
@@ -5938,8 +5938,8 @@ class WriteBinaryInputBasicOutOfService : public ModelCommand
 public:
     WriteBinaryInputBasicOutOfService() : ModelCommand("write")
     {
-        AddArgument("attr-name", "out-of-service");
-        AddArgument("attr-value", 0, 1, &mValue);
+        AddArgument("attr-name", "out-of-service", false);
+        AddArgument("attr-value", 0, 1, &mValue, false);
         ModelCommand::AddArguments();
     }
 
@@ -5974,7 +5974,7 @@ class ReadBinaryInputBasicPresentValue : public ModelCommand
 public:
     ReadBinaryInputBasicPresentValue() : ModelCommand("read")
     {
-        AddArgument("attr-name", "present-value");
+        AddArgument("attr-name", "present-value", false);
         ModelCommand::AddArguments();
     }
 
@@ -6005,8 +6005,8 @@ class WriteBinaryInputBasicPresentValue : public ModelCommand
 public:
     WriteBinaryInputBasicPresentValue() : ModelCommand("write")
     {
-        AddArgument("attr-name", "present-value");
-        AddArgument("attr-value", 0, 1, &mValue);
+        AddArgument("attr-name", "present-value", false);
+        AddArgument("attr-value", 0, 1, &mValue, false);
         ModelCommand::AddArguments();
     }
 
@@ -6038,10 +6038,10 @@ class ReportBinaryInputBasicPresentValue : public ModelCommand
 public:
     ReportBinaryInputBasicPresentValue() : ModelCommand("report")
     {
-        AddArgument("attr-name", "present-value");
-        AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
-        AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval);
-        AddArgument("wait", 0, 1, &mWait);
+        AddArgument("attr-name", "present-value", false);
+        AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval, false);
+        AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval, false);
+        AddArgument("wait", 0, 1, &mWait, false);
         ModelCommand::AddArguments();
     }
 
@@ -6093,7 +6093,7 @@ class ReadBinaryInputBasicStatusFlags : public ModelCommand
 public:
     ReadBinaryInputBasicStatusFlags() : ModelCommand("read")
     {
-        AddArgument("attr-name", "status-flags");
+        AddArgument("attr-name", "status-flags", false);
         ModelCommand::AddArguments();
     }
 
@@ -6124,10 +6124,10 @@ class ReportBinaryInputBasicStatusFlags : public ModelCommand
 public:
     ReportBinaryInputBasicStatusFlags() : ModelCommand("report")
     {
-        AddArgument("attr-name", "status-flags");
-        AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
-        AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval);
-        AddArgument("wait", 0, 1, &mWait);
+        AddArgument("attr-name", "status-flags", false);
+        AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval, false);
+        AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval, false);
+        AddArgument("wait", 0, 1, &mWait, false);
         ModelCommand::AddArguments();
     }
 
@@ -6179,7 +6179,7 @@ class ReadBinaryInputBasicClusterRevision : public ModelCommand
 public:
     ReadBinaryInputBasicClusterRevision() : ModelCommand("read")
     {
-        AddArgument("attr-name", "cluster-revision");
+        AddArgument("attr-name", "cluster-revision", false);
         ModelCommand::AddArguments();
     }
 
@@ -6224,10 +6224,10 @@ class BindingBind : public ModelCommand
 public:
     BindingBind() : ModelCommand("bind")
     {
-        AddArgument("NodeId", 0, UINT64_MAX, &mRequest.nodeId);
-        AddArgument("GroupId", 0, UINT16_MAX, &mRequest.groupId);
-        AddArgument("EndpointId", 0, UINT16_MAX, &mRequest.endpointId);
-        AddArgument("ClusterId", 0, UINT32_MAX, &mRequest.clusterId);
+        AddArgument("NodeId", 0, UINT64_MAX, &mRequest.nodeId, false);
+        AddArgument("GroupId", 0, UINT16_MAX, &mRequest.groupId, false);
+        AddArgument("EndpointId", 0, UINT16_MAX, &mRequest.endpointId, false);
+        AddArgument("ClusterId", 0, UINT32_MAX, &mRequest.clusterId, false);
         ModelCommand::AddArguments();
     }
 
@@ -6252,10 +6252,10 @@ class BindingUnbind : public ModelCommand
 public:
     BindingUnbind() : ModelCommand("unbind")
     {
-        AddArgument("NodeId", 0, UINT64_MAX, &mRequest.nodeId);
-        AddArgument("GroupId", 0, UINT16_MAX, &mRequest.groupId);
-        AddArgument("EndpointId", 0, UINT16_MAX, &mRequest.endpointId);
-        AddArgument("ClusterId", 0, UINT32_MAX, &mRequest.clusterId);
+        AddArgument("NodeId", 0, UINT64_MAX, &mRequest.nodeId, false);
+        AddArgument("GroupId", 0, UINT16_MAX, &mRequest.groupId, false);
+        AddArgument("EndpointId", 0, UINT16_MAX, &mRequest.endpointId, false);
+        AddArgument("ClusterId", 0, UINT32_MAX, &mRequest.clusterId, false);
         ModelCommand::AddArguments();
     }
 
@@ -6280,7 +6280,7 @@ class ReadBindingClusterRevision : public ModelCommand
 public:
     ReadBindingClusterRevision() : ModelCommand("read")
     {
-        AddArgument("attr-name", "cluster-revision");
+        AddArgument("attr-name", "cluster-revision", false);
         ModelCommand::AddArguments();
     }
 
@@ -6324,7 +6324,7 @@ class ReadBooleanStateStateValue : public ModelCommand
 public:
     ReadBooleanStateStateValue() : ModelCommand("read")
     {
-        AddArgument("attr-name", "state-value");
+        AddArgument("attr-name", "state-value", false);
         ModelCommand::AddArguments();
     }
 
@@ -6355,10 +6355,10 @@ class ReportBooleanStateStateValue : public ModelCommand
 public:
     ReportBooleanStateStateValue() : ModelCommand("report")
     {
-        AddArgument("attr-name", "state-value");
-        AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
-        AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval);
-        AddArgument("wait", 0, 1, &mWait);
+        AddArgument("attr-name", "state-value", false);
+        AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval, false);
+        AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval, false);
+        AddArgument("wait", 0, 1, &mWait, false);
         ModelCommand::AddArguments();
     }
 
@@ -6410,7 +6410,7 @@ class ReadBooleanStateClusterRevision : public ModelCommand
 public:
     ReadBooleanStateClusterRevision() : ModelCommand("read")
     {
-        AddArgument("attr-name", "cluster-revision");
+        AddArgument("attr-name", "cluster-revision", false);
         ModelCommand::AddArguments();
     }
 
@@ -6468,8 +6468,8 @@ class BridgedActionsDisableAction : public ModelCommand
 public:
     BridgedActionsDisableAction() : ModelCommand("disable-action")
     {
-        AddArgument("ActionID", 0, UINT16_MAX, &mRequest.actionID);
-        AddArgument("InvokeID", 0, UINT32_MAX, &mRequest.invokeID);
+        AddArgument("ActionID", 0, UINT16_MAX, &mRequest.actionID, false);
+        AddArgument("InvokeID", 0, UINT32_MAX, &mRequest.invokeID, false);
         ModelCommand::AddArguments();
     }
 
@@ -6494,9 +6494,9 @@ class BridgedActionsDisableActionWithDuration : public ModelCommand
 public:
     BridgedActionsDisableActionWithDuration() : ModelCommand("disable-action-with-duration")
     {
-        AddArgument("ActionID", 0, UINT16_MAX, &mRequest.actionID);
-        AddArgument("InvokeID", 0, UINT32_MAX, &mRequest.invokeID);
-        AddArgument("Duration", 0, UINT32_MAX, &mRequest.duration);
+        AddArgument("ActionID", 0, UINT16_MAX, &mRequest.actionID, false);
+        AddArgument("InvokeID", 0, UINT32_MAX, &mRequest.invokeID, false);
+        AddArgument("Duration", 0, UINT32_MAX, &mRequest.duration, false);
         ModelCommand::AddArguments();
     }
 
@@ -6521,8 +6521,8 @@ class BridgedActionsEnableAction : public ModelCommand
 public:
     BridgedActionsEnableAction() : ModelCommand("enable-action")
     {
-        AddArgument("ActionID", 0, UINT16_MAX, &mRequest.actionID);
-        AddArgument("InvokeID", 0, UINT32_MAX, &mRequest.invokeID);
+        AddArgument("ActionID", 0, UINT16_MAX, &mRequest.actionID, false);
+        AddArgument("InvokeID", 0, UINT32_MAX, &mRequest.invokeID, false);
         ModelCommand::AddArguments();
     }
 
@@ -6547,9 +6547,9 @@ class BridgedActionsEnableActionWithDuration : public ModelCommand
 public:
     BridgedActionsEnableActionWithDuration() : ModelCommand("enable-action-with-duration")
     {
-        AddArgument("ActionID", 0, UINT16_MAX, &mRequest.actionID);
-        AddArgument("InvokeID", 0, UINT32_MAX, &mRequest.invokeID);
-        AddArgument("Duration", 0, UINT32_MAX, &mRequest.duration);
+        AddArgument("ActionID", 0, UINT16_MAX, &mRequest.actionID, false);
+        AddArgument("InvokeID", 0, UINT32_MAX, &mRequest.invokeID, false);
+        AddArgument("Duration", 0, UINT32_MAX, &mRequest.duration, false);
         ModelCommand::AddArguments();
     }
 
@@ -6574,8 +6574,8 @@ class BridgedActionsInstantAction : public ModelCommand
 public:
     BridgedActionsInstantAction() : ModelCommand("instant-action")
     {
-        AddArgument("ActionID", 0, UINT16_MAX, &mRequest.actionID);
-        AddArgument("InvokeID", 0, UINT32_MAX, &mRequest.invokeID);
+        AddArgument("ActionID", 0, UINT16_MAX, &mRequest.actionID, false);
+        AddArgument("InvokeID", 0, UINT32_MAX, &mRequest.invokeID, false);
         ModelCommand::AddArguments();
     }
 
@@ -6600,9 +6600,9 @@ class BridgedActionsInstantActionWithTransition : public ModelCommand
 public:
     BridgedActionsInstantActionWithTransition() : ModelCommand("instant-action-with-transition")
     {
-        AddArgument("ActionID", 0, UINT16_MAX, &mRequest.actionID);
-        AddArgument("InvokeID", 0, UINT32_MAX, &mRequest.invokeID);
-        AddArgument("TransitionTime", 0, UINT16_MAX, &mRequest.transitionTime);
+        AddArgument("ActionID", 0, UINT16_MAX, &mRequest.actionID, false);
+        AddArgument("InvokeID", 0, UINT32_MAX, &mRequest.invokeID, false);
+        AddArgument("TransitionTime", 0, UINT16_MAX, &mRequest.transitionTime, false);
         ModelCommand::AddArguments();
     }
 
@@ -6627,8 +6627,8 @@ class BridgedActionsPauseAction : public ModelCommand
 public:
     BridgedActionsPauseAction() : ModelCommand("pause-action")
     {
-        AddArgument("ActionID", 0, UINT16_MAX, &mRequest.actionID);
-        AddArgument("InvokeID", 0, UINT32_MAX, &mRequest.invokeID);
+        AddArgument("ActionID", 0, UINT16_MAX, &mRequest.actionID, false);
+        AddArgument("InvokeID", 0, UINT32_MAX, &mRequest.invokeID, false);
         ModelCommand::AddArguments();
     }
 
@@ -6653,9 +6653,9 @@ class BridgedActionsPauseActionWithDuration : public ModelCommand
 public:
     BridgedActionsPauseActionWithDuration() : ModelCommand("pause-action-with-duration")
     {
-        AddArgument("ActionID", 0, UINT16_MAX, &mRequest.actionID);
-        AddArgument("InvokeID", 0, UINT32_MAX, &mRequest.invokeID);
-        AddArgument("Duration", 0, UINT32_MAX, &mRequest.duration);
+        AddArgument("ActionID", 0, UINT16_MAX, &mRequest.actionID, false);
+        AddArgument("InvokeID", 0, UINT32_MAX, &mRequest.invokeID, false);
+        AddArgument("Duration", 0, UINT32_MAX, &mRequest.duration, false);
         ModelCommand::AddArguments();
     }
 
@@ -6680,8 +6680,8 @@ class BridgedActionsResumeAction : public ModelCommand
 public:
     BridgedActionsResumeAction() : ModelCommand("resume-action")
     {
-        AddArgument("ActionID", 0, UINT16_MAX, &mRequest.actionID);
-        AddArgument("InvokeID", 0, UINT32_MAX, &mRequest.invokeID);
+        AddArgument("ActionID", 0, UINT16_MAX, &mRequest.actionID, false);
+        AddArgument("InvokeID", 0, UINT32_MAX, &mRequest.invokeID, false);
         ModelCommand::AddArguments();
     }
 
@@ -6706,8 +6706,8 @@ class BridgedActionsStartAction : public ModelCommand
 public:
     BridgedActionsStartAction() : ModelCommand("start-action")
     {
-        AddArgument("ActionID", 0, UINT16_MAX, &mRequest.actionID);
-        AddArgument("InvokeID", 0, UINT32_MAX, &mRequest.invokeID);
+        AddArgument("ActionID", 0, UINT16_MAX, &mRequest.actionID, false);
+        AddArgument("InvokeID", 0, UINT32_MAX, &mRequest.invokeID, false);
         ModelCommand::AddArguments();
     }
 
@@ -6732,9 +6732,9 @@ class BridgedActionsStartActionWithDuration : public ModelCommand
 public:
     BridgedActionsStartActionWithDuration() : ModelCommand("start-action-with-duration")
     {
-        AddArgument("ActionID", 0, UINT16_MAX, &mRequest.actionID);
-        AddArgument("InvokeID", 0, UINT32_MAX, &mRequest.invokeID);
-        AddArgument("Duration", 0, UINT32_MAX, &mRequest.duration);
+        AddArgument("ActionID", 0, UINT16_MAX, &mRequest.actionID, false);
+        AddArgument("InvokeID", 0, UINT32_MAX, &mRequest.invokeID, false);
+        AddArgument("Duration", 0, UINT32_MAX, &mRequest.duration, false);
         ModelCommand::AddArguments();
     }
 
@@ -6759,8 +6759,8 @@ class BridgedActionsStopAction : public ModelCommand
 public:
     BridgedActionsStopAction() : ModelCommand("stop-action")
     {
-        AddArgument("ActionID", 0, UINT16_MAX, &mRequest.actionID);
-        AddArgument("InvokeID", 0, UINT32_MAX, &mRequest.invokeID);
+        AddArgument("ActionID", 0, UINT16_MAX, &mRequest.actionID, false);
+        AddArgument("InvokeID", 0, UINT32_MAX, &mRequest.invokeID, false);
         ModelCommand::AddArguments();
     }
 
@@ -6785,7 +6785,7 @@ class ReadBridgedActionsActionList : public ModelCommand
 public:
     ReadBridgedActionsActionList() : ModelCommand("read")
     {
-        AddArgument("attr-name", "action-list");
+        AddArgument("attr-name", "action-list", false);
         ModelCommand::AddArguments();
     }
 
@@ -6820,7 +6820,7 @@ class ReadBridgedActionsEndpointList : public ModelCommand
 public:
     ReadBridgedActionsEndpointList() : ModelCommand("read")
     {
-        AddArgument("attr-name", "endpoint-list");
+        AddArgument("attr-name", "endpoint-list", false);
         ModelCommand::AddArguments();
     }
 
@@ -6855,7 +6855,7 @@ class ReadBridgedActionsSetupUrl : public ModelCommand
 public:
     ReadBridgedActionsSetupUrl() : ModelCommand("read")
     {
-        AddArgument("attr-name", "setup-url");
+        AddArgument("attr-name", "setup-url", false);
         ModelCommand::AddArguments();
     }
 
@@ -6889,7 +6889,7 @@ class ReadBridgedActionsClusterRevision : public ModelCommand
 public:
     ReadBridgedActionsClusterRevision() : ModelCommand("read")
     {
-        AddArgument("attr-name", "cluster-revision");
+        AddArgument("attr-name", "cluster-revision", false);
         ModelCommand::AddArguments();
     }
 
@@ -6946,7 +6946,7 @@ class ReadBridgedDeviceBasicVendorName : public ModelCommand
 public:
     ReadBridgedDeviceBasicVendorName() : ModelCommand("read")
     {
-        AddArgument("attr-name", "vendor-name");
+        AddArgument("attr-name", "vendor-name", false);
         ModelCommand::AddArguments();
     }
 
@@ -6980,7 +6980,7 @@ class ReadBridgedDeviceBasicVendorID : public ModelCommand
 public:
     ReadBridgedDeviceBasicVendorID() : ModelCommand("read")
     {
-        AddArgument("attr-name", "vendor-id");
+        AddArgument("attr-name", "vendor-id", false);
         ModelCommand::AddArguments();
     }
 
@@ -7014,7 +7014,7 @@ class ReadBridgedDeviceBasicProductName : public ModelCommand
 public:
     ReadBridgedDeviceBasicProductName() : ModelCommand("read")
     {
-        AddArgument("attr-name", "product-name");
+        AddArgument("attr-name", "product-name", false);
         ModelCommand::AddArguments();
     }
 
@@ -7048,7 +7048,7 @@ class ReadBridgedDeviceBasicUserLabel : public ModelCommand
 public:
     ReadBridgedDeviceBasicUserLabel() : ModelCommand("read")
     {
-        AddArgument("attr-name", "user-label");
+        AddArgument("attr-name", "user-label", false);
         ModelCommand::AddArguments();
     }
 
@@ -7079,8 +7079,8 @@ class WriteBridgedDeviceBasicUserLabel : public ModelCommand
 public:
     WriteBridgedDeviceBasicUserLabel() : ModelCommand("write")
     {
-        AddArgument("attr-name", "user-label");
-        AddArgument("attr-value", &mValue);
+        AddArgument("attr-name", "user-label", false);
+        AddArgument("attr-value", &mValue, false);
         ModelCommand::AddArguments();
     }
 
@@ -7115,7 +7115,7 @@ class ReadBridgedDeviceBasicHardwareVersion : public ModelCommand
 public:
     ReadBridgedDeviceBasicHardwareVersion() : ModelCommand("read")
     {
-        AddArgument("attr-name", "hardware-version");
+        AddArgument("attr-name", "hardware-version", false);
         ModelCommand::AddArguments();
     }
 
@@ -7149,7 +7149,7 @@ class ReadBridgedDeviceBasicHardwareVersionString : public ModelCommand
 public:
     ReadBridgedDeviceBasicHardwareVersionString() : ModelCommand("read")
     {
-        AddArgument("attr-name", "hardware-version-string");
+        AddArgument("attr-name", "hardware-version-string", false);
         ModelCommand::AddArguments();
     }
 
@@ -7183,7 +7183,7 @@ class ReadBridgedDeviceBasicSoftwareVersion : public ModelCommand
 public:
     ReadBridgedDeviceBasicSoftwareVersion() : ModelCommand("read")
     {
-        AddArgument("attr-name", "software-version");
+        AddArgument("attr-name", "software-version", false);
         ModelCommand::AddArguments();
     }
 
@@ -7217,7 +7217,7 @@ class ReadBridgedDeviceBasicSoftwareVersionString : public ModelCommand
 public:
     ReadBridgedDeviceBasicSoftwareVersionString() : ModelCommand("read")
     {
-        AddArgument("attr-name", "software-version-string");
+        AddArgument("attr-name", "software-version-string", false);
         ModelCommand::AddArguments();
     }
 
@@ -7251,7 +7251,7 @@ class ReadBridgedDeviceBasicManufacturingDate : public ModelCommand
 public:
     ReadBridgedDeviceBasicManufacturingDate() : ModelCommand("read")
     {
-        AddArgument("attr-name", "manufacturing-date");
+        AddArgument("attr-name", "manufacturing-date", false);
         ModelCommand::AddArguments();
     }
 
@@ -7285,7 +7285,7 @@ class ReadBridgedDeviceBasicPartNumber : public ModelCommand
 public:
     ReadBridgedDeviceBasicPartNumber() : ModelCommand("read")
     {
-        AddArgument("attr-name", "part-number");
+        AddArgument("attr-name", "part-number", false);
         ModelCommand::AddArguments();
     }
 
@@ -7319,7 +7319,7 @@ class ReadBridgedDeviceBasicProductURL : public ModelCommand
 public:
     ReadBridgedDeviceBasicProductURL() : ModelCommand("read")
     {
-        AddArgument("attr-name", "product-url");
+        AddArgument("attr-name", "product-url", false);
         ModelCommand::AddArguments();
     }
 
@@ -7353,7 +7353,7 @@ class ReadBridgedDeviceBasicProductLabel : public ModelCommand
 public:
     ReadBridgedDeviceBasicProductLabel() : ModelCommand("read")
     {
-        AddArgument("attr-name", "product-label");
+        AddArgument("attr-name", "product-label", false);
         ModelCommand::AddArguments();
     }
 
@@ -7387,7 +7387,7 @@ class ReadBridgedDeviceBasicSerialNumber : public ModelCommand
 public:
     ReadBridgedDeviceBasicSerialNumber() : ModelCommand("read")
     {
-        AddArgument("attr-name", "serial-number");
+        AddArgument("attr-name", "serial-number", false);
         ModelCommand::AddArguments();
     }
 
@@ -7421,7 +7421,7 @@ class ReadBridgedDeviceBasicReachable : public ModelCommand
 public:
     ReadBridgedDeviceBasicReachable() : ModelCommand("read")
     {
-        AddArgument("attr-name", "reachable");
+        AddArgument("attr-name", "reachable", false);
         ModelCommand::AddArguments();
     }
 
@@ -7455,7 +7455,7 @@ class ReadBridgedDeviceBasicClusterRevision : public ModelCommand
 public:
     ReadBridgedDeviceBasicClusterRevision() : ModelCommand("read")
     {
-        AddArgument("attr-name", "cluster-revision");
+        AddArgument("attr-name", "cluster-revision", false);
         ModelCommand::AddArguments();
     }
 
@@ -7571,15 +7571,16 @@ public:
     {
         AddArgument("UpdateFlags", 0, UINT8_MAX,
                     reinterpret_cast<std::underlying_type_t<chip::app::Clusters::ColorControl::ColorLoopUpdateFlags> *>(
-                        &mRequest.updateFlags));
-        AddArgument("Action", 0, UINT8_MAX,
-                    reinterpret_cast<std::underlying_type_t<decltype(mRequest.action)> *>(&mRequest.action));
+                        &mRequest.updateFlags),
+                    false);
+        AddArgument("Action", 0, UINT8_MAX, reinterpret_cast<std::underlying_type_t<decltype(mRequest.action)> *>(&mRequest.action),
+                    false);
         AddArgument("Direction", 0, UINT8_MAX,
-                    reinterpret_cast<std::underlying_type_t<decltype(mRequest.direction)> *>(&mRequest.direction));
-        AddArgument("Time", 0, UINT16_MAX, &mRequest.time);
-        AddArgument("StartHue", 0, UINT16_MAX, &mRequest.startHue);
-        AddArgument("OptionsMask", 0, UINT8_MAX, &mRequest.optionsMask);
-        AddArgument("OptionsOverride", 0, UINT8_MAX, &mRequest.optionsOverride);
+                    reinterpret_cast<std::underlying_type_t<decltype(mRequest.direction)> *>(&mRequest.direction), false);
+        AddArgument("Time", 0, UINT16_MAX, &mRequest.time, false);
+        AddArgument("StartHue", 0, UINT16_MAX, &mRequest.startHue, false);
+        AddArgument("OptionsMask", 0, UINT8_MAX, &mRequest.optionsMask, false);
+        AddArgument("OptionsOverride", 0, UINT8_MAX, &mRequest.optionsOverride, false);
         ModelCommand::AddArguments();
     }
 
@@ -7605,10 +7606,10 @@ public:
     ColorControlEnhancedMoveHue() : ModelCommand("enhanced-move-hue")
     {
         AddArgument("MoveMode", 0, UINT8_MAX,
-                    reinterpret_cast<std::underlying_type_t<decltype(mRequest.moveMode)> *>(&mRequest.moveMode));
-        AddArgument("Rate", 0, UINT16_MAX, &mRequest.rate);
-        AddArgument("OptionsMask", 0, UINT8_MAX, &mRequest.optionsMask);
-        AddArgument("OptionsOverride", 0, UINT8_MAX, &mRequest.optionsOverride);
+                    reinterpret_cast<std::underlying_type_t<decltype(mRequest.moveMode)> *>(&mRequest.moveMode), false);
+        AddArgument("Rate", 0, UINT16_MAX, &mRequest.rate, false);
+        AddArgument("OptionsMask", 0, UINT8_MAX, &mRequest.optionsMask, false);
+        AddArgument("OptionsOverride", 0, UINT8_MAX, &mRequest.optionsOverride, false);
         ModelCommand::AddArguments();
     }
 
@@ -7633,12 +7634,12 @@ class ColorControlEnhancedMoveToHue : public ModelCommand
 public:
     ColorControlEnhancedMoveToHue() : ModelCommand("enhanced-move-to-hue")
     {
-        AddArgument("EnhancedHue", 0, UINT16_MAX, &mRequest.enhancedHue);
+        AddArgument("EnhancedHue", 0, UINT16_MAX, &mRequest.enhancedHue, false);
         AddArgument("Direction", 0, UINT8_MAX,
-                    reinterpret_cast<std::underlying_type_t<decltype(mRequest.direction)> *>(&mRequest.direction));
-        AddArgument("TransitionTime", 0, UINT16_MAX, &mRequest.transitionTime);
-        AddArgument("OptionsMask", 0, UINT8_MAX, &mRequest.optionsMask);
-        AddArgument("OptionsOverride", 0, UINT8_MAX, &mRequest.optionsOverride);
+                    reinterpret_cast<std::underlying_type_t<decltype(mRequest.direction)> *>(&mRequest.direction), false);
+        AddArgument("TransitionTime", 0, UINT16_MAX, &mRequest.transitionTime, false);
+        AddArgument("OptionsMask", 0, UINT8_MAX, &mRequest.optionsMask, false);
+        AddArgument("OptionsOverride", 0, UINT8_MAX, &mRequest.optionsOverride, false);
         ModelCommand::AddArguments();
     }
 
@@ -7663,11 +7664,11 @@ class ColorControlEnhancedMoveToHueAndSaturation : public ModelCommand
 public:
     ColorControlEnhancedMoveToHueAndSaturation() : ModelCommand("enhanced-move-to-hue-and-saturation")
     {
-        AddArgument("EnhancedHue", 0, UINT16_MAX, &mRequest.enhancedHue);
-        AddArgument("Saturation", 0, UINT8_MAX, &mRequest.saturation);
-        AddArgument("TransitionTime", 0, UINT16_MAX, &mRequest.transitionTime);
-        AddArgument("OptionsMask", 0, UINT8_MAX, &mRequest.optionsMask);
-        AddArgument("OptionsOverride", 0, UINT8_MAX, &mRequest.optionsOverride);
+        AddArgument("EnhancedHue", 0, UINT16_MAX, &mRequest.enhancedHue, false);
+        AddArgument("Saturation", 0, UINT8_MAX, &mRequest.saturation, false);
+        AddArgument("TransitionTime", 0, UINT16_MAX, &mRequest.transitionTime, false);
+        AddArgument("OptionsMask", 0, UINT8_MAX, &mRequest.optionsMask, false);
+        AddArgument("OptionsOverride", 0, UINT8_MAX, &mRequest.optionsOverride, false);
         ModelCommand::AddArguments();
     }
 
@@ -7693,11 +7694,11 @@ public:
     ColorControlEnhancedStepHue() : ModelCommand("enhanced-step-hue")
     {
         AddArgument("StepMode", 0, UINT8_MAX,
-                    reinterpret_cast<std::underlying_type_t<decltype(mRequest.stepMode)> *>(&mRequest.stepMode));
-        AddArgument("StepSize", 0, UINT16_MAX, &mRequest.stepSize);
-        AddArgument("TransitionTime", 0, UINT16_MAX, &mRequest.transitionTime);
-        AddArgument("OptionsMask", 0, UINT8_MAX, &mRequest.optionsMask);
-        AddArgument("OptionsOverride", 0, UINT8_MAX, &mRequest.optionsOverride);
+                    reinterpret_cast<std::underlying_type_t<decltype(mRequest.stepMode)> *>(&mRequest.stepMode), false);
+        AddArgument("StepSize", 0, UINT16_MAX, &mRequest.stepSize, false);
+        AddArgument("TransitionTime", 0, UINT16_MAX, &mRequest.transitionTime, false);
+        AddArgument("OptionsMask", 0, UINT8_MAX, &mRequest.optionsMask, false);
+        AddArgument("OptionsOverride", 0, UINT8_MAX, &mRequest.optionsOverride, false);
         ModelCommand::AddArguments();
     }
 
@@ -7722,10 +7723,10 @@ class ColorControlMoveColor : public ModelCommand
 public:
     ColorControlMoveColor() : ModelCommand("move-color")
     {
-        AddArgument("RateX", INT16_MIN, INT16_MAX, &mRequest.rateX);
-        AddArgument("RateY", INT16_MIN, INT16_MAX, &mRequest.rateY);
-        AddArgument("OptionsMask", 0, UINT8_MAX, &mRequest.optionsMask);
-        AddArgument("OptionsOverride", 0, UINT8_MAX, &mRequest.optionsOverride);
+        AddArgument("RateX", INT16_MIN, INT16_MAX, &mRequest.rateX, false);
+        AddArgument("RateY", INT16_MIN, INT16_MAX, &mRequest.rateY, false);
+        AddArgument("OptionsMask", 0, UINT8_MAX, &mRequest.optionsMask, false);
+        AddArgument("OptionsOverride", 0, UINT8_MAX, &mRequest.optionsOverride, false);
         ModelCommand::AddArguments();
     }
 
@@ -7751,12 +7752,12 @@ public:
     ColorControlMoveColorTemperature() : ModelCommand("move-color-temperature")
     {
         AddArgument("MoveMode", 0, UINT8_MAX,
-                    reinterpret_cast<std::underlying_type_t<decltype(mRequest.moveMode)> *>(&mRequest.moveMode));
-        AddArgument("Rate", 0, UINT16_MAX, &mRequest.rate);
-        AddArgument("ColorTemperatureMinimum", 0, UINT16_MAX, &mRequest.colorTemperatureMinimum);
-        AddArgument("ColorTemperatureMaximum", 0, UINT16_MAX, &mRequest.colorTemperatureMaximum);
-        AddArgument("OptionsMask", 0, UINT8_MAX, &mRequest.optionsMask);
-        AddArgument("OptionsOverride", 0, UINT8_MAX, &mRequest.optionsOverride);
+                    reinterpret_cast<std::underlying_type_t<decltype(mRequest.moveMode)> *>(&mRequest.moveMode), false);
+        AddArgument("Rate", 0, UINT16_MAX, &mRequest.rate, false);
+        AddArgument("ColorTemperatureMinimum", 0, UINT16_MAX, &mRequest.colorTemperatureMinimum, false);
+        AddArgument("ColorTemperatureMaximum", 0, UINT16_MAX, &mRequest.colorTemperatureMaximum, false);
+        AddArgument("OptionsMask", 0, UINT8_MAX, &mRequest.optionsMask, false);
+        AddArgument("OptionsOverride", 0, UINT8_MAX, &mRequest.optionsOverride, false);
         ModelCommand::AddArguments();
     }
 
@@ -7782,10 +7783,10 @@ public:
     ColorControlMoveHue() : ModelCommand("move-hue")
     {
         AddArgument("MoveMode", 0, UINT8_MAX,
-                    reinterpret_cast<std::underlying_type_t<decltype(mRequest.moveMode)> *>(&mRequest.moveMode));
-        AddArgument("Rate", 0, UINT8_MAX, &mRequest.rate);
-        AddArgument("OptionsMask", 0, UINT8_MAX, &mRequest.optionsMask);
-        AddArgument("OptionsOverride", 0, UINT8_MAX, &mRequest.optionsOverride);
+                    reinterpret_cast<std::underlying_type_t<decltype(mRequest.moveMode)> *>(&mRequest.moveMode), false);
+        AddArgument("Rate", 0, UINT8_MAX, &mRequest.rate, false);
+        AddArgument("OptionsMask", 0, UINT8_MAX, &mRequest.optionsMask, false);
+        AddArgument("OptionsOverride", 0, UINT8_MAX, &mRequest.optionsOverride, false);
         ModelCommand::AddArguments();
     }
 
@@ -7811,10 +7812,10 @@ public:
     ColorControlMoveSaturation() : ModelCommand("move-saturation")
     {
         AddArgument("MoveMode", 0, UINT8_MAX,
-                    reinterpret_cast<std::underlying_type_t<decltype(mRequest.moveMode)> *>(&mRequest.moveMode));
-        AddArgument("Rate", 0, UINT8_MAX, &mRequest.rate);
-        AddArgument("OptionsMask", 0, UINT8_MAX, &mRequest.optionsMask);
-        AddArgument("OptionsOverride", 0, UINT8_MAX, &mRequest.optionsOverride);
+                    reinterpret_cast<std::underlying_type_t<decltype(mRequest.moveMode)> *>(&mRequest.moveMode), false);
+        AddArgument("Rate", 0, UINT8_MAX, &mRequest.rate, false);
+        AddArgument("OptionsMask", 0, UINT8_MAX, &mRequest.optionsMask, false);
+        AddArgument("OptionsOverride", 0, UINT8_MAX, &mRequest.optionsOverride, false);
         ModelCommand::AddArguments();
     }
 
@@ -7839,11 +7840,11 @@ class ColorControlMoveToColor : public ModelCommand
 public:
     ColorControlMoveToColor() : ModelCommand("move-to-color")
     {
-        AddArgument("ColorX", 0, UINT16_MAX, &mRequest.colorX);
-        AddArgument("ColorY", 0, UINT16_MAX, &mRequest.colorY);
-        AddArgument("TransitionTime", 0, UINT16_MAX, &mRequest.transitionTime);
-        AddArgument("OptionsMask", 0, UINT8_MAX, &mRequest.optionsMask);
-        AddArgument("OptionsOverride", 0, UINT8_MAX, &mRequest.optionsOverride);
+        AddArgument("ColorX", 0, UINT16_MAX, &mRequest.colorX, false);
+        AddArgument("ColorY", 0, UINT16_MAX, &mRequest.colorY, false);
+        AddArgument("TransitionTime", 0, UINT16_MAX, &mRequest.transitionTime, false);
+        AddArgument("OptionsMask", 0, UINT8_MAX, &mRequest.optionsMask, false);
+        AddArgument("OptionsOverride", 0, UINT8_MAX, &mRequest.optionsOverride, false);
         ModelCommand::AddArguments();
     }
 
@@ -7868,10 +7869,10 @@ class ColorControlMoveToColorTemperature : public ModelCommand
 public:
     ColorControlMoveToColorTemperature() : ModelCommand("move-to-color-temperature")
     {
-        AddArgument("ColorTemperature", 0, UINT16_MAX, &mRequest.colorTemperature);
-        AddArgument("TransitionTime", 0, UINT16_MAX, &mRequest.transitionTime);
-        AddArgument("OptionsMask", 0, UINT8_MAX, &mRequest.optionsMask);
-        AddArgument("OptionsOverride", 0, UINT8_MAX, &mRequest.optionsOverride);
+        AddArgument("ColorTemperature", 0, UINT16_MAX, &mRequest.colorTemperature, false);
+        AddArgument("TransitionTime", 0, UINT16_MAX, &mRequest.transitionTime, false);
+        AddArgument("OptionsMask", 0, UINT8_MAX, &mRequest.optionsMask, false);
+        AddArgument("OptionsOverride", 0, UINT8_MAX, &mRequest.optionsOverride, false);
         ModelCommand::AddArguments();
     }
 
@@ -7896,12 +7897,12 @@ class ColorControlMoveToHue : public ModelCommand
 public:
     ColorControlMoveToHue() : ModelCommand("move-to-hue")
     {
-        AddArgument("Hue", 0, UINT8_MAX, &mRequest.hue);
+        AddArgument("Hue", 0, UINT8_MAX, &mRequest.hue, false);
         AddArgument("Direction", 0, UINT8_MAX,
-                    reinterpret_cast<std::underlying_type_t<decltype(mRequest.direction)> *>(&mRequest.direction));
-        AddArgument("TransitionTime", 0, UINT16_MAX, &mRequest.transitionTime);
-        AddArgument("OptionsMask", 0, UINT8_MAX, &mRequest.optionsMask);
-        AddArgument("OptionsOverride", 0, UINT8_MAX, &mRequest.optionsOverride);
+                    reinterpret_cast<std::underlying_type_t<decltype(mRequest.direction)> *>(&mRequest.direction), false);
+        AddArgument("TransitionTime", 0, UINT16_MAX, &mRequest.transitionTime, false);
+        AddArgument("OptionsMask", 0, UINT8_MAX, &mRequest.optionsMask, false);
+        AddArgument("OptionsOverride", 0, UINT8_MAX, &mRequest.optionsOverride, false);
         ModelCommand::AddArguments();
     }
 
@@ -7926,11 +7927,11 @@ class ColorControlMoveToHueAndSaturation : public ModelCommand
 public:
     ColorControlMoveToHueAndSaturation() : ModelCommand("move-to-hue-and-saturation")
     {
-        AddArgument("Hue", 0, UINT8_MAX, &mRequest.hue);
-        AddArgument("Saturation", 0, UINT8_MAX, &mRequest.saturation);
-        AddArgument("TransitionTime", 0, UINT16_MAX, &mRequest.transitionTime);
-        AddArgument("OptionsMask", 0, UINT8_MAX, &mRequest.optionsMask);
-        AddArgument("OptionsOverride", 0, UINT8_MAX, &mRequest.optionsOverride);
+        AddArgument("Hue", 0, UINT8_MAX, &mRequest.hue, false);
+        AddArgument("Saturation", 0, UINT8_MAX, &mRequest.saturation, false);
+        AddArgument("TransitionTime", 0, UINT16_MAX, &mRequest.transitionTime, false);
+        AddArgument("OptionsMask", 0, UINT8_MAX, &mRequest.optionsMask, false);
+        AddArgument("OptionsOverride", 0, UINT8_MAX, &mRequest.optionsOverride, false);
         ModelCommand::AddArguments();
     }
 
@@ -7955,10 +7956,10 @@ class ColorControlMoveToSaturation : public ModelCommand
 public:
     ColorControlMoveToSaturation() : ModelCommand("move-to-saturation")
     {
-        AddArgument("Saturation", 0, UINT8_MAX, &mRequest.saturation);
-        AddArgument("TransitionTime", 0, UINT16_MAX, &mRequest.transitionTime);
-        AddArgument("OptionsMask", 0, UINT8_MAX, &mRequest.optionsMask);
-        AddArgument("OptionsOverride", 0, UINT8_MAX, &mRequest.optionsOverride);
+        AddArgument("Saturation", 0, UINT8_MAX, &mRequest.saturation, false);
+        AddArgument("TransitionTime", 0, UINT16_MAX, &mRequest.transitionTime, false);
+        AddArgument("OptionsMask", 0, UINT8_MAX, &mRequest.optionsMask, false);
+        AddArgument("OptionsOverride", 0, UINT8_MAX, &mRequest.optionsOverride, false);
         ModelCommand::AddArguments();
     }
 
@@ -7983,11 +7984,11 @@ class ColorControlStepColor : public ModelCommand
 public:
     ColorControlStepColor() : ModelCommand("step-color")
     {
-        AddArgument("StepX", INT16_MIN, INT16_MAX, &mRequest.stepX);
-        AddArgument("StepY", INT16_MIN, INT16_MAX, &mRequest.stepY);
-        AddArgument("TransitionTime", 0, UINT16_MAX, &mRequest.transitionTime);
-        AddArgument("OptionsMask", 0, UINT8_MAX, &mRequest.optionsMask);
-        AddArgument("OptionsOverride", 0, UINT8_MAX, &mRequest.optionsOverride);
+        AddArgument("StepX", INT16_MIN, INT16_MAX, &mRequest.stepX, false);
+        AddArgument("StepY", INT16_MIN, INT16_MAX, &mRequest.stepY, false);
+        AddArgument("TransitionTime", 0, UINT16_MAX, &mRequest.transitionTime, false);
+        AddArgument("OptionsMask", 0, UINT8_MAX, &mRequest.optionsMask, false);
+        AddArgument("OptionsOverride", 0, UINT8_MAX, &mRequest.optionsOverride, false);
         ModelCommand::AddArguments();
     }
 
@@ -8013,13 +8014,13 @@ public:
     ColorControlStepColorTemperature() : ModelCommand("step-color-temperature")
     {
         AddArgument("StepMode", 0, UINT8_MAX,
-                    reinterpret_cast<std::underlying_type_t<decltype(mRequest.stepMode)> *>(&mRequest.stepMode));
-        AddArgument("StepSize", 0, UINT16_MAX, &mRequest.stepSize);
-        AddArgument("TransitionTime", 0, UINT16_MAX, &mRequest.transitionTime);
-        AddArgument("ColorTemperatureMinimum", 0, UINT16_MAX, &mRequest.colorTemperatureMinimum);
-        AddArgument("ColorTemperatureMaximum", 0, UINT16_MAX, &mRequest.colorTemperatureMaximum);
-        AddArgument("OptionsMask", 0, UINT8_MAX, &mRequest.optionsMask);
-        AddArgument("OptionsOverride", 0, UINT8_MAX, &mRequest.optionsOverride);
+                    reinterpret_cast<std::underlying_type_t<decltype(mRequest.stepMode)> *>(&mRequest.stepMode), false);
+        AddArgument("StepSize", 0, UINT16_MAX, &mRequest.stepSize, false);
+        AddArgument("TransitionTime", 0, UINT16_MAX, &mRequest.transitionTime, false);
+        AddArgument("ColorTemperatureMinimum", 0, UINT16_MAX, &mRequest.colorTemperatureMinimum, false);
+        AddArgument("ColorTemperatureMaximum", 0, UINT16_MAX, &mRequest.colorTemperatureMaximum, false);
+        AddArgument("OptionsMask", 0, UINT8_MAX, &mRequest.optionsMask, false);
+        AddArgument("OptionsOverride", 0, UINT8_MAX, &mRequest.optionsOverride, false);
         ModelCommand::AddArguments();
     }
 
@@ -8045,11 +8046,11 @@ public:
     ColorControlStepHue() : ModelCommand("step-hue")
     {
         AddArgument("StepMode", 0, UINT8_MAX,
-                    reinterpret_cast<std::underlying_type_t<decltype(mRequest.stepMode)> *>(&mRequest.stepMode));
-        AddArgument("StepSize", 0, UINT8_MAX, &mRequest.stepSize);
-        AddArgument("TransitionTime", 0, UINT8_MAX, &mRequest.transitionTime);
-        AddArgument("OptionsMask", 0, UINT8_MAX, &mRequest.optionsMask);
-        AddArgument("OptionsOverride", 0, UINT8_MAX, &mRequest.optionsOverride);
+                    reinterpret_cast<std::underlying_type_t<decltype(mRequest.stepMode)> *>(&mRequest.stepMode), false);
+        AddArgument("StepSize", 0, UINT8_MAX, &mRequest.stepSize, false);
+        AddArgument("TransitionTime", 0, UINT8_MAX, &mRequest.transitionTime, false);
+        AddArgument("OptionsMask", 0, UINT8_MAX, &mRequest.optionsMask, false);
+        AddArgument("OptionsOverride", 0, UINT8_MAX, &mRequest.optionsOverride, false);
         ModelCommand::AddArguments();
     }
 
@@ -8075,11 +8076,11 @@ public:
     ColorControlStepSaturation() : ModelCommand("step-saturation")
     {
         AddArgument("StepMode", 0, UINT8_MAX,
-                    reinterpret_cast<std::underlying_type_t<decltype(mRequest.stepMode)> *>(&mRequest.stepMode));
-        AddArgument("StepSize", 0, UINT8_MAX, &mRequest.stepSize);
-        AddArgument("TransitionTime", 0, UINT8_MAX, &mRequest.transitionTime);
-        AddArgument("OptionsMask", 0, UINT8_MAX, &mRequest.optionsMask);
-        AddArgument("OptionsOverride", 0, UINT8_MAX, &mRequest.optionsOverride);
+                    reinterpret_cast<std::underlying_type_t<decltype(mRequest.stepMode)> *>(&mRequest.stepMode), false);
+        AddArgument("StepSize", 0, UINT8_MAX, &mRequest.stepSize, false);
+        AddArgument("TransitionTime", 0, UINT8_MAX, &mRequest.transitionTime, false);
+        AddArgument("OptionsMask", 0, UINT8_MAX, &mRequest.optionsMask, false);
+        AddArgument("OptionsOverride", 0, UINT8_MAX, &mRequest.optionsOverride, false);
         ModelCommand::AddArguments();
     }
 
@@ -8104,8 +8105,8 @@ class ColorControlStopMoveStep : public ModelCommand
 public:
     ColorControlStopMoveStep() : ModelCommand("stop-move-step")
     {
-        AddArgument("OptionsMask", 0, UINT8_MAX, &mRequest.optionsMask);
-        AddArgument("OptionsOverride", 0, UINT8_MAX, &mRequest.optionsOverride);
+        AddArgument("OptionsMask", 0, UINT8_MAX, &mRequest.optionsMask, false);
+        AddArgument("OptionsOverride", 0, UINT8_MAX, &mRequest.optionsOverride, false);
         ModelCommand::AddArguments();
     }
 
@@ -8130,7 +8131,7 @@ class ReadColorControlCurrentHue : public ModelCommand
 public:
     ReadColorControlCurrentHue() : ModelCommand("read")
     {
-        AddArgument("attr-name", "current-hue");
+        AddArgument("attr-name", "current-hue", false);
         ModelCommand::AddArguments();
     }
 
@@ -8161,10 +8162,10 @@ class ReportColorControlCurrentHue : public ModelCommand
 public:
     ReportColorControlCurrentHue() : ModelCommand("report")
     {
-        AddArgument("attr-name", "current-hue");
-        AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
-        AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval);
-        AddArgument("wait", 0, 1, &mWait);
+        AddArgument("attr-name", "current-hue", false);
+        AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval, false);
+        AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval, false);
+        AddArgument("wait", 0, 1, &mWait, false);
         ModelCommand::AddArguments();
     }
 
@@ -8216,7 +8217,7 @@ class ReadColorControlCurrentSaturation : public ModelCommand
 public:
     ReadColorControlCurrentSaturation() : ModelCommand("read")
     {
-        AddArgument("attr-name", "current-saturation");
+        AddArgument("attr-name", "current-saturation", false);
         ModelCommand::AddArguments();
     }
 
@@ -8247,10 +8248,10 @@ class ReportColorControlCurrentSaturation : public ModelCommand
 public:
     ReportColorControlCurrentSaturation() : ModelCommand("report")
     {
-        AddArgument("attr-name", "current-saturation");
-        AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
-        AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval);
-        AddArgument("wait", 0, 1, &mWait);
+        AddArgument("attr-name", "current-saturation", false);
+        AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval, false);
+        AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval, false);
+        AddArgument("wait", 0, 1, &mWait, false);
         ModelCommand::AddArguments();
     }
 
@@ -8303,7 +8304,7 @@ class ReadColorControlRemainingTime : public ModelCommand
 public:
     ReadColorControlRemainingTime() : ModelCommand("read")
     {
-        AddArgument("attr-name", "remaining-time");
+        AddArgument("attr-name", "remaining-time", false);
         ModelCommand::AddArguments();
     }
 
@@ -8337,7 +8338,7 @@ class ReadColorControlCurrentX : public ModelCommand
 public:
     ReadColorControlCurrentX() : ModelCommand("read")
     {
-        AddArgument("attr-name", "current-x");
+        AddArgument("attr-name", "current-x", false);
         ModelCommand::AddArguments();
     }
 
@@ -8368,10 +8369,10 @@ class ReportColorControlCurrentX : public ModelCommand
 public:
     ReportColorControlCurrentX() : ModelCommand("report")
     {
-        AddArgument("attr-name", "current-x");
-        AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
-        AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval);
-        AddArgument("wait", 0, 1, &mWait);
+        AddArgument("attr-name", "current-x", false);
+        AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval, false);
+        AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval, false);
+        AddArgument("wait", 0, 1, &mWait, false);
         ModelCommand::AddArguments();
     }
 
@@ -8423,7 +8424,7 @@ class ReadColorControlCurrentY : public ModelCommand
 public:
     ReadColorControlCurrentY() : ModelCommand("read")
     {
-        AddArgument("attr-name", "current-y");
+        AddArgument("attr-name", "current-y", false);
         ModelCommand::AddArguments();
     }
 
@@ -8454,10 +8455,10 @@ class ReportColorControlCurrentY : public ModelCommand
 public:
     ReportColorControlCurrentY() : ModelCommand("report")
     {
-        AddArgument("attr-name", "current-y");
-        AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
-        AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval);
-        AddArgument("wait", 0, 1, &mWait);
+        AddArgument("attr-name", "current-y", false);
+        AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval, false);
+        AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval, false);
+        AddArgument("wait", 0, 1, &mWait, false);
         ModelCommand::AddArguments();
     }
 
@@ -8509,7 +8510,7 @@ class ReadColorControlDriftCompensation : public ModelCommand
 public:
     ReadColorControlDriftCompensation() : ModelCommand("read")
     {
-        AddArgument("attr-name", "drift-compensation");
+        AddArgument("attr-name", "drift-compensation", false);
         ModelCommand::AddArguments();
     }
 
@@ -8543,7 +8544,7 @@ class ReadColorControlCompensationText : public ModelCommand
 public:
     ReadColorControlCompensationText() : ModelCommand("read")
     {
-        AddArgument("attr-name", "compensation-text");
+        AddArgument("attr-name", "compensation-text", false);
         ModelCommand::AddArguments();
     }
 
@@ -8577,7 +8578,7 @@ class ReadColorControlColorTemperature : public ModelCommand
 public:
     ReadColorControlColorTemperature() : ModelCommand("read")
     {
-        AddArgument("attr-name", "color-temperature");
+        AddArgument("attr-name", "color-temperature", false);
         ModelCommand::AddArguments();
     }
 
@@ -8608,10 +8609,10 @@ class ReportColorControlColorTemperature : public ModelCommand
 public:
     ReportColorControlColorTemperature() : ModelCommand("report")
     {
-        AddArgument("attr-name", "color-temperature");
-        AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
-        AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval);
-        AddArgument("wait", 0, 1, &mWait);
+        AddArgument("attr-name", "color-temperature", false);
+        AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval, false);
+        AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval, false);
+        AddArgument("wait", 0, 1, &mWait, false);
         ModelCommand::AddArguments();
     }
 
@@ -8663,7 +8664,7 @@ class ReadColorControlColorMode : public ModelCommand
 public:
     ReadColorControlColorMode() : ModelCommand("read")
     {
-        AddArgument("attr-name", "color-mode");
+        AddArgument("attr-name", "color-mode", false);
         ModelCommand::AddArguments();
     }
 
@@ -8697,7 +8698,7 @@ class ReadColorControlColorControlOptions : public ModelCommand
 public:
     ReadColorControlColorControlOptions() : ModelCommand("read")
     {
-        AddArgument("attr-name", "color-control-options");
+        AddArgument("attr-name", "color-control-options", false);
         ModelCommand::AddArguments();
     }
 
@@ -8728,8 +8729,8 @@ class WriteColorControlColorControlOptions : public ModelCommand
 public:
     WriteColorControlColorControlOptions() : ModelCommand("write")
     {
-        AddArgument("attr-name", "color-control-options");
-        AddArgument("attr-value", 0, UINT8_MAX, &mValue);
+        AddArgument("attr-name", "color-control-options", false);
+        AddArgument("attr-value", 0, UINT8_MAX, &mValue, false);
         ModelCommand::AddArguments();
     }
 
@@ -8764,7 +8765,7 @@ class ReadColorControlNumberOfPrimaries : public ModelCommand
 public:
     ReadColorControlNumberOfPrimaries() : ModelCommand("read")
     {
-        AddArgument("attr-name", "number-of-primaries");
+        AddArgument("attr-name", "number-of-primaries", false);
         ModelCommand::AddArguments();
     }
 
@@ -8798,7 +8799,7 @@ class ReadColorControlPrimary1X : public ModelCommand
 public:
     ReadColorControlPrimary1X() : ModelCommand("read")
     {
-        AddArgument("attr-name", "primary1x");
+        AddArgument("attr-name", "primary1x", false);
         ModelCommand::AddArguments();
     }
 
@@ -8832,7 +8833,7 @@ class ReadColorControlPrimary1Y : public ModelCommand
 public:
     ReadColorControlPrimary1Y() : ModelCommand("read")
     {
-        AddArgument("attr-name", "primary1y");
+        AddArgument("attr-name", "primary1y", false);
         ModelCommand::AddArguments();
     }
 
@@ -8866,7 +8867,7 @@ class ReadColorControlPrimary1Intensity : public ModelCommand
 public:
     ReadColorControlPrimary1Intensity() : ModelCommand("read")
     {
-        AddArgument("attr-name", "primary1intensity");
+        AddArgument("attr-name", "primary1intensity", false);
         ModelCommand::AddArguments();
     }
 
@@ -8900,7 +8901,7 @@ class ReadColorControlPrimary2X : public ModelCommand
 public:
     ReadColorControlPrimary2X() : ModelCommand("read")
     {
-        AddArgument("attr-name", "primary2x");
+        AddArgument("attr-name", "primary2x", false);
         ModelCommand::AddArguments();
     }
 
@@ -8934,7 +8935,7 @@ class ReadColorControlPrimary2Y : public ModelCommand
 public:
     ReadColorControlPrimary2Y() : ModelCommand("read")
     {
-        AddArgument("attr-name", "primary2y");
+        AddArgument("attr-name", "primary2y", false);
         ModelCommand::AddArguments();
     }
 
@@ -8968,7 +8969,7 @@ class ReadColorControlPrimary2Intensity : public ModelCommand
 public:
     ReadColorControlPrimary2Intensity() : ModelCommand("read")
     {
-        AddArgument("attr-name", "primary2intensity");
+        AddArgument("attr-name", "primary2intensity", false);
         ModelCommand::AddArguments();
     }
 
@@ -9002,7 +9003,7 @@ class ReadColorControlPrimary3X : public ModelCommand
 public:
     ReadColorControlPrimary3X() : ModelCommand("read")
     {
-        AddArgument("attr-name", "primary3x");
+        AddArgument("attr-name", "primary3x", false);
         ModelCommand::AddArguments();
     }
 
@@ -9036,7 +9037,7 @@ class ReadColorControlPrimary3Y : public ModelCommand
 public:
     ReadColorControlPrimary3Y() : ModelCommand("read")
     {
-        AddArgument("attr-name", "primary3y");
+        AddArgument("attr-name", "primary3y", false);
         ModelCommand::AddArguments();
     }
 
@@ -9070,7 +9071,7 @@ class ReadColorControlPrimary3Intensity : public ModelCommand
 public:
     ReadColorControlPrimary3Intensity() : ModelCommand("read")
     {
-        AddArgument("attr-name", "primary3intensity");
+        AddArgument("attr-name", "primary3intensity", false);
         ModelCommand::AddArguments();
     }
 
@@ -9104,7 +9105,7 @@ class ReadColorControlPrimary4X : public ModelCommand
 public:
     ReadColorControlPrimary4X() : ModelCommand("read")
     {
-        AddArgument("attr-name", "primary4x");
+        AddArgument("attr-name", "primary4x", false);
         ModelCommand::AddArguments();
     }
 
@@ -9138,7 +9139,7 @@ class ReadColorControlPrimary4Y : public ModelCommand
 public:
     ReadColorControlPrimary4Y() : ModelCommand("read")
     {
-        AddArgument("attr-name", "primary4y");
+        AddArgument("attr-name", "primary4y", false);
         ModelCommand::AddArguments();
     }
 
@@ -9172,7 +9173,7 @@ class ReadColorControlPrimary4Intensity : public ModelCommand
 public:
     ReadColorControlPrimary4Intensity() : ModelCommand("read")
     {
-        AddArgument("attr-name", "primary4intensity");
+        AddArgument("attr-name", "primary4intensity", false);
         ModelCommand::AddArguments();
     }
 
@@ -9206,7 +9207,7 @@ class ReadColorControlPrimary5X : public ModelCommand
 public:
     ReadColorControlPrimary5X() : ModelCommand("read")
     {
-        AddArgument("attr-name", "primary5x");
+        AddArgument("attr-name", "primary5x", false);
         ModelCommand::AddArguments();
     }
 
@@ -9240,7 +9241,7 @@ class ReadColorControlPrimary5Y : public ModelCommand
 public:
     ReadColorControlPrimary5Y() : ModelCommand("read")
     {
-        AddArgument("attr-name", "primary5y");
+        AddArgument("attr-name", "primary5y", false);
         ModelCommand::AddArguments();
     }
 
@@ -9274,7 +9275,7 @@ class ReadColorControlPrimary5Intensity : public ModelCommand
 public:
     ReadColorControlPrimary5Intensity() : ModelCommand("read")
     {
-        AddArgument("attr-name", "primary5intensity");
+        AddArgument("attr-name", "primary5intensity", false);
         ModelCommand::AddArguments();
     }
 
@@ -9308,7 +9309,7 @@ class ReadColorControlPrimary6X : public ModelCommand
 public:
     ReadColorControlPrimary6X() : ModelCommand("read")
     {
-        AddArgument("attr-name", "primary6x");
+        AddArgument("attr-name", "primary6x", false);
         ModelCommand::AddArguments();
     }
 
@@ -9342,7 +9343,7 @@ class ReadColorControlPrimary6Y : public ModelCommand
 public:
     ReadColorControlPrimary6Y() : ModelCommand("read")
     {
-        AddArgument("attr-name", "primary6y");
+        AddArgument("attr-name", "primary6y", false);
         ModelCommand::AddArguments();
     }
 
@@ -9376,7 +9377,7 @@ class ReadColorControlPrimary6Intensity : public ModelCommand
 public:
     ReadColorControlPrimary6Intensity() : ModelCommand("read")
     {
-        AddArgument("attr-name", "primary6intensity");
+        AddArgument("attr-name", "primary6intensity", false);
         ModelCommand::AddArguments();
     }
 
@@ -9410,7 +9411,7 @@ class ReadColorControlWhitePointX : public ModelCommand
 public:
     ReadColorControlWhitePointX() : ModelCommand("read")
     {
-        AddArgument("attr-name", "white-point-x");
+        AddArgument("attr-name", "white-point-x", false);
         ModelCommand::AddArguments();
     }
 
@@ -9441,8 +9442,8 @@ class WriteColorControlWhitePointX : public ModelCommand
 public:
     WriteColorControlWhitePointX() : ModelCommand("write")
     {
-        AddArgument("attr-name", "white-point-x");
-        AddArgument("attr-value", 0, UINT16_MAX, &mValue);
+        AddArgument("attr-name", "white-point-x", false);
+        AddArgument("attr-value", 0, UINT16_MAX, &mValue, false);
         ModelCommand::AddArguments();
     }
 
@@ -9477,7 +9478,7 @@ class ReadColorControlWhitePointY : public ModelCommand
 public:
     ReadColorControlWhitePointY() : ModelCommand("read")
     {
-        AddArgument("attr-name", "white-point-y");
+        AddArgument("attr-name", "white-point-y", false);
         ModelCommand::AddArguments();
     }
 
@@ -9508,8 +9509,8 @@ class WriteColorControlWhitePointY : public ModelCommand
 public:
     WriteColorControlWhitePointY() : ModelCommand("write")
     {
-        AddArgument("attr-name", "white-point-y");
-        AddArgument("attr-value", 0, UINT16_MAX, &mValue);
+        AddArgument("attr-name", "white-point-y", false);
+        AddArgument("attr-value", 0, UINT16_MAX, &mValue, false);
         ModelCommand::AddArguments();
     }
 
@@ -9544,7 +9545,7 @@ class ReadColorControlColorPointRX : public ModelCommand
 public:
     ReadColorControlColorPointRX() : ModelCommand("read")
     {
-        AddArgument("attr-name", "color-point-rx");
+        AddArgument("attr-name", "color-point-rx", false);
         ModelCommand::AddArguments();
     }
 
@@ -9575,8 +9576,8 @@ class WriteColorControlColorPointRX : public ModelCommand
 public:
     WriteColorControlColorPointRX() : ModelCommand("write")
     {
-        AddArgument("attr-name", "color-point-rx");
-        AddArgument("attr-value", 0, UINT16_MAX, &mValue);
+        AddArgument("attr-name", "color-point-rx", false);
+        AddArgument("attr-value", 0, UINT16_MAX, &mValue, false);
         ModelCommand::AddArguments();
     }
 
@@ -9611,7 +9612,7 @@ class ReadColorControlColorPointRY : public ModelCommand
 public:
     ReadColorControlColorPointRY() : ModelCommand("read")
     {
-        AddArgument("attr-name", "color-point-ry");
+        AddArgument("attr-name", "color-point-ry", false);
         ModelCommand::AddArguments();
     }
 
@@ -9642,8 +9643,8 @@ class WriteColorControlColorPointRY : public ModelCommand
 public:
     WriteColorControlColorPointRY() : ModelCommand("write")
     {
-        AddArgument("attr-name", "color-point-ry");
-        AddArgument("attr-value", 0, UINT16_MAX, &mValue);
+        AddArgument("attr-name", "color-point-ry", false);
+        AddArgument("attr-value", 0, UINT16_MAX, &mValue, false);
         ModelCommand::AddArguments();
     }
 
@@ -9678,7 +9679,7 @@ class ReadColorControlColorPointRIntensity : public ModelCommand
 public:
     ReadColorControlColorPointRIntensity() : ModelCommand("read")
     {
-        AddArgument("attr-name", "color-point-rintensity");
+        AddArgument("attr-name", "color-point-rintensity", false);
         ModelCommand::AddArguments();
     }
 
@@ -9709,8 +9710,8 @@ class WriteColorControlColorPointRIntensity : public ModelCommand
 public:
     WriteColorControlColorPointRIntensity() : ModelCommand("write")
     {
-        AddArgument("attr-name", "color-point-rintensity");
-        AddArgument("attr-value", 0, UINT8_MAX, &mValue);
+        AddArgument("attr-name", "color-point-rintensity", false);
+        AddArgument("attr-value", 0, UINT8_MAX, &mValue, false);
         ModelCommand::AddArguments();
     }
 
@@ -9745,7 +9746,7 @@ class ReadColorControlColorPointGX : public ModelCommand
 public:
     ReadColorControlColorPointGX() : ModelCommand("read")
     {
-        AddArgument("attr-name", "color-point-gx");
+        AddArgument("attr-name", "color-point-gx", false);
         ModelCommand::AddArguments();
     }
 
@@ -9776,8 +9777,8 @@ class WriteColorControlColorPointGX : public ModelCommand
 public:
     WriteColorControlColorPointGX() : ModelCommand("write")
     {
-        AddArgument("attr-name", "color-point-gx");
-        AddArgument("attr-value", 0, UINT16_MAX, &mValue);
+        AddArgument("attr-name", "color-point-gx", false);
+        AddArgument("attr-value", 0, UINT16_MAX, &mValue, false);
         ModelCommand::AddArguments();
     }
 
@@ -9812,7 +9813,7 @@ class ReadColorControlColorPointGY : public ModelCommand
 public:
     ReadColorControlColorPointGY() : ModelCommand("read")
     {
-        AddArgument("attr-name", "color-point-gy");
+        AddArgument("attr-name", "color-point-gy", false);
         ModelCommand::AddArguments();
     }
 
@@ -9843,8 +9844,8 @@ class WriteColorControlColorPointGY : public ModelCommand
 public:
     WriteColorControlColorPointGY() : ModelCommand("write")
     {
-        AddArgument("attr-name", "color-point-gy");
-        AddArgument("attr-value", 0, UINT16_MAX, &mValue);
+        AddArgument("attr-name", "color-point-gy", false);
+        AddArgument("attr-value", 0, UINT16_MAX, &mValue, false);
         ModelCommand::AddArguments();
     }
 
@@ -9879,7 +9880,7 @@ class ReadColorControlColorPointGIntensity : public ModelCommand
 public:
     ReadColorControlColorPointGIntensity() : ModelCommand("read")
     {
-        AddArgument("attr-name", "color-point-gintensity");
+        AddArgument("attr-name", "color-point-gintensity", false);
         ModelCommand::AddArguments();
     }
 
@@ -9910,8 +9911,8 @@ class WriteColorControlColorPointGIntensity : public ModelCommand
 public:
     WriteColorControlColorPointGIntensity() : ModelCommand("write")
     {
-        AddArgument("attr-name", "color-point-gintensity");
-        AddArgument("attr-value", 0, UINT8_MAX, &mValue);
+        AddArgument("attr-name", "color-point-gintensity", false);
+        AddArgument("attr-value", 0, UINT8_MAX, &mValue, false);
         ModelCommand::AddArguments();
     }
 
@@ -9946,7 +9947,7 @@ class ReadColorControlColorPointBX : public ModelCommand
 public:
     ReadColorControlColorPointBX() : ModelCommand("read")
     {
-        AddArgument("attr-name", "color-point-bx");
+        AddArgument("attr-name", "color-point-bx", false);
         ModelCommand::AddArguments();
     }
 
@@ -9977,8 +9978,8 @@ class WriteColorControlColorPointBX : public ModelCommand
 public:
     WriteColorControlColorPointBX() : ModelCommand("write")
     {
-        AddArgument("attr-name", "color-point-bx");
-        AddArgument("attr-value", 0, UINT16_MAX, &mValue);
+        AddArgument("attr-name", "color-point-bx", false);
+        AddArgument("attr-value", 0, UINT16_MAX, &mValue, false);
         ModelCommand::AddArguments();
     }
 
@@ -10013,7 +10014,7 @@ class ReadColorControlColorPointBY : public ModelCommand
 public:
     ReadColorControlColorPointBY() : ModelCommand("read")
     {
-        AddArgument("attr-name", "color-point-by");
+        AddArgument("attr-name", "color-point-by", false);
         ModelCommand::AddArguments();
     }
 
@@ -10044,8 +10045,8 @@ class WriteColorControlColorPointBY : public ModelCommand
 public:
     WriteColorControlColorPointBY() : ModelCommand("write")
     {
-        AddArgument("attr-name", "color-point-by");
-        AddArgument("attr-value", 0, UINT16_MAX, &mValue);
+        AddArgument("attr-name", "color-point-by", false);
+        AddArgument("attr-value", 0, UINT16_MAX, &mValue, false);
         ModelCommand::AddArguments();
     }
 
@@ -10080,7 +10081,7 @@ class ReadColorControlColorPointBIntensity : public ModelCommand
 public:
     ReadColorControlColorPointBIntensity() : ModelCommand("read")
     {
-        AddArgument("attr-name", "color-point-bintensity");
+        AddArgument("attr-name", "color-point-bintensity", false);
         ModelCommand::AddArguments();
     }
 
@@ -10111,8 +10112,8 @@ class WriteColorControlColorPointBIntensity : public ModelCommand
 public:
     WriteColorControlColorPointBIntensity() : ModelCommand("write")
     {
-        AddArgument("attr-name", "color-point-bintensity");
-        AddArgument("attr-value", 0, UINT8_MAX, &mValue);
+        AddArgument("attr-name", "color-point-bintensity", false);
+        AddArgument("attr-value", 0, UINT8_MAX, &mValue, false);
         ModelCommand::AddArguments();
     }
 
@@ -10147,7 +10148,7 @@ class ReadColorControlEnhancedCurrentHue : public ModelCommand
 public:
     ReadColorControlEnhancedCurrentHue() : ModelCommand("read")
     {
-        AddArgument("attr-name", "enhanced-current-hue");
+        AddArgument("attr-name", "enhanced-current-hue", false);
         ModelCommand::AddArguments();
     }
 
@@ -10181,7 +10182,7 @@ class ReadColorControlEnhancedColorMode : public ModelCommand
 public:
     ReadColorControlEnhancedColorMode() : ModelCommand("read")
     {
-        AddArgument("attr-name", "enhanced-color-mode");
+        AddArgument("attr-name", "enhanced-color-mode", false);
         ModelCommand::AddArguments();
     }
 
@@ -10215,7 +10216,7 @@ class ReadColorControlColorLoopActive : public ModelCommand
 public:
     ReadColorControlColorLoopActive() : ModelCommand("read")
     {
-        AddArgument("attr-name", "color-loop-active");
+        AddArgument("attr-name", "color-loop-active", false);
         ModelCommand::AddArguments();
     }
 
@@ -10249,7 +10250,7 @@ class ReadColorControlColorLoopDirection : public ModelCommand
 public:
     ReadColorControlColorLoopDirection() : ModelCommand("read")
     {
-        AddArgument("attr-name", "color-loop-direction");
+        AddArgument("attr-name", "color-loop-direction", false);
         ModelCommand::AddArguments();
     }
 
@@ -10283,7 +10284,7 @@ class ReadColorControlColorLoopTime : public ModelCommand
 public:
     ReadColorControlColorLoopTime() : ModelCommand("read")
     {
-        AddArgument("attr-name", "color-loop-time");
+        AddArgument("attr-name", "color-loop-time", false);
         ModelCommand::AddArguments();
     }
 
@@ -10317,7 +10318,7 @@ class ReadColorControlColorLoopStartEnhancedHue : public ModelCommand
 public:
     ReadColorControlColorLoopStartEnhancedHue() : ModelCommand("read")
     {
-        AddArgument("attr-name", "color-loop-start-enhanced-hue");
+        AddArgument("attr-name", "color-loop-start-enhanced-hue", false);
         ModelCommand::AddArguments();
     }
 
@@ -10351,7 +10352,7 @@ class ReadColorControlColorLoopStoredEnhancedHue : public ModelCommand
 public:
     ReadColorControlColorLoopStoredEnhancedHue() : ModelCommand("read")
     {
-        AddArgument("attr-name", "color-loop-stored-enhanced-hue");
+        AddArgument("attr-name", "color-loop-stored-enhanced-hue", false);
         ModelCommand::AddArguments();
     }
 
@@ -10385,7 +10386,7 @@ class ReadColorControlColorCapabilities : public ModelCommand
 public:
     ReadColorControlColorCapabilities() : ModelCommand("read")
     {
-        AddArgument("attr-name", "color-capabilities");
+        AddArgument("attr-name", "color-capabilities", false);
         ModelCommand::AddArguments();
     }
 
@@ -10419,7 +10420,7 @@ class ReadColorControlColorTempPhysicalMin : public ModelCommand
 public:
     ReadColorControlColorTempPhysicalMin() : ModelCommand("read")
     {
-        AddArgument("attr-name", "color-temp-physical-min");
+        AddArgument("attr-name", "color-temp-physical-min", false);
         ModelCommand::AddArguments();
     }
 
@@ -10453,7 +10454,7 @@ class ReadColorControlColorTempPhysicalMax : public ModelCommand
 public:
     ReadColorControlColorTempPhysicalMax() : ModelCommand("read")
     {
-        AddArgument("attr-name", "color-temp-physical-max");
+        AddArgument("attr-name", "color-temp-physical-max", false);
         ModelCommand::AddArguments();
     }
 
@@ -10487,7 +10488,7 @@ class ReadColorControlCoupleColorTempToLevelMinMireds : public ModelCommand
 public:
     ReadColorControlCoupleColorTempToLevelMinMireds() : ModelCommand("read")
     {
-        AddArgument("attr-name", "couple-color-temp-to-level-min-mireds");
+        AddArgument("attr-name", "couple-color-temp-to-level-min-mireds", false);
         ModelCommand::AddArguments();
     }
 
@@ -10521,7 +10522,7 @@ class ReadColorControlStartUpColorTemperatureMireds : public ModelCommand
 public:
     ReadColorControlStartUpColorTemperatureMireds() : ModelCommand("read")
     {
-        AddArgument("attr-name", "start-up-color-temperature-mireds");
+        AddArgument("attr-name", "start-up-color-temperature-mireds", false);
         ModelCommand::AddArguments();
     }
 
@@ -10552,8 +10553,8 @@ class WriteColorControlStartUpColorTemperatureMireds : public ModelCommand
 public:
     WriteColorControlStartUpColorTemperatureMireds() : ModelCommand("write")
     {
-        AddArgument("attr-name", "start-up-color-temperature-mireds");
-        AddArgument("attr-value", 0, UINT16_MAX, &mValue);
+        AddArgument("attr-name", "start-up-color-temperature-mireds", false);
+        AddArgument("attr-value", 0, UINT16_MAX, &mValue, false);
         ModelCommand::AddArguments();
     }
 
@@ -10589,7 +10590,7 @@ class ReadColorControlClusterRevision : public ModelCommand
 public:
     ReadColorControlClusterRevision() : ModelCommand("read")
     {
-        AddArgument("attr-name", "cluster-revision");
+        AddArgument("attr-name", "cluster-revision", false);
         ModelCommand::AddArguments();
     }
 
@@ -10636,8 +10637,8 @@ class ContentLauncherLaunchContent : public ModelCommand
 public:
     ContentLauncherLaunchContent() : ModelCommand("launch-content")
     {
-        AddArgument("AutoPlay", 0, 1, &mRequest.autoPlay);
-        AddArgument("Data", &mRequest.data);
+        AddArgument("AutoPlay", 0, 1, &mRequest.autoPlay, false);
+        AddArgument("Data", &mRequest.data, false);
         ModelCommand::AddArguments();
     }
 
@@ -10662,8 +10663,8 @@ class ContentLauncherLaunchURL : public ModelCommand
 public:
     ContentLauncherLaunchURL() : ModelCommand("launch-url")
     {
-        AddArgument("ContentURL", &mRequest.contentURL);
-        AddArgument("DisplayString", &mRequest.displayString);
+        AddArgument("ContentURL", &mRequest.contentURL, false);
+        AddArgument("DisplayString", &mRequest.displayString, false);
         ModelCommand::AddArguments();
     }
 
@@ -10688,7 +10689,7 @@ class ReadContentLauncherAcceptsHeaderList : public ModelCommand
 public:
     ReadContentLauncherAcceptsHeaderList() : ModelCommand("read")
     {
-        AddArgument("attr-name", "accepts-header-list");
+        AddArgument("attr-name", "accepts-header-list", false);
         ModelCommand::AddArguments();
     }
 
@@ -10723,7 +10724,7 @@ class ReadContentLauncherSupportedStreamingTypes : public ModelCommand
 public:
     ReadContentLauncherSupportedStreamingTypes() : ModelCommand("read")
     {
-        AddArgument("attr-name", "supported-streaming-types");
+        AddArgument("attr-name", "supported-streaming-types", false);
         ModelCommand::AddArguments();
     }
 
@@ -10758,7 +10759,7 @@ class ReadContentLauncherClusterRevision : public ModelCommand
 public:
     ReadContentLauncherClusterRevision() : ModelCommand("read")
     {
-        AddArgument("attr-name", "cluster-revision");
+        AddArgument("attr-name", "cluster-revision", false);
         ModelCommand::AddArguments();
     }
 
@@ -10805,7 +10806,7 @@ class ReadDescriptorDeviceList : public ModelCommand
 public:
     ReadDescriptorDeviceList() : ModelCommand("read")
     {
-        AddArgument("attr-name", "device-list");
+        AddArgument("attr-name", "device-list", false);
         ModelCommand::AddArguments();
     }
 
@@ -10839,7 +10840,7 @@ class ReadDescriptorServerList : public ModelCommand
 public:
     ReadDescriptorServerList() : ModelCommand("read")
     {
-        AddArgument("attr-name", "server-list");
+        AddArgument("attr-name", "server-list", false);
         ModelCommand::AddArguments();
     }
 
@@ -10873,7 +10874,7 @@ class ReadDescriptorClientList : public ModelCommand
 public:
     ReadDescriptorClientList() : ModelCommand("read")
     {
-        AddArgument("attr-name", "client-list");
+        AddArgument("attr-name", "client-list", false);
         ModelCommand::AddArguments();
     }
 
@@ -10907,7 +10908,7 @@ class ReadDescriptorPartsList : public ModelCommand
 public:
     ReadDescriptorPartsList() : ModelCommand("read")
     {
-        AddArgument("attr-name", "parts-list");
+        AddArgument("attr-name", "parts-list", false);
         ModelCommand::AddArguments();
     }
 
@@ -10941,7 +10942,7 @@ class ReadDescriptorClusterRevision : public ModelCommand
 public:
     ReadDescriptorClusterRevision() : ModelCommand("read")
     {
-        AddArgument("attr-name", "cluster-revision");
+        AddArgument("attr-name", "cluster-revision", false);
         ModelCommand::AddArguments();
     }
 
@@ -10984,11 +10985,12 @@ class DiagnosticLogsRetrieveLogsRequest : public ModelCommand
 public:
     DiagnosticLogsRetrieveLogsRequest() : ModelCommand("retrieve-logs-request")
     {
-        AddArgument("Intent", 0, UINT8_MAX,
-                    reinterpret_cast<std::underlying_type_t<decltype(mRequest.intent)> *>(&mRequest.intent));
+        AddArgument("Intent", 0, UINT8_MAX, reinterpret_cast<std::underlying_type_t<decltype(mRequest.intent)> *>(&mRequest.intent),
+                    false);
         AddArgument("RequestedProtocol", 0, UINT8_MAX,
-                    reinterpret_cast<std::underlying_type_t<decltype(mRequest.requestedProtocol)> *>(&mRequest.requestedProtocol));
-        AddArgument("TransferFileDesignator", &mRequest.transferFileDesignator);
+                    reinterpret_cast<std::underlying_type_t<decltype(mRequest.requestedProtocol)> *>(&mRequest.requestedProtocol),
+                    false);
+        AddArgument("TransferFileDesignator", &mRequest.transferFileDesignator, false);
         ModelCommand::AddArguments();
     }
 
@@ -11090,7 +11092,7 @@ class DoorLockClearHolidaySchedule : public ModelCommand
 public:
     DoorLockClearHolidaySchedule() : ModelCommand("clear-holiday-schedule")
     {
-        AddArgument("ScheduleId", 0, UINT8_MAX, &mRequest.scheduleId);
+        AddArgument("ScheduleId", 0, UINT8_MAX, &mRequest.scheduleId, false);
         ModelCommand::AddArguments();
     }
 
@@ -11115,7 +11117,7 @@ class DoorLockClearPin : public ModelCommand
 public:
     DoorLockClearPin() : ModelCommand("clear-pin")
     {
-        AddArgument("UserId", 0, UINT16_MAX, &mRequest.userId);
+        AddArgument("UserId", 0, UINT16_MAX, &mRequest.userId, false);
         ModelCommand::AddArguments();
     }
 
@@ -11140,7 +11142,7 @@ class DoorLockClearRfid : public ModelCommand
 public:
     DoorLockClearRfid() : ModelCommand("clear-rfid")
     {
-        AddArgument("UserId", 0, UINT16_MAX, &mRequest.userId);
+        AddArgument("UserId", 0, UINT16_MAX, &mRequest.userId, false);
         ModelCommand::AddArguments();
     }
 
@@ -11165,8 +11167,8 @@ class DoorLockClearWeekdaySchedule : public ModelCommand
 public:
     DoorLockClearWeekdaySchedule() : ModelCommand("clear-weekday-schedule")
     {
-        AddArgument("ScheduleId", 0, UINT8_MAX, &mRequest.scheduleId);
-        AddArgument("UserId", 0, UINT16_MAX, &mRequest.userId);
+        AddArgument("ScheduleId", 0, UINT8_MAX, &mRequest.scheduleId, false);
+        AddArgument("UserId", 0, UINT16_MAX, &mRequest.userId, false);
         ModelCommand::AddArguments();
     }
 
@@ -11191,8 +11193,8 @@ class DoorLockClearYeardaySchedule : public ModelCommand
 public:
     DoorLockClearYeardaySchedule() : ModelCommand("clear-yearday-schedule")
     {
-        AddArgument("ScheduleId", 0, UINT8_MAX, &mRequest.scheduleId);
-        AddArgument("UserId", 0, UINT16_MAX, &mRequest.userId);
+        AddArgument("ScheduleId", 0, UINT8_MAX, &mRequest.scheduleId, false);
+        AddArgument("UserId", 0, UINT16_MAX, &mRequest.userId, false);
         ModelCommand::AddArguments();
     }
 
@@ -11217,7 +11219,7 @@ class DoorLockGetHolidaySchedule : public ModelCommand
 public:
     DoorLockGetHolidaySchedule() : ModelCommand("get-holiday-schedule")
     {
-        AddArgument("ScheduleId", 0, UINT8_MAX, &mRequest.scheduleId);
+        AddArgument("ScheduleId", 0, UINT8_MAX, &mRequest.scheduleId, false);
         ModelCommand::AddArguments();
     }
 
@@ -11242,7 +11244,7 @@ class DoorLockGetLogRecord : public ModelCommand
 public:
     DoorLockGetLogRecord() : ModelCommand("get-log-record")
     {
-        AddArgument("LogIndex", 0, UINT16_MAX, &mRequest.logIndex);
+        AddArgument("LogIndex", 0, UINT16_MAX, &mRequest.logIndex, false);
         ModelCommand::AddArguments();
     }
 
@@ -11267,7 +11269,7 @@ class DoorLockGetPin : public ModelCommand
 public:
     DoorLockGetPin() : ModelCommand("get-pin")
     {
-        AddArgument("UserId", 0, UINT16_MAX, &mRequest.userId);
+        AddArgument("UserId", 0, UINT16_MAX, &mRequest.userId, false);
         ModelCommand::AddArguments();
     }
 
@@ -11292,7 +11294,7 @@ class DoorLockGetRfid : public ModelCommand
 public:
     DoorLockGetRfid() : ModelCommand("get-rfid")
     {
-        AddArgument("UserId", 0, UINT16_MAX, &mRequest.userId);
+        AddArgument("UserId", 0, UINT16_MAX, &mRequest.userId, false);
         ModelCommand::AddArguments();
     }
 
@@ -11317,7 +11319,7 @@ class DoorLockGetUserType : public ModelCommand
 public:
     DoorLockGetUserType() : ModelCommand("get-user-type")
     {
-        AddArgument("UserId", 0, UINT16_MAX, &mRequest.userId);
+        AddArgument("UserId", 0, UINT16_MAX, &mRequest.userId, false);
         ModelCommand::AddArguments();
     }
 
@@ -11342,8 +11344,8 @@ class DoorLockGetWeekdaySchedule : public ModelCommand
 public:
     DoorLockGetWeekdaySchedule() : ModelCommand("get-weekday-schedule")
     {
-        AddArgument("ScheduleId", 0, UINT8_MAX, &mRequest.scheduleId);
-        AddArgument("UserId", 0, UINT16_MAX, &mRequest.userId);
+        AddArgument("ScheduleId", 0, UINT8_MAX, &mRequest.scheduleId, false);
+        AddArgument("UserId", 0, UINT16_MAX, &mRequest.userId, false);
         ModelCommand::AddArguments();
     }
 
@@ -11368,8 +11370,8 @@ class DoorLockGetYeardaySchedule : public ModelCommand
 public:
     DoorLockGetYeardaySchedule() : ModelCommand("get-yearday-schedule")
     {
-        AddArgument("ScheduleId", 0, UINT8_MAX, &mRequest.scheduleId);
-        AddArgument("UserId", 0, UINT16_MAX, &mRequest.userId);
+        AddArgument("ScheduleId", 0, UINT8_MAX, &mRequest.scheduleId, false);
+        AddArgument("UserId", 0, UINT16_MAX, &mRequest.userId, false);
         ModelCommand::AddArguments();
     }
 
@@ -11394,7 +11396,7 @@ class DoorLockLockDoor : public ModelCommand
 public:
     DoorLockLockDoor() : ModelCommand("lock-door")
     {
-        AddArgument("Pin", &mRequest.pin);
+        AddArgument("Pin", &mRequest.pin, false);
         ModelCommand::AddArguments();
     }
 
@@ -11419,10 +11421,10 @@ class DoorLockSetHolidaySchedule : public ModelCommand
 public:
     DoorLockSetHolidaySchedule() : ModelCommand("set-holiday-schedule")
     {
-        AddArgument("ScheduleId", 0, UINT8_MAX, &mRequest.scheduleId);
-        AddArgument("LocalStartTime", 0, UINT32_MAX, &mRequest.localStartTime);
-        AddArgument("LocalEndTime", 0, UINT32_MAX, &mRequest.localEndTime);
-        AddArgument("OperatingModeDuringHoliday", 0, UINT8_MAX, &mRequest.operatingModeDuringHoliday);
+        AddArgument("ScheduleId", 0, UINT8_MAX, &mRequest.scheduleId, false);
+        AddArgument("LocalStartTime", 0, UINT32_MAX, &mRequest.localStartTime, false);
+        AddArgument("LocalEndTime", 0, UINT32_MAX, &mRequest.localEndTime, false);
+        AddArgument("OperatingModeDuringHoliday", 0, UINT8_MAX, &mRequest.operatingModeDuringHoliday, false);
         ModelCommand::AddArguments();
     }
 
@@ -11447,12 +11449,12 @@ class DoorLockSetPin : public ModelCommand
 public:
     DoorLockSetPin() : ModelCommand("set-pin")
     {
-        AddArgument("UserId", 0, UINT16_MAX, &mRequest.userId);
+        AddArgument("UserId", 0, UINT16_MAX, &mRequest.userId, false);
         AddArgument("UserStatus", 0, UINT8_MAX,
-                    reinterpret_cast<std::underlying_type_t<decltype(mRequest.userStatus)> *>(&mRequest.userStatus));
+                    reinterpret_cast<std::underlying_type_t<decltype(mRequest.userStatus)> *>(&mRequest.userStatus), false);
         AddArgument("UserType", 0, UINT8_MAX,
-                    reinterpret_cast<std::underlying_type_t<decltype(mRequest.userType)> *>(&mRequest.userType));
-        AddArgument("Pin", &mRequest.pin);
+                    reinterpret_cast<std::underlying_type_t<decltype(mRequest.userType)> *>(&mRequest.userType), false);
+        AddArgument("Pin", &mRequest.pin, false);
         ModelCommand::AddArguments();
     }
 
@@ -11477,12 +11479,12 @@ class DoorLockSetRfid : public ModelCommand
 public:
     DoorLockSetRfid() : ModelCommand("set-rfid")
     {
-        AddArgument("UserId", 0, UINT16_MAX, &mRequest.userId);
+        AddArgument("UserId", 0, UINT16_MAX, &mRequest.userId, false);
         AddArgument("UserStatus", 0, UINT8_MAX,
-                    reinterpret_cast<std::underlying_type_t<decltype(mRequest.userStatus)> *>(&mRequest.userStatus));
+                    reinterpret_cast<std::underlying_type_t<decltype(mRequest.userStatus)> *>(&mRequest.userStatus), false);
         AddArgument("UserType", 0, UINT8_MAX,
-                    reinterpret_cast<std::underlying_type_t<decltype(mRequest.userType)> *>(&mRequest.userType));
-        AddArgument("Id", &mRequest.id);
+                    reinterpret_cast<std::underlying_type_t<decltype(mRequest.userType)> *>(&mRequest.userType), false);
+        AddArgument("Id", &mRequest.id, false);
         ModelCommand::AddArguments();
     }
 
@@ -11507,9 +11509,9 @@ class DoorLockSetUserType : public ModelCommand
 public:
     DoorLockSetUserType() : ModelCommand("set-user-type")
     {
-        AddArgument("UserId", 0, UINT16_MAX, &mRequest.userId);
+        AddArgument("UserId", 0, UINT16_MAX, &mRequest.userId, false);
         AddArgument("UserType", 0, UINT8_MAX,
-                    reinterpret_cast<std::underlying_type_t<decltype(mRequest.userType)> *>(&mRequest.userType));
+                    reinterpret_cast<std::underlying_type_t<decltype(mRequest.userType)> *>(&mRequest.userType), false);
         ModelCommand::AddArguments();
     }
 
@@ -11534,15 +11536,16 @@ class DoorLockSetWeekdaySchedule : public ModelCommand
 public:
     DoorLockSetWeekdaySchedule() : ModelCommand("set-weekday-schedule")
     {
-        AddArgument("ScheduleId", 0, UINT8_MAX, &mRequest.scheduleId);
-        AddArgument("UserId", 0, UINT16_MAX, &mRequest.userId);
+        AddArgument("ScheduleId", 0, UINT8_MAX, &mRequest.scheduleId, false);
+        AddArgument("UserId", 0, UINT16_MAX, &mRequest.userId, false);
         AddArgument(
             "DaysMask", 0, UINT8_MAX,
-            reinterpret_cast<std::underlying_type_t<chip::app::Clusters::DoorLock::DoorLockDayOfWeek> *>(&mRequest.daysMask));
-        AddArgument("StartHour", 0, UINT8_MAX, &mRequest.startHour);
-        AddArgument("StartMinute", 0, UINT8_MAX, &mRequest.startMinute);
-        AddArgument("EndHour", 0, UINT8_MAX, &mRequest.endHour);
-        AddArgument("EndMinute", 0, UINT8_MAX, &mRequest.endMinute);
+            reinterpret_cast<std::underlying_type_t<chip::app::Clusters::DoorLock::DoorLockDayOfWeek> *>(&mRequest.daysMask),
+            false);
+        AddArgument("StartHour", 0, UINT8_MAX, &mRequest.startHour, false);
+        AddArgument("StartMinute", 0, UINT8_MAX, &mRequest.startMinute, false);
+        AddArgument("EndHour", 0, UINT8_MAX, &mRequest.endHour, false);
+        AddArgument("EndMinute", 0, UINT8_MAX, &mRequest.endMinute, false);
         ModelCommand::AddArguments();
     }
 
@@ -11567,10 +11570,10 @@ class DoorLockSetYeardaySchedule : public ModelCommand
 public:
     DoorLockSetYeardaySchedule() : ModelCommand("set-yearday-schedule")
     {
-        AddArgument("ScheduleId", 0, UINT8_MAX, &mRequest.scheduleId);
-        AddArgument("UserId", 0, UINT16_MAX, &mRequest.userId);
-        AddArgument("LocalStartTime", 0, UINT32_MAX, &mRequest.localStartTime);
-        AddArgument("LocalEndTime", 0, UINT32_MAX, &mRequest.localEndTime);
+        AddArgument("ScheduleId", 0, UINT8_MAX, &mRequest.scheduleId, false);
+        AddArgument("UserId", 0, UINT16_MAX, &mRequest.userId, false);
+        AddArgument("LocalStartTime", 0, UINT32_MAX, &mRequest.localStartTime, false);
+        AddArgument("LocalEndTime", 0, UINT32_MAX, &mRequest.localEndTime, false);
         ModelCommand::AddArguments();
     }
 
@@ -11595,7 +11598,7 @@ class DoorLockUnlockDoor : public ModelCommand
 public:
     DoorLockUnlockDoor() : ModelCommand("unlock-door")
     {
-        AddArgument("Pin", &mRequest.pin);
+        AddArgument("Pin", &mRequest.pin, false);
         ModelCommand::AddArguments();
     }
 
@@ -11620,8 +11623,8 @@ class DoorLockUnlockWithTimeout : public ModelCommand
 public:
     DoorLockUnlockWithTimeout() : ModelCommand("unlock-with-timeout")
     {
-        AddArgument("TimeoutInSeconds", 0, UINT16_MAX, &mRequest.timeoutInSeconds);
-        AddArgument("Pin", &mRequest.pin);
+        AddArgument("TimeoutInSeconds", 0, UINT16_MAX, &mRequest.timeoutInSeconds, false);
+        AddArgument("Pin", &mRequest.pin, false);
         ModelCommand::AddArguments();
     }
 
@@ -11646,7 +11649,7 @@ class ReadDoorLockLockState : public ModelCommand
 public:
     ReadDoorLockLockState() : ModelCommand("read")
     {
-        AddArgument("attr-name", "lock-state");
+        AddArgument("attr-name", "lock-state", false);
         ModelCommand::AddArguments();
     }
 
@@ -11677,10 +11680,10 @@ class ReportDoorLockLockState : public ModelCommand
 public:
     ReportDoorLockLockState() : ModelCommand("report")
     {
-        AddArgument("attr-name", "lock-state");
-        AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
-        AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval);
-        AddArgument("wait", 0, 1, &mWait);
+        AddArgument("attr-name", "lock-state", false);
+        AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval, false);
+        AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval, false);
+        AddArgument("wait", 0, 1, &mWait, false);
         ModelCommand::AddArguments();
     }
 
@@ -11732,7 +11735,7 @@ class ReadDoorLockLockType : public ModelCommand
 public:
     ReadDoorLockLockType() : ModelCommand("read")
     {
-        AddArgument("attr-name", "lock-type");
+        AddArgument("attr-name", "lock-type", false);
         ModelCommand::AddArguments();
     }
 
@@ -11766,7 +11769,7 @@ class ReadDoorLockActuatorEnabled : public ModelCommand
 public:
     ReadDoorLockActuatorEnabled() : ModelCommand("read")
     {
-        AddArgument("attr-name", "actuator-enabled");
+        AddArgument("attr-name", "actuator-enabled", false);
         ModelCommand::AddArguments();
     }
 
@@ -11800,7 +11803,7 @@ class ReadDoorLockClusterRevision : public ModelCommand
 public:
     ReadDoorLockClusterRevision() : ModelCommand("read")
     {
-        AddArgument("attr-name", "cluster-revision");
+        AddArgument("attr-name", "cluster-revision", false);
         ModelCommand::AddArguments();
     }
 
@@ -11854,7 +11857,7 @@ class ReadElectricalMeasurementMeasurementType : public ModelCommand
 public:
     ReadElectricalMeasurementMeasurementType() : ModelCommand("read")
     {
-        AddArgument("attr-name", "measurement-type");
+        AddArgument("attr-name", "measurement-type", false);
         ModelCommand::AddArguments();
     }
 
@@ -11888,7 +11891,7 @@ class ReadElectricalMeasurementTotalActivePower : public ModelCommand
 public:
     ReadElectricalMeasurementTotalActivePower() : ModelCommand("read")
     {
-        AddArgument("attr-name", "total-active-power");
+        AddArgument("attr-name", "total-active-power", false);
         ModelCommand::AddArguments();
     }
 
@@ -11922,7 +11925,7 @@ class ReadElectricalMeasurementRmsVoltage : public ModelCommand
 public:
     ReadElectricalMeasurementRmsVoltage() : ModelCommand("read")
     {
-        AddArgument("attr-name", "rms-voltage");
+        AddArgument("attr-name", "rms-voltage", false);
         ModelCommand::AddArguments();
     }
 
@@ -11956,7 +11959,7 @@ class ReadElectricalMeasurementRmsVoltageMin : public ModelCommand
 public:
     ReadElectricalMeasurementRmsVoltageMin() : ModelCommand("read")
     {
-        AddArgument("attr-name", "rms-voltage-min");
+        AddArgument("attr-name", "rms-voltage-min", false);
         ModelCommand::AddArguments();
     }
 
@@ -11990,7 +11993,7 @@ class ReadElectricalMeasurementRmsVoltageMax : public ModelCommand
 public:
     ReadElectricalMeasurementRmsVoltageMax() : ModelCommand("read")
     {
-        AddArgument("attr-name", "rms-voltage-max");
+        AddArgument("attr-name", "rms-voltage-max", false);
         ModelCommand::AddArguments();
     }
 
@@ -12024,7 +12027,7 @@ class ReadElectricalMeasurementRmsCurrent : public ModelCommand
 public:
     ReadElectricalMeasurementRmsCurrent() : ModelCommand("read")
     {
-        AddArgument("attr-name", "rms-current");
+        AddArgument("attr-name", "rms-current", false);
         ModelCommand::AddArguments();
     }
 
@@ -12058,7 +12061,7 @@ class ReadElectricalMeasurementRmsCurrentMin : public ModelCommand
 public:
     ReadElectricalMeasurementRmsCurrentMin() : ModelCommand("read")
     {
-        AddArgument("attr-name", "rms-current-min");
+        AddArgument("attr-name", "rms-current-min", false);
         ModelCommand::AddArguments();
     }
 
@@ -12092,7 +12095,7 @@ class ReadElectricalMeasurementRmsCurrentMax : public ModelCommand
 public:
     ReadElectricalMeasurementRmsCurrentMax() : ModelCommand("read")
     {
-        AddArgument("attr-name", "rms-current-max");
+        AddArgument("attr-name", "rms-current-max", false);
         ModelCommand::AddArguments();
     }
 
@@ -12126,7 +12129,7 @@ class ReadElectricalMeasurementActivePower : public ModelCommand
 public:
     ReadElectricalMeasurementActivePower() : ModelCommand("read")
     {
-        AddArgument("attr-name", "active-power");
+        AddArgument("attr-name", "active-power", false);
         ModelCommand::AddArguments();
     }
 
@@ -12160,7 +12163,7 @@ class ReadElectricalMeasurementActivePowerMin : public ModelCommand
 public:
     ReadElectricalMeasurementActivePowerMin() : ModelCommand("read")
     {
-        AddArgument("attr-name", "active-power-min");
+        AddArgument("attr-name", "active-power-min", false);
         ModelCommand::AddArguments();
     }
 
@@ -12194,7 +12197,7 @@ class ReadElectricalMeasurementActivePowerMax : public ModelCommand
 public:
     ReadElectricalMeasurementActivePowerMax() : ModelCommand("read")
     {
-        AddArgument("attr-name", "active-power-max");
+        AddArgument("attr-name", "active-power-max", false);
         ModelCommand::AddArguments();
     }
 
@@ -12228,7 +12231,7 @@ class ReadElectricalMeasurementClusterRevision : public ModelCommand
 public:
     ReadElectricalMeasurementClusterRevision() : ModelCommand("read")
     {
-        AddArgument("attr-name", "cluster-revision");
+        AddArgument("attr-name", "cluster-revision", false);
         ModelCommand::AddArguments();
     }
 
@@ -12302,7 +12305,7 @@ class ReadEthernetNetworkDiagnosticsPHYRate : public ModelCommand
 public:
     ReadEthernetNetworkDiagnosticsPHYRate() : ModelCommand("read")
     {
-        AddArgument("attr-name", "phyrate");
+        AddArgument("attr-name", "phyrate", false);
         ModelCommand::AddArguments();
     }
 
@@ -12336,7 +12339,7 @@ class ReadEthernetNetworkDiagnosticsFullDuplex : public ModelCommand
 public:
     ReadEthernetNetworkDiagnosticsFullDuplex() : ModelCommand("read")
     {
-        AddArgument("attr-name", "full-duplex");
+        AddArgument("attr-name", "full-duplex", false);
         ModelCommand::AddArguments();
     }
 
@@ -12370,7 +12373,7 @@ class ReadEthernetNetworkDiagnosticsPacketRxCount : public ModelCommand
 public:
     ReadEthernetNetworkDiagnosticsPacketRxCount() : ModelCommand("read")
     {
-        AddArgument("attr-name", "packet-rx-count");
+        AddArgument("attr-name", "packet-rx-count", false);
         ModelCommand::AddArguments();
     }
 
@@ -12404,7 +12407,7 @@ class ReadEthernetNetworkDiagnosticsPacketTxCount : public ModelCommand
 public:
     ReadEthernetNetworkDiagnosticsPacketTxCount() : ModelCommand("read")
     {
-        AddArgument("attr-name", "packet-tx-count");
+        AddArgument("attr-name", "packet-tx-count", false);
         ModelCommand::AddArguments();
     }
 
@@ -12438,7 +12441,7 @@ class ReadEthernetNetworkDiagnosticsTxErrCount : public ModelCommand
 public:
     ReadEthernetNetworkDiagnosticsTxErrCount() : ModelCommand("read")
     {
-        AddArgument("attr-name", "tx-err-count");
+        AddArgument("attr-name", "tx-err-count", false);
         ModelCommand::AddArguments();
     }
 
@@ -12472,7 +12475,7 @@ class ReadEthernetNetworkDiagnosticsCollisionCount : public ModelCommand
 public:
     ReadEthernetNetworkDiagnosticsCollisionCount() : ModelCommand("read")
     {
-        AddArgument("attr-name", "collision-count");
+        AddArgument("attr-name", "collision-count", false);
         ModelCommand::AddArguments();
     }
 
@@ -12506,7 +12509,7 @@ class ReadEthernetNetworkDiagnosticsOverrunCount : public ModelCommand
 public:
     ReadEthernetNetworkDiagnosticsOverrunCount() : ModelCommand("read")
     {
-        AddArgument("attr-name", "overrun-count");
+        AddArgument("attr-name", "overrun-count", false);
         ModelCommand::AddArguments();
     }
 
@@ -12540,7 +12543,7 @@ class ReadEthernetNetworkDiagnosticsCarrierDetect : public ModelCommand
 public:
     ReadEthernetNetworkDiagnosticsCarrierDetect() : ModelCommand("read")
     {
-        AddArgument("attr-name", "carrier-detect");
+        AddArgument("attr-name", "carrier-detect", false);
         ModelCommand::AddArguments();
     }
 
@@ -12574,7 +12577,7 @@ class ReadEthernetNetworkDiagnosticsTimeSinceReset : public ModelCommand
 public:
     ReadEthernetNetworkDiagnosticsTimeSinceReset() : ModelCommand("read")
     {
-        AddArgument("attr-name", "time-since-reset");
+        AddArgument("attr-name", "time-since-reset", false);
         ModelCommand::AddArguments();
     }
 
@@ -12608,7 +12611,7 @@ class ReadEthernetNetworkDiagnosticsClusterRevision : public ModelCommand
 public:
     ReadEthernetNetworkDiagnosticsClusterRevision() : ModelCommand("read")
     {
-        AddArgument("attr-name", "cluster-revision");
+        AddArgument("attr-name", "cluster-revision", false);
         ModelCommand::AddArguments();
     }
 
@@ -12652,7 +12655,7 @@ class ReadFixedLabelLabelList : public ModelCommand
 public:
     ReadFixedLabelLabelList() : ModelCommand("read")
     {
-        AddArgument("attr-name", "label-list");
+        AddArgument("attr-name", "label-list", false);
         ModelCommand::AddArguments();
     }
 
@@ -12686,7 +12689,7 @@ class ReadFixedLabelClusterRevision : public ModelCommand
 public:
     ReadFixedLabelClusterRevision() : ModelCommand("read")
     {
-        AddArgument("attr-name", "cluster-revision");
+        AddArgument("attr-name", "cluster-revision", false);
         ModelCommand::AddArguments();
     }
 
@@ -12733,7 +12736,7 @@ class ReadFlowMeasurementMeasuredValue : public ModelCommand
 public:
     ReadFlowMeasurementMeasuredValue() : ModelCommand("read")
     {
-        AddArgument("attr-name", "measured-value");
+        AddArgument("attr-name", "measured-value", false);
         ModelCommand::AddArguments();
     }
 
@@ -12767,7 +12770,7 @@ class ReadFlowMeasurementMinMeasuredValue : public ModelCommand
 public:
     ReadFlowMeasurementMinMeasuredValue() : ModelCommand("read")
     {
-        AddArgument("attr-name", "min-measured-value");
+        AddArgument("attr-name", "min-measured-value", false);
         ModelCommand::AddArguments();
     }
 
@@ -12801,7 +12804,7 @@ class ReadFlowMeasurementMaxMeasuredValue : public ModelCommand
 public:
     ReadFlowMeasurementMaxMeasuredValue() : ModelCommand("read")
     {
-        AddArgument("attr-name", "max-measured-value");
+        AddArgument("attr-name", "max-measured-value", false);
         ModelCommand::AddArguments();
     }
 
@@ -12835,7 +12838,7 @@ class ReadFlowMeasurementTolerance : public ModelCommand
 public:
     ReadFlowMeasurementTolerance() : ModelCommand("read")
     {
-        AddArgument("attr-name", "tolerance");
+        AddArgument("attr-name", "tolerance", false);
         ModelCommand::AddArguments();
     }
 
@@ -12869,7 +12872,7 @@ class ReadFlowMeasurementClusterRevision : public ModelCommand
 public:
     ReadFlowMeasurementClusterRevision() : ModelCommand("read")
     {
-        AddArgument("attr-name", "cluster-revision");
+        AddArgument("attr-name", "cluster-revision", false);
         ModelCommand::AddArguments();
     }
 
@@ -12917,9 +12920,9 @@ class GeneralCommissioningArmFailSafe : public ModelCommand
 public:
     GeneralCommissioningArmFailSafe() : ModelCommand("arm-fail-safe")
     {
-        AddArgument("ExpiryLengthSeconds", 0, UINT16_MAX, &mRequest.expiryLengthSeconds);
-        AddArgument("Breadcrumb", 0, UINT64_MAX, &mRequest.breadcrumb);
-        AddArgument("TimeoutMs", 0, UINT32_MAX, &mRequest.timeoutMs);
+        AddArgument("ExpiryLengthSeconds", 0, UINT16_MAX, &mRequest.expiryLengthSeconds, false);
+        AddArgument("Breadcrumb", 0, UINT64_MAX, &mRequest.breadcrumb, false);
+        AddArgument("TimeoutMs", 0, UINT32_MAX, &mRequest.timeoutMs, false);
         ModelCommand::AddArguments();
     }
 
@@ -12966,10 +12969,10 @@ public:
     GeneralCommissioningSetRegulatoryConfig() : ModelCommand("set-regulatory-config")
     {
         AddArgument("Location", 0, UINT8_MAX,
-                    reinterpret_cast<std::underlying_type_t<decltype(mRequest.location)> *>(&mRequest.location));
-        AddArgument("CountryCode", &mRequest.countryCode);
-        AddArgument("Breadcrumb", 0, UINT64_MAX, &mRequest.breadcrumb);
-        AddArgument("TimeoutMs", 0, UINT32_MAX, &mRequest.timeoutMs);
+                    reinterpret_cast<std::underlying_type_t<decltype(mRequest.location)> *>(&mRequest.location), false);
+        AddArgument("CountryCode", &mRequest.countryCode, false);
+        AddArgument("Breadcrumb", 0, UINT64_MAX, &mRequest.breadcrumb, false);
+        AddArgument("TimeoutMs", 0, UINT32_MAX, &mRequest.timeoutMs, false);
         ModelCommand::AddArguments();
     }
 
@@ -12994,7 +12997,7 @@ class ReadGeneralCommissioningBreadcrumb : public ModelCommand
 public:
     ReadGeneralCommissioningBreadcrumb() : ModelCommand("read")
     {
-        AddArgument("attr-name", "breadcrumb");
+        AddArgument("attr-name", "breadcrumb", false);
         ModelCommand::AddArguments();
     }
 
@@ -13025,8 +13028,8 @@ class WriteGeneralCommissioningBreadcrumb : public ModelCommand
 public:
     WriteGeneralCommissioningBreadcrumb() : ModelCommand("write")
     {
-        AddArgument("attr-name", "breadcrumb");
-        AddArgument("attr-value", 0, UINT64_MAX, &mValue);
+        AddArgument("attr-name", "breadcrumb", false);
+        AddArgument("attr-value", 0, UINT64_MAX, &mValue, false);
         ModelCommand::AddArguments();
     }
 
@@ -13061,7 +13064,7 @@ class ReadGeneralCommissioningBasicCommissioningInfoList : public ModelCommand
 public:
     ReadGeneralCommissioningBasicCommissioningInfoList() : ModelCommand("read")
     {
-        AddArgument("attr-name", "basic-commissioning-info-list");
+        AddArgument("attr-name", "basic-commissioning-info-list", false);
         ModelCommand::AddArguments();
     }
 
@@ -13096,7 +13099,7 @@ class ReadGeneralCommissioningClusterRevision : public ModelCommand
 public:
     ReadGeneralCommissioningClusterRevision() : ModelCommand("read")
     {
-        AddArgument("attr-name", "cluster-revision");
+        AddArgument("attr-name", "cluster-revision", false);
         ModelCommand::AddArguments();
     }
 
@@ -13144,7 +13147,7 @@ class ReadGeneralDiagnosticsNetworkInterfaces : public ModelCommand
 public:
     ReadGeneralDiagnosticsNetworkInterfaces() : ModelCommand("read")
     {
-        AddArgument("attr-name", "network-interfaces");
+        AddArgument("attr-name", "network-interfaces", false);
         ModelCommand::AddArguments();
     }
 
@@ -13179,7 +13182,7 @@ class ReadGeneralDiagnosticsRebootCount : public ModelCommand
 public:
     ReadGeneralDiagnosticsRebootCount() : ModelCommand("read")
     {
-        AddArgument("attr-name", "reboot-count");
+        AddArgument("attr-name", "reboot-count", false);
         ModelCommand::AddArguments();
     }
 
@@ -13213,7 +13216,7 @@ class ReadGeneralDiagnosticsUpTime : public ModelCommand
 public:
     ReadGeneralDiagnosticsUpTime() : ModelCommand("read")
     {
-        AddArgument("attr-name", "up-time");
+        AddArgument("attr-name", "up-time", false);
         ModelCommand::AddArguments();
     }
 
@@ -13247,7 +13250,7 @@ class ReadGeneralDiagnosticsTotalOperationalHours : public ModelCommand
 public:
     ReadGeneralDiagnosticsTotalOperationalHours() : ModelCommand("read")
     {
-        AddArgument("attr-name", "total-operational-hours");
+        AddArgument("attr-name", "total-operational-hours", false);
         ModelCommand::AddArguments();
     }
 
@@ -13281,7 +13284,7 @@ class ReadGeneralDiagnosticsBootReasons : public ModelCommand
 public:
     ReadGeneralDiagnosticsBootReasons() : ModelCommand("read")
     {
-        AddArgument("attr-name", "boot-reasons");
+        AddArgument("attr-name", "boot-reasons", false);
         ModelCommand::AddArguments();
     }
 
@@ -13315,7 +13318,7 @@ class ReadGeneralDiagnosticsClusterRevision : public ModelCommand
 public:
     ReadGeneralDiagnosticsClusterRevision() : ModelCommand("read")
     {
-        AddArgument("attr-name", "cluster-revision");
+        AddArgument("attr-name", "cluster-revision", false);
         ModelCommand::AddArguments();
     }
 
@@ -13360,7 +13363,7 @@ class ReadGroupKeyManagementGroups : public ModelCommand
 public:
     ReadGroupKeyManagementGroups() : ModelCommand("read")
     {
-        AddArgument("attr-name", "groups");
+        AddArgument("attr-name", "groups", false);
         ModelCommand::AddArguments();
     }
 
@@ -13395,7 +13398,7 @@ class ReadGroupKeyManagementGroupKeys : public ModelCommand
 public:
     ReadGroupKeyManagementGroupKeys() : ModelCommand("read")
     {
-        AddArgument("attr-name", "group-keys");
+        AddArgument("attr-name", "group-keys", false);
         ModelCommand::AddArguments();
     }
 
@@ -13430,7 +13433,7 @@ class ReadGroupKeyManagementClusterRevision : public ModelCommand
 public:
     ReadGroupKeyManagementClusterRevision() : ModelCommand("read")
     {
-        AddArgument("attr-name", "cluster-revision");
+        AddArgument("attr-name", "cluster-revision", false);
         ModelCommand::AddArguments();
     }
 
@@ -13480,8 +13483,8 @@ class GroupsAddGroup : public ModelCommand
 public:
     GroupsAddGroup() : ModelCommand("add-group")
     {
-        AddArgument("GroupId", 0, UINT16_MAX, &mRequest.groupId);
-        AddArgument("GroupName", &mRequest.groupName);
+        AddArgument("GroupId", 0, UINT16_MAX, &mRequest.groupId, false);
+        AddArgument("GroupName", &mRequest.groupName, false);
         ModelCommand::AddArguments();
     }
 
@@ -13506,8 +13509,8 @@ class GroupsAddGroupIfIdentifying : public ModelCommand
 public:
     GroupsAddGroupIfIdentifying() : ModelCommand("add-group-if-identifying")
     {
-        AddArgument("GroupId", 0, UINT16_MAX, &mRequest.groupId);
-        AddArgument("GroupName", &mRequest.groupName);
+        AddArgument("GroupId", 0, UINT16_MAX, &mRequest.groupId, false);
+        AddArgument("GroupName", &mRequest.groupName, false);
         ModelCommand::AddArguments();
     }
 
@@ -13532,7 +13535,7 @@ class GroupsGetGroupMembership : public ModelCommand
 public:
     GroupsGetGroupMembership() : ModelCommand("get-group-membership")
     {
-        AddArgument("GroupCount", 0, UINT8_MAX, &mRequest.groupCount);
+        AddArgument("GroupCount", 0, UINT8_MAX, &mRequest.groupCount, false);
         // groupList Array parsing is not supported yet
         ModelCommand::AddArguments();
     }
@@ -13579,7 +13582,7 @@ class GroupsRemoveGroup : public ModelCommand
 public:
     GroupsRemoveGroup() : ModelCommand("remove-group")
     {
-        AddArgument("GroupId", 0, UINT16_MAX, &mRequest.groupId);
+        AddArgument("GroupId", 0, UINT16_MAX, &mRequest.groupId, false);
         ModelCommand::AddArguments();
     }
 
@@ -13604,7 +13607,7 @@ class GroupsViewGroup : public ModelCommand
 public:
     GroupsViewGroup() : ModelCommand("view-group")
     {
-        AddArgument("GroupId", 0, UINT16_MAX, &mRequest.groupId);
+        AddArgument("GroupId", 0, UINT16_MAX, &mRequest.groupId, false);
         ModelCommand::AddArguments();
     }
 
@@ -13629,7 +13632,7 @@ class ReadGroupsNameSupport : public ModelCommand
 public:
     ReadGroupsNameSupport() : ModelCommand("read")
     {
-        AddArgument("attr-name", "name-support");
+        AddArgument("attr-name", "name-support", false);
         ModelCommand::AddArguments();
     }
 
@@ -13663,7 +13666,7 @@ class ReadGroupsClusterRevision : public ModelCommand
 public:
     ReadGroupsClusterRevision() : ModelCommand("read")
     {
-        AddArgument("attr-name", "cluster-revision");
+        AddArgument("attr-name", "cluster-revision", false);
         ModelCommand::AddArguments();
     }
 
@@ -13711,7 +13714,7 @@ class IdentifyIdentify : public ModelCommand
 public:
     IdentifyIdentify() : ModelCommand("identify")
     {
-        AddArgument("IdentifyTime", 0, UINT16_MAX, &mRequest.identifyTime);
+        AddArgument("IdentifyTime", 0, UINT16_MAX, &mRequest.identifyTime, false);
         ModelCommand::AddArguments();
     }
 
@@ -13758,9 +13761,10 @@ public:
     IdentifyTriggerEffect() : ModelCommand("trigger-effect")
     {
         AddArgument("EffectIdentifier", 0, UINT8_MAX,
-                    reinterpret_cast<std::underlying_type_t<decltype(mRequest.effectIdentifier)> *>(&mRequest.effectIdentifier));
+                    reinterpret_cast<std::underlying_type_t<decltype(mRequest.effectIdentifier)> *>(&mRequest.effectIdentifier),
+                    false);
         AddArgument("EffectVariant", 0, UINT8_MAX,
-                    reinterpret_cast<std::underlying_type_t<decltype(mRequest.effectVariant)> *>(&mRequest.effectVariant));
+                    reinterpret_cast<std::underlying_type_t<decltype(mRequest.effectVariant)> *>(&mRequest.effectVariant), false);
         ModelCommand::AddArguments();
     }
 
@@ -13785,7 +13789,7 @@ class ReadIdentifyIdentifyTime : public ModelCommand
 public:
     ReadIdentifyIdentifyTime() : ModelCommand("read")
     {
-        AddArgument("attr-name", "identify-time");
+        AddArgument("attr-name", "identify-time", false);
         ModelCommand::AddArguments();
     }
 
@@ -13816,8 +13820,8 @@ class WriteIdentifyIdentifyTime : public ModelCommand
 public:
     WriteIdentifyIdentifyTime() : ModelCommand("write")
     {
-        AddArgument("attr-name", "identify-time");
-        AddArgument("attr-value", 0, UINT16_MAX, &mValue);
+        AddArgument("attr-name", "identify-time", false);
+        AddArgument("attr-value", 0, UINT16_MAX, &mValue, false);
         ModelCommand::AddArguments();
     }
 
@@ -13852,7 +13856,7 @@ class ReadIdentifyIdentifyType : public ModelCommand
 public:
     ReadIdentifyIdentifyType() : ModelCommand("read")
     {
-        AddArgument("attr-name", "identify-type");
+        AddArgument("attr-name", "identify-type", false);
         ModelCommand::AddArguments();
     }
 
@@ -13886,7 +13890,7 @@ class ReadIdentifyClusterRevision : public ModelCommand
 public:
     ReadIdentifyClusterRevision() : ModelCommand("read")
     {
-        AddArgument("attr-name", "cluster-revision");
+        AddArgument("attr-name", "cluster-revision", false);
         ModelCommand::AddArguments();
     }
 
@@ -13934,7 +13938,7 @@ class ReadIlluminanceMeasurementMeasuredValue : public ModelCommand
 public:
     ReadIlluminanceMeasurementMeasuredValue() : ModelCommand("read")
     {
-        AddArgument("attr-name", "measured-value");
+        AddArgument("attr-name", "measured-value", false);
         ModelCommand::AddArguments();
     }
 
@@ -13965,10 +13969,10 @@ class ReportIlluminanceMeasurementMeasuredValue : public ModelCommand
 public:
     ReportIlluminanceMeasurementMeasuredValue() : ModelCommand("report")
     {
-        AddArgument("attr-name", "measured-value");
-        AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
-        AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval);
-        AddArgument("wait", 0, 1, &mWait);
+        AddArgument("attr-name", "measured-value", false);
+        AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval, false);
+        AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval, false);
+        AddArgument("wait", 0, 1, &mWait, false);
         ModelCommand::AddArguments();
     }
 
@@ -14020,7 +14024,7 @@ class ReadIlluminanceMeasurementMinMeasuredValue : public ModelCommand
 public:
     ReadIlluminanceMeasurementMinMeasuredValue() : ModelCommand("read")
     {
-        AddArgument("attr-name", "min-measured-value");
+        AddArgument("attr-name", "min-measured-value", false);
         ModelCommand::AddArguments();
     }
 
@@ -14054,7 +14058,7 @@ class ReadIlluminanceMeasurementMaxMeasuredValue : public ModelCommand
 public:
     ReadIlluminanceMeasurementMaxMeasuredValue() : ModelCommand("read")
     {
-        AddArgument("attr-name", "max-measured-value");
+        AddArgument("attr-name", "max-measured-value", false);
         ModelCommand::AddArguments();
     }
 
@@ -14088,7 +14092,7 @@ class ReadIlluminanceMeasurementTolerance : public ModelCommand
 public:
     ReadIlluminanceMeasurementTolerance() : ModelCommand("read")
     {
-        AddArgument("attr-name", "tolerance");
+        AddArgument("attr-name", "tolerance", false);
         ModelCommand::AddArguments();
     }
 
@@ -14122,7 +14126,7 @@ class ReadIlluminanceMeasurementLightSensorType : public ModelCommand
 public:
     ReadIlluminanceMeasurementLightSensorType() : ModelCommand("read")
     {
-        AddArgument("attr-name", "light-sensor-type");
+        AddArgument("attr-name", "light-sensor-type", false);
         ModelCommand::AddArguments();
     }
 
@@ -14156,7 +14160,7 @@ class ReadIlluminanceMeasurementClusterRevision : public ModelCommand
 public:
     ReadIlluminanceMeasurementClusterRevision() : ModelCommand("read")
     {
-        AddArgument("attr-name", "cluster-revision");
+        AddArgument("attr-name", "cluster-revision", false);
         ModelCommand::AddArguments();
     }
 
@@ -14201,7 +14205,7 @@ public:
     KeypadInputSendKey() : ModelCommand("send-key")
     {
         AddArgument("KeyCode", 0, UINT8_MAX,
-                    reinterpret_cast<std::underlying_type_t<decltype(mRequest.keyCode)> *>(&mRequest.keyCode));
+                    reinterpret_cast<std::underlying_type_t<decltype(mRequest.keyCode)> *>(&mRequest.keyCode), false);
         ModelCommand::AddArguments();
     }
 
@@ -14226,7 +14230,7 @@ class ReadKeypadInputClusterRevision : public ModelCommand
 public:
     ReadKeypadInputClusterRevision() : ModelCommand("read")
     {
-        AddArgument("attr-name", "cluster-revision");
+        AddArgument("attr-name", "cluster-revision", false);
         ModelCommand::AddArguments();
     }
 
@@ -14292,10 +14296,10 @@ public:
     LevelControlMove() : ModelCommand("move")
     {
         AddArgument("MoveMode", 0, UINT8_MAX,
-                    reinterpret_cast<std::underlying_type_t<decltype(mRequest.moveMode)> *>(&mRequest.moveMode));
-        AddArgument("Rate", 0, UINT8_MAX, &mRequest.rate);
-        AddArgument("OptionMask", 0, UINT8_MAX, &mRequest.optionMask);
-        AddArgument("OptionOverride", 0, UINT8_MAX, &mRequest.optionOverride);
+                    reinterpret_cast<std::underlying_type_t<decltype(mRequest.moveMode)> *>(&mRequest.moveMode), false);
+        AddArgument("Rate", 0, UINT8_MAX, &mRequest.rate, false);
+        AddArgument("OptionMask", 0, UINT8_MAX, &mRequest.optionMask, false);
+        AddArgument("OptionOverride", 0, UINT8_MAX, &mRequest.optionOverride, false);
         ModelCommand::AddArguments();
     }
 
@@ -14320,10 +14324,10 @@ class LevelControlMoveToLevel : public ModelCommand
 public:
     LevelControlMoveToLevel() : ModelCommand("move-to-level")
     {
-        AddArgument("Level", 0, UINT8_MAX, &mRequest.level);
-        AddArgument("TransitionTime", 0, UINT16_MAX, &mRequest.transitionTime);
-        AddArgument("OptionMask", 0, UINT8_MAX, &mRequest.optionMask);
-        AddArgument("OptionOverride", 0, UINT8_MAX, &mRequest.optionOverride);
+        AddArgument("Level", 0, UINT8_MAX, &mRequest.level, false);
+        AddArgument("TransitionTime", 0, UINT16_MAX, &mRequest.transitionTime, false);
+        AddArgument("OptionMask", 0, UINT8_MAX, &mRequest.optionMask, false);
+        AddArgument("OptionOverride", 0, UINT8_MAX, &mRequest.optionOverride, false);
         ModelCommand::AddArguments();
     }
 
@@ -14348,8 +14352,8 @@ class LevelControlMoveToLevelWithOnOff : public ModelCommand
 public:
     LevelControlMoveToLevelWithOnOff() : ModelCommand("move-to-level-with-on-off")
     {
-        AddArgument("Level", 0, UINT8_MAX, &mRequest.level);
-        AddArgument("TransitionTime", 0, UINT16_MAX, &mRequest.transitionTime);
+        AddArgument("Level", 0, UINT8_MAX, &mRequest.level, false);
+        AddArgument("TransitionTime", 0, UINT16_MAX, &mRequest.transitionTime, false);
         ModelCommand::AddArguments();
     }
 
@@ -14375,8 +14379,8 @@ public:
     LevelControlMoveWithOnOff() : ModelCommand("move-with-on-off")
     {
         AddArgument("MoveMode", 0, UINT8_MAX,
-                    reinterpret_cast<std::underlying_type_t<decltype(mRequest.moveMode)> *>(&mRequest.moveMode));
-        AddArgument("Rate", 0, UINT8_MAX, &mRequest.rate);
+                    reinterpret_cast<std::underlying_type_t<decltype(mRequest.moveMode)> *>(&mRequest.moveMode), false);
+        AddArgument("Rate", 0, UINT8_MAX, &mRequest.rate, false);
         ModelCommand::AddArguments();
     }
 
@@ -14402,11 +14406,11 @@ public:
     LevelControlStep() : ModelCommand("step")
     {
         AddArgument("StepMode", 0, UINT8_MAX,
-                    reinterpret_cast<std::underlying_type_t<decltype(mRequest.stepMode)> *>(&mRequest.stepMode));
-        AddArgument("StepSize", 0, UINT8_MAX, &mRequest.stepSize);
-        AddArgument("TransitionTime", 0, UINT16_MAX, &mRequest.transitionTime);
-        AddArgument("OptionMask", 0, UINT8_MAX, &mRequest.optionMask);
-        AddArgument("OptionOverride", 0, UINT8_MAX, &mRequest.optionOverride);
+                    reinterpret_cast<std::underlying_type_t<decltype(mRequest.stepMode)> *>(&mRequest.stepMode), false);
+        AddArgument("StepSize", 0, UINT8_MAX, &mRequest.stepSize, false);
+        AddArgument("TransitionTime", 0, UINT16_MAX, &mRequest.transitionTime, false);
+        AddArgument("OptionMask", 0, UINT8_MAX, &mRequest.optionMask, false);
+        AddArgument("OptionOverride", 0, UINT8_MAX, &mRequest.optionOverride, false);
         ModelCommand::AddArguments();
     }
 
@@ -14432,9 +14436,9 @@ public:
     LevelControlStepWithOnOff() : ModelCommand("step-with-on-off")
     {
         AddArgument("StepMode", 0, UINT8_MAX,
-                    reinterpret_cast<std::underlying_type_t<decltype(mRequest.stepMode)> *>(&mRequest.stepMode));
-        AddArgument("StepSize", 0, UINT8_MAX, &mRequest.stepSize);
-        AddArgument("TransitionTime", 0, UINT16_MAX, &mRequest.transitionTime);
+                    reinterpret_cast<std::underlying_type_t<decltype(mRequest.stepMode)> *>(&mRequest.stepMode), false);
+        AddArgument("StepSize", 0, UINT8_MAX, &mRequest.stepSize, false);
+        AddArgument("TransitionTime", 0, UINT16_MAX, &mRequest.transitionTime, false);
         ModelCommand::AddArguments();
     }
 
@@ -14459,8 +14463,8 @@ class LevelControlStop : public ModelCommand
 public:
     LevelControlStop() : ModelCommand("stop")
     {
-        AddArgument("OptionMask", 0, UINT8_MAX, &mRequest.optionMask);
-        AddArgument("OptionOverride", 0, UINT8_MAX, &mRequest.optionOverride);
+        AddArgument("OptionMask", 0, UINT8_MAX, &mRequest.optionMask, false);
+        AddArgument("OptionOverride", 0, UINT8_MAX, &mRequest.optionOverride, false);
         ModelCommand::AddArguments();
     }
 
@@ -14506,7 +14510,7 @@ class ReadLevelControlCurrentLevel : public ModelCommand
 public:
     ReadLevelControlCurrentLevel() : ModelCommand("read")
     {
-        AddArgument("attr-name", "current-level");
+        AddArgument("attr-name", "current-level", false);
         ModelCommand::AddArguments();
     }
 
@@ -14537,10 +14541,10 @@ class ReportLevelControlCurrentLevel : public ModelCommand
 public:
     ReportLevelControlCurrentLevel() : ModelCommand("report")
     {
-        AddArgument("attr-name", "current-level");
-        AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
-        AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval);
-        AddArgument("wait", 0, 1, &mWait);
+        AddArgument("attr-name", "current-level", false);
+        AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval, false);
+        AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval, false);
+        AddArgument("wait", 0, 1, &mWait, false);
         ModelCommand::AddArguments();
     }
 
@@ -14592,7 +14596,7 @@ class ReadLevelControlRemainingTime : public ModelCommand
 public:
     ReadLevelControlRemainingTime() : ModelCommand("read")
     {
-        AddArgument("attr-name", "remaining-time");
+        AddArgument("attr-name", "remaining-time", false);
         ModelCommand::AddArguments();
     }
 
@@ -14626,7 +14630,7 @@ class ReadLevelControlMinLevel : public ModelCommand
 public:
     ReadLevelControlMinLevel() : ModelCommand("read")
     {
-        AddArgument("attr-name", "min-level");
+        AddArgument("attr-name", "min-level", false);
         ModelCommand::AddArguments();
     }
 
@@ -14660,7 +14664,7 @@ class ReadLevelControlMaxLevel : public ModelCommand
 public:
     ReadLevelControlMaxLevel() : ModelCommand("read")
     {
-        AddArgument("attr-name", "max-level");
+        AddArgument("attr-name", "max-level", false);
         ModelCommand::AddArguments();
     }
 
@@ -14694,7 +14698,7 @@ class ReadLevelControlCurrentFrequency : public ModelCommand
 public:
     ReadLevelControlCurrentFrequency() : ModelCommand("read")
     {
-        AddArgument("attr-name", "current-frequency");
+        AddArgument("attr-name", "current-frequency", false);
         ModelCommand::AddArguments();
     }
 
@@ -14728,7 +14732,7 @@ class ReadLevelControlMinFrequency : public ModelCommand
 public:
     ReadLevelControlMinFrequency() : ModelCommand("read")
     {
-        AddArgument("attr-name", "min-frequency");
+        AddArgument("attr-name", "min-frequency", false);
         ModelCommand::AddArguments();
     }
 
@@ -14762,7 +14766,7 @@ class ReadLevelControlMaxFrequency : public ModelCommand
 public:
     ReadLevelControlMaxFrequency() : ModelCommand("read")
     {
-        AddArgument("attr-name", "max-frequency");
+        AddArgument("attr-name", "max-frequency", false);
         ModelCommand::AddArguments();
     }
 
@@ -14796,7 +14800,7 @@ class ReadLevelControlOptions : public ModelCommand
 public:
     ReadLevelControlOptions() : ModelCommand("read")
     {
-        AddArgument("attr-name", "options");
+        AddArgument("attr-name", "options", false);
         ModelCommand::AddArguments();
     }
 
@@ -14827,8 +14831,8 @@ class WriteLevelControlOptions : public ModelCommand
 public:
     WriteLevelControlOptions() : ModelCommand("write")
     {
-        AddArgument("attr-name", "options");
-        AddArgument("attr-value", 0, UINT8_MAX, &mValue);
+        AddArgument("attr-name", "options", false);
+        AddArgument("attr-value", 0, UINT8_MAX, &mValue, false);
         ModelCommand::AddArguments();
     }
 
@@ -14863,7 +14867,7 @@ class ReadLevelControlOnOffTransitionTime : public ModelCommand
 public:
     ReadLevelControlOnOffTransitionTime() : ModelCommand("read")
     {
-        AddArgument("attr-name", "on-off-transition-time");
+        AddArgument("attr-name", "on-off-transition-time", false);
         ModelCommand::AddArguments();
     }
 
@@ -14894,8 +14898,8 @@ class WriteLevelControlOnOffTransitionTime : public ModelCommand
 public:
     WriteLevelControlOnOffTransitionTime() : ModelCommand("write")
     {
-        AddArgument("attr-name", "on-off-transition-time");
-        AddArgument("attr-value", 0, UINT16_MAX, &mValue);
+        AddArgument("attr-name", "on-off-transition-time", false);
+        AddArgument("attr-value", 0, UINT16_MAX, &mValue, false);
         ModelCommand::AddArguments();
     }
 
@@ -14930,7 +14934,7 @@ class ReadLevelControlOnLevel : public ModelCommand
 public:
     ReadLevelControlOnLevel() : ModelCommand("read")
     {
-        AddArgument("attr-name", "on-level");
+        AddArgument("attr-name", "on-level", false);
         ModelCommand::AddArguments();
     }
 
@@ -14961,8 +14965,8 @@ class WriteLevelControlOnLevel : public ModelCommand
 public:
     WriteLevelControlOnLevel() : ModelCommand("write")
     {
-        AddArgument("attr-name", "on-level");
-        AddArgument("attr-value", 0, UINT8_MAX, &mValue);
+        AddArgument("attr-name", "on-level", false);
+        AddArgument("attr-value", 0, UINT8_MAX, &mValue, false);
         ModelCommand::AddArguments();
     }
 
@@ -14997,7 +15001,7 @@ class ReadLevelControlOnTransitionTime : public ModelCommand
 public:
     ReadLevelControlOnTransitionTime() : ModelCommand("read")
     {
-        AddArgument("attr-name", "on-transition-time");
+        AddArgument("attr-name", "on-transition-time", false);
         ModelCommand::AddArguments();
     }
 
@@ -15028,8 +15032,8 @@ class WriteLevelControlOnTransitionTime : public ModelCommand
 public:
     WriteLevelControlOnTransitionTime() : ModelCommand("write")
     {
-        AddArgument("attr-name", "on-transition-time");
-        AddArgument("attr-value", 0, UINT16_MAX, &mValue);
+        AddArgument("attr-name", "on-transition-time", false);
+        AddArgument("attr-value", 0, UINT16_MAX, &mValue, false);
         ModelCommand::AddArguments();
     }
 
@@ -15064,7 +15068,7 @@ class ReadLevelControlOffTransitionTime : public ModelCommand
 public:
     ReadLevelControlOffTransitionTime() : ModelCommand("read")
     {
-        AddArgument("attr-name", "off-transition-time");
+        AddArgument("attr-name", "off-transition-time", false);
         ModelCommand::AddArguments();
     }
 
@@ -15095,8 +15099,8 @@ class WriteLevelControlOffTransitionTime : public ModelCommand
 public:
     WriteLevelControlOffTransitionTime() : ModelCommand("write")
     {
-        AddArgument("attr-name", "off-transition-time");
-        AddArgument("attr-value", 0, UINT16_MAX, &mValue);
+        AddArgument("attr-name", "off-transition-time", false);
+        AddArgument("attr-value", 0, UINT16_MAX, &mValue, false);
         ModelCommand::AddArguments();
     }
 
@@ -15131,7 +15135,7 @@ class ReadLevelControlDefaultMoveRate : public ModelCommand
 public:
     ReadLevelControlDefaultMoveRate() : ModelCommand("read")
     {
-        AddArgument("attr-name", "default-move-rate");
+        AddArgument("attr-name", "default-move-rate", false);
         ModelCommand::AddArguments();
     }
 
@@ -15162,8 +15166,8 @@ class WriteLevelControlDefaultMoveRate : public ModelCommand
 public:
     WriteLevelControlDefaultMoveRate() : ModelCommand("write")
     {
-        AddArgument("attr-name", "default-move-rate");
-        AddArgument("attr-value", 0, UINT8_MAX, &mValue);
+        AddArgument("attr-name", "default-move-rate", false);
+        AddArgument("attr-value", 0, UINT8_MAX, &mValue, false);
         ModelCommand::AddArguments();
     }
 
@@ -15198,7 +15202,7 @@ class ReadLevelControlStartUpCurrentLevel : public ModelCommand
 public:
     ReadLevelControlStartUpCurrentLevel() : ModelCommand("read")
     {
-        AddArgument("attr-name", "start-up-current-level");
+        AddArgument("attr-name", "start-up-current-level", false);
         ModelCommand::AddArguments();
     }
 
@@ -15229,8 +15233,8 @@ class WriteLevelControlStartUpCurrentLevel : public ModelCommand
 public:
     WriteLevelControlStartUpCurrentLevel() : ModelCommand("write")
     {
-        AddArgument("attr-name", "start-up-current-level");
-        AddArgument("attr-value", 0, UINT8_MAX, &mValue);
+        AddArgument("attr-name", "start-up-current-level", false);
+        AddArgument("attr-value", 0, UINT8_MAX, &mValue, false);
         ModelCommand::AddArguments();
     }
 
@@ -15265,7 +15269,7 @@ class ReadLevelControlClusterRevision : public ModelCommand
 public:
     ReadLevelControlClusterRevision() : ModelCommand("read")
     {
-        AddArgument("attr-name", "cluster-revision");
+        AddArgument("attr-name", "cluster-revision", false);
         ModelCommand::AddArguments();
     }
 
@@ -15330,7 +15334,7 @@ class ReadLowPowerClusterRevision : public ModelCommand
 public:
     ReadLowPowerClusterRevision() : ModelCommand("read")
     {
-        AddArgument("attr-name", "cluster-revision");
+        AddArgument("attr-name", "cluster-revision", false);
         ModelCommand::AddArguments();
     }
 
@@ -15400,8 +15404,8 @@ class MediaInputRenameInput : public ModelCommand
 public:
     MediaInputRenameInput() : ModelCommand("rename-input")
     {
-        AddArgument("Index", 0, UINT8_MAX, &mRequest.index);
-        AddArgument("Name", &mRequest.name);
+        AddArgument("Index", 0, UINT8_MAX, &mRequest.index, false);
+        AddArgument("Name", &mRequest.name, false);
         ModelCommand::AddArguments();
     }
 
@@ -15426,7 +15430,7 @@ class MediaInputSelectInput : public ModelCommand
 public:
     MediaInputSelectInput() : ModelCommand("select-input")
     {
-        AddArgument("Index", 0, UINT8_MAX, &mRequest.index);
+        AddArgument("Index", 0, UINT8_MAX, &mRequest.index, false);
         ModelCommand::AddArguments();
     }
 
@@ -15472,7 +15476,7 @@ class ReadMediaInputMediaInputList : public ModelCommand
 public:
     ReadMediaInputMediaInputList() : ModelCommand("read")
     {
-        AddArgument("attr-name", "media-input-list");
+        AddArgument("attr-name", "media-input-list", false);
         ModelCommand::AddArguments();
     }
 
@@ -15507,7 +15511,7 @@ class ReadMediaInputCurrentMediaInput : public ModelCommand
 public:
     ReadMediaInputCurrentMediaInput() : ModelCommand("read")
     {
-        AddArgument("attr-name", "current-media-input");
+        AddArgument("attr-name", "current-media-input", false);
         ModelCommand::AddArguments();
     }
 
@@ -15541,7 +15545,7 @@ class ReadMediaInputClusterRevision : public ModelCommand
 public:
     ReadMediaInputClusterRevision() : ModelCommand("read")
     {
-        AddArgument("attr-name", "cluster-revision");
+        AddArgument("attr-name", "cluster-revision", false);
         ModelCommand::AddArguments();
     }
 
@@ -15729,7 +15733,7 @@ class MediaPlaybackMediaSeek : public ModelCommand
 public:
     MediaPlaybackMediaSeek() : ModelCommand("media-seek")
     {
-        AddArgument("Position", 0, UINT64_MAX, &mRequest.position);
+        AddArgument("Position", 0, UINT64_MAX, &mRequest.position, false);
         ModelCommand::AddArguments();
     }
 
@@ -15754,7 +15758,7 @@ class MediaPlaybackMediaSkipBackward : public ModelCommand
 public:
     MediaPlaybackMediaSkipBackward() : ModelCommand("media-skip-backward")
     {
-        AddArgument("DeltaPositionMilliseconds", 0, UINT64_MAX, &mRequest.deltaPositionMilliseconds);
+        AddArgument("DeltaPositionMilliseconds", 0, UINT64_MAX, &mRequest.deltaPositionMilliseconds, false);
         ModelCommand::AddArguments();
     }
 
@@ -15779,7 +15783,7 @@ class MediaPlaybackMediaSkipForward : public ModelCommand
 public:
     MediaPlaybackMediaSkipForward() : ModelCommand("media-skip-forward")
     {
-        AddArgument("DeltaPositionMilliseconds", 0, UINT64_MAX, &mRequest.deltaPositionMilliseconds);
+        AddArgument("DeltaPositionMilliseconds", 0, UINT64_MAX, &mRequest.deltaPositionMilliseconds, false);
         ModelCommand::AddArguments();
     }
 
@@ -15846,7 +15850,7 @@ class ReadMediaPlaybackPlaybackState : public ModelCommand
 public:
     ReadMediaPlaybackPlaybackState() : ModelCommand("read")
     {
-        AddArgument("attr-name", "playback-state");
+        AddArgument("attr-name", "playback-state", false);
         ModelCommand::AddArguments();
     }
 
@@ -15880,7 +15884,7 @@ class ReadMediaPlaybackStartTime : public ModelCommand
 public:
     ReadMediaPlaybackStartTime() : ModelCommand("read")
     {
-        AddArgument("attr-name", "start-time");
+        AddArgument("attr-name", "start-time", false);
         ModelCommand::AddArguments();
     }
 
@@ -15914,7 +15918,7 @@ class ReadMediaPlaybackDuration : public ModelCommand
 public:
     ReadMediaPlaybackDuration() : ModelCommand("read")
     {
-        AddArgument("attr-name", "duration");
+        AddArgument("attr-name", "duration", false);
         ModelCommand::AddArguments();
     }
 
@@ -15948,7 +15952,7 @@ class ReadMediaPlaybackPositionUpdatedAt : public ModelCommand
 public:
     ReadMediaPlaybackPositionUpdatedAt() : ModelCommand("read")
     {
-        AddArgument("attr-name", "position-updated-at");
+        AddArgument("attr-name", "position-updated-at", false);
         ModelCommand::AddArguments();
     }
 
@@ -15982,7 +15986,7 @@ class ReadMediaPlaybackPosition : public ModelCommand
 public:
     ReadMediaPlaybackPosition() : ModelCommand("read")
     {
-        AddArgument("attr-name", "position");
+        AddArgument("attr-name", "position", false);
         ModelCommand::AddArguments();
     }
 
@@ -16016,7 +16020,7 @@ class ReadMediaPlaybackPlaybackSpeed : public ModelCommand
 public:
     ReadMediaPlaybackPlaybackSpeed() : ModelCommand("read")
     {
-        AddArgument("attr-name", "playback-speed");
+        AddArgument("attr-name", "playback-speed", false);
         ModelCommand::AddArguments();
     }
 
@@ -16050,7 +16054,7 @@ class ReadMediaPlaybackSeekRangeEnd : public ModelCommand
 public:
     ReadMediaPlaybackSeekRangeEnd() : ModelCommand("read")
     {
-        AddArgument("attr-name", "seek-range-end");
+        AddArgument("attr-name", "seek-range-end", false);
         ModelCommand::AddArguments();
     }
 
@@ -16084,7 +16088,7 @@ class ReadMediaPlaybackSeekRangeStart : public ModelCommand
 public:
     ReadMediaPlaybackSeekRangeStart() : ModelCommand("read")
     {
-        AddArgument("attr-name", "seek-range-start");
+        AddArgument("attr-name", "seek-range-start", false);
         ModelCommand::AddArguments();
     }
 
@@ -16118,7 +16122,7 @@ class ReadMediaPlaybackClusterRevision : public ModelCommand
 public:
     ReadMediaPlaybackClusterRevision() : ModelCommand("read")
     {
-        AddArgument("attr-name", "cluster-revision");
+        AddArgument("attr-name", "cluster-revision", false);
         ModelCommand::AddArguments();
     }
 
@@ -16167,7 +16171,7 @@ class ModeSelectChangeToMode : public ModelCommand
 public:
     ModeSelectChangeToMode() : ModelCommand("change-to-mode")
     {
-        AddArgument("NewMode", 0, UINT8_MAX, &mRequest.newMode);
+        AddArgument("NewMode", 0, UINT8_MAX, &mRequest.newMode, false);
         ModelCommand::AddArguments();
     }
 
@@ -16192,7 +16196,7 @@ class ReadModeSelectCurrentMode : public ModelCommand
 public:
     ReadModeSelectCurrentMode() : ModelCommand("read")
     {
-        AddArgument("attr-name", "current-mode");
+        AddArgument("attr-name", "current-mode", false);
         ModelCommand::AddArguments();
     }
 
@@ -16223,10 +16227,10 @@ class ReportModeSelectCurrentMode : public ModelCommand
 public:
     ReportModeSelectCurrentMode() : ModelCommand("report")
     {
-        AddArgument("attr-name", "current-mode");
-        AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
-        AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval);
-        AddArgument("wait", 0, 1, &mWait);
+        AddArgument("attr-name", "current-mode", false);
+        AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval, false);
+        AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval, false);
+        AddArgument("wait", 0, 1, &mWait, false);
         ModelCommand::AddArguments();
     }
 
@@ -16278,7 +16282,7 @@ class ReadModeSelectSupportedModes : public ModelCommand
 public:
     ReadModeSelectSupportedModes() : ModelCommand("read")
     {
-        AddArgument("attr-name", "supported-modes");
+        AddArgument("attr-name", "supported-modes", false);
         ModelCommand::AddArguments();
     }
 
@@ -16313,7 +16317,7 @@ class ReadModeSelectOnMode : public ModelCommand
 public:
     ReadModeSelectOnMode() : ModelCommand("read")
     {
-        AddArgument("attr-name", "on-mode");
+        AddArgument("attr-name", "on-mode", false);
         ModelCommand::AddArguments();
     }
 
@@ -16344,8 +16348,8 @@ class WriteModeSelectOnMode : public ModelCommand
 public:
     WriteModeSelectOnMode() : ModelCommand("write")
     {
-        AddArgument("attr-name", "on-mode");
-        AddArgument("attr-value", 0, UINT8_MAX, &mValue);
+        AddArgument("attr-name", "on-mode", false);
+        AddArgument("attr-value", 0, UINT8_MAX, &mValue, false);
         ModelCommand::AddArguments();
     }
 
@@ -16380,7 +16384,7 @@ class ReadModeSelectStartUpMode : public ModelCommand
 public:
     ReadModeSelectStartUpMode() : ModelCommand("read")
     {
-        AddArgument("attr-name", "start-up-mode");
+        AddArgument("attr-name", "start-up-mode", false);
         ModelCommand::AddArguments();
     }
 
@@ -16414,7 +16418,7 @@ class ReadModeSelectDescription : public ModelCommand
 public:
     ReadModeSelectDescription() : ModelCommand("read")
     {
-        AddArgument("attr-name", "description");
+        AddArgument("attr-name", "description", false);
         ModelCommand::AddArguments();
     }
 
@@ -16448,7 +16452,7 @@ class ReadModeSelectClusterRevision : public ModelCommand
 public:
     ReadModeSelectClusterRevision() : ModelCommand("read")
     {
-        AddArgument("attr-name", "cluster-revision");
+        AddArgument("attr-name", "cluster-revision", false);
         ModelCommand::AddArguments();
     }
 
@@ -16500,9 +16504,9 @@ class NetworkCommissioningAddThreadNetwork : public ModelCommand
 public:
     NetworkCommissioningAddThreadNetwork() : ModelCommand("add-thread-network")
     {
-        AddArgument("OperationalDataset", &mRequest.operationalDataset);
-        AddArgument("Breadcrumb", 0, UINT64_MAX, &mRequest.breadcrumb);
-        AddArgument("TimeoutMs", 0, UINT32_MAX, &mRequest.timeoutMs);
+        AddArgument("OperationalDataset", &mRequest.operationalDataset, false);
+        AddArgument("Breadcrumb", 0, UINT64_MAX, &mRequest.breadcrumb, false);
+        AddArgument("TimeoutMs", 0, UINT32_MAX, &mRequest.timeoutMs, false);
         ModelCommand::AddArguments();
     }
 
@@ -16527,10 +16531,10 @@ class NetworkCommissioningAddWiFiNetwork : public ModelCommand
 public:
     NetworkCommissioningAddWiFiNetwork() : ModelCommand("add-wi-fi-network")
     {
-        AddArgument("Ssid", &mRequest.ssid);
-        AddArgument("Credentials", &mRequest.credentials);
-        AddArgument("Breadcrumb", 0, UINT64_MAX, &mRequest.breadcrumb);
-        AddArgument("TimeoutMs", 0, UINT32_MAX, &mRequest.timeoutMs);
+        AddArgument("Ssid", &mRequest.ssid, false);
+        AddArgument("Credentials", &mRequest.credentials, false);
+        AddArgument("Breadcrumb", 0, UINT64_MAX, &mRequest.breadcrumb, false);
+        AddArgument("TimeoutMs", 0, UINT32_MAX, &mRequest.timeoutMs, false);
         ModelCommand::AddArguments();
     }
 
@@ -16555,9 +16559,9 @@ class NetworkCommissioningDisableNetwork : public ModelCommand
 public:
     NetworkCommissioningDisableNetwork() : ModelCommand("disable-network")
     {
-        AddArgument("NetworkID", &mRequest.networkID);
-        AddArgument("Breadcrumb", 0, UINT64_MAX, &mRequest.breadcrumb);
-        AddArgument("TimeoutMs", 0, UINT32_MAX, &mRequest.timeoutMs);
+        AddArgument("NetworkID", &mRequest.networkID, false);
+        AddArgument("Breadcrumb", 0, UINT64_MAX, &mRequest.breadcrumb, false);
+        AddArgument("TimeoutMs", 0, UINT32_MAX, &mRequest.timeoutMs, false);
         ModelCommand::AddArguments();
     }
 
@@ -16582,9 +16586,9 @@ class NetworkCommissioningEnableNetwork : public ModelCommand
 public:
     NetworkCommissioningEnableNetwork() : ModelCommand("enable-network")
     {
-        AddArgument("NetworkID", &mRequest.networkID);
-        AddArgument("Breadcrumb", 0, UINT64_MAX, &mRequest.breadcrumb);
-        AddArgument("TimeoutMs", 0, UINT32_MAX, &mRequest.timeoutMs);
+        AddArgument("NetworkID", &mRequest.networkID, false);
+        AddArgument("Breadcrumb", 0, UINT64_MAX, &mRequest.breadcrumb, false);
+        AddArgument("TimeoutMs", 0, UINT32_MAX, &mRequest.timeoutMs, false);
         ModelCommand::AddArguments();
     }
 
@@ -16609,9 +16613,9 @@ class NetworkCommissioningRemoveNetwork : public ModelCommand
 public:
     NetworkCommissioningRemoveNetwork() : ModelCommand("remove-network")
     {
-        AddArgument("NetworkID", &mRequest.networkID);
-        AddArgument("Breadcrumb", 0, UINT64_MAX, &mRequest.breadcrumb);
-        AddArgument("TimeoutMs", 0, UINT32_MAX, &mRequest.timeoutMs);
+        AddArgument("NetworkID", &mRequest.networkID, false);
+        AddArgument("Breadcrumb", 0, UINT64_MAX, &mRequest.breadcrumb, false);
+        AddArgument("TimeoutMs", 0, UINT32_MAX, &mRequest.timeoutMs, false);
         ModelCommand::AddArguments();
     }
 
@@ -16636,9 +16640,9 @@ class NetworkCommissioningScanNetworks : public ModelCommand
 public:
     NetworkCommissioningScanNetworks() : ModelCommand("scan-networks")
     {
-        AddArgument("Ssid", &mRequest.ssid);
-        AddArgument("Breadcrumb", 0, UINT64_MAX, &mRequest.breadcrumb);
-        AddArgument("TimeoutMs", 0, UINT32_MAX, &mRequest.timeoutMs);
+        AddArgument("Ssid", &mRequest.ssid, false);
+        AddArgument("Breadcrumb", 0, UINT64_MAX, &mRequest.breadcrumb, false);
+        AddArgument("TimeoutMs", 0, UINT32_MAX, &mRequest.timeoutMs, false);
         ModelCommand::AddArguments();
     }
 
@@ -16663,9 +16667,9 @@ class NetworkCommissioningUpdateThreadNetwork : public ModelCommand
 public:
     NetworkCommissioningUpdateThreadNetwork() : ModelCommand("update-thread-network")
     {
-        AddArgument("OperationalDataset", &mRequest.operationalDataset);
-        AddArgument("Breadcrumb", 0, UINT64_MAX, &mRequest.breadcrumb);
-        AddArgument("TimeoutMs", 0, UINT32_MAX, &mRequest.timeoutMs);
+        AddArgument("OperationalDataset", &mRequest.operationalDataset, false);
+        AddArgument("Breadcrumb", 0, UINT64_MAX, &mRequest.breadcrumb, false);
+        AddArgument("TimeoutMs", 0, UINT32_MAX, &mRequest.timeoutMs, false);
         ModelCommand::AddArguments();
     }
 
@@ -16690,10 +16694,10 @@ class NetworkCommissioningUpdateWiFiNetwork : public ModelCommand
 public:
     NetworkCommissioningUpdateWiFiNetwork() : ModelCommand("update-wi-fi-network")
     {
-        AddArgument("Ssid", &mRequest.ssid);
-        AddArgument("Credentials", &mRequest.credentials);
-        AddArgument("Breadcrumb", 0, UINT64_MAX, &mRequest.breadcrumb);
-        AddArgument("TimeoutMs", 0, UINT32_MAX, &mRequest.timeoutMs);
+        AddArgument("Ssid", &mRequest.ssid, false);
+        AddArgument("Credentials", &mRequest.credentials, false);
+        AddArgument("Breadcrumb", 0, UINT64_MAX, &mRequest.breadcrumb, false);
+        AddArgument("TimeoutMs", 0, UINT32_MAX, &mRequest.timeoutMs, false);
         ModelCommand::AddArguments();
     }
 
@@ -16718,7 +16722,7 @@ class ReadNetworkCommissioningFeatureMap : public ModelCommand
 public:
     ReadNetworkCommissioningFeatureMap() : ModelCommand("read")
     {
-        AddArgument("attr-name", "feature-map");
+        AddArgument("attr-name", "feature-map", false);
         ModelCommand::AddArguments();
     }
 
@@ -16752,7 +16756,7 @@ class ReadNetworkCommissioningClusterRevision : public ModelCommand
 public:
     ReadNetworkCommissioningClusterRevision() : ModelCommand("read")
     {
-        AddArgument("attr-name", "cluster-revision");
+        AddArgument("attr-name", "cluster-revision", false);
         ModelCommand::AddArguments();
     }
 
@@ -16798,8 +16802,8 @@ class OtaSoftwareUpdateProviderApplyUpdateRequest : public ModelCommand
 public:
     OtaSoftwareUpdateProviderApplyUpdateRequest() : ModelCommand("apply-update-request")
     {
-        AddArgument("UpdateToken", &mRequest.updateToken);
-        AddArgument("NewVersion", 0, UINT32_MAX, &mRequest.newVersion);
+        AddArgument("UpdateToken", &mRequest.updateToken, false);
+        AddArgument("NewVersion", 0, UINT32_MAX, &mRequest.newVersion, false);
         ModelCommand::AddArguments();
     }
 
@@ -16824,8 +16828,8 @@ class OtaSoftwareUpdateProviderNotifyUpdateApplied : public ModelCommand
 public:
     OtaSoftwareUpdateProviderNotifyUpdateApplied() : ModelCommand("notify-update-applied")
     {
-        AddArgument("UpdateToken", &mRequest.updateToken);
-        AddArgument("SoftwareVersion", 0, UINT32_MAX, &mRequest.softwareVersion);
+        AddArgument("UpdateToken", &mRequest.updateToken, false);
+        AddArgument("SoftwareVersion", 0, UINT32_MAX, &mRequest.softwareVersion, false);
         ModelCommand::AddArguments();
     }
 
@@ -16850,14 +16854,14 @@ class OtaSoftwareUpdateProviderQueryImage : public ModelCommand
 public:
     OtaSoftwareUpdateProviderQueryImage() : ModelCommand("query-image")
     {
-        AddArgument("VendorId", 0, UINT16_MAX, &mRequest.vendorId);
-        AddArgument("ProductId", 0, UINT16_MAX, &mRequest.productId);
-        AddArgument("SoftwareVersion", 0, UINT32_MAX, &mRequest.softwareVersion);
+        AddArgument("VendorId", 0, UINT16_MAX, &mRequest.vendorId, false);
+        AddArgument("ProductId", 0, UINT16_MAX, &mRequest.productId, false);
+        AddArgument("SoftwareVersion", 0, UINT32_MAX, &mRequest.softwareVersion, false);
         // protocolsSupported Array parsing is not supported yet
-        AddArgument("HardwareVersion", 0, UINT16_MAX, &mRequest.hardwareVersion);
-        AddArgument("Location", &mRequest.location);
-        AddArgument("RequestorCanConsent", 0, 1, &mRequest.requestorCanConsent);
-        AddArgument("MetadataForProvider", &mRequest.metadataForProvider);
+        AddArgument("HardwareVersion", 0, UINT16_MAX, &mRequest.hardwareVersion, false);
+        AddArgument("Location", &mRequest.location, false);
+        AddArgument("RequestorCanConsent", 0, 1, &mRequest.requestorCanConsent, false);
+        AddArgument("MetadataForProvider", &mRequest.metadataForProvider, false);
         ModelCommand::AddArguments();
     }
 
@@ -16882,7 +16886,7 @@ class ReadOtaSoftwareUpdateProviderClusterRevision : public ModelCommand
 public:
     ReadOtaSoftwareUpdateProviderClusterRevision() : ModelCommand("read")
     {
-        AddArgument("attr-name", "cluster-revision");
+        AddArgument("attr-name", "cluster-revision", false);
         ModelCommand::AddArguments();
     }
 
@@ -16928,12 +16932,12 @@ class OtaSoftwareUpdateRequestorAnnounceOtaProvider : public ModelCommand
 public:
     OtaSoftwareUpdateRequestorAnnounceOtaProvider() : ModelCommand("announce-ota-provider")
     {
-        AddArgument("ProviderLocation", 0, UINT64_MAX, &mRequest.providerLocation);
-        AddArgument("VendorId", 0, UINT16_MAX, &mRequest.vendorId);
-        AddArgument(
-            "AnnouncementReason", 0, UINT8_MAX,
-            reinterpret_cast<std::underlying_type_t<decltype(mRequest.announcementReason)> *>(&mRequest.announcementReason));
-        AddArgument("MetadataForNode", &mRequest.metadataForNode);
+        AddArgument("ProviderLocation", 0, UINT64_MAX, &mRequest.providerLocation, false);
+        AddArgument("VendorId", 0, UINT16_MAX, &mRequest.vendorId, false);
+        AddArgument("AnnouncementReason", 0, UINT8_MAX,
+                    reinterpret_cast<std::underlying_type_t<decltype(mRequest.announcementReason)> *>(&mRequest.announcementReason),
+                    false);
+        AddArgument("MetadataForNode", &mRequest.metadataForNode, false);
         ModelCommand::AddArguments();
     }
 
@@ -16958,7 +16962,7 @@ class ReadOtaSoftwareUpdateRequestorDefaultOtaProvider : public ModelCommand
 public:
     ReadOtaSoftwareUpdateRequestorDefaultOtaProvider() : ModelCommand("read")
     {
-        AddArgument("attr-name", "default-ota-provider");
+        AddArgument("attr-name", "default-ota-provider", false);
         ModelCommand::AddArguments();
     }
 
@@ -16989,8 +16993,8 @@ class WriteOtaSoftwareUpdateRequestorDefaultOtaProvider : public ModelCommand
 public:
     WriteOtaSoftwareUpdateRequestorDefaultOtaProvider() : ModelCommand("write")
     {
-        AddArgument("attr-name", "default-ota-provider");
-        AddArgument("attr-value", &mValue);
+        AddArgument("attr-name", "default-ota-provider", false);
+        AddArgument("attr-value", &mValue, false);
         ModelCommand::AddArguments();
     }
 
@@ -17025,7 +17029,7 @@ class ReadOtaSoftwareUpdateRequestorUpdatePossible : public ModelCommand
 public:
     ReadOtaSoftwareUpdateRequestorUpdatePossible() : ModelCommand("read")
     {
-        AddArgument("attr-name", "update-possible");
+        AddArgument("attr-name", "update-possible", false);
         ModelCommand::AddArguments();
     }
 
@@ -17059,7 +17063,7 @@ class ReadOtaSoftwareUpdateRequestorClusterRevision : public ModelCommand
 public:
     ReadOtaSoftwareUpdateRequestorClusterRevision() : ModelCommand("read")
     {
-        AddArgument("attr-name", "cluster-revision");
+        AddArgument("attr-name", "cluster-revision", false);
         ModelCommand::AddArguments();
     }
 
@@ -17105,7 +17109,7 @@ class ReadOccupancySensingOccupancy : public ModelCommand
 public:
     ReadOccupancySensingOccupancy() : ModelCommand("read")
     {
-        AddArgument("attr-name", "occupancy");
+        AddArgument("attr-name", "occupancy", false);
         ModelCommand::AddArguments();
     }
 
@@ -17136,10 +17140,10 @@ class ReportOccupancySensingOccupancy : public ModelCommand
 public:
     ReportOccupancySensingOccupancy() : ModelCommand("report")
     {
-        AddArgument("attr-name", "occupancy");
-        AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
-        AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval);
-        AddArgument("wait", 0, 1, &mWait);
+        AddArgument("attr-name", "occupancy", false);
+        AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval, false);
+        AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval, false);
+        AddArgument("wait", 0, 1, &mWait, false);
         ModelCommand::AddArguments();
     }
 
@@ -17191,7 +17195,7 @@ class ReadOccupancySensingOccupancySensorType : public ModelCommand
 public:
     ReadOccupancySensingOccupancySensorType() : ModelCommand("read")
     {
-        AddArgument("attr-name", "occupancy-sensor-type");
+        AddArgument("attr-name", "occupancy-sensor-type", false);
         ModelCommand::AddArguments();
     }
 
@@ -17225,7 +17229,7 @@ class ReadOccupancySensingOccupancySensorTypeBitmap : public ModelCommand
 public:
     ReadOccupancySensingOccupancySensorTypeBitmap() : ModelCommand("read")
     {
-        AddArgument("attr-name", "occupancy-sensor-type-bitmap");
+        AddArgument("attr-name", "occupancy-sensor-type-bitmap", false);
         ModelCommand::AddArguments();
     }
 
@@ -17259,7 +17263,7 @@ class ReadOccupancySensingClusterRevision : public ModelCommand
 public:
     ReadOccupancySensingClusterRevision() : ModelCommand("read")
     {
-        AddArgument("attr-name", "cluster-revision");
+        AddArgument("attr-name", "cluster-revision", false);
         ModelCommand::AddArguments();
     }
 
@@ -17336,9 +17340,9 @@ public:
     OnOffOffWithEffect() : ModelCommand("off-with-effect")
     {
         AddArgument("EffectId", 0, UINT8_MAX,
-                    reinterpret_cast<std::underlying_type_t<decltype(mRequest.effectId)> *>(&mRequest.effectId));
+                    reinterpret_cast<std::underlying_type_t<decltype(mRequest.effectId)> *>(&mRequest.effectId), false);
         AddArgument("EffectVariant", 0, UINT8_MAX,
-                    reinterpret_cast<std::underlying_type_t<decltype(mRequest.effectVariant)> *>(&mRequest.effectVariant));
+                    reinterpret_cast<std::underlying_type_t<decltype(mRequest.effectVariant)> *>(&mRequest.effectVariant), false);
         ModelCommand::AddArguments();
     }
 
@@ -17406,9 +17410,10 @@ public:
     OnOffOnWithTimedOff() : ModelCommand("on-with-timed-off")
     {
         AddArgument("OnOffControl", 0, UINT8_MAX,
-                    reinterpret_cast<std::underlying_type_t<chip::app::Clusters::OnOff::OnOffControl> *>(&mRequest.onOffControl));
-        AddArgument("OnTime", 0, UINT16_MAX, &mRequest.onTime);
-        AddArgument("OffWaitTime", 0, UINT16_MAX, &mRequest.offWaitTime);
+                    reinterpret_cast<std::underlying_type_t<chip::app::Clusters::OnOff::OnOffControl> *>(&mRequest.onOffControl),
+                    false);
+        AddArgument("OnTime", 0, UINT16_MAX, &mRequest.onTime, false);
+        AddArgument("OffWaitTime", 0, UINT16_MAX, &mRequest.offWaitTime, false);
         ModelCommand::AddArguments();
     }
 
@@ -17454,7 +17459,7 @@ class ReadOnOffOnOff : public ModelCommand
 public:
     ReadOnOffOnOff() : ModelCommand("read")
     {
-        AddArgument("attr-name", "on-off");
+        AddArgument("attr-name", "on-off", false);
         ModelCommand::AddArguments();
     }
 
@@ -17485,10 +17490,10 @@ class ReportOnOffOnOff : public ModelCommand
 public:
     ReportOnOffOnOff() : ModelCommand("report")
     {
-        AddArgument("attr-name", "on-off");
-        AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
-        AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval);
-        AddArgument("wait", 0, 1, &mWait);
+        AddArgument("attr-name", "on-off", false);
+        AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval, false);
+        AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval, false);
+        AddArgument("wait", 0, 1, &mWait, false);
         ModelCommand::AddArguments();
     }
 
@@ -17540,7 +17545,7 @@ class ReadOnOffGlobalSceneControl : public ModelCommand
 public:
     ReadOnOffGlobalSceneControl() : ModelCommand("read")
     {
-        AddArgument("attr-name", "global-scene-control");
+        AddArgument("attr-name", "global-scene-control", false);
         ModelCommand::AddArguments();
     }
 
@@ -17574,7 +17579,7 @@ class ReadOnOffOnTime : public ModelCommand
 public:
     ReadOnOffOnTime() : ModelCommand("read")
     {
-        AddArgument("attr-name", "on-time");
+        AddArgument("attr-name", "on-time", false);
         ModelCommand::AddArguments();
     }
 
@@ -17605,8 +17610,8 @@ class WriteOnOffOnTime : public ModelCommand
 public:
     WriteOnOffOnTime() : ModelCommand("write")
     {
-        AddArgument("attr-name", "on-time");
-        AddArgument("attr-value", 0, UINT16_MAX, &mValue);
+        AddArgument("attr-name", "on-time", false);
+        AddArgument("attr-value", 0, UINT16_MAX, &mValue, false);
         ModelCommand::AddArguments();
     }
 
@@ -17641,7 +17646,7 @@ class ReadOnOffOffWaitTime : public ModelCommand
 public:
     ReadOnOffOffWaitTime() : ModelCommand("read")
     {
-        AddArgument("attr-name", "off-wait-time");
+        AddArgument("attr-name", "off-wait-time", false);
         ModelCommand::AddArguments();
     }
 
@@ -17672,8 +17677,8 @@ class WriteOnOffOffWaitTime : public ModelCommand
 public:
     WriteOnOffOffWaitTime() : ModelCommand("write")
     {
-        AddArgument("attr-name", "off-wait-time");
-        AddArgument("attr-value", 0, UINT16_MAX, &mValue);
+        AddArgument("attr-name", "off-wait-time", false);
+        AddArgument("attr-value", 0, UINT16_MAX, &mValue, false);
         ModelCommand::AddArguments();
     }
 
@@ -17708,7 +17713,7 @@ class ReadOnOffStartUpOnOff : public ModelCommand
 public:
     ReadOnOffStartUpOnOff() : ModelCommand("read")
     {
-        AddArgument("attr-name", "start-up-on-off");
+        AddArgument("attr-name", "start-up-on-off", false);
         ModelCommand::AddArguments();
     }
 
@@ -17739,8 +17744,8 @@ class WriteOnOffStartUpOnOff : public ModelCommand
 public:
     WriteOnOffStartUpOnOff() : ModelCommand("write")
     {
-        AddArgument("attr-name", "start-up-on-off");
-        AddArgument("attr-value", 0, UINT8_MAX, &mValue);
+        AddArgument("attr-name", "start-up-on-off", false);
+        AddArgument("attr-value", 0, UINT8_MAX, &mValue, false);
         ModelCommand::AddArguments();
     }
 
@@ -17775,7 +17780,7 @@ class ReadOnOffFeatureMap : public ModelCommand
 public:
     ReadOnOffFeatureMap() : ModelCommand("read")
     {
-        AddArgument("attr-name", "feature-map");
+        AddArgument("attr-name", "feature-map", false);
         ModelCommand::AddArguments();
     }
 
@@ -17809,7 +17814,7 @@ class ReadOnOffClusterRevision : public ModelCommand
 public:
     ReadOnOffClusterRevision() : ModelCommand("read")
     {
-        AddArgument("attr-name", "cluster-revision");
+        AddArgument("attr-name", "cluster-revision", false);
         ModelCommand::AddArguments();
     }
 
@@ -17854,7 +17859,7 @@ class ReadOnOffSwitchConfigurationSwitchType : public ModelCommand
 public:
     ReadOnOffSwitchConfigurationSwitchType() : ModelCommand("read")
     {
-        AddArgument("attr-name", "switch-type");
+        AddArgument("attr-name", "switch-type", false);
         ModelCommand::AddArguments();
     }
 
@@ -17888,7 +17893,7 @@ class ReadOnOffSwitchConfigurationSwitchActions : public ModelCommand
 public:
     ReadOnOffSwitchConfigurationSwitchActions() : ModelCommand("read")
     {
-        AddArgument("attr-name", "switch-actions");
+        AddArgument("attr-name", "switch-actions", false);
         ModelCommand::AddArguments();
     }
 
@@ -17919,8 +17924,8 @@ class WriteOnOffSwitchConfigurationSwitchActions : public ModelCommand
 public:
     WriteOnOffSwitchConfigurationSwitchActions() : ModelCommand("write")
     {
-        AddArgument("attr-name", "switch-actions");
-        AddArgument("attr-value", 0, UINT8_MAX, &mValue);
+        AddArgument("attr-name", "switch-actions", false);
+        AddArgument("attr-value", 0, UINT8_MAX, &mValue, false);
         ModelCommand::AddArguments();
     }
 
@@ -17955,7 +17960,7 @@ class ReadOnOffSwitchConfigurationClusterRevision : public ModelCommand
 public:
     ReadOnOffSwitchConfigurationClusterRevision() : ModelCommand("read")
     {
-        AddArgument("attr-name", "cluster-revision");
+        AddArgument("attr-name", "cluster-revision", false);
         ModelCommand::AddArguments();
     }
 
@@ -18012,11 +18017,11 @@ class OperationalCredentialsAddNOC : public ModelCommand
 public:
     OperationalCredentialsAddNOC() : ModelCommand("add-noc")
     {
-        AddArgument("NOCValue", &mRequest.NOCValue);
-        AddArgument("ICACValue", &mRequest.ICACValue);
-        AddArgument("IPKValue", &mRequest.IPKValue);
-        AddArgument("CaseAdminNode", 0, UINT64_MAX, &mRequest.caseAdminNode);
-        AddArgument("AdminVendorId", 0, UINT16_MAX, &mRequest.adminVendorId);
+        AddArgument("NOCValue", &mRequest.NOCValue, false);
+        AddArgument("ICACValue", &mRequest.ICACValue, false);
+        AddArgument("IPKValue", &mRequest.IPKValue, false);
+        AddArgument("CaseAdminNode", 0, UINT64_MAX, &mRequest.caseAdminNode, false);
+        AddArgument("AdminVendorId", 0, UINT16_MAX, &mRequest.adminVendorId, false);
         ModelCommand::AddArguments();
     }
 
@@ -18041,7 +18046,7 @@ class OperationalCredentialsAddTrustedRootCertificate : public ModelCommand
 public:
     OperationalCredentialsAddTrustedRootCertificate() : ModelCommand("add-trusted-root-certificate")
     {
-        AddArgument("RootCertificate", &mRequest.rootCertificate);
+        AddArgument("RootCertificate", &mRequest.rootCertificate, false);
         ModelCommand::AddArguments();
     }
 
@@ -18066,7 +18071,7 @@ class OperationalCredentialsAttestationRequest : public ModelCommand
 public:
     OperationalCredentialsAttestationRequest() : ModelCommand("attestation-request")
     {
-        AddArgument("AttestationNonce", &mRequest.attestationNonce);
+        AddArgument("AttestationNonce", &mRequest.attestationNonce, false);
         ModelCommand::AddArguments();
     }
 
@@ -18091,7 +18096,7 @@ class OperationalCredentialsCertificateChainRequest : public ModelCommand
 public:
     OperationalCredentialsCertificateChainRequest() : ModelCommand("certificate-chain-request")
     {
-        AddArgument("CertificateType", 0, UINT8_MAX, &mRequest.certificateType);
+        AddArgument("CertificateType", 0, UINT8_MAX, &mRequest.certificateType, false);
         ModelCommand::AddArguments();
     }
 
@@ -18116,7 +18121,7 @@ class OperationalCredentialsOpCSRRequest : public ModelCommand
 public:
     OperationalCredentialsOpCSRRequest() : ModelCommand("op-csrrequest")
     {
-        AddArgument("CSRNonce", &mRequest.CSRNonce);
+        AddArgument("CSRNonce", &mRequest.CSRNonce, false);
         ModelCommand::AddArguments();
     }
 
@@ -18141,7 +18146,7 @@ class OperationalCredentialsRemoveFabric : public ModelCommand
 public:
     OperationalCredentialsRemoveFabric() : ModelCommand("remove-fabric")
     {
-        AddArgument("FabricIndex", 0, UINT8_MAX, &mRequest.fabricIndex);
+        AddArgument("FabricIndex", 0, UINT8_MAX, &mRequest.fabricIndex, false);
         ModelCommand::AddArguments();
     }
 
@@ -18166,7 +18171,7 @@ class OperationalCredentialsRemoveTrustedRootCertificate : public ModelCommand
 public:
     OperationalCredentialsRemoveTrustedRootCertificate() : ModelCommand("remove-trusted-root-certificate")
     {
-        AddArgument("TrustedRootIdentifier", &mRequest.trustedRootIdentifier);
+        AddArgument("TrustedRootIdentifier", &mRequest.trustedRootIdentifier, false);
         ModelCommand::AddArguments();
     }
 
@@ -18191,7 +18196,7 @@ class OperationalCredentialsUpdateFabricLabel : public ModelCommand
 public:
     OperationalCredentialsUpdateFabricLabel() : ModelCommand("update-fabric-label")
     {
-        AddArgument("Label", &mRequest.label);
+        AddArgument("Label", &mRequest.label, false);
         ModelCommand::AddArguments();
     }
 
@@ -18216,8 +18221,8 @@ class OperationalCredentialsUpdateNOC : public ModelCommand
 public:
     OperationalCredentialsUpdateNOC() : ModelCommand("update-noc")
     {
-        AddArgument("NOCValue", &mRequest.NOCValue);
-        AddArgument("ICACValue", &mRequest.ICACValue);
+        AddArgument("NOCValue", &mRequest.NOCValue, false);
+        AddArgument("ICACValue", &mRequest.ICACValue, false);
         ModelCommand::AddArguments();
     }
 
@@ -18242,7 +18247,7 @@ class ReadOperationalCredentialsFabricsList : public ModelCommand
 public:
     ReadOperationalCredentialsFabricsList() : ModelCommand("read")
     {
-        AddArgument("attr-name", "fabrics-list");
+        AddArgument("attr-name", "fabrics-list", false);
         ModelCommand::AddArguments();
     }
 
@@ -18277,7 +18282,7 @@ class ReadOperationalCredentialsSupportedFabrics : public ModelCommand
 public:
     ReadOperationalCredentialsSupportedFabrics() : ModelCommand("read")
     {
-        AddArgument("attr-name", "supported-fabrics");
+        AddArgument("attr-name", "supported-fabrics", false);
         ModelCommand::AddArguments();
     }
 
@@ -18311,7 +18316,7 @@ class ReadOperationalCredentialsCommissionedFabrics : public ModelCommand
 public:
     ReadOperationalCredentialsCommissionedFabrics() : ModelCommand("read")
     {
-        AddArgument("attr-name", "commissioned-fabrics");
+        AddArgument("attr-name", "commissioned-fabrics", false);
         ModelCommand::AddArguments();
     }
 
@@ -18345,7 +18350,7 @@ class ReadOperationalCredentialsTrustedRootCertificates : public ModelCommand
 public:
     ReadOperationalCredentialsTrustedRootCertificates() : ModelCommand("read")
     {
-        AddArgument("attr-name", "trusted-root-certificates");
+        AddArgument("attr-name", "trusted-root-certificates", false);
         ModelCommand::AddArguments();
     }
 
@@ -18380,7 +18385,7 @@ class ReadOperationalCredentialsCurrentFabricIndex : public ModelCommand
 public:
     ReadOperationalCredentialsCurrentFabricIndex() : ModelCommand("read")
     {
-        AddArgument("attr-name", "current-fabric-index");
+        AddArgument("attr-name", "current-fabric-index", false);
         ModelCommand::AddArguments();
     }
 
@@ -18414,7 +18419,7 @@ class ReadOperationalCredentialsClusterRevision : public ModelCommand
 public:
     ReadOperationalCredentialsClusterRevision() : ModelCommand("read")
     {
-        AddArgument("attr-name", "cluster-revision");
+        AddArgument("attr-name", "cluster-revision", false);
         ModelCommand::AddArguments();
     }
 
@@ -18467,7 +18472,7 @@ class ReadPowerSourceStatus : public ModelCommand
 public:
     ReadPowerSourceStatus() : ModelCommand("read")
     {
-        AddArgument("attr-name", "status");
+        AddArgument("attr-name", "status", false);
         ModelCommand::AddArguments();
     }
 
@@ -18501,7 +18506,7 @@ class ReadPowerSourceOrder : public ModelCommand
 public:
     ReadPowerSourceOrder() : ModelCommand("read")
     {
-        AddArgument("attr-name", "order");
+        AddArgument("attr-name", "order", false);
         ModelCommand::AddArguments();
     }
 
@@ -18535,7 +18540,7 @@ class ReadPowerSourceDescription : public ModelCommand
 public:
     ReadPowerSourceDescription() : ModelCommand("read")
     {
-        AddArgument("attr-name", "description");
+        AddArgument("attr-name", "description", false);
         ModelCommand::AddArguments();
     }
 
@@ -18569,7 +18574,7 @@ class ReadPowerSourceBatteryVoltage : public ModelCommand
 public:
     ReadPowerSourceBatteryVoltage() : ModelCommand("read")
     {
-        AddArgument("attr-name", "battery-voltage");
+        AddArgument("attr-name", "battery-voltage", false);
         ModelCommand::AddArguments();
     }
 
@@ -18603,7 +18608,7 @@ class ReadPowerSourceBatteryPercentRemaining : public ModelCommand
 public:
     ReadPowerSourceBatteryPercentRemaining() : ModelCommand("read")
     {
-        AddArgument("attr-name", "battery-percent-remaining");
+        AddArgument("attr-name", "battery-percent-remaining", false);
         ModelCommand::AddArguments();
     }
 
@@ -18637,7 +18642,7 @@ class ReadPowerSourceBatteryTimeRemaining : public ModelCommand
 public:
     ReadPowerSourceBatteryTimeRemaining() : ModelCommand("read")
     {
-        AddArgument("attr-name", "battery-time-remaining");
+        AddArgument("attr-name", "battery-time-remaining", false);
         ModelCommand::AddArguments();
     }
 
@@ -18671,7 +18676,7 @@ class ReadPowerSourceBatteryChargeLevel : public ModelCommand
 public:
     ReadPowerSourceBatteryChargeLevel() : ModelCommand("read")
     {
-        AddArgument("attr-name", "battery-charge-level");
+        AddArgument("attr-name", "battery-charge-level", false);
         ModelCommand::AddArguments();
     }
 
@@ -18705,7 +18710,7 @@ class ReadPowerSourceActiveBatteryFaults : public ModelCommand
 public:
     ReadPowerSourceActiveBatteryFaults() : ModelCommand("read")
     {
-        AddArgument("attr-name", "active-battery-faults");
+        AddArgument("attr-name", "active-battery-faults", false);
         ModelCommand::AddArguments();
     }
 
@@ -18740,7 +18745,7 @@ class ReadPowerSourceBatteryChargeState : public ModelCommand
 public:
     ReadPowerSourceBatteryChargeState() : ModelCommand("read")
     {
-        AddArgument("attr-name", "battery-charge-state");
+        AddArgument("attr-name", "battery-charge-state", false);
         ModelCommand::AddArguments();
     }
 
@@ -18774,7 +18779,7 @@ class ReadPowerSourceFeatureMap : public ModelCommand
 public:
     ReadPowerSourceFeatureMap() : ModelCommand("read")
     {
-        AddArgument("attr-name", "feature-map");
+        AddArgument("attr-name", "feature-map", false);
         ModelCommand::AddArguments();
     }
 
@@ -18808,7 +18813,7 @@ class ReadPowerSourceClusterRevision : public ModelCommand
 public:
     ReadPowerSourceClusterRevision() : ModelCommand("read")
     {
-        AddArgument("attr-name", "cluster-revision");
+        AddArgument("attr-name", "cluster-revision", false);
         ModelCommand::AddArguments();
     }
 
@@ -18854,7 +18859,7 @@ class ReadPressureMeasurementMeasuredValue : public ModelCommand
 public:
     ReadPressureMeasurementMeasuredValue() : ModelCommand("read")
     {
-        AddArgument("attr-name", "measured-value");
+        AddArgument("attr-name", "measured-value", false);
         ModelCommand::AddArguments();
     }
 
@@ -18885,10 +18890,10 @@ class ReportPressureMeasurementMeasuredValue : public ModelCommand
 public:
     ReportPressureMeasurementMeasuredValue() : ModelCommand("report")
     {
-        AddArgument("attr-name", "measured-value");
-        AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
-        AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval);
-        AddArgument("wait", 0, 1, &mWait);
+        AddArgument("attr-name", "measured-value", false);
+        AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval, false);
+        AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval, false);
+        AddArgument("wait", 0, 1, &mWait, false);
         ModelCommand::AddArguments();
     }
 
@@ -18940,7 +18945,7 @@ class ReadPressureMeasurementMinMeasuredValue : public ModelCommand
 public:
     ReadPressureMeasurementMinMeasuredValue() : ModelCommand("read")
     {
-        AddArgument("attr-name", "min-measured-value");
+        AddArgument("attr-name", "min-measured-value", false);
         ModelCommand::AddArguments();
     }
 
@@ -18974,7 +18979,7 @@ class ReadPressureMeasurementMaxMeasuredValue : public ModelCommand
 public:
     ReadPressureMeasurementMaxMeasuredValue() : ModelCommand("read")
     {
-        AddArgument("attr-name", "max-measured-value");
+        AddArgument("attr-name", "max-measured-value", false);
         ModelCommand::AddArguments();
     }
 
@@ -19008,7 +19013,7 @@ class ReadPressureMeasurementClusterRevision : public ModelCommand
 public:
     ReadPressureMeasurementClusterRevision() : ModelCommand("read")
     {
-        AddArgument("attr-name", "cluster-revision");
+        AddArgument("attr-name", "cluster-revision", false);
         ModelCommand::AddArguments();
     }
 
@@ -19074,7 +19079,7 @@ class ReadPumpConfigurationAndControlMaxPressure : public ModelCommand
 public:
     ReadPumpConfigurationAndControlMaxPressure() : ModelCommand("read")
     {
-        AddArgument("attr-name", "max-pressure");
+        AddArgument("attr-name", "max-pressure", false);
         ModelCommand::AddArguments();
     }
 
@@ -19108,7 +19113,7 @@ class ReadPumpConfigurationAndControlMaxSpeed : public ModelCommand
 public:
     ReadPumpConfigurationAndControlMaxSpeed() : ModelCommand("read")
     {
-        AddArgument("attr-name", "max-speed");
+        AddArgument("attr-name", "max-speed", false);
         ModelCommand::AddArguments();
     }
 
@@ -19142,7 +19147,7 @@ class ReadPumpConfigurationAndControlMaxFlow : public ModelCommand
 public:
     ReadPumpConfigurationAndControlMaxFlow() : ModelCommand("read")
     {
-        AddArgument("attr-name", "max-flow");
+        AddArgument("attr-name", "max-flow", false);
         ModelCommand::AddArguments();
     }
 
@@ -19176,7 +19181,7 @@ class ReadPumpConfigurationAndControlMinConstPressure : public ModelCommand
 public:
     ReadPumpConfigurationAndControlMinConstPressure() : ModelCommand("read")
     {
-        AddArgument("attr-name", "min-const-pressure");
+        AddArgument("attr-name", "min-const-pressure", false);
         ModelCommand::AddArguments();
     }
 
@@ -19210,7 +19215,7 @@ class ReadPumpConfigurationAndControlMaxConstPressure : public ModelCommand
 public:
     ReadPumpConfigurationAndControlMaxConstPressure() : ModelCommand("read")
     {
-        AddArgument("attr-name", "max-const-pressure");
+        AddArgument("attr-name", "max-const-pressure", false);
         ModelCommand::AddArguments();
     }
 
@@ -19244,7 +19249,7 @@ class ReadPumpConfigurationAndControlMinCompPressure : public ModelCommand
 public:
     ReadPumpConfigurationAndControlMinCompPressure() : ModelCommand("read")
     {
-        AddArgument("attr-name", "min-comp-pressure");
+        AddArgument("attr-name", "min-comp-pressure", false);
         ModelCommand::AddArguments();
     }
 
@@ -19278,7 +19283,7 @@ class ReadPumpConfigurationAndControlMaxCompPressure : public ModelCommand
 public:
     ReadPumpConfigurationAndControlMaxCompPressure() : ModelCommand("read")
     {
-        AddArgument("attr-name", "max-comp-pressure");
+        AddArgument("attr-name", "max-comp-pressure", false);
         ModelCommand::AddArguments();
     }
 
@@ -19312,7 +19317,7 @@ class ReadPumpConfigurationAndControlMinConstSpeed : public ModelCommand
 public:
     ReadPumpConfigurationAndControlMinConstSpeed() : ModelCommand("read")
     {
-        AddArgument("attr-name", "min-const-speed");
+        AddArgument("attr-name", "min-const-speed", false);
         ModelCommand::AddArguments();
     }
 
@@ -19346,7 +19351,7 @@ class ReadPumpConfigurationAndControlMaxConstSpeed : public ModelCommand
 public:
     ReadPumpConfigurationAndControlMaxConstSpeed() : ModelCommand("read")
     {
-        AddArgument("attr-name", "max-const-speed");
+        AddArgument("attr-name", "max-const-speed", false);
         ModelCommand::AddArguments();
     }
 
@@ -19380,7 +19385,7 @@ class ReadPumpConfigurationAndControlMinConstFlow : public ModelCommand
 public:
     ReadPumpConfigurationAndControlMinConstFlow() : ModelCommand("read")
     {
-        AddArgument("attr-name", "min-const-flow");
+        AddArgument("attr-name", "min-const-flow", false);
         ModelCommand::AddArguments();
     }
 
@@ -19414,7 +19419,7 @@ class ReadPumpConfigurationAndControlMaxConstFlow : public ModelCommand
 public:
     ReadPumpConfigurationAndControlMaxConstFlow() : ModelCommand("read")
     {
-        AddArgument("attr-name", "max-const-flow");
+        AddArgument("attr-name", "max-const-flow", false);
         ModelCommand::AddArguments();
     }
 
@@ -19448,7 +19453,7 @@ class ReadPumpConfigurationAndControlMinConstTemp : public ModelCommand
 public:
     ReadPumpConfigurationAndControlMinConstTemp() : ModelCommand("read")
     {
-        AddArgument("attr-name", "min-const-temp");
+        AddArgument("attr-name", "min-const-temp", false);
         ModelCommand::AddArguments();
     }
 
@@ -19482,7 +19487,7 @@ class ReadPumpConfigurationAndControlMaxConstTemp : public ModelCommand
 public:
     ReadPumpConfigurationAndControlMaxConstTemp() : ModelCommand("read")
     {
-        AddArgument("attr-name", "max-const-temp");
+        AddArgument("attr-name", "max-const-temp", false);
         ModelCommand::AddArguments();
     }
 
@@ -19516,7 +19521,7 @@ class ReadPumpConfigurationAndControlPumpStatus : public ModelCommand
 public:
     ReadPumpConfigurationAndControlPumpStatus() : ModelCommand("read")
     {
-        AddArgument("attr-name", "pump-status");
+        AddArgument("attr-name", "pump-status", false);
         ModelCommand::AddArguments();
     }
 
@@ -19547,10 +19552,10 @@ class ReportPumpConfigurationAndControlPumpStatus : public ModelCommand
 public:
     ReportPumpConfigurationAndControlPumpStatus() : ModelCommand("report")
     {
-        AddArgument("attr-name", "pump-status");
-        AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
-        AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval);
-        AddArgument("wait", 0, 1, &mWait);
+        AddArgument("attr-name", "pump-status", false);
+        AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval, false);
+        AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval, false);
+        AddArgument("wait", 0, 1, &mWait, false);
         ModelCommand::AddArguments();
     }
 
@@ -19602,7 +19607,7 @@ class ReadPumpConfigurationAndControlEffectiveOperationMode : public ModelComman
 public:
     ReadPumpConfigurationAndControlEffectiveOperationMode() : ModelCommand("read")
     {
-        AddArgument("attr-name", "effective-operation-mode");
+        AddArgument("attr-name", "effective-operation-mode", false);
         ModelCommand::AddArguments();
     }
 
@@ -19636,7 +19641,7 @@ class ReadPumpConfigurationAndControlEffectiveControlMode : public ModelCommand
 public:
     ReadPumpConfigurationAndControlEffectiveControlMode() : ModelCommand("read")
     {
-        AddArgument("attr-name", "effective-control-mode");
+        AddArgument("attr-name", "effective-control-mode", false);
         ModelCommand::AddArguments();
     }
 
@@ -19670,7 +19675,7 @@ class ReadPumpConfigurationAndControlCapacity : public ModelCommand
 public:
     ReadPumpConfigurationAndControlCapacity() : ModelCommand("read")
     {
-        AddArgument("attr-name", "capacity");
+        AddArgument("attr-name", "capacity", false);
         ModelCommand::AddArguments();
     }
 
@@ -19701,10 +19706,10 @@ class ReportPumpConfigurationAndControlCapacity : public ModelCommand
 public:
     ReportPumpConfigurationAndControlCapacity() : ModelCommand("report")
     {
-        AddArgument("attr-name", "capacity");
-        AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
-        AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval);
-        AddArgument("wait", 0, 1, &mWait);
+        AddArgument("attr-name", "capacity", false);
+        AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval, false);
+        AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval, false);
+        AddArgument("wait", 0, 1, &mWait, false);
         ModelCommand::AddArguments();
     }
 
@@ -19756,7 +19761,7 @@ class ReadPumpConfigurationAndControlSpeed : public ModelCommand
 public:
     ReadPumpConfigurationAndControlSpeed() : ModelCommand("read")
     {
-        AddArgument("attr-name", "speed");
+        AddArgument("attr-name", "speed", false);
         ModelCommand::AddArguments();
     }
 
@@ -19790,7 +19795,7 @@ class ReadPumpConfigurationAndControlLifetimeEnergyConsumed : public ModelComman
 public:
     ReadPumpConfigurationAndControlLifetimeEnergyConsumed() : ModelCommand("read")
     {
-        AddArgument("attr-name", "lifetime-energy-consumed");
+        AddArgument("attr-name", "lifetime-energy-consumed", false);
         ModelCommand::AddArguments();
     }
 
@@ -19824,7 +19829,7 @@ class ReadPumpConfigurationAndControlOperationMode : public ModelCommand
 public:
     ReadPumpConfigurationAndControlOperationMode() : ModelCommand("read")
     {
-        AddArgument("attr-name", "operation-mode");
+        AddArgument("attr-name", "operation-mode", false);
         ModelCommand::AddArguments();
     }
 
@@ -19855,8 +19860,8 @@ class WritePumpConfigurationAndControlOperationMode : public ModelCommand
 public:
     WritePumpConfigurationAndControlOperationMode() : ModelCommand("write")
     {
-        AddArgument("attr-name", "operation-mode");
-        AddArgument("attr-value", 0, UINT8_MAX, &mValue);
+        AddArgument("attr-name", "operation-mode", false);
+        AddArgument("attr-value", 0, UINT8_MAX, &mValue, false);
         ModelCommand::AddArguments();
     }
 
@@ -19891,7 +19896,7 @@ class ReadPumpConfigurationAndControlControlMode : public ModelCommand
 public:
     ReadPumpConfigurationAndControlControlMode() : ModelCommand("read")
     {
-        AddArgument("attr-name", "control-mode");
+        AddArgument("attr-name", "control-mode", false);
         ModelCommand::AddArguments();
     }
 
@@ -19922,8 +19927,8 @@ class WritePumpConfigurationAndControlControlMode : public ModelCommand
 public:
     WritePumpConfigurationAndControlControlMode() : ModelCommand("write")
     {
-        AddArgument("attr-name", "control-mode");
-        AddArgument("attr-value", 0, UINT8_MAX, &mValue);
+        AddArgument("attr-name", "control-mode", false);
+        AddArgument("attr-value", 0, UINT8_MAX, &mValue, false);
         ModelCommand::AddArguments();
     }
 
@@ -19958,7 +19963,7 @@ class ReadPumpConfigurationAndControlAlarmMask : public ModelCommand
 public:
     ReadPumpConfigurationAndControlAlarmMask() : ModelCommand("read")
     {
-        AddArgument("attr-name", "alarm-mask");
+        AddArgument("attr-name", "alarm-mask", false);
         ModelCommand::AddArguments();
     }
 
@@ -19992,7 +19997,7 @@ class ReadPumpConfigurationAndControlFeatureMap : public ModelCommand
 public:
     ReadPumpConfigurationAndControlFeatureMap() : ModelCommand("read")
     {
-        AddArgument("attr-name", "feature-map");
+        AddArgument("attr-name", "feature-map", false);
         ModelCommand::AddArguments();
     }
 
@@ -20026,7 +20031,7 @@ class ReadPumpConfigurationAndControlClusterRevision : public ModelCommand
 public:
     ReadPumpConfigurationAndControlClusterRevision() : ModelCommand("read")
     {
-        AddArgument("attr-name", "cluster-revision");
+        AddArgument("attr-name", "cluster-revision", false);
         ModelCommand::AddArguments();
     }
 
@@ -20073,7 +20078,7 @@ class ReadRelativeHumidityMeasurementMeasuredValue : public ModelCommand
 public:
     ReadRelativeHumidityMeasurementMeasuredValue() : ModelCommand("read")
     {
-        AddArgument("attr-name", "measured-value");
+        AddArgument("attr-name", "measured-value", false);
         ModelCommand::AddArguments();
     }
 
@@ -20104,10 +20109,10 @@ class ReportRelativeHumidityMeasurementMeasuredValue : public ModelCommand
 public:
     ReportRelativeHumidityMeasurementMeasuredValue() : ModelCommand("report")
     {
-        AddArgument("attr-name", "measured-value");
-        AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
-        AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval);
-        AddArgument("wait", 0, 1, &mWait);
+        AddArgument("attr-name", "measured-value", false);
+        AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval, false);
+        AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval, false);
+        AddArgument("wait", 0, 1, &mWait, false);
         ModelCommand::AddArguments();
     }
 
@@ -20159,7 +20164,7 @@ class ReadRelativeHumidityMeasurementMinMeasuredValue : public ModelCommand
 public:
     ReadRelativeHumidityMeasurementMinMeasuredValue() : ModelCommand("read")
     {
-        AddArgument("attr-name", "min-measured-value");
+        AddArgument("attr-name", "min-measured-value", false);
         ModelCommand::AddArguments();
     }
 
@@ -20193,7 +20198,7 @@ class ReadRelativeHumidityMeasurementMaxMeasuredValue : public ModelCommand
 public:
     ReadRelativeHumidityMeasurementMaxMeasuredValue() : ModelCommand("read")
     {
-        AddArgument("attr-name", "max-measured-value");
+        AddArgument("attr-name", "max-measured-value", false);
         ModelCommand::AddArguments();
     }
 
@@ -20227,7 +20232,7 @@ class ReadRelativeHumidityMeasurementTolerance : public ModelCommand
 public:
     ReadRelativeHumidityMeasurementTolerance() : ModelCommand("read")
     {
-        AddArgument("attr-name", "tolerance");
+        AddArgument("attr-name", "tolerance", false);
         ModelCommand::AddArguments();
     }
 
@@ -20258,10 +20263,10 @@ class ReportRelativeHumidityMeasurementTolerance : public ModelCommand
 public:
     ReportRelativeHumidityMeasurementTolerance() : ModelCommand("report")
     {
-        AddArgument("attr-name", "tolerance");
-        AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
-        AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval);
-        AddArgument("wait", 0, 1, &mWait);
+        AddArgument("attr-name", "tolerance", false);
+        AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval, false);
+        AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval, false);
+        AddArgument("wait", 0, 1, &mWait, false);
         ModelCommand::AddArguments();
     }
 
@@ -20313,7 +20318,7 @@ class ReadRelativeHumidityMeasurementClusterRevision : public ModelCommand
 public:
     ReadRelativeHumidityMeasurementClusterRevision() : ModelCommand("read")
     {
-        AddArgument("attr-name", "cluster-revision");
+        AddArgument("attr-name", "cluster-revision", false);
         ModelCommand::AddArguments();
     }
 
@@ -20368,10 +20373,10 @@ class ScenesAddScene : public ModelCommand
 public:
     ScenesAddScene() : ModelCommand("add-scene")
     {
-        AddArgument("GroupId", 0, UINT16_MAX, &mRequest.groupId);
-        AddArgument("SceneId", 0, UINT8_MAX, &mRequest.sceneId);
-        AddArgument("TransitionTime", 0, UINT16_MAX, &mRequest.transitionTime);
-        AddArgument("SceneName", &mRequest.sceneName);
+        AddArgument("GroupId", 0, UINT16_MAX, &mRequest.groupId, false);
+        AddArgument("SceneId", 0, UINT8_MAX, &mRequest.sceneId, false);
+        AddArgument("TransitionTime", 0, UINT16_MAX, &mRequest.transitionTime, false);
+        AddArgument("SceneName", &mRequest.sceneName, false);
         // extensionFieldSets Array parsing is not supported yet
         ModelCommand::AddArguments();
     }
@@ -20397,7 +20402,7 @@ class ScenesGetSceneMembership : public ModelCommand
 public:
     ScenesGetSceneMembership() : ModelCommand("get-scene-membership")
     {
-        AddArgument("GroupId", 0, UINT16_MAX, &mRequest.groupId);
+        AddArgument("GroupId", 0, UINT16_MAX, &mRequest.groupId, false);
         ModelCommand::AddArguments();
     }
 
@@ -20422,9 +20427,9 @@ class ScenesRecallScene : public ModelCommand
 public:
     ScenesRecallScene() : ModelCommand("recall-scene")
     {
-        AddArgument("GroupId", 0, UINT16_MAX, &mRequest.groupId);
-        AddArgument("SceneId", 0, UINT8_MAX, &mRequest.sceneId);
-        AddArgument("TransitionTime", 0, UINT16_MAX, &mRequest.transitionTime);
+        AddArgument("GroupId", 0, UINT16_MAX, &mRequest.groupId, false);
+        AddArgument("SceneId", 0, UINT8_MAX, &mRequest.sceneId, false);
+        AddArgument("TransitionTime", 0, UINT16_MAX, &mRequest.transitionTime, false);
         ModelCommand::AddArguments();
     }
 
@@ -20449,7 +20454,7 @@ class ScenesRemoveAllScenes : public ModelCommand
 public:
     ScenesRemoveAllScenes() : ModelCommand("remove-all-scenes")
     {
-        AddArgument("GroupId", 0, UINT16_MAX, &mRequest.groupId);
+        AddArgument("GroupId", 0, UINT16_MAX, &mRequest.groupId, false);
         ModelCommand::AddArguments();
     }
 
@@ -20474,8 +20479,8 @@ class ScenesRemoveScene : public ModelCommand
 public:
     ScenesRemoveScene() : ModelCommand("remove-scene")
     {
-        AddArgument("GroupId", 0, UINT16_MAX, &mRequest.groupId);
-        AddArgument("SceneId", 0, UINT8_MAX, &mRequest.sceneId);
+        AddArgument("GroupId", 0, UINT16_MAX, &mRequest.groupId, false);
+        AddArgument("SceneId", 0, UINT8_MAX, &mRequest.sceneId, false);
         ModelCommand::AddArguments();
     }
 
@@ -20500,8 +20505,8 @@ class ScenesStoreScene : public ModelCommand
 public:
     ScenesStoreScene() : ModelCommand("store-scene")
     {
-        AddArgument("GroupId", 0, UINT16_MAX, &mRequest.groupId);
-        AddArgument("SceneId", 0, UINT8_MAX, &mRequest.sceneId);
+        AddArgument("GroupId", 0, UINT16_MAX, &mRequest.groupId, false);
+        AddArgument("SceneId", 0, UINT8_MAX, &mRequest.sceneId, false);
         ModelCommand::AddArguments();
     }
 
@@ -20526,8 +20531,8 @@ class ScenesViewScene : public ModelCommand
 public:
     ScenesViewScene() : ModelCommand("view-scene")
     {
-        AddArgument("GroupId", 0, UINT16_MAX, &mRequest.groupId);
-        AddArgument("SceneId", 0, UINT8_MAX, &mRequest.sceneId);
+        AddArgument("GroupId", 0, UINT16_MAX, &mRequest.groupId, false);
+        AddArgument("SceneId", 0, UINT8_MAX, &mRequest.sceneId, false);
         ModelCommand::AddArguments();
     }
 
@@ -20552,7 +20557,7 @@ class ReadScenesSceneCount : public ModelCommand
 public:
     ReadScenesSceneCount() : ModelCommand("read")
     {
-        AddArgument("attr-name", "scene-count");
+        AddArgument("attr-name", "scene-count", false);
         ModelCommand::AddArguments();
     }
 
@@ -20586,7 +20591,7 @@ class ReadScenesCurrentScene : public ModelCommand
 public:
     ReadScenesCurrentScene() : ModelCommand("read")
     {
-        AddArgument("attr-name", "current-scene");
+        AddArgument("attr-name", "current-scene", false);
         ModelCommand::AddArguments();
     }
 
@@ -20620,7 +20625,7 @@ class ReadScenesCurrentGroup : public ModelCommand
 public:
     ReadScenesCurrentGroup() : ModelCommand("read")
     {
-        AddArgument("attr-name", "current-group");
+        AddArgument("attr-name", "current-group", false);
         ModelCommand::AddArguments();
     }
 
@@ -20654,7 +20659,7 @@ class ReadScenesSceneValid : public ModelCommand
 public:
     ReadScenesSceneValid() : ModelCommand("read")
     {
-        AddArgument("attr-name", "scene-valid");
+        AddArgument("attr-name", "scene-valid", false);
         ModelCommand::AddArguments();
     }
 
@@ -20688,7 +20693,7 @@ class ReadScenesNameSupport : public ModelCommand
 public:
     ReadScenesNameSupport() : ModelCommand("read")
     {
-        AddArgument("attr-name", "name-support");
+        AddArgument("attr-name", "name-support", false);
         ModelCommand::AddArguments();
     }
 
@@ -20722,7 +20727,7 @@ class ReadScenesClusterRevision : public ModelCommand
 public:
     ReadScenesClusterRevision() : ModelCommand("read")
     {
-        AddArgument("attr-name", "cluster-revision");
+        AddArgument("attr-name", "cluster-revision", false);
         ModelCommand::AddArguments();
     }
 
@@ -20790,7 +20795,7 @@ class ReadSoftwareDiagnosticsCurrentHeapFree : public ModelCommand
 public:
     ReadSoftwareDiagnosticsCurrentHeapFree() : ModelCommand("read")
     {
-        AddArgument("attr-name", "current-heap-free");
+        AddArgument("attr-name", "current-heap-free", false);
         ModelCommand::AddArguments();
     }
 
@@ -20824,7 +20829,7 @@ class ReadSoftwareDiagnosticsCurrentHeapUsed : public ModelCommand
 public:
     ReadSoftwareDiagnosticsCurrentHeapUsed() : ModelCommand("read")
     {
-        AddArgument("attr-name", "current-heap-used");
+        AddArgument("attr-name", "current-heap-used", false);
         ModelCommand::AddArguments();
     }
 
@@ -20858,7 +20863,7 @@ class ReadSoftwareDiagnosticsCurrentHeapHighWatermark : public ModelCommand
 public:
     ReadSoftwareDiagnosticsCurrentHeapHighWatermark() : ModelCommand("read")
     {
-        AddArgument("attr-name", "current-heap-high-watermark");
+        AddArgument("attr-name", "current-heap-high-watermark", false);
         ModelCommand::AddArguments();
     }
 
@@ -20892,7 +20897,7 @@ class ReadSoftwareDiagnosticsClusterRevision : public ModelCommand
 public:
     ReadSoftwareDiagnosticsClusterRevision() : ModelCommand("read")
     {
-        AddArgument("attr-name", "cluster-revision");
+        AddArgument("attr-name", "cluster-revision", false);
         ModelCommand::AddArguments();
     }
 
@@ -20939,7 +20944,7 @@ class ReadSwitchNumberOfPositions : public ModelCommand
 public:
     ReadSwitchNumberOfPositions() : ModelCommand("read")
     {
-        AddArgument("attr-name", "number-of-positions");
+        AddArgument("attr-name", "number-of-positions", false);
         ModelCommand::AddArguments();
     }
 
@@ -20973,7 +20978,7 @@ class ReadSwitchCurrentPosition : public ModelCommand
 public:
     ReadSwitchCurrentPosition() : ModelCommand("read")
     {
-        AddArgument("attr-name", "current-position");
+        AddArgument("attr-name", "current-position", false);
         ModelCommand::AddArguments();
     }
 
@@ -21004,10 +21009,10 @@ class ReportSwitchCurrentPosition : public ModelCommand
 public:
     ReportSwitchCurrentPosition() : ModelCommand("report")
     {
-        AddArgument("attr-name", "current-position");
-        AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
-        AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval);
-        AddArgument("wait", 0, 1, &mWait);
+        AddArgument("attr-name", "current-position", false);
+        AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval, false);
+        AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval, false);
+        AddArgument("wait", 0, 1, &mWait, false);
         ModelCommand::AddArguments();
     }
 
@@ -21059,7 +21064,7 @@ class ReadSwitchMultiPressMax : public ModelCommand
 public:
     ReadSwitchMultiPressMax() : ModelCommand("read")
     {
-        AddArgument("attr-name", "multi-press-max");
+        AddArgument("attr-name", "multi-press-max", false);
         ModelCommand::AddArguments();
     }
 
@@ -21093,7 +21098,7 @@ class ReadSwitchFeatureMap : public ModelCommand
 public:
     ReadSwitchFeatureMap() : ModelCommand("read")
     {
-        AddArgument("attr-name", "feature-map");
+        AddArgument("attr-name", "feature-map", false);
         ModelCommand::AddArguments();
     }
 
@@ -21127,7 +21132,7 @@ class ReadSwitchClusterRevision : public ModelCommand
 public:
     ReadSwitchClusterRevision() : ModelCommand("read")
     {
-        AddArgument("attr-name", "cluster-revision");
+        AddArgument("attr-name", "cluster-revision", false);
         ModelCommand::AddArguments();
     }
 
@@ -21176,7 +21181,7 @@ class TvChannelChangeChannel : public ModelCommand
 public:
     TvChannelChangeChannel() : ModelCommand("change-channel")
     {
-        AddArgument("Match", &mRequest.match);
+        AddArgument("Match", &mRequest.match, false);
         ModelCommand::AddArguments();
     }
 
@@ -21201,8 +21206,8 @@ class TvChannelChangeChannelByNumber : public ModelCommand
 public:
     TvChannelChangeChannelByNumber() : ModelCommand("change-channel-by-number")
     {
-        AddArgument("MajorNumber", 0, UINT16_MAX, &mRequest.majorNumber);
-        AddArgument("MinorNumber", 0, UINT16_MAX, &mRequest.minorNumber);
+        AddArgument("MajorNumber", 0, UINT16_MAX, &mRequest.majorNumber, false);
+        AddArgument("MinorNumber", 0, UINT16_MAX, &mRequest.minorNumber, false);
         ModelCommand::AddArguments();
     }
 
@@ -21227,7 +21232,7 @@ class TvChannelSkipChannel : public ModelCommand
 public:
     TvChannelSkipChannel() : ModelCommand("skip-channel")
     {
-        AddArgument("Count", 0, UINT16_MAX, &mRequest.count);
+        AddArgument("Count", 0, UINT16_MAX, &mRequest.count, false);
         ModelCommand::AddArguments();
     }
 
@@ -21252,7 +21257,7 @@ class ReadTvChannelTvChannelList : public ModelCommand
 public:
     ReadTvChannelTvChannelList() : ModelCommand("read")
     {
-        AddArgument("attr-name", "tv-channel-list");
+        AddArgument("attr-name", "tv-channel-list", false);
         ModelCommand::AddArguments();
     }
 
@@ -21287,7 +21292,7 @@ class ReadTvChannelTvChannelLineup : public ModelCommand
 public:
     ReadTvChannelTvChannelLineup() : ModelCommand("read")
     {
-        AddArgument("attr-name", "tv-channel-lineup");
+        AddArgument("attr-name", "tv-channel-lineup", false);
         ModelCommand::AddArguments();
     }
 
@@ -21321,7 +21326,7 @@ class ReadTvChannelCurrentTvChannel : public ModelCommand
 public:
     ReadTvChannelCurrentTvChannel() : ModelCommand("read")
     {
-        AddArgument("attr-name", "current-tv-channel");
+        AddArgument("attr-name", "current-tv-channel", false);
         ModelCommand::AddArguments();
     }
 
@@ -21355,7 +21360,7 @@ class ReadTvChannelClusterRevision : public ModelCommand
 public:
     ReadTvChannelClusterRevision() : ModelCommand("read")
     {
-        AddArgument("attr-name", "cluster-revision");
+        AddArgument("attr-name", "cluster-revision", false);
         ModelCommand::AddArguments();
     }
 
@@ -21400,8 +21405,8 @@ class TargetNavigatorNavigateTarget : public ModelCommand
 public:
     TargetNavigatorNavigateTarget() : ModelCommand("navigate-target")
     {
-        AddArgument("Target", 0, UINT8_MAX, &mRequest.target);
-        AddArgument("Data", &mRequest.data);
+        AddArgument("Target", 0, UINT8_MAX, &mRequest.target, false);
+        AddArgument("Data", &mRequest.data, false);
         ModelCommand::AddArguments();
     }
 
@@ -21426,7 +21431,7 @@ class ReadTargetNavigatorTargetNavigatorList : public ModelCommand
 public:
     ReadTargetNavigatorTargetNavigatorList() : ModelCommand("read")
     {
-        AddArgument("attr-name", "target-navigator-list");
+        AddArgument("attr-name", "target-navigator-list", false);
         ModelCommand::AddArguments();
     }
 
@@ -21461,7 +21466,7 @@ class ReadTargetNavigatorClusterRevision : public ModelCommand
 public:
     ReadTargetNavigatorClusterRevision() : ModelCommand("read")
     {
-        AddArgument("attr-name", "cluster-revision");
+        AddArgument("attr-name", "cluster-revision", false);
         ModelCommand::AddArguments();
     }
 
@@ -21508,7 +21513,7 @@ class ReadTemperatureMeasurementMeasuredValue : public ModelCommand
 public:
     ReadTemperatureMeasurementMeasuredValue() : ModelCommand("read")
     {
-        AddArgument("attr-name", "measured-value");
+        AddArgument("attr-name", "measured-value", false);
         ModelCommand::AddArguments();
     }
 
@@ -21539,10 +21544,10 @@ class ReportTemperatureMeasurementMeasuredValue : public ModelCommand
 public:
     ReportTemperatureMeasurementMeasuredValue() : ModelCommand("report")
     {
-        AddArgument("attr-name", "measured-value");
-        AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
-        AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval);
-        AddArgument("wait", 0, 1, &mWait);
+        AddArgument("attr-name", "measured-value", false);
+        AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval, false);
+        AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval, false);
+        AddArgument("wait", 0, 1, &mWait, false);
         ModelCommand::AddArguments();
     }
 
@@ -21594,7 +21599,7 @@ class ReadTemperatureMeasurementMinMeasuredValue : public ModelCommand
 public:
     ReadTemperatureMeasurementMinMeasuredValue() : ModelCommand("read")
     {
-        AddArgument("attr-name", "min-measured-value");
+        AddArgument("attr-name", "min-measured-value", false);
         ModelCommand::AddArguments();
     }
 
@@ -21628,7 +21633,7 @@ class ReadTemperatureMeasurementMaxMeasuredValue : public ModelCommand
 public:
     ReadTemperatureMeasurementMaxMeasuredValue() : ModelCommand("read")
     {
-        AddArgument("attr-name", "max-measured-value");
+        AddArgument("attr-name", "max-measured-value", false);
         ModelCommand::AddArguments();
     }
 
@@ -21662,7 +21667,7 @@ class ReadTemperatureMeasurementTolerance : public ModelCommand
 public:
     ReadTemperatureMeasurementTolerance() : ModelCommand("read")
     {
-        AddArgument("attr-name", "tolerance");
+        AddArgument("attr-name", "tolerance", false);
         ModelCommand::AddArguments();
     }
 
@@ -21693,10 +21698,10 @@ class ReportTemperatureMeasurementTolerance : public ModelCommand
 public:
     ReportTemperatureMeasurementTolerance() : ModelCommand("report")
     {
-        AddArgument("attr-name", "tolerance");
-        AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
-        AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval);
-        AddArgument("wait", 0, 1, &mWait);
+        AddArgument("attr-name", "tolerance", false);
+        AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval, false);
+        AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval, false);
+        AddArgument("wait", 0, 1, &mWait, false);
         ModelCommand::AddArguments();
     }
 
@@ -21748,7 +21753,7 @@ class ReadTemperatureMeasurementClusterRevision : public ModelCommand
 public:
     ReadTemperatureMeasurementClusterRevision() : ModelCommand("read")
     {
-        AddArgument("attr-name", "cluster-revision");
+        AddArgument("attr-name", "cluster-revision", false);
         ModelCommand::AddArguments();
     }
 
@@ -21850,8 +21855,8 @@ class TestClusterTestAddArguments : public ModelCommand
 public:
     TestClusterTestAddArguments() : ModelCommand("test-add-arguments")
     {
-        AddArgument("Arg1", 0, UINT8_MAX, &mRequest.arg1);
-        AddArgument("Arg2", 0, UINT8_MAX, &mRequest.arg2);
+        AddArgument("Arg1", 0, UINT8_MAX, &mRequest.arg1, false);
+        AddArgument("Arg2", 0, UINT8_MAX, &mRequest.arg2, false);
         ModelCommand::AddArguments();
     }
 
@@ -21876,8 +21881,9 @@ class TestClusterTestEnumsRequest : public ModelCommand
 public:
     TestClusterTestEnumsRequest() : ModelCommand("test-enums-request")
     {
-        AddArgument("Arg1", 0, UINT16_MAX, &mRequest.arg1);
-        AddArgument("Arg2", 0, UINT8_MAX, reinterpret_cast<std::underlying_type_t<decltype(mRequest.arg2)> *>(&mRequest.arg2));
+        AddArgument("Arg1", 0, UINT16_MAX, &mRequest.arg1, false);
+        AddArgument("Arg2", 0, UINT8_MAX, reinterpret_cast<std::underlying_type_t<decltype(mRequest.arg2)> *>(&mRequest.arg2),
+                    false);
         ModelCommand::AddArguments();
     }
 
@@ -21998,7 +22004,7 @@ class TestClusterTestNullableOptionalRequest : public ModelCommand
 public:
     TestClusterTestNullableOptionalRequest() : ModelCommand("test-nullable-optional-request")
     {
-        AddArgument("Arg1", 0, UINT8_MAX, &mRequest.arg1);
+        AddArgument("Arg1", 0, UINT8_MAX, &mRequest.arg1, false);
         ModelCommand::AddArguments();
     }
 
@@ -22090,7 +22096,7 @@ class ReadTestClusterBoolean : public ModelCommand
 public:
     ReadTestClusterBoolean() : ModelCommand("read")
     {
-        AddArgument("attr-name", "boolean");
+        AddArgument("attr-name", "boolean", false);
         ModelCommand::AddArguments();
     }
 
@@ -22121,8 +22127,8 @@ class WriteTestClusterBoolean : public ModelCommand
 public:
     WriteTestClusterBoolean() : ModelCommand("write")
     {
-        AddArgument("attr-name", "boolean");
-        AddArgument("attr-value", 0, 1, &mValue);
+        AddArgument("attr-name", "boolean", false);
+        AddArgument("attr-value", 0, 1, &mValue, false);
         ModelCommand::AddArguments();
     }
 
@@ -22157,7 +22163,7 @@ class ReadTestClusterBitmap8 : public ModelCommand
 public:
     ReadTestClusterBitmap8() : ModelCommand("read")
     {
-        AddArgument("attr-name", "bitmap8");
+        AddArgument("attr-name", "bitmap8", false);
         ModelCommand::AddArguments();
     }
 
@@ -22188,8 +22194,8 @@ class WriteTestClusterBitmap8 : public ModelCommand
 public:
     WriteTestClusterBitmap8() : ModelCommand("write")
     {
-        AddArgument("attr-name", "bitmap8");
-        AddArgument("attr-value", 0, UINT8_MAX, &mValue);
+        AddArgument("attr-name", "bitmap8", false);
+        AddArgument("attr-value", 0, UINT8_MAX, &mValue, false);
         ModelCommand::AddArguments();
     }
 
@@ -22224,7 +22230,7 @@ class ReadTestClusterBitmap16 : public ModelCommand
 public:
     ReadTestClusterBitmap16() : ModelCommand("read")
     {
-        AddArgument("attr-name", "bitmap16");
+        AddArgument("attr-name", "bitmap16", false);
         ModelCommand::AddArguments();
     }
 
@@ -22255,8 +22261,8 @@ class WriteTestClusterBitmap16 : public ModelCommand
 public:
     WriteTestClusterBitmap16() : ModelCommand("write")
     {
-        AddArgument("attr-name", "bitmap16");
-        AddArgument("attr-value", 0, UINT16_MAX, &mValue);
+        AddArgument("attr-name", "bitmap16", false);
+        AddArgument("attr-value", 0, UINT16_MAX, &mValue, false);
         ModelCommand::AddArguments();
     }
 
@@ -22291,7 +22297,7 @@ class ReadTestClusterBitmap32 : public ModelCommand
 public:
     ReadTestClusterBitmap32() : ModelCommand("read")
     {
-        AddArgument("attr-name", "bitmap32");
+        AddArgument("attr-name", "bitmap32", false);
         ModelCommand::AddArguments();
     }
 
@@ -22322,8 +22328,8 @@ class WriteTestClusterBitmap32 : public ModelCommand
 public:
     WriteTestClusterBitmap32() : ModelCommand("write")
     {
-        AddArgument("attr-name", "bitmap32");
-        AddArgument("attr-value", 0, UINT32_MAX, &mValue);
+        AddArgument("attr-name", "bitmap32", false);
+        AddArgument("attr-value", 0, UINT32_MAX, &mValue, false);
         ModelCommand::AddArguments();
     }
 
@@ -22358,7 +22364,7 @@ class ReadTestClusterBitmap64 : public ModelCommand
 public:
     ReadTestClusterBitmap64() : ModelCommand("read")
     {
-        AddArgument("attr-name", "bitmap64");
+        AddArgument("attr-name", "bitmap64", false);
         ModelCommand::AddArguments();
     }
 
@@ -22389,8 +22395,8 @@ class WriteTestClusterBitmap64 : public ModelCommand
 public:
     WriteTestClusterBitmap64() : ModelCommand("write")
     {
-        AddArgument("attr-name", "bitmap64");
-        AddArgument("attr-value", 0, UINT64_MAX, &mValue);
+        AddArgument("attr-name", "bitmap64", false);
+        AddArgument("attr-value", 0, UINT64_MAX, &mValue, false);
         ModelCommand::AddArguments();
     }
 
@@ -22425,7 +22431,7 @@ class ReadTestClusterInt8u : public ModelCommand
 public:
     ReadTestClusterInt8u() : ModelCommand("read")
     {
-        AddArgument("attr-name", "int8u");
+        AddArgument("attr-name", "int8u", false);
         ModelCommand::AddArguments();
     }
 
@@ -22456,8 +22462,8 @@ class WriteTestClusterInt8u : public ModelCommand
 public:
     WriteTestClusterInt8u() : ModelCommand("write")
     {
-        AddArgument("attr-name", "int8u");
-        AddArgument("attr-value", 0, UINT8_MAX, &mValue);
+        AddArgument("attr-name", "int8u", false);
+        AddArgument("attr-value", 0, UINT8_MAX, &mValue, false);
         ModelCommand::AddArguments();
     }
 
@@ -22492,7 +22498,7 @@ class ReadTestClusterInt16u : public ModelCommand
 public:
     ReadTestClusterInt16u() : ModelCommand("read")
     {
-        AddArgument("attr-name", "int16u");
+        AddArgument("attr-name", "int16u", false);
         ModelCommand::AddArguments();
     }
 
@@ -22523,8 +22529,8 @@ class WriteTestClusterInt16u : public ModelCommand
 public:
     WriteTestClusterInt16u() : ModelCommand("write")
     {
-        AddArgument("attr-name", "int16u");
-        AddArgument("attr-value", 0, UINT16_MAX, &mValue);
+        AddArgument("attr-name", "int16u", false);
+        AddArgument("attr-value", 0, UINT16_MAX, &mValue, false);
         ModelCommand::AddArguments();
     }
 
@@ -22559,7 +22565,7 @@ class ReadTestClusterInt32u : public ModelCommand
 public:
     ReadTestClusterInt32u() : ModelCommand("read")
     {
-        AddArgument("attr-name", "int32u");
+        AddArgument("attr-name", "int32u", false);
         ModelCommand::AddArguments();
     }
 
@@ -22590,8 +22596,8 @@ class WriteTestClusterInt32u : public ModelCommand
 public:
     WriteTestClusterInt32u() : ModelCommand("write")
     {
-        AddArgument("attr-name", "int32u");
-        AddArgument("attr-value", 0, UINT32_MAX, &mValue);
+        AddArgument("attr-name", "int32u", false);
+        AddArgument("attr-value", 0, UINT32_MAX, &mValue, false);
         ModelCommand::AddArguments();
     }
 
@@ -22626,7 +22632,7 @@ class ReadTestClusterInt64u : public ModelCommand
 public:
     ReadTestClusterInt64u() : ModelCommand("read")
     {
-        AddArgument("attr-name", "int64u");
+        AddArgument("attr-name", "int64u", false);
         ModelCommand::AddArguments();
     }
 
@@ -22657,8 +22663,8 @@ class WriteTestClusterInt64u : public ModelCommand
 public:
     WriteTestClusterInt64u() : ModelCommand("write")
     {
-        AddArgument("attr-name", "int64u");
-        AddArgument("attr-value", 0, UINT64_MAX, &mValue);
+        AddArgument("attr-name", "int64u", false);
+        AddArgument("attr-value", 0, UINT64_MAX, &mValue, false);
         ModelCommand::AddArguments();
     }
 
@@ -22693,7 +22699,7 @@ class ReadTestClusterInt8s : public ModelCommand
 public:
     ReadTestClusterInt8s() : ModelCommand("read")
     {
-        AddArgument("attr-name", "int8s");
+        AddArgument("attr-name", "int8s", false);
         ModelCommand::AddArguments();
     }
 
@@ -22724,8 +22730,8 @@ class WriteTestClusterInt8s : public ModelCommand
 public:
     WriteTestClusterInt8s() : ModelCommand("write")
     {
-        AddArgument("attr-name", "int8s");
-        AddArgument("attr-value", INT8_MIN, INT8_MAX, &mValue);
+        AddArgument("attr-name", "int8s", false);
+        AddArgument("attr-value", INT8_MIN, INT8_MAX, &mValue, false);
         ModelCommand::AddArguments();
     }
 
@@ -22760,7 +22766,7 @@ class ReadTestClusterInt16s : public ModelCommand
 public:
     ReadTestClusterInt16s() : ModelCommand("read")
     {
-        AddArgument("attr-name", "int16s");
+        AddArgument("attr-name", "int16s", false);
         ModelCommand::AddArguments();
     }
 
@@ -22791,8 +22797,8 @@ class WriteTestClusterInt16s : public ModelCommand
 public:
     WriteTestClusterInt16s() : ModelCommand("write")
     {
-        AddArgument("attr-name", "int16s");
-        AddArgument("attr-value", INT16_MIN, INT16_MAX, &mValue);
+        AddArgument("attr-name", "int16s", false);
+        AddArgument("attr-value", INT16_MIN, INT16_MAX, &mValue, false);
         ModelCommand::AddArguments();
     }
 
@@ -22827,7 +22833,7 @@ class ReadTestClusterInt32s : public ModelCommand
 public:
     ReadTestClusterInt32s() : ModelCommand("read")
     {
-        AddArgument("attr-name", "int32s");
+        AddArgument("attr-name", "int32s", false);
         ModelCommand::AddArguments();
     }
 
@@ -22858,8 +22864,8 @@ class WriteTestClusterInt32s : public ModelCommand
 public:
     WriteTestClusterInt32s() : ModelCommand("write")
     {
-        AddArgument("attr-name", "int32s");
-        AddArgument("attr-value", INT32_MIN, INT32_MAX, &mValue);
+        AddArgument("attr-name", "int32s", false);
+        AddArgument("attr-value", INT32_MIN, INT32_MAX, &mValue, false);
         ModelCommand::AddArguments();
     }
 
@@ -22894,7 +22900,7 @@ class ReadTestClusterInt64s : public ModelCommand
 public:
     ReadTestClusterInt64s() : ModelCommand("read")
     {
-        AddArgument("attr-name", "int64s");
+        AddArgument("attr-name", "int64s", false);
         ModelCommand::AddArguments();
     }
 
@@ -22925,8 +22931,8 @@ class WriteTestClusterInt64s : public ModelCommand
 public:
     WriteTestClusterInt64s() : ModelCommand("write")
     {
-        AddArgument("attr-name", "int64s");
-        AddArgument("attr-value", INT64_MIN, INT64_MAX, &mValue);
+        AddArgument("attr-name", "int64s", false);
+        AddArgument("attr-value", INT64_MIN, INT64_MAX, &mValue, false);
         ModelCommand::AddArguments();
     }
 
@@ -22961,7 +22967,7 @@ class ReadTestClusterEnum8 : public ModelCommand
 public:
     ReadTestClusterEnum8() : ModelCommand("read")
     {
-        AddArgument("attr-name", "enum8");
+        AddArgument("attr-name", "enum8", false);
         ModelCommand::AddArguments();
     }
 
@@ -22992,8 +22998,8 @@ class WriteTestClusterEnum8 : public ModelCommand
 public:
     WriteTestClusterEnum8() : ModelCommand("write")
     {
-        AddArgument("attr-name", "enum8");
-        AddArgument("attr-value", 0, UINT8_MAX, &mValue);
+        AddArgument("attr-name", "enum8", false);
+        AddArgument("attr-value", 0, UINT8_MAX, &mValue, false);
         ModelCommand::AddArguments();
     }
 
@@ -23028,7 +23034,7 @@ class ReadTestClusterEnum16 : public ModelCommand
 public:
     ReadTestClusterEnum16() : ModelCommand("read")
     {
-        AddArgument("attr-name", "enum16");
+        AddArgument("attr-name", "enum16", false);
         ModelCommand::AddArguments();
     }
 
@@ -23059,8 +23065,8 @@ class WriteTestClusterEnum16 : public ModelCommand
 public:
     WriteTestClusterEnum16() : ModelCommand("write")
     {
-        AddArgument("attr-name", "enum16");
-        AddArgument("attr-value", 0, UINT16_MAX, &mValue);
+        AddArgument("attr-name", "enum16", false);
+        AddArgument("attr-value", 0, UINT16_MAX, &mValue, false);
         ModelCommand::AddArguments();
     }
 
@@ -23095,7 +23101,7 @@ class ReadTestClusterOctetString : public ModelCommand
 public:
     ReadTestClusterOctetString() : ModelCommand("read")
     {
-        AddArgument("attr-name", "octet-string");
+        AddArgument("attr-name", "octet-string", false);
         ModelCommand::AddArguments();
     }
 
@@ -23126,8 +23132,8 @@ class WriteTestClusterOctetString : public ModelCommand
 public:
     WriteTestClusterOctetString() : ModelCommand("write")
     {
-        AddArgument("attr-name", "octet-string");
-        AddArgument("attr-value", &mValue);
+        AddArgument("attr-name", "octet-string", false);
+        AddArgument("attr-value", &mValue, false);
         ModelCommand::AddArguments();
     }
 
@@ -23162,7 +23168,7 @@ class ReadTestClusterListInt8u : public ModelCommand
 public:
     ReadTestClusterListInt8u() : ModelCommand("read")
     {
-        AddArgument("attr-name", "list-int8u");
+        AddArgument("attr-name", "list-int8u", false);
         ModelCommand::AddArguments();
     }
 
@@ -23196,7 +23202,7 @@ class ReadTestClusterListOctetString : public ModelCommand
 public:
     ReadTestClusterListOctetString() : ModelCommand("read")
     {
-        AddArgument("attr-name", "list-octet-string");
+        AddArgument("attr-name", "list-octet-string", false);
         ModelCommand::AddArguments();
     }
 
@@ -23231,7 +23237,7 @@ class ReadTestClusterListStructOctetString : public ModelCommand
 public:
     ReadTestClusterListStructOctetString() : ModelCommand("read")
     {
-        AddArgument("attr-name", "list-struct-octet-string");
+        AddArgument("attr-name", "list-struct-octet-string", false);
         ModelCommand::AddArguments();
     }
 
@@ -23266,7 +23272,7 @@ class ReadTestClusterLongOctetString : public ModelCommand
 public:
     ReadTestClusterLongOctetString() : ModelCommand("read")
     {
-        AddArgument("attr-name", "long-octet-string");
+        AddArgument("attr-name", "long-octet-string", false);
         ModelCommand::AddArguments();
     }
 
@@ -23297,8 +23303,8 @@ class WriteTestClusterLongOctetString : public ModelCommand
 public:
     WriteTestClusterLongOctetString() : ModelCommand("write")
     {
-        AddArgument("attr-name", "long-octet-string");
-        AddArgument("attr-value", &mValue);
+        AddArgument("attr-name", "long-octet-string", false);
+        AddArgument("attr-value", &mValue, false);
         ModelCommand::AddArguments();
     }
 
@@ -23333,7 +23339,7 @@ class ReadTestClusterCharString : public ModelCommand
 public:
     ReadTestClusterCharString() : ModelCommand("read")
     {
-        AddArgument("attr-name", "char-string");
+        AddArgument("attr-name", "char-string", false);
         ModelCommand::AddArguments();
     }
 
@@ -23364,8 +23370,8 @@ class WriteTestClusterCharString : public ModelCommand
 public:
     WriteTestClusterCharString() : ModelCommand("write")
     {
-        AddArgument("attr-name", "char-string");
-        AddArgument("attr-value", &mValue);
+        AddArgument("attr-name", "char-string", false);
+        AddArgument("attr-value", &mValue, false);
         ModelCommand::AddArguments();
     }
 
@@ -23400,7 +23406,7 @@ class ReadTestClusterLongCharString : public ModelCommand
 public:
     ReadTestClusterLongCharString() : ModelCommand("read")
     {
-        AddArgument("attr-name", "long-char-string");
+        AddArgument("attr-name", "long-char-string", false);
         ModelCommand::AddArguments();
     }
 
@@ -23431,8 +23437,8 @@ class WriteTestClusterLongCharString : public ModelCommand
 public:
     WriteTestClusterLongCharString() : ModelCommand("write")
     {
-        AddArgument("attr-name", "long-char-string");
-        AddArgument("attr-value", &mValue);
+        AddArgument("attr-name", "long-char-string", false);
+        AddArgument("attr-value", &mValue, false);
         ModelCommand::AddArguments();
     }
 
@@ -23467,7 +23473,7 @@ class ReadTestClusterEpochUs : public ModelCommand
 public:
     ReadTestClusterEpochUs() : ModelCommand("read")
     {
-        AddArgument("attr-name", "epoch-us");
+        AddArgument("attr-name", "epoch-us", false);
         ModelCommand::AddArguments();
     }
 
@@ -23498,8 +23504,8 @@ class WriteTestClusterEpochUs : public ModelCommand
 public:
     WriteTestClusterEpochUs() : ModelCommand("write")
     {
-        AddArgument("attr-name", "epoch-us");
-        AddArgument("attr-value", 0, UINT64_MAX, &mValue);
+        AddArgument("attr-name", "epoch-us", false);
+        AddArgument("attr-value", 0, UINT64_MAX, &mValue, false);
         ModelCommand::AddArguments();
     }
 
@@ -23534,7 +23540,7 @@ class ReadTestClusterEpochS : public ModelCommand
 public:
     ReadTestClusterEpochS() : ModelCommand("read")
     {
-        AddArgument("attr-name", "epoch-s");
+        AddArgument("attr-name", "epoch-s", false);
         ModelCommand::AddArguments();
     }
 
@@ -23565,8 +23571,8 @@ class WriteTestClusterEpochS : public ModelCommand
 public:
     WriteTestClusterEpochS() : ModelCommand("write")
     {
-        AddArgument("attr-name", "epoch-s");
-        AddArgument("attr-value", 0, UINT32_MAX, &mValue);
+        AddArgument("attr-name", "epoch-s", false);
+        AddArgument("attr-value", 0, UINT32_MAX, &mValue, false);
         ModelCommand::AddArguments();
     }
 
@@ -23601,7 +23607,7 @@ class ReadTestClusterVendorId : public ModelCommand
 public:
     ReadTestClusterVendorId() : ModelCommand("read")
     {
-        AddArgument("attr-name", "vendor-id");
+        AddArgument("attr-name", "vendor-id", false);
         ModelCommand::AddArguments();
     }
 
@@ -23632,8 +23638,8 @@ class WriteTestClusterVendorId : public ModelCommand
 public:
     WriteTestClusterVendorId() : ModelCommand("write")
     {
-        AddArgument("attr-name", "vendor-id");
-        AddArgument("attr-value", 0, UINT16_MAX, &mValue);
+        AddArgument("attr-name", "vendor-id", false);
+        AddArgument("attr-value", 0, UINT16_MAX, &mValue, false);
         ModelCommand::AddArguments();
     }
 
@@ -23668,7 +23674,7 @@ class ReadTestClusterListNullablesAndOptionalsStruct : public ModelCommand
 public:
     ReadTestClusterListNullablesAndOptionalsStruct() : ModelCommand("read")
     {
-        AddArgument("attr-name", "list-nullables-and-optionals-struct");
+        AddArgument("attr-name", "list-nullables-and-optionals-struct", false);
         ModelCommand::AddArguments();
     }
 
@@ -23703,7 +23709,7 @@ class ReadTestClusterUnsupported : public ModelCommand
 public:
     ReadTestClusterUnsupported() : ModelCommand("read")
     {
-        AddArgument("attr-name", "unsupported");
+        AddArgument("attr-name", "unsupported", false);
         ModelCommand::AddArguments();
     }
 
@@ -23734,8 +23740,8 @@ class WriteTestClusterUnsupported : public ModelCommand
 public:
     WriteTestClusterUnsupported() : ModelCommand("write")
     {
-        AddArgument("attr-name", "unsupported");
-        AddArgument("attr-value", 0, 1, &mValue);
+        AddArgument("attr-name", "unsupported", false);
+        AddArgument("attr-value", 0, 1, &mValue, false);
         ModelCommand::AddArguments();
     }
 
@@ -23770,7 +23776,7 @@ class ReadTestClusterClusterRevision : public ModelCommand
 public:
     ReadTestClusterClusterRevision() : ModelCommand("read")
     {
-        AddArgument("attr-name", "cluster-revision");
+        AddArgument("attr-name", "cluster-revision", false);
         ModelCommand::AddArguments();
     }
 
@@ -23879,10 +23885,12 @@ public:
     ThermostatGetWeeklySchedule() : ModelCommand("get-weekly-schedule")
     {
         AddArgument("DaysToReturn", 0, UINT8_MAX,
-                    reinterpret_cast<std::underlying_type_t<chip::app::Clusters::Thermostat::DayOfWeek> *>(&mRequest.daysToReturn));
+                    reinterpret_cast<std::underlying_type_t<chip::app::Clusters::Thermostat::DayOfWeek> *>(&mRequest.daysToReturn),
+                    false);
         AddArgument(
             "ModeToReturn", 0, UINT8_MAX,
-            reinterpret_cast<std::underlying_type_t<chip::app::Clusters::Thermostat::ModeForSequence> *>(&mRequest.modeToReturn));
+            reinterpret_cast<std::underlying_type_t<chip::app::Clusters::Thermostat::ModeForSequence> *>(&mRequest.modeToReturn),
+            false);
         ModelCommand::AddArguments();
     }
 
@@ -23907,13 +23915,15 @@ class ThermostatSetWeeklySchedule : public ModelCommand
 public:
     ThermostatSetWeeklySchedule() : ModelCommand("set-weekly-schedule")
     {
-        AddArgument("NumberOfTransitionsForSequence", 0, UINT8_MAX, &mRequest.numberOfTransitionsForSequence);
+        AddArgument("NumberOfTransitionsForSequence", 0, UINT8_MAX, &mRequest.numberOfTransitionsForSequence, false);
         AddArgument(
             "DayOfWeekForSequence", 0, UINT8_MAX,
-            reinterpret_cast<std::underlying_type_t<chip::app::Clusters::Thermostat::DayOfWeek> *>(&mRequest.dayOfWeekForSequence));
-        AddArgument("ModeForSequence", 0, UINT8_MAX,
-                    reinterpret_cast<std::underlying_type_t<chip::app::Clusters::Thermostat::ModeForSequence> *>(
-                        &mRequest.modeForSequence));
+            reinterpret_cast<std::underlying_type_t<chip::app::Clusters::Thermostat::DayOfWeek> *>(&mRequest.dayOfWeekForSequence),
+            false);
+        AddArgument(
+            "ModeForSequence", 0, UINT8_MAX,
+            reinterpret_cast<std::underlying_type_t<chip::app::Clusters::Thermostat::ModeForSequence> *>(&mRequest.modeForSequence),
+            false);
         // payload Array parsing is not supported yet
         ModelCommand::AddArguments();
     }
@@ -23939,8 +23949,9 @@ class ThermostatSetpointRaiseLower : public ModelCommand
 public:
     ThermostatSetpointRaiseLower() : ModelCommand("setpoint-raise-lower")
     {
-        AddArgument("Mode", 0, UINT8_MAX, reinterpret_cast<std::underlying_type_t<decltype(mRequest.mode)> *>(&mRequest.mode));
-        AddArgument("Amount", INT8_MIN, INT8_MAX, &mRequest.amount);
+        AddArgument("Mode", 0, UINT8_MAX, reinterpret_cast<std::underlying_type_t<decltype(mRequest.mode)> *>(&mRequest.mode),
+                    false);
+        AddArgument("Amount", INT8_MIN, INT8_MAX, &mRequest.amount, false);
         ModelCommand::AddArguments();
     }
 
@@ -23965,7 +23976,7 @@ class ReadThermostatLocalTemperature : public ModelCommand
 public:
     ReadThermostatLocalTemperature() : ModelCommand("read")
     {
-        AddArgument("attr-name", "local-temperature");
+        AddArgument("attr-name", "local-temperature", false);
         ModelCommand::AddArguments();
     }
 
@@ -23996,10 +24007,10 @@ class ReportThermostatLocalTemperature : public ModelCommand
 public:
     ReportThermostatLocalTemperature() : ModelCommand("report")
     {
-        AddArgument("attr-name", "local-temperature");
-        AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
-        AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval);
-        AddArgument("wait", 0, 1, &mWait);
+        AddArgument("attr-name", "local-temperature", false);
+        AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval, false);
+        AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval, false);
+        AddArgument("wait", 0, 1, &mWait, false);
         ModelCommand::AddArguments();
     }
 
@@ -24051,7 +24062,7 @@ class ReadThermostatAbsMinHeatSetpointLimit : public ModelCommand
 public:
     ReadThermostatAbsMinHeatSetpointLimit() : ModelCommand("read")
     {
-        AddArgument("attr-name", "abs-min-heat-setpoint-limit");
+        AddArgument("attr-name", "abs-min-heat-setpoint-limit", false);
         ModelCommand::AddArguments();
     }
 
@@ -24085,7 +24096,7 @@ class ReadThermostatAbsMaxHeatSetpointLimit : public ModelCommand
 public:
     ReadThermostatAbsMaxHeatSetpointLimit() : ModelCommand("read")
     {
-        AddArgument("attr-name", "abs-max-heat-setpoint-limit");
+        AddArgument("attr-name", "abs-max-heat-setpoint-limit", false);
         ModelCommand::AddArguments();
     }
 
@@ -24119,7 +24130,7 @@ class ReadThermostatAbsMinCoolSetpointLimit : public ModelCommand
 public:
     ReadThermostatAbsMinCoolSetpointLimit() : ModelCommand("read")
     {
-        AddArgument("attr-name", "abs-min-cool-setpoint-limit");
+        AddArgument("attr-name", "abs-min-cool-setpoint-limit", false);
         ModelCommand::AddArguments();
     }
 
@@ -24153,7 +24164,7 @@ class ReadThermostatAbsMaxCoolSetpointLimit : public ModelCommand
 public:
     ReadThermostatAbsMaxCoolSetpointLimit() : ModelCommand("read")
     {
-        AddArgument("attr-name", "abs-max-cool-setpoint-limit");
+        AddArgument("attr-name", "abs-max-cool-setpoint-limit", false);
         ModelCommand::AddArguments();
     }
 
@@ -24187,7 +24198,7 @@ class ReadThermostatOccupiedCoolingSetpoint : public ModelCommand
 public:
     ReadThermostatOccupiedCoolingSetpoint() : ModelCommand("read")
     {
-        AddArgument("attr-name", "occupied-cooling-setpoint");
+        AddArgument("attr-name", "occupied-cooling-setpoint", false);
         ModelCommand::AddArguments();
     }
 
@@ -24218,8 +24229,8 @@ class WriteThermostatOccupiedCoolingSetpoint : public ModelCommand
 public:
     WriteThermostatOccupiedCoolingSetpoint() : ModelCommand("write")
     {
-        AddArgument("attr-name", "occupied-cooling-setpoint");
-        AddArgument("attr-value", INT16_MIN, INT16_MAX, &mValue);
+        AddArgument("attr-name", "occupied-cooling-setpoint", false);
+        AddArgument("attr-value", INT16_MIN, INT16_MAX, &mValue, false);
         ModelCommand::AddArguments();
     }
 
@@ -24254,7 +24265,7 @@ class ReadThermostatOccupiedHeatingSetpoint : public ModelCommand
 public:
     ReadThermostatOccupiedHeatingSetpoint() : ModelCommand("read")
     {
-        AddArgument("attr-name", "occupied-heating-setpoint");
+        AddArgument("attr-name", "occupied-heating-setpoint", false);
         ModelCommand::AddArguments();
     }
 
@@ -24285,8 +24296,8 @@ class WriteThermostatOccupiedHeatingSetpoint : public ModelCommand
 public:
     WriteThermostatOccupiedHeatingSetpoint() : ModelCommand("write")
     {
-        AddArgument("attr-name", "occupied-heating-setpoint");
-        AddArgument("attr-value", INT16_MIN, INT16_MAX, &mValue);
+        AddArgument("attr-name", "occupied-heating-setpoint", false);
+        AddArgument("attr-value", INT16_MIN, INT16_MAX, &mValue, false);
         ModelCommand::AddArguments();
     }
 
@@ -24321,7 +24332,7 @@ class ReadThermostatMinHeatSetpointLimit : public ModelCommand
 public:
     ReadThermostatMinHeatSetpointLimit() : ModelCommand("read")
     {
-        AddArgument("attr-name", "min-heat-setpoint-limit");
+        AddArgument("attr-name", "min-heat-setpoint-limit", false);
         ModelCommand::AddArguments();
     }
 
@@ -24352,8 +24363,8 @@ class WriteThermostatMinHeatSetpointLimit : public ModelCommand
 public:
     WriteThermostatMinHeatSetpointLimit() : ModelCommand("write")
     {
-        AddArgument("attr-name", "min-heat-setpoint-limit");
-        AddArgument("attr-value", INT16_MIN, INT16_MAX, &mValue);
+        AddArgument("attr-name", "min-heat-setpoint-limit", false);
+        AddArgument("attr-value", INT16_MIN, INT16_MAX, &mValue, false);
         ModelCommand::AddArguments();
     }
 
@@ -24388,7 +24399,7 @@ class ReadThermostatMaxHeatSetpointLimit : public ModelCommand
 public:
     ReadThermostatMaxHeatSetpointLimit() : ModelCommand("read")
     {
-        AddArgument("attr-name", "max-heat-setpoint-limit");
+        AddArgument("attr-name", "max-heat-setpoint-limit", false);
         ModelCommand::AddArguments();
     }
 
@@ -24419,8 +24430,8 @@ class WriteThermostatMaxHeatSetpointLimit : public ModelCommand
 public:
     WriteThermostatMaxHeatSetpointLimit() : ModelCommand("write")
     {
-        AddArgument("attr-name", "max-heat-setpoint-limit");
-        AddArgument("attr-value", INT16_MIN, INT16_MAX, &mValue);
+        AddArgument("attr-name", "max-heat-setpoint-limit", false);
+        AddArgument("attr-value", INT16_MIN, INT16_MAX, &mValue, false);
         ModelCommand::AddArguments();
     }
 
@@ -24455,7 +24466,7 @@ class ReadThermostatMinCoolSetpointLimit : public ModelCommand
 public:
     ReadThermostatMinCoolSetpointLimit() : ModelCommand("read")
     {
-        AddArgument("attr-name", "min-cool-setpoint-limit");
+        AddArgument("attr-name", "min-cool-setpoint-limit", false);
         ModelCommand::AddArguments();
     }
 
@@ -24486,8 +24497,8 @@ class WriteThermostatMinCoolSetpointLimit : public ModelCommand
 public:
     WriteThermostatMinCoolSetpointLimit() : ModelCommand("write")
     {
-        AddArgument("attr-name", "min-cool-setpoint-limit");
-        AddArgument("attr-value", INT16_MIN, INT16_MAX, &mValue);
+        AddArgument("attr-name", "min-cool-setpoint-limit", false);
+        AddArgument("attr-value", INT16_MIN, INT16_MAX, &mValue, false);
         ModelCommand::AddArguments();
     }
 
@@ -24522,7 +24533,7 @@ class ReadThermostatMaxCoolSetpointLimit : public ModelCommand
 public:
     ReadThermostatMaxCoolSetpointLimit() : ModelCommand("read")
     {
-        AddArgument("attr-name", "max-cool-setpoint-limit");
+        AddArgument("attr-name", "max-cool-setpoint-limit", false);
         ModelCommand::AddArguments();
     }
 
@@ -24553,8 +24564,8 @@ class WriteThermostatMaxCoolSetpointLimit : public ModelCommand
 public:
     WriteThermostatMaxCoolSetpointLimit() : ModelCommand("write")
     {
-        AddArgument("attr-name", "max-cool-setpoint-limit");
-        AddArgument("attr-value", INT16_MIN, INT16_MAX, &mValue);
+        AddArgument("attr-name", "max-cool-setpoint-limit", false);
+        AddArgument("attr-value", INT16_MIN, INT16_MAX, &mValue, false);
         ModelCommand::AddArguments();
     }
 
@@ -24589,7 +24600,7 @@ class ReadThermostatMinSetpointDeadBand : public ModelCommand
 public:
     ReadThermostatMinSetpointDeadBand() : ModelCommand("read")
     {
-        AddArgument("attr-name", "min-setpoint-dead-band");
+        AddArgument("attr-name", "min-setpoint-dead-band", false);
         ModelCommand::AddArguments();
     }
 
@@ -24620,8 +24631,8 @@ class WriteThermostatMinSetpointDeadBand : public ModelCommand
 public:
     WriteThermostatMinSetpointDeadBand() : ModelCommand("write")
     {
-        AddArgument("attr-name", "min-setpoint-dead-band");
-        AddArgument("attr-value", INT8_MIN, INT8_MAX, &mValue);
+        AddArgument("attr-name", "min-setpoint-dead-band", false);
+        AddArgument("attr-value", INT8_MIN, INT8_MAX, &mValue, false);
         ModelCommand::AddArguments();
     }
 
@@ -24656,7 +24667,7 @@ class ReadThermostatControlSequenceOfOperation : public ModelCommand
 public:
     ReadThermostatControlSequenceOfOperation() : ModelCommand("read")
     {
-        AddArgument("attr-name", "control-sequence-of-operation");
+        AddArgument("attr-name", "control-sequence-of-operation", false);
         ModelCommand::AddArguments();
     }
 
@@ -24687,8 +24698,8 @@ class WriteThermostatControlSequenceOfOperation : public ModelCommand
 public:
     WriteThermostatControlSequenceOfOperation() : ModelCommand("write")
     {
-        AddArgument("attr-name", "control-sequence-of-operation");
-        AddArgument("attr-value", 0, UINT8_MAX, &mValue);
+        AddArgument("attr-name", "control-sequence-of-operation", false);
+        AddArgument("attr-value", 0, UINT8_MAX, &mValue, false);
         ModelCommand::AddArguments();
     }
 
@@ -24723,7 +24734,7 @@ class ReadThermostatSystemMode : public ModelCommand
 public:
     ReadThermostatSystemMode() : ModelCommand("read")
     {
-        AddArgument("attr-name", "system-mode");
+        AddArgument("attr-name", "system-mode", false);
         ModelCommand::AddArguments();
     }
 
@@ -24754,8 +24765,8 @@ class WriteThermostatSystemMode : public ModelCommand
 public:
     WriteThermostatSystemMode() : ModelCommand("write")
     {
-        AddArgument("attr-name", "system-mode");
-        AddArgument("attr-value", 0, UINT8_MAX, &mValue);
+        AddArgument("attr-name", "system-mode", false);
+        AddArgument("attr-value", 0, UINT8_MAX, &mValue, false);
         ModelCommand::AddArguments();
     }
 
@@ -24790,7 +24801,7 @@ class ReadThermostatStartOfWeek : public ModelCommand
 public:
     ReadThermostatStartOfWeek() : ModelCommand("read")
     {
-        AddArgument("attr-name", "start-of-week");
+        AddArgument("attr-name", "start-of-week", false);
         ModelCommand::AddArguments();
     }
 
@@ -24824,7 +24835,7 @@ class ReadThermostatNumberOfWeeklyTransitions : public ModelCommand
 public:
     ReadThermostatNumberOfWeeklyTransitions() : ModelCommand("read")
     {
-        AddArgument("attr-name", "number-of-weekly-transitions");
+        AddArgument("attr-name", "number-of-weekly-transitions", false);
         ModelCommand::AddArguments();
     }
 
@@ -24858,7 +24869,7 @@ class ReadThermostatNumberOfDailyTransitions : public ModelCommand
 public:
     ReadThermostatNumberOfDailyTransitions() : ModelCommand("read")
     {
-        AddArgument("attr-name", "number-of-daily-transitions");
+        AddArgument("attr-name", "number-of-daily-transitions", false);
         ModelCommand::AddArguments();
     }
 
@@ -24892,7 +24903,7 @@ class ReadThermostatFeatureMap : public ModelCommand
 public:
     ReadThermostatFeatureMap() : ModelCommand("read")
     {
-        AddArgument("attr-name", "feature-map");
+        AddArgument("attr-name", "feature-map", false);
         ModelCommand::AddArguments();
     }
 
@@ -24926,7 +24937,7 @@ class ReadThermostatClusterRevision : public ModelCommand
 public:
     ReadThermostatClusterRevision() : ModelCommand("read")
     {
-        AddArgument("attr-name", "cluster-revision");
+        AddArgument("attr-name", "cluster-revision", false);
         ModelCommand::AddArguments();
     }
 
@@ -24972,7 +24983,7 @@ class ReadThermostatUserInterfaceConfigurationTemperatureDisplayMode : public Mo
 public:
     ReadThermostatUserInterfaceConfigurationTemperatureDisplayMode() : ModelCommand("read")
     {
-        AddArgument("attr-name", "temperature-display-mode");
+        AddArgument("attr-name", "temperature-display-mode", false);
         ModelCommand::AddArguments();
     }
 
@@ -25003,8 +25014,8 @@ class WriteThermostatUserInterfaceConfigurationTemperatureDisplayMode : public M
 public:
     WriteThermostatUserInterfaceConfigurationTemperatureDisplayMode() : ModelCommand("write")
     {
-        AddArgument("attr-name", "temperature-display-mode");
-        AddArgument("attr-value", 0, UINT8_MAX, &mValue);
+        AddArgument("attr-name", "temperature-display-mode", false);
+        AddArgument("attr-value", 0, UINT8_MAX, &mValue, false);
         ModelCommand::AddArguments();
     }
 
@@ -25039,7 +25050,7 @@ class ReadThermostatUserInterfaceConfigurationKeypadLockout : public ModelComman
 public:
     ReadThermostatUserInterfaceConfigurationKeypadLockout() : ModelCommand("read")
     {
-        AddArgument("attr-name", "keypad-lockout");
+        AddArgument("attr-name", "keypad-lockout", false);
         ModelCommand::AddArguments();
     }
 
@@ -25070,8 +25081,8 @@ class WriteThermostatUserInterfaceConfigurationKeypadLockout : public ModelComma
 public:
     WriteThermostatUserInterfaceConfigurationKeypadLockout() : ModelCommand("write")
     {
-        AddArgument("attr-name", "keypad-lockout");
-        AddArgument("attr-value", 0, UINT8_MAX, &mValue);
+        AddArgument("attr-name", "keypad-lockout", false);
+        AddArgument("attr-value", 0, UINT8_MAX, &mValue, false);
         ModelCommand::AddArguments();
     }
 
@@ -25106,7 +25117,7 @@ class ReadThermostatUserInterfaceConfigurationScheduleProgrammingVisibility : pu
 public:
     ReadThermostatUserInterfaceConfigurationScheduleProgrammingVisibility() : ModelCommand("read")
     {
-        AddArgument("attr-name", "schedule-programming-visibility");
+        AddArgument("attr-name", "schedule-programming-visibility", false);
         ModelCommand::AddArguments();
     }
 
@@ -25137,8 +25148,8 @@ class WriteThermostatUserInterfaceConfigurationScheduleProgrammingVisibility : p
 public:
     WriteThermostatUserInterfaceConfigurationScheduleProgrammingVisibility() : ModelCommand("write")
     {
-        AddArgument("attr-name", "schedule-programming-visibility");
-        AddArgument("attr-value", 0, UINT8_MAX, &mValue);
+        AddArgument("attr-name", "schedule-programming-visibility", false);
+        AddArgument("attr-value", 0, UINT8_MAX, &mValue, false);
         ModelCommand::AddArguments();
     }
 
@@ -25174,7 +25185,7 @@ class ReadThermostatUserInterfaceConfigurationClusterRevision : public ModelComm
 public:
     ReadThermostatUserInterfaceConfigurationClusterRevision() : ModelCommand("read")
     {
-        AddArgument("attr-name", "cluster-revision");
+        AddArgument("attr-name", "cluster-revision", false);
         ModelCommand::AddArguments();
     }
 
@@ -25302,7 +25313,7 @@ class ReadThreadNetworkDiagnosticsChannel : public ModelCommand
 public:
     ReadThreadNetworkDiagnosticsChannel() : ModelCommand("read")
     {
-        AddArgument("attr-name", "channel");
+        AddArgument("attr-name", "channel", false);
         ModelCommand::AddArguments();
     }
 
@@ -25336,7 +25347,7 @@ class ReadThreadNetworkDiagnosticsRoutingRole : public ModelCommand
 public:
     ReadThreadNetworkDiagnosticsRoutingRole() : ModelCommand("read")
     {
-        AddArgument("attr-name", "routing-role");
+        AddArgument("attr-name", "routing-role", false);
         ModelCommand::AddArguments();
     }
 
@@ -25370,7 +25381,7 @@ class ReadThreadNetworkDiagnosticsNetworkName : public ModelCommand
 public:
     ReadThreadNetworkDiagnosticsNetworkName() : ModelCommand("read")
     {
-        AddArgument("attr-name", "network-name");
+        AddArgument("attr-name", "network-name", false);
         ModelCommand::AddArguments();
     }
 
@@ -25404,7 +25415,7 @@ class ReadThreadNetworkDiagnosticsPanId : public ModelCommand
 public:
     ReadThreadNetworkDiagnosticsPanId() : ModelCommand("read")
     {
-        AddArgument("attr-name", "pan-id");
+        AddArgument("attr-name", "pan-id", false);
         ModelCommand::AddArguments();
     }
 
@@ -25438,7 +25449,7 @@ class ReadThreadNetworkDiagnosticsExtendedPanId : public ModelCommand
 public:
     ReadThreadNetworkDiagnosticsExtendedPanId() : ModelCommand("read")
     {
-        AddArgument("attr-name", "extended-pan-id");
+        AddArgument("attr-name", "extended-pan-id", false);
         ModelCommand::AddArguments();
     }
 
@@ -25472,7 +25483,7 @@ class ReadThreadNetworkDiagnosticsMeshLocalPrefix : public ModelCommand
 public:
     ReadThreadNetworkDiagnosticsMeshLocalPrefix() : ModelCommand("read")
     {
-        AddArgument("attr-name", "mesh-local-prefix");
+        AddArgument("attr-name", "mesh-local-prefix", false);
         ModelCommand::AddArguments();
     }
 
@@ -25506,7 +25517,7 @@ class ReadThreadNetworkDiagnosticsOverrunCount : public ModelCommand
 public:
     ReadThreadNetworkDiagnosticsOverrunCount() : ModelCommand("read")
     {
-        AddArgument("attr-name", "overrun-count");
+        AddArgument("attr-name", "overrun-count", false);
         ModelCommand::AddArguments();
     }
 
@@ -25540,7 +25551,7 @@ class ReadThreadNetworkDiagnosticsNeighborTableList : public ModelCommand
 public:
     ReadThreadNetworkDiagnosticsNeighborTableList() : ModelCommand("read")
     {
-        AddArgument("attr-name", "neighbor-table-list");
+        AddArgument("attr-name", "neighbor-table-list", false);
         ModelCommand::AddArguments();
     }
 
@@ -25575,7 +25586,7 @@ class ReadThreadNetworkDiagnosticsRouteTableList : public ModelCommand
 public:
     ReadThreadNetworkDiagnosticsRouteTableList() : ModelCommand("read")
     {
-        AddArgument("attr-name", "route-table-list");
+        AddArgument("attr-name", "route-table-list", false);
         ModelCommand::AddArguments();
     }
 
@@ -25610,7 +25621,7 @@ class ReadThreadNetworkDiagnosticsPartitionId : public ModelCommand
 public:
     ReadThreadNetworkDiagnosticsPartitionId() : ModelCommand("read")
     {
-        AddArgument("attr-name", "partition-id");
+        AddArgument("attr-name", "partition-id", false);
         ModelCommand::AddArguments();
     }
 
@@ -25644,7 +25655,7 @@ class ReadThreadNetworkDiagnosticsWeighting : public ModelCommand
 public:
     ReadThreadNetworkDiagnosticsWeighting() : ModelCommand("read")
     {
-        AddArgument("attr-name", "weighting");
+        AddArgument("attr-name", "weighting", false);
         ModelCommand::AddArguments();
     }
 
@@ -25678,7 +25689,7 @@ class ReadThreadNetworkDiagnosticsDataVersion : public ModelCommand
 public:
     ReadThreadNetworkDiagnosticsDataVersion() : ModelCommand("read")
     {
-        AddArgument("attr-name", "data-version");
+        AddArgument("attr-name", "data-version", false);
         ModelCommand::AddArguments();
     }
 
@@ -25712,7 +25723,7 @@ class ReadThreadNetworkDiagnosticsStableDataVersion : public ModelCommand
 public:
     ReadThreadNetworkDiagnosticsStableDataVersion() : ModelCommand("read")
     {
-        AddArgument("attr-name", "stable-data-version");
+        AddArgument("attr-name", "stable-data-version", false);
         ModelCommand::AddArguments();
     }
 
@@ -25746,7 +25757,7 @@ class ReadThreadNetworkDiagnosticsLeaderRouterId : public ModelCommand
 public:
     ReadThreadNetworkDiagnosticsLeaderRouterId() : ModelCommand("read")
     {
-        AddArgument("attr-name", "leader-router-id");
+        AddArgument("attr-name", "leader-router-id", false);
         ModelCommand::AddArguments();
     }
 
@@ -25780,7 +25791,7 @@ class ReadThreadNetworkDiagnosticsDetachedRoleCount : public ModelCommand
 public:
     ReadThreadNetworkDiagnosticsDetachedRoleCount() : ModelCommand("read")
     {
-        AddArgument("attr-name", "detached-role-count");
+        AddArgument("attr-name", "detached-role-count", false);
         ModelCommand::AddArguments();
     }
 
@@ -25814,7 +25825,7 @@ class ReadThreadNetworkDiagnosticsChildRoleCount : public ModelCommand
 public:
     ReadThreadNetworkDiagnosticsChildRoleCount() : ModelCommand("read")
     {
-        AddArgument("attr-name", "child-role-count");
+        AddArgument("attr-name", "child-role-count", false);
         ModelCommand::AddArguments();
     }
 
@@ -25848,7 +25859,7 @@ class ReadThreadNetworkDiagnosticsRouterRoleCount : public ModelCommand
 public:
     ReadThreadNetworkDiagnosticsRouterRoleCount() : ModelCommand("read")
     {
-        AddArgument("attr-name", "router-role-count");
+        AddArgument("attr-name", "router-role-count", false);
         ModelCommand::AddArguments();
     }
 
@@ -25882,7 +25893,7 @@ class ReadThreadNetworkDiagnosticsLeaderRoleCount : public ModelCommand
 public:
     ReadThreadNetworkDiagnosticsLeaderRoleCount() : ModelCommand("read")
     {
-        AddArgument("attr-name", "leader-role-count");
+        AddArgument("attr-name", "leader-role-count", false);
         ModelCommand::AddArguments();
     }
 
@@ -25916,7 +25927,7 @@ class ReadThreadNetworkDiagnosticsAttachAttemptCount : public ModelCommand
 public:
     ReadThreadNetworkDiagnosticsAttachAttemptCount() : ModelCommand("read")
     {
-        AddArgument("attr-name", "attach-attempt-count");
+        AddArgument("attr-name", "attach-attempt-count", false);
         ModelCommand::AddArguments();
     }
 
@@ -25950,7 +25961,7 @@ class ReadThreadNetworkDiagnosticsPartitionIdChangeCount : public ModelCommand
 public:
     ReadThreadNetworkDiagnosticsPartitionIdChangeCount() : ModelCommand("read")
     {
-        AddArgument("attr-name", "partition-id-change-count");
+        AddArgument("attr-name", "partition-id-change-count", false);
         ModelCommand::AddArguments();
     }
 
@@ -25984,7 +25995,7 @@ class ReadThreadNetworkDiagnosticsBetterPartitionAttachAttemptCount : public Mod
 public:
     ReadThreadNetworkDiagnosticsBetterPartitionAttachAttemptCount() : ModelCommand("read")
     {
-        AddArgument("attr-name", "better-partition-attach-attempt-count");
+        AddArgument("attr-name", "better-partition-attach-attempt-count", false);
         ModelCommand::AddArguments();
     }
 
@@ -26018,7 +26029,7 @@ class ReadThreadNetworkDiagnosticsParentChangeCount : public ModelCommand
 public:
     ReadThreadNetworkDiagnosticsParentChangeCount() : ModelCommand("read")
     {
-        AddArgument("attr-name", "parent-change-count");
+        AddArgument("attr-name", "parent-change-count", false);
         ModelCommand::AddArguments();
     }
 
@@ -26052,7 +26063,7 @@ class ReadThreadNetworkDiagnosticsTxTotalCount : public ModelCommand
 public:
     ReadThreadNetworkDiagnosticsTxTotalCount() : ModelCommand("read")
     {
-        AddArgument("attr-name", "tx-total-count");
+        AddArgument("attr-name", "tx-total-count", false);
         ModelCommand::AddArguments();
     }
 
@@ -26086,7 +26097,7 @@ class ReadThreadNetworkDiagnosticsTxUnicastCount : public ModelCommand
 public:
     ReadThreadNetworkDiagnosticsTxUnicastCount() : ModelCommand("read")
     {
-        AddArgument("attr-name", "tx-unicast-count");
+        AddArgument("attr-name", "tx-unicast-count", false);
         ModelCommand::AddArguments();
     }
 
@@ -26120,7 +26131,7 @@ class ReadThreadNetworkDiagnosticsTxBroadcastCount : public ModelCommand
 public:
     ReadThreadNetworkDiagnosticsTxBroadcastCount() : ModelCommand("read")
     {
-        AddArgument("attr-name", "tx-broadcast-count");
+        AddArgument("attr-name", "tx-broadcast-count", false);
         ModelCommand::AddArguments();
     }
 
@@ -26154,7 +26165,7 @@ class ReadThreadNetworkDiagnosticsTxAckRequestedCount : public ModelCommand
 public:
     ReadThreadNetworkDiagnosticsTxAckRequestedCount() : ModelCommand("read")
     {
-        AddArgument("attr-name", "tx-ack-requested-count");
+        AddArgument("attr-name", "tx-ack-requested-count", false);
         ModelCommand::AddArguments();
     }
 
@@ -26188,7 +26199,7 @@ class ReadThreadNetworkDiagnosticsTxAckedCount : public ModelCommand
 public:
     ReadThreadNetworkDiagnosticsTxAckedCount() : ModelCommand("read")
     {
-        AddArgument("attr-name", "tx-acked-count");
+        AddArgument("attr-name", "tx-acked-count", false);
         ModelCommand::AddArguments();
     }
 
@@ -26222,7 +26233,7 @@ class ReadThreadNetworkDiagnosticsTxNoAckRequestedCount : public ModelCommand
 public:
     ReadThreadNetworkDiagnosticsTxNoAckRequestedCount() : ModelCommand("read")
     {
-        AddArgument("attr-name", "tx-no-ack-requested-count");
+        AddArgument("attr-name", "tx-no-ack-requested-count", false);
         ModelCommand::AddArguments();
     }
 
@@ -26256,7 +26267,7 @@ class ReadThreadNetworkDiagnosticsTxDataCount : public ModelCommand
 public:
     ReadThreadNetworkDiagnosticsTxDataCount() : ModelCommand("read")
     {
-        AddArgument("attr-name", "tx-data-count");
+        AddArgument("attr-name", "tx-data-count", false);
         ModelCommand::AddArguments();
     }
 
@@ -26290,7 +26301,7 @@ class ReadThreadNetworkDiagnosticsTxDataPollCount : public ModelCommand
 public:
     ReadThreadNetworkDiagnosticsTxDataPollCount() : ModelCommand("read")
     {
-        AddArgument("attr-name", "tx-data-poll-count");
+        AddArgument("attr-name", "tx-data-poll-count", false);
         ModelCommand::AddArguments();
     }
 
@@ -26324,7 +26335,7 @@ class ReadThreadNetworkDiagnosticsTxBeaconCount : public ModelCommand
 public:
     ReadThreadNetworkDiagnosticsTxBeaconCount() : ModelCommand("read")
     {
-        AddArgument("attr-name", "tx-beacon-count");
+        AddArgument("attr-name", "tx-beacon-count", false);
         ModelCommand::AddArguments();
     }
 
@@ -26358,7 +26369,7 @@ class ReadThreadNetworkDiagnosticsTxBeaconRequestCount : public ModelCommand
 public:
     ReadThreadNetworkDiagnosticsTxBeaconRequestCount() : ModelCommand("read")
     {
-        AddArgument("attr-name", "tx-beacon-request-count");
+        AddArgument("attr-name", "tx-beacon-request-count", false);
         ModelCommand::AddArguments();
     }
 
@@ -26392,7 +26403,7 @@ class ReadThreadNetworkDiagnosticsTxOtherCount : public ModelCommand
 public:
     ReadThreadNetworkDiagnosticsTxOtherCount() : ModelCommand("read")
     {
-        AddArgument("attr-name", "tx-other-count");
+        AddArgument("attr-name", "tx-other-count", false);
         ModelCommand::AddArguments();
     }
 
@@ -26426,7 +26437,7 @@ class ReadThreadNetworkDiagnosticsTxRetryCount : public ModelCommand
 public:
     ReadThreadNetworkDiagnosticsTxRetryCount() : ModelCommand("read")
     {
-        AddArgument("attr-name", "tx-retry-count");
+        AddArgument("attr-name", "tx-retry-count", false);
         ModelCommand::AddArguments();
     }
 
@@ -26460,7 +26471,7 @@ class ReadThreadNetworkDiagnosticsTxDirectMaxRetryExpiryCount : public ModelComm
 public:
     ReadThreadNetworkDiagnosticsTxDirectMaxRetryExpiryCount() : ModelCommand("read")
     {
-        AddArgument("attr-name", "tx-direct-max-retry-expiry-count");
+        AddArgument("attr-name", "tx-direct-max-retry-expiry-count", false);
         ModelCommand::AddArguments();
     }
 
@@ -26494,7 +26505,7 @@ class ReadThreadNetworkDiagnosticsTxIndirectMaxRetryExpiryCount : public ModelCo
 public:
     ReadThreadNetworkDiagnosticsTxIndirectMaxRetryExpiryCount() : ModelCommand("read")
     {
-        AddArgument("attr-name", "tx-indirect-max-retry-expiry-count");
+        AddArgument("attr-name", "tx-indirect-max-retry-expiry-count", false);
         ModelCommand::AddArguments();
     }
 
@@ -26528,7 +26539,7 @@ class ReadThreadNetworkDiagnosticsTxErrCcaCount : public ModelCommand
 public:
     ReadThreadNetworkDiagnosticsTxErrCcaCount() : ModelCommand("read")
     {
-        AddArgument("attr-name", "tx-err-cca-count");
+        AddArgument("attr-name", "tx-err-cca-count", false);
         ModelCommand::AddArguments();
     }
 
@@ -26562,7 +26573,7 @@ class ReadThreadNetworkDiagnosticsTxErrAbortCount : public ModelCommand
 public:
     ReadThreadNetworkDiagnosticsTxErrAbortCount() : ModelCommand("read")
     {
-        AddArgument("attr-name", "tx-err-abort-count");
+        AddArgument("attr-name", "tx-err-abort-count", false);
         ModelCommand::AddArguments();
     }
 
@@ -26596,7 +26607,7 @@ class ReadThreadNetworkDiagnosticsTxErrBusyChannelCount : public ModelCommand
 public:
     ReadThreadNetworkDiagnosticsTxErrBusyChannelCount() : ModelCommand("read")
     {
-        AddArgument("attr-name", "tx-err-busy-channel-count");
+        AddArgument("attr-name", "tx-err-busy-channel-count", false);
         ModelCommand::AddArguments();
     }
 
@@ -26630,7 +26641,7 @@ class ReadThreadNetworkDiagnosticsRxTotalCount : public ModelCommand
 public:
     ReadThreadNetworkDiagnosticsRxTotalCount() : ModelCommand("read")
     {
-        AddArgument("attr-name", "rx-total-count");
+        AddArgument("attr-name", "rx-total-count", false);
         ModelCommand::AddArguments();
     }
 
@@ -26664,7 +26675,7 @@ class ReadThreadNetworkDiagnosticsRxUnicastCount : public ModelCommand
 public:
     ReadThreadNetworkDiagnosticsRxUnicastCount() : ModelCommand("read")
     {
-        AddArgument("attr-name", "rx-unicast-count");
+        AddArgument("attr-name", "rx-unicast-count", false);
         ModelCommand::AddArguments();
     }
 
@@ -26698,7 +26709,7 @@ class ReadThreadNetworkDiagnosticsRxBroadcastCount : public ModelCommand
 public:
     ReadThreadNetworkDiagnosticsRxBroadcastCount() : ModelCommand("read")
     {
-        AddArgument("attr-name", "rx-broadcast-count");
+        AddArgument("attr-name", "rx-broadcast-count", false);
         ModelCommand::AddArguments();
     }
 
@@ -26732,7 +26743,7 @@ class ReadThreadNetworkDiagnosticsRxDataCount : public ModelCommand
 public:
     ReadThreadNetworkDiagnosticsRxDataCount() : ModelCommand("read")
     {
-        AddArgument("attr-name", "rx-data-count");
+        AddArgument("attr-name", "rx-data-count", false);
         ModelCommand::AddArguments();
     }
 
@@ -26766,7 +26777,7 @@ class ReadThreadNetworkDiagnosticsRxDataPollCount : public ModelCommand
 public:
     ReadThreadNetworkDiagnosticsRxDataPollCount() : ModelCommand("read")
     {
-        AddArgument("attr-name", "rx-data-poll-count");
+        AddArgument("attr-name", "rx-data-poll-count", false);
         ModelCommand::AddArguments();
     }
 
@@ -26800,7 +26811,7 @@ class ReadThreadNetworkDiagnosticsRxBeaconCount : public ModelCommand
 public:
     ReadThreadNetworkDiagnosticsRxBeaconCount() : ModelCommand("read")
     {
-        AddArgument("attr-name", "rx-beacon-count");
+        AddArgument("attr-name", "rx-beacon-count", false);
         ModelCommand::AddArguments();
     }
 
@@ -26834,7 +26845,7 @@ class ReadThreadNetworkDiagnosticsRxBeaconRequestCount : public ModelCommand
 public:
     ReadThreadNetworkDiagnosticsRxBeaconRequestCount() : ModelCommand("read")
     {
-        AddArgument("attr-name", "rx-beacon-request-count");
+        AddArgument("attr-name", "rx-beacon-request-count", false);
         ModelCommand::AddArguments();
     }
 
@@ -26868,7 +26879,7 @@ class ReadThreadNetworkDiagnosticsRxOtherCount : public ModelCommand
 public:
     ReadThreadNetworkDiagnosticsRxOtherCount() : ModelCommand("read")
     {
-        AddArgument("attr-name", "rx-other-count");
+        AddArgument("attr-name", "rx-other-count", false);
         ModelCommand::AddArguments();
     }
 
@@ -26902,7 +26913,7 @@ class ReadThreadNetworkDiagnosticsRxAddressFilteredCount : public ModelCommand
 public:
     ReadThreadNetworkDiagnosticsRxAddressFilteredCount() : ModelCommand("read")
     {
-        AddArgument("attr-name", "rx-address-filtered-count");
+        AddArgument("attr-name", "rx-address-filtered-count", false);
         ModelCommand::AddArguments();
     }
 
@@ -26936,7 +26947,7 @@ class ReadThreadNetworkDiagnosticsRxDestAddrFilteredCount : public ModelCommand
 public:
     ReadThreadNetworkDiagnosticsRxDestAddrFilteredCount() : ModelCommand("read")
     {
-        AddArgument("attr-name", "rx-dest-addr-filtered-count");
+        AddArgument("attr-name", "rx-dest-addr-filtered-count", false);
         ModelCommand::AddArguments();
     }
 
@@ -26970,7 +26981,7 @@ class ReadThreadNetworkDiagnosticsRxDuplicatedCount : public ModelCommand
 public:
     ReadThreadNetworkDiagnosticsRxDuplicatedCount() : ModelCommand("read")
     {
-        AddArgument("attr-name", "rx-duplicated-count");
+        AddArgument("attr-name", "rx-duplicated-count", false);
         ModelCommand::AddArguments();
     }
 
@@ -27004,7 +27015,7 @@ class ReadThreadNetworkDiagnosticsRxErrNoFrameCount : public ModelCommand
 public:
     ReadThreadNetworkDiagnosticsRxErrNoFrameCount() : ModelCommand("read")
     {
-        AddArgument("attr-name", "rx-err-no-frame-count");
+        AddArgument("attr-name", "rx-err-no-frame-count", false);
         ModelCommand::AddArguments();
     }
 
@@ -27038,7 +27049,7 @@ class ReadThreadNetworkDiagnosticsRxErrUnknownNeighborCount : public ModelComman
 public:
     ReadThreadNetworkDiagnosticsRxErrUnknownNeighborCount() : ModelCommand("read")
     {
-        AddArgument("attr-name", "rx-err-unknown-neighbor-count");
+        AddArgument("attr-name", "rx-err-unknown-neighbor-count", false);
         ModelCommand::AddArguments();
     }
 
@@ -27072,7 +27083,7 @@ class ReadThreadNetworkDiagnosticsRxErrInvalidSrcAddrCount : public ModelCommand
 public:
     ReadThreadNetworkDiagnosticsRxErrInvalidSrcAddrCount() : ModelCommand("read")
     {
-        AddArgument("attr-name", "rx-err-invalid-src-addr-count");
+        AddArgument("attr-name", "rx-err-invalid-src-addr-count", false);
         ModelCommand::AddArguments();
     }
 
@@ -27106,7 +27117,7 @@ class ReadThreadNetworkDiagnosticsRxErrSecCount : public ModelCommand
 public:
     ReadThreadNetworkDiagnosticsRxErrSecCount() : ModelCommand("read")
     {
-        AddArgument("attr-name", "rx-err-sec-count");
+        AddArgument("attr-name", "rx-err-sec-count", false);
         ModelCommand::AddArguments();
     }
 
@@ -27140,7 +27151,7 @@ class ReadThreadNetworkDiagnosticsRxErrFcsCount : public ModelCommand
 public:
     ReadThreadNetworkDiagnosticsRxErrFcsCount() : ModelCommand("read")
     {
-        AddArgument("attr-name", "rx-err-fcs-count");
+        AddArgument("attr-name", "rx-err-fcs-count", false);
         ModelCommand::AddArguments();
     }
 
@@ -27174,7 +27185,7 @@ class ReadThreadNetworkDiagnosticsRxErrOtherCount : public ModelCommand
 public:
     ReadThreadNetworkDiagnosticsRxErrOtherCount() : ModelCommand("read")
     {
-        AddArgument("attr-name", "rx-err-other-count");
+        AddArgument("attr-name", "rx-err-other-count", false);
         ModelCommand::AddArguments();
     }
 
@@ -27208,7 +27219,7 @@ class ReadThreadNetworkDiagnosticsActiveTimestamp : public ModelCommand
 public:
     ReadThreadNetworkDiagnosticsActiveTimestamp() : ModelCommand("read")
     {
-        AddArgument("attr-name", "active-timestamp");
+        AddArgument("attr-name", "active-timestamp", false);
         ModelCommand::AddArguments();
     }
 
@@ -27242,7 +27253,7 @@ class ReadThreadNetworkDiagnosticsPendingTimestamp : public ModelCommand
 public:
     ReadThreadNetworkDiagnosticsPendingTimestamp() : ModelCommand("read")
     {
-        AddArgument("attr-name", "pending-timestamp");
+        AddArgument("attr-name", "pending-timestamp", false);
         ModelCommand::AddArguments();
     }
 
@@ -27276,7 +27287,7 @@ class ReadThreadNetworkDiagnosticsDelay : public ModelCommand
 public:
     ReadThreadNetworkDiagnosticsDelay() : ModelCommand("read")
     {
-        AddArgument("attr-name", "delay");
+        AddArgument("attr-name", "delay", false);
         ModelCommand::AddArguments();
     }
 
@@ -27310,7 +27321,7 @@ class ReadThreadNetworkDiagnosticsSecurityPolicy : public ModelCommand
 public:
     ReadThreadNetworkDiagnosticsSecurityPolicy() : ModelCommand("read")
     {
-        AddArgument("attr-name", "security-policy");
+        AddArgument("attr-name", "security-policy", false);
         ModelCommand::AddArguments();
     }
 
@@ -27345,7 +27356,7 @@ class ReadThreadNetworkDiagnosticsChannelMask : public ModelCommand
 public:
     ReadThreadNetworkDiagnosticsChannelMask() : ModelCommand("read")
     {
-        AddArgument("attr-name", "channel-mask");
+        AddArgument("attr-name", "channel-mask", false);
         ModelCommand::AddArguments();
     }
 
@@ -27379,7 +27390,7 @@ class ReadThreadNetworkDiagnosticsOperationalDatasetComponents : public ModelCom
 public:
     ReadThreadNetworkDiagnosticsOperationalDatasetComponents() : ModelCommand("read")
     {
-        AddArgument("attr-name", "operational-dataset-components");
+        AddArgument("attr-name", "operational-dataset-components", false);
         ModelCommand::AddArguments();
     }
 
@@ -27414,7 +27425,7 @@ class ReadThreadNetworkDiagnosticsActiveNetworkFaultsList : public ModelCommand
 public:
     ReadThreadNetworkDiagnosticsActiveNetworkFaultsList() : ModelCommand("read")
     {
-        AddArgument("attr-name", "active-network-faults-list");
+        AddArgument("attr-name", "active-network-faults-list", false);
         ModelCommand::AddArguments();
     }
 
@@ -27449,7 +27460,7 @@ class ReadThreadNetworkDiagnosticsClusterRevision : public ModelCommand
 public:
     ReadThreadNetworkDiagnosticsClusterRevision() : ModelCommand("read")
     {
-        AddArgument("attr-name", "cluster-revision");
+        AddArgument("attr-name", "cluster-revision", false);
         ModelCommand::AddArguments();
     }
 
@@ -27493,7 +27504,7 @@ class ReadWakeOnLanWakeOnLanMacAddress : public ModelCommand
 public:
     ReadWakeOnLanWakeOnLanMacAddress() : ModelCommand("read")
     {
-        AddArgument("attr-name", "wake-on-lan-mac-address");
+        AddArgument("attr-name", "wake-on-lan-mac-address", false);
         ModelCommand::AddArguments();
     }
 
@@ -27527,7 +27538,7 @@ class ReadWakeOnLanClusterRevision : public ModelCommand
 public:
     ReadWakeOnLanClusterRevision() : ModelCommand("read")
     {
-        AddArgument("attr-name", "cluster-revision");
+        AddArgument("attr-name", "cluster-revision", false);
         ModelCommand::AddArguments();
     }
 
@@ -27605,7 +27616,7 @@ class ReadWiFiNetworkDiagnosticsBssid : public ModelCommand
 public:
     ReadWiFiNetworkDiagnosticsBssid() : ModelCommand("read")
     {
-        AddArgument("attr-name", "bssid");
+        AddArgument("attr-name", "bssid", false);
         ModelCommand::AddArguments();
     }
 
@@ -27639,7 +27650,7 @@ class ReadWiFiNetworkDiagnosticsSecurityType : public ModelCommand
 public:
     ReadWiFiNetworkDiagnosticsSecurityType() : ModelCommand("read")
     {
-        AddArgument("attr-name", "security-type");
+        AddArgument("attr-name", "security-type", false);
         ModelCommand::AddArguments();
     }
 
@@ -27673,7 +27684,7 @@ class ReadWiFiNetworkDiagnosticsWiFiVersion : public ModelCommand
 public:
     ReadWiFiNetworkDiagnosticsWiFiVersion() : ModelCommand("read")
     {
-        AddArgument("attr-name", "wi-fi-version");
+        AddArgument("attr-name", "wi-fi-version", false);
         ModelCommand::AddArguments();
     }
 
@@ -27707,7 +27718,7 @@ class ReadWiFiNetworkDiagnosticsChannelNumber : public ModelCommand
 public:
     ReadWiFiNetworkDiagnosticsChannelNumber() : ModelCommand("read")
     {
-        AddArgument("attr-name", "channel-number");
+        AddArgument("attr-name", "channel-number", false);
         ModelCommand::AddArguments();
     }
 
@@ -27741,7 +27752,7 @@ class ReadWiFiNetworkDiagnosticsRssi : public ModelCommand
 public:
     ReadWiFiNetworkDiagnosticsRssi() : ModelCommand("read")
     {
-        AddArgument("attr-name", "rssi");
+        AddArgument("attr-name", "rssi", false);
         ModelCommand::AddArguments();
     }
 
@@ -27775,7 +27786,7 @@ class ReadWiFiNetworkDiagnosticsBeaconLostCount : public ModelCommand
 public:
     ReadWiFiNetworkDiagnosticsBeaconLostCount() : ModelCommand("read")
     {
-        AddArgument("attr-name", "beacon-lost-count");
+        AddArgument("attr-name", "beacon-lost-count", false);
         ModelCommand::AddArguments();
     }
 
@@ -27809,7 +27820,7 @@ class ReadWiFiNetworkDiagnosticsBeaconRxCount : public ModelCommand
 public:
     ReadWiFiNetworkDiagnosticsBeaconRxCount() : ModelCommand("read")
     {
-        AddArgument("attr-name", "beacon-rx-count");
+        AddArgument("attr-name", "beacon-rx-count", false);
         ModelCommand::AddArguments();
     }
 
@@ -27843,7 +27854,7 @@ class ReadWiFiNetworkDiagnosticsPacketMulticastRxCount : public ModelCommand
 public:
     ReadWiFiNetworkDiagnosticsPacketMulticastRxCount() : ModelCommand("read")
     {
-        AddArgument("attr-name", "packet-multicast-rx-count");
+        AddArgument("attr-name", "packet-multicast-rx-count", false);
         ModelCommand::AddArguments();
     }
 
@@ -27877,7 +27888,7 @@ class ReadWiFiNetworkDiagnosticsPacketMulticastTxCount : public ModelCommand
 public:
     ReadWiFiNetworkDiagnosticsPacketMulticastTxCount() : ModelCommand("read")
     {
-        AddArgument("attr-name", "packet-multicast-tx-count");
+        AddArgument("attr-name", "packet-multicast-tx-count", false);
         ModelCommand::AddArguments();
     }
 
@@ -27911,7 +27922,7 @@ class ReadWiFiNetworkDiagnosticsPacketUnicastRxCount : public ModelCommand
 public:
     ReadWiFiNetworkDiagnosticsPacketUnicastRxCount() : ModelCommand("read")
     {
-        AddArgument("attr-name", "packet-unicast-rx-count");
+        AddArgument("attr-name", "packet-unicast-rx-count", false);
         ModelCommand::AddArguments();
     }
 
@@ -27945,7 +27956,7 @@ class ReadWiFiNetworkDiagnosticsPacketUnicastTxCount : public ModelCommand
 public:
     ReadWiFiNetworkDiagnosticsPacketUnicastTxCount() : ModelCommand("read")
     {
-        AddArgument("attr-name", "packet-unicast-tx-count");
+        AddArgument("attr-name", "packet-unicast-tx-count", false);
         ModelCommand::AddArguments();
     }
 
@@ -27979,7 +27990,7 @@ class ReadWiFiNetworkDiagnosticsCurrentMaxRate : public ModelCommand
 public:
     ReadWiFiNetworkDiagnosticsCurrentMaxRate() : ModelCommand("read")
     {
-        AddArgument("attr-name", "current-max-rate");
+        AddArgument("attr-name", "current-max-rate", false);
         ModelCommand::AddArguments();
     }
 
@@ -28013,7 +28024,7 @@ class ReadWiFiNetworkDiagnosticsOverrunCount : public ModelCommand
 public:
     ReadWiFiNetworkDiagnosticsOverrunCount() : ModelCommand("read")
     {
-        AddArgument("attr-name", "overrun-count");
+        AddArgument("attr-name", "overrun-count", false);
         ModelCommand::AddArguments();
     }
 
@@ -28047,7 +28058,7 @@ class ReadWiFiNetworkDiagnosticsClusterRevision : public ModelCommand
 public:
     ReadWiFiNetworkDiagnosticsClusterRevision() : ModelCommand("read")
     {
-        AddArgument("attr-name", "cluster-revision");
+        AddArgument("attr-name", "cluster-revision", false);
         ModelCommand::AddArguments();
     }
 
@@ -28137,8 +28148,8 @@ class WindowCoveringGoToLiftPercentage : public ModelCommand
 public:
     WindowCoveringGoToLiftPercentage() : ModelCommand("go-to-lift-percentage")
     {
-        AddArgument("LiftPercentageValue", 0, UINT8_MAX, &mRequest.liftPercentageValue);
-        AddArgument("LiftPercent100thsValue", 0, UINT16_MAX, &mRequest.liftPercent100thsValue);
+        AddArgument("LiftPercentageValue", 0, UINT8_MAX, &mRequest.liftPercentageValue, false);
+        AddArgument("LiftPercent100thsValue", 0, UINT16_MAX, &mRequest.liftPercent100thsValue, false);
         ModelCommand::AddArguments();
     }
 
@@ -28163,7 +28174,7 @@ class WindowCoveringGoToLiftValue : public ModelCommand
 public:
     WindowCoveringGoToLiftValue() : ModelCommand("go-to-lift-value")
     {
-        AddArgument("LiftValue", 0, UINT16_MAX, &mRequest.liftValue);
+        AddArgument("LiftValue", 0, UINT16_MAX, &mRequest.liftValue, false);
         ModelCommand::AddArguments();
     }
 
@@ -28188,8 +28199,8 @@ class WindowCoveringGoToTiltPercentage : public ModelCommand
 public:
     WindowCoveringGoToTiltPercentage() : ModelCommand("go-to-tilt-percentage")
     {
-        AddArgument("TiltPercentageValue", 0, UINT8_MAX, &mRequest.tiltPercentageValue);
-        AddArgument("TiltPercent100thsValue", 0, UINT16_MAX, &mRequest.tiltPercent100thsValue);
+        AddArgument("TiltPercentageValue", 0, UINT8_MAX, &mRequest.tiltPercentageValue, false);
+        AddArgument("TiltPercent100thsValue", 0, UINT16_MAX, &mRequest.tiltPercent100thsValue, false);
         ModelCommand::AddArguments();
     }
 
@@ -28214,7 +28225,7 @@ class WindowCoveringGoToTiltValue : public ModelCommand
 public:
     WindowCoveringGoToTiltValue() : ModelCommand("go-to-tilt-value")
     {
-        AddArgument("TiltValue", 0, UINT16_MAX, &mRequest.tiltValue);
+        AddArgument("TiltValue", 0, UINT16_MAX, &mRequest.tiltValue, false);
         ModelCommand::AddArguments();
     }
 
@@ -28281,7 +28292,7 @@ class ReadWindowCoveringType : public ModelCommand
 public:
     ReadWindowCoveringType() : ModelCommand("read")
     {
-        AddArgument("attr-name", "type");
+        AddArgument("attr-name", "type", false);
         ModelCommand::AddArguments();
     }
 
@@ -28315,7 +28326,7 @@ class ReadWindowCoveringCurrentPositionLift : public ModelCommand
 public:
     ReadWindowCoveringCurrentPositionLift() : ModelCommand("read")
     {
-        AddArgument("attr-name", "current-position-lift");
+        AddArgument("attr-name", "current-position-lift", false);
         ModelCommand::AddArguments();
     }
 
@@ -28349,7 +28360,7 @@ class ReadWindowCoveringCurrentPositionTilt : public ModelCommand
 public:
     ReadWindowCoveringCurrentPositionTilt() : ModelCommand("read")
     {
-        AddArgument("attr-name", "current-position-tilt");
+        AddArgument("attr-name", "current-position-tilt", false);
         ModelCommand::AddArguments();
     }
 
@@ -28383,7 +28394,7 @@ class ReadWindowCoveringConfigStatus : public ModelCommand
 public:
     ReadWindowCoveringConfigStatus() : ModelCommand("read")
     {
-        AddArgument("attr-name", "config-status");
+        AddArgument("attr-name", "config-status", false);
         ModelCommand::AddArguments();
     }
 
@@ -28417,7 +28428,7 @@ class ReadWindowCoveringCurrentPositionLiftPercentage : public ModelCommand
 public:
     ReadWindowCoveringCurrentPositionLiftPercentage() : ModelCommand("read")
     {
-        AddArgument("attr-name", "current-position-lift-percentage");
+        AddArgument("attr-name", "current-position-lift-percentage", false);
         ModelCommand::AddArguments();
     }
 
@@ -28448,10 +28459,10 @@ class ReportWindowCoveringCurrentPositionLiftPercentage : public ModelCommand
 public:
     ReportWindowCoveringCurrentPositionLiftPercentage() : ModelCommand("report")
     {
-        AddArgument("attr-name", "current-position-lift-percentage");
-        AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
-        AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval);
-        AddArgument("wait", 0, 1, &mWait);
+        AddArgument("attr-name", "current-position-lift-percentage", false);
+        AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval, false);
+        AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval, false);
+        AddArgument("wait", 0, 1, &mWait, false);
         ModelCommand::AddArguments();
     }
 
@@ -28504,7 +28515,7 @@ class ReadWindowCoveringCurrentPositionTiltPercentage : public ModelCommand
 public:
     ReadWindowCoveringCurrentPositionTiltPercentage() : ModelCommand("read")
     {
-        AddArgument("attr-name", "current-position-tilt-percentage");
+        AddArgument("attr-name", "current-position-tilt-percentage", false);
         ModelCommand::AddArguments();
     }
 
@@ -28535,10 +28546,10 @@ class ReportWindowCoveringCurrentPositionTiltPercentage : public ModelCommand
 public:
     ReportWindowCoveringCurrentPositionTiltPercentage() : ModelCommand("report")
     {
-        AddArgument("attr-name", "current-position-tilt-percentage");
-        AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
-        AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval);
-        AddArgument("wait", 0, 1, &mWait);
+        AddArgument("attr-name", "current-position-tilt-percentage", false);
+        AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval, false);
+        AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval, false);
+        AddArgument("wait", 0, 1, &mWait, false);
         ModelCommand::AddArguments();
     }
 
@@ -28591,7 +28602,7 @@ class ReadWindowCoveringOperationalStatus : public ModelCommand
 public:
     ReadWindowCoveringOperationalStatus() : ModelCommand("read")
     {
-        AddArgument("attr-name", "operational-status");
+        AddArgument("attr-name", "operational-status", false);
         ModelCommand::AddArguments();
     }
 
@@ -28622,10 +28633,10 @@ class ReportWindowCoveringOperationalStatus : public ModelCommand
 public:
     ReportWindowCoveringOperationalStatus() : ModelCommand("report")
     {
-        AddArgument("attr-name", "operational-status");
-        AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
-        AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval);
-        AddArgument("wait", 0, 1, &mWait);
+        AddArgument("attr-name", "operational-status", false);
+        AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval, false);
+        AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval, false);
+        AddArgument("wait", 0, 1, &mWait, false);
         ModelCommand::AddArguments();
     }
 
@@ -28678,7 +28689,7 @@ class ReadWindowCoveringTargetPositionLiftPercent100ths : public ModelCommand
 public:
     ReadWindowCoveringTargetPositionLiftPercent100ths() : ModelCommand("read")
     {
-        AddArgument("attr-name", "target-position-lift-percent100ths");
+        AddArgument("attr-name", "target-position-lift-percent100ths", false);
         ModelCommand::AddArguments();
     }
 
@@ -28709,10 +28720,10 @@ class ReportWindowCoveringTargetPositionLiftPercent100ths : public ModelCommand
 public:
     ReportWindowCoveringTargetPositionLiftPercent100ths() : ModelCommand("report")
     {
-        AddArgument("attr-name", "target-position-lift-percent100ths");
-        AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
-        AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval);
-        AddArgument("wait", 0, 1, &mWait);
+        AddArgument("attr-name", "target-position-lift-percent100ths", false);
+        AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval, false);
+        AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval, false);
+        AddArgument("wait", 0, 1, &mWait, false);
         ModelCommand::AddArguments();
     }
 
@@ -28765,7 +28776,7 @@ class ReadWindowCoveringTargetPositionTiltPercent100ths : public ModelCommand
 public:
     ReadWindowCoveringTargetPositionTiltPercent100ths() : ModelCommand("read")
     {
-        AddArgument("attr-name", "target-position-tilt-percent100ths");
+        AddArgument("attr-name", "target-position-tilt-percent100ths", false);
         ModelCommand::AddArguments();
     }
 
@@ -28796,10 +28807,10 @@ class ReportWindowCoveringTargetPositionTiltPercent100ths : public ModelCommand
 public:
     ReportWindowCoveringTargetPositionTiltPercent100ths() : ModelCommand("report")
     {
-        AddArgument("attr-name", "target-position-tilt-percent100ths");
-        AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
-        AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval);
-        AddArgument("wait", 0, 1, &mWait);
+        AddArgument("attr-name", "target-position-tilt-percent100ths", false);
+        AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval, false);
+        AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval, false);
+        AddArgument("wait", 0, 1, &mWait, false);
         ModelCommand::AddArguments();
     }
 
@@ -28852,7 +28863,7 @@ class ReadWindowCoveringEndProductType : public ModelCommand
 public:
     ReadWindowCoveringEndProductType() : ModelCommand("read")
     {
-        AddArgument("attr-name", "end-product-type");
+        AddArgument("attr-name", "end-product-type", false);
         ModelCommand::AddArguments();
     }
 
@@ -28886,7 +28897,7 @@ class ReadWindowCoveringCurrentPositionLiftPercent100ths : public ModelCommand
 public:
     ReadWindowCoveringCurrentPositionLiftPercent100ths() : ModelCommand("read")
     {
-        AddArgument("attr-name", "current-position-lift-percent100ths");
+        AddArgument("attr-name", "current-position-lift-percent100ths", false);
         ModelCommand::AddArguments();
     }
 
@@ -28917,10 +28928,10 @@ class ReportWindowCoveringCurrentPositionLiftPercent100ths : public ModelCommand
 public:
     ReportWindowCoveringCurrentPositionLiftPercent100ths() : ModelCommand("report")
     {
-        AddArgument("attr-name", "current-position-lift-percent100ths");
-        AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
-        AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval);
-        AddArgument("wait", 0, 1, &mWait);
+        AddArgument("attr-name", "current-position-lift-percent100ths", false);
+        AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval, false);
+        AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval, false);
+        AddArgument("wait", 0, 1, &mWait, false);
         ModelCommand::AddArguments();
     }
 
@@ -28973,7 +28984,7 @@ class ReadWindowCoveringCurrentPositionTiltPercent100ths : public ModelCommand
 public:
     ReadWindowCoveringCurrentPositionTiltPercent100ths() : ModelCommand("read")
     {
-        AddArgument("attr-name", "current-position-tilt-percent100ths");
+        AddArgument("attr-name", "current-position-tilt-percent100ths", false);
         ModelCommand::AddArguments();
     }
 
@@ -29004,10 +29015,10 @@ class ReportWindowCoveringCurrentPositionTiltPercent100ths : public ModelCommand
 public:
     ReportWindowCoveringCurrentPositionTiltPercent100ths() : ModelCommand("report")
     {
-        AddArgument("attr-name", "current-position-tilt-percent100ths");
-        AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
-        AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval);
-        AddArgument("wait", 0, 1, &mWait);
+        AddArgument("attr-name", "current-position-tilt-percent100ths", false);
+        AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval, false);
+        AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval, false);
+        AddArgument("wait", 0, 1, &mWait, false);
         ModelCommand::AddArguments();
     }
 
@@ -29060,7 +29071,7 @@ class ReadWindowCoveringInstalledOpenLimitLift : public ModelCommand
 public:
     ReadWindowCoveringInstalledOpenLimitLift() : ModelCommand("read")
     {
-        AddArgument("attr-name", "installed-open-limit-lift");
+        AddArgument("attr-name", "installed-open-limit-lift", false);
         ModelCommand::AddArguments();
     }
 
@@ -29094,7 +29105,7 @@ class ReadWindowCoveringInstalledClosedLimitLift : public ModelCommand
 public:
     ReadWindowCoveringInstalledClosedLimitLift() : ModelCommand("read")
     {
-        AddArgument("attr-name", "installed-closed-limit-lift");
+        AddArgument("attr-name", "installed-closed-limit-lift", false);
         ModelCommand::AddArguments();
     }
 
@@ -29128,7 +29139,7 @@ class ReadWindowCoveringInstalledOpenLimitTilt : public ModelCommand
 public:
     ReadWindowCoveringInstalledOpenLimitTilt() : ModelCommand("read")
     {
-        AddArgument("attr-name", "installed-open-limit-tilt");
+        AddArgument("attr-name", "installed-open-limit-tilt", false);
         ModelCommand::AddArguments();
     }
 
@@ -29162,7 +29173,7 @@ class ReadWindowCoveringInstalledClosedLimitTilt : public ModelCommand
 public:
     ReadWindowCoveringInstalledClosedLimitTilt() : ModelCommand("read")
     {
-        AddArgument("attr-name", "installed-closed-limit-tilt");
+        AddArgument("attr-name", "installed-closed-limit-tilt", false);
         ModelCommand::AddArguments();
     }
 
@@ -29196,7 +29207,7 @@ class ReadWindowCoveringMode : public ModelCommand
 public:
     ReadWindowCoveringMode() : ModelCommand("read")
     {
-        AddArgument("attr-name", "mode");
+        AddArgument("attr-name", "mode", false);
         ModelCommand::AddArguments();
     }
 
@@ -29227,8 +29238,8 @@ class WriteWindowCoveringMode : public ModelCommand
 public:
     WriteWindowCoveringMode() : ModelCommand("write")
     {
-        AddArgument("attr-name", "mode");
-        AddArgument("attr-value", 0, UINT8_MAX, &mValue);
+        AddArgument("attr-name", "mode", false);
+        AddArgument("attr-value", 0, UINT8_MAX, &mValue, false);
         ModelCommand::AddArguments();
     }
 
@@ -29263,7 +29274,7 @@ class ReadWindowCoveringSafetyStatus : public ModelCommand
 public:
     ReadWindowCoveringSafetyStatus() : ModelCommand("read")
     {
-        AddArgument("attr-name", "safety-status");
+        AddArgument("attr-name", "safety-status", false);
         ModelCommand::AddArguments();
     }
 
@@ -29294,10 +29305,10 @@ class ReportWindowCoveringSafetyStatus : public ModelCommand
 public:
     ReportWindowCoveringSafetyStatus() : ModelCommand("report")
     {
-        AddArgument("attr-name", "safety-status");
-        AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
-        AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval);
-        AddArgument("wait", 0, 1, &mWait);
+        AddArgument("attr-name", "safety-status", false);
+        AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval, false);
+        AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval, false);
+        AddArgument("wait", 0, 1, &mWait, false);
         ModelCommand::AddArguments();
     }
 
@@ -29349,7 +29360,7 @@ class ReadWindowCoveringFeatureMap : public ModelCommand
 public:
     ReadWindowCoveringFeatureMap() : ModelCommand("read")
     {
-        AddArgument("attr-name", "feature-map");
+        AddArgument("attr-name", "feature-map", false);
         ModelCommand::AddArguments();
     }
 
@@ -29383,7 +29394,7 @@ class ReadWindowCoveringClusterRevision : public ModelCommand
 public:
     ReadWindowCoveringClusterRevision() : ModelCommand("read")
     {
-        AddArgument("attr-name", "cluster-revision");
+        AddArgument("attr-name", "cluster-revision", false);
         ModelCommand::AddArguments();
     }
 

--- a/zzz_generated/chip-tool/zap-generated/test/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/test/Commands.h
@@ -116,7 +116,14 @@ private:
     CHIP_ERROR TestReadTheGlobalAttributeClusterRevision_0()
     {
         chip::Controller::BinaryInputBasicClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeClusterRevision(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel());
     }
@@ -132,7 +139,14 @@ private:
     CHIP_ERROR TestWriteTheDefaultValuesToMandatoryGlobalAttributeClusterRevision_1()
     {
         chip::Controller::BinaryInputBasicClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint16_t clusterRevisionArgument;
         clusterRevisionArgument = 1U;
@@ -148,7 +162,14 @@ private:
     CHIP_ERROR TestReadsBackGlobalAttributeClusterRevision_2()
     {
         chip::Controller::BinaryInputBasicClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeClusterRevision(mOnSuccessCallback_2.Cancel(), mOnFailureCallback_2.Cancel());
     }
@@ -377,7 +398,14 @@ private:
     CHIP_ERROR TestReadMandatoryNonGlobalAttributeOutOfService_0()
     {
         chip::Controller::BinaryInputBasicClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOutOfService(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel());
     }
@@ -393,7 +421,14 @@ private:
     CHIP_ERROR TestReadMandatoryNonGlobalAttributeConstraintsOutOfService_1()
     {
         chip::Controller::BinaryInputBasicClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOutOfService(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
     }
@@ -409,7 +444,14 @@ private:
     CHIP_ERROR TestWriteTheDefaultValuesToMandatoryNonGlobalAttributeOutOfService_2()
     {
         chip::Controller::BinaryInputBasicClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         bool outOfServiceArgument;
         outOfServiceArgument = 0;
@@ -425,7 +467,14 @@ private:
     CHIP_ERROR TestReadsBackTheMandatoryNonGlobalAttributeOutOfService_3()
     {
         chip::Controller::BinaryInputBasicClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOutOfService(mOnSuccessCallback_3.Cancel(), mOnFailureCallback_3.Cancel());
     }
@@ -441,7 +490,14 @@ private:
     CHIP_ERROR TestReadMandatoryNonGlobalAttributeConstraintsPresentValue_4()
     {
         chip::Controller::BinaryInputBasicClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributePresentValue(mOnSuccessCallback_4.Cancel(), mOnFailureCallback_4.Cancel());
     }
@@ -457,7 +513,14 @@ private:
     CHIP_ERROR TestWriteTheDefaultValuesToMandatoryNonGlobalAttributePresentValue_5()
     {
         chip::Controller::BinaryInputBasicClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         bool presentValueArgument;
         presentValueArgument = 0;
@@ -473,7 +536,14 @@ private:
     CHIP_ERROR TestReadsBackTheMandatoryNonGlobalAttributePresentValue_6()
     {
         chip::Controller::BinaryInputBasicClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributePresentValue(mOnSuccessCallback_6.Cancel(), mOnFailureCallback_6.Cancel());
     }
@@ -489,7 +559,14 @@ private:
     CHIP_ERROR TestReadMandatoryNonGlobalAttributeStatusFlags_7()
     {
         chip::Controller::BinaryInputBasicClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeStatusFlags(mOnSuccessCallback_7.Cancel(), mOnFailureCallback_7.Cancel());
     }
@@ -505,7 +582,14 @@ private:
     CHIP_ERROR TestReadMandatoryNonGlobalAttributeConstraintsStatusFlags_8()
     {
         chip::Controller::BinaryInputBasicClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeStatusFlags(mOnSuccessCallback_8.Cancel(), mOnFailureCallback_8.Cancel());
     }
@@ -522,7 +606,14 @@ private:
     CHIP_ERROR TestWriteTheDefaultValuesToMandatoryNonGlobalAttributeStatusFlags_9()
     {
         chip::Controller::BinaryInputBasicClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint8_t statusFlagsArgument;
         statusFlagsArgument = 0;
@@ -538,7 +629,14 @@ private:
     CHIP_ERROR TestReadsBackTheMandatoryNonGlobalAttributeStatusFlags_10()
     {
         chip::Controller::BinaryInputBasicClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeStatusFlags(mOnSuccessCallback_10.Cancel(), mOnFailureCallback_10.Cancel());
     }
@@ -647,7 +745,14 @@ private:
     CHIP_ERROR TestReadTheGlobalAttributeClusterRevision_0()
     {
         chip::Controller::BooleanStateClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeClusterRevision(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel());
     }
@@ -663,7 +768,14 @@ private:
     CHIP_ERROR TestWriteTheDefaultValuesToMandatoryGlobalAttributeClusterRevision_1()
     {
         chip::Controller::BooleanStateClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint16_t clusterRevisionArgument;
         clusterRevisionArgument = 1U;
@@ -679,7 +791,14 @@ private:
     CHIP_ERROR TestReadsBackGlobalAttributeClusterRevision_2()
     {
         chip::Controller::BooleanStateClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeClusterRevision(mOnSuccessCallback_2.Cancel(), mOnFailureCallback_2.Cancel());
     }
@@ -804,7 +923,14 @@ private:
     CHIP_ERROR TestReadMandatoryNonGlobalAttributeStateValue_0()
     {
         chip::Controller::BooleanStateClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeStateValue(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel());
     }
@@ -820,7 +946,14 @@ private:
     CHIP_ERROR TestReadMandatoryNonGlobalAttributeConstraintsStateValue_1()
     {
         chip::Controller::BooleanStateClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeStateValue(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
     }
@@ -836,7 +969,14 @@ private:
     CHIP_ERROR TestWriteTheDefaultValueToMandatoryNonGlobalAttributeStateValue_2()
     {
         chip::Controller::BooleanStateClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         bool stateValueArgument;
         stateValueArgument = 1;
@@ -852,7 +992,14 @@ private:
     CHIP_ERROR TestReadsBackTheMandatoryNonGlobalAttributeStateValue_3()
     {
         chip::Controller::BooleanStateClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeStateValue(mOnSuccessCallback_3.Cancel(), mOnFailureCallback_3.Cancel());
     }
@@ -928,7 +1075,14 @@ private:
     CHIP_ERROR TestWriteTheDefaultValuesToMandatoryGlobalAttributeClusterRevision_0()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint16_t clusterRevisionArgument;
         clusterRevisionArgument = 4U;
@@ -3181,7 +3335,14 @@ private:
     CHIP_ERROR TestReadsMandatoryAttributeCurrentHue_0()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeCurrentHue(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel());
     }
@@ -3197,7 +3358,14 @@ private:
     CHIP_ERROR TestValidateConstraintsOfAttributeCurrentHue_1()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeCurrentHue(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
     }
@@ -3214,7 +3382,14 @@ private:
     CHIP_ERROR TestWriteTheDefaultValueToMandatoryAttributeCurrentHue_2()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint8_t currentHueArgument;
         currentHueArgument = 0;
@@ -3230,7 +3405,14 @@ private:
     CHIP_ERROR TestReadsBackMandatoryAttributeCurrentHue_3()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeCurrentHue(mOnSuccessCallback_3.Cancel(), mOnFailureCallback_3.Cancel());
     }
@@ -3246,7 +3428,14 @@ private:
     CHIP_ERROR TestReadsMandatoryAttributeCurrentSaturation_4()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeCurrentSaturation(mOnSuccessCallback_4.Cancel(), mOnFailureCallback_4.Cancel());
     }
@@ -3262,7 +3451,14 @@ private:
     CHIP_ERROR TestValidateConstraintsOfAttributeCurrentSaturation_5()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeCurrentSaturation(mOnSuccessCallback_5.Cancel(), mOnFailureCallback_5.Cancel());
     }
@@ -3279,7 +3475,14 @@ private:
     CHIP_ERROR TestWriteTheDefaultValueToMandatoryAttributeCurrentSaturation_6()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint8_t currentSaturationArgument;
         currentSaturationArgument = 0;
@@ -3295,7 +3498,14 @@ private:
     CHIP_ERROR TestReadsBackMandatoryAttributeCurrentSaturation_7()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeCurrentSaturation(mOnSuccessCallback_7.Cancel(), mOnFailureCallback_7.Cancel());
     }
@@ -3311,7 +3521,14 @@ private:
     CHIP_ERROR TestReadTheMandatoryAttributeCurrentX_8()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeCurrentX(mOnSuccessCallback_8.Cancel(), mOnFailureCallback_8.Cancel());
     }
@@ -3327,7 +3544,14 @@ private:
     CHIP_ERROR TestValidateConstraintsOfAttributeCurrentX_9()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeCurrentX(mOnSuccessCallback_9.Cancel(), mOnFailureCallback_9.Cancel());
     }
@@ -3344,7 +3568,14 @@ private:
     CHIP_ERROR TestWriteTheDefaultValueToMandatoryAttributeCurrentX_10()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint16_t currentXArgument;
         currentXArgument = 24939U;
@@ -3360,7 +3591,14 @@ private:
     CHIP_ERROR TestReadsBackMandatoryAttributeCurrentX_11()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeCurrentX(mOnSuccessCallback_11.Cancel(), mOnFailureCallback_11.Cancel());
     }
@@ -3376,7 +3614,14 @@ private:
     CHIP_ERROR TestReadTheMandatoryAttributeCurrentY_12()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeCurrentY(mOnSuccessCallback_12.Cancel(), mOnFailureCallback_12.Cancel());
     }
@@ -3392,7 +3637,14 @@ private:
     CHIP_ERROR TestValidateConstraintsOfAttributeCurrentY_13()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeCurrentY(mOnSuccessCallback_13.Cancel(), mOnFailureCallback_13.Cancel());
     }
@@ -3409,7 +3661,14 @@ private:
     CHIP_ERROR TestWriteTheDefaultValuesToMandatoryAttributeCurrentY_14()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint16_t currentYArgument;
         currentYArgument = 24701U;
@@ -3425,7 +3684,14 @@ private:
     CHIP_ERROR TestReadsBackMandatoryAttributeCurrentY_15()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeCurrentY(mOnSuccessCallback_15.Cancel(), mOnFailureCallback_15.Cancel());
     }
@@ -3441,7 +3707,14 @@ private:
     CHIP_ERROR TestValidateConstraintsOfAttributeColorTemperatureMireds_16()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeColorTemperature(mOnSuccessCallback_16.Cancel(), mOnFailureCallback_16.Cancel());
     }
@@ -3458,7 +3731,14 @@ private:
     CHIP_ERROR TestValidateConstraintsOfAttributeColorMode_17()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeColorMode(mOnSuccessCallback_17.Cancel(), mOnFailureCallback_17.Cancel());
     }
@@ -3475,7 +3755,14 @@ private:
     CHIP_ERROR TestReadTheMandatoryAttributeOptions_18()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeColorControlOptions(mOnSuccessCallback_18.Cancel(), mOnFailureCallback_18.Cancel());
     }
@@ -3491,7 +3778,14 @@ private:
     CHIP_ERROR TestValidateConstraintsOfAttributeOptions_19()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeColorControlOptions(mOnSuccessCallback_19.Cancel(), mOnFailureCallback_19.Cancel());
     }
@@ -3507,7 +3801,14 @@ private:
     CHIP_ERROR TestWriteTheDefaultValuesToMandatoryAttributeOptions_20()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint8_t colorControlOptionsArgument;
         colorControlOptionsArgument = 0;
@@ -3523,7 +3824,14 @@ private:
     CHIP_ERROR TestReadsBackMandatoryAttributeOptions_21()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeColorControlOptions(mOnSuccessCallback_21.Cancel(), mOnFailureCallback_21.Cancel());
     }
@@ -3539,7 +3847,14 @@ private:
     CHIP_ERROR TestReadTheMandatoryAttributeEnhancedCurrentHue_22()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeEnhancedCurrentHue(mOnSuccessCallback_22.Cancel(), mOnFailureCallback_22.Cancel());
     }
@@ -3555,7 +3870,14 @@ private:
     CHIP_ERROR TestValidateConstraintsOfAttributeEnhancedCurrentHue_23()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeEnhancedCurrentHue(mOnSuccessCallback_23.Cancel(), mOnFailureCallback_23.Cancel());
     }
@@ -3571,7 +3893,14 @@ private:
     CHIP_ERROR TestWriteTheDefaultValuesToMandatoryAttributeEnhancedCurrentHue_24()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint16_t enhancedCurrentHueArgument;
         enhancedCurrentHueArgument = 0U;
@@ -3587,7 +3916,14 @@ private:
     CHIP_ERROR TestReadsBackMandatoryAttributeEnhancedCurrentHue_25()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeEnhancedCurrentHue(mOnSuccessCallback_25.Cancel(), mOnFailureCallback_25.Cancel());
     }
@@ -3603,7 +3939,14 @@ private:
     CHIP_ERROR TestValidateConstraintsOfAttributeEnhancedColorMode_26()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeEnhancedColorMode(mOnSuccessCallback_26.Cancel(), mOnFailureCallback_26.Cancel());
     }
@@ -3619,7 +3962,14 @@ private:
     CHIP_ERROR TestReadTheMandatoryAttributeColorLoopActive_27()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeColorLoopActive(mOnSuccessCallback_27.Cancel(), mOnFailureCallback_27.Cancel());
     }
@@ -3635,7 +3985,14 @@ private:
     CHIP_ERROR TestValidateConstraintsOfAttributeColorLoopActive_28()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeColorLoopActive(mOnSuccessCallback_28.Cancel(), mOnFailureCallback_28.Cancel());
     }
@@ -3651,7 +4008,14 @@ private:
     CHIP_ERROR TestWriteTheDefaultValuesToMandatoryAttributeColorLoopActive_29()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint8_t colorLoopActiveArgument;
         colorLoopActiveArgument = 0;
@@ -3667,7 +4031,14 @@ private:
     CHIP_ERROR TestReadsBackMandatoryAttributeColorLoopActive_30()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeColorLoopActive(mOnSuccessCallback_30.Cancel(), mOnFailureCallback_30.Cancel());
     }
@@ -3683,7 +4054,14 @@ private:
     CHIP_ERROR TestReadTheMandatoryAttributeColorLoopDirection_31()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeColorLoopDirection(mOnSuccessCallback_31.Cancel(), mOnFailureCallback_31.Cancel());
     }
@@ -3699,7 +4077,14 @@ private:
     CHIP_ERROR TestValidateConstraintsOfAttributeColorLoopDirection_32()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeColorLoopDirection(mOnSuccessCallback_32.Cancel(), mOnFailureCallback_32.Cancel());
     }
@@ -3715,7 +4100,14 @@ private:
     CHIP_ERROR TestWriteTheDefaultValuesToMandatoryAttributeColorLoopDirection_33()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint8_t colorLoopDirectionArgument;
         colorLoopDirectionArgument = 0;
@@ -3731,7 +4123,14 @@ private:
     CHIP_ERROR TestReadsBackMandatoryAttributeColorLoopDirection_34()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeColorLoopDirection(mOnSuccessCallback_34.Cancel(), mOnFailureCallback_34.Cancel());
     }
@@ -3747,7 +4146,14 @@ private:
     CHIP_ERROR TestReadTheMandatoryAttributeColorLoopTime_35()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeColorLoopTime(mOnSuccessCallback_35.Cancel(), mOnFailureCallback_35.Cancel());
     }
@@ -3763,7 +4169,14 @@ private:
     CHIP_ERROR TestValidateConstraintsOfAttributeColorLoopTime_36()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeColorLoopTime(mOnSuccessCallback_36.Cancel(), mOnFailureCallback_36.Cancel());
     }
@@ -3779,7 +4192,14 @@ private:
     CHIP_ERROR TestWriteTheDefaultValuesToMandatoryAttributeColorLoopTime_37()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint16_t colorLoopTimeArgument;
         colorLoopTimeArgument = 25U;
@@ -3795,7 +4215,14 @@ private:
     CHIP_ERROR TestReadsBackMandatoryAttributeColorLoopTime_38()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeColorLoopTime(mOnSuccessCallback_38.Cancel(), mOnFailureCallback_38.Cancel());
     }
@@ -3811,7 +4238,14 @@ private:
     CHIP_ERROR TestReadTheMandatoryAttributeColorLoopStartEnhancedHue_39()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeColorLoopStartEnhancedHue(mOnSuccessCallback_39.Cancel(), mOnFailureCallback_39.Cancel());
     }
@@ -3827,7 +4261,14 @@ private:
     CHIP_ERROR TestValidateConstraintsOfAttributeColorLoopStartEnhancedHue_40()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeColorLoopStartEnhancedHue(mOnSuccessCallback_40.Cancel(), mOnFailureCallback_40.Cancel());
     }
@@ -3843,7 +4284,14 @@ private:
     CHIP_ERROR TestWriteTheDefaultValuesToMandatoryAttributeColorLoopStartEnhancedHue_41()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint16_t colorLoopStartEnhancedHueArgument;
         colorLoopStartEnhancedHueArgument = 8960U;
@@ -3859,7 +4307,14 @@ private:
     CHIP_ERROR TestReadsBackMandatoryAttributeColorLoopStartEnhancedHue_42()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeColorLoopStartEnhancedHue(mOnSuccessCallback_42.Cancel(), mOnFailureCallback_42.Cancel());
     }
@@ -3875,7 +4330,14 @@ private:
     CHIP_ERROR TestReadTheMandatoryAttributeColorLoopStoredEnhancedHue_43()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeColorLoopStoredEnhancedHue(mOnSuccessCallback_43.Cancel(), mOnFailureCallback_43.Cancel());
     }
@@ -3891,7 +4353,14 @@ private:
     CHIP_ERROR TestValidateConstraintsOfAttributeColorLoopStoredEnhancedHue_44()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeColorLoopStoredEnhancedHue(mOnSuccessCallback_44.Cancel(), mOnFailureCallback_44.Cancel());
     }
@@ -3907,7 +4376,14 @@ private:
     CHIP_ERROR TestWriteTheDefaultValuesToMandatoryAttributeColorLoopStoredEnhancedHue_45()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint16_t colorLoopStoredEnhancedHueArgument;
         colorLoopStoredEnhancedHueArgument = 0U;
@@ -3923,7 +4399,14 @@ private:
     CHIP_ERROR TestReadsBackMandatoryAttributeColorLoopStoredEnhancedHue_46()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeColorLoopStoredEnhancedHue(mOnSuccessCallback_46.Cancel(), mOnFailureCallback_46.Cancel());
     }
@@ -3939,7 +4422,14 @@ private:
     CHIP_ERROR TestReadTheMandatoryAttributeColorCapabilities_47()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeColorCapabilities(mOnSuccessCallback_47.Cancel(), mOnFailureCallback_47.Cancel());
     }
@@ -3955,7 +4445,14 @@ private:
     CHIP_ERROR TestValidateConstraintsOfAttributeColorCapabilities_48()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeColorCapabilities(mOnSuccessCallback_48.Cancel(), mOnFailureCallback_48.Cancel());
     }
@@ -3972,7 +4469,14 @@ private:
     CHIP_ERROR TestWriteTheDefaultValuesToMandatoryAttributeColorCapabilities_49()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint16_t colorCapabilitiesArgument;
         colorCapabilitiesArgument = 0U;
@@ -3988,7 +4492,14 @@ private:
     CHIP_ERROR TestReadsBackMandatoryAttributeColorCapabilities_50()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeColorCapabilities(mOnSuccessCallback_50.Cancel(), mOnFailureCallback_50.Cancel());
     }
@@ -4004,7 +4515,14 @@ private:
     CHIP_ERROR TestReadTheMandatoryAttributeColorTempPhysicalMinMireds_51()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeColorTempPhysicalMin(mOnSuccessCallback_51.Cancel(), mOnFailureCallback_51.Cancel());
     }
@@ -4020,7 +4538,14 @@ private:
     CHIP_ERROR TestValidateConstraintsOfAttributeColorTempPhysicalMinMireds_52()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeColorTempPhysicalMin(mOnSuccessCallback_52.Cancel(), mOnFailureCallback_52.Cancel());
     }
@@ -4037,7 +4562,14 @@ private:
     CHIP_ERROR TestWriteTheDefaultValuesToMandatoryAttributeColorTempPhysicalMinMireds_53()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint16_t colorTempPhysicalMinArgument;
         colorTempPhysicalMinArgument = 0U;
@@ -4053,7 +4585,14 @@ private:
     CHIP_ERROR TestReadsBackMandatoryAttributeColorTempPhysicalMinMireds_54()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeColorTempPhysicalMin(mOnSuccessCallback_54.Cancel(), mOnFailureCallback_54.Cancel());
     }
@@ -4069,7 +4608,14 @@ private:
     CHIP_ERROR TestReadTheMandatoryAttributeColorTempPhysicalMaxMireds_55()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeColorTempPhysicalMax(mOnSuccessCallback_55.Cancel(), mOnFailureCallback_55.Cancel());
     }
@@ -4085,7 +4631,14 @@ private:
     CHIP_ERROR TestValidateConstraintsOfAttributeColorTempPhysicalMaxMireds_56()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeColorTempPhysicalMax(mOnSuccessCallback_56.Cancel(), mOnFailureCallback_56.Cancel());
     }
@@ -4102,7 +4655,14 @@ private:
     CHIP_ERROR TestWriteTheDefaultValuesToMandatoryAttributeColorTempPhysicalMaxMireds_57()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint16_t colorTempPhysicalMaxArgument;
         colorTempPhysicalMaxArgument = 65279U;
@@ -4118,7 +4678,14 @@ private:
     CHIP_ERROR TestReadsBackMandatoryAttributeColorTempPhysicalMaxMireds_58()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeColorTempPhysicalMax(mOnSuccessCallback_58.Cancel(), mOnFailureCallback_58.Cancel());
     }
@@ -4134,7 +4701,14 @@ private:
     CHIP_ERROR TestReadTheOptionalAttributeCoupleColorTempToLevelMinMireds_59()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeCoupleColorTempToLevelMinMireds(mOnSuccessCallback_59.Cancel(), mOnFailureCallback_59.Cancel());
     }
@@ -4150,7 +4724,14 @@ private:
     CHIP_ERROR TestWriteTheDefaultValuesToOptionalAttributeCoupleColorTempToLevelMinMireds_60()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint16_t coupleColorTempToLevelMinMiredsArgument;
         coupleColorTempToLevelMinMiredsArgument = 0U;
@@ -4166,7 +4747,14 @@ private:
     CHIP_ERROR TestReadsBackOptionalAttributeCoupleColorTempToLevelMinMireds_61()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeCoupleColorTempToLevelMinMireds(mOnSuccessCallback_61.Cancel(), mOnFailureCallback_61.Cancel());
     }
@@ -4182,7 +4770,14 @@ private:
     CHIP_ERROR TestReadTheOptionalAttributeStartUpColorTemperatureMireds_62()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeStartUpColorTemperatureMireds(mOnSuccessCallback_62.Cancel(), mOnFailureCallback_62.Cancel());
     }
@@ -4199,7 +4794,14 @@ private:
     CHIP_ERROR TestWriteTheDefaultValuesToOptionalAttributeStartUpColorTemperatureMireds_63()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint16_t startUpColorTemperatureMiredsArgument;
         startUpColorTemperatureMiredsArgument = 0U;
@@ -4215,7 +4817,14 @@ private:
     CHIP_ERROR TestReadsBackOptionalAttributeStartUpColorTemperatureMireds_64()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeStartUpColorTemperatureMireds(mOnSuccessCallback_64.Cancel(), mOnFailureCallback_64.Cancel());
     }
@@ -4231,7 +4840,14 @@ private:
     CHIP_ERROR TestReadTheOptionalAttributeRemainingTime_65()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeRemainingTime(mOnSuccessCallback_65.Cancel(), mOnFailureCallback_65.Cancel());
     }
@@ -4247,7 +4863,14 @@ private:
     CHIP_ERROR TestValidateConstraintsOfAttributeRemainingTime_66()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeRemainingTime(mOnSuccessCallback_66.Cancel(), mOnFailureCallback_66.Cancel());
     }
@@ -4264,7 +4887,14 @@ private:
     CHIP_ERROR TestWriteTheDefaultValuesToOptionalAttributeRemainingTime_67()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint16_t remainingTimeArgument;
         remainingTimeArgument = 0U;
@@ -4280,7 +4910,14 @@ private:
     CHIP_ERROR TestReadsBackOptionalAttributeRemainingTime_68()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeRemainingTime(mOnSuccessCallback_68.Cancel(), mOnFailureCallback_68.Cancel());
     }
@@ -4296,7 +4933,14 @@ private:
     CHIP_ERROR TestReadTheOptionalAttributeDriftCompensation_69()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeDriftCompensation(mOnSuccessCallback_69.Cancel(), mOnFailureCallback_69.Cancel());
     }
@@ -4313,7 +4957,14 @@ private:
     CHIP_ERROR TestWriteTheDefaultValuesToOptionalAttributeDriftCompensation_70()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint8_t driftCompensationArgument;
         driftCompensationArgument = static_cast<uint8_t>(0);
@@ -4329,7 +4980,14 @@ private:
     CHIP_ERROR TestReadsBackOptionalAttributeDriftCompensation_71()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeDriftCompensation(mOnSuccessCallback_71.Cancel(), mOnFailureCallback_71.Cancel());
     }
@@ -4345,7 +5003,14 @@ private:
     CHIP_ERROR TestReadTheOptionalAttributeCompensationText_72()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeCompensationText(mOnSuccessCallback_72.Cancel(), mOnFailureCallback_72.Cancel());
     }
@@ -4362,7 +5027,14 @@ private:
     CHIP_ERROR TestReadTheMandatoryAttributeNumberOfPrimaries_73()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeNumberOfPrimaries(mOnSuccessCallback_73.Cancel(), mOnFailureCallback_73.Cancel());
     }
@@ -4379,7 +5051,14 @@ private:
     CHIP_ERROR TestWriteTheDefaultMandatoryAttributeNumberOfPrimaries_74()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint8_t numberOfPrimariesArgument;
         numberOfPrimariesArgument = 0;
@@ -4395,7 +5074,14 @@ private:
     CHIP_ERROR TestReadBackTheMandatoryAttributeNumberOfPrimaries_75()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeNumberOfPrimaries(mOnSuccessCallback_75.Cancel(), mOnFailureCallback_75.Cancel());
     }
@@ -4411,7 +5097,14 @@ private:
     CHIP_ERROR TestReadTheMandatoryAttributePrimary1X_76()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributePrimary1X(mOnSuccessCallback_76.Cancel(), mOnFailureCallback_76.Cancel());
     }
@@ -4428,7 +5121,14 @@ private:
     CHIP_ERROR TestWriteTheDefaultMandatoryAttributePrimary1X_77()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint16_t primary1XArgument;
         primary1XArgument = 0U;
@@ -4444,7 +5144,14 @@ private:
     CHIP_ERROR TestReadBackTheMandatoryAttributePrimary1X_78()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributePrimary1X(mOnSuccessCallback_78.Cancel(), mOnFailureCallback_78.Cancel());
     }
@@ -4460,7 +5167,14 @@ private:
     CHIP_ERROR TestReadTheMandatoryAttributePrimary1Y_79()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributePrimary1Y(mOnSuccessCallback_79.Cancel(), mOnFailureCallback_79.Cancel());
     }
@@ -4477,7 +5191,14 @@ private:
     CHIP_ERROR TestWriteTheDefaultMandatoryAttributePrimary1Y_80()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint16_t primary1YArgument;
         primary1YArgument = 0U;
@@ -4493,7 +5214,14 @@ private:
     CHIP_ERROR TestReadBackTheMandatoryAttributePrimary1Y_81()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributePrimary1Y(mOnSuccessCallback_81.Cancel(), mOnFailureCallback_81.Cancel());
     }
@@ -4509,7 +5237,14 @@ private:
     CHIP_ERROR TestReadTheMandatoryAttributePrimary1Intensity_82()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributePrimary1Intensity(mOnSuccessCallback_82.Cancel(), mOnFailureCallback_82.Cancel());
     }
@@ -4525,7 +5260,14 @@ private:
     CHIP_ERROR TestReadTheMandatoryAttributePrimary2X_83()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributePrimary2X(mOnSuccessCallback_83.Cancel(), mOnFailureCallback_83.Cancel());
     }
@@ -4542,7 +5284,14 @@ private:
     CHIP_ERROR TestWriteTheDefaultMandatoryAttributePrimary2X_84()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint16_t primary2XArgument;
         primary2XArgument = 0U;
@@ -4558,7 +5307,14 @@ private:
     CHIP_ERROR TestReadBackTheMandatoryAttributePrimary2X_85()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributePrimary2X(mOnSuccessCallback_85.Cancel(), mOnFailureCallback_85.Cancel());
     }
@@ -4574,7 +5330,14 @@ private:
     CHIP_ERROR TestReadTheMandatoryAttributePrimary2Y_86()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributePrimary2Y(mOnSuccessCallback_86.Cancel(), mOnFailureCallback_86.Cancel());
     }
@@ -4591,7 +5354,14 @@ private:
     CHIP_ERROR TestWriteTheDefaultMandatoryAttributePrimary2Y_87()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint16_t primary2YArgument;
         primary2YArgument = 0U;
@@ -4607,7 +5377,14 @@ private:
     CHIP_ERROR TestReadBackTheMandatoryAttributePrimary2Y_88()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributePrimary2Y(mOnSuccessCallback_88.Cancel(), mOnFailureCallback_88.Cancel());
     }
@@ -4623,7 +5400,14 @@ private:
     CHIP_ERROR TestValidateConstraintsOfAttributePrimary2Intensity_89()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributePrimary2Intensity(mOnSuccessCallback_89.Cancel(), mOnFailureCallback_89.Cancel());
     }
@@ -4639,7 +5423,14 @@ private:
     CHIP_ERROR TestReadTheMandatoryAttributePrimary3X_90()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributePrimary3X(mOnSuccessCallback_90.Cancel(), mOnFailureCallback_90.Cancel());
     }
@@ -4656,7 +5447,14 @@ private:
     CHIP_ERROR TestWriteTheDefaultMandatoryAttributePrimary3X_91()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint16_t primary3XArgument;
         primary3XArgument = 0U;
@@ -4672,7 +5470,14 @@ private:
     CHIP_ERROR TestReadBackTheMandatoryAttributePrimary3X_92()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributePrimary3X(mOnSuccessCallback_92.Cancel(), mOnFailureCallback_92.Cancel());
     }
@@ -4688,7 +5493,14 @@ private:
     CHIP_ERROR TestReadTheMandatoryAttributePrimary3Y_93()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributePrimary3Y(mOnSuccessCallback_93.Cancel(), mOnFailureCallback_93.Cancel());
     }
@@ -4705,7 +5517,14 @@ private:
     CHIP_ERROR TestWriteTheDefaultMandatoryAttributePrimary3Y_94()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint16_t primary3YArgument;
         primary3YArgument = 0U;
@@ -4721,7 +5540,14 @@ private:
     CHIP_ERROR TestReadBackTheMandatoryAttributePrimary3Y_95()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributePrimary3Y(mOnSuccessCallback_95.Cancel(), mOnFailureCallback_95.Cancel());
     }
@@ -4737,7 +5563,14 @@ private:
     CHIP_ERROR TestReadTheMandatoryAttributePrimary3Intensity_96()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributePrimary3Intensity(mOnSuccessCallback_96.Cancel(), mOnFailureCallback_96.Cancel());
     }
@@ -4753,7 +5586,14 @@ private:
     CHIP_ERROR TestReadTheMandatoryAttributePrimary4X_97()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributePrimary4X(mOnSuccessCallback_97.Cancel(), mOnFailureCallback_97.Cancel());
     }
@@ -4770,7 +5610,14 @@ private:
     CHIP_ERROR TestWriteTheDefaultMandatoryAttributePrimary4X_98()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint16_t primary4XArgument;
         primary4XArgument = 0U;
@@ -4786,7 +5633,14 @@ private:
     CHIP_ERROR TestReadBackTheMandatoryAttributePrimary4X_99()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributePrimary4X(mOnSuccessCallback_99.Cancel(), mOnFailureCallback_99.Cancel());
     }
@@ -4802,7 +5656,14 @@ private:
     CHIP_ERROR TestReadTheMandatoryAttributePrimary4Y_100()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributePrimary4Y(mOnSuccessCallback_100.Cancel(), mOnFailureCallback_100.Cancel());
     }
@@ -4819,7 +5680,14 @@ private:
     CHIP_ERROR TestWriteTheDefaultMandatoryAttributePrimary4Y_101()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint16_t primary4YArgument;
         primary4YArgument = 0U;
@@ -4835,7 +5703,14 @@ private:
     CHIP_ERROR TestReadBackTheMandatoryAttributePrimary4Y_102()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributePrimary4Y(mOnSuccessCallback_102.Cancel(), mOnFailureCallback_102.Cancel());
     }
@@ -4851,7 +5726,14 @@ private:
     CHIP_ERROR TestReadTheMandatoryAttributePrimary4Intensity_103()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributePrimary4Intensity(mOnSuccessCallback_103.Cancel(), mOnFailureCallback_103.Cancel());
     }
@@ -4867,7 +5749,14 @@ private:
     CHIP_ERROR TestReadTheMandatoryAttributePrimary5X_104()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributePrimary5X(mOnSuccessCallback_104.Cancel(), mOnFailureCallback_104.Cancel());
     }
@@ -4884,7 +5773,14 @@ private:
     CHIP_ERROR TestWriteTheDefaultMandatoryAttributePrimary5X_105()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint16_t primary5XArgument;
         primary5XArgument = 0U;
@@ -4900,7 +5796,14 @@ private:
     CHIP_ERROR TestReadBackTheMandatoryAttributePrimary5X_106()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributePrimary5X(mOnSuccessCallback_106.Cancel(), mOnFailureCallback_106.Cancel());
     }
@@ -4916,7 +5819,14 @@ private:
     CHIP_ERROR TestReadTheMandatoryAttributePrimary5Y_107()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributePrimary5Y(mOnSuccessCallback_107.Cancel(), mOnFailureCallback_107.Cancel());
     }
@@ -4933,7 +5843,14 @@ private:
     CHIP_ERROR TestWriteTheDefaultMandatoryAttributePrimary5Y_108()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint16_t primary5YArgument;
         primary5YArgument = 0U;
@@ -4949,7 +5866,14 @@ private:
     CHIP_ERROR TestReadBackTheMandatoryAttributePrimary5Y_109()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributePrimary5Y(mOnSuccessCallback_109.Cancel(), mOnFailureCallback_109.Cancel());
     }
@@ -4965,7 +5889,14 @@ private:
     CHIP_ERROR TestReadTheMandatoryAttributePrimary5Intensity_110()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributePrimary5Intensity(mOnSuccessCallback_110.Cancel(), mOnFailureCallback_110.Cancel());
     }
@@ -4981,7 +5912,14 @@ private:
     CHIP_ERROR TestReadTheMandatoryAttributePrimary6X_111()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributePrimary6X(mOnSuccessCallback_111.Cancel(), mOnFailureCallback_111.Cancel());
     }
@@ -4998,7 +5936,14 @@ private:
     CHIP_ERROR TestWriteTheDefaultMandatoryAttributePrimary6X_112()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint16_t primary6XArgument;
         primary6XArgument = 0U;
@@ -5014,7 +5959,14 @@ private:
     CHIP_ERROR TestReadBackTheMandatoryAttributePrimary6X_113()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributePrimary6X(mOnSuccessCallback_113.Cancel(), mOnFailureCallback_113.Cancel());
     }
@@ -5030,7 +5982,14 @@ private:
     CHIP_ERROR TestReadTheMandatoryAttributePrimary6Y_114()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributePrimary6Y(mOnSuccessCallback_114.Cancel(), mOnFailureCallback_114.Cancel());
     }
@@ -5047,7 +6006,14 @@ private:
     CHIP_ERROR TestWriteTheDefaultMandatoryAttributePrimary6Y_115()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint16_t primary6YArgument;
         primary6YArgument = 0U;
@@ -5063,7 +6029,14 @@ private:
     CHIP_ERROR TestReadBackTheMandatoryAttributePrimary6Y_116()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributePrimary6Y(mOnSuccessCallback_116.Cancel(), mOnFailureCallback_116.Cancel());
     }
@@ -5079,7 +6052,14 @@ private:
     CHIP_ERROR TestReadTheMandatoryAttributePrimary6Intensity_117()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributePrimary6Intensity(mOnSuccessCallback_117.Cancel(), mOnFailureCallback_117.Cancel());
     }
@@ -5095,7 +6075,14 @@ private:
     CHIP_ERROR TestReadTheOptionalAttributeWhitePointX_118()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeWhitePointX(mOnSuccessCallback_118.Cancel(), mOnFailureCallback_118.Cancel());
     }
@@ -5112,7 +6099,14 @@ private:
     CHIP_ERROR TestWriteTheDefaultOptionalAttributeWhitePointX_119()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint16_t whitePointXArgument;
         whitePointXArgument = 0U;
@@ -5128,7 +6122,14 @@ private:
     CHIP_ERROR TestReadBackTheOptionalAttributeWhitePointX_120()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeWhitePointX(mOnSuccessCallback_120.Cancel(), mOnFailureCallback_120.Cancel());
     }
@@ -5144,7 +6145,14 @@ private:
     CHIP_ERROR TestReadTheOptionalAttributeWhitePointY_121()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeWhitePointY(mOnSuccessCallback_121.Cancel(), mOnFailureCallback_121.Cancel());
     }
@@ -5161,7 +6169,14 @@ private:
     CHIP_ERROR TestWriteTheDefaultOptionalAttributeWhitePointY_122()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint16_t whitePointYArgument;
         whitePointYArgument = 0U;
@@ -5177,7 +6192,14 @@ private:
     CHIP_ERROR TestReadBackTheOptionalAttributeWhitePointY_123()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeWhitePointY(mOnSuccessCallback_123.Cancel(), mOnFailureCallback_123.Cancel());
     }
@@ -5193,7 +6215,14 @@ private:
     CHIP_ERROR TestReadTheOptionalAttributeColorPointRX_124()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeColorPointRX(mOnSuccessCallback_124.Cancel(), mOnFailureCallback_124.Cancel());
     }
@@ -5210,7 +6239,14 @@ private:
     CHIP_ERROR TestWriteTheDefaultOptionalAttributeColorPointRX_125()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint16_t colorPointRXArgument;
         colorPointRXArgument = 0U;
@@ -5226,7 +6262,14 @@ private:
     CHIP_ERROR TestReadBackTheOptionalAttributeColorPointRX_126()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeColorPointRX(mOnSuccessCallback_126.Cancel(), mOnFailureCallback_126.Cancel());
     }
@@ -5242,7 +6285,14 @@ private:
     CHIP_ERROR TestReadTheOptionalAttributeColorPointRY_127()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeColorPointRY(mOnSuccessCallback_127.Cancel(), mOnFailureCallback_127.Cancel());
     }
@@ -5259,7 +6309,14 @@ private:
     CHIP_ERROR TestWriteTheDefaultOptionalAttributeColorPointRY_128()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint16_t colorPointRYArgument;
         colorPointRYArgument = 0U;
@@ -5275,7 +6332,14 @@ private:
     CHIP_ERROR TestReadBackTheOptionalAttributeColorPointRY_129()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeColorPointRY(mOnSuccessCallback_129.Cancel(), mOnFailureCallback_129.Cancel());
     }
@@ -5291,7 +6355,14 @@ private:
     CHIP_ERROR TestReadTheOptionalAttributeColorPointRIntensity_130()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeColorPointRIntensity(mOnSuccessCallback_130.Cancel(), mOnFailureCallback_130.Cancel());
     }
@@ -5307,7 +6378,14 @@ private:
     CHIP_ERROR TestReadTheOptionalAttributeColorPointGX_131()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeColorPointGX(mOnSuccessCallback_131.Cancel(), mOnFailureCallback_131.Cancel());
     }
@@ -5324,7 +6402,14 @@ private:
     CHIP_ERROR TestWriteTheDefaultOptionalAttributeColorPointGX_132()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint16_t colorPointGXArgument;
         colorPointGXArgument = 0U;
@@ -5340,7 +6425,14 @@ private:
     CHIP_ERROR TestReadBackTheOptionalAttributeColorPointGX_133()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeColorPointGX(mOnSuccessCallback_133.Cancel(), mOnFailureCallback_133.Cancel());
     }
@@ -5356,7 +6448,14 @@ private:
     CHIP_ERROR TestReadTheOptionalAttributeColorPointGY_134()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeColorPointGY(mOnSuccessCallback_134.Cancel(), mOnFailureCallback_134.Cancel());
     }
@@ -5373,7 +6472,14 @@ private:
     CHIP_ERROR TestWriteTheDefaultOptionalAttributeColorPointGY_135()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint16_t colorPointGYArgument;
         colorPointGYArgument = 0U;
@@ -5389,7 +6495,14 @@ private:
     CHIP_ERROR TestReadBackTheOptionalAttributeColorPointGY_136()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeColorPointGY(mOnSuccessCallback_136.Cancel(), mOnFailureCallback_136.Cancel());
     }
@@ -5405,7 +6518,14 @@ private:
     CHIP_ERROR TestReadTheOptionalAttributeColorPointGIntensity_137()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeColorPointGIntensity(mOnSuccessCallback_137.Cancel(), mOnFailureCallback_137.Cancel());
     }
@@ -5421,7 +6541,14 @@ private:
     CHIP_ERROR TestReadTheOptionalAttributeColorPointBX_138()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeColorPointBX(mOnSuccessCallback_138.Cancel(), mOnFailureCallback_138.Cancel());
     }
@@ -5438,7 +6565,14 @@ private:
     CHIP_ERROR TestWriteTheDefaultOptionalAttributeColorPointBX_139()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint16_t colorPointBXArgument;
         colorPointBXArgument = 0U;
@@ -5454,7 +6588,14 @@ private:
     CHIP_ERROR TestReadBackTheOptionalAttributeColorPointBX_140()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeColorPointBX(mOnSuccessCallback_140.Cancel(), mOnFailureCallback_140.Cancel());
     }
@@ -5470,7 +6611,14 @@ private:
     CHIP_ERROR TestReadTheOptionalAttributeColorPointBY_141()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeColorPointBY(mOnSuccessCallback_141.Cancel(), mOnFailureCallback_141.Cancel());
     }
@@ -5487,7 +6635,14 @@ private:
     CHIP_ERROR TestWriteTheDefaultOptionalAttributeColorPointBY_142()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint16_t colorPointBYArgument;
         colorPointBYArgument = 0U;
@@ -5503,7 +6658,14 @@ private:
     CHIP_ERROR TestReadBackTheOptionalAttributeColorPointBY_143()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeColorPointBY(mOnSuccessCallback_143.Cancel(), mOnFailureCallback_143.Cancel());
     }
@@ -5519,7 +6681,14 @@ private:
     CHIP_ERROR TestReadTheOptionalAttributeColorPointBIntensity_144()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeColorPointBIntensity(mOnSuccessCallback_144.Cancel(), mOnFailureCallback_144.Cancel());
     }
@@ -5640,7 +6809,14 @@ private:
     CHIP_ERROR TestTurnOnLightForColorControlTests_0()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::OnOff::Commands::On::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -5664,7 +6840,14 @@ private:
     CHIP_ERROR TestCheckOnOffAttributeValueIsTrueAfterOnCommand_1()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOnOff(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
     }
@@ -5680,7 +6863,14 @@ private:
     CHIP_ERROR TestMoveToHueShortestDistanceCommand_2()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::ColorControl::Commands::MoveToHue::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -5709,7 +6899,14 @@ private:
     CHIP_ERROR TestMoveToHueLongestDistanceCommand_3()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::ColorControl::Commands::MoveToHue::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -5738,7 +6935,14 @@ private:
     CHIP_ERROR TestMoveToHueUpCommand_4()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::ColorControl::Commands::MoveToHue::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -5767,7 +6971,14 @@ private:
     CHIP_ERROR TestMoveToHueDownCommand_5()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::ColorControl::Commands::MoveToHue::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -5796,7 +7007,14 @@ private:
     CHIP_ERROR TestTurnOffLightThatWeTurnedOn_6()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::OnOff::Commands::Off::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -5820,7 +7038,14 @@ private:
     CHIP_ERROR TestCheckOnOffAttributeValueIsFalseAfterOffCommand_7()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOnOff(mOnSuccessCallback_7.Cancel(), mOnFailureCallback_7.Cancel());
     }
@@ -5941,7 +7166,14 @@ private:
     CHIP_ERROR TestTurnOnLightForColorControlTests_0()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::OnOff::Commands::On::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -5965,7 +7197,14 @@ private:
     CHIP_ERROR TestCheckOnOffAttributeValueIsTrueAfterOnCommand_1()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOnOff(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
     }
@@ -5981,7 +7220,14 @@ private:
     CHIP_ERROR TestMoveHueUpCommand_2()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::ColorControl::Commands::MoveHue::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -6009,7 +7255,14 @@ private:
     CHIP_ERROR TestMoveHueStopCommand_3()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::ColorControl::Commands::MoveHue::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -6037,7 +7290,14 @@ private:
     CHIP_ERROR TestMoveHueDownCommand_4()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::ColorControl::Commands::MoveHue::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -6065,7 +7325,14 @@ private:
     CHIP_ERROR TestMoveHueStopCommand_5()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::ColorControl::Commands::MoveHue::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -6093,7 +7360,14 @@ private:
     CHIP_ERROR TestTurnOffLightThatWeTurnedOn_6()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::OnOff::Commands::Off::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -6117,7 +7391,14 @@ private:
     CHIP_ERROR TestCheckOnOffAttributeValueIsFalseAfterOffCommand_7()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOnOff(mOnSuccessCallback_7.Cancel(), mOnFailureCallback_7.Cancel());
     }
@@ -6230,7 +7511,14 @@ private:
     CHIP_ERROR TestTurnOnLightForColorControlTests_0()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::OnOff::Commands::On::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -6254,7 +7542,14 @@ private:
     CHIP_ERROR TestCheckOnOffAttributeValueIsTrueAfterOnCommand_1()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOnOff(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
     }
@@ -6270,7 +7565,14 @@ private:
     CHIP_ERROR TestStepHueUpCommand_2()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::ColorControl::Commands::StepHue::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -6299,7 +7601,14 @@ private:
     CHIP_ERROR TestStepHueDownCommand_3()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::ColorControl::Commands::StepHue::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -6328,7 +7637,14 @@ private:
     CHIP_ERROR TestTurnOffLightThatWeTurnedOn_4()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::OnOff::Commands::Off::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -6352,7 +7668,14 @@ private:
     CHIP_ERROR TestCheckOnOffAttributeValueIsFalseAfterOffCommand_5()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOnOff(mOnSuccessCallback_5.Cancel(), mOnFailureCallback_5.Cancel());
     }
@@ -6461,7 +7784,14 @@ private:
     CHIP_ERROR TestTurnOnLightForColorControlTests_0()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::OnOff::Commands::On::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -6485,7 +7815,14 @@ private:
     CHIP_ERROR TestCheckOnOffAttributeValueIsTrueAfterOnCommand_1()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOnOff(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
     }
@@ -6501,7 +7838,14 @@ private:
     CHIP_ERROR TestMoveToSaturationCommand_2()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::ColorControl::Commands::MoveToSaturation::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -6529,7 +7873,14 @@ private:
     CHIP_ERROR TestTurnOffLightThatWeTurnedOn_3()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::OnOff::Commands::Off::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -6553,7 +7904,14 @@ private:
     CHIP_ERROR TestCheckOnOffAttributeValueIsFalseAfterOffCommand_4()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOnOff(mOnSuccessCallback_4.Cancel(), mOnFailureCallback_4.Cancel());
     }
@@ -6666,7 +8024,14 @@ private:
     CHIP_ERROR TestTurnOnLightForColorControlTests_0()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::OnOff::Commands::On::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -6690,7 +8055,14 @@ private:
     CHIP_ERROR TestCheckOnOffAttributeValueIsTrueAfterOnCommand_1()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOnOff(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
     }
@@ -6706,7 +8078,14 @@ private:
     CHIP_ERROR TestMoveSaturationUpCommand_2()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::ColorControl::Commands::MoveSaturation::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -6734,7 +8113,14 @@ private:
     CHIP_ERROR TestMoveSaturationDownCommand_3()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::ColorControl::Commands::MoveSaturation::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -6762,7 +8148,14 @@ private:
     CHIP_ERROR TestTurnOffLightThatWeTurnedOn_4()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::OnOff::Commands::Off::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -6786,7 +8179,14 @@ private:
     CHIP_ERROR TestCheckOnOffAttributeValueIsFalseAfterOffCommand_5()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOnOff(mOnSuccessCallback_5.Cancel(), mOnFailureCallback_5.Cancel());
     }
@@ -6899,7 +8299,14 @@ private:
     CHIP_ERROR TestTurnOnLightForColorControlTests_0()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::OnOff::Commands::On::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -6923,7 +8330,14 @@ private:
     CHIP_ERROR TestCheckOnOffAttributeValueIsTrueAfterOnCommand_1()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOnOff(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
     }
@@ -6939,7 +8353,14 @@ private:
     CHIP_ERROR TestStepSaturationUpCommand_2()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::ColorControl::Commands::StepSaturation::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -6968,7 +8389,14 @@ private:
     CHIP_ERROR TestStepSaturationDownCommand_3()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::ColorControl::Commands::StepSaturation::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -6997,7 +8425,14 @@ private:
     CHIP_ERROR TestTurnOffLightThatWeTurnedOn_4()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::OnOff::Commands::Off::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -7021,7 +8456,14 @@ private:
     CHIP_ERROR TestCheckOnOffAttributeValueIsFalseAfterOffCommand_5()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOnOff(mOnSuccessCallback_5.Cancel(), mOnFailureCallback_5.Cancel());
     }
@@ -7130,7 +8572,14 @@ private:
     CHIP_ERROR TestTurnOnLightForColorControlTests_0()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::OnOff::Commands::On::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -7154,7 +8603,14 @@ private:
     CHIP_ERROR TestCheckOnOffAttributeValueIsTrueAfterOnCommand_1()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOnOff(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
     }
@@ -7170,7 +8626,14 @@ private:
     CHIP_ERROR TestMoveToCurrentHueAndSaturationCommand_2()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::ColorControl::Commands::MoveToHueAndSaturation::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -7199,7 +8662,14 @@ private:
     CHIP_ERROR TestTurnOffLightThatWeTurnedOn_3()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::OnOff::Commands::Off::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -7223,7 +8693,14 @@ private:
     CHIP_ERROR TestCheckOnOffAttributeValueIsFalseAfterOffCommand_4()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOnOff(mOnSuccessCallback_4.Cancel(), mOnFailureCallback_4.Cancel());
     }
@@ -7332,7 +8809,14 @@ private:
     CHIP_ERROR TestTurnOnLightForColorControlTests_0()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::OnOff::Commands::On::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -7356,7 +8840,14 @@ private:
     CHIP_ERROR TestCheckOnOffAttributeValueIsTrueAfterOnCommand_1()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOnOff(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
     }
@@ -7372,7 +8863,14 @@ private:
     CHIP_ERROR TestMoveToColorCommand_2()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::ColorControl::Commands::MoveToColor::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -7401,7 +8899,14 @@ private:
     CHIP_ERROR TestTurnOffLightThatWeTurnedOn_3()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::OnOff::Commands::Off::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -7425,7 +8930,14 @@ private:
     CHIP_ERROR TestCheckOnOffAttributeValueIsFalseAfterOffCommand_4()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOnOff(mOnSuccessCallback_4.Cancel(), mOnFailureCallback_4.Cancel());
     }
@@ -7538,7 +9050,14 @@ private:
     CHIP_ERROR TestTurnOnLightForColorControlTests_0()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::OnOff::Commands::On::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -7562,7 +9081,14 @@ private:
     CHIP_ERROR TestCheckOnOffAttributeValueIsTrueAfterOnCommand_1()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOnOff(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
     }
@@ -7578,7 +9104,14 @@ private:
     CHIP_ERROR TestMoveColorCommand_2()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::ColorControl::Commands::MoveColor::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -7606,7 +9139,14 @@ private:
     CHIP_ERROR TestStopMoveStepCommand_3()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::ColorControl::Commands::StopMoveStep::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -7632,7 +9172,14 @@ private:
     CHIP_ERROR TestTurnOffLightThatWeTurnedOn_4()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::OnOff::Commands::Off::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -7656,7 +9203,14 @@ private:
     CHIP_ERROR TestCheckOnOffAttributeValueIsFalseAfterOffCommand_5()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOnOff(mOnSuccessCallback_5.Cancel(), mOnFailureCallback_5.Cancel());
     }
@@ -7765,7 +9319,14 @@ private:
     CHIP_ERROR TestTurnOnLightForColorControlTests_0()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::OnOff::Commands::On::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -7789,7 +9350,14 @@ private:
     CHIP_ERROR TestCheckOnOffAttributeValueIsTrueAfterOnCommand_1()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOnOff(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
     }
@@ -7805,7 +9373,14 @@ private:
     CHIP_ERROR TestStepColorCommand_2()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::ColorControl::Commands::StepColor::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -7834,7 +9409,14 @@ private:
     CHIP_ERROR TestTurnOffLightThatWeTurnedOn_3()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::OnOff::Commands::Off::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -7858,7 +9440,14 @@ private:
     CHIP_ERROR TestCheckOnOffAttributeValueIsFalseAfterOffCommand_4()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOnOff(mOnSuccessCallback_4.Cancel(), mOnFailureCallback_4.Cancel());
     }
@@ -7967,7 +9556,14 @@ private:
     CHIP_ERROR TestTurnOnLightForColorControlTests_0()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::OnOff::Commands::On::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -7991,7 +9587,14 @@ private:
     CHIP_ERROR TestCheckOnOffAttributeValueIsTrueAfterOnCommand_1()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOnOff(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
     }
@@ -8007,7 +9610,14 @@ private:
     CHIP_ERROR TestMoveToColorTemperatureCommand_2()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::ColorControl::Commands::MoveToColorTemperature::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -8035,7 +9645,14 @@ private:
     CHIP_ERROR TestTurnOffLightThatWeTurnedOn_3()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::OnOff::Commands::Off::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -8059,7 +9676,14 @@ private:
     CHIP_ERROR TestCheckOnOffAttributeValueIsFalseAfterOffCommand_4()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOnOff(mOnSuccessCallback_4.Cancel(), mOnFailureCallback_4.Cancel());
     }
@@ -8176,7 +9800,14 @@ private:
     CHIP_ERROR TestTurnOnLightForColorControlTests_0()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::OnOff::Commands::On::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -8200,7 +9831,14 @@ private:
     CHIP_ERROR TestCheckOnOffAttributeValueIsTrueAfterOnCommand_1()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOnOff(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
     }
@@ -8216,7 +9854,14 @@ private:
     CHIP_ERROR TestMoveUpColorTemperatureCommand_2()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::ColorControl::Commands::MoveColorTemperature::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -8246,7 +9891,14 @@ private:
     CHIP_ERROR TestStopColorTemperatureCommand_3()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::ColorControl::Commands::MoveColorTemperature::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -8276,7 +9928,14 @@ private:
     CHIP_ERROR TestMoveDownColorTemperatureCommand_4()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::ColorControl::Commands::MoveColorTemperature::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -8306,7 +9965,14 @@ private:
     CHIP_ERROR TestTurnOffLightThatWeTurnedOn_5()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::OnOff::Commands::Off::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -8330,7 +9996,14 @@ private:
     CHIP_ERROR TestCheckOnOffAttributeValueIsFalseAfterOffCommand_6()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOnOff(mOnSuccessCallback_6.Cancel(), mOnFailureCallback_6.Cancel());
     }
@@ -8443,7 +10116,14 @@ private:
     CHIP_ERROR TestTurnOnLightForColorControlTests_0()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::OnOff::Commands::On::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -8467,7 +10147,14 @@ private:
     CHIP_ERROR TestCheckOnOffAttributeValueIsTrueAfterOnCommand_1()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOnOff(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
     }
@@ -8483,7 +10170,14 @@ private:
     CHIP_ERROR TestStepUpColorTemperatureCommand_2()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::ColorControl::Commands::StepColorTemperature::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -8514,7 +10208,14 @@ private:
     CHIP_ERROR TestStepDownColorTemperatureCommand_3()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::ColorControl::Commands::StepColorTemperature::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -8545,7 +10246,14 @@ private:
     CHIP_ERROR TestTurnOffLightThatWeTurnedOn_4()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::OnOff::Commands::Off::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -8569,7 +10277,14 @@ private:
     CHIP_ERROR TestCheckOnOffAttributeValueIsFalseAfterOffCommand_5()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOnOff(mOnSuccessCallback_5.Cancel(), mOnFailureCallback_5.Cancel());
     }
@@ -8695,7 +10410,14 @@ private:
     CHIP_ERROR TestTurnOnLightForColorControlTests_0()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::OnOff::Commands::On::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -8719,7 +10441,14 @@ private:
     CHIP_ERROR TestCheckOnOffAttributeValueIsTrueAfterOnCommand_1()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOnOff(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
     }
@@ -8735,7 +10464,14 @@ private:
     CHIP_ERROR TestEnhancedMoveToHueCommand_2()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::ColorControl::Commands::EnhancedMoveToHue::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -8764,7 +10500,14 @@ private:
     CHIP_ERROR TestCheckRemainingTimeAttributeValueMatchedTheValueSentByTheLastCommand_3()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeRemainingTime(mOnSuccessCallback_3.Cancel(), mOnFailureCallback_3.Cancel());
     }
@@ -8780,7 +10523,14 @@ private:
     CHIP_ERROR TestTurnOffLightThatWeTurnedOn_4()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::OnOff::Commands::Off::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -8804,7 +10554,14 @@ private:
     CHIP_ERROR TestCheckOnOffAttributeValueIsFalseAfterOffCommand_5()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOnOff(mOnSuccessCallback_5.Cancel(), mOnFailureCallback_5.Cancel());
     }
@@ -8925,7 +10682,14 @@ private:
     CHIP_ERROR TestTurnOnLightForColorControlTests_0()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::OnOff::Commands::On::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -8949,7 +10713,14 @@ private:
     CHIP_ERROR TestCheckOnOffAttributeValueIsTrueAfterOnCommand_1()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOnOff(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
     }
@@ -8965,7 +10736,14 @@ private:
     CHIP_ERROR TestEnhancedMoveHueDownCommand_2()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::ColorControl::Commands::EnhancedMoveHue::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -8993,7 +10771,14 @@ private:
     CHIP_ERROR TestEnhancedMoveHueStopCommand_3()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::ColorControl::Commands::EnhancedMoveHue::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -9021,7 +10806,14 @@ private:
     CHIP_ERROR TestEnhancedMoveHueUpCommand_4()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::ColorControl::Commands::EnhancedMoveHue::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -9049,7 +10841,14 @@ private:
     CHIP_ERROR TestEnhancedMoveHueStopCommand_5()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::ColorControl::Commands::EnhancedMoveHue::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -9077,7 +10876,14 @@ private:
     CHIP_ERROR TestTurnOffLightThatWeTurnedOn_6()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::OnOff::Commands::Off::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -9101,7 +10907,14 @@ private:
     CHIP_ERROR TestCheckOnOffAttributeValueIsFalseAfterOffCommand_7()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOnOff(mOnSuccessCallback_7.Cancel(), mOnFailureCallback_7.Cancel());
     }
@@ -9214,7 +11027,14 @@ private:
     CHIP_ERROR TestTurnOnLightForColorControlTests_0()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::OnOff::Commands::On::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -9238,7 +11058,14 @@ private:
     CHIP_ERROR TestCheckOnOffAttributeValueIsTrueAfterOnCommand_1()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOnOff(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
     }
@@ -9254,7 +11081,14 @@ private:
     CHIP_ERROR TestEnhancedStepHueUpCommand_2()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::ColorControl::Commands::EnhancedStepHue::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -9283,7 +11117,14 @@ private:
     CHIP_ERROR TestEnhancedStepHueDownCommand_3()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::ColorControl::Commands::EnhancedStepHue::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -9312,7 +11153,14 @@ private:
     CHIP_ERROR TestTurnOffLightThatWeTurnedOn_4()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::OnOff::Commands::Off::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -9336,7 +11184,14 @@ private:
     CHIP_ERROR TestCheckOnOffAttributeValueIsFalseAfterOffCommand_5()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOnOff(mOnSuccessCallback_5.Cancel(), mOnFailureCallback_5.Cancel());
     }
@@ -9445,7 +11300,14 @@ private:
     CHIP_ERROR TestTurnOnLightForColorControlTests_0()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::OnOff::Commands::On::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -9469,7 +11331,14 @@ private:
     CHIP_ERROR TestCheckOnOffAttributeValueIsTrueAfterOnCommand_1()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOnOff(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
     }
@@ -9485,7 +11354,14 @@ private:
     CHIP_ERROR TestEnhancedMoveToHueAndSaturationCommand_2()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::ColorControl::Commands::EnhancedMoveToHueAndSaturation::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -9514,7 +11390,14 @@ private:
     CHIP_ERROR TestTurnOffLightThatWeTurnedOn_3()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::OnOff::Commands::Off::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -9538,7 +11421,14 @@ private:
     CHIP_ERROR TestCheckOnOffAttributeValueIsFalseAfterOffCommand_4()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOnOff(mOnSuccessCallback_4.Cancel(), mOnFailureCallback_4.Cancel());
     }
@@ -9792,7 +11682,14 @@ private:
     CHIP_ERROR TestTurnOnLightForColorControlTests_0()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::OnOff::Commands::On::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -9816,7 +11713,14 @@ private:
     CHIP_ERROR TestCheckOnOffAttributeValueIsTrueAfterOnCommand_1()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOnOff(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
     }
@@ -9832,7 +11736,14 @@ private:
     CHIP_ERROR TestColorLoopSetCommandSetAllAttributs_2()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -9863,7 +11774,14 @@ private:
     CHIP_ERROR TestCheckColorLoopDirectionValue_3()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeColorLoopDirection(mOnSuccessCallback_3.Cancel(), mOnFailureCallback_3.Cancel());
     }
@@ -9879,7 +11797,14 @@ private:
     CHIP_ERROR TestCheckColorLoopTimeValue_4()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeColorLoopTime(mOnSuccessCallback_4.Cancel(), mOnFailureCallback_4.Cancel());
     }
@@ -9895,7 +11820,14 @@ private:
     CHIP_ERROR TestCheckColorLoopStartEnhancedHueValue_5()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeColorLoopStartEnhancedHue(mOnSuccessCallback_5.Cancel(), mOnFailureCallback_5.Cancel());
     }
@@ -9911,7 +11843,14 @@ private:
     CHIP_ERROR TestCheckColorLoopActiveValue_6()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeColorLoopActive(mOnSuccessCallback_6.Cancel(), mOnFailureCallback_6.Cancel());
     }
@@ -9927,7 +11866,14 @@ private:
     CHIP_ERROR TestColorLoopSetCommandStartColorLoop_7()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -9958,7 +11904,14 @@ private:
     CHIP_ERROR TestCheckColorLoopActiveValue_8()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeColorLoopActive(mOnSuccessCallback_8.Cancel(), mOnFailureCallback_8.Cancel());
     }
@@ -9974,7 +11927,14 @@ private:
     CHIP_ERROR TestColorLoopSetCommandSetDirectionAndTimeWhileRunning_9()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -10005,7 +11965,14 @@ private:
     CHIP_ERROR TestCheckColorLoopDirectionValue_10()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeColorLoopDirection(mOnSuccessCallback_10.Cancel(), mOnFailureCallback_10.Cancel());
     }
@@ -10021,7 +11988,14 @@ private:
     CHIP_ERROR TestCheckColorLoopTimeValue_11()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeColorLoopTime(mOnSuccessCallback_11.Cancel(), mOnFailureCallback_11.Cancel());
     }
@@ -10037,7 +12011,14 @@ private:
     CHIP_ERROR TestColorLoopSetCommandSetDirectionWhileRunning_12()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -10068,7 +12049,14 @@ private:
     CHIP_ERROR TestCheckColorLoopDirectionValue_13()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeColorLoopDirection(mOnSuccessCallback_13.Cancel(), mOnFailureCallback_13.Cancel());
     }
@@ -10084,7 +12072,14 @@ private:
     CHIP_ERROR TestTurnOffLightThatWeTurnedOn_14()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::OnOff::Commands::Off::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -10108,7 +12103,14 @@ private:
     CHIP_ERROR TestCheckOnOffAttributeValueIsFalseAfterOffCommand_15()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOnOff(mOnSuccessCallback_15.Cancel(), mOnFailureCallback_15.Cancel());
     }
@@ -10528,7 +12530,14 @@ private:
     CHIP_ERROR TestPreconditionTurnOnLightForColorControlTests_0()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::OnOff::Commands::On::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -10552,7 +12561,14 @@ private:
     CHIP_ERROR TestCheckOnOffAttributeValueIsTrueAfterOnCommand_1()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOnOff(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
     }
@@ -10568,7 +12584,14 @@ private:
     CHIP_ERROR TestSendsColorLoopSetCommandSetAllAttributes_2()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -10599,7 +12622,14 @@ private:
     CHIP_ERROR TestReadColorLoopActiveAttributeFromDut_3()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeColorLoopActive(mOnSuccessCallback_3.Cancel(), mOnFailureCallback_3.Cancel());
     }
@@ -10615,7 +12645,14 @@ private:
     CHIP_ERROR TestSendsColorLoopSetCommandSetAllAttributes_4()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -10646,7 +12683,14 @@ private:
     CHIP_ERROR TestReadColorLoopDirectionAttributeFromDut_5()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeColorLoopDirection(mOnSuccessCallback_5.Cancel(), mOnFailureCallback_5.Cancel());
     }
@@ -10662,7 +12706,14 @@ private:
     CHIP_ERROR TestSendsColorLoopSetCommandSetAllAttributes_6()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -10693,7 +12744,14 @@ private:
     CHIP_ERROR TestReadColorLoopTimeAttributeFromDut_7()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeColorLoopTime(mOnSuccessCallback_7.Cancel(), mOnFailureCallback_7.Cancel());
     }
@@ -10709,7 +12767,14 @@ private:
     CHIP_ERROR TestSendsColorLoopSetCommandSetAllAttributes_8()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -10740,7 +12805,14 @@ private:
     CHIP_ERROR TestReadColorLoopStartEnhancedHueAttributeFromDut_9()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeColorLoopStartEnhancedHue(mOnSuccessCallback_9.Cancel(), mOnFailureCallback_9.Cancel());
     }
@@ -10756,7 +12828,14 @@ private:
     CHIP_ERROR TestSendsColorLoopSetCommandSetAllAttributes_10()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -10787,7 +12866,14 @@ private:
     CHIP_ERROR TestReadColorLoopActiveAttributeFromDut_11()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeColorLoopActive(mOnSuccessCallback_11.Cancel(), mOnFailureCallback_11.Cancel());
     }
@@ -10803,7 +12889,14 @@ private:
     CHIP_ERROR TestSendsColorLoopSetCommandSetAllAttributes_12()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -10834,7 +12927,14 @@ private:
     CHIP_ERROR TestReadColorLoopActiveAttributeFromDut_13()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeColorLoopActive(mOnSuccessCallback_13.Cancel(), mOnFailureCallback_13.Cancel());
     }
@@ -10850,7 +12950,14 @@ private:
     CHIP_ERROR TestSendsColorLoopSetCommandSetAllAttributes_14()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -10881,7 +12988,14 @@ private:
     CHIP_ERROR TestReadColorLoopDirectionAttributeFromDut_15()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeColorLoopDirection(mOnSuccessCallback_15.Cancel(), mOnFailureCallback_15.Cancel());
     }
@@ -10897,7 +13011,14 @@ private:
     CHIP_ERROR TestSendsColorLoopSetCommandSetAllAttributes_16()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -10928,7 +13049,14 @@ private:
     CHIP_ERROR TestReadColorLoopActiveAttributeFromDut_17()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeColorLoopActive(mOnSuccessCallback_17.Cancel(), mOnFailureCallback_17.Cancel());
     }
@@ -10944,7 +13072,14 @@ private:
     CHIP_ERROR TestSendsColorLoopSetCommandSetAllAttributes_18()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -10975,7 +13110,14 @@ private:
     CHIP_ERROR TestReadColorLoopActiveAttributeFromDut_19()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeColorLoopActive(mOnSuccessCallback_19.Cancel(), mOnFailureCallback_19.Cancel());
     }
@@ -10991,7 +13133,14 @@ private:
     CHIP_ERROR TestEnhancedMoveToHueCommand10_20()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::ColorControl::Commands::EnhancedMoveToHue::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -11022,7 +13171,14 @@ private:
     CHIP_ERROR TestReadEnhancedCurrentHueAttributeFromDut_22()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeEnhancedCurrentHue(mOnSuccessCallback_22.Cancel(), mOnFailureCallback_22.Cancel());
     }
@@ -11038,7 +13194,14 @@ private:
     CHIP_ERROR TestSendsColorLoopSetCommandSetAllAttributes_23()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -11069,7 +13232,14 @@ private:
     CHIP_ERROR TestReadColorLoopDirectionAttributeFromDut_24()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeColorLoopDirection(mOnSuccessCallback_24.Cancel(), mOnFailureCallback_24.Cancel());
     }
@@ -11085,7 +13255,14 @@ private:
     CHIP_ERROR TestSendsColorLoopSetCommandSetAllAttributes_25()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -11116,7 +13293,14 @@ private:
     CHIP_ERROR TestReadColorLoopActiveAttributeFromDut_26()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeColorLoopActive(mOnSuccessCallback_26.Cancel(), mOnFailureCallback_26.Cancel());
     }
@@ -11132,7 +13316,14 @@ private:
     CHIP_ERROR TestSendsColorLoopSetCommandSetAllAttributes_27()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -11163,7 +13354,14 @@ private:
     CHIP_ERROR TestReadColorLoopActiveAttributeFromDut_28()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeColorLoopActive(mOnSuccessCallback_28.Cancel(), mOnFailureCallback_28.Cancel());
     }
@@ -11179,7 +13377,14 @@ private:
     CHIP_ERROR TestSendsColorLoopSetCommandSetAllAttributes_29()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -11210,7 +13415,14 @@ private:
     CHIP_ERROR TestReadColorLoopDirectionAttributeFromDut_30()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeColorLoopDirection(mOnSuccessCallback_30.Cancel(), mOnFailureCallback_30.Cancel());
     }
@@ -11226,7 +13438,14 @@ private:
     CHIP_ERROR TestSendsColorLoopSetCommandSetAllAttributes_31()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -11257,7 +13476,14 @@ private:
     CHIP_ERROR TestReadColorLoopActiveAttributeFromDut_32()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeColorLoopActive(mOnSuccessCallback_32.Cancel(), mOnFailureCallback_32.Cancel());
     }
@@ -11273,7 +13499,14 @@ private:
     CHIP_ERROR TestSendsColorLoopSetCommandSetAllAttributes_33()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -11304,7 +13537,14 @@ private:
     CHIP_ERROR TestReadColorLoopActiveAttributeFromDut_34()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeColorLoopActive(mOnSuccessCallback_34.Cancel(), mOnFailureCallback_34.Cancel());
     }
@@ -11320,7 +13560,14 @@ private:
     CHIP_ERROR TestTurnOffLightForColorControlTests_35()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::OnOff::Commands::Off::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -11549,7 +13796,14 @@ private:
     CHIP_ERROR TestPreconditionTurnOnLightForColorControlTests_0()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::OnOff::Commands::On::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -11573,7 +13827,14 @@ private:
     CHIP_ERROR TestPreconditionCheckOnOffAttributeValueIsTrueAfterOnCommand_1()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOnOff(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
     }
@@ -11589,7 +13850,14 @@ private:
     CHIP_ERROR TestSendsColorLoopSetCommandSetAllAttributes_2()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -11620,7 +13888,14 @@ private:
     CHIP_ERROR TestReadColorLoopActiveAttributeFromDut_3()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeColorLoopActive(mOnSuccessCallback_3.Cancel(), mOnFailureCallback_3.Cancel());
     }
@@ -11636,7 +13911,14 @@ private:
     CHIP_ERROR TestReadColorLoopDirectionAttributeFromDut_4()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeColorLoopDirection(mOnSuccessCallback_4.Cancel(), mOnFailureCallback_4.Cancel());
     }
@@ -11652,7 +13934,14 @@ private:
     CHIP_ERROR TestReadColorLoopTimeAttributeFromDut_5()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeColorLoopTime(mOnSuccessCallback_5.Cancel(), mOnFailureCallback_5.Cancel());
     }
@@ -11668,7 +13957,14 @@ private:
     CHIP_ERROR TestReadColorLoopStartEnhancedHueAttributeFromDut_6()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeColorLoopStartEnhancedHue(mOnSuccessCallback_6.Cancel(), mOnFailureCallback_6.Cancel());
     }
@@ -11684,7 +13980,14 @@ private:
     CHIP_ERROR TestColorLoopSetCommandSetAllAttributes_7()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -11715,7 +14018,14 @@ private:
     CHIP_ERROR TestReadColorLoopActiveAttributeFromDut_8()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeColorLoopActive(mOnSuccessCallback_8.Cancel(), mOnFailureCallback_8.Cancel());
     }
@@ -11731,7 +14041,14 @@ private:
     CHIP_ERROR TestColorLoopSetCommandStartColorLoop_9()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -11762,7 +14079,14 @@ private:
     CHIP_ERROR TestReadColorLoopDirectionAttributeFromDut_10()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeColorLoopDirection(mOnSuccessCallback_10.Cancel(), mOnFailureCallback_10.Cancel());
     }
@@ -11778,7 +14102,14 @@ private:
     CHIP_ERROR TestColorLoopSetCommandStartColorLoop_11()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -11809,7 +14140,14 @@ private:
     CHIP_ERROR TestReadColorLoopActiveAttributeFromDut_12()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeColorLoopActive(mOnSuccessCallback_12.Cancel(), mOnFailureCallback_12.Cancel());
     }
@@ -11825,7 +14163,14 @@ private:
     CHIP_ERROR TestTurnOffLightForColorControlTests_13()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::OnOff::Commands::Off::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -12053,7 +14398,14 @@ private:
     CHIP_ERROR TestPreconditionTurnOnLightForColorControlTests_0()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::OnOff::Commands::On::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -12077,7 +14429,14 @@ private:
     CHIP_ERROR TestPreconditionCheckOnOffAttributeValueIsTrueAfterOnCommand_1()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOnOff(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
     }
@@ -12093,7 +14452,14 @@ private:
     CHIP_ERROR TestSendsColorLoopSetCommandSetAllAttributes_2()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -12124,7 +14490,14 @@ private:
     CHIP_ERROR TestReadColorLoopActiveAttributeFromDut_3()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeColorLoopActive(mOnSuccessCallback_3.Cancel(), mOnFailureCallback_3.Cancel());
     }
@@ -12140,7 +14513,14 @@ private:
     CHIP_ERROR TestReadColorLoopDirectionAttributeFromDut_4()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeColorLoopDirection(mOnSuccessCallback_4.Cancel(), mOnFailureCallback_4.Cancel());
     }
@@ -12156,7 +14536,14 @@ private:
     CHIP_ERROR TestReadColorLoopTimeAttributeFromDut_5()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeColorLoopTime(mOnSuccessCallback_5.Cancel(), mOnFailureCallback_5.Cancel());
     }
@@ -12172,7 +14559,14 @@ private:
     CHIP_ERROR TestReadColorLoopStartEnhancedHueAttributeFromDut_6()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeColorLoopStartEnhancedHue(mOnSuccessCallback_6.Cancel(), mOnFailureCallback_6.Cancel());
     }
@@ -12188,7 +14582,14 @@ private:
     CHIP_ERROR TestColorLoopSetCommandSetAllAttributes_7()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -12219,7 +14620,14 @@ private:
     CHIP_ERROR TestReadColorLoopActiveAttributeFromDut_8()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeColorLoopActive(mOnSuccessCallback_8.Cancel(), mOnFailureCallback_8.Cancel());
     }
@@ -12235,7 +14643,14 @@ private:
     CHIP_ERROR TestColorLoopSetCommandStartColorLoop_9()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -12266,7 +14681,14 @@ private:
     CHIP_ERROR TestReadColorLoopTimeAttributeFromDut_10()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeColorLoopTime(mOnSuccessCallback_10.Cancel(), mOnFailureCallback_10.Cancel());
     }
@@ -12282,7 +14704,14 @@ private:
     CHIP_ERROR TestColorLoopSetCommandStartColorLoop_11()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::ColorControl::Commands::ColorLoopSet::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -12313,7 +14742,14 @@ private:
     CHIP_ERROR TestReadColorLoopActiveAttributeFromDut_12()
     {
         chip::Controller::ColorControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeColorLoopActive(mOnSuccessCallback_12.Cancel(), mOnFailureCallback_12.Cancel());
     }
@@ -12329,7 +14765,14 @@ private:
     CHIP_ERROR TestTurnOffLightForColorControlTests_13()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::OnOff::Commands::Off::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -12703,7 +15146,14 @@ private:
     CHIP_ERROR TestQueryInteractionModelVersion_0()
     {
         chip::Controller::BasicClusterTest cluster;
-        cluster.Associate(mDevice, 0);
+        uint8_t endPoint = 0;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeInteractionModelVersion(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel());
     }
@@ -12719,7 +15169,14 @@ private:
     CHIP_ERROR TestQueryVendorName_1()
     {
         chip::Controller::BasicClusterTest cluster;
-        cluster.Associate(mDevice, 0);
+        uint8_t endPoint = 0;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeVendorName(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
     }
@@ -12736,7 +15193,14 @@ private:
     CHIP_ERROR TestQueryVendorID_2()
     {
         chip::Controller::BasicClusterTest cluster;
-        cluster.Associate(mDevice, 0);
+        uint8_t endPoint = 0;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeVendorID(mOnSuccessCallback_2.Cancel(), mOnFailureCallback_2.Cancel());
     }
@@ -12752,7 +15216,14 @@ private:
     CHIP_ERROR TestQueryProductName_3()
     {
         chip::Controller::BasicClusterTest cluster;
-        cluster.Associate(mDevice, 0);
+        uint8_t endPoint = 0;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeProductName(mOnSuccessCallback_3.Cancel(), mOnFailureCallback_3.Cancel());
     }
@@ -12769,7 +15240,14 @@ private:
     CHIP_ERROR TestQueryProductID_4()
     {
         chip::Controller::BasicClusterTest cluster;
-        cluster.Associate(mDevice, 0);
+        uint8_t endPoint = 0;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeProductID(mOnSuccessCallback_4.Cancel(), mOnFailureCallback_4.Cancel());
     }
@@ -12785,7 +15263,14 @@ private:
     CHIP_ERROR TestQueryUserLabel_5()
     {
         chip::Controller::BasicClusterTest cluster;
-        cluster.Associate(mDevice, 0);
+        uint8_t endPoint = 0;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeUserLabel(mOnSuccessCallback_5.Cancel(), mOnFailureCallback_5.Cancel());
     }
@@ -12802,7 +15287,14 @@ private:
     CHIP_ERROR TestQueryUserLocation_6()
     {
         chip::Controller::BasicClusterTest cluster;
-        cluster.Associate(mDevice, 0);
+        uint8_t endPoint = 0;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeLocation(mOnSuccessCallback_6.Cancel(), mOnFailureCallback_6.Cancel());
     }
@@ -12820,7 +15312,14 @@ private:
     CHIP_ERROR TestQueryHardwareVersion_7()
     {
         chip::Controller::BasicClusterTest cluster;
-        cluster.Associate(mDevice, 0);
+        uint8_t endPoint = 0;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeHardwareVersion(mOnSuccessCallback_7.Cancel(), mOnFailureCallback_7.Cancel());
     }
@@ -12836,7 +15335,14 @@ private:
     CHIP_ERROR TestQueryHardwareVersionString_8()
     {
         chip::Controller::BasicClusterTest cluster;
-        cluster.Associate(mDevice, 0);
+        uint8_t endPoint = 0;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeHardwareVersionString(mOnSuccessCallback_8.Cancel(), mOnFailureCallback_8.Cancel());
     }
@@ -12854,7 +15360,14 @@ private:
     CHIP_ERROR TestQuerySoftwareVersion_9()
     {
         chip::Controller::BasicClusterTest cluster;
-        cluster.Associate(mDevice, 0);
+        uint8_t endPoint = 0;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeSoftwareVersion(mOnSuccessCallback_9.Cancel(), mOnFailureCallback_9.Cancel());
     }
@@ -12870,7 +15383,14 @@ private:
     CHIP_ERROR TestQuerySoftwareVersionString_10()
     {
         chip::Controller::BasicClusterTest cluster;
-        cluster.Associate(mDevice, 0);
+        uint8_t endPoint = 0;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeSoftwareVersionString(mOnSuccessCallback_10.Cancel(), mOnFailureCallback_10.Cancel());
     }
@@ -12889,7 +15409,14 @@ private:
     CHIP_ERROR TestQueryManufacturingDate_11()
     {
         chip::Controller::BasicClusterTest cluster;
-        cluster.Associate(mDevice, 0);
+        uint8_t endPoint = 0;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeManufacturingDate(mOnSuccessCallback_11.Cancel(), mOnFailureCallback_11.Cancel());
     }
@@ -12911,7 +15438,14 @@ private:
     CHIP_ERROR TestQueryPartNumber_12()
     {
         chip::Controller::BasicClusterTest cluster;
-        cluster.Associate(mDevice, 0);
+        uint8_t endPoint = 0;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributePartNumber(mOnSuccessCallback_12.Cancel(), mOnFailureCallback_12.Cancel());
     }
@@ -12931,7 +15465,14 @@ private:
     CHIP_ERROR TestQueryProductURL_13()
     {
         chip::Controller::BasicClusterTest cluster;
-        cluster.Associate(mDevice, 0);
+        uint8_t endPoint = 0;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeProductURL(mOnSuccessCallback_13.Cancel(), mOnFailureCallback_13.Cancel());
     }
@@ -12952,7 +15493,14 @@ private:
     CHIP_ERROR TestQueryProductLabel_14()
     {
         chip::Controller::BasicClusterTest cluster;
-        cluster.Associate(mDevice, 0);
+        uint8_t endPoint = 0;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeProductLabel(mOnSuccessCallback_14.Cancel(), mOnFailureCallback_14.Cancel());
     }
@@ -12972,7 +15520,14 @@ private:
     CHIP_ERROR TestQuerySerialNumber_15()
     {
         chip::Controller::BasicClusterTest cluster;
-        cluster.Associate(mDevice, 0);
+        uint8_t endPoint = 0;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeSerialNumber(mOnSuccessCallback_15.Cancel(), mOnFailureCallback_15.Cancel());
     }
@@ -12992,7 +15547,14 @@ private:
     CHIP_ERROR TestQueryLocalConfigDisabled_16()
     {
         chip::Controller::BasicClusterTest cluster;
-        cluster.Associate(mDevice, 0);
+        uint8_t endPoint = 0;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeLocalConfigDisabled(mOnSuccessCallback_16.Cancel(), mOnFailureCallback_16.Cancel());
     }
@@ -13011,7 +15573,14 @@ private:
     CHIP_ERROR TestQueryReachable_17()
     {
         chip::Controller::BasicClusterTest cluster;
-        cluster.Associate(mDevice, 0);
+        uint8_t endPoint = 0;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeReachable(mOnSuccessCallback_17.Cancel(), mOnFailureCallback_17.Cancel());
     }
@@ -13202,7 +15771,14 @@ private:
     CHIP_ERROR TestQueryFabricsList_0()
     {
         chip::Controller::OperationalCredentialsClusterTest cluster;
-        cluster.Associate(mDevice, 0);
+        uint8_t endPoint = 0;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeFabricsList(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel());
     }
@@ -13221,7 +15797,14 @@ private:
     CHIP_ERROR TestQuerySupportedFabrics_1()
     {
         chip::Controller::OperationalCredentialsClusterTest cluster;
-        cluster.Associate(mDevice, 0);
+        uint8_t endPoint = 0;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeSupportedFabrics(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
     }
@@ -13237,7 +15820,14 @@ private:
     CHIP_ERROR TestQueryCommissionedFabrics_2()
     {
         chip::Controller::OperationalCredentialsClusterTest cluster;
-        cluster.Associate(mDevice, 0);
+        uint8_t endPoint = 0;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeCommissionedFabrics(mOnSuccessCallback_2.Cancel(), mOnFailureCallback_2.Cancel());
     }
@@ -13253,7 +15843,14 @@ private:
     CHIP_ERROR TestQueryUserTrustedRootCertificates_3()
     {
         chip::Controller::OperationalCredentialsClusterTest cluster;
-        cluster.Associate(mDevice, 0);
+        uint8_t endPoint = 0;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeTrustedRootCertificates(mOnSuccessCallback_3.Cancel(), mOnFailureCallback_3.Cancel());
     }
@@ -13362,7 +15959,14 @@ private:
     CHIP_ERROR TestReadTheGlobalAttributeClusterRevision_0()
     {
         chip::Controller::ElectricalMeasurementClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeClusterRevision(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel());
     }
@@ -13378,7 +15982,14 @@ private:
     CHIP_ERROR TestWriteTheDefaultValuesToMandatoryGlobalAttributeClusterRevision_1()
     {
         chip::Controller::ElectricalMeasurementClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint16_t clusterRevisionArgument;
         clusterRevisionArgument = 1U;
@@ -13394,7 +16005,14 @@ private:
     CHIP_ERROR TestReadsBackGlobalAttributeClusterRevision_2()
     {
         chip::Controller::ElectricalMeasurementClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeClusterRevision(mOnSuccessCallback_2.Cancel(), mOnFailureCallback_2.Cancel());
     }
@@ -13470,7 +16088,14 @@ private:
     CHIP_ERROR TestWriteTheDefaultValuesToMandatoryGlobalAttributeClusterRevision_0()
     {
         chip::Controller::FlowMeasurementClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint16_t clusterRevisionArgument;
         clusterRevisionArgument = 2U;
@@ -13653,7 +16278,14 @@ private:
     CHIP_ERROR TestReadTheMandatoryAttributeMeasuredValue_0()
     {
         chip::Controller::FlowMeasurementClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeMeasuredValue(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel());
     }
@@ -13669,7 +16301,14 @@ private:
     CHIP_ERROR TestReadTheMandatoryAttributeMinMeasuredValue_1()
     {
         chip::Controller::FlowMeasurementClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeMinMeasuredValue(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
     }
@@ -13685,7 +16324,14 @@ private:
     CHIP_ERROR TestReadTheMandatoryAttributeMaxMeasuredValue_2()
     {
         chip::Controller::FlowMeasurementClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeMaxMeasuredValue(mOnSuccessCallback_2.Cancel(), mOnFailureCallback_2.Cancel());
     }
@@ -13701,7 +16347,14 @@ private:
     CHIP_ERROR TestWriteTheDefaultValueToOptionalAttributeMinMeasuredValue_3()
     {
         chip::Controller::FlowMeasurementClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         int16_t minMeasuredValueArgument;
         minMeasuredValueArgument = 0;
@@ -13717,7 +16370,14 @@ private:
     CHIP_ERROR TestWriteTheDefaultValueToOptionalAttributeMaxMeasuredValue_4()
     {
         chip::Controller::FlowMeasurementClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         int16_t maxMeasuredValueArgument;
         maxMeasuredValueArgument = 0;
@@ -13733,7 +16393,14 @@ private:
     CHIP_ERROR TestReadTheMandatoryAttributeMeasuredValue_5()
     {
         chip::Controller::FlowMeasurementClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeMeasuredValue(mOnSuccessCallback_5.Cancel(), mOnFailureCallback_5.Cancel());
     }
@@ -13749,7 +16416,14 @@ private:
     CHIP_ERROR TestReadTheMandatoryAttributeMinMeasuredValue_6()
     {
         chip::Controller::FlowMeasurementClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeMinMeasuredValue(mOnSuccessCallback_6.Cancel(), mOnFailureCallback_6.Cancel());
     }
@@ -13765,7 +16439,14 @@ private:
     CHIP_ERROR TestReadTheMandatoryAttributeMaxMeasuredValue_7()
     {
         chip::Controller::FlowMeasurementClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeMaxMeasuredValue(mOnSuccessCallback_7.Cancel(), mOnFailureCallback_7.Cancel());
     }
@@ -13862,7 +16543,14 @@ private:
     CHIP_ERROR TestReadTheMandatoryAttributeMeasuredValue_0()
     {
         chip::Controller::FlowMeasurementClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeMeasuredValue(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel());
     }
@@ -13878,7 +16566,14 @@ private:
     CHIP_ERROR TestReadTheMandatoryAttributeMeasuredValue_1()
     {
         chip::Controller::FlowMeasurementClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeMeasuredValue(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
     }
@@ -13954,7 +16649,14 @@ private:
     CHIP_ERROR TestWriteTheDefaultValuesToMandatoryGlobalAttributeClusterRevision_0()
     {
         chip::Controller::LevelControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint16_t clusterRevisionArgument;
         clusterRevisionArgument = 4U;
@@ -14132,7 +16834,14 @@ private:
     CHIP_ERROR TestReadsCurrentLevelAttributeFromDut_0()
     {
         chip::Controller::LevelControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeCurrentLevel(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel());
     }
@@ -14148,7 +16857,14 @@ private:
     CHIP_ERROR TestSendsAMoveToLevelCommand_1()
     {
         chip::Controller::LevelControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::LevelControl::Commands::MoveToLevel::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -14178,7 +16894,14 @@ private:
     CHIP_ERROR TestReadsCurrentLevelAttributeFromDut_3()
     {
         chip::Controller::LevelControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeCurrentLevel(mOnSuccessCallback_3.Cancel(), mOnFailureCallback_3.Cancel());
     }
@@ -14194,7 +16917,14 @@ private:
     CHIP_ERROR TestSendsAMoveToLevelCommand_4()
     {
         chip::Controller::LevelControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::LevelControl::Commands::MoveToLevel::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -14224,7 +16954,14 @@ private:
     CHIP_ERROR TestReadsCurrentLevelAttributeFromDut_6()
     {
         chip::Controller::LevelControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeCurrentLevel(mOnSuccessCallback_6.Cancel(), mOnFailureCallback_6.Cancel());
     }
@@ -14240,7 +16977,14 @@ private:
     CHIP_ERROR TestReadsOnOffTransitionTimeAttributeFromDut_7()
     {
         chip::Controller::LevelControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOnOffTransitionTime(mOnSuccessCallback_7.Cancel(), mOnFailureCallback_7.Cancel());
     }
@@ -14256,7 +17000,14 @@ private:
     CHIP_ERROR TestSendsAMoveToLevelCommand_8()
     {
         chip::Controller::LevelControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::LevelControl::Commands::MoveToLevel::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -14286,7 +17037,14 @@ private:
     CHIP_ERROR TestReadsCurrentLevelAttributeFromDut_10()
     {
         chip::Controller::LevelControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeCurrentLevel(mOnSuccessCallback_10.Cancel(), mOnFailureCallback_10.Cancel());
     }
@@ -14302,7 +17060,14 @@ private:
     CHIP_ERROR TestResetLevelTo0_11()
     {
         chip::Controller::LevelControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::LevelControl::Commands::MoveToLevel::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -14528,7 +17293,14 @@ private:
     CHIP_ERROR TestReadsCurrentLevelAttributeFromDut_0()
     {
         chip::Controller::LevelControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeCurrentLevel(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel());
     }
@@ -14544,7 +17316,14 @@ private:
     CHIP_ERROR TestReadsMaxLevelAttributeFromDut_1()
     {
         chip::Controller::LevelControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeMaxLevel(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
     }
@@ -14560,7 +17339,14 @@ private:
     CHIP_ERROR TestSendsAMoveUpCommand_2()
     {
         chip::Controller::LevelControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::LevelControl::Commands::Move::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -14590,7 +17376,14 @@ private:
     CHIP_ERROR TestReadsCurrentLevelAttributeFromDut_4()
     {
         chip::Controller::LevelControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeCurrentLevel(mOnSuccessCallback_4.Cancel(), mOnFailureCallback_4.Cancel());
     }
@@ -14606,7 +17399,14 @@ private:
     CHIP_ERROR TestReadsMinLevelAttributeFromDut_5()
     {
         chip::Controller::LevelControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeMinLevel(mOnSuccessCallback_5.Cancel(), mOnFailureCallback_5.Cancel());
     }
@@ -14622,7 +17422,14 @@ private:
     CHIP_ERROR TestSendsAMoveDownCommand_6()
     {
         chip::Controller::LevelControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::LevelControl::Commands::Move::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -14652,7 +17459,14 @@ private:
     CHIP_ERROR TestReadsCurrentLevelAttributeFromDut_8()
     {
         chip::Controller::LevelControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeCurrentLevel(mOnSuccessCallback_8.Cancel(), mOnFailureCallback_8.Cancel());
     }
@@ -14668,7 +17482,14 @@ private:
     CHIP_ERROR TestWriteDefaultMoveRateAttributeFromDut_9()
     {
         chip::Controller::LevelControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint8_t defaultMoveRateArgument;
         defaultMoveRateArgument = 20;
@@ -14684,7 +17505,14 @@ private:
     CHIP_ERROR TestReadsDefaultMoveRateAttributeFromDut_10()
     {
         chip::Controller::LevelControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeDefaultMoveRate(mOnSuccessCallback_10.Cancel(), mOnFailureCallback_10.Cancel());
     }
@@ -14700,7 +17528,14 @@ private:
     CHIP_ERROR TestSendsAMoveUpCommandAtDefaultMoveRate_11()
     {
         chip::Controller::LevelControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::LevelControl::Commands::Move::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -14730,7 +17565,14 @@ private:
     CHIP_ERROR TestReadsCurrentLevelAttributeFromDut_13()
     {
         chip::Controller::LevelControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeCurrentLevel(mOnSuccessCallback_13.Cancel(), mOnFailureCallback_13.Cancel());
     }
@@ -14875,7 +17717,14 @@ private:
     CHIP_ERROR TestSendingOnCommand_0()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::OnOff::Commands::On::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -14899,7 +17748,14 @@ private:
     CHIP_ERROR TestPreconditionDutLevelIsSetTo0x80_1()
     {
         chip::Controller::LevelControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::LevelControl::Commands::Step::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -14930,7 +17786,14 @@ private:
     CHIP_ERROR TestReadsCurrentLevelAttributeFromDut_3()
     {
         chip::Controller::LevelControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeCurrentLevel(mOnSuccessCallback_3.Cancel(), mOnFailureCallback_3.Cancel());
     }
@@ -14946,7 +17809,14 @@ private:
     CHIP_ERROR TestSendsStepDownCommandToDut_4()
     {
         chip::Controller::LevelControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::LevelControl::Commands::Step::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -14977,7 +17847,14 @@ private:
     CHIP_ERROR TestReadsCurrentLevelAttributeFromDut_6()
     {
         chip::Controller::LevelControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeCurrentLevel(mOnSuccessCallback_6.Cancel(), mOnFailureCallback_6.Cancel());
     }
@@ -14993,7 +17870,14 @@ private:
     CHIP_ERROR TestSendsAStepUpCommand_7()
     {
         chip::Controller::LevelControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::LevelControl::Commands::Step::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -15024,7 +17908,14 @@ private:
     CHIP_ERROR TestReadsCurrentLevelAttributeFromDut_9()
     {
         chip::Controller::LevelControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeCurrentLevel(mOnSuccessCallback_9.Cancel(), mOnFailureCallback_9.Cancel());
     }
@@ -15040,7 +17931,14 @@ private:
     CHIP_ERROR TestSendingOffCommand_10()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::OnOff::Commands::Off::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -15140,7 +18038,14 @@ private:
     CHIP_ERROR TestSendingOnCommand_0()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::OnOff::Commands::On::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -15164,7 +18069,14 @@ private:
     CHIP_ERROR TestPreconditionDutLevelIsSetTo0x80_1()
     {
         chip::Controller::LevelControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::LevelControl::Commands::Step::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -15195,7 +18107,14 @@ private:
     CHIP_ERROR TestSendsAMoveUpCommandToDut_3()
     {
         chip::Controller::LevelControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::LevelControl::Commands::Move::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -15225,7 +18144,14 @@ private:
     CHIP_ERROR TestSendsStopCommandToDut_5()
     {
         chip::Controller::LevelControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::LevelControl::Commands::Stop::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -15251,7 +18177,14 @@ private:
     CHIP_ERROR TestSendingOffCommand_6()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::OnOff::Commands::Off::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -15335,7 +18268,14 @@ private:
     CHIP_ERROR TestWriteTheDefaultValuesToMandatoryGlobalAttributeClusterRevision_0()
     {
         chip::Controller::RelativeHumidityMeasurementClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint16_t clusterRevisionArgument;
         clusterRevisionArgument = 1U;
@@ -15403,7 +18343,14 @@ private:
     CHIP_ERROR TestPutTheDeviceIntoLowPowerMode_0()
     {
         chip::Controller::LowPowerClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::LowPower::Commands::Sleep::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -16032,7 +18979,14 @@ private:
     CHIP_ERROR TestReadTheGlobalAttributeClusterRevision_0()
     {
         chip::Controller::OccupancySensingClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeClusterRevision(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel());
     }
@@ -16048,7 +19002,14 @@ private:
     CHIP_ERROR TestWriteTheDefaultValuesToMandatoryGlobalAttributeClusterRevision_1()
     {
         chip::Controller::OccupancySensingClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint16_t clusterRevisionArgument;
         clusterRevisionArgument = 2U;
@@ -16250,7 +19211,14 @@ private:
     CHIP_ERROR TestReadsMandatoryAttributeConstrainsOccupancy_0()
     {
         chip::Controller::OccupancySensingClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOccupancy(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel());
     }
@@ -16267,7 +19235,14 @@ private:
     CHIP_ERROR TestWritesTheRespectiveDefaultValueToMandatoryAttributeOccupancy_1()
     {
         chip::Controller::OccupancySensingClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint8_t occupancyArgument;
         occupancyArgument = 0;
@@ -16283,7 +19258,14 @@ private:
     CHIP_ERROR TestReadsBackMandatoryAttributeOccupancy_2()
     {
         chip::Controller::OccupancySensingClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOccupancy(mOnSuccessCallback_2.Cancel(), mOnFailureCallback_2.Cancel());
     }
@@ -16299,7 +19281,14 @@ private:
     CHIP_ERROR TestReadsMandatoryAttributeConstrainsOccupancySensorType_3()
     {
         chip::Controller::OccupancySensingClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOccupancySensorType(mOnSuccessCallback_3.Cancel(), mOnFailureCallback_3.Cancel());
     }
@@ -16316,7 +19305,14 @@ private:
     CHIP_ERROR TestWritesTheRespectiveDefaultValueToMandatoryAttributeOccupancySensorType_4()
     {
         chip::Controller::OccupancySensingClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint8_t occupancySensorTypeArgument;
         occupancySensorTypeArgument = static_cast<uint8_t>(0);
@@ -16332,7 +19328,14 @@ private:
     CHIP_ERROR TestReadsBackMandatoryAttributeOccupancySensorType_5()
     {
         chip::Controller::OccupancySensingClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOccupancySensorType(mOnSuccessCallback_5.Cancel(), mOnFailureCallback_5.Cancel());
     }
@@ -16348,7 +19351,14 @@ private:
     CHIP_ERROR TestReadsMandatoryAttributeConstrainsOccupancySensorTypeBitmap_6()
     {
         chip::Controller::OccupancySensingClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOccupancySensorTypeBitmap(mOnSuccessCallback_6.Cancel(), mOnFailureCallback_6.Cancel());
     }
@@ -16366,7 +19376,14 @@ private:
     CHIP_ERROR TestWritesTheRespectiveDefaultValueToMandatoryAttributeOccupancySensorTypeBitmap_7()
     {
         chip::Controller::OccupancySensingClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint8_t occupancySensorTypeBitmapArgument;
         occupancySensorTypeBitmapArgument = 1;
@@ -16382,7 +19399,14 @@ private:
     CHIP_ERROR TestReadsBackMandatoryAttributeOccupancySensorTypeBitmap_8()
     {
         chip::Controller::OccupancySensingClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOccupancySensorTypeBitmap(mOnSuccessCallback_8.Cancel(), mOnFailureCallback_8.Cancel());
     }
@@ -16479,7 +19503,14 @@ private:
     CHIP_ERROR TestReadsOccupancyAttributeFromDut_0()
     {
         chip::Controller::OccupancySensingClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOccupancy(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel());
     }
@@ -16495,7 +19526,14 @@ private:
     CHIP_ERROR TestReadsOccupancyAttributeFromDut_1()
     {
         chip::Controller::OccupancySensingClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOccupancy(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
     }
@@ -16647,7 +19685,14 @@ private:
     CHIP_ERROR TestReadTheGlobalAttributeClusterRevision_0()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeClusterRevision(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel());
     }
@@ -16663,7 +19708,14 @@ private:
     CHIP_ERROR TestWriteTheDefaultValuesToMandatoryGlobalAttributeClusterRevision_1()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint16_t clusterRevisionArgument;
         clusterRevisionArgument = 3U;
@@ -16679,7 +19731,14 @@ private:
     CHIP_ERROR TestReadsBackGlobalAttributeClusterRevision_2()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeClusterRevision(mOnSuccessCallback_2.Cancel(), mOnFailureCallback_2.Cancel());
     }
@@ -16695,7 +19754,14 @@ private:
     CHIP_ERROR TestReadTheOptionalGlobalAttributeFeatureMap_3()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeFeatureMap(mOnSuccessCallback_3.Cancel(), mOnFailureCallback_3.Cancel());
     }
@@ -16711,7 +19777,14 @@ private:
     CHIP_ERROR TestWriteTheDefaultValuesToOptionalGlobalAttributeFeatureMap_4()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint32_t featureMapArgument;
         featureMapArgument = 0UL;
@@ -16727,7 +19800,14 @@ private:
     CHIP_ERROR TestReadsBackOptionalGlobalAttributeFeatureMap_5()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeFeatureMap(mOnSuccessCallback_5.Cancel(), mOnFailureCallback_5.Cancel());
     }
@@ -16969,7 +20049,14 @@ private:
     CHIP_ERROR TestReadTheMandatoryAttributeOnOff_0()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOnOff(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel());
     }
@@ -16985,7 +20072,14 @@ private:
     CHIP_ERROR TestReadsBackMandatoryAttributeOnOff_1()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOnOff(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
     }
@@ -17001,7 +20095,14 @@ private:
     CHIP_ERROR TestReadLtAttributeGlobalSceneControl_2()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeGlobalSceneControl(mOnSuccessCallback_2.Cancel(), mOnFailureCallback_2.Cancel());
     }
@@ -17017,7 +20118,14 @@ private:
     CHIP_ERROR TestReadLtAttributeOnTime_3()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOnTime(mOnSuccessCallback_3.Cancel(), mOnFailureCallback_3.Cancel());
     }
@@ -17033,7 +20141,14 @@ private:
     CHIP_ERROR TestReadLtAttributeOffWaitTime_4()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOffWaitTime(mOnSuccessCallback_4.Cancel(), mOnFailureCallback_4.Cancel());
     }
@@ -17049,7 +20164,14 @@ private:
     CHIP_ERROR TestReadLtAttributeStartUpOnOff_5()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeStartUpOnOff(mOnSuccessCallback_5.Cancel(), mOnFailureCallback_5.Cancel());
     }
@@ -17065,7 +20187,14 @@ private:
     CHIP_ERROR TestWriteTheDefaultValueToLtAttributeOnTime_6()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint16_t onTimeArgument;
         onTimeArgument = 0U;
@@ -17081,7 +20210,14 @@ private:
     CHIP_ERROR TestWriteTheDefaultValueToLtAttributeOffWaitTime_7()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint16_t offWaitTimeArgument;
         offWaitTimeArgument = 0U;
@@ -17097,7 +20233,14 @@ private:
     CHIP_ERROR TestWriteTheDefaultValueToLtAttributeStartUpOnOff_8()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint8_t startUpOnOffArgument;
         startUpOnOffArgument = static_cast<uint8_t>(0);
@@ -17113,7 +20256,14 @@ private:
     CHIP_ERROR TestReadsBackLtAttributeOnTime_9()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOnTime(mOnSuccessCallback_9.Cancel(), mOnFailureCallback_9.Cancel());
     }
@@ -17129,7 +20279,14 @@ private:
     CHIP_ERROR TestReadsBackLtAttributeOffWaitTime_10()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOffWaitTime(mOnSuccessCallback_10.Cancel(), mOnFailureCallback_10.Cancel());
     }
@@ -17145,7 +20302,14 @@ private:
     CHIP_ERROR TestReadsBackLtAttributeStartUpOnOff_11()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeStartUpOnOff(mOnSuccessCallback_11.Cancel(), mOnFailureCallback_11.Cancel());
     }
@@ -17350,7 +20514,14 @@ private:
     CHIP_ERROR TestSendOffCommand_0()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::OnOff::Commands::Off::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -17374,7 +20545,14 @@ private:
     CHIP_ERROR TestCheckOnOffAttributeValueIsFalseAfterOffCommand_1()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOnOff(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
     }
@@ -17390,7 +20568,14 @@ private:
     CHIP_ERROR TestSendOnCommand_2()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::OnOff::Commands::On::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -17414,7 +20599,14 @@ private:
     CHIP_ERROR TestCheckOnOffAttributeValueIsTrueAfterOnCommand_3()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOnOff(mOnSuccessCallback_3.Cancel(), mOnFailureCallback_3.Cancel());
     }
@@ -17430,7 +20622,14 @@ private:
     CHIP_ERROR TestSendOffCommand_4()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::OnOff::Commands::Off::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -17454,7 +20653,14 @@ private:
     CHIP_ERROR TestCheckOnOffAttributeValueIsFalseAfterOffCommand_5()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOnOff(mOnSuccessCallback_5.Cancel(), mOnFailureCallback_5.Cancel());
     }
@@ -17470,7 +20676,14 @@ private:
     CHIP_ERROR TestSendToggleCommand_6()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::OnOff::Commands::Toggle::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -17494,7 +20707,14 @@ private:
     CHIP_ERROR TestCheckOnOffAttributeValueIsTrueAfterToggleCommand_7()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOnOff(mOnSuccessCallback_7.Cancel(), mOnFailureCallback_7.Cancel());
     }
@@ -17510,7 +20730,14 @@ private:
     CHIP_ERROR TestSendToggleCommand_8()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::OnOff::Commands::Toggle::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -17534,7 +20761,14 @@ private:
     CHIP_ERROR TestCheckOnOffAttributeValueIsFalseAfterToggleCommand_9()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOnOff(mOnSuccessCallback_9.Cancel(), mOnFailureCallback_9.Cancel());
     }
@@ -17550,7 +20784,14 @@ private:
     CHIP_ERROR TestSendOnCommand_10()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::OnOff::Commands::On::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -17574,7 +20815,14 @@ private:
     CHIP_ERROR TestCheckOnOffAttributeValueIsTrueAfterOnCommand_11()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOnOff(mOnSuccessCallback_11.Cancel(), mOnFailureCallback_11.Cancel());
     }
@@ -17590,7 +20838,14 @@ private:
     CHIP_ERROR TestSendOffCommand_12()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::OnOff::Commands::Off::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -17614,7 +20869,14 @@ private:
     CHIP_ERROR TestCheckOnOffAttributeValueIsFalseAfterOffCommand_13()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOnOff(mOnSuccessCallback_13.Cancel(), mOnFailureCallback_13.Cancel());
     }
@@ -18259,7 +21521,14 @@ private:
     CHIP_ERROR TestSendOnCommand_0()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::OnOff::Commands::On::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -18285,7 +21554,14 @@ private:
     CHIP_ERROR TestReadsOnOffAttributeFromDut_2()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOnOff(mOnSuccessCallback_2.Cancel(), mOnFailureCallback_2.Cancel());
     }
@@ -18301,7 +21577,14 @@ private:
     CHIP_ERROR TestReadsGlobalSceneControlAttributeFromDut_3()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeGlobalSceneControl(mOnSuccessCallback_3.Cancel(), mOnFailureCallback_3.Cancel());
     }
@@ -18317,7 +21600,14 @@ private:
     CHIP_ERROR TestSendOnCommand_4()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::OnOff::Commands::On::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -18343,7 +21633,14 @@ private:
     CHIP_ERROR TestReadsOnOffAttributeFromDut_6()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOnOff(mOnSuccessCallback_6.Cancel(), mOnFailureCallback_6.Cancel());
     }
@@ -18359,7 +21656,14 @@ private:
     CHIP_ERROR TestReadsGlobalSceneControlAttributeFromDut_7()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeGlobalSceneControl(mOnSuccessCallback_7.Cancel(), mOnFailureCallback_7.Cancel());
     }
@@ -18375,7 +21679,14 @@ private:
     CHIP_ERROR TestSendOnCommand_8()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::OnOff::Commands::On::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -18401,7 +21712,14 @@ private:
     CHIP_ERROR TestReadsOnOffAttributeFromDut_10()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOnOff(mOnSuccessCallback_10.Cancel(), mOnFailureCallback_10.Cancel());
     }
@@ -18417,7 +21735,14 @@ private:
     CHIP_ERROR TestReadsGlobalSceneControlAttributeFromDut_11()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeGlobalSceneControl(mOnSuccessCallback_11.Cancel(), mOnFailureCallback_11.Cancel());
     }
@@ -18433,7 +21758,14 @@ private:
     CHIP_ERROR TestReadsOnTimeAttributeFromDut_12()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOnTime(mOnSuccessCallback_12.Cancel(), mOnFailureCallback_12.Cancel());
     }
@@ -18449,7 +21781,14 @@ private:
     CHIP_ERROR TestReadsOffWaitTimeAttributeFromDut_13()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOffWaitTime(mOnSuccessCallback_13.Cancel(), mOnFailureCallback_13.Cancel());
     }
@@ -18465,7 +21804,14 @@ private:
     CHIP_ERROR TestSendOnCommand_14()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::OnOff::Commands::On::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -18489,7 +21835,14 @@ private:
     CHIP_ERROR TestReadsOnOffAttributeFromDut_15()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOnOff(mOnSuccessCallback_15.Cancel(), mOnFailureCallback_15.Cancel());
     }
@@ -18505,7 +21858,14 @@ private:
     CHIP_ERROR TestReadsOnTimeAttributeFromDut_16()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOnTime(mOnSuccessCallback_16.Cancel(), mOnFailureCallback_16.Cancel());
     }
@@ -18521,7 +21881,14 @@ private:
     CHIP_ERROR TestReadsOffWaitTimeAttributeFromDut_17()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOffWaitTime(mOnSuccessCallback_17.Cancel(), mOnFailureCallback_17.Cancel());
     }
@@ -18537,7 +21904,14 @@ private:
     CHIP_ERROR TestSendOffCommand_18()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::OnOff::Commands::Off::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -18561,7 +21935,14 @@ private:
     CHIP_ERROR TestReadsOnOffAttributeFromDut_19()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOnOff(mOnSuccessCallback_19.Cancel(), mOnFailureCallback_19.Cancel());
     }
@@ -18577,7 +21958,14 @@ private:
     CHIP_ERROR TestReadsOnTimeAttributeFromDut_20()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOnTime(mOnSuccessCallback_20.Cancel(), mOnFailureCallback_20.Cancel());
     }
@@ -18593,7 +21981,14 @@ private:
     CHIP_ERROR TestReadsOnOffAttributeFromDut_21()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOnOff(mOnSuccessCallback_21.Cancel(), mOnFailureCallback_21.Cancel());
     }
@@ -18609,7 +22004,14 @@ private:
     CHIP_ERROR TestReadsOnTimeAttributeFromDut_22()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOnTime(mOnSuccessCallback_22.Cancel(), mOnFailureCallback_22.Cancel());
     }
@@ -18625,7 +22027,14 @@ private:
     CHIP_ERROR TestReadsOffWaitTimeAttributeFromDut_23()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOffWaitTime(mOnSuccessCallback_23.Cancel(), mOnFailureCallback_23.Cancel());
     }
@@ -18641,7 +22050,14 @@ private:
     CHIP_ERROR TestSendOnCommand_24()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::OnOff::Commands::On::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -18665,7 +22081,14 @@ private:
     CHIP_ERROR TestReadsOnTimeAttributeFromDut_25()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOnTime(mOnSuccessCallback_25.Cancel(), mOnFailureCallback_25.Cancel());
     }
@@ -18681,7 +22104,14 @@ private:
     CHIP_ERROR TestReadsOffWaitTimeAttributeFromDut_26()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOffWaitTime(mOnSuccessCallback_26.Cancel(), mOnFailureCallback_26.Cancel());
     }
@@ -18697,7 +22127,14 @@ private:
     CHIP_ERROR TestSendOffCommand_27()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::OnOff::Commands::Off::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -18721,7 +22158,14 @@ private:
     CHIP_ERROR TestReadsOnOffAttributeFromDut_28()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOnOff(mOnSuccessCallback_28.Cancel(), mOnFailureCallback_28.Cancel());
     }
@@ -18737,7 +22181,14 @@ private:
     CHIP_ERROR TestReadsOnTimeAttributeFromDut_29()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOnTime(mOnSuccessCallback_29.Cancel(), mOnFailureCallback_29.Cancel());
     }
@@ -18753,7 +22204,14 @@ private:
     CHIP_ERROR TestReadsOnOffAttributeFromDut_30()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOnOff(mOnSuccessCallback_30.Cancel(), mOnFailureCallback_30.Cancel());
     }
@@ -18769,7 +22227,14 @@ private:
     CHIP_ERROR TestReadsOnTimeAttributeFromDut_31()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOnTime(mOnSuccessCallback_31.Cancel(), mOnFailureCallback_31.Cancel());
     }
@@ -18785,7 +22250,14 @@ private:
     CHIP_ERROR TestSendOnCommand_32()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::OnOff::Commands::On::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -18809,7 +22281,14 @@ private:
     CHIP_ERROR TestReadsOnOffAttributeFromDut_33()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOnOff(mOnSuccessCallback_33.Cancel(), mOnFailureCallback_33.Cancel());
     }
@@ -18825,7 +22304,14 @@ private:
     CHIP_ERROR TestReadsOnTimeAttributeFromDut_34()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOnTime(mOnSuccessCallback_34.Cancel(), mOnFailureCallback_34.Cancel());
     }
@@ -18841,7 +22327,14 @@ private:
     CHIP_ERROR TestReadsOffWaitTimeAttributeFromDut_35()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOffWaitTime(mOnSuccessCallback_35.Cancel(), mOnFailureCallback_35.Cancel());
     }
@@ -18857,7 +22350,14 @@ private:
     CHIP_ERROR TestSendOffCommand_36()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::OnOff::Commands::Off::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -18881,7 +22381,14 @@ private:
     CHIP_ERROR TestReadsOnOffAttributeFromDut_37()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOnOff(mOnSuccessCallback_37.Cancel(), mOnFailureCallback_37.Cancel());
     }
@@ -18897,7 +22404,14 @@ private:
     CHIP_ERROR TestReadsOnTimeAttributeFromDut_38()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOnTime(mOnSuccessCallback_38.Cancel(), mOnFailureCallback_38.Cancel());
     }
@@ -18913,7 +22427,14 @@ private:
     CHIP_ERROR TestReadsOnOffAttributeFromDut_39()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOnOff(mOnSuccessCallback_39.Cancel(), mOnFailureCallback_39.Cancel());
     }
@@ -18929,7 +22450,14 @@ private:
     CHIP_ERROR TestReadsOnTimeAttributeFromDut_40()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOnTime(mOnSuccessCallback_40.Cancel(), mOnFailureCallback_40.Cancel());
     }
@@ -18945,7 +22473,14 @@ private:
     CHIP_ERROR TestReadsOffWaitTimeAttributeFromDut_41()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOffWaitTime(mOnSuccessCallback_41.Cancel(), mOnFailureCallback_41.Cancel());
     }
@@ -18961,7 +22496,14 @@ private:
     CHIP_ERROR TestReadsOnOffAttributeFromDut_42()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOnOff(mOnSuccessCallback_42.Cancel(), mOnFailureCallback_42.Cancel());
     }
@@ -18977,7 +22519,14 @@ private:
     CHIP_ERROR TestReadsOnTimeAttributeFromDut_43()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOnTime(mOnSuccessCallback_43.Cancel(), mOnFailureCallback_43.Cancel());
     }
@@ -18993,7 +22542,14 @@ private:
     CHIP_ERROR TestReadsOffWaitTimeAttributeFromDut_44()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOffWaitTime(mOnSuccessCallback_44.Cancel(), mOnFailureCallback_44.Cancel());
     }
@@ -19009,7 +22565,14 @@ private:
     CHIP_ERROR TestSendOffCommand_45()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::OnOff::Commands::Off::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -19142,7 +22705,14 @@ private:
     CHIP_ERROR TestReadTheGlobalAttributeClusterRevision_0()
     {
         chip::Controller::PressureMeasurementClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeClusterRevision(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel());
     }
@@ -19158,7 +22728,14 @@ private:
     CHIP_ERROR TestReadTheGlobalAttributeConstraintsClusterRevision_1()
     {
         chip::Controller::PressureMeasurementClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeClusterRevision(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
     }
@@ -19174,7 +22751,14 @@ private:
     CHIP_ERROR TestWriteTheDefaultValuesToMandatoryGlobalAttributeClusterRevision_2()
     {
         chip::Controller::PressureMeasurementClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint16_t clusterRevisionArgument;
         clusterRevisionArgument = 2U;
@@ -19190,7 +22774,14 @@ private:
     CHIP_ERROR TestReadsBackGlobalAttributeClusterRevision_3()
     {
         chip::Controller::PressureMeasurementClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeClusterRevision(mOnSuccessCallback_3.Cancel(), mOnFailureCallback_3.Cancel());
     }
@@ -19384,7 +22975,14 @@ private:
     CHIP_ERROR TestReadTheMandatoryAttributeConstraintsMeasuredValue_0()
     {
         chip::Controller::PressureMeasurementClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeMeasuredValue(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel());
     }
@@ -19400,7 +22998,14 @@ private:
     CHIP_ERROR TestWriteTheDefaultValuesToMandatoryAttributeMeasuredValue_1()
     {
         chip::Controller::PressureMeasurementClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         int16_t measuredValueArgument;
         measuredValueArgument = 0;
@@ -19416,7 +23021,14 @@ private:
     CHIP_ERROR TestReadsBackMandatoryAttributeMeasuredValue_2()
     {
         chip::Controller::PressureMeasurementClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeMeasuredValue(mOnSuccessCallback_2.Cancel(), mOnFailureCallback_2.Cancel());
     }
@@ -19432,7 +23044,14 @@ private:
     CHIP_ERROR TestReadTheMandatoryAttributeConstraintsMinMeasuredValue_3()
     {
         chip::Controller::PressureMeasurementClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeMinMeasuredValue(mOnSuccessCallback_3.Cancel(), mOnFailureCallback_3.Cancel());
     }
@@ -19448,7 +23067,14 @@ private:
     CHIP_ERROR TestWriteTheDefaultValuesToMandatoryAttributeMinMeasuredValue_4()
     {
         chip::Controller::PressureMeasurementClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         int16_t minMeasuredValueArgument;
         minMeasuredValueArgument = 0;
@@ -19464,7 +23090,14 @@ private:
     CHIP_ERROR TestReadsBackMandatoryAttributeMinMeasuredValue_5()
     {
         chip::Controller::PressureMeasurementClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeMinMeasuredValue(mOnSuccessCallback_5.Cancel(), mOnFailureCallback_5.Cancel());
     }
@@ -19480,7 +23113,14 @@ private:
     CHIP_ERROR TestReadTheMandatoryAttributeConstraintsMaxMeasuredValue_6()
     {
         chip::Controller::PressureMeasurementClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeMaxMeasuredValue(mOnSuccessCallback_6.Cancel(), mOnFailureCallback_6.Cancel());
     }
@@ -19496,7 +23136,14 @@ private:
     CHIP_ERROR TestWriteTheDefaultValuesToMandatoryAttributeMaxMeasuredValue_7()
     {
         chip::Controller::PressureMeasurementClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         int16_t maxMeasuredValueArgument;
         maxMeasuredValueArgument = 0;
@@ -19512,7 +23159,14 @@ private:
     CHIP_ERROR TestReadsBackMandatoryAttributeMaxMeasuredValue_8()
     {
         chip::Controller::PressureMeasurementClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeMaxMeasuredValue(mOnSuccessCallback_8.Cancel(), mOnFailureCallback_8.Cancel());
     }
@@ -19588,7 +23242,14 @@ private:
     CHIP_ERROR TestWriteTheDefaultValuesToMandatoryGlobalAttributeClusterRevision_0()
     {
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint16_t clusterRevisionArgument;
         clusterRevisionArgument = 3U;
@@ -19785,7 +23446,14 @@ private:
     CHIP_ERROR TestReadTheMandatoryAttributeMaxPressure_0()
     {
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeMaxPressure(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel());
     }
@@ -19801,7 +23469,14 @@ private:
     CHIP_ERROR TestReadTheMandatoryAttributeEffectiveOperationMode_1()
     {
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeEffectiveOperationMode(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
     }
@@ -19817,7 +23492,14 @@ private:
     CHIP_ERROR TestReadTheMandatoryAttributeEffectiveControlMode_2()
     {
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeEffectiveControlMode(mOnSuccessCallback_2.Cancel(), mOnFailureCallback_2.Cancel());
     }
@@ -19833,7 +23515,14 @@ private:
     CHIP_ERROR TestReadTheMandatoryAttributeCapacity_3()
     {
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeCapacity(mOnSuccessCallback_3.Cancel(), mOnFailureCallback_3.Cancel());
     }
@@ -19849,7 +23538,14 @@ private:
     CHIP_ERROR TestReadTheMandatoryAttributeMaxPressure_4()
     {
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeMaxPressure(mOnSuccessCallback_4.Cancel(), mOnFailureCallback_4.Cancel());
     }
@@ -19865,7 +23561,14 @@ private:
     CHIP_ERROR TestReadTheMandatoryAttributeEffectiveOperationMode_5()
     {
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeEffectiveOperationMode(mOnSuccessCallback_5.Cancel(), mOnFailureCallback_5.Cancel());
     }
@@ -19881,7 +23584,14 @@ private:
     CHIP_ERROR TestReadTheMandatoryAttributeEffectiveControlMode_6()
     {
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeEffectiveControlMode(mOnSuccessCallback_6.Cancel(), mOnFailureCallback_6.Cancel());
     }
@@ -19897,7 +23607,14 @@ private:
     CHIP_ERROR TestReadTheMandatoryAttributeCapacity_7()
     {
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeCapacity(mOnSuccessCallback_7.Cancel(), mOnFailureCallback_7.Cancel());
     }
@@ -19994,7 +23711,14 @@ private:
     CHIP_ERROR TestWrite1ToTheOperationModeAttributeToDutOperationMode_0()
     {
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint8_t operationModeArgument;
         operationModeArgument = static_cast<uint8_t>(1);
@@ -20010,7 +23734,14 @@ private:
     CHIP_ERROR TestWrite2ToTheOperationModeAttributeToDutOperationMode_1()
     {
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint8_t operationModeArgument;
         operationModeArgument = static_cast<uint8_t>(2);
@@ -20026,7 +23757,14 @@ private:
     CHIP_ERROR TestWrite3ToTheOperationModeAttributeToDutOperationMode_2()
     {
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint8_t operationModeArgument;
         operationModeArgument = static_cast<uint8_t>(3);
@@ -20119,7 +23857,14 @@ private:
     CHIP_ERROR TestWrite0ToTheOperationModeAttributeToDut_0()
     {
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint8_t operationModeArgument;
         operationModeArgument = static_cast<uint8_t>(0);
@@ -20135,7 +23880,14 @@ private:
     CHIP_ERROR TestReadsTheAttributeEffectiveOperationMode_1()
     {
         chip::Controller::PumpConfigurationAndControlClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeEffectiveOperationMode(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
     }
@@ -20211,7 +23963,14 @@ private:
     CHIP_ERROR TestWriteTheDefaultValuesToMandatoryGlobalAttributeClusterRevision_0()
     {
         chip::Controller::RelativeHumidityMeasurementClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint16_t clusterRevisionArgument;
         clusterRevisionArgument = 1U;
@@ -20308,7 +24067,14 @@ private:
     CHIP_ERROR TestReadsConstraintsOfAttributeMeasuredValue_0()
     {
         chip::Controller::RelativeHumidityMeasurementClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeMeasuredValue(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel());
     }
@@ -20324,7 +24090,14 @@ private:
     CHIP_ERROR TestReadsConstraintsOfAttributeMinMeasuredValue_1()
     {
         chip::Controller::RelativeHumidityMeasurementClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeMinMeasuredValue(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
     }
@@ -20422,7 +24195,14 @@ private:
     CHIP_ERROR TestReadsMeasuredValueAttributeFromDut_0()
     {
         chip::Controller::RelativeHumidityMeasurementClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeMeasuredValue(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel());
     }
@@ -20438,7 +24218,14 @@ private:
     CHIP_ERROR TestReadTheMandatoryAttributeMeasuredValue_1()
     {
         chip::Controller::RelativeHumidityMeasurementClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeMeasuredValue(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
     }
@@ -20547,7 +24334,14 @@ private:
     CHIP_ERROR TestReadTheGlobalAttributeClusterRevision_0()
     {
         chip::Controller::TemperatureMeasurementClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeClusterRevision(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel());
     }
@@ -20563,7 +24357,14 @@ private:
     CHIP_ERROR TestWriteTheDefaultValuesToMandatoryGlobalAttributeClusterRevision_1()
     {
         chip::Controller::TemperatureMeasurementClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint16_t clusterRevisionArgument;
         clusterRevisionArgument = 3U;
@@ -20579,7 +24380,14 @@ private:
     CHIP_ERROR TestReadsBackGlobalAttributeClusterRevision_2()
     {
         chip::Controller::TemperatureMeasurementClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeClusterRevision(mOnSuccessCallback_2.Cancel(), mOnFailureCallback_2.Cancel());
     }
@@ -20660,7 +24468,14 @@ private:
     CHIP_ERROR TestReadTheMandatoryAttributeMeasuredValue_0()
     {
         chip::Controller::TemperatureMeasurementClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeMeasuredValue(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel());
     }
@@ -20757,7 +24572,14 @@ private:
     CHIP_ERROR TestReadsMeasuredValueAttributeFromDut_0()
     {
         chip::Controller::TemperatureMeasurementClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeMeasuredValue(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel());
     }
@@ -20773,7 +24595,14 @@ private:
     CHIP_ERROR TestReadTheMandatoryAttributeMeasuredValue_1()
     {
         chip::Controller::TemperatureMeasurementClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeMeasuredValue(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
     }
@@ -20849,7 +24678,14 @@ private:
     CHIP_ERROR TestWriteTheDefaultValuesToMandatoryGlobalAttributeClusterRevision_0()
     {
         chip::Controller::ThermostatClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint16_t clusterRevisionArgument;
         clusterRevisionArgument = 5U;
@@ -20925,7 +24761,14 @@ private:
     CHIP_ERROR TestWriteTheDefaultValuesToMandatoryGlobalAttributeClusterRevision_0()
     {
         chip::Controller::ThermostatUserInterfaceConfigurationClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint16_t clusterRevisionArgument;
         clusterRevisionArgument = 2U;
@@ -21228,7 +25071,14 @@ private:
     CHIP_ERROR TestReadTheMandatoryAttributeTemperatureDisplayMode_0()
     {
         chip::Controller::ThermostatUserInterfaceConfigurationClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeTemperatureDisplayMode(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel());
     }
@@ -21244,7 +25094,14 @@ private:
     CHIP_ERROR TestReadTheMandatoryAttributeTemperatureDisplayMode_1()
     {
         chip::Controller::ThermostatUserInterfaceConfigurationClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeTemperatureDisplayMode(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
     }
@@ -21260,7 +25117,14 @@ private:
     CHIP_ERROR TestWriteToTheMandatoryAttributeTemperatureDisplayMode_2()
     {
         chip::Controller::ThermostatUserInterfaceConfigurationClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint8_t temperatureDisplayModeArgument;
         temperatureDisplayModeArgument = static_cast<uint8_t>(0);
@@ -21277,7 +25141,14 @@ private:
     CHIP_ERROR TestReadTheMandatoryAttributeTemperatureDisplayMode_3()
     {
         chip::Controller::ThermostatUserInterfaceConfigurationClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeTemperatureDisplayMode(mOnSuccessCallback_3.Cancel(), mOnFailureCallback_3.Cancel());
     }
@@ -21293,7 +25164,14 @@ private:
     CHIP_ERROR TestReadTheMandatoryAttributeTemperatureDisplayMode_4()
     {
         chip::Controller::ThermostatUserInterfaceConfigurationClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeTemperatureDisplayMode(mOnSuccessCallback_4.Cancel(), mOnFailureCallback_4.Cancel());
     }
@@ -21309,7 +25187,14 @@ private:
     CHIP_ERROR TestReadTheMandatoryAttributeKeypadLockout_5()
     {
         chip::Controller::ThermostatUserInterfaceConfigurationClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeKeypadLockout(mOnSuccessCallback_5.Cancel(), mOnFailureCallback_5.Cancel());
     }
@@ -21325,7 +25210,14 @@ private:
     CHIP_ERROR TestReadTheMandatoryAttributeKeypadLockout_6()
     {
         chip::Controller::ThermostatUserInterfaceConfigurationClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeKeypadLockout(mOnSuccessCallback_6.Cancel(), mOnFailureCallback_6.Cancel());
     }
@@ -21341,7 +25233,14 @@ private:
     CHIP_ERROR TestWriteToTheMandatoryAttributeKeypadLockout_7()
     {
         chip::Controller::ThermostatUserInterfaceConfigurationClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint8_t keypadLockoutArgument;
         keypadLockoutArgument = static_cast<uint8_t>(0);
@@ -21358,7 +25257,14 @@ private:
     CHIP_ERROR TestReadTheMandatoryAttributeKeypadLockout_8()
     {
         chip::Controller::ThermostatUserInterfaceConfigurationClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeKeypadLockout(mOnSuccessCallback_8.Cancel(), mOnFailureCallback_8.Cancel());
     }
@@ -21374,7 +25280,14 @@ private:
     CHIP_ERROR TestReadTheMandatoryAttributeKeypadLockout_9()
     {
         chip::Controller::ThermostatUserInterfaceConfigurationClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeKeypadLockout(mOnSuccessCallback_9.Cancel(), mOnFailureCallback_9.Cancel());
     }
@@ -21390,7 +25303,14 @@ private:
     CHIP_ERROR TestReadTheOptionalAttributeScheduleProgrammingVisibility_10()
     {
         chip::Controller::ThermostatUserInterfaceConfigurationClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeScheduleProgrammingVisibility(mOnSuccessCallback_10.Cancel(), mOnFailureCallback_10.Cancel());
     }
@@ -21406,7 +25326,14 @@ private:
     CHIP_ERROR TestReadTheOptionalAttributeScheduleProgrammingVisibility_11()
     {
         chip::Controller::ThermostatUserInterfaceConfigurationClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeScheduleProgrammingVisibility(mOnSuccessCallback_11.Cancel(), mOnFailureCallback_11.Cancel());
     }
@@ -21422,7 +25349,14 @@ private:
     CHIP_ERROR TestWriteToTheMandatoryAttributeScheduleProgrammingVisibility_12()
     {
         chip::Controller::ThermostatUserInterfaceConfigurationClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint8_t scheduleProgrammingVisibilityArgument;
         scheduleProgrammingVisibilityArgument = static_cast<uint8_t>(0);
@@ -21439,7 +25373,14 @@ private:
     CHIP_ERROR TestReadTheOptionalAttributeScheduleProgrammingVisibility_13()
     {
         chip::Controller::ThermostatUserInterfaceConfigurationClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeScheduleProgrammingVisibility(mOnSuccessCallback_13.Cancel(), mOnFailureCallback_13.Cancel());
     }
@@ -21455,7 +25396,14 @@ private:
     CHIP_ERROR TestReadTheOptionalAttributeScheduleProgrammingVisibility_14()
     {
         chip::Controller::ThermostatUserInterfaceConfigurationClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeScheduleProgrammingVisibility(mOnSuccessCallback_14.Cancel(), mOnFailureCallback_14.Cancel());
     }
@@ -21631,7 +25579,14 @@ private:
     CHIP_ERROR TestWritesAValueOf0ToTemperatureDisplayModeAttributeOfDut_0()
     {
         chip::Controller::ThermostatUserInterfaceConfigurationClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint8_t temperatureDisplayModeArgument;
         temperatureDisplayModeArgument = static_cast<uint8_t>(0);
@@ -21648,7 +25603,14 @@ private:
     CHIP_ERROR TestWritesAValueOf1ToTemperatureDisplayModeAttributeOfDut_1()
     {
         chip::Controller::ThermostatUserInterfaceConfigurationClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint8_t temperatureDisplayModeArgument;
         temperatureDisplayModeArgument = static_cast<uint8_t>(1);
@@ -21665,7 +25627,14 @@ private:
     CHIP_ERROR TestWritesAValueOf0ToKeypadLockoutAttributeOfDut_2()
     {
         chip::Controller::ThermostatUserInterfaceConfigurationClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint8_t keypadLockoutArgument;
         keypadLockoutArgument = static_cast<uint8_t>(0);
@@ -21682,7 +25651,14 @@ private:
     CHIP_ERROR TestWritesAValueOf1ToKeypadLockoutAttributeOfDut_3()
     {
         chip::Controller::ThermostatUserInterfaceConfigurationClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint8_t keypadLockoutArgument;
         keypadLockoutArgument = static_cast<uint8_t>(1);
@@ -21699,7 +25675,14 @@ private:
     CHIP_ERROR TestWritesAValueOf2ToKeypadLockoutAttributeOfDut_4()
     {
         chip::Controller::ThermostatUserInterfaceConfigurationClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint8_t keypadLockoutArgument;
         keypadLockoutArgument = static_cast<uint8_t>(2);
@@ -21716,7 +25699,14 @@ private:
     CHIP_ERROR TestWritesAValueOf3ToKeypadLockoutAttributeOfDut_5()
     {
         chip::Controller::ThermostatUserInterfaceConfigurationClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint8_t keypadLockoutArgument;
         keypadLockoutArgument = static_cast<uint8_t>(3);
@@ -21733,7 +25723,14 @@ private:
     CHIP_ERROR TestWritesAValueOf4ToKeypadLockoutAttributeOfDut_6()
     {
         chip::Controller::ThermostatUserInterfaceConfigurationClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint8_t keypadLockoutArgument;
         keypadLockoutArgument = static_cast<uint8_t>(4);
@@ -21750,7 +25747,14 @@ private:
     CHIP_ERROR TestWritesAValueOf5ToKeypadLockoutAttributeOfDut_7()
     {
         chip::Controller::ThermostatUserInterfaceConfigurationClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint8_t keypadLockoutArgument;
         keypadLockoutArgument = static_cast<uint8_t>(5);
@@ -21767,7 +25771,14 @@ private:
     CHIP_ERROR TestWritesAValueOf0ToScheduleProgrammingVisibilityAttributeOfDut_8()
     {
         chip::Controller::ThermostatUserInterfaceConfigurationClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint8_t scheduleProgrammingVisibilityArgument;
         scheduleProgrammingVisibilityArgument = static_cast<uint8_t>(0);
@@ -21784,7 +25795,14 @@ private:
     CHIP_ERROR TestWritesAValueOf1ToScheduleProgrammingVisibilityAttributeOfDut_9()
     {
         chip::Controller::ThermostatUserInterfaceConfigurationClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint8_t scheduleProgrammingVisibilityArgument;
         scheduleProgrammingVisibilityArgument = static_cast<uint8_t>(1);
@@ -21894,7 +25912,14 @@ private:
     CHIP_ERROR TestReadTheGlobalAttributeClusterRevision_0()
     {
         chip::Controller::ThreadNetworkDiagnosticsClusterTest cluster;
-        cluster.Associate(mDevice, 0);
+        uint8_t endPoint = 0;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeClusterRevision(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel());
     }
@@ -21910,7 +25935,14 @@ private:
     CHIP_ERROR TestWriteTheDefaultValuesToMandatoryGlobalAttributeClusterRevision_1()
     {
         chip::Controller::ThreadNetworkDiagnosticsClusterTest cluster;
-        cluster.Associate(mDevice, 0);
+        uint8_t endPoint = 0;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint16_t clusterRevisionArgument;
         clusterRevisionArgument = 1U;
@@ -21926,7 +25958,14 @@ private:
     CHIP_ERROR TestReadsBackGlobalAttributeClusterRevision_2()
     {
         chip::Controller::ThreadNetworkDiagnosticsClusterTest cluster;
-        cluster.Associate(mDevice, 0);
+        uint8_t endPoint = 0;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeClusterRevision(mOnSuccessCallback_2.Cancel(), mOnFailureCallback_2.Cancel());
     }
@@ -22067,7 +26106,14 @@ private:
     CHIP_ERROR TestReadTheGlobalAttributeClusterRevision_0()
     {
         chip::Controller::WindowCoveringClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeClusterRevision(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel());
     }
@@ -22083,7 +26129,14 @@ private:
     CHIP_ERROR TestWriteTheDefaultValueToMandatoryGlobalAttributeClusterRevision_1()
     {
         chip::Controller::WindowCoveringClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint16_t clusterRevisionArgument;
         clusterRevisionArgument = 5U;
@@ -22099,7 +26152,14 @@ private:
     CHIP_ERROR TestReadsBackGlobalAttributeClusterRevision_2()
     {
         chip::Controller::WindowCoveringClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeClusterRevision(mOnSuccessCallback_2.Cancel(), mOnFailureCallback_2.Cancel());
     }
@@ -22115,7 +26175,14 @@ private:
     CHIP_ERROR TestReadTheGlobalAttributeFeatureMap_3()
     {
         chip::Controller::WindowCoveringClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeFeatureMap(mOnSuccessCallback_3.Cancel(), mOnFailureCallback_3.Cancel());
     }
@@ -22131,7 +26198,14 @@ private:
     CHIP_ERROR TestReadsBackGlobalAttributeFeatureMap_4()
     {
         chip::Controller::WindowCoveringClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeFeatureMap(mOnSuccessCallback_4.Cancel(), mOnFailureCallback_4.Cancel());
     }
@@ -22367,7 +26441,14 @@ private:
     CHIP_ERROR TestReadTheRoMandatoryAttributeDefaultType_0()
     {
         chip::Controller::WindowCoveringClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeType(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel());
     }
@@ -22383,7 +26464,14 @@ private:
     CHIP_ERROR TestReadsBackTheRoMandatoryAttributeType_1()
     {
         chip::Controller::WindowCoveringClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeType(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
     }
@@ -22399,7 +26487,14 @@ private:
     CHIP_ERROR TestReadTheRoMandatoryAttributeDefaultConfigStatus_2()
     {
         chip::Controller::WindowCoveringClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeConfigStatus(mOnSuccessCallback_2.Cancel(), mOnFailureCallback_2.Cancel());
     }
@@ -22415,7 +26510,14 @@ private:
     CHIP_ERROR TestReadsBackTheRoMandatoryAttributeConfigStatus_3()
     {
         chip::Controller::WindowCoveringClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeConfigStatus(mOnSuccessCallback_3.Cancel(), mOnFailureCallback_3.Cancel());
     }
@@ -22431,7 +26533,14 @@ private:
     CHIP_ERROR TestReadTheRoMandatoryAttributeDefaultOperationalStatus_4()
     {
         chip::Controller::WindowCoveringClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOperationalStatus(mOnSuccessCallback_4.Cancel(), mOnFailureCallback_4.Cancel());
     }
@@ -22447,7 +26556,14 @@ private:
     CHIP_ERROR TestReadsBackTheRoMandatoryAttributeOperationalStatus_5()
     {
         chip::Controller::WindowCoveringClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOperationalStatus(mOnSuccessCallback_5.Cancel(), mOnFailureCallback_5.Cancel());
     }
@@ -22463,7 +26579,14 @@ private:
     CHIP_ERROR TestReadTheRoMandatoryAttributeDefaultEndProductType_6()
     {
         chip::Controller::WindowCoveringClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeEndProductType(mOnSuccessCallback_6.Cancel(), mOnFailureCallback_6.Cancel());
     }
@@ -22479,7 +26602,14 @@ private:
     CHIP_ERROR TestReadsBackTheRoMandatoryAttributeEndProductType_7()
     {
         chip::Controller::WindowCoveringClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeEndProductType(mOnSuccessCallback_7.Cancel(), mOnFailureCallback_7.Cancel());
     }
@@ -22495,7 +26625,14 @@ private:
     CHIP_ERROR TestReadTheRwMandatoryAttributeDefaultMode_8()
     {
         chip::Controller::WindowCoveringClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeMode(mOnSuccessCallback_8.Cancel(), mOnFailureCallback_8.Cancel());
     }
@@ -22511,7 +26648,14 @@ private:
     CHIP_ERROR TestWriteAValueIntoTheRwMandatoryAttributeMode_9()
     {
         chip::Controller::WindowCoveringClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint8_t modeArgument;
         modeArgument = 7;
@@ -22527,7 +26671,14 @@ private:
     CHIP_ERROR TestReadsBackTheRwMandatoryAttributeMode_10()
     {
         chip::Controller::WindowCoveringClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeMode(mOnSuccessCallback_10.Cancel(), mOnFailureCallback_10.Cancel());
     }
@@ -22672,7 +26823,14 @@ private:
     CHIP_ERROR TestReadsEndProductTypeAttributeFromDut_0()
     {
         chip::Controller::WindowCoveringClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeEndProductType(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel());
     }
@@ -22688,7 +26846,14 @@ private:
     CHIP_ERROR TestReadsEndProductTypeAttributeConstraintsFromDut_1()
     {
         chip::Controller::WindowCoveringClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeEndProductType(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
     }
@@ -22778,7 +26943,14 @@ private:
     CHIP_ERROR Test1aThAdjustsTheTheDutToANonOpenPosition_0()
     {
         chip::Controller::WindowCoveringClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::WindowCovering::Commands::DownOrClose::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -22802,7 +26974,14 @@ private:
     CHIP_ERROR Test2aThSendsUpOrOpenCommandToDut_1()
     {
         chip::Controller::WindowCoveringClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::WindowCovering::Commands::UpOrOpen::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -22826,7 +27005,14 @@ private:
     CHIP_ERROR Test3aThReadsOperationalStatusAttributeFromDut_2()
     {
         chip::Controller::WindowCoveringClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOperationalStatus(mOnSuccessCallback_2.Cancel(), mOnFailureCallback_2.Cancel());
     }
@@ -22915,7 +27101,14 @@ private:
     CHIP_ERROR Test1aThAdjustsTheTheDutToANonClosedPosition_0()
     {
         chip::Controller::WindowCoveringClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::WindowCovering::Commands::UpOrOpen::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -22939,7 +27132,14 @@ private:
     CHIP_ERROR Test2aThSendsDownOrCloseCommandToDut_1()
     {
         chip::Controller::WindowCoveringClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::WindowCovering::Commands::DownOrClose::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -22963,7 +27163,14 @@ private:
     CHIP_ERROR Test3aThReadsOperationalStatusAttributeFromDut_2()
     {
         chip::Controller::WindowCoveringClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOperationalStatus(mOnSuccessCallback_2.Cancel(), mOnFailureCallback_2.Cancel());
     }
@@ -23052,7 +27259,14 @@ private:
     CHIP_ERROR Test1aThAdjustsTheTheDutToANonOpenPosition_0()
     {
         chip::Controller::WindowCoveringClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::WindowCovering::Commands::UpOrOpen::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -23076,7 +27290,14 @@ private:
     CHIP_ERROR Test2aThSendsStopMotionCommandToDut_1()
     {
         chip::Controller::WindowCoveringClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::WindowCovering::Commands::StopMotion::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -23100,7 +27321,14 @@ private:
     CHIP_ERROR Test2bThReadsOperationalStatusAttributeFromDut_2()
     {
         chip::Controller::WindowCoveringClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOperationalStatus(mOnSuccessCallback_2.Cancel(), mOnFailureCallback_2.Cancel());
     }
@@ -23192,7 +27420,14 @@ private:
     CHIP_ERROR TestReadAttributeTargetNavigatorList_0()
     {
         chip::Controller::TargetNavigatorClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeTargetNavigatorList(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel());
     }
@@ -23217,7 +27452,14 @@ private:
     CHIP_ERROR TestNavigateTargetCommand_1()
     {
         chip::Controller::TargetNavigatorClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::TargetNavigator::Commands::NavigateTarget::Type;
         using responseType = chip::app::Clusters::TargetNavigator::Commands::NavigateTargetResponse::DecodableType;
@@ -23323,7 +27565,14 @@ private:
     CHIP_ERROR TestReadAttributeAudioOutputList_0()
     {
         chip::Controller::AudioOutputClusterTest cluster;
-        cluster.Associate(mDevice, 2);
+        uint8_t endPoint = 2;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeAudioOutputList(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel());
     }
@@ -23354,7 +27603,14 @@ private:
     CHIP_ERROR TestSelectOutputCommand_1()
     {
         chip::Controller::AudioOutputClusterTest cluster;
-        cluster.Associate(mDevice, 2);
+        uint8_t endPoint = 2;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::AudioOutput::Commands::SelectOutput::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -23379,7 +27635,14 @@ private:
     CHIP_ERROR TestRenameOutputCommand_2()
     {
         chip::Controller::AudioOutputClusterTest cluster;
-        cluster.Associate(mDevice, 2);
+        uint8_t endPoint = 2;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::AudioOutput::Commands::RenameOutput::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -23508,7 +27771,14 @@ private:
     CHIP_ERROR TestReadAttributeApplicationLauncherList_0()
     {
         chip::Controller::ApplicationLauncherClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeApplicationLauncherList(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel());
     }
@@ -23529,7 +27799,14 @@ private:
     CHIP_ERROR TestLaunchAppCommand_1()
     {
         chip::Controller::ApplicationLauncherClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::ApplicationLauncher::Commands::LaunchApp::Type;
         using responseType = chip::app::Clusters::ApplicationLauncher::Commands::LaunchAppResponse::DecodableType;
@@ -23560,7 +27837,14 @@ private:
     CHIP_ERROR TestReadAttributeCatalogVendorId_2()
     {
         chip::Controller::ApplicationLauncherClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeCatalogVendorId(mOnSuccessCallback_2.Cancel(), mOnFailureCallback_2.Cancel());
     }
@@ -23576,7 +27860,14 @@ private:
     CHIP_ERROR TestReadAttributeApplicationId_3()
     {
         chip::Controller::ApplicationLauncherClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeApplicationId(mOnSuccessCallback_3.Cancel(), mOnFailureCallback_3.Cancel());
     }
@@ -23644,7 +27935,14 @@ private:
     CHIP_ERROR TestSendKeyCommand_0()
     {
         chip::Controller::KeypadInputClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::KeypadInput::Commands::SendKey::Type;
         using responseType = chip::app::Clusters::KeypadInput::Commands::SendKeyResponse::DecodableType;
@@ -23725,7 +28023,14 @@ private:
     CHIP_ERROR TestGetSetupPinCommand_0()
     {
         chip::Controller::AccountLoginClusterTest cluster;
-        cluster.Associate(mDevice, 3);
+        uint8_t endPoint = 3;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::AccountLogin::Commands::GetSetupPIN::Type;
         using responseType = chip::app::Clusters::AccountLogin::Commands::GetSetupPINResponse::DecodableType;
@@ -23750,7 +28055,14 @@ private:
     CHIP_ERROR TestLoginCommand_1()
     {
         chip::Controller::AccountLoginClusterTest cluster;
-        cluster.Associate(mDevice, 3);
+        uint8_t endPoint = 3;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::AccountLogin::Commands::Login::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -23843,7 +28155,14 @@ private:
     CHIP_ERROR TestReadMacAddress_0()
     {
         chip::Controller::WakeOnLanClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeWakeOnLanMacAddress(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel());
     }
@@ -23960,7 +28279,14 @@ private:
     CHIP_ERROR TestChangeStatusCommand_0()
     {
         chip::Controller::ApplicationBasicClusterTest cluster;
-        cluster.Associate(mDevice, 3);
+        uint8_t endPoint = 3;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::ApplicationBasic::Commands::ChangeStatus::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -23985,7 +28311,14 @@ private:
     CHIP_ERROR TestReadAttributeVendorId_1()
     {
         chip::Controller::ApplicationBasicClusterTest cluster;
-        cluster.Associate(mDevice, 3);
+        uint8_t endPoint = 3;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeVendorId(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
     }
@@ -24001,7 +28334,14 @@ private:
     CHIP_ERROR TestReadAttributeProductId_2()
     {
         chip::Controller::ApplicationBasicClusterTest cluster;
-        cluster.Associate(mDevice, 3);
+        uint8_t endPoint = 3;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeProductId(mOnSuccessCallback_2.Cancel(), mOnFailureCallback_2.Cancel());
     }
@@ -24017,7 +28357,14 @@ private:
     CHIP_ERROR TestReadAttributeCatalogVendorId_3()
     {
         chip::Controller::ApplicationBasicClusterTest cluster;
-        cluster.Associate(mDevice, 3);
+        uint8_t endPoint = 3;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeCatalogVendorId(mOnSuccessCallback_3.Cancel(), mOnFailureCallback_3.Cancel());
     }
@@ -24125,7 +28472,14 @@ private:
     CHIP_ERROR TestMediaPlaybackPlayCommand_0()
     {
         chip::Controller::MediaPlaybackClusterTest cluster;
-        cluster.Associate(mDevice, 3);
+        uint8_t endPoint = 3;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::MediaPlayback::Commands::MediaPlay::Type;
         using responseType = chip::app::Clusters::MediaPlayback::Commands::MediaPlayResponse::DecodableType;
@@ -24153,7 +28507,14 @@ private:
     CHIP_ERROR TestMediaPlaybackPauseCommand_1()
     {
         chip::Controller::MediaPlaybackClusterTest cluster;
-        cluster.Associate(mDevice, 3);
+        uint8_t endPoint = 3;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::MediaPlayback::Commands::MediaPause::Type;
         using responseType = chip::app::Clusters::MediaPlayback::Commands::MediaPauseResponse::DecodableType;
@@ -24181,7 +28542,14 @@ private:
     CHIP_ERROR TestMediaPlaybackStopCommand_2()
     {
         chip::Controller::MediaPlaybackClusterTest cluster;
-        cluster.Associate(mDevice, 3);
+        uint8_t endPoint = 3;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::MediaPlayback::Commands::MediaStop::Type;
         using responseType = chip::app::Clusters::MediaPlayback::Commands::MediaStopResponse::DecodableType;
@@ -24209,7 +28577,14 @@ private:
     CHIP_ERROR TestMediaPlaybackStartOverCommand_3()
     {
         chip::Controller::MediaPlaybackClusterTest cluster;
-        cluster.Associate(mDevice, 3);
+        uint8_t endPoint = 3;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::MediaPlayback::Commands::MediaStartOver::Type;
         using responseType = chip::app::Clusters::MediaPlayback::Commands::MediaStartOverResponse::DecodableType;
@@ -24237,7 +28612,14 @@ private:
     CHIP_ERROR TestMediaPlaybackPreviousCommand_4()
     {
         chip::Controller::MediaPlaybackClusterTest cluster;
-        cluster.Associate(mDevice, 3);
+        uint8_t endPoint = 3;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::MediaPlayback::Commands::MediaPrevious::Type;
         using responseType = chip::app::Clusters::MediaPlayback::Commands::MediaPreviousResponse::DecodableType;
@@ -24265,7 +28647,14 @@ private:
     CHIP_ERROR TestMediaPlaybackNextCommand_5()
     {
         chip::Controller::MediaPlaybackClusterTest cluster;
-        cluster.Associate(mDevice, 3);
+        uint8_t endPoint = 3;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::MediaPlayback::Commands::MediaNext::Type;
         using responseType = chip::app::Clusters::MediaPlayback::Commands::MediaNextResponse::DecodableType;
@@ -24293,7 +28682,14 @@ private:
     CHIP_ERROR TestMediaPlaybackRewindCommand_6()
     {
         chip::Controller::MediaPlaybackClusterTest cluster;
-        cluster.Associate(mDevice, 3);
+        uint8_t endPoint = 3;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::MediaPlayback::Commands::MediaRewind::Type;
         using responseType = chip::app::Clusters::MediaPlayback::Commands::MediaRewindResponse::DecodableType;
@@ -24321,7 +28717,14 @@ private:
     CHIP_ERROR TestMediaPlaybackFastForwardCommand_7()
     {
         chip::Controller::MediaPlaybackClusterTest cluster;
-        cluster.Associate(mDevice, 3);
+        uint8_t endPoint = 3;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::MediaPlayback::Commands::MediaFastForward::Type;
         using responseType = chip::app::Clusters::MediaPlayback::Commands::MediaFastForwardResponse::DecodableType;
@@ -24349,7 +28752,14 @@ private:
     CHIP_ERROR TestMediaPlaybackSkipForwardCommand_8()
     {
         chip::Controller::MediaPlaybackClusterTest cluster;
-        cluster.Associate(mDevice, 3);
+        uint8_t endPoint = 3;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::MediaPlayback::Commands::MediaSkipForward::Type;
         using responseType = chip::app::Clusters::MediaPlayback::Commands::MediaSkipForwardResponse::DecodableType;
@@ -24378,7 +28788,14 @@ private:
     CHIP_ERROR TestMediaPlaybackSkipBackwardCommand_9()
     {
         chip::Controller::MediaPlaybackClusterTest cluster;
-        cluster.Associate(mDevice, 3);
+        uint8_t endPoint = 3;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::MediaPlayback::Commands::MediaSkipBackward::Type;
         using responseType = chip::app::Clusters::MediaPlayback::Commands::MediaSkipBackwardResponse::DecodableType;
@@ -24407,7 +28824,14 @@ private:
     CHIP_ERROR TestMediaPlaybackSeekCommand_10()
     {
         chip::Controller::MediaPlaybackClusterTest cluster;
-        cluster.Associate(mDevice, 3);
+        uint8_t endPoint = 3;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::MediaPlayback::Commands::MediaSeek::Type;
         using responseType = chip::app::Clusters::MediaPlayback::Commands::MediaSeekResponse::DecodableType;
@@ -24515,7 +28939,14 @@ private:
     CHIP_ERROR TestReadAttributeTvChannelList_0()
     {
         chip::Controller::TvChannelClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeTvChannelList(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel());
     }
@@ -24546,7 +28977,14 @@ private:
     CHIP_ERROR TestChangeChannelByNumberCommand_1()
     {
         chip::Controller::TvChannelClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::TvChannel::Commands::ChangeChannelByNumber::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -24572,7 +29010,14 @@ private:
     CHIP_ERROR TestSkipChannelCommand_2()
     {
         chip::Controller::TvChannelClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::TvChannel::Commands::SkipChannel::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -24649,7 +29094,14 @@ private:
     CHIP_ERROR TestSleepInputStatusCommand_0()
     {
         chip::Controller::LowPowerClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::LowPower::Commands::Sleep::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -24777,7 +29229,14 @@ private:
     CHIP_ERROR TestReadAttributeMediaInputList_0()
     {
         chip::Controller::MediaInputClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeMediaInputList(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel());
     }
@@ -24806,7 +29265,14 @@ private:
     CHIP_ERROR TestSelectInputCommand_1()
     {
         chip::Controller::MediaInputClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::MediaInput::Commands::SelectInput::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -24831,7 +29297,14 @@ private:
     CHIP_ERROR TestReadCurrentInputList_2()
     {
         chip::Controller::MediaInputClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeCurrentMediaInput(mOnSuccessCallback_2.Cancel(), mOnFailureCallback_2.Cancel());
     }
@@ -24847,7 +29320,14 @@ private:
     CHIP_ERROR TestHideInputStatusCommand_3()
     {
         chip::Controller::MediaInputClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::MediaInput::Commands::HideInputStatus::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -24871,7 +29351,14 @@ private:
     CHIP_ERROR TestShowInputStatusCommand_4()
     {
         chip::Controller::MediaInputClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::MediaInput::Commands::ShowInputStatus::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -24895,7 +29382,14 @@ private:
     CHIP_ERROR TestRenameInputCommand_5()
     {
         chip::Controller::MediaInputClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::MediaInput::Commands::RenameInput::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -26682,7 +31176,14 @@ private:
     CHIP_ERROR TestSendTestCommand_0()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::TestCluster::Commands::Test::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -26706,7 +31207,14 @@ private:
     CHIP_ERROR TestSendTestNotHandledCommand_1()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::TestCluster::Commands::TestNotHandled::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -26730,7 +31238,14 @@ private:
     CHIP_ERROR TestSendTestSpecificCommand_2()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::TestCluster::Commands::TestSpecific::Type;
         using responseType = chip::app::Clusters::TestCluster::Commands::TestSpecificResponse::DecodableType;
@@ -26758,7 +31273,14 @@ private:
     CHIP_ERROR TestSendTestAddArgumentsCommand_3()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::TestCluster::Commands::TestAddArguments::Type;
         using responseType = chip::app::Clusters::TestCluster::Commands::TestAddArgumentsResponse::DecodableType;
@@ -26788,7 +31310,14 @@ private:
     CHIP_ERROR TestSendFailingTestAddArgumentsCommand_4()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::TestCluster::Commands::TestAddArguments::Type;
         using responseType = chip::app::Clusters::TestCluster::Commands::TestAddArgumentsResponse::DecodableType;
@@ -26814,7 +31343,14 @@ private:
     CHIP_ERROR TestReadAttributeBooleanDefaultValue_5()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeBoolean(mOnSuccessCallback_5.Cancel(), mOnFailureCallback_5.Cancel());
     }
@@ -26830,7 +31366,14 @@ private:
     CHIP_ERROR TestWriteAttributeBooleanTrue_6()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         bool booleanArgument;
         booleanArgument = 1;
@@ -26846,7 +31389,14 @@ private:
     CHIP_ERROR TestReadAttributeBooleanTrue_7()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeBoolean(mOnSuccessCallback_7.Cancel(), mOnFailureCallback_7.Cancel());
     }
@@ -26862,7 +31412,14 @@ private:
     CHIP_ERROR TestWriteAttributeBooleanFalse_8()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         bool booleanArgument;
         booleanArgument = 0;
@@ -26878,7 +31435,14 @@ private:
     CHIP_ERROR TestReadAttributeBooleanFalse_9()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeBoolean(mOnSuccessCallback_9.Cancel(), mOnFailureCallback_9.Cancel());
     }
@@ -26894,7 +31458,14 @@ private:
     CHIP_ERROR TestReadAttributeBitmap8DefaultValue_10()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeBitmap8(mOnSuccessCallback_10.Cancel(), mOnFailureCallback_10.Cancel());
     }
@@ -26910,7 +31481,14 @@ private:
     CHIP_ERROR TestWriteAttributeBitmap8MaxValue_11()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint8_t bitmap8Argument;
         bitmap8Argument = 255;
@@ -26926,7 +31504,14 @@ private:
     CHIP_ERROR TestReadAttributeBitmap8MaxValue_12()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeBitmap8(mOnSuccessCallback_12.Cancel(), mOnFailureCallback_12.Cancel());
     }
@@ -26942,7 +31527,14 @@ private:
     CHIP_ERROR TestWriteAttributeBitmap8MinValue_13()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint8_t bitmap8Argument;
         bitmap8Argument = 0;
@@ -26958,7 +31550,14 @@ private:
     CHIP_ERROR TestReadAttributeBitmap8MinValue_14()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeBitmap8(mOnSuccessCallback_14.Cancel(), mOnFailureCallback_14.Cancel());
     }
@@ -26974,7 +31573,14 @@ private:
     CHIP_ERROR TestReadAttributeBitmap16DefaultValue_15()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeBitmap16(mOnSuccessCallback_15.Cancel(), mOnFailureCallback_15.Cancel());
     }
@@ -26990,7 +31596,14 @@ private:
     CHIP_ERROR TestWriteAttributeBitmap16MaxValue_16()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint16_t bitmap16Argument;
         bitmap16Argument = 65535U;
@@ -27006,7 +31619,14 @@ private:
     CHIP_ERROR TestReadAttributeBitmap16MaxValue_17()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeBitmap16(mOnSuccessCallback_17.Cancel(), mOnFailureCallback_17.Cancel());
     }
@@ -27022,7 +31642,14 @@ private:
     CHIP_ERROR TestWriteAttributeBitmap16MinValue_18()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint16_t bitmap16Argument;
         bitmap16Argument = 0U;
@@ -27038,7 +31665,14 @@ private:
     CHIP_ERROR TestReadAttributeBitmap16MinValue_19()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeBitmap16(mOnSuccessCallback_19.Cancel(), mOnFailureCallback_19.Cancel());
     }
@@ -27054,7 +31688,14 @@ private:
     CHIP_ERROR TestReadAttributeBitmap32DefaultValue_20()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeBitmap32(mOnSuccessCallback_20.Cancel(), mOnFailureCallback_20.Cancel());
     }
@@ -27070,7 +31711,14 @@ private:
     CHIP_ERROR TestWriteAttributeBitmap32MaxValue_21()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint32_t bitmap32Argument;
         bitmap32Argument = 4294967295UL;
@@ -27086,7 +31734,14 @@ private:
     CHIP_ERROR TestReadAttributeBitmap32MaxValue_22()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeBitmap32(mOnSuccessCallback_22.Cancel(), mOnFailureCallback_22.Cancel());
     }
@@ -27102,7 +31757,14 @@ private:
     CHIP_ERROR TestWriteAttributeBitmap32MinValue_23()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint32_t bitmap32Argument;
         bitmap32Argument = 0UL;
@@ -27118,7 +31780,14 @@ private:
     CHIP_ERROR TestReadAttributeBitmap32MinValue_24()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeBitmap32(mOnSuccessCallback_24.Cancel(), mOnFailureCallback_24.Cancel());
     }
@@ -27134,7 +31803,14 @@ private:
     CHIP_ERROR TestReadAttributeBitmap64DefaultValue_25()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeBitmap64(mOnSuccessCallback_25.Cancel(), mOnFailureCallback_25.Cancel());
     }
@@ -27150,7 +31826,14 @@ private:
     CHIP_ERROR TestWriteAttributeBitmap64MaxValue_26()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint64_t bitmap64Argument;
         bitmap64Argument = 18446744073709551615ULL;
@@ -27166,7 +31849,14 @@ private:
     CHIP_ERROR TestReadAttributeBitmap64MaxValue_27()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeBitmap64(mOnSuccessCallback_27.Cancel(), mOnFailureCallback_27.Cancel());
     }
@@ -27182,7 +31872,14 @@ private:
     CHIP_ERROR TestWriteAttributeBitmap64MinValue_28()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint64_t bitmap64Argument;
         bitmap64Argument = 0ULL;
@@ -27198,7 +31895,14 @@ private:
     CHIP_ERROR TestReadAttributeBitmap64MinValue_29()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeBitmap64(mOnSuccessCallback_29.Cancel(), mOnFailureCallback_29.Cancel());
     }
@@ -27214,7 +31918,14 @@ private:
     CHIP_ERROR TestReadAttributeInt8uDefaultValue_30()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeInt8u(mOnSuccessCallback_30.Cancel(), mOnFailureCallback_30.Cancel());
     }
@@ -27230,7 +31941,14 @@ private:
     CHIP_ERROR TestWriteAttributeInt8uMaxValue_31()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint8_t int8uArgument;
         int8uArgument = 255;
@@ -27246,7 +31964,14 @@ private:
     CHIP_ERROR TestReadAttributeInt8uMaxValue_32()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeInt8u(mOnSuccessCallback_32.Cancel(), mOnFailureCallback_32.Cancel());
     }
@@ -27262,7 +31987,14 @@ private:
     CHIP_ERROR TestWriteAttributeInt8uMinValue_33()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint8_t int8uArgument;
         int8uArgument = 0;
@@ -27278,7 +32010,14 @@ private:
     CHIP_ERROR TestReadAttributeInt8uMinValue_34()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeInt8u(mOnSuccessCallback_34.Cancel(), mOnFailureCallback_34.Cancel());
     }
@@ -27294,7 +32033,14 @@ private:
     CHIP_ERROR TestReadAttributeInt16uDefaultValue_35()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeInt16u(mOnSuccessCallback_35.Cancel(), mOnFailureCallback_35.Cancel());
     }
@@ -27310,7 +32056,14 @@ private:
     CHIP_ERROR TestWriteAttributeInt16uMaxValue_36()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint16_t int16uArgument;
         int16uArgument = 65535U;
@@ -27326,7 +32079,14 @@ private:
     CHIP_ERROR TestReadAttributeInt16uMaxValue_37()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeInt16u(mOnSuccessCallback_37.Cancel(), mOnFailureCallback_37.Cancel());
     }
@@ -27342,7 +32102,14 @@ private:
     CHIP_ERROR TestWriteAttributeInt16uMinValue_38()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint16_t int16uArgument;
         int16uArgument = 0U;
@@ -27358,7 +32125,14 @@ private:
     CHIP_ERROR TestReadAttributeInt16uMinValue_39()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeInt16u(mOnSuccessCallback_39.Cancel(), mOnFailureCallback_39.Cancel());
     }
@@ -27374,7 +32148,14 @@ private:
     CHIP_ERROR TestReadAttributeInt32uDefaultValue_40()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeInt32u(mOnSuccessCallback_40.Cancel(), mOnFailureCallback_40.Cancel());
     }
@@ -27390,7 +32171,14 @@ private:
     CHIP_ERROR TestWriteAttributeInt32uMaxValue_41()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint32_t int32uArgument;
         int32uArgument = 4294967295UL;
@@ -27406,7 +32194,14 @@ private:
     CHIP_ERROR TestReadAttributeInt32uMaxValue_42()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeInt32u(mOnSuccessCallback_42.Cancel(), mOnFailureCallback_42.Cancel());
     }
@@ -27422,7 +32217,14 @@ private:
     CHIP_ERROR TestWriteAttributeInt32uMinValue_43()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint32_t int32uArgument;
         int32uArgument = 0UL;
@@ -27438,7 +32240,14 @@ private:
     CHIP_ERROR TestReadAttributeInt32uMinValue_44()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeInt32u(mOnSuccessCallback_44.Cancel(), mOnFailureCallback_44.Cancel());
     }
@@ -27454,7 +32263,14 @@ private:
     CHIP_ERROR TestReadAttributeInt64uDefaultValue_45()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeInt64u(mOnSuccessCallback_45.Cancel(), mOnFailureCallback_45.Cancel());
     }
@@ -27470,7 +32286,14 @@ private:
     CHIP_ERROR TestWriteAttributeInt64uMaxValue_46()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint64_t int64uArgument;
         int64uArgument = 18446744073709551615ULL;
@@ -27486,7 +32309,14 @@ private:
     CHIP_ERROR TestReadAttributeInt64uMaxValue_47()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeInt64u(mOnSuccessCallback_47.Cancel(), mOnFailureCallback_47.Cancel());
     }
@@ -27502,7 +32332,14 @@ private:
     CHIP_ERROR TestWriteAttributeInt64uMinValue_48()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint64_t int64uArgument;
         int64uArgument = 0ULL;
@@ -27518,7 +32355,14 @@ private:
     CHIP_ERROR TestReadAttributeInt64uMinValue_49()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeInt64u(mOnSuccessCallback_49.Cancel(), mOnFailureCallback_49.Cancel());
     }
@@ -27534,7 +32378,14 @@ private:
     CHIP_ERROR TestReadAttributeInt8sDefaultValue_50()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeInt8s(mOnSuccessCallback_50.Cancel(), mOnFailureCallback_50.Cancel());
     }
@@ -27550,7 +32401,14 @@ private:
     CHIP_ERROR TestWriteAttributeInt8sMaxValue_51()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         int8_t int8sArgument;
         int8sArgument = 127;
@@ -27566,7 +32424,14 @@ private:
     CHIP_ERROR TestReadAttributeInt8sMaxValue_52()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeInt8s(mOnSuccessCallback_52.Cancel(), mOnFailureCallback_52.Cancel());
     }
@@ -27582,7 +32447,14 @@ private:
     CHIP_ERROR TestWriteAttributeInt8sMinValue_53()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         int8_t int8sArgument;
         int8sArgument = -128;
@@ -27598,7 +32470,14 @@ private:
     CHIP_ERROR TestReadAttributeInt8sMinValue_54()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeInt8s(mOnSuccessCallback_54.Cancel(), mOnFailureCallback_54.Cancel());
     }
@@ -27614,7 +32493,14 @@ private:
     CHIP_ERROR TestWriteAttributeInt8sDefaultValue_55()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         int8_t int8sArgument;
         int8sArgument = 0;
@@ -27630,7 +32516,14 @@ private:
     CHIP_ERROR TestReadAttributeInt8sDefaultValue_56()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeInt8s(mOnSuccessCallback_56.Cancel(), mOnFailureCallback_56.Cancel());
     }
@@ -27646,7 +32539,14 @@ private:
     CHIP_ERROR TestReadAttributeInt16sDefaultValue_57()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeInt16s(mOnSuccessCallback_57.Cancel(), mOnFailureCallback_57.Cancel());
     }
@@ -27662,7 +32562,14 @@ private:
     CHIP_ERROR TestWriteAttributeInt16sMaxValue_58()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         int16_t int16sArgument;
         int16sArgument = 32767;
@@ -27678,7 +32585,14 @@ private:
     CHIP_ERROR TestReadAttributeInt16sMaxValue_59()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeInt16s(mOnSuccessCallback_59.Cancel(), mOnFailureCallback_59.Cancel());
     }
@@ -27694,7 +32608,14 @@ private:
     CHIP_ERROR TestWriteAttributeInt16sMinValue_60()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         int16_t int16sArgument;
         int16sArgument = -32768;
@@ -27710,7 +32631,14 @@ private:
     CHIP_ERROR TestReadAttributeInt16sMinValue_61()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeInt16s(mOnSuccessCallback_61.Cancel(), mOnFailureCallback_61.Cancel());
     }
@@ -27726,7 +32654,14 @@ private:
     CHIP_ERROR TestWriteAttributeInt16sDefaultValue_62()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         int16_t int16sArgument;
         int16sArgument = 0;
@@ -27742,7 +32677,14 @@ private:
     CHIP_ERROR TestReadAttributeInt16sDefaultValue_63()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeInt16s(mOnSuccessCallback_63.Cancel(), mOnFailureCallback_63.Cancel());
     }
@@ -27758,7 +32700,14 @@ private:
     CHIP_ERROR TestReadAttributeInt32sDefaultValue_64()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeInt32s(mOnSuccessCallback_64.Cancel(), mOnFailureCallback_64.Cancel());
     }
@@ -27774,7 +32723,14 @@ private:
     CHIP_ERROR TestWriteAttributeInt32sMaxValue_65()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         int32_t int32sArgument;
         int32sArgument = 2147483647L;
@@ -27790,7 +32746,14 @@ private:
     CHIP_ERROR TestReadAttributeInt32sMaxValue_66()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeInt32s(mOnSuccessCallback_66.Cancel(), mOnFailureCallback_66.Cancel());
     }
@@ -27806,7 +32769,14 @@ private:
     CHIP_ERROR TestWriteAttributeInt32sMinValue_67()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         int32_t int32sArgument;
         int32sArgument = -2147483648L;
@@ -27822,7 +32792,14 @@ private:
     CHIP_ERROR TestReadAttributeInt32sMinValue_68()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeInt32s(mOnSuccessCallback_68.Cancel(), mOnFailureCallback_68.Cancel());
     }
@@ -27838,7 +32815,14 @@ private:
     CHIP_ERROR TestWriteAttributeInt32sDefaultValue_69()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         int32_t int32sArgument;
         int32sArgument = 0L;
@@ -27854,7 +32838,14 @@ private:
     CHIP_ERROR TestReadAttributeInt32sDefaultValue_70()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeInt32s(mOnSuccessCallback_70.Cancel(), mOnFailureCallback_70.Cancel());
     }
@@ -27870,7 +32861,14 @@ private:
     CHIP_ERROR TestReadAttributeInt64sDefaultValue_71()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeInt64s(mOnSuccessCallback_71.Cancel(), mOnFailureCallback_71.Cancel());
     }
@@ -27886,7 +32884,14 @@ private:
     CHIP_ERROR TestWriteAttributeInt64sMaxValue_72()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         int64_t int64sArgument;
         int64sArgument = 9223372036854775807LL;
@@ -27902,7 +32907,14 @@ private:
     CHIP_ERROR TestReadAttributeInt64sMaxValue_73()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeInt64s(mOnSuccessCallback_73.Cancel(), mOnFailureCallback_73.Cancel());
     }
@@ -27918,7 +32930,14 @@ private:
     CHIP_ERROR TestWriteAttributeInt64sMinValue_74()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         int64_t int64sArgument;
         int64sArgument = -9223372036854775807LL;
@@ -27934,7 +32953,14 @@ private:
     CHIP_ERROR TestReadAttributeInt64sMinValue_75()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeInt64s(mOnSuccessCallback_75.Cancel(), mOnFailureCallback_75.Cancel());
     }
@@ -27950,7 +32976,14 @@ private:
     CHIP_ERROR TestWriteAttributeInt64sDefaultValue_76()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         int64_t int64sArgument;
         int64sArgument = 0LL;
@@ -27966,7 +32999,14 @@ private:
     CHIP_ERROR TestReadAttributeInt64sDefaultValue_77()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeInt64s(mOnSuccessCallback_77.Cancel(), mOnFailureCallback_77.Cancel());
     }
@@ -27982,7 +33022,14 @@ private:
     CHIP_ERROR TestReadAttributeEnum8DefaultValue_78()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeEnum8(mOnSuccessCallback_78.Cancel(), mOnFailureCallback_78.Cancel());
     }
@@ -27998,7 +33045,14 @@ private:
     CHIP_ERROR TestWriteAttributeEnum8MaxValue_79()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint8_t enum8Argument;
         enum8Argument = static_cast<uint8_t>(255);
@@ -28014,7 +33068,14 @@ private:
     CHIP_ERROR TestReadAttributeEnum8MaxValue_80()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeEnum8(mOnSuccessCallback_80.Cancel(), mOnFailureCallback_80.Cancel());
     }
@@ -28030,7 +33091,14 @@ private:
     CHIP_ERROR TestWriteAttributeEnum8MinValue_81()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint8_t enum8Argument;
         enum8Argument = static_cast<uint8_t>(0);
@@ -28046,7 +33114,14 @@ private:
     CHIP_ERROR TestReadAttributeEnum8MinValue_82()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeEnum8(mOnSuccessCallback_82.Cancel(), mOnFailureCallback_82.Cancel());
     }
@@ -28062,7 +33137,14 @@ private:
     CHIP_ERROR TestReadAttributeEnum16DefaultValue_83()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeEnum16(mOnSuccessCallback_83.Cancel(), mOnFailureCallback_83.Cancel());
     }
@@ -28078,7 +33160,14 @@ private:
     CHIP_ERROR TestWriteAttributeEnum16MaxValue_84()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint16_t enum16Argument;
         enum16Argument = static_cast<uint16_t>(65535);
@@ -28094,7 +33183,14 @@ private:
     CHIP_ERROR TestReadAttributeEnum16MaxValue_85()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeEnum16(mOnSuccessCallback_85.Cancel(), mOnFailureCallback_85.Cancel());
     }
@@ -28110,7 +33206,14 @@ private:
     CHIP_ERROR TestWriteAttributeEnum16MinValue_86()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint16_t enum16Argument;
         enum16Argument = static_cast<uint16_t>(0);
@@ -28126,7 +33229,14 @@ private:
     CHIP_ERROR TestReadAttributeEnum16MinValue_87()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeEnum16(mOnSuccessCallback_87.Cancel(), mOnFailureCallback_87.Cancel());
     }
@@ -28142,7 +33252,14 @@ private:
     CHIP_ERROR TestReadAttributeOctetStringDefaultValue_88()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOctetString(mOnSuccessCallback_88.Cancel(), mOnFailureCallback_88.Cancel());
     }
@@ -28158,7 +33275,14 @@ private:
     CHIP_ERROR TestWriteAttributeOctetString_89()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         chip::ByteSpan octetStringArgument;
         octetStringArgument = chip::ByteSpan(chip::Uint8::from_const_char("TestValue"), strlen("TestValue"));
@@ -28174,7 +33298,14 @@ private:
     CHIP_ERROR TestReadAttributeOctetString_90()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOctetString(mOnSuccessCallback_90.Cancel(), mOnFailureCallback_90.Cancel());
     }
@@ -28190,7 +33321,14 @@ private:
     CHIP_ERROR TestWriteAttributeOctetString_91()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         chip::ByteSpan octetStringArgument;
         octetStringArgument =
@@ -28207,7 +33345,14 @@ private:
     CHIP_ERROR TestReadAttributeOctetString_92()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOctetString(mOnSuccessCallback_92.Cancel(), mOnFailureCallback_92.Cancel());
     }
@@ -28223,7 +33368,14 @@ private:
     CHIP_ERROR TestWriteAttributeOctetString_93()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         chip::ByteSpan octetStringArgument;
         octetStringArgument = chip::ByteSpan(chip::Uint8::from_const_char(""), strlen(""));
@@ -28239,7 +33391,14 @@ private:
     CHIP_ERROR TestReadAttributeLongOctetStringDefaultValue_94()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeLongOctetString(mOnSuccessCallback_94.Cancel(), mOnFailureCallback_94.Cancel());
     }
@@ -28255,7 +33414,14 @@ private:
     CHIP_ERROR TestWriteAttributeLongOctetString_95()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         chip::ByteSpan longOctetStringArgument;
         longOctetStringArgument = chip::ByteSpan(
@@ -28278,7 +33444,14 @@ private:
     CHIP_ERROR TestReadAttributeLongOctetString_96()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeLongOctetString(mOnSuccessCallback_96.Cancel(), mOnFailureCallback_96.Cancel());
     }
@@ -28298,7 +33471,14 @@ private:
     CHIP_ERROR TestWriteAttributeLongOctetString_97()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         chip::ByteSpan longOctetStringArgument;
         longOctetStringArgument = chip::ByteSpan(chip::Uint8::from_const_char(""), strlen(""));
@@ -28314,7 +33494,14 @@ private:
     CHIP_ERROR TestReadAttributeCharStringDefaultValue_98()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeCharString(mOnSuccessCallback_98.Cancel(), mOnFailureCallback_98.Cancel());
     }
@@ -28330,7 +33517,14 @@ private:
     CHIP_ERROR TestWriteAttributeCharString_99()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         chip::CharSpan charStringArgument;
         charStringArgument = chip::Span<const char>("☉T☉", strlen("☉T☉"));
@@ -28346,7 +33540,14 @@ private:
     CHIP_ERROR TestWriteAttributeCharStringValueTooLong_100()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         chip::CharSpan charStringArgument;
         charStringArgument = chip::Span<const char>("☉TestValueLongerThan10☉", strlen("☉TestValueLongerThan10☉"));
@@ -28362,7 +33563,14 @@ private:
     CHIP_ERROR TestWriteAttributeCharStringEmpty_101()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         chip::CharSpan charStringArgument;
         charStringArgument = chip::Span<const char>("", strlen(""));
@@ -28378,7 +33586,14 @@ private:
     CHIP_ERROR TestReadAttributeLongCharStringDefaultValue_102()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeLongCharString(mOnSuccessCallback_102.Cancel(), mOnFailureCallback_102.Cancel());
     }
@@ -28394,7 +33609,14 @@ private:
     CHIP_ERROR TestWriteAttributeLongCharString_103()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         chip::CharSpan longCharStringArgument;
         longCharStringArgument = chip::Span<const char>(
@@ -28416,7 +33638,14 @@ private:
     CHIP_ERROR TestReadAttributeLongCharString_104()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeLongCharString(mOnSuccessCallback_104.Cancel(), mOnFailureCallback_104.Cancel());
     }
@@ -28436,7 +33665,14 @@ private:
     CHIP_ERROR TestWriteAttributeLongCharString_105()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         chip::CharSpan longCharStringArgument;
         longCharStringArgument = chip::Span<const char>("", strlen(""));
@@ -28452,7 +33688,14 @@ private:
     CHIP_ERROR TestReadAttributeList_106()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeListInt8u(mOnSuccessCallback_106.Cancel(), mOnFailureCallback_106.Cancel());
     }
@@ -28477,7 +33720,14 @@ private:
     CHIP_ERROR TestReadAttributeListOctetString_107()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeListOctetString(mOnSuccessCallback_107.Cancel(), mOnFailureCallback_107.Cancel());
     }
@@ -28502,7 +33752,14 @@ private:
     CHIP_ERROR TestReadAttributeListStructOctetString_108()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeListStructOctetString(mOnSuccessCallback_108.Cancel(), mOnFailureCallback_108.Cancel());
     }
@@ -28533,7 +33790,14 @@ private:
     CHIP_ERROR TestReadAttributeEpochUsDefaultValue_109()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeEpochUs(mOnSuccessCallback_109.Cancel(), mOnFailureCallback_109.Cancel());
     }
@@ -28549,7 +33813,14 @@ private:
     CHIP_ERROR TestWriteAttributeEpochUsMaxValue_110()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint64_t epochUsArgument;
         epochUsArgument = 18446744073709551615ULL;
@@ -28565,7 +33836,14 @@ private:
     CHIP_ERROR TestReadAttributeEpochUsMaxValue_111()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeEpochUs(mOnSuccessCallback_111.Cancel(), mOnFailureCallback_111.Cancel());
     }
@@ -28581,7 +33859,14 @@ private:
     CHIP_ERROR TestWriteAttributeEpochUsMinValue_112()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint64_t epochUsArgument;
         epochUsArgument = 0ULL;
@@ -28597,7 +33882,14 @@ private:
     CHIP_ERROR TestReadAttributeEpochUsMinValue_113()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeEpochUs(mOnSuccessCallback_113.Cancel(), mOnFailureCallback_113.Cancel());
     }
@@ -28613,7 +33905,14 @@ private:
     CHIP_ERROR TestReadAttributeEpochSDefaultValue_114()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeEpochS(mOnSuccessCallback_114.Cancel(), mOnFailureCallback_114.Cancel());
     }
@@ -28629,7 +33928,14 @@ private:
     CHIP_ERROR TestWriteAttributeEpochSMaxValue_115()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint32_t epochSArgument;
         epochSArgument = 4294967295UL;
@@ -28645,7 +33951,14 @@ private:
     CHIP_ERROR TestReadAttributeEpochSMaxValue_116()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeEpochS(mOnSuccessCallback_116.Cancel(), mOnFailureCallback_116.Cancel());
     }
@@ -28661,7 +33974,14 @@ private:
     CHIP_ERROR TestWriteAttributeEpochSMinValue_117()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint32_t epochSArgument;
         epochSArgument = 0UL;
@@ -28677,7 +33997,14 @@ private:
     CHIP_ERROR TestReadAttributeEpochSMinValue_118()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeEpochS(mOnSuccessCallback_118.Cancel(), mOnFailureCallback_118.Cancel());
     }
@@ -28693,7 +34020,14 @@ private:
     CHIP_ERROR TestReadAttributeUnsupported_119()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeUnsupported(mOnSuccessCallback_119.Cancel(), mOnFailureCallback_119.Cancel());
     }
@@ -28712,7 +34046,14 @@ private:
     CHIP_ERROR TestWriteattributeUnsupported_120()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         bool unsupportedArgument;
         unsupportedArgument = 0;
@@ -28731,7 +34072,14 @@ private:
     CHIP_ERROR TestSendTestCommandToUnsupportedEndpoint_121()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 200);
+        uint8_t endPoint = 200;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::TestCluster::Commands::Test::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -28755,7 +34103,14 @@ private:
     CHIP_ERROR TestReadAttributeVendorIdDefaultValue_122()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeVendorId(mOnSuccessCallback_122.Cancel(), mOnFailureCallback_122.Cancel());
     }
@@ -28771,7 +34126,14 @@ private:
     CHIP_ERROR TestWriteAttributeVendorId_123()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         chip::VendorId vendorIdArgument;
         vendorIdArgument = static_cast<chip::VendorId>(17);
@@ -28787,7 +34149,14 @@ private:
     CHIP_ERROR TestReadAttributeVendorId_124()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeVendorId(mOnSuccessCallback_124.Cancel(), mOnFailureCallback_124.Cancel());
     }
@@ -28803,7 +34172,14 @@ private:
     CHIP_ERROR TestRestoreAttributeVendorId_125()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         chip::VendorId vendorIdArgument;
         vendorIdArgument = static_cast<chip::VendorId>(0);
@@ -28819,7 +34195,14 @@ private:
     CHIP_ERROR TestSendACommandWithAVendorIdAndEnum_126()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::TestCluster::Commands::TestEnumsRequest::Type;
         using responseType = chip::app::Clusters::TestCluster::Commands::TestEnumsResponse::DecodableType;
@@ -28947,7 +34330,14 @@ private:
     CHIP_ERROR TestSendTestCommandWithStructArgumentAndArg1bIsTrue_0()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::TestCluster::Commands::TestStructArgumentRequest::Type;
         using responseType = chip::app::Clusters::TestCluster::Commands::BooleanResponse::DecodableType;
@@ -28982,7 +34372,14 @@ private:
     CHIP_ERROR TestSendTestCommandWithStructArgumentAndArg1bIsFalse_1()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::TestCluster::Commands::TestStructArgumentRequest::Type;
         using responseType = chip::app::Clusters::TestCluster::Commands::BooleanResponse::DecodableType;
@@ -29017,7 +34414,14 @@ private:
     CHIP_ERROR TestSendTestCommandWithListOfInt8uAndNoneOfThemIsSetTo0_2()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::TestCluster::Commands::TestListInt8UArgumentRequest::Type;
         using responseType = chip::app::Clusters::TestCluster::Commands::BooleanResponse::DecodableType;
@@ -29057,7 +34461,14 @@ private:
     CHIP_ERROR TestSendTestCommandWithListOfInt8uAndOneOfThemIsSetTo0_3()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::TestCluster::Commands::TestListInt8UArgumentRequest::Type;
         using responseType = chip::app::Clusters::TestCluster::Commands::BooleanResponse::DecodableType;
@@ -29098,7 +34509,14 @@ private:
     CHIP_ERROR TestSendTestCommandWithListOfInt8uAndGetItReversed_4()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::TestCluster::Commands::TestListInt8UReverseRequest::Type;
         using responseType = chip::app::Clusters::TestCluster::Commands::TestListInt8UReverseResponse::DecodableType;
@@ -29157,7 +34575,14 @@ private:
     CHIP_ERROR TestSendTestCommandWithEmptyListOfInt8uAndGetAnEmptyListBack_5()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::TestCluster::Commands::TestListInt8UReverseRequest::Type;
         using responseType = chip::app::Clusters::TestCluster::Commands::TestListInt8UReverseResponse::DecodableType;
@@ -29188,7 +34613,14 @@ private:
     CHIP_ERROR TestSendTestCommandWithListOfStructArgumentAndArg1bOfFirstItemIsTrue_6()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::TestCluster::Commands::TestListStructArgumentRequest::Type;
         using responseType = chip::app::Clusters::TestCluster::Commands::BooleanResponse::DecodableType;
@@ -29234,7 +34666,14 @@ private:
     CHIP_ERROR TestSendTestCommandWithListOfStructArgumentAndArg1bOfFirstItemIsFalse_7()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::TestCluster::Commands::TestListStructArgumentRequest::Type;
         using responseType = chip::app::Clusters::TestCluster::Commands::BooleanResponse::DecodableType;
@@ -29280,7 +34719,14 @@ private:
     CHIP_ERROR TestSendTestCommandWithOptionalArgSet_8()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::TestCluster::Commands::TestNullableOptionalRequest::Type;
         using responseType = chip::app::Clusters::TestCluster::Commands::TestNullableOptionalResponse::DecodableType;
@@ -29321,7 +34767,14 @@ private:
     CHIP_ERROR TestSendTestCommandWithoutItsOptionalArg_9()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::TestCluster::Commands::TestNullableOptionalRequest::Type;
         using responseType = chip::app::Clusters::TestCluster::Commands::TestNullableOptionalResponse::DecodableType;
@@ -29352,7 +34805,14 @@ private:
     CHIP_ERROR TestSendTestCommandWithOptionalArgSetToNull_10()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::TestCluster::Commands::TestNullableOptionalRequest::Type;
         using responseType = chip::app::Clusters::TestCluster::Commands::TestNullableOptionalResponse::DecodableType;
@@ -29497,7 +34957,14 @@ private:
     CHIP_ERROR TestWriteAttributeInt32uValue_0()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint32_t int32uArgument;
         int32uArgument = 5UL;
@@ -29513,7 +34980,14 @@ private:
     CHIP_ERROR TestReadAttributeInt32uValueMinValueConstraints_1()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeInt32u(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
     }
@@ -29529,7 +35003,14 @@ private:
     CHIP_ERROR TestReadAttributeInt32uValueMaxValueConstraints_2()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeInt32u(mOnSuccessCallback_2.Cancel(), mOnFailureCallback_2.Cancel());
     }
@@ -29545,7 +35026,14 @@ private:
     CHIP_ERROR TestReadAttributeInt32uValueNotValueConstraints_3()
     {
         chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeInt32u(mOnSuccessCallback_3.Cancel(), mOnFailureCallback_3.Cancel());
     }
@@ -29790,7 +35278,14 @@ private:
     CHIP_ERROR TestReadAttributeDeviceList_0()
     {
         chip::Controller::DescriptorClusterTest cluster;
-        cluster.Associate(mDevice, 0);
+        uint8_t endPoint = 0;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeDeviceList(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel());
     }
@@ -29810,7 +35305,14 @@ private:
     CHIP_ERROR TestReadAttributeServerList_1()
     {
         chip::Controller::DescriptorClusterTest cluster;
-        cluster.Associate(mDevice, 0);
+        uint8_t endPoint = 0;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeServerList(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
     }
@@ -29863,7 +35365,14 @@ private:
     CHIP_ERROR TestReadAttributeClientList_2()
     {
         chip::Controller::DescriptorClusterTest cluster;
-        cluster.Associate(mDevice, 0);
+        uint8_t endPoint = 0;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeClientList(mOnSuccessCallback_2.Cancel(), mOnFailureCallback_2.Cancel());
     }
@@ -29880,7 +35389,14 @@ private:
     CHIP_ERROR TestReadAttributePartsList_3()
     {
         chip::Controller::DescriptorClusterTest cluster;
-        cluster.Associate(mDevice, 0);
+        uint8_t endPoint = 0;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributePartsList(mOnSuccessCallback_3.Cancel(), mOnFailureCallback_3.Cancel());
     }
@@ -30004,7 +35520,14 @@ private:
     CHIP_ERROR TestReadLocation_0()
     {
         chip::Controller::BasicClusterTest cluster;
-        cluster.Associate(mDevice, 0);
+        uint8_t endPoint = 0;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeLocation(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel());
     }
@@ -30020,7 +35543,14 @@ private:
     CHIP_ERROR TestWriteLocation_1()
     {
         chip::Controller::BasicClusterTest cluster;
-        cluster.Associate(mDevice, 0);
+        uint8_t endPoint = 0;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         chip::CharSpan locationArgument;
         locationArgument = chip::Span<const char>("us", strlen("us"));
@@ -30036,7 +35566,14 @@ private:
     CHIP_ERROR TestReadBackLocation_2()
     {
         chip::Controller::BasicClusterTest cluster;
-        cluster.Associate(mDevice, 0);
+        uint8_t endPoint = 0;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeLocation(mOnSuccessCallback_2.Cancel(), mOnFailureCallback_2.Cancel());
     }
@@ -30052,7 +35589,14 @@ private:
     CHIP_ERROR TestRestoreInitialLocationValue_3()
     {
         chip::Controller::BasicClusterTest cluster;
-        cluster.Associate(mDevice, 0);
+        uint8_t endPoint = 0;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         chip::CharSpan locationArgument;
         locationArgument = chip::Span<const char>("", strlen(""));
@@ -30120,7 +35664,14 @@ private:
     CHIP_ERROR TestSendIdentifyCommandAndExpectSuccessResponse_0()
     {
         chip::Controller::IdentifyClusterTest cluster;
-        cluster.Associate(mDevice, 0);
+        uint8_t endPoint = 0;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::Identify::Commands::Identify::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -30245,7 +35796,14 @@ private:
     CHIP_ERROR TestReadNumberOfSupportedFabrics_0()
     {
         chip::Controller::OperationalCredentialsClusterTest cluster;
-        cluster.Associate(mDevice, 0);
+        uint8_t endPoint = 0;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeSupportedFabrics(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel());
     }
@@ -30262,7 +35820,14 @@ private:
     CHIP_ERROR TestReadNumberOfCommissionedFabrics_1()
     {
         chip::Controller::OperationalCredentialsClusterTest cluster;
-        cluster.Associate(mDevice, 0);
+        uint8_t endPoint = 0;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeCommissionedFabrics(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
     }
@@ -30279,7 +35844,14 @@ private:
     CHIP_ERROR TestReadCurrentFabricIndex_2()
     {
         chip::Controller::OperationalCredentialsClusterTest cluster;
-        cluster.Associate(mDevice, 0);
+        uint8_t endPoint = 0;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeCurrentFabricIndex(mOnSuccessCallback_2.Cancel(), mOnFailureCallback_2.Cancel());
     }
@@ -30457,7 +36029,14 @@ private:
     CHIP_ERROR TestReadCurrentMode_0()
     {
         chip::Controller::ModeSelectClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeCurrentMode(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel());
     }
@@ -30473,7 +36052,14 @@ private:
     CHIP_ERROR TestReadOnMode_1()
     {
         chip::Controller::ModeSelectClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeOnMode(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
     }
@@ -30489,7 +36075,14 @@ private:
     CHIP_ERROR TestReadStartUpMode_2()
     {
         chip::Controller::ModeSelectClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeStartUpMode(mOnSuccessCallback_2.Cancel(), mOnFailureCallback_2.Cancel());
     }
@@ -30505,7 +36098,14 @@ private:
     CHIP_ERROR TestReadDescription_3()
     {
         chip::Controller::ModeSelectClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeDescription(mOnSuccessCallback_3.Cancel(), mOnFailureCallback_3.Cancel());
     }
@@ -30521,7 +36121,14 @@ private:
     CHIP_ERROR TestReadSupportedModes_4()
     {
         chip::Controller::ModeSelectClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeSupportedModes(mOnSuccessCallback_4.Cancel(), mOnFailureCallback_4.Cancel());
     }
@@ -30552,7 +36159,14 @@ private:
     CHIP_ERROR TestChangeToSupportedMode_5()
     {
         chip::Controller::ModeSelectClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::ModeSelect::Commands::ChangeToMode::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -30577,7 +36191,14 @@ private:
     CHIP_ERROR TestVerifyCurrentModeChange_6()
     {
         chip::Controller::ModeSelectClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeCurrentMode(mOnSuccessCallback_6.Cancel(), mOnFailureCallback_6.Cancel());
     }
@@ -30593,7 +36214,14 @@ private:
     CHIP_ERROR TestChangeToUnsupportedMode_7()
     {
         chip::Controller::ModeSelectClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::ModeSelect::Commands::ChangeToMode::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -30716,7 +36344,14 @@ private:
     CHIP_ERROR TestReadsCurrentHeapFreeNonGlobalAttributeValueFromDut_0()
     {
         chip::Controller::SoftwareDiagnosticsClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeCurrentHeapFree(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel());
     }
@@ -30735,7 +36370,14 @@ private:
     CHIP_ERROR TestReadsCurrentHeapUsedNonGlobalAttributeValueFromDut_1()
     {
         chip::Controller::SoftwareDiagnosticsClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeCurrentHeapUsed(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
     }
@@ -30754,7 +36396,14 @@ private:
     CHIP_ERROR TestReadsCurrentHeapHighWaterMarkNonGlobalAttributeValueFromDut_2()
     {
         chip::Controller::SoftwareDiagnosticsClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReadAttributeCurrentHeapHighWatermark(mOnSuccessCallback_2.Cancel(), mOnFailureCallback_2.Cancel());
     }
@@ -30904,7 +36553,14 @@ private:
     CHIP_ERROR TestSetOnOffAttributeToFalse_0()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::OnOff::Commands::Off::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -30928,7 +36584,14 @@ private:
     CHIP_ERROR TestReportSubscribeOnOffAttribute_1()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         ReturnErrorOnFailure(cluster.ReportAttributeOnOff(mOnSuccessCallback_1.Cancel()));
 
@@ -30948,7 +36611,14 @@ private:
     CHIP_ERROR TestSubscribeOnOffAttribute_2()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         uint16_t minIntervalArgument;
         minIntervalArgument = 2U;
@@ -30971,7 +36641,14 @@ private:
     CHIP_ERROR TestTurnOnTheLightToSeeAttributeChange_3()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::OnOff::Commands::On::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -30995,7 +36672,14 @@ private:
     CHIP_ERROR TestCheckForAttributeReport_4()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReportAttributeOnOff(mOnSuccessCallback_4.Cancel());
     }
@@ -31014,7 +36698,14 @@ private:
     CHIP_ERROR TestTurnOffTheLightToSeeAttributeChange_5()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         using requestType  = chip::app::Clusters::OnOff::Commands::Off::Type;
         using responseType = chip::app::DataModel::NullObjectType;
@@ -31038,7 +36729,14 @@ private:
     CHIP_ERROR TestCheckForAttributeReport_6()
     {
         chip::Controller::OnOffClusterTest cluster;
-        cluster.Associate(mDevice, 1);
+        uint8_t endPoint = 1;
+        Argument arg     = mOptionalArgs.at((size_t) 0);
+        if (arg.isProvided)
+        {
+            endPoint = mEndPointId;
+        }
+        ChipLogProgress(chipTool, "Was Provided: %s and Enpoint Value: %d", arg.isProvided ? "true" : "false", endPoint);
+        cluster.Associate(mDevice, endPoint);
 
         return cluster.ReportAttributeOnOff(mOnSuccessCallback_6.Cancel());
     }


### PR DESCRIPTION
#### Problem
- Add optional arguments to chip-tool
- Add ability to set EndPoint ID on chip tool command run.
- Issued [Here #11100 ](https://github.com/project-chip/connectedhomeip/issues/11102)


#### Change overview
In chip-tool add an argument that will allow adding optional arguments. Optional arguments. ZAP file updates to add the optional flag to false.

#### Testing
- Tested Zap generation with the generate command. 
- Testsed compilation with ninja
- Tested chip-tool optional arguments.
- Tested pairing command.
- Tested tests command in chip-tool.
