### PR TITLE
[Group] Move group session check to ExchangeContext

### DIFF
--- a/src/messaging/ExchangeContext.cpp
+++ b/src/messaging/ExchangeContext.cpp
@@ -119,15 +119,6 @@ CHIP_ERROR ExchangeContext::SendMessage(Protocols::Id protocolId, uint8_t msgTyp
     // Don't let method get called on a freed object.
     VerifyOrDie(mExchangeMgr != nullptr && GetReferenceCount() > 0);
 
-    // Check if we can safely send message to a group
-    if (IsGroupExchangeContext())
-    {
-        if (!IsValidGroupMsgType(protocolId, msgType))
-        {
-            return CHIP_ERROR_INCORRECT_STATE;
-        }
-    }
-
     // we hold the exchange context here in case the entity that
     // originally generated it tries to close it as a result of
     // an error arising below. at the end, we have to close it.
@@ -508,23 +499,6 @@ void ExchangeContext::MessageHandled()
     }
 
     Close();
-}
-
-bool ExchangeContext::IsValidGroupMsgType(Protocols::Id protocolId, uint8_t msgType)
-{
-    // Spec 8.2.4
-    if (protocolId == Protocols::InteractionModel::Id)
-    {
-        switch (msgType)
-        {
-        case to_underlying(Protocols::InteractionModel::MsgType::WriteRequest):
-        case to_underlying(Protocols::InteractionModel::MsgType::InvokeCommandRequest):
-            return true;
-        default:
-            return false;
-        }
-    }
-    return false;
 }
 
 } // namespace Messaging

--- a/src/messaging/ExchangeContext.cpp
+++ b/src/messaging/ExchangeContext.cpp
@@ -139,8 +139,9 @@ CHIP_ERROR ExchangeContext::SendMessage(Protocols::Id protocolId, uint8_t msgTyp
     // Treat unknown peer address as "not UDP", because we have no idea whether
     // it's safe to do MRP there.
     bool isUDPTransport = peerAddress && peerAddress->GetTransportType() == Transport::Type::kUdp;
-    bool reliableTransmissionRequested =
-        isUDPTransport && !sendFlags.Has(SendMessageFlags::kNoAutoRequestAck) && !IsGroupExchangeContext();
+
+    // this check is ignored by the ExchangeMsgDispatch if !AutoRequestAck()
+    bool reliableTransmissionRequested = isUDPTransport && !sendFlags.Has(SendMessageFlags::kNoAutoRequestAck);
 
     // If a response message is expected...
     if (sendFlags.Has(SendMessageFlags::kExpectResponse) && !IsGroupExchangeContext())

--- a/src/messaging/ExchangeContext.h
+++ b/src/messaging/ExchangeContext.h
@@ -234,8 +234,6 @@ private:
 
     void DoClose(bool clearRetransTable);
 
-    static bool IsValidGroupMsgType(Protocols::Id protocolId, uint8_t msgType);
-
     /**
      * We have handled an application-level message in some way and should
      * re-evaluate out state to see whether we should still be open.

--- a/src/messaging/ExchangeContext.h
+++ b/src/messaging/ExchangeContext.h
@@ -76,6 +76,8 @@ public:
 
     bool IsEncryptionRequired() const { return mDispatch->IsEncryptionRequired(); }
 
+    bool IsGroupExchangeContext() const { return (mSession.HasValue() && mSession.Value().IsGroupSession()); }
+
     /**
      *  Send a CHIP message on this exchange.
      *
@@ -231,6 +233,8 @@ private:
     static void HandleResponseTimeout(System::Layer * aSystemLayer, void * aAppState);
 
     void DoClose(bool clearRetransTable);
+
+    static bool IsValidGroupMsgType(Protocols::Id protocolId, uint8_t msgType);
 
     /**
      * We have handled an application-level message in some way and should


### PR DESCRIPTION
#### Problem
Partial Fix of #11631 

#### Change overview
Move Group check from WriteClient to ExchangeContext.
Exchange Timeout and Response flag are now ignored for a group exchange

#### Testing
Tested with Unit tests