### PR TITLE
[esp32] migrate ESP32 dokcer image to 0.5.27

### DIFF
--- a/.github/workflows/examples-esp32.yaml
+++ b/.github/workflows/examples-esp32.yaml
@@ -38,7 +38,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: connectedhomeip/chip-build-esp32:0.5.25
+            image: connectedhomeip/chip-build-esp32:0.5.27
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
 

--- a/.github/workflows/qemu.yaml
+++ b/.github/workflows/qemu.yaml
@@ -34,7 +34,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: connectedhomeip/chip-build-esp32-qemu:0.5.25
+            image: connectedhomeip/chip-build-esp32-qemu:0.5.27
             volumes:
                 - "/tmp/log_output:/tmp/test_logs"
 

--- a/.github/workflows/release_artifacts.yaml
+++ b/.github/workflows/release_artifacts.yaml
@@ -29,7 +29,7 @@ jobs:
         runs-on: ubuntu-latest
 
         container:
-            image: connectedhomeip/chip-build-esp32:0.5.25
+            image: connectedhomeip/chip-build-esp32:0.5.27
 
         steps:
             - name: Checkout

--- a/config/esp32/components/chip/component.mk
+++ b/config/esp32/components/chip/component.mk
@@ -99,8 +99,8 @@ COMPONENT_ADD_INCLUDEDIRS +=   $(REL_OUTPUT_DIR)/src/include \
 
 # Tell the ESP-IDF build system that the CHIP component defines its own build
 # and clean targets.
-COMPONENT_OWNBUILDTARGET 	 = 1
-COMPONENT_OWNCLEANTARGET 	 = 1
+COMPONENT_OWNBUILDTARGET 	 := chip_build
+COMPONENT_OWNCLEANTARGET 	 := chip_clean
 
 is_debug ?= true
 
@@ -156,10 +156,10 @@ endif
 	cd $(COMPONENT_PATH); ninja $(subst 1,-v,$(filter 1,$(V))) -C $(OUTPUT_DIR) esp32
 
 
-build : install-chip
+chip_build : install-chip
 	echo "CHIP built and installed..."
 	cp -a ${OUTPUT_DIR}/lib/libCHIP.a ${OUTPUT_DIR}/libchip.a
 
-clean:
+chip_clean:
 	echo "RM $(OUTPUT_DIR)"
 	rm -rf $(OUTPUT_DIR)

--- a/scripts/requirements.esp32.txt
+++ b/scripts/requirements.esp32.txt
@@ -1,10 +1,11 @@
 setuptools>=21
-click>=5.0
-pyserial>=3.0
+click>=7.0
+pyserial>=3.3
 future>=0.15.2
 cryptography>=2.1.4
 pyparsing>=2.0.3,<2.4.0
 pyelftools>=0.22
+idf-component-manager>=0.2.99-beta
 gdbgui==0.13.2.0
 pygdbmi<=0.9.0.2
 reedsolo>=1.5.3,<=1.5.4


### PR DESCRIPTION
#### Problem

Updating to docker image 0.5.27 will cause ESP32 build to fail.

#### Change overview

As required in https://github.com/project-chip/connectedhomeip/pull/11588, we'll create a separate PR for the build fix.
The MR updates the docker image used for ESP32 and fixes build with ESP-IDF v4.4 release.

#### Testing

Tested by github action.
