### PR TITLE
Inet: Remove INET_CONFIG_MAX_DROPPABLE_EVENTS

### DIFF
--- a/src/inet/InetConfig.h
+++ b/src/inet/InetConfig.h
@@ -114,33 +114,6 @@
 #endif // INET_CONFIG_WILL_OVERRIDE_LWIP_ERROR_FUNCS
 
 /**
- *  @def INET_CONFIG_MAX_DROPPABLE_EVENTS
- *
- *  @brief
- *    This is the maximum number of UDP or raw network transport
- *    packet events / messages that may be dropped due to packet
- *    buffer starvation.
- *
- *    In some implementations, there may be a shared event / message
- *    queue for the InetLayer used by other system events / messages.
- *
- *    If the length of that queue is considerably longer than the
- *    number of packet buffers available, it may lead to buffer
- *    exhaustion. As a result, using the queue itself to implement
- *    backpressure is insufficient, and we need an external mechanism
- *    to prevent buffer starvation in the rest of the system and
- *    getting into deadlock situations.
- *
- *    For both UDP and raw network transport traffic we can easily
- *    drop incoming packets without impacting the correctness of
- *    higher level protocols.
- *
- */
-#ifndef INET_CONFIG_MAX_DROPPABLE_EVENTS
-#define INET_CONFIG_MAX_DROPPABLE_EVENTS                    0
-#endif // INET_CONFIG_MAX_DROPPABLE_EVENTS
-
-/**
  *  @def INET_CONFIG_NUM_TCP_ENDPOINTS
  *
  *  @brief

--- a/src/inet/InetLayer.h
+++ b/src/inet/InetLayer.h
@@ -70,24 +70,6 @@
 #include <lib/support/DLLUtil.h>
 #include <lib/support/ObjectLifeCycle.h>
 
-#if INET_CONFIG_MAX_DROPPABLE_EVENTS
-
-#if CHIP_SYSTEM_CONFIG_POSIX_LOCKING
-#include <pthread.h>
-#include <semaphore.h>
-#endif // CHIP_SYSTEM_CONFIG_POSIX_LOCKING
-
-#if CHIP_SYSTEM_CONFIG_FREERTOS_LOCKING
-#if defined(ESP_PLATFORM)
-#include "freertos/FreeRTOS.h"
-#else
-#include <FreeRTOS.h>
-#endif
-#include <semphr.h>
-#endif // CHIP_SYSTEM_CONFIG_FREERTOS_LOCKING
-
-#endif // INET_CONFIG_MAX_DROPPABLE_EVENTS
-
 #include <stdint.h>
 
 namespace chip {
@@ -152,56 +134,6 @@ public:
 
     void * GetPlatformData();
     void SetPlatformData(void * aPlatformData);
-
-#if CHIP_SYSTEM_CONFIG_USE_LWIP
-    // In some implementations, there may be a shared event / message
-    // queue for the InetLayer used by other system events / messages.
-    //
-    // If the length of that queue is considerably longer than the
-    // number of packet buffers available, it may lead to buffer
-    // exhaustion. As a result, using the queue itself to implement
-    // backpressure is insufficient, and we need an external mechanism
-    // to prevent buffer starvation in the rest of the system and
-    // getting into deadlock situations.
-
-    // For both UDP and raw network transport traffic we can easily
-    // drop incoming packets without impacting the correctness of
-    // higher level protocols.
-
-#if INET_CONFIG_MAX_DROPPABLE_EVENTS
-    inline static bool IsDroppableEvent(chip::System::EventType type)
-    {
-        return
-#if INET_CONFIG_ENABLE_UDP_ENDPOINT
-            type == kInetEvent_UDPDataReceived ||
-#endif // INET_CONFIG_ENABLE_UDP_ENDPOINT
-            false;
-    }
-
-    CHIP_ERROR InitQueueLimiter(void);
-    bool CanEnqueueDroppableEvent(void);
-    void DroppableEventDequeued(void);
-
-#if CHIP_SYSTEM_CONFIG_NO_LOCKING
-    volatile int32_t mDroppableEvents;
-#elif CHIP_SYSTEM_CONFIG_POSIX_LOCKING
-    sem_t mDroppableEvents;
-#elif CHIP_SYSTEM_CONFIG_FREERTOS_LOCKING
-#if (configSUPPORT_STATIC_ALLOCATION == 1)
-    StaticSemaphore_t mDroppableEventsObj;
-#endif // (configSUPPORT_STATIC_ALLOCATION == 1)
-    SemaphoreHandle_t mDroppableEvents;
-#endif // CHIP_SYSTEM_CONFIG_FREERTOS_LOCKING
-
-#else  // !INET_CONFIG_MAX_DROPPABLE_EVENTS
-
-    inline static bool IsDroppableEvent(chip::System::EventType aType) { return false; }
-
-    inline CHIP_ERROR InitQueueLimiter(void) { return CHIP_NO_ERROR; }
-    inline bool CanEnqueueDroppableEvent(void) { return true; }
-    inline void DroppableEventDequeued(void) { return; }
-#endif // !INET_CONFIG_MAX_DROPPABLE_EVENTS
-#endif // CHIP_SYSTEM_CONFIG_USE_LWIP
 
 #if INET_CONFIG_ENABLE_TCP_ENDPOINT && INET_TCP_IDLE_CHECK_INTERVAL > 0
     static void HandleTCPInactivityTimer(chip::System::Layer * aSystemLayer, void * aAppState);

--- a/src/inet/UDPEndPoint.cpp
+++ b/src/inet/UDPEndPoint.cpp
@@ -588,8 +588,6 @@ void UDPEndPoint::LwIPReceiveUDPMessage(void * arg, struct udp_pcb * pcb, struct
     ep->Retain();
     CHIP_ERROR err = lSystemLayer->ScheduleLambda([ep, p = System::LwIPPacketBufferView::UnsafeGetLwIPpbuf(buf)] {
         ep->HandleDataReceived(System::PacketBufferHandle::Adopt(p));
-        InetLayer & lInetLayer = ep->Layer();
-        lInetLayer.DroppableEventDequeued();
         ep->Release();
     });
     if (err == CHIP_NO_ERROR)


### PR DESCRIPTION
#### Problem

`INET_CONFIG_MAX_DROPPABLE_EVENTS` is not used anywhere; code that
used it was removed by PR #1051 _Remove
CHIP_SYSTEM_CONFIG_PROVIDE_OBSOLESCENT_INTERFACES_
over a year ago.

#### Change overview

Remove code controlled by `INET_CONFIG_MAX_DROPPABLE_EVENTS`.

#### Testing

CI; no changes to functionality.
