### PR TITLE
Set commissionee device to active on start of pairing process

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -906,6 +906,9 @@ CHIP_ERROR DeviceCommissioner::PairDevice(NodeId remoteDeviceId, RendezvousParam
     err = mIDAllocator.Allocate(keyID);
     SuccessOrExit(err);
 
+    // TODO - Remove use of SetActive/IsActive from CommissioneeDeviceProxy
+    device->SetActive(true);
+
     err = device->GetPairing().Pair(params.GetPeerAddress(), params.GetSetupPINCode(), keyID, exchangeCtxt, this);
     // Immediately persist the updted mNextKeyID value
     // TODO maybe remove FreeRendezvousSession() since mNextKeyID is always persisted immediately


### PR DESCRIPTION
#### Problem
* Fixes #11671

#### Change overview
The Commissionee device was not being set to active state. That caused `IsSecureConnected()` check to fail while getting the connected device.

The CommissioneeDeviceProxy code could use some refactor and cleanup, as IsActive flag is no longer needed. However, it's being used at a few places in the code base. Added a TODO to create an issue for it.

#### Testing
Noticed that Python controller was failing in network commissioning for BLE/WiFi as well. Tested manually by commissioning m5stack using Python controller.

I don't have test setup for Thread device. So, that is not tested. But, the cause of failure is same between network commissioning for BLE/WiFi and Thread.
