### PR TITLE
Add CHIPTool cmd to start UDC server and listen for UDC requests

### DIFF
--- a/examples/chip-tool/BUILD.gn
+++ b/examples/chip-tool/BUILD.gn
@@ -52,6 +52,7 @@ executable("chip-tool") {
   defines = [ "CONFIG_USE_SEPARATE_EVENTLOOP=${config_use_separate_eventloop}" ]
 
   deps = [
+    "${chip_root}/src/app/server",
     "${chip_root}/src/controller/data_model",
     "${chip_root}/src/lib",
     "${chip_root}/src/platform",

--- a/examples/chip-tool/args.gni
+++ b/examples/chip-tool/args.gni
@@ -15,3 +15,10 @@
 import("//build_overrides/chip.gni")
 
 import("${chip_root}/config/standalone/args.gni")
+
+chip_device_project_config_include = "<CHIPProjectAppConfig.h>"
+chip_project_config_include = "<CHIPProjectAppConfig.h>"
+chip_system_project_config_include = "<SystemProjectConfig.h>"
+
+chip_project_config_include_dirs = [ "${chip_root}/examples/chip-tool/include" ]
+chip_project_config_include_dirs += [ "${chip_root}/config/standalone" ]

--- a/examples/chip-tool/commands/pairing/Commands.h
+++ b/examples/chip-tool/commands/pairing/Commands.h
@@ -22,6 +22,9 @@
 #include "ConfigureFabricCommand.h"
 #include "PairingCommand.h"
 
+#include <app/server/Dnssd.h>
+#include <lib/dnssd/Resolver.h>
+
 class Unpair : public PairingCommand
 {
 public:
@@ -149,6 +152,19 @@ public:
     {}
 };
 
+class StartUdcServerCommand : public CHIPCommand
+{
+public:
+    StartUdcServerCommand() : CHIPCommand("start-udc-server") {}
+    chip::System::Clock::Timeout GetWaitDuration() const override { return chip::System::Clock::Seconds16(300); }
+
+    CHIP_ERROR RunCommand() override
+    {
+        chip::app::DnssdServer::Instance().StartServer(chip::Dnssd::CommissioningMode::kDisabled);
+        return CHIP_NO_ERROR;
+    }
+};
+
 void registerCommandsPairing(Commands & commands)
 {
     const char * clusterName = "Pairing";
@@ -174,6 +190,7 @@ void registerCommandsPairing(Commands & commands)
         // TODO - enable CommissionedListCommand once DNS Cache is implemented
         //        make_unique<CommissionedListCommand>(),
         make_unique<ConfigureFabricCommand>(),
+        make_unique<StartUdcServerCommand>(),
     };
 
     commands.Register(clusterName, clusterCommands);

--- a/examples/chip-tool/include/CHIPProjectAppConfig.h
+++ b/examples/chip-tool/include/CHIPProjectAppConfig.h
@@ -1,0 +1,75 @@
+/*
+ *
+ *    Copyright (c) 2020-2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      Project configuration for CHIP Tool.
+ *
+ */
+#ifndef CHIPPROJECTCONFIG_H
+#define CHIPPROJECTCONFIG_H
+
+#define CHIP_CONFIG_ENABLE_EPHEMERAL_UDP_PORT 1
+
+#define CHIP_CONFIG_EVENT_LOGGING_UTC_TIMESTAMPS 1
+
+#define CHIP_CONFIG_EVENT_LOGGING_NUM_EXTERNAL_CALLBACKS 2
+
+#define CHIP_CONFIG_EVENT_LOGGING_EXTERNAL_EVENT_SUPPORT 1
+
+// Uncomment this for a large Tunnel MTU.
+//#define CHIP_CONFIG_TUNNEL_INTERFACE_MTU                           (9000)
+
+// Enable support functions for parsing command-line arguments
+#define CHIP_CONFIG_ENABLE_ARG_PARSER 1
+
+// Use a default pairing code if one hasn't been provisioned in flash.
+#define CHIP_DEVICE_CONFIG_USE_TEST_SETUP_PIN_CODE 20202021
+#define CHIP_DEVICE_CONFIG_USE_TEST_SETUP_DISCRIMINATOR 0xF00
+
+// Enable reading DRBG seed data from /dev/(u)random.
+// This is needed for test applications and the CHIP device manager to function
+// properly when CHIP_CONFIG_RNG_IMPLEMENTATION_CHIPDRBG is enabled.
+#define CHIP_CONFIG_DEV_RANDOM_DRBG_SEED 1
+
+// For convenience, Chip Security Test Mode can be enabled and the
+// requirement for authentication in various protocols can be disabled.
+//
+//    WARNING: These options make it possible to circumvent basic Chip security functionality,
+//    including message encryption. Because of this they MUST NEVER BE ENABLED IN PRODUCTION BUILDS.
+//
+#define CHIP_CONFIG_SECURITY_TEST_MODE 0
+#define CHIP_CONFIG_REQUIRE_AUTH 1
+
+// Increase session idle timeout in stand-alone builds for the convenience of developers.
+#define CHIP_CONFIG_DEFAULT_SECURITY_SESSION_IDLE_TIMEOUT 120000
+
+#define CHIP_CONFIG_ENABLE_UPDATE 1
+
+#define CHIP_CONFIG_LEGACY_CASE_AUTH_DELEGATE 0
+
+#define CHIP_CONFIG_LEGACY_KEY_EXPORT_DELEGATE 0
+
+#define CHIP_SYSTEM_CONFIG_PACKETBUFFER_POOL_SIZE 0
+
+#define CHIP_CONFIG_DATA_MANAGEMENT_CLIENT_EXPERIMENTAL 1
+
+#define CHIP_DEVICE_CONFIG_ENABLE_TEST_DEVICE_IDENTITY 1
+
+#define CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY 1
+
+#endif /* CHIPPROJECTCONFIG_H */


### PR DESCRIPTION
#### Problem
For a Matter Test event, we need to run the chip-tool on a raspi and test the tv-casting-app against it. For this the tool needs to be discoverable over DNS-SD as a commissioner,  have it listen to UDC requests, parse and log the output.
(After this, the tool would be used to commission the tv-casting-app onnetwork, for which the chip-tool command already exists)

#### Change overview
1. Introduces a new pairing start-udc-server command that advertises commissioner and 
2. Provides a way to override feature flags for the CHIP tool project (needed to set CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY to 1).

#### Testing
Tested to make sure that the chip-tool, when running the start-udc-server command can be discovered by the tv-casting-app AND that it receives and logs information about the UDC request that is sent by the tv-casting-app.