### PR TITLE
esp32: fix QR code URL in shell command

### DIFF
--- a/examples/all-clusters-app/esp32/main/main.cpp
+++ b/examples/all-clusters-app/esp32/main/main.cpp
@@ -582,12 +582,12 @@ extern "C" void app_main()
     chip::DeviceLayer::PlatformMgr().ScheduleWork(InitServer, reinterpret_cast<intptr_t>(nullptr));
 
     // Print QR Code URL
-    PrintOnboardingCodes(chip::RendezvousInformationFlags(chip::RendezvousInformationFlag::kBLE));
+    PrintOnboardingCodes(chip::RendezvousInformationFlags(CONFIG_RENDEZVOUS_MODE));
 
 #if CONFIG_HAVE_DISPLAY
     std::string qrCodeText;
 
-    GetQRCode(qrCodeText, chip::RendezvousInformationFlags(chip::RendezvousInformationFlag::kBLE));
+    GetQRCode(qrCodeText, chip::RendezvousInformationFlags(CONFIG_RENDEZVOUS_MODE));
 
     // Initialize the display device.
     err = InitDisplay();

--- a/examples/all-clusters-app/esp32/main/main.cpp
+++ b/examples/all-clusters-app/esp32/main/main.cpp
@@ -81,8 +81,6 @@ using namespace ::chip::Credentials;
 using namespace ::chip::DeviceManager;
 using namespace ::chip::DeviceLayer;
 
-#define QRCODE_BASE_URL "https://dhrishi.github.io/connectedhomeip/qrcode.html"
-
 #if CONFIG_DEVICE_TYPE_M5STACK
 
 #define BUTTON_1_GPIO_NUM GPIO_NUM_39    // Left button on M5Stack
@@ -495,119 +493,6 @@ void SetupPretendDevices()
     AddAttribute("State", "Closed");
 }
 
-void GetGatewayIP(char * ip_buf, size_t ip_len)
-{
-    esp_netif_ip_info_t ipInfo;
-    esp_netif_get_ip_info(esp_netif_get_handle_from_ifkey("WIFI_AP_DEF"), &ipInfo);
-    esp_ip4addr_ntoa(&ipInfo.ip, ip_buf, ip_len);
-    ESP_LOGI(TAG, "Got gateway ip %s", ip_buf);
-}
-
-bool isRendezvousBLE()
-{
-    RendezvousInformationFlags flags = RendezvousInformationFlags(CONFIG_RENDEZVOUS_MODE);
-    return flags.Has(RendezvousInformationFlag::kBLE);
-}
-
-std::string createSetupPayload()
-{
-    CHIP_ERROR err = CHIP_NO_ERROR;
-    std::string result;
-
-    uint16_t discriminator;
-    err = ConfigurationMgr().GetSetupDiscriminator(discriminator);
-    if (err != CHIP_NO_ERROR)
-    {
-        ESP_LOGE(TAG, "Couldn't get discriminator: %s", ErrorStr(err));
-        return result;
-    }
-    ESP_LOGI(TAG, "Setup discriminator: %u (0x%x)", discriminator, discriminator);
-
-    uint32_t setupPINCode;
-    err = ConfigurationMgr().GetSetupPinCode(setupPINCode);
-    if (err != CHIP_NO_ERROR)
-    {
-        ESP_LOGE(TAG, "Couldn't get setupPINCode: %s", ErrorStr(err));
-        return result;
-    }
-    ESP_LOGI(TAG, "Setup PIN code: %u (0x%x)", setupPINCode, setupPINCode);
-
-    uint16_t vendorId;
-    err = ConfigurationMgr().GetVendorId(vendorId);
-    if (err != CHIP_NO_ERROR)
-    {
-        ESP_LOGE(TAG, "Couldn't get vendorId: %s", ErrorStr(err));
-        return result;
-    }
-
-    uint16_t productId;
-    err = ConfigurationMgr().GetProductId(productId);
-    if (err != CHIP_NO_ERROR)
-    {
-        ESP_LOGE(TAG, "Couldn't get productId: %s", ErrorStr(err));
-        return result;
-    }
-
-    SetupPayload payload;
-    payload.version               = 0;
-    payload.discriminator         = discriminator;
-    payload.setUpPINCode          = setupPINCode;
-    payload.rendezvousInformation = RendezvousInformationFlags(CONFIG_RENDEZVOUS_MODE);
-    payload.vendorID              = vendorId;
-    payload.productID             = productId;
-
-    if (!isRendezvousBLE())
-    {
-        char gw_ip[INET6_ADDRSTRLEN];
-        GetGatewayIP(gw_ip, sizeof(gw_ip));
-        payload.addOptionalVendorData(EXAMPLE_VENDOR_TAG_IP, gw_ip);
-
-        QRCodeSetupPayloadGenerator generator(payload);
-
-        size_t tlvDataLen = sizeof(gw_ip);
-        uint8_t tlvDataStart[tlvDataLen];
-        err = generator.payloadBase38Representation(result, tlvDataStart, tlvDataLen);
-    }
-    else
-    {
-        QRCodeSetupPayloadGenerator generator(payload);
-        err = generator.payloadBase38Representation(result);
-    }
-
-    {
-        ManualSetupPayloadGenerator generator(payload);
-        std::string outCode;
-
-        if (generator.payloadDecimalStringRepresentation(outCode) == CHIP_NO_ERROR)
-        {
-            ESP_LOGI(TAG, "Short Manual(decimal) setup code: %s", outCode.c_str());
-        }
-        else
-        {
-            ESP_LOGE(TAG, "Failed to get decimal setup code");
-        }
-
-        payload.commissioningFlow = CommissioningFlow::kCustom;
-        generator                 = ManualSetupPayloadGenerator(payload);
-
-        if (generator.payloadDecimalStringRepresentation(outCode) == CHIP_NO_ERROR)
-        {
-            // intentional extra space here to align the log with the short code
-            ESP_LOGI(TAG, "Long Manual(decimal) setup code:  %s", outCode.c_str());
-        }
-        else
-        {
-            ESP_LOGE(TAG, "Failed to get decimal setup code");
-        }
-    }
-
-    if (err != CHIP_NO_ERROR)
-    {
-        ESP_LOGE(TAG, "Couldn't get payload string %" CHIP_ERROR_FORMAT, err.Format());
-    }
-    return result;
-};
-
 WiFiWidget pairingWindowLED;
 
 class AppCallbacks : public AppDelegate
