### PR TITLE
Inet: Split UDPEndPoint and TCPEndPoint

### DIFF
--- a/src/inet/BUILD.gn
+++ b/src/inet/BUILD.gn
@@ -49,8 +49,6 @@ buildconfig_header("inet_buildconfig") {
     defines +=
         [ "INET_PLATFORM_CONFIG_INCLUDE=${chip_inet_platform_config_include}" ]
   }
-
-  defines += [ "CHIP_INET_END_POINT_IMPL_CONFIG_FILE=<inet/EndPointBasisImpl${chip_system_config_inet}.h>" ]
 }
 
 source_set("inet_config_header") {
@@ -69,7 +67,7 @@ static_library("inet") {
 
   sources = [
     "EndPointBasis.h",
-    "EndPointBasisImpl${chip_system_config_inet}.h",
+    "EndPointState${chip_system_config_inet}.h",
     "IANAConstants.h",
     "IPAddress-StringFuncts.cpp",
     "IPAddress.cpp",

--- a/src/inet/EndPointBasis.h
+++ b/src/inet/EndPointBasis.h
@@ -39,7 +39,6 @@ class DLL_EXPORT EndPointBase
 {
 public:
     EndPointBase(InetLayer & aInetLayer, void * aAppState = nullptr) : mAppState(aAppState), mInetLayer(aInetLayer) {}
-    virtual ~EndPointBase() = default;
 
     /**
      *  Returns a reference to the Inet layer object that owns this basis object.
@@ -54,9 +53,3 @@ private:
 
 } // namespace Inet
 } // namespace chip
-
-#ifdef CHIP_INET_END_POINT_IMPL_CONFIG_FILE
-#include CHIP_INET_END_POINT_IMPL_CONFIG_FILE
-#else // CHIP_INET_END_POINT_IMPL_CONFIG_FILE
-#include <inet/EndPointBasisImplSockets.h>
-#endif // CHIP_INET_END_POINT_IMPL_CONFIG_FILE

--- a/src/inet/EndPointStateLwIP.h
+++ b/src/inet/EndPointStateLwIP.h
@@ -17,7 +17,7 @@
  */
 
 /**
- *  LwIP implementation of EndPointBase.
+ *  Shared state for LwIP implementations of TCPEndPoint and UDPEndPoint.
  */
 
 #pragma once
@@ -32,12 +32,10 @@ struct tcp_pcb;
 namespace chip {
 namespace Inet {
 
-class DLL_EXPORT EndPointImplLwIP : public EndPointBase
+class DLL_EXPORT EndPointStateLwIP
 {
 protected:
-    EndPointImplLwIP(InetLayer & inetLayer, void * appState = nullptr) :
-        EndPointBase(inetLayer, appState), mLwIPEndPointType(LwIPEndPointType::Unknown)
-    {}
+    EndPointStateLwIP() : mLwIPEndPointType(LwIPEndPointType::Unknown) {}
 
     /** Encapsulated LwIP protocol control block */
     union
@@ -58,8 +56,6 @@ protected:
         TCP     = 2
     } mLwIPEndPointType;
 };
-
-using EndPointBasis = EndPointImplLwIP;
 
 } // namespace Inet
 } // namespace chip

--- a/src/inet/EndPointStateNetworkFramework.h
+++ b/src/inet/EndPointStateNetworkFramework.h
@@ -17,7 +17,7 @@
  */
 
 /**
- *  Network Framework implementation of EndPointBase.
+ *  Shared state for Network Framework implementations of TCPEndPoint and UDPEndPoint.
  */
 
 #pragma once
@@ -31,16 +31,14 @@
 namespace chip {
 namespace Inet {
 
-class DLL_EXPORT EndPointImplNetworkFramework : public EndPointBase
+class DLL_EXPORT EndPointStateNetworkFramework
 {
 protected:
-    EndPointImplNetworkFramework(InetLayer & inetLayer, void * appState = nullptr) : EndPointBase(inetLayer, appState) {}
+    EndPointStateNetworkFramework() {}
 
     nw_parameters_t mParameters;
     IPAddressType mAddrType; /**< Protocol family, i.e. IPv4 or IPv6. */
 };
-
-using EndPointBasis = EndPointImplNetworkFramework;
 
 } // namespace Inet
 } // namespace chip

--- a/src/inet/EndPointStateSockets.h
+++ b/src/inet/EndPointStateSockets.h
@@ -17,7 +17,7 @@
  */
 
 /**
- *  Sockets implementation of EndPointBase.
+ *  Shared state for socket implementations of TCPEndPoint and UDPEndPoint.
  */
 
 #pragma once
@@ -30,20 +30,16 @@
 namespace chip {
 namespace Inet {
 
-class DLL_EXPORT EndPointImplSockets : public EndPointBase
+class DLL_EXPORT EndPointStateSockets
 {
 protected:
-    EndPointImplSockets(InetLayer & inetLayer, void * appState = nullptr) :
-        EndPointBase(inetLayer, appState), mSocket(kInvalidSocketFd)
-    {}
+    EndPointStateSockets() : mSocket(kInvalidSocketFd) {}
 
     static constexpr int kInvalidSocketFd = -1;
     int mSocket;                     /**< Encapsulated socket descriptor. */
     IPAddressType mAddrType;         /**< Protocol family, i.e. IPv4 or IPv6. */
     System::SocketWatchToken mWatch; /**< Socket event watcher */
 };
-
-using EndPointBasis = EndPointImplSockets;
 
 } // namespace Inet
 } // namespace chip

--- a/src/inet/InetLayer.cpp
+++ b/src/inet/InetLayer.cpp
@@ -150,7 +150,7 @@ CHIP_ERROR InetLayer::Shutdown()
 
 #if INET_CONFIG_ENABLE_TCP_ENDPOINT
     // Abort all TCP endpoints owned by this instance.
-    TCPEndPoint::sPool.ForEachActiveObject([&](TCPEndPoint * lEndPoint) {
+    TCPEndPointImpl::sPool.ForEachActiveObject([&](TCPEndPoint * lEndPoint) {
         if ((lEndPoint != nullptr) && &lEndPoint->Layer() == this)
         {
             lEndPoint->Abort();
@@ -161,7 +161,7 @@ CHIP_ERROR InetLayer::Shutdown()
 
 #if INET_CONFIG_ENABLE_UDP_ENDPOINT
     // Close all UDP endpoints owned by this instance.
-    UDPEndPoint::sPool.ForEachActiveObject([&](UDPEndPoint * lEndPoint) {
+    UDPEndPointImpl::sPool.ForEachActiveObject([&](UDPEndPoint * lEndPoint) {
         if ((lEndPoint != nullptr) && &lEndPoint->Layer() == this)
         {
             lEndPoint->Close();
@@ -206,7 +206,7 @@ bool InetLayer::IsIdleTimerRunning()
     bool timerRunning = false;
 
     // See if there are any TCP connections with the idle timer check in use.
-    TCPEndPoint::sPool.ForEachActiveObject([&](TCPEndPoint * lEndPoint) {
+    TCPEndPointImpl::sPool.ForEachActiveObject([&](TCPEndPoint * lEndPoint) {
         if ((lEndPoint != nullptr) && (lEndPoint->mIdleTimeout != 0))
         {
             timerRunning = true;
@@ -330,7 +330,7 @@ CHIP_ERROR InetLayer::NewTCPEndPoint(TCPEndPoint ** retEndPoint)
 
     VerifyOrReturnError(mLayerState.IsInitialized(), CHIP_ERROR_INCORRECT_STATE);
 
-    *retEndPoint = TCPEndPoint::sPool.CreateObject(*this);
+    *retEndPoint = TCPEndPointImpl::sPool.CreateObject(*this);
     if (*retEndPoint == nullptr)
     {
         ChipLogError(Inet, "%s endpoint pool FULL", "TCP");
@@ -369,7 +369,7 @@ CHIP_ERROR InetLayer::NewUDPEndPoint(UDPEndPoint ** retEndPoint)
 
     VerifyOrReturnError(mLayerState.IsInitialized(), CHIP_ERROR_INCORRECT_STATE);
 
-    *retEndPoint = UDPEndPoint::sPool.CreateObject(*this);
+    *retEndPoint = UDPEndPointImpl::sPool.CreateObject(*this);
     if (*retEndPoint == nullptr)
     {
         ChipLogError(Inet, "%s endpoint pool FULL", "UDP");
@@ -456,7 +456,7 @@ void InetLayer::HandleTCPInactivityTimer(chip::System::Layer * aSystemLayer, voi
     InetLayer & lInetLayer = *reinterpret_cast<InetLayer *>(aAppState);
     bool lTimerRequired    = lInetLayer.IsIdleTimerRunning();
 
-    TCPEndPoint::sPool.ForEachActiveObject([&](TCPEndPoint * lEndPoint) {
+    TCPEndPointImpl::sPool.ForEachActiveObject([&](TCPEndPoint * lEndPoint) {
         if (&lEndPoint->Layer() != &lInetLayer)
             return true;
         if (!lEndPoint->IsConnected())

--- a/src/inet/TCPEndPoint.cpp
+++ b/src/inet/TCPEndPoint.cpp
@@ -87,9 +87,10 @@
 namespace chip {
 namespace Inet {
 
-BitMapObjectPool<TCPEndPoint, INET_CONFIG_NUM_TCP_ENDPOINTS> TCPEndPoint::sPool;
-
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
+
+BitMapObjectPool<TCPEndPointImplLwIP, INET_CONFIG_NUM_TCP_ENDPOINTS> TCPEndPointImplLwIP::sPool;
+
 namespace {
 
 /*
@@ -108,7 +109,7 @@ err_t start_tcp_timers(void)
 
 } // anonymous namespace
 
-CHIP_ERROR TCPEndPoint::BindImpl(IPAddressType addrType, const IPAddress & addr, uint16_t port, bool reuseAddr)
+CHIP_ERROR TCPEndPointImplLwIP::BindImpl(IPAddressType addrType, const IPAddress & addr, uint16_t port, bool reuseAddr)
 {
     // Lock LwIP stack
     LOCK_TCPIP_CORE();
@@ -170,7 +171,7 @@ CHIP_ERROR TCPEndPoint::BindImpl(IPAddressType addrType, const IPAddress & addr,
     return res;
 }
 
-CHIP_ERROR TCPEndPoint::ListenImpl(uint16_t backlog)
+CHIP_ERROR TCPEndPointImplLwIP::ListenImpl(uint16_t backlog)
 {
     // Start listening for incoming connections.
     mTCP              = tcp_listen(mTCP);
@@ -183,7 +184,7 @@ CHIP_ERROR TCPEndPoint::ListenImpl(uint16_t backlog)
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR TCPEndPoint::ConnectImpl(const IPAddress & addr, uint16_t port, InterfaceId intfId)
+CHIP_ERROR TCPEndPointImplLwIP::ConnectImpl(const IPAddress & addr, uint16_t port, InterfaceId intfId)
 {
     CHIP_ERROR res         = CHIP_NO_ERROR;
     IPAddressType addrType = addr.Type();
@@ -261,7 +262,7 @@ CHIP_ERROR TCPEndPoint::ConnectImpl(const IPAddress & addr, uint16_t port, Inter
     return res;
 }
 
-CHIP_ERROR TCPEndPoint::GetPeerInfo(IPAddress * retAddr, uint16_t * retPort) const
+CHIP_ERROR TCPEndPointImplLwIP::GetPeerInfo(IPAddress * retAddr, uint16_t * retPort) const
 {
     VerifyOrReturnError(IsConnected(), CHIP_ERROR_INCORRECT_STATE);
 
@@ -291,7 +292,7 @@ CHIP_ERROR TCPEndPoint::GetPeerInfo(IPAddress * retAddr, uint16_t * retPort) con
     return res;
 }
 
-CHIP_ERROR TCPEndPoint::GetLocalInfo(IPAddress * retAddr, uint16_t * retPort) const
+CHIP_ERROR TCPEndPointImplLwIP::GetLocalInfo(IPAddress * retAddr, uint16_t * retPort) const
 {
     VerifyOrReturnError(IsConnected(), CHIP_ERROR_INCORRECT_STATE);
 
@@ -321,7 +322,7 @@ CHIP_ERROR TCPEndPoint::GetLocalInfo(IPAddress * retAddr, uint16_t * retPort) co
     return res;
 }
 
-CHIP_ERROR TCPEndPoint::GetInterfaceId(InterfaceId * retInterface)
+CHIP_ERROR TCPEndPointImplLwIP::GetInterfaceId(InterfaceId * retInterface)
 {
     VerifyOrReturnError(IsConnected(), CHIP_ERROR_INCORRECT_STATE);
 
@@ -332,7 +333,7 @@ CHIP_ERROR TCPEndPoint::GetInterfaceId(InterfaceId * retInterface)
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR TCPEndPoint::SendQueuedImpl(bool queueWasEmpty)
+CHIP_ERROR TCPEndPointImplLwIP::SendQueuedImpl(bool queueWasEmpty)
 {
 #if INET_CONFIG_OVERRIDE_SYSTEM_TCP_USER_TIMEOUT
     if (!mUserTimeoutTimerRunning)
@@ -345,7 +346,7 @@ CHIP_ERROR TCPEndPoint::SendQueuedImpl(bool queueWasEmpty)
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR TCPEndPoint::EnableNoDelay()
+CHIP_ERROR TCPEndPointImplLwIP::EnableNoDelay()
 {
     VerifyOrReturnError(IsConnected(), CHIP_ERROR_INCORRECT_STATE);
 
@@ -365,7 +366,7 @@ CHIP_ERROR TCPEndPoint::EnableNoDelay()
     return res;
 }
 
-CHIP_ERROR TCPEndPoint::EnableKeepAlive(uint16_t interval, uint16_t timeoutCount)
+CHIP_ERROR TCPEndPointImplLwIP::EnableKeepAlive(uint16_t interval, uint16_t timeoutCount)
 {
     VerifyOrReturnError(IsConnected(), CHIP_ERROR_INCORRECT_STATE);
     CHIP_ERROR res = CHIP_ERROR_NOT_IMPLEMENTED;
@@ -403,7 +404,7 @@ CHIP_ERROR TCPEndPoint::EnableKeepAlive(uint16_t interval, uint16_t timeoutCount
     return res;
 }
 
-CHIP_ERROR TCPEndPoint::DisableKeepAlive()
+CHIP_ERROR TCPEndPointImplLwIP::DisableKeepAlive()
 {
     VerifyOrReturnError(IsConnected(), CHIP_ERROR_INCORRECT_STATE);
     CHIP_ERROR res = CHIP_ERROR_NOT_IMPLEMENTED;
@@ -432,17 +433,12 @@ CHIP_ERROR TCPEndPoint::DisableKeepAlive()
     return res;
 }
 
-CHIP_ERROR TCPEndPoint::SetUserTimeoutImpl(uint32_t userTimeoutMillis)
+CHIP_ERROR TCPEndPointImplLwIP::SetUserTimeoutImpl(uint32_t userTimeoutMillis)
 {
     return CHIP_ERROR_NOT_IMPLEMENTED;
 }
 
-void TCPEndPoint::InitImpl()
-{
-    mUnackedLength = 0;
-}
-
-CHIP_ERROR TCPEndPoint::DriveSendingImpl()
+CHIP_ERROR TCPEndPointImplLwIP::DriveSendingImpl()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
@@ -463,7 +459,7 @@ CHIP_ERROR TCPEndPoint::DriveSendingImpl()
         {
             // Find first packet buffer with remaining data to send by skipping
             // all sent but un-acked data.
-            TCPEndPoint::BufferOffset startOfUnsent = FindStartOfUnsent();
+            TCPEndPointImplLwIP::BufferOffset startOfUnsent = FindStartOfUnsent();
 
             // While there's data to be sent and a window to send it in...
             do
@@ -547,9 +543,9 @@ CHIP_ERROR TCPEndPoint::DriveSendingImpl()
     return err;
 }
 
-void TCPEndPoint::HandleConnectCompleteImpl() {}
+void TCPEndPointImplLwIP::HandleConnectCompleteImpl() {}
 
-void TCPEndPoint::DoCloseImpl(CHIP_ERROR err, State oldState)
+void TCPEndPointImplLwIP::DoCloseImpl(CHIP_ERROR err, State oldState)
 {
     // Lock LwIP stack
     LOCK_TCPIP_CORE();
@@ -622,7 +618,7 @@ void TCPEndPoint::DoCloseImpl(CHIP_ERROR err, State oldState)
     }
 }
 
-CHIP_ERROR TCPEndPoint::AckReceive(uint16_t len)
+CHIP_ERROR TCPEndPointImplLwIP::AckReceive(uint16_t len)
 {
     VerifyOrReturnError(IsConnected(), CHIP_ERROR_INCORRECT_STATE);
     CHIP_ERROR res = CHIP_NO_ERROR;
@@ -642,23 +638,18 @@ CHIP_ERROR TCPEndPoint::AckReceive(uint16_t len)
 }
 
 #if INET_CONFIG_OVERRIDE_SYSTEM_TCP_USER_TIMEOUT
-void TCPEndPoint::TCPUserTimeoutHandler(chip::System::Layer * aSystemLayer, void * aAppState)
+void TCPEndPointImplLwIP::TCPUserTimeoutHandler()
 {
-    TCPEndPoint * tcpEndPoint = reinterpret_cast<TCPEndPoint *>(aAppState);
-
-    VerifyOrDie((aSystemLayer != nullptr) && (tcpEndPoint != nullptr));
-
     // Set the timer running flag to false
-    tcpEndPoint->mUserTimeoutTimerRunning = false;
+    mUserTimeoutTimerRunning = false;
 
     // Close Connection as we have timed out and there is still
     // data not sent out successfully.
-
-    tcpEndPoint->DoClose(INET_ERROR_TCP_USER_TIMEOUT, false);
+    DoClose(INET_ERROR_TCP_USER_TIMEOUT, false);
 }
 #endif // INET_CONFIG_OVERRIDE_SYSTEM_TCP_USER_TIMEOUT
 
-uint16_t TCPEndPoint::RemainingToSend()
+uint16_t TCPEndPointImplLwIP::RemainingToSend()
 {
     if (mSendQueue.IsNull())
     {
@@ -674,7 +665,7 @@ uint16_t TCPEndPoint::RemainingToSend()
     }
 }
 
-TCPEndPoint::BufferOffset TCPEndPoint::FindStartOfUnsent()
+TCPEndPointImplLwIP::BufferOffset TCPEndPointImplLwIP::FindStartOfUnsent()
 {
     // Find first packet buffer with remaining data to send by skipping
     // all sent but un-acked data. This is necessary because of the Consume()
@@ -686,7 +677,7 @@ TCPEndPoint::BufferOffset TCPEndPoint::FindStartOfUnsent()
     // unsent data while retaining the buffers that have un-acked data is to
     // traverse all sent-but-unacked data in the chain to reach the beginning
     // of ready-to-send data.
-    TCPEndPoint::BufferOffset startOfUnsent(mSendQueue.Retain());
+    TCPEndPointImplLwIP::BufferOffset startOfUnsent(mSendQueue.Retain());
     uint16_t leftToSkip = mUnackedLength;
 
     VerifyOrDie(leftToSkip < mSendQueue->TotalLength());
@@ -714,7 +705,7 @@ TCPEndPoint::BufferOffset TCPEndPoint::FindStartOfUnsent()
     return startOfUnsent;
 }
 
-CHIP_ERROR TCPEndPoint::GetPCB(IPAddressType addrType)
+CHIP_ERROR TCPEndPointImplLwIP::GetPCB(IPAddressType addrType)
 {
     // IMMPORTANT: This method MUST be called with the LwIP stack LOCKED!
 
@@ -801,7 +792,7 @@ CHIP_ERROR TCPEndPoint::GetPCB(IPAddressType addrType)
     return CHIP_NO_ERROR;
 }
 
-void TCPEndPoint::HandleDataSent(uint16_t lenSent)
+void TCPEndPointImplLwIP::HandleDataSent(uint16_t lenSent)
 {
     if (IsConnected())
     {
@@ -868,7 +859,7 @@ void TCPEndPoint::HandleDataSent(uint16_t lenSent)
     }
 }
 
-void TCPEndPoint::HandleDataReceived(System::PacketBufferHandle && buf)
+void TCPEndPointImplLwIP::HandleDataReceived(System::PacketBufferHandle && buf)
 {
     // Only receive new data while in the Connected or SendShutdown states.
     if (mState == State::kConnected || mState == State::kSendShutdown)
@@ -915,7 +906,7 @@ void TCPEndPoint::HandleDataReceived(System::PacketBufferHandle && buf)
     }
 }
 
-void TCPEndPoint::HandleIncomingConnection(TCPEndPoint * conEP)
+void TCPEndPointImplLwIP::HandleIncomingConnection(TCPEndPoint * conEP)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     IPAddress peerAddr;
@@ -947,7 +938,7 @@ void TCPEndPoint::HandleIncomingConnection(TCPEndPoint * conEP)
         conEP->Free();
 }
 
-void TCPEndPoint::HandleError(CHIP_ERROR err)
+void TCPEndPointImplLwIP::HandleError(CHIP_ERROR err)
 {
     if (mState == State::kListening)
     {
@@ -958,13 +949,13 @@ void TCPEndPoint::HandleError(CHIP_ERROR err)
         DoClose(err, false);
 }
 
-err_t TCPEndPoint::LwIPHandleConnectComplete(void * arg, struct tcp_pcb * tpcb, err_t lwipErr)
+err_t TCPEndPointImplLwIP::LwIPHandleConnectComplete(void * arg, struct tcp_pcb * tpcb, err_t lwipErr)
 {
     err_t res = ERR_OK;
 
     if (arg != NULL)
     {
-        TCPEndPoint * ep             = static_cast<TCPEndPoint *>(arg);
+        TCPEndPointImplLwIP * ep     = static_cast<TCPEndPointImplLwIP *>(arg);
         System::Layer * lSystemLayer = ep->Layer().SystemLayer();
 
         if (lwipErr == ERR_OK)
@@ -995,15 +986,15 @@ err_t TCPEndPoint::LwIPHandleConnectComplete(void * arg, struct tcp_pcb * tpcb, 
     return res;
 }
 
-err_t TCPEndPoint::LwIPHandleIncomingConnection(void * arg, struct tcp_pcb * tpcb, err_t lwipErr)
+err_t TCPEndPointImplLwIP::LwIPHandleIncomingConnection(void * arg, struct tcp_pcb * tpcb, err_t lwipErr)
 {
     CHIP_ERROR err = chip::System::MapErrorLwIP(lwipErr);
 
     if (arg != NULL)
     {
-        TCPEndPoint * listenEP       = static_cast<TCPEndPoint *>(arg);
-        TCPEndPoint * conEP          = NULL;
-        System::Layer * lSystemLayer = listenEP->Layer().SystemLayer();
+        TCPEndPointImplLwIP * listenEP = static_cast<TCPEndPointImplLwIP *>(arg);
+        TCPEndPointImplLwIP * conEP    = NULL;
+        System::Layer * lSystemLayer   = listenEP->Layer().SystemLayer();
 
         // Tell LwIP we've accepted the connection so it can decrement the listen PCB's pending_accepts counter.
         tcp_accepted(listenEP->mTCP);
@@ -1019,7 +1010,9 @@ err_t TCPEndPoint::LwIPHandleIncomingConnection(void * arg, struct tcp_pcb * tpc
         {
             InetLayer & lInetLayer = listenEP->Layer();
 
-            err = lInetLayer.NewTCPEndPoint(&conEP);
+            TCPEndPoint * connectEndPoint = nullptr;
+            err                           = lInetLayer.NewTCPEndPoint(&connectEndPoint);
+            conEP                         = static_cast<TCPEndPointImplLwIP *>(connectEndPoint);
         }
 
         // Ensure that TCP timers have been started
@@ -1093,13 +1086,13 @@ err_t TCPEndPoint::LwIPHandleIncomingConnection(void * arg, struct tcp_pcb * tpc
     }
 }
 
-err_t TCPEndPoint::LwIPHandleDataReceived(void * arg, struct tcp_pcb * tpcb, struct pbuf * p, err_t _err)
+err_t TCPEndPointImplLwIP::LwIPHandleDataReceived(void * arg, struct tcp_pcb * tpcb, struct pbuf * p, err_t _err)
 {
     err_t res = ERR_OK;
 
     if (arg != NULL)
     {
-        TCPEndPoint * ep             = static_cast<TCPEndPoint *>(arg);
+        TCPEndPointImplLwIP * ep     = static_cast<TCPEndPointImplLwIP *>(arg);
         System::Layer * lSystemLayer = ep->Layer().SystemLayer();
 
         // Post callback to HandleDataReceived.
@@ -1129,13 +1122,13 @@ err_t TCPEndPoint::LwIPHandleDataReceived(void * arg, struct tcp_pcb * tpcb, str
     return res;
 }
 
-err_t TCPEndPoint::LwIPHandleDataSent(void * arg, struct tcp_pcb * tpcb, u16_t len)
+err_t TCPEndPointImplLwIP::LwIPHandleDataSent(void * arg, struct tcp_pcb * tpcb, u16_t len)
 {
     err_t res = ERR_OK;
 
     if (arg != NULL)
     {
-        TCPEndPoint * ep             = static_cast<TCPEndPoint *>(arg);
+        TCPEndPointImplLwIP * ep     = static_cast<TCPEndPointImplLwIP *>(arg);
         System::Layer * lSystemLayer = ep->Layer().SystemLayer();
 
         // Post callback to HandleDataReceived.
@@ -1159,11 +1152,11 @@ err_t TCPEndPoint::LwIPHandleDataSent(void * arg, struct tcp_pcb * tpcb, u16_t l
     return res;
 }
 
-void TCPEndPoint::LwIPHandleError(void * arg, err_t lwipErr)
+void TCPEndPointImplLwIP::LwIPHandleError(void * arg, err_t lwipErr)
 {
     if (arg != NULL)
     {
-        TCPEndPoint * ep                 = static_cast<TCPEndPoint *>(arg);
+        TCPEndPointImplLwIP * ep         = static_cast<TCPEndPointImplLwIP *>(arg);
         System::LayerLwIP * lSystemLayer = static_cast<System::LayerLwIP *>(ep->Layer().SystemLayer());
 
         // At this point LwIP has already freed the PCB.  Since the thread that owns the TCPEndPoint may
@@ -1189,7 +1182,9 @@ void TCPEndPoint::LwIPHandleError(void * arg, err_t lwipErr)
 
 #if CHIP_SYSTEM_CONFIG_USE_SOCKETS
 
-CHIP_ERROR TCPEndPoint::BindImpl(IPAddressType addrType, const IPAddress & addr, uint16_t port, bool reuseAddr)
+BitMapObjectPool<TCPEndPointImplSockets, INET_CONFIG_NUM_TCP_ENDPOINTS> TCPEndPointImplSockets::sPool;
+
+CHIP_ERROR TCPEndPointImplSockets::BindImpl(IPAddressType addrType, const IPAddress & addr, uint16_t port, bool reuseAddr)
 {
     CHIP_ERROR res = GetSocket(addrType);
 
@@ -1281,7 +1276,7 @@ CHIP_ERROR TCPEndPoint::BindImpl(IPAddressType addrType, const IPAddress & addr,
     return res;
 }
 
-CHIP_ERROR TCPEndPoint::ListenImpl(uint16_t backlog)
+CHIP_ERROR TCPEndPointImplSockets::ListenImpl(uint16_t backlog)
 {
     if (listen(mSocket, backlog) != 0)
     {
@@ -1303,7 +1298,7 @@ CHIP_ERROR TCPEndPoint::ListenImpl(uint16_t backlog)
     return res;
 }
 
-CHIP_ERROR TCPEndPoint::ConnectImpl(const IPAddress & addr, uint16_t port, InterfaceId intfId)
+CHIP_ERROR TCPEndPointImplSockets::ConnectImpl(const IPAddress & addr, uint16_t port, InterfaceId intfId)
 {
     IPAddressType addrType = addr.Type();
 
@@ -1430,17 +1425,18 @@ CHIP_ERROR TCPEndPoint::ConnectImpl(const IPAddress & addr, uint16_t port, Inter
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR TCPEndPoint::GetPeerInfo(IPAddress * retAddr, uint16_t * retPort) const
+CHIP_ERROR TCPEndPointImplSockets::GetPeerInfo(IPAddress * retAddr, uint16_t * retPort) const
 {
     return GetSocketInfo(getpeername, retAddr, retPort);
 }
 
-CHIP_ERROR TCPEndPoint::GetLocalInfo(IPAddress * retAddr, uint16_t * retPort) const
+CHIP_ERROR TCPEndPointImplSockets::GetLocalInfo(IPAddress * retAddr, uint16_t * retPort) const
 {
     return GetSocketInfo(getsockname, retAddr, retPort);
 }
 
-CHIP_ERROR TCPEndPoint::GetSocketInfo(int getname(int, sockaddr *, socklen_t *), IPAddress * retAddr, uint16_t * retPort) const
+CHIP_ERROR TCPEndPointImplSockets::GetSocketInfo(int getname(int, sockaddr *, socklen_t *), IPAddress * retAddr,
+                                                 uint16_t * retPort) const
 {
     VerifyOrReturnError(IsConnected(), CHIP_ERROR_INCORRECT_STATE);
 
@@ -1472,7 +1468,7 @@ CHIP_ERROR TCPEndPoint::GetSocketInfo(int getname(int, sockaddr *, socklen_t *),
     return CHIP_ERROR_INCORRECT_STATE;
 }
 
-CHIP_ERROR TCPEndPoint::GetInterfaceId(InterfaceId * retInterface)
+CHIP_ERROR TCPEndPointImplSockets::GetInterfaceId(InterfaceId * retInterface)
 {
     VerifyOrReturnError(IsConnected(), CHIP_ERROR_INCORRECT_STATE);
 
@@ -1512,7 +1508,7 @@ CHIP_ERROR TCPEndPoint::GetInterfaceId(InterfaceId * retInterface)
     return INET_ERROR_WRONG_ADDRESS_TYPE;
 }
 
-CHIP_ERROR TCPEndPoint::SendQueuedImpl(bool queueWasEmpty)
+CHIP_ERROR TCPEndPointImplSockets::SendQueuedImpl(bool queueWasEmpty)
 {
     if (queueWasEmpty)
     {
@@ -1522,7 +1518,7 @@ CHIP_ERROR TCPEndPoint::SendQueuedImpl(bool queueWasEmpty)
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR TCPEndPoint::EnableNoDelay()
+CHIP_ERROR TCPEndPointImplSockets::EnableNoDelay()
 {
     VerifyOrReturnError(IsConnected(), CHIP_ERROR_INCORRECT_STATE);
 
@@ -1538,7 +1534,7 @@ CHIP_ERROR TCPEndPoint::EnableNoDelay()
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR TCPEndPoint::EnableKeepAlive(uint16_t interval, uint16_t timeoutCount)
+CHIP_ERROR TCPEndPointImplSockets::EnableKeepAlive(uint16_t interval, uint16_t timeoutCount)
 {
     VerifyOrReturnError(IsConnected(), CHIP_ERROR_INCORRECT_STATE);
 
@@ -1573,7 +1569,7 @@ CHIP_ERROR TCPEndPoint::EnableKeepAlive(uint16_t interval, uint16_t timeoutCount
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR TCPEndPoint::DisableKeepAlive()
+CHIP_ERROR TCPEndPointImplSockets::DisableKeepAlive()
 {
     VerifyOrReturnError(IsConnected(), CHIP_ERROR_INCORRECT_STATE);
 
@@ -1587,7 +1583,7 @@ CHIP_ERROR TCPEndPoint::DisableKeepAlive()
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR TCPEndPoint::AckReceive(uint16_t len)
+CHIP_ERROR TCPEndPointImplSockets::AckReceive(uint16_t len)
 {
     VerifyOrReturnError(IsConnected(), CHIP_ERROR_INCORRECT_STATE);
 
@@ -1595,7 +1591,7 @@ CHIP_ERROR TCPEndPoint::AckReceive(uint16_t len)
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR TCPEndPoint::SetUserTimeoutImpl(uint32_t userTimeoutMillis)
+CHIP_ERROR TCPEndPointImplSockets::SetUserTimeoutImpl(uint32_t userTimeoutMillis)
 {
 #if defined(TCP_USER_TIMEOUT)
     // Set the user timeout
@@ -1610,15 +1606,7 @@ CHIP_ERROR TCPEndPoint::SetUserTimeoutImpl(uint32_t userTimeoutMillis)
 #endif // defined(TCP_USER_TIMEOUT)
 }
 
-void TCPEndPoint::InitImpl()
-{
-#if INET_CONFIG_OVERRIDE_SYSTEM_TCP_USER_TIMEOUT
-    mBytesWrittenSinceLastProbe = 0;
-    mLastTCPKernelSendQueueLen  = 0;
-#endif // INET_CONFIG_OVERRIDE_SYSTEM_TCP_USER_TIMEOUT
-}
-
-CHIP_ERROR TCPEndPoint::DriveSendingImpl()
+CHIP_ERROR TCPEndPointImplSockets::DriveSendingImpl()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
@@ -1739,7 +1727,7 @@ CHIP_ERROR TCPEndPoint::DriveSendingImpl()
     return err;
 }
 
-void TCPEndPoint::HandleConnectCompleteImpl()
+void TCPEndPointImplSockets::HandleConnectCompleteImpl()
 {
     // Wait for ability to read or write on this endpoint.
     CHIP_ERROR err = static_cast<System::LayerSockets *>(Layer().SystemLayer())->RequestCallbackOnPendingRead(mWatch);
@@ -1754,7 +1742,7 @@ void TCPEndPoint::HandleConnectCompleteImpl()
     }
 }
 
-void TCPEndPoint::DoCloseImpl(CHIP_ERROR err, State oldState)
+void TCPEndPointImplSockets::DoCloseImpl(CHIP_ERROR err, State oldState)
 {
     struct linger lingerStruct;
 
@@ -1799,30 +1787,26 @@ void TCPEndPoint::DoCloseImpl(CHIP_ERROR err, State oldState)
 }
 
 #if INET_CONFIG_OVERRIDE_SYSTEM_TCP_USER_TIMEOUT
-void TCPEndPoint::TCPUserTimeoutHandler(chip::System::Layer * aSystemLayer, void * aAppState)
+void TCPEndPointImplSockets::TCPUserTimeoutHandler()
 {
-    TCPEndPoint * tcpEndPoint = reinterpret_cast<TCPEndPoint *>(aAppState);
-
-    VerifyOrDie((aSystemLayer != nullptr) && (tcpEndPoint != nullptr));
-
     // Set the timer running flag to false
-    tcpEndPoint->mUserTimeoutTimerRunning = false;
+    mUserTimeoutTimerRunning = false;
 
     CHIP_ERROR err     = CHIP_NO_ERROR;
     bool isProgressing = false;
-    err                = tcpEndPoint->CheckConnectionProgress(isProgressing);
+    err                = CheckConnectionProgress(isProgressing);
     SuccessOrExit(err);
 
-    if (tcpEndPoint->mLastTCPKernelSendQueueLen == 0)
+    if (mLastTCPKernelSendQueueLen == 0)
     {
 #if INET_CONFIG_ENABLE_TCP_SEND_IDLE_CALLBACKS
         // If the kernel TCP send queue as well as the TCPEndPoint
         // send queue have been flushed then notify application
         // that all data has been acknowledged.
 
-        if (tcpEndPoint->mSendQueue.IsNull())
+        if (mSendQueue.IsNull())
         {
-            tcpEndPoint->SetTCPSendIdleAndNotifyChange(true);
+            SetTCPSendIdleAndNotifyChange(true);
         }
 #endif // INET_CONFIG_ENABLE_TCP_SEND_IDLE_CALLBACKS
     }
@@ -1835,7 +1819,7 @@ void TCPEndPoint::TCPUserTimeoutHandler(chip::System::Layer * aSystemLayer, void
             // to shift it forward while also resetting the max
             // poll count.
 
-            tcpEndPoint->StartTCPUserTimeoutTimer();
+            StartTCPUserTimeoutTimer();
         }
         else
         {
@@ -1843,13 +1827,13 @@ void TCPEndPoint::TCPUserTimeoutHandler(chip::System::Layer * aSystemLayer, void
             // Data flow is not progressing.
             // Decrement the remaining max TCP send queue polls.
 
-            tcpEndPoint->mTCPSendQueueRemainingPollCount--;
+            mTCPSendQueueRemainingPollCount--;
 
-            VerifyOrExit(tcpEndPoint->mTCPSendQueueRemainingPollCount != 0, err = INET_ERROR_TCP_USER_TIMEOUT);
+            VerifyOrExit(mTCPSendQueueRemainingPollCount != 0, err = INET_ERROR_TCP_USER_TIMEOUT);
 
             // Restart timer to poll again
 
-            tcpEndPoint->ScheduleNextTCPUserTimeoutPoll(tcpEndPoint->mTCPSendQueuePollPeriodMillis);
+            ScheduleNextTCPUserTimeoutPoll(mTCPSendQueuePollPeriodMillis);
 #else
             // Close the connection as the TCP UserTimeout has expired
 
@@ -1864,12 +1848,12 @@ exit:
     {
         // Close the connection as the TCP UserTimeout has expired
 
-        tcpEndPoint->DoClose(err, false);
+        DoClose(err, false);
     }
 }
 #endif // INET_CONFIG_OVERRIDE_SYSTEM_TCP_USER_TIMEOUT
 
-CHIP_ERROR TCPEndPoint::BindSrcAddrFromIntf(IPAddressType addrType, InterfaceId intfId)
+CHIP_ERROR TCPEndPointImplSockets::BindSrcAddrFromIntf(IPAddressType addrType, InterfaceId intfId)
 {
     // If we are trying to make a TCP connection over a 'specified target interface',
     // then we bind the TCPEndPoint to an IP address on that target interface
@@ -1923,7 +1907,7 @@ CHIP_ERROR TCPEndPoint::BindSrcAddrFromIntf(IPAddressType addrType, InterfaceId 
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR TCPEndPoint::GetSocket(IPAddressType addrType)
+CHIP_ERROR TCPEndPointImplSockets::GetSocket(IPAddressType addrType)
 {
     if (mSocket == kInvalidSocketFd)
     {
@@ -1982,12 +1966,12 @@ CHIP_ERROR TCPEndPoint::GetSocket(IPAddressType addrType)
 }
 
 // static
-void TCPEndPoint::HandlePendingIO(System::SocketEvents events, intptr_t data)
+void TCPEndPointImplSockets::HandlePendingIO(System::SocketEvents events, intptr_t data)
 {
-    reinterpret_cast<TCPEndPoint *>(data)->HandlePendingIO(events);
+    reinterpret_cast<TCPEndPointImplSockets *>(data)->HandlePendingIO(events);
 }
 
-void TCPEndPoint::HandlePendingIO(System::SocketEvents events)
+void TCPEndPointImplSockets::HandlePendingIO(System::SocketEvents events)
 {
     // Prevent the end point from being freed while in the middle of a callback.
     Retain();
@@ -2049,7 +2033,7 @@ void TCPEndPoint::HandlePendingIO(System::SocketEvents events)
     Release();
 }
 
-void TCPEndPoint::ReceiveData()
+void TCPEndPointImplSockets::ReceiveData()
 {
     System::PacketBufferHandle rcvBuf;
     bool isNewBuf = true;
@@ -2193,10 +2177,10 @@ void TCPEndPoint::ReceiveData()
     DriveReceiving();
 }
 
-void TCPEndPoint::HandleIncomingConnection()
+void TCPEndPointImplSockets::HandleIncomingConnection()
 {
-    CHIP_ERROR err      = CHIP_NO_ERROR;
-    TCPEndPoint * conEP = nullptr;
+    CHIP_ERROR err                 = CHIP_NO_ERROR;
+    TCPEndPointImplSockets * conEP = nullptr;
     IPAddress peerAddr;
     uint16_t peerPort;
 
@@ -2250,7 +2234,9 @@ void TCPEndPoint::HandleIncomingConnection()
     {
         InetLayer & lInetLayer = Layer();
 
-        err = lInetLayer.NewTCPEndPoint(&conEP);
+        TCPEndPoint * connectEndPoint = nullptr;
+        err                           = lInetLayer.NewTCPEndPoint(&connectEndPoint);
+        conEP                         = static_cast<TCPEndPointImplSockets *>(connectEndPoint);
     }
 
     // If all went well...
@@ -2309,7 +2295,7 @@ void TCPEndPoint::HandleIncomingConnection()
  *  This function probes the TCP output queue and checks if data is successfully
  *  being transferred to the other end.
  */
-CHIP_ERROR TCPEndPoint::CheckConnectionProgress(bool & isProgressing)
+CHIP_ERROR TCPEndPointImplSockets::CheckConnectionProgress(bool & isProgressing)
 {
     int currPendingBytesRaw = 0;
     uint32_t currPendingBytes; // Will be initialized once we know it's safe.
@@ -2580,11 +2566,9 @@ void TCPEndPoint::StopConnectTimer()
 void TCPEndPoint::TCPConnectTimeoutHandler(chip::System::Layer * aSystemLayer, void * aAppState)
 {
     TCPEndPoint * tcpEndPoint = reinterpret_cast<TCPEndPoint *>(aAppState);
-
     VerifyOrDie((aSystemLayer != nullptr) && (tcpEndPoint != nullptr));
 
-    // Close Connection as we have timed out and Connect has not returned to
-    // stop this timer.
+    // Close Connection as we have timed out and Connect has not returned to stop this timer.
     tcpEndPoint->DoClose(INET_ERROR_TCP_CONNECT_TIMEOUT, false);
 }
 
@@ -2788,6 +2772,14 @@ void TCPEndPoint::RestartTCPUserTimeoutTimer()
 {
     StopTCPUserTimeoutTimer();
     StartTCPUserTimeoutTimer();
+}
+
+// static
+void TCPEndPoint::TCPUserTimeoutHandler(chip::System::Layer * aSystemLayer, void * aAppState)
+{
+    TCPEndPoint * tcpEndPoint = reinterpret_cast<TCPEndPoint *>(aAppState);
+    VerifyOrDie((aSystemLayer != nullptr) && (tcpEndPoint != nullptr));
+    tcpEndPoint->TCPUserTimeoutHandler();
 }
 
 #endif // INET_CONFIG_OVERRIDE_SYSTEM_TCP_USER_TIMEOUT

--- a/src/inet/UDPEndPoint.h
+++ b/src/inet/UDPEndPoint.h
@@ -35,6 +35,16 @@
 #include <lib/support/Pool.h>
 #include <system/SystemPacketBuffer.h>
 
+#if CHIP_SYSTEM_CONFIG_USE_LWIP
+#include <inet/EndPointStateLwIP.h>
+#endif // CHIP_SYSTEM_CONFIG_USE_LWIP
+#if CHIP_SYSTEM_CONFIG_USE_SOCKETS
+#include <inet/EndPointStateSockets.h>
+#endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS
+#if CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK
+#include <inet/EndPointStateNetworkFramework.h>
+#endif // CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK
+
 #if CHIP_SYSTEM_CONFIG_USE_DISPATCH
 #include <dispatch/dispatch.h>
 #endif
@@ -60,19 +70,19 @@ public:
  *  endpoints (SOCK_DGRAM sockets on Linux and BSD-derived systems) or LwIP
  *  UDP protocol control blocks, as the system is configured accordingly.
  */
-class DLL_EXPORT UDPEndPoint : public EndPointBasis, public ReferenceCounted<UDPEndPoint, UDPEndPointDeletor>
+class DLL_EXPORT UDPEndPoint : public EndPointBase, public ReferenceCounted<UDPEndPoint, UDPEndPointDeletor>
 {
 public:
     UDPEndPoint(InetLayer & inetLayer, void * appState = nullptr) :
-        EndPointBasis(inetLayer, appState), mState(State::kReady), OnMessageReceived(nullptr), OnReceiveError(nullptr)
-    {
-        InitImpl();
-    }
+        EndPointBase(inetLayer, appState), mState(State::kReady), OnMessageReceived(nullptr), OnReceiveError(nullptr)
+    {}
 
     UDPEndPoint(const UDPEndPoint &) = delete;
     UDPEndPoint(UDPEndPoint &&)      = delete;
     UDPEndPoint & operator=(const UDPEndPoint &) = delete;
     UDPEndPoint & operator=(UDPEndPoint &&) = delete;
+
+    virtual ~UDPEndPoint() = default;
 
     /**
      * Type of message text reception event handling function.
@@ -104,7 +114,7 @@ public:
     /**
      * Set whether IP multicast traffic should be looped back.
      */
-    CHIP_ERROR SetMulticastLoopback(IPVersion aIPVersion, bool aLoopback);
+    virtual CHIP_ERROR SetMulticastLoopback(IPVersion aIPVersion, bool aLoopback) = 0;
 
     /**
      * Join an IP multicast group.
@@ -175,12 +185,12 @@ public:
     /**
      * Get the bound interface on this endpoint.
      */
-    InterfaceId GetBoundInterface() const;
+    virtual InterfaceId GetBoundInterface() const = 0;
 
     /**
      * Get the bound port on this endpoint.
      */
-    uint16_t GetBoundPort() const;
+    virtual uint16_t GetBoundPort() const = 0;
 
     /**
      * Prepare the endpoint to receive UDP messages.
@@ -261,11 +271,9 @@ public:
      *
      *  On LwIP systems, this method must not be called with the LwIP stack lock already acquired.
      */
-    void Free();
+    virtual void Free() = 0;
 
-private:
-    friend class InetLayer;
-
+protected:
     /**
      * Basic dynamic state of the underlying endpoint.
      *
@@ -288,20 +296,58 @@ private:
     /** The endpoint's receive error event handling function delegate. */
     OnReceiveErrorFunct OnReceiveError;
 
-    void InitImpl();
-    CHIP_ERROR IPv4JoinLeaveMulticastGroupImpl(InterfaceId aInterfaceId, const IPAddress & aAddress, bool join);
-    CHIP_ERROR IPv6JoinLeaveMulticastGroupImpl(InterfaceId aInterfaceId, const IPAddress & aAddress, bool join);
-
     friend class UDPEndPointDeletor;
-    static BitMapObjectPool<UDPEndPoint, INET_CONFIG_NUM_UDP_ENDPOINTS> sPool;
+    virtual void Delete() = 0;
 
-    CHIP_ERROR BindImpl(IPAddressType addressType, const IPAddress & address, uint16_t port, InterfaceId interfaceId);
-    CHIP_ERROR BindInterfaceImpl(IPAddressType addressType, InterfaceId interfaceId);
-    CHIP_ERROR ListenImpl();
-    CHIP_ERROR SendMsgImpl(const IPPacketInfo * pktInfo, chip::System::PacketBufferHandle && msg);
-    void CloseImpl();
+    /*
+     * Implementation helpers for shared methods.
+     */
+#if INET_CONFIG_ENABLE_IPV4
+    virtual CHIP_ERROR IPv4JoinLeaveMulticastGroupImpl(InterfaceId aInterfaceId, const IPAddress & aAddress, bool join) = 0;
+#endif // INET_CONFIG_ENABLE_IPV4
+    virtual CHIP_ERROR IPv6JoinLeaveMulticastGroupImpl(InterfaceId aInterfaceId, const IPAddress & aAddress, bool join) = 0;
+
+    virtual CHIP_ERROR BindImpl(IPAddressType addressType, const IPAddress & address, uint16_t port, InterfaceId interfaceId) = 0;
+    virtual CHIP_ERROR BindInterfaceImpl(IPAddressType addressType, InterfaceId interfaceId)                                  = 0;
+    virtual CHIP_ERROR ListenImpl()                                                                                           = 0;
+    virtual CHIP_ERROR SendMsgImpl(const IPPacketInfo * pktInfo, chip::System::PacketBufferHandle && msg)                     = 0;
+    virtual void CloseImpl()                                                                                                  = 0;
+};
+
+inline void UDPEndPointDeletor::Release(UDPEndPoint * obj)
+{
+    obj->Delete();
+}
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
+
+class UDPEndPointImplLwIP : public UDPEndPoint, public EndPointStateLwIP
+{
+public:
+    UDPEndPointImplLwIP(InetLayer & inetLayer, void * appState = nullptr) : UDPEndPoint(inetLayer, appState) {}
+
+    // UDPEndPoint overrides.
+    CHIP_ERROR SetMulticastLoopback(IPVersion aIPVersion, bool aLoopback) override;
+    InterfaceId GetBoundInterface() const override;
+    uint16_t GetBoundPort() const override;
+    void Free() override;
+
+private:
+    friend class InetLayer;
+    friend class BitMapObjectPool<UDPEndPointImplLwIP, INET_CONFIG_NUM_UDP_ENDPOINTS>;
+    static BitMapObjectPool<UDPEndPointImplLwIP, INET_CONFIG_NUM_UDP_ENDPOINTS> sPool;
+    void Delete() override { sPool.ReleaseObject(this); }
+
+    // UDPEndPoint overrides.
+#if INET_CONFIG_ENABLE_IPV4
+    CHIP_ERROR IPv4JoinLeaveMulticastGroupImpl(InterfaceId aInterfaceId, const IPAddress & aAddress, bool join) override;
+#endif // INET_CONFIG_ENABLE_IPV4
+    CHIP_ERROR IPv6JoinLeaveMulticastGroupImpl(InterfaceId aInterfaceId, const IPAddress & aAddress, bool join) override;
+    CHIP_ERROR BindImpl(IPAddressType addressType, const IPAddress & address, uint16_t port, InterfaceId interfaceId) override;
+    CHIP_ERROR BindInterfaceImpl(IPAddressType addressType, InterfaceId interfaceId) override;
+    CHIP_ERROR ListenImpl() override;
+    CHIP_ERROR SendMsgImpl(const IPPacketInfo * pktInfo, chip::System::PacketBufferHandle && msg) override;
+    void CloseImpl() override;
 
     static struct netif * FindNetifFromInterfaceId(InterfaceId aInterfaceId);
     static CHIP_ERROR LwIPBindInterface(struct udp_pcb * aUDP, InterfaceId intfId);
@@ -335,13 +381,54 @@ private:
 #else  // LWIP_VERSION_MAJOR <= 1 && LWIP_VERSION_MINOR < 5
     static void LwIPReceiveUDPMessage(void * arg, struct udp_pcb * pcb, struct pbuf * p, ip_addr_t * addr, u16_t port);
 #endif // LWIP_VERSION_MAJOR > 1 || LWIP_VERSION_MINOR >= 5
+};
+
+using UDPEndPointImpl = UDPEndPointImplLwIP;
 
 #endif // CHIP_SYSTEM_CONFIG_USE_LWIP
 
 #if CHIP_SYSTEM_CONFIG_USE_SOCKETS
+
+class UDPEndPointImplSockets : public UDPEndPoint, public EndPointStateSockets
+{
+public:
+    UDPEndPointImplSockets(InetLayer & inetLayer, void * appState = nullptr) :
+        UDPEndPoint(inetLayer, appState), mBoundIntfId(InterfaceId::Null())
+    {}
+
+    // UDPEndPoint overrides.
+    CHIP_ERROR SetMulticastLoopback(IPVersion aIPVersion, bool aLoopback) override;
+    InterfaceId GetBoundInterface() const override;
+    uint16_t GetBoundPort() const override;
+    void Free() override;
+
+private:
+    friend class InetLayer;
+    friend class BitMapObjectPool<UDPEndPointImplSockets, INET_CONFIG_NUM_UDP_ENDPOINTS>;
+    static BitMapObjectPool<UDPEndPointImplSockets, INET_CONFIG_NUM_UDP_ENDPOINTS> sPool;
+    void Delete() override { sPool.ReleaseObject(this); }
+
+    // UDPEndPoint overrides.
+#if INET_CONFIG_ENABLE_IPV4
+    CHIP_ERROR IPv4JoinLeaveMulticastGroupImpl(InterfaceId aInterfaceId, const IPAddress & aAddress, bool join) override;
+#endif // INET_CONFIG_ENABLE_IPV4
+    CHIP_ERROR IPv6JoinLeaveMulticastGroupImpl(InterfaceId aInterfaceId, const IPAddress & aAddress, bool join) override;
+    CHIP_ERROR BindImpl(IPAddressType addressType, const IPAddress & address, uint16_t port, InterfaceId interfaceId) override;
+    CHIP_ERROR BindInterfaceImpl(IPAddressType addressType, InterfaceId interfaceId) override;
+    CHIP_ERROR ListenImpl() override;
+    CHIP_ERROR SendMsgImpl(const IPPacketInfo * pktInfo, chip::System::PacketBufferHandle && msg) override;
+    void CloseImpl() override;
+
     CHIP_ERROR GetSocket(IPAddressType addressType);
     void HandlePendingIO(System::SocketEvents events);
     static void HandlePendingIO(System::SocketEvents events, intptr_t data);
+
+    InterfaceId mBoundIntfId;
+    uint16_t mBoundPort;
+
+#if CHIP_SYSTEM_CONFIG_USE_DISPATCH
+    dispatch_source_t mReadableSource = nullptr;
+#endif // CHIP_SYSTEM_CONFIG_USE_DISPATCH
 
 #if CHIP_SYSTEM_CONFIG_USE_PLATFORM_MULTICAST_API
 public:
@@ -353,16 +440,42 @@ private:
     static MulticastGroupHandler sJoinMulticastGroupHandler;
     static MulticastGroupHandler sLeaveMulticastGroupHandler;
 #endif // CHIP_SYSTEM_CONFIG_USE_PLATFORM_MULTICAST_API
+};
 
-    InterfaceId mBoundIntfId;
-    uint16_t mBoundPort;
+using UDPEndPointImpl = UDPEndPointImplSockets;
 
-#if CHIP_SYSTEM_CONFIG_USE_DISPATCH
-    dispatch_source_t mReadableSource = nullptr;
-#endif // CHIP_SYSTEM_CONFIG_USE_DISPATCH
 #endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS
 
 #if CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK
+
+class UDPEndPointImplNetworkFramework : public UDPEndPoint, public EndPointStateNetworkFramework
+{
+public:
+    UDPEndPointImplNetworkFramework(InetLayer & inetLayer, void * appState = nullptr) : UDPEndPoint(inetLayer, appState) {}
+
+    // UDPEndPoint overrides.
+    CHIP_ERROR SetMulticastLoopback(IPVersion aIPVersion, bool aLoopback) override;
+    InterfaceId GetBoundInterface() const override;
+    uint16_t GetBoundPort() const override;
+    void Free() override;
+
+private:
+    friend class InetLayer;
+    friend class BitMapObjectPool<UDPEndPointImplNetworkFramework, INET_CONFIG_NUM_UDP_ENDPOINTS>;
+    static BitMapObjectPool<UDPEndPointImplNetworkFramework, INET_CONFIG_NUM_UDP_ENDPOINTS> sPool;
+    void Delete() override { sPool.ReleaseObject(this); }
+
+    // UDPEndPoint overrides.
+#if INET_CONFIG_ENABLE_IPV4
+    CHIP_ERROR IPv4JoinLeaveMulticastGroupImpl(InterfaceId aInterfaceId, const IPAddress & aAddress, bool join) override;
+#endif // INET_CONFIG_ENABLE_IPV4
+    CHIP_ERROR IPv6JoinLeaveMulticastGroupImpl(InterfaceId aInterfaceId, const IPAddress & aAddress, bool join) override;
+    CHIP_ERROR BindImpl(IPAddressType addressType, const IPAddress & address, uint16_t port, InterfaceId interfaceId) override;
+    CHIP_ERROR BindInterfaceImpl(IPAddressType addressType, InterfaceId interfaceId) override;
+    CHIP_ERROR ListenImpl() override;
+    CHIP_ERROR SendMsgImpl(const IPPacketInfo * pktInfo, chip::System::PacketBufferHandle && msg) override;
+    void CloseImpl() override;
+
     nw_listener_t mListener;
     dispatch_semaphore_t mListenerSemaphore;
     dispatch_queue_t mListenerQueue;
@@ -381,13 +494,11 @@ private:
     CHIP_ERROR ReleaseListener();
     CHIP_ERROR ReleaseConnection();
     void ReleaseAll();
-#endif // CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK
 };
 
-inline void UDPEndPointDeletor::Release(UDPEndPoint * obj)
-{
-    UDPEndPoint::sPool.ReleaseObject(obj);
-}
+using UDPEndPointImpl = UDPEndPointImplNetworkFramework;
+
+#endif // CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK
 
 } // namespace Inet
 } // namespace chip

--- a/src/platform/Zephyr/ThreadStackManagerImpl.cpp
+++ b/src/platform/Zephyr/ThreadStackManagerImpl.cpp
@@ -46,13 +46,13 @@ CHIP_ERROR ThreadStackManagerImpl::_InitThreadStack()
 
     ReturnErrorOnFailure(GenericThreadStackManagerImpl_OpenThread<ThreadStackManagerImpl>::DoInit(instance));
 
-    UDPEndPoint::SetJoinMulticastGroupHandler([](InterfaceId, const IPAddress & address) {
+    UDPEndPointImplSockets::SetJoinMulticastGroupHandler([](InterfaceId, const IPAddress & address) {
         const otIp6Address otAddress = ToOpenThreadIP6Address(address);
         const auto otError           = otIp6SubscribeMulticastAddress(openthread_get_default_instance(), &otAddress);
         return MapOpenThreadError(otError);
     });
 
-    UDPEndPoint::SetLeaveMulticastGroupHandler([](InterfaceId, const IPAddress & address) {
+    UDPEndPointImplSockets::SetLeaveMulticastGroupHandler([](InterfaceId, const IPAddress & address) {
         const otIp6Address otAddress = ToOpenThreadIP6Address(address);
         const auto otError           = otIp6UnsubscribeMulticastAddress(openthread_get_default_instance(), &otAddress);
         return MapOpenThreadError(otError);

--- a/src/system/SystemPacketBuffer.h
+++ b/src/system/SystemPacketBuffer.h
@@ -844,7 +844,7 @@ using PacketBufferWriter = PacketBufferWriterBase<chip::Encoding::BigEndian::Buf
 namespace chip {
 
 namespace Inet {
-class UDPEndPoint;
+class UDPEndPointImplLwIP;
 } // namespace Inet
 
 namespace System {
@@ -863,7 +863,7 @@ private:
      * @note This should be used ONLY by low-level code interfacing with LwIP.
      */
     static struct pbuf * UnsafeGetLwIPpbuf(const PacketBufferHandle & handle) { return PacketBufferHandle::GetLwIPpbuf(handle); }
-    friend class Inet::UDPEndPoint;
+    friend class Inet::UDPEndPointImplLwIP;
 };
 
 } // namespace System


### PR DESCRIPTION
#### Problem

This is a step toward #7715 _Virtualize System and Inet interfaces_.

#### Change overview

- The per-implementation subclasses (formerly `#if` sections) of
  `EndPointBase` didn't actually depend on `EndPointBase` at all,
  so they are split off into `EndPointState${IMPL}` classes,
  separately inherited by the leaf classes.

- `UDPEndPoint` and `TCPEndPoint` are split into base classes and
  per-implementation subclasses. Transitionally, the implementation
  classes remain in the main files, and are instantiated using a single
  concrete name by `#if`.

#### Testing

CI; no changes to functionality.

