### PR TITLE
Fix chip-tool open-commissioning-window to not crash.

### DIFF
--- a/examples/chip-tool/commands/pairing/PairingCommand.cpp
+++ b/examples/chip-tool/commands/pairing/PairingCommand.cpp
@@ -36,8 +36,15 @@ CHIP_ERROR PairingCommand::RunCommand()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    mController.RegisterDeviceAddressUpdateDelegate(this);
-    mController.RegisterPairingDelegate(this);
+    // If we're OpenCommissioningWindow we don't need to be registered as a
+    // delegate; we just get notified directly via the callbacks we pass to
+    // GetConnectedDevice.  In fact, if we _do_ register as a delegate we get
+    // callbacks we don't expect and then weird things happen.
+    if (mPairingMode != PairingMode::OpenCommissioningWindow)
+    {
+        mController.RegisterDeviceAddressUpdateDelegate(this);
+        mController.RegisterPairingDelegate(this);
+    }
 
     err = RunInternal(mNodeId);
     VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(chipTool, "Init Failure! PairDevice: %s", ErrorStr(err)));


### PR DESCRIPTION
PairingCommand::RunCommand called mController.RegisterPairingDelegate
even in the open-commissioning-window case.  Then when the device was
connected we'd land in DeviceCommissioner::OnDeviceConnectedFn. This
would call OnCommissioningComplete on the pairing delegate, which
would land us in PairingCommand::OnCommissioningComplete and thinks
the command is done.

So we would exit without waiting for an actual response from the
server and with exchanges still open.

In PairingMode::OpenCommissioningWindow we should not be registering
as a pairing delegate and whatnot; we are just sending normal cluster
commands.

Fixes https://github.com/project-chip/connectedhomeip/issues/11644

#### Problem
See above.

#### Change overview
See above.

#### Testing
Manually ran steps from #11644 and verified crash before this change, no crash after.