@@ -696,20 +581,14 @@ extern "C" void app_main()
 
     chip::DeviceLayer::PlatformMgr().ScheduleWork(InitServer, reinterpret_cast<intptr_t>(nullptr));
 
-    std::string qrCodeText = createSetupPayload();
-    ESP_LOGI(TAG, "QR CODE Text: '%s'", qrCodeText.c_str());
-
-    {
-        std::vector<char> qrCode(3 * qrCodeText.size() + 1);
-        CHIP_ERROR error = EncodeQRCodeToUrl(qrCodeText.c_str(), qrCodeText.size(), qrCode.data(), qrCode.max_size());
-        if (error == CHIP_NO_ERROR)
-        {
-            ESP_LOGI(TAG, "Copy/paste the below URL in a browser to see the QR CODE:\n\t%s?data=%s", QRCODE_BASE_URL,
-                     qrCode.data());
-        }
-    }
+    // Print QR Code URL
+    PrintOnboardingCodes(chip::RendezvousInformationFlags(chip::RendezvousInformationFlag::kBLE));
 
 #if CONFIG_HAVE_DISPLAY
+    std::string qrCodeText;
+
+    GetQRCode(qrCodeText, chip::RendezvousInformationFlags(chip::RendezvousInformationFlag::kBLE));
+
     // Initialize the display device.
     err = InitDisplay();
     if (err != ESP_OK)

--- a/src/app/server/OnboardingCodesUtil.cpp
+++ b/src/app/server/OnboardingCodesUtil.cpp
@@ -48,8 +48,7 @@ void PrintOnboardingCodes(chip::RendezvousInformationFlags aRendezvousFlags)
         ChipLogProgress(AppServer, "SetupQRCode: [%s]", qrCode.c_str());
         if (GetQRCodeUrl(qrCodeBuffer.Get(), qrCodeBufferMaxSize, qrCode) == CHIP_NO_ERROR)
         {
-            ChipLogProgress(AppServer, "Copy/paste the below URL in a browser to see the QR Code:");
-            ChipLogProgress(AppServer, "%s", qrCodeBuffer.Get());
+            ChipLogProgress(AppServer, "Copy/paste the below URL in a browser to see the QR Code:\r\n    %s", qrCodeBuffer.Get());
         }
     }
     else

--- a/src/lib/shell/commands/OnboardingCodes.cpp
+++ b/src/lib/shell/commands/OnboardingCodes.cpp
@@ -54,7 +54,7 @@ static CHIP_ERROR GetOnboardingQRCodeUrl(bool printHeader)
 
     if (printHeader)
     {
-        streamer_printf(sout, "QRCodeUrl:          ");
+        streamer_printf(sout, "QRCodeUrl:         ");
     }
     ReturnErrorOnFailure(GetQRCode(QRCode, chip::RendezvousInformationFlags(chip::RendezvousInformationFlag::kBLE)));
 
