### PR TITLE
Add a ld file in all-cluster-app/esp32 for tracing

### DIFF
--- a/examples/all-clusters-app/esp32/main/CMakeLists.txt
+++ b/examples/all-clusters-app/esp32/main/CMakeLists.txt
@@ -219,6 +219,11 @@ target_link_libraries(${COMPONENT_LIB} PUBLIC
   pw_trace_tokenized.protos.nanopb_rpc
 )
 
+target_link_options(${COMPONENT_LIB}
+  PUBLIC
+    "-T${PIGWEED_ROOT}/pw_tokenizer/pw_tokenizer_linker_sections.ld"
+)
+
 set_property(TARGET ${chip_lib} APPEND PROPERTY LINK_LIBRARIES ${COMPONENT_LIB})
 target_include_directories(${chip_lib} PUBLIC
                           "$<TARGET_FILE_DIR:${chip_lib}>/protocol_buffer/gen/third_party/connectedhomeip/third_party/pigweed/repo/pw_rpc/protos.proto_library/nanopb_rpc"


### PR DESCRIPTION
pw_trace_tokenized backend depends on pw_tokenizer which requires
this ld file.

#### Problem
PR #11203 adds trace functionality to the example but it is missing this ld file.

#### Change overview
Add pw_tokenizer_linker_sections.ld

#### Testing
build eps32 all-cluster-app and check string tokenized.
