### PR TITLE
[Android] Move InitChipStack() to AndroidChipPlatform

### DIFF
--- a/src/app/server/java/AppMain.cpp
+++ b/src/app/server/java/AppMain.cpp
@@ -45,9 +45,6 @@ CHIP_ERROR ChipAndroidAppInit(void)
     err = chip::Platform::MemoryInit();
     SuccessOrExit(err);
 
-    err = chip::DeviceLayer::PlatformMgr().InitChipStack();
-    SuccessOrExit(err);
-
     ConfigurationMgr().LogDeviceConfig();
 
     // Init ZCL Data Model and CHIP App Server

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -146,10 +146,6 @@ JNI_METHOD(jlong, newDeviceController)(JNIEnv * env, jobject self)
 
     ChipLogProgress(Controller, "newDeviceController() called");
 
-    // sSystemLayer and sInetLayer are in platform/android to share with app server
-    err = DeviceLayer::PlatformMgr().InitChipStack();
-    SuccessOrExit(err);
-
     wrapper = AndroidDeviceControllerWrapper::AllocateNew(sJVM, self, kLocalDeviceId, &DeviceLayer::SystemLayer(),
                                                           &DeviceLayer::InetLayer(), &err);
     SuccessOrExit(err);

--- a/src/platform/android/AndroidChipPlatform-JNI.cpp
+++ b/src/platform/android/AndroidChipPlatform-JNI.cpp
@@ -96,7 +96,8 @@ void AndroidChipPlatformJNI_OnUnload(JavaVM * jvm, void * reserved)
     chip::Platform::MemoryShutdown();
 }
 
-JNI_METHOD(void, initChipStack)(JNIEnv * env, jobject self) {
+JNI_METHOD(void, initChipStack)(JNIEnv * env, jobject self)
+{
     CHIP_ERROR err = chip::DeviceLayer::PlatformMgr().InitChipStack();
     VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(DeviceLayer, "Error initializing CHIP stack: %s", ErrorStr(err)));
 }

--- a/src/platform/android/AndroidChipPlatform-JNI.cpp
+++ b/src/platform/android/AndroidChipPlatform-JNI.cpp
@@ -96,6 +96,11 @@ void AndroidChipPlatformJNI_OnUnload(JavaVM * jvm, void * reserved)
     chip::Platform::MemoryShutdown();
 }
 
+JNI_METHOD(void, initChipStack)(JNIEnv * env, jobject self) {
+    CHIP_ERROR err = chip::DeviceLayer::PlatformMgr().InitChipStack();
+    VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(DeviceLayer, "Error initializing CHIP stack: %s", ErrorStr(err)));
+}
+
 // for BLEManager
 JNI_METHOD(void, nativeSetBLEManager)(JNIEnv *, jobject, jobject manager)
 {

--- a/src/platform/android/java/chip/platform/AndroidChipPlatform.java
+++ b/src/platform/android/java/chip/platform/AndroidChipPlatform.java
@@ -26,7 +26,10 @@ public final class AndroidChipPlatform {
       ConfigurationManager cfg,
       ServiceResolver resolver,
       ChipMdnsCallback chipMdnsCallback) {
+    // Order is important here: initChipStack() initializes the BLEManagerImpl, which depends on the
+    // BLEManager being set. setConfigurationManager() depends on the CHIP stack being initialized.
     setBLEManager(ble);
+    initChipStack();
     setKeyValueStoreManager(kvm);
     setConfigurationManager(cfg);
     setServiceResolver(resolver, chipMdnsCallback);
@@ -71,6 +74,9 @@ public final class AndroidChipPlatform {
 
   // for ConfigurationManager
   private native void setConfigurationManager(ConfigurationManager manager);
+
+  /** Initialize the CHIP stack. */
+  private native void initChipStack();
 
   // for ServiceResolver
   private void setServiceResolver(ServiceResolver resolver, ChipMdnsCallback chipMdnsCallback) {


### PR DESCRIPTION
#### Problem
* After #11534, `setConfigurationManager()` relies on `chip::DeviceLayer::ConfigurationMgr()`, but since the CHIP stack has not been initialized at this point, it aborts.

#### Change overview
* Move `InitChipStack()` to native method in `AndroidChipPlatform.java`. Call it in the constructor before `setConfigurationManager()`.
* Remove `InitChipStack()` calls from CHIPDeviceController-JNI.cpp and AppMain.cpp.

#### Testing
* Was able to initialize ChipDeviceController. Can't test full commissioning/control since commissioning was broken sometime recently (still investigating).