@@ -72,7 +72,7 @@ static CHIP_ERROR GetOnboardingManualPairingCode(bool printHeader)
 
     if (printHeader)
     {
-        streamer_printf(sout, "ManualPairingCode:  ");
+        streamer_printf(sout, "ManualPairingCode: ");
     }
     ReturnErrorOnFailure(
         GetManualPairingCode(manualPairingCode, chip::RendezvousInformationFlags(chip::RendezvousInformationFlag::kBLE)));

--- a/src/lib/shell/streamer_esp32.cpp
+++ b/src/lib/shell/streamer_esp32.cpp
@@ -72,6 +72,12 @@ int streamer_esp32_init(streamer_t * streamer)
     linenoiseSetMultiLine(1);
     linenoiseHistorySetMaxLen(100);
 
+    if (linenoiseProbe())
+    {
+        // Set if terminal does not recognize escape sequences.
+        linenoiseSetDumbMode(1);
+    }
+
     esp_console_cmd_t command = { .command = "chip", .help = "CHIP utilities", .func = chip_command_handler };
     ESP_ERROR_CHECK(esp_console_cmd_register(&command));
     return 0;
@@ -84,7 +90,7 @@ ssize_t streamer_esp32_read(streamer_t * streamer, char * buf, size_t len)
 
 ssize_t streamer_esp32_write(streamer_t * streamer, const char * buf, size_t len)
 {
-    return fprintf(stdout, buf, len);
+    return uart_write_bytes(UART_NUM_0, buf, len);
 }
 
 static streamer_t streamer_stdio = {

--- a/src/lib/shell/streamer_esp32.cpp
+++ b/src/lib/shell/streamer_esp32.cpp
@@ -52,7 +52,7 @@ int streamer_esp32_init(streamer_t * streamer)
     esp_vfs_dev_uart_port_set_rx_line_endings(CONFIG_ESP_CONSOLE_UART_NUM, ESP_LINE_ENDINGS_CR);
     esp_vfs_dev_uart_port_set_tx_line_endings(CONFIG_ESP_CONSOLE_UART_NUM, ESP_LINE_ENDINGS_CRLF);
 
-    ESP_ERROR_CHECK(uart_driver_install(UART_NUM_0, 256, 0, 0, NULL, 0));
+    ESP_ERROR_CHECK(uart_driver_install(CONFIG_ESP_CONSOLE_UART_NUM, 256, 0, 0, NULL, 0));
     uart_config_t uart_config = {
         .baud_rate           = 115200,
         .data_bits           = UART_DATA_8_BITS,
@@ -62,7 +62,7 @@ int streamer_esp32_init(streamer_t * streamer)
         .rx_flow_ctrl_thresh = 0,
         .source_clk          = UART_SCLK_APB,
     };
-    ESP_ERROR_CHECK(uart_param_config(UART_NUM_0, &uart_config));
+    ESP_ERROR_CHECK(uart_param_config(CONFIG_ESP_CONSOLE_UART_NUM, &uart_config));
     esp_vfs_dev_uart_use_driver(0);
     esp_console_config_t console_config = {
         .max_cmdline_length = 256,
@@ -90,7 +90,7 @@ ssize_t streamer_esp32_read(streamer_t * streamer, char * buf, size_t len)
 
 ssize_t streamer_esp32_write(streamer_t * streamer, const char * buf, size_t len)
 {
-    return uart_write_bytes(UART_NUM_0, buf, len);
+    return uart_write_bytes(CONFIG_ESP_CONSOLE_UART_NUM, buf, len);
 }
 
 static streamer_t streamer_stdio = {


### PR DESCRIPTION
#### Problem
The QR code URL is wrong in `chip onboardingcodes` shell command, in ESP platform:
```
> chip onboardingcodes
QRCode:            MT:C8XA0SRB00KA0648G00
QRCodeUrl:          https://dhrishi.github.io/connectedhomeip/qrcode.html?data=MT0X1.E249000000055P+0C8XA0SRB00KA0648G00
ManualPairingCode:  34970112332
Done
```

#### Change overview
* fixed the QR code URL format issue
* use common API to print QR code URL in ESP32 all-clusters-app

#### Testing
Tested all-clusters-app on ESP32, the QR code URL is correct now:
```
> chip onboardingcodes
QRCode:            MT:C8XA0SRB00KA0648G00
QRCodeUrl:         https://dhrishi.github.io/connectedhomeip/qrcode.html?data=MT%3AC8XA0SRB00KA0648G00
ManualPairingCode: 34970112332
Done
```