### PR TITLE
String values in YAML should test edge cases better.

### DIFF
--- a/examples/chip-tool/commands/tests/TestCommand.cpp
+++ b/examples/chip-tool/commands/tests/TestCommand.cpp
@@ -109,25 +109,23 @@ bool TestCommand::CheckConstraintMaxLength(const char * itemName, uint64_t curre
     return true;
 }
 
-bool TestCommand::CheckValueAsString(const char * itemName, const chip::ByteSpan current, const char * expected)
+bool TestCommand::CheckValueAsString(const char * itemName, chip::ByteSpan current, chip::ByteSpan expected)
 {
-    const chip::ByteSpan expectedArgument = chip::ByteSpan(chip::Uint8::from_const_char(expected), strlen(expected));
-
-    if (!current.data_equal(expectedArgument))
+    if (!current.data_equal(expected))
     {
-        Exit(std::string(itemName) + " value mismatch, expecting " + std::string(expected));
+        Exit(std::string(itemName) + " value mismatch, expecting " +
+             std::string(chip::Uint8::to_const_char(expected.data()), expected.size()));
         return false;
     }
 
     return true;
 }
 
-bool TestCommand::CheckValueAsString(const char * itemName, const chip::CharSpan current, const char * expected)
+bool TestCommand::CheckValueAsString(const char * itemName, chip::CharSpan current, chip::CharSpan expected)
 {
-    const chip::CharSpan expectedArgument(expected, strlen(expected));
-    if (!current.data_equal(expectedArgument))
+    if (!current.data_equal(expected))
     {
-        Exit(std::string(itemName) + " value mismatch, expected '" + expected + "' but got '" +
+        Exit(std::string(itemName) + " value mismatch, expected '" + std::string(expected.data(), expected.size()) + "' but got '" +
              std::string(current.data(), current.size()) + "'");
         return false;
     }

--- a/examples/chip-tool/commands/tests/TestCommand.h
+++ b/examples/chip-tool/commands/tests/TestCommand.h
@@ -171,9 +171,9 @@ protected:
         return false;
     }
 
-    bool CheckValueAsString(const char * itemName, chip::ByteSpan current, const char * expected);
+    bool CheckValueAsString(const char * itemName, chip::ByteSpan current, chip::ByteSpan expected);
 
-    bool CheckValueAsString(const char * itemName, chip::CharSpan current, const char * expected);
+    bool CheckValueAsString(const char * itemName, chip::CharSpan current, chip::CharSpan expected);
 
     template <typename T>
     bool CheckValuePresent(const char * itemName, const chip::Optional<T> & value)

--- a/examples/chip-tool/templates/partials/test_cluster_command_value.zapt
+++ b/examples/chip-tool/templates/partials/test_cluster_command_value.zapt
@@ -32,9 +32,9 @@
     {{#if_chip_enum type}}
       static_cast<{{zapTypeToEncodableClusterObjectType type ns=ns}}>({{definedValue}});
     {{else if (isCharString type)}}
-      chip::Span<const char>("{{definedValue}}", strlen("{{definedValue}}"));
+      chip::Span<const char>("{{definedValue}}garbage: not in length on purpose", {{definedValue.length}});
     {{else if (isOctetString type)}}
-      chip::ByteSpan(chip::Uint8::from_const_char("{{definedValue}}"), strlen("{{definedValue}}"));
+      chip::ByteSpan(chip::Uint8::from_const_char("{{octetStringEscapedForCLiteral definedValue}}garbage: not in length on purpose"), {{definedValue.length}});
     {{else}}
       {{#if_is_bitmap type}}
       static_cast<{{zapTypeToEncodableClusterObjectType type ns=ns}}>({{definedValue}});

--- a/examples/chip-tool/templates/partials/test_cluster_value_equals.zapt
+++ b/examples/chip-tool/templates/partials/test_cluster_value_equals.zapt
@@ -29,7 +29,8 @@
         than "global") that are not present in the struct ? }}
   {{else}}
     VerifyOrReturn(CheckValue
-      {{~#if (isString type)}}AsString("{{label}}", {{actual}}, "{{expected}}")
+      {{~#if (isOctetString type)}}AsString("{{label}}", {{actual}}, chip::ByteSpan(chip::Uint8::from_const_char("{{octetStringEscapedForCLiteral expected}}"), {{expected.length}}))
+      {{else if (isCharString type)}}AsString("{{label}}", {{actual}}, chip::CharSpan("{{expected}}", {{expected.length}}))
       {{else}}<{{chipType}}>("{{label}}", {{actual}}, {{expected}}{{asTypeLiteralSuffix type}})
       {{/if}}
     );

--- a/src/app/tests/suites/TV_TargetNavigatorCluster.yaml
+++ b/src/app/tests/suites/TV_TargetNavigatorCluster.yaml
@@ -36,4 +36,4 @@ tests:
               - name: "target"
                 value: 1
               - name: "data"
-                value: 1
+                value: "1"

--- a/src/app/tests/suites/TestCluster.yaml
+++ b/src/app/tests/suites/TestCluster.yaml
@@ -594,6 +594,18 @@ tests:
       response:
           value: ""
 
+    - label: "Write attribute OCTET_STRING with embedded null"
+      command: "writeAttribute"
+      attribute: "octet_string"
+      arguments:
+          value: "Tes\x00ti\x00ng"
+
+    - label: "Read attribute OCTET_STRING with embedded null"
+      command: "readAttribute"
+      attribute: "octet_string"
+      response:
+          value: "Tes\x00ti\x00ng"
+
     - label: "Write attribute OCTET_STRING"
       command: "writeAttribute"
       attribute: "octet_string"

--- a/src/app/zap-templates/common/ClusterTestGeneration.js
+++ b/src/app/zap-templates/common/ClusterTestGeneration.js
@@ -582,6 +582,18 @@ function expectedValueHasProp(value, name)
   return name in value;
 }
 
+function octetStringEscapedForCLiteral(value)
+{
+  return value.replace(/\p{Control}/gu, ch => {
+    let code = ch.charCodeAt(0);
+    code     = code.toString();
+    if (code.length == 1) {
+      code = "0" + code;
+    }
+    return "\\x" + code;
+  });
+}
+
 //
 // Module exports
 //
@@ -593,3 +605,4 @@ exports.chip_tests_pics                     = chip_tests_pics;
 exports.isTestOnlyCluster                   = isTestOnlyCluster;
 exports.isLiteralNull                       = isLiteralNull;
 exports.expectedValueHasProp                = expectedValueHasProp;
+exports.octetStringEscapedForCLiteral       = octetStringEscapedForCLiteral;

--- a/src/darwin/Framework/CHIP/templates/partials/test_cluster.zapt
+++ b/src/darwin/Framework/CHIP/templates/partials/test_cluster.zapt
@@ -21,8 +21,7 @@ bool testSendCluster{{parent.filename}}_{{asTestIndex index}}_{{asUpperCamelCase
     {{#chip_tests_item_parameters}}
     {{#if (isString type)}}
     {{#if (isOctetString type)}}
-    NSString * {{asLowerCamelCase name}}ArgumentString= @"{{definedValue}}";
-    NSData * {{asLowerCamelCase name}}Argument = [{{asLowerCamelCase name}}ArgumentString dataUsingEncoding:NSUTF8StringEncoding];
+    NSData * {{asLowerCamelCase name}}Argument = [[NSData alloc] initWithBytes:"{{octetStringEscapedForCLiteral definedValue}}" length:{{definedValue.length}}];
     {{else}}
     NSString * {{asLowerCamelCase name}}Argument= @"{{definedValue}}";
     {{/if}}
@@ -67,8 +66,7 @@ bool testSendCluster{{parent.filename}}_{{asTestIndex index}}_{{asUpperCamelCase
         {{else}}
         {{#if (isString type)}}
         {{#if (isOctetString type)}}
-        NSString * {{asLowerCamelCase name}}ArgumentString= @"{{expectedValue}}";
-        NSData * {{asLowerCamelCase name}}Argument = [{{asLowerCamelCase name}}ArgumentString dataUsingEncoding:NSUTF8StringEncoding];
+        NSData * {{asLowerCamelCase name}}Argument = [[NSData alloc] initWithBytes:"{{octetStringEscapedForCLiteral expectedValue}}" length:{{expectedValue.length}}];
         XCTAssertTrue([values[@"{{#if parent.isAttribute}}value{{else}}{{name}}{{/if}}"] isEqualToData:{{asLowerCamelCase name}}Argument]);
         {{else}}
         NSString * {{asLowerCamelCase name}}Argument= @"{{expectedValue}}";

--- a/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
+++ b/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
@@ -16969,8 +16969,7 @@ CHIPDevice * GetConnectedDevice()
 
         XCTAssertEqual(err.code, 0);
 
-        NSString * octetStringArgumentString = @"";
-        NSData * octetStringArgument = [octetStringArgumentString dataUsingEncoding:NSUTF8StringEncoding];
+        NSData * octetStringArgument = [[NSData alloc] initWithBytes:"" length:0];
         XCTAssertTrue([values[@"value"] isEqualToData:octetStringArgument]);
 
         [expectation fulfill];
@@ -16980,18 +16979,17 @@ CHIPDevice * GetConnectedDevice()
 }
 - (void)testSendClusterTestCluster_000089_WriteAttribute
 {
-    XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute OCTET_STRING"];
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute OCTET_STRING with embedded null"];
 
     CHIPDevice * device = GetConnectedDevice();
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    NSString * octetStringArgumentString = @"TestValue";
-    NSData * octetStringArgument = [octetStringArgumentString dataUsingEncoding:NSUTF8StringEncoding];
+    NSData * octetStringArgument = [[NSData alloc] initWithBytes:"Tes\x00ti\x00ng" length:9];
     [cluster writeAttributeOctetStringWithValue:octetStringArgument
                                 responseHandler:^(NSError * err, NSDictionary * values) {
-                                    NSLog(@"Write attribute OCTET_STRING Error: %@", err);
+                                    NSLog(@"Write attribute OCTET_STRING with embedded null Error: %@", err);
 
                                     XCTAssertEqual(err.code, 0);
 
@@ -17002,7 +17000,7 @@ CHIPDevice * GetConnectedDevice()
 }
 - (void)testSendClusterTestCluster_000090_ReadAttribute
 {
-    XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute OCTET_STRING"];
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute OCTET_STRING with embedded null"];
 
     CHIPDevice * device = GetConnectedDevice();
     dispatch_queue_t queue = dispatch_get_main_queue();
@@ -17010,12 +17008,11 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     [cluster readAttributeOctetStringWithResponseHandler:^(NSError * err, NSDictionary * values) {
-        NSLog(@"Read attribute OCTET_STRING Error: %@", err);
+        NSLog(@"Read attribute OCTET_STRING with embedded null Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
 
-        NSString * octetStringArgumentString = @"TestValue";
-        NSData * octetStringArgument = [octetStringArgumentString dataUsingEncoding:NSUTF8StringEncoding];
+        NSData * octetStringArgument = [[NSData alloc] initWithBytes:"Tes\x00ti\x00ng" length:9];
         XCTAssertTrue([values[@"value"] isEqualToData:octetStringArgument]);
 
         [expectation fulfill];
@@ -17032,13 +17029,13 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    NSString * octetStringArgumentString = @"TestValueLongerThan10";
-    NSData * octetStringArgument = [octetStringArgumentString dataUsingEncoding:NSUTF8StringEncoding];
+    NSData * octetStringArgument = [[NSData alloc] initWithBytes:"TestValue" length:9];
     [cluster writeAttributeOctetStringWithValue:octetStringArgument
                                 responseHandler:^(NSError * err, NSDictionary * values) {
                                     NSLog(@"Write attribute OCTET_STRING Error: %@", err);
 
-                                    XCTAssertEqual(err.code, true);
+                                    XCTAssertEqual(err.code, 0);
+
                                     [expectation fulfill];
                                 }];
 
@@ -17058,8 +17055,7 @@ CHIPDevice * GetConnectedDevice()
 
         XCTAssertEqual(err.code, 0);
 
-        NSString * octetStringArgumentString = @"TestValue";
-        NSData * octetStringArgument = [octetStringArgumentString dataUsingEncoding:NSUTF8StringEncoding];
+        NSData * octetStringArgument = [[NSData alloc] initWithBytes:"TestValue" length:9];
         XCTAssertTrue([values[@"value"] isEqualToData:octetStringArgument]);
 
         [expectation fulfill];
@@ -17076,8 +17072,49 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    NSString * octetStringArgumentString = @"";
-    NSData * octetStringArgument = [octetStringArgumentString dataUsingEncoding:NSUTF8StringEncoding];
+    NSData * octetStringArgument = [[NSData alloc] initWithBytes:"TestValueLongerThan10" length:21];
+    [cluster writeAttributeOctetStringWithValue:octetStringArgument
+                                responseHandler:^(NSError * err, NSDictionary * values) {
+                                    NSLog(@"Write attribute OCTET_STRING Error: %@", err);
+
+                                    XCTAssertEqual(err.code, true);
+                                    [expectation fulfill];
+                                }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestCluster_000094_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute OCTET_STRING"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeOctetStringWithResponseHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"Read attribute OCTET_STRING Error: %@", err);
+
+        XCTAssertEqual(err.code, 0);
+
+        NSData * octetStringArgument = [[NSData alloc] initWithBytes:"TestValue" length:9];
+        XCTAssertTrue([values[@"value"] isEqualToData:octetStringArgument]);
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestCluster_000095_WriteAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute OCTET_STRING"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    NSData * octetStringArgument = [[NSData alloc] initWithBytes:"" length:0];
     [cluster writeAttributeOctetStringWithValue:octetStringArgument
                                 responseHandler:^(NSError * err, NSDictionary * values) {
                                     NSLog(@"Write attribute OCTET_STRING Error: %@", err);
@@ -17089,7 +17126,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000094_ReadAttribute
+- (void)testSendClusterTestCluster_000096_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute LONG_OCTET_STRING Default Value"];
 
@@ -17103,59 +17140,7 @@ CHIPDevice * GetConnectedDevice()
 
         XCTAssertEqual(err.code, 0);
 
-        NSString * longOctetStringArgumentString = @"";
-        NSData * longOctetStringArgument = [longOctetStringArgumentString dataUsingEncoding:NSUTF8StringEncoding];
-        XCTAssertTrue([values[@"value"] isEqualToData:longOctetStringArgument]);
-
-        [expectation fulfill];
-    }];
-
-    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
-}
-- (void)testSendClusterTestCluster_000095_WriteAttribute
-{
-    XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute LONG_OCTET_STRING"];
-
-    CHIPDevice * device = GetConnectedDevice();
-    dispatch_queue_t queue = dispatch_get_main_queue();
-    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
-    XCTAssertNotNil(cluster);
-
-    NSString * longOctetStringArgumentString
-        = @"11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111"
-          @"11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111"
-          @"11111111111111111111111111111111111111111111111111111111111111";
-    NSData * longOctetStringArgument = [longOctetStringArgumentString dataUsingEncoding:NSUTF8StringEncoding];
-    [cluster writeAttributeLongOctetStringWithValue:longOctetStringArgument
-                                    responseHandler:^(NSError * err, NSDictionary * values) {
-                                        NSLog(@"Write attribute LONG_OCTET_STRING Error: %@", err);
-
-                                        XCTAssertEqual(err.code, 0);
-
-                                        [expectation fulfill];
-                                    }];
-
-    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
-}
-- (void)testSendClusterTestCluster_000096_ReadAttribute
-{
-    XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute LONG_OCTET_STRING"];
-
-    CHIPDevice * device = GetConnectedDevice();
-    dispatch_queue_t queue = dispatch_get_main_queue();
-    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
-    XCTAssertNotNil(cluster);
-
-    [cluster readAttributeLongOctetStringWithResponseHandler:^(NSError * err, NSDictionary * values) {
-        NSLog(@"Read attribute LONG_OCTET_STRING Error: %@", err);
-
-        XCTAssertEqual(err.code, 0);
-
-        NSString * longOctetStringArgumentString
-            = @"1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111"
-              @"1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111"
-              @"1111111111111111111111111111111111111111111111111111111111111111111111";
-        NSData * longOctetStringArgument = [longOctetStringArgumentString dataUsingEncoding:NSUTF8StringEncoding];
+        NSData * longOctetStringArgument = [[NSData alloc] initWithBytes:"" length:0];
         XCTAssertTrue([values[@"value"] isEqualToData:longOctetStringArgument]);
 
         [expectation fulfill];
@@ -17172,8 +17157,11 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    NSString * longOctetStringArgumentString = @"";
-    NSData * longOctetStringArgument = [longOctetStringArgumentString dataUsingEncoding:NSUTF8StringEncoding];
+    NSData * longOctetStringArgument = [[NSData alloc]
+        initWithBytes:"111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111"
+                      "111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111"
+                      "111111111111111111111111111111111111111111111111111111111111111111111111111111111111"
+               length:300];
     [cluster writeAttributeLongOctetStringWithValue:longOctetStringArgument
                                     responseHandler:^(NSError * err, NSDictionary * values) {
                                         NSLog(@"Write attribute LONG_OCTET_STRING Error: %@", err);
@@ -17186,6 +17174,53 @@ CHIPDevice * GetConnectedDevice()
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 - (void)testSendClusterTestCluster_000098_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute LONG_OCTET_STRING"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeLongOctetStringWithResponseHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"Read attribute LONG_OCTET_STRING Error: %@", err);
+
+        XCTAssertEqual(err.code, 0);
+
+        NSData * longOctetStringArgument = [[NSData alloc]
+            initWithBytes:"11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111"
+                          "11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111"
+                          "11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111"
+                   length:300];
+        XCTAssertTrue([values[@"value"] isEqualToData:longOctetStringArgument]);
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestCluster_000099_WriteAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute LONG_OCTET_STRING"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    NSData * longOctetStringArgument = [[NSData alloc] initWithBytes:"" length:0];
+    [cluster writeAttributeLongOctetStringWithValue:longOctetStringArgument
+                                    responseHandler:^(NSError * err, NSDictionary * values) {
+                                        NSLog(@"Write attribute LONG_OCTET_STRING Error: %@", err);
+
+                                        XCTAssertEqual(err.code, 0);
+
+                                        [expectation fulfill];
+                                    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestCluster_000100_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute CHAR_STRING Default Value"];
 
@@ -17207,7 +17242,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000099_WriteAttribute
+- (void)testSendClusterTestCluster_000101_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute CHAR_STRING"];
 
@@ -17228,7 +17263,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000100_WriteAttribute
+- (void)testSendClusterTestCluster_000102_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute CHAR_STRING - Value too long"];
 
@@ -17248,7 +17283,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000101_WriteAttribute
+- (void)testSendClusterTestCluster_000103_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute CHAR_STRING - Empty"];
 
@@ -17269,7 +17304,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000102_ReadAttribute
+- (void)testSendClusterTestCluster_000104_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute LONG_CHAR_STRING Default Value"];
 
@@ -17291,7 +17326,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000103_WriteAttribute
+- (void)testSendClusterTestCluster_000105_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute LONG_CHAR_STRING"];
 
@@ -17315,7 +17350,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000104_ReadAttribute
+- (void)testSendClusterTestCluster_000106_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute LONG_CHAR_STRING"];
 
@@ -17340,7 +17375,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000105_WriteAttribute
+- (void)testSendClusterTestCluster_000107_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute LONG_CHAR_STRING"];
 
@@ -17361,7 +17396,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000106_ReadAttribute
+- (void)testSendClusterTestCluster_000108_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute LIST"];
 
@@ -17382,7 +17417,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000107_ReadAttribute
+- (void)testSendClusterTestCluster_000109_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute LIST_OCTET_STRING"];
 
@@ -17403,7 +17438,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000108_ReadAttribute
+- (void)testSendClusterTestCluster_000110_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute LIST_STRUCT_OCTET_STRING"];
 
@@ -17424,7 +17459,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000109_ReadAttribute
+- (void)testSendClusterTestCluster_000111_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute EPOCH_US Default Value"];
 
@@ -17445,7 +17480,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000110_WriteAttribute
+- (void)testSendClusterTestCluster_000112_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute EPOCH_US Max Value"];
 
@@ -17466,7 +17501,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000111_ReadAttribute
+- (void)testSendClusterTestCluster_000113_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute EPOCH_US Max Value"];
 
@@ -17487,7 +17522,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000112_WriteAttribute
+- (void)testSendClusterTestCluster_000114_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute EPOCH_US Min Value"];
 
@@ -17508,7 +17543,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000113_ReadAttribute
+- (void)testSendClusterTestCluster_000115_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute EPOCH_US Min Value"];
 
@@ -17529,7 +17564,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000114_ReadAttribute
+- (void)testSendClusterTestCluster_000116_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute EPOCH_S Default Value"];
 
@@ -17550,7 +17585,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000115_WriteAttribute
+- (void)testSendClusterTestCluster_000117_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute EPOCH_S Max Value"];
 
@@ -17571,7 +17606,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000116_ReadAttribute
+- (void)testSendClusterTestCluster_000118_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute EPOCH_S Max Value"];
 
@@ -17592,7 +17627,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000117_WriteAttribute
+- (void)testSendClusterTestCluster_000119_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute EPOCH_S Min Value"];
 
@@ -17613,7 +17648,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000118_ReadAttribute
+- (void)testSendClusterTestCluster_000120_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute EPOCH_S Min Value"];
 
@@ -17634,7 +17669,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000119_ReadAttribute
+- (void)testSendClusterTestCluster_000121_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute UNSUPPORTED"];
 
@@ -17660,7 +17695,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000120_WriteAttribute
+- (void)testSendClusterTestCluster_000122_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Writeattribute UNSUPPORTED"];
 
@@ -17686,7 +17721,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000121_Test
+- (void)testSendClusterTestCluster_000123_Test
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Send Test Command to unsupported endpoint"];
 
@@ -17704,7 +17739,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000122_ReadAttribute
+- (void)testSendClusterTestCluster_000124_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute vendor_id Default Value"];
 
@@ -17725,7 +17760,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000123_WriteAttribute
+- (void)testSendClusterTestCluster_000125_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute vendor_id"];
 
@@ -17746,7 +17781,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000124_ReadAttribute
+- (void)testSendClusterTestCluster_000126_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute vendor_id"];
 
@@ -17767,7 +17802,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000125_WriteAttribute
+- (void)testSendClusterTestCluster_000127_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Restore attribute vendor_id"];
 
@@ -17788,7 +17823,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000126_TestEnumsRequest
+- (void)testSendClusterTestCluster_000128_TestEnumsRequest
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Send a command with a vendor_id and enum"];
 

--- a/zzz_generated/chip-tool/zap-generated/test/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/test/Commands.h
@@ -24787,10 +24787,10 @@ private:
         auto iter = targetNavigatorList.begin();
         VerifyOrReturn(CheckNextListItemDecodes<decltype(targetNavigatorList)>("targetNavigatorList", iter, 0));
         VerifyOrReturn(CheckValue<>("targetNavigatorList[0].identifier", iter.GetValue().identifier, 1));
-        VerifyOrReturn(CheckValueAsString("targetNavigatorList[0].name", iter.GetValue().name, "exampleName"));
+        VerifyOrReturn(CheckValueAsString("targetNavigatorList[0].name", iter.GetValue().name, chip::CharSpan("exampleName", 11)));
         VerifyOrReturn(CheckNextListItemDecodes<decltype(targetNavigatorList)>("targetNavigatorList", iter, 1));
         VerifyOrReturn(CheckValue<>("targetNavigatorList[1].identifier", iter.GetValue().identifier, 2));
-        VerifyOrReturn(CheckValueAsString("targetNavigatorList[1].name", iter.GetValue().name, "exampleName"));
+        VerifyOrReturn(CheckValueAsString("targetNavigatorList[1].name", iter.GetValue().name, chip::CharSpan("exampleName", 11)));
         VerifyOrReturn(CheckNoMoreListItems<decltype(targetNavigatorList)>("targetNavigatorList", iter, 2));
         NextTest();
     }
@@ -24804,7 +24804,7 @@ private:
 
         RequestType request;
         request.target = 1;
-        request.data   = chip::Span<const char>("1", strlen("1"));
+        request.data   = chip::Span<const char>("1garbage: not in length on purpose", 1);
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<TV_TargetNavigatorCluster *>(context))->OnSuccessResponse_1(data.status, data.data);
@@ -24912,15 +24912,15 @@ private:
         VerifyOrReturn(CheckNextListItemDecodes<decltype(audioOutputList)>("audioOutputList", iter, 0));
         VerifyOrReturn(CheckValue<>("audioOutputList[0].index", iter.GetValue().index, 1));
         VerifyOrReturn(CheckValue<>("audioOutputList[0].outputType", iter.GetValue().outputType, 0));
-        VerifyOrReturn(CheckValueAsString("audioOutputList[0].name", iter.GetValue().name, "exampleName"));
+        VerifyOrReturn(CheckValueAsString("audioOutputList[0].name", iter.GetValue().name, chip::CharSpan("exampleName", 11)));
         VerifyOrReturn(CheckNextListItemDecodes<decltype(audioOutputList)>("audioOutputList", iter, 1));
         VerifyOrReturn(CheckValue<>("audioOutputList[1].index", iter.GetValue().index, 2));
         VerifyOrReturn(CheckValue<>("audioOutputList[1].outputType", iter.GetValue().outputType, 0));
-        VerifyOrReturn(CheckValueAsString("audioOutputList[1].name", iter.GetValue().name, "exampleName"));
+        VerifyOrReturn(CheckValueAsString("audioOutputList[1].name", iter.GetValue().name, chip::CharSpan("exampleName", 11)));
         VerifyOrReturn(CheckNextListItemDecodes<decltype(audioOutputList)>("audioOutputList", iter, 2));
         VerifyOrReturn(CheckValue<>("audioOutputList[2].index", iter.GetValue().index, 3));
         VerifyOrReturn(CheckValue<>("audioOutputList[2].outputType", iter.GetValue().outputType, 0));
-        VerifyOrReturn(CheckValueAsString("audioOutputList[2].name", iter.GetValue().name, "exampleName"));
+        VerifyOrReturn(CheckValueAsString("audioOutputList[2].name", iter.GetValue().name, chip::CharSpan("exampleName", 11)));
         VerifyOrReturn(CheckNoMoreListItems<decltype(audioOutputList)>("audioOutputList", iter, 3));
         NextTest();
     }
@@ -24958,7 +24958,7 @@ private:
 
         RequestType request;
         request.index = 1;
-        request.name  = chip::Span<const char>("exampleName", strlen("exampleName"));
+        request.name  = chip::Span<const char>("exampleNamegarbage: not in length on purpose", 11);
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<TV_AudioOutputCluster *>(context))->OnSuccessResponse_2();
@@ -25098,9 +25098,9 @@ private:
         using RequestType = chip::app::Clusters::ApplicationLauncher::Commands::LaunchApp::Type;
 
         RequestType request;
-        request.data            = chip::Span<const char>("exampleData", strlen("exampleData"));
+        request.data            = chip::Span<const char>("exampleDatagarbage: not in length on purpose", 11);
         request.catalogVendorId = 1U;
-        request.applicationId   = chip::Span<const char>("appId", strlen("appId"));
+        request.applicationId   = chip::Span<const char>("appIdgarbage: not in length on purpose", 5);
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<TV_ApplicationLauncherCluster *>(context))->OnSuccessResponse_1(data.status, data.data);
@@ -25294,7 +25294,7 @@ private:
         using RequestType = chip::app::Clusters::AccountLogin::Commands::GetSetupPIN::Type;
 
         RequestType request;
-        request.tempAccountIdentifier = chip::Span<const char>("asdf", strlen("asdf"));
+        request.tempAccountIdentifier = chip::Span<const char>("asdfgarbage: not in length on purpose", 4);
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<TV_AccountLoginCluster *>(context))->OnSuccessResponse_0(data.setupPIN);
@@ -25318,8 +25318,8 @@ private:
         using RequestType = chip::app::Clusters::AccountLogin::Commands::Login::Type;
 
         RequestType request;
-        request.tempAccountIdentifier = chip::Span<const char>("asdf", strlen("asdf"));
-        request.setupPIN              = chip::Span<const char>("tempPin123", strlen("tempPin123"));
+        request.tempAccountIdentifier = chip::Span<const char>("asdfgarbage: not in length on purpose", 4);
+        request.setupPIN              = chip::Span<const char>("tempPin123garbage: not in length on purpose", 10);
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<TV_AccountLoginCluster *>(context))->OnSuccessResponse_1();
@@ -25410,7 +25410,7 @@ private:
 
     void OnSuccessResponse_0(chip::CharSpan wakeOnLanMacAddress)
     {
-        VerifyOrReturn(CheckValueAsString("wakeOnLanMacAddress", wakeOnLanMacAddress, "00:00:00:00:00"));
+        VerifyOrReturn(CheckValueAsString("wakeOnLanMacAddress", wakeOnLanMacAddress, chip::CharSpan("00:00:00:00:00", 14)));
         NextTest();
     }
 };
@@ -26067,15 +26067,19 @@ private:
         VerifyOrReturn(CheckNextListItemDecodes<decltype(tvChannelList)>("tvChannelList", iter, 0));
         VerifyOrReturn(CheckValue<>("tvChannelList[0].majorNumber", iter.GetValue().majorNumber, 1U));
         VerifyOrReturn(CheckValue<>("tvChannelList[0].minorNumber", iter.GetValue().minorNumber, 2U));
-        VerifyOrReturn(CheckValueAsString("tvChannelList[0].name", iter.GetValue().name, "exampleName"));
-        VerifyOrReturn(CheckValueAsString("tvChannelList[0].callSign", iter.GetValue().callSign, "exampleCSign"));
-        VerifyOrReturn(CheckValueAsString("tvChannelList[0].affiliateCallSign", iter.GetValue().affiliateCallSign, "exampleASign"));
+        VerifyOrReturn(CheckValueAsString("tvChannelList[0].name", iter.GetValue().name, chip::CharSpan("exampleName", 11)));
+        VerifyOrReturn(
+            CheckValueAsString("tvChannelList[0].callSign", iter.GetValue().callSign, chip::CharSpan("exampleCSign", 12)));
+        VerifyOrReturn(CheckValueAsString("tvChannelList[0].affiliateCallSign", iter.GetValue().affiliateCallSign,
+                                          chip::CharSpan("exampleASign", 12)));
         VerifyOrReturn(CheckNextListItemDecodes<decltype(tvChannelList)>("tvChannelList", iter, 1));
         VerifyOrReturn(CheckValue<>("tvChannelList[1].majorNumber", iter.GetValue().majorNumber, 2U));
         VerifyOrReturn(CheckValue<>("tvChannelList[1].minorNumber", iter.GetValue().minorNumber, 3U));
-        VerifyOrReturn(CheckValueAsString("tvChannelList[1].name", iter.GetValue().name, "exampleName"));
-        VerifyOrReturn(CheckValueAsString("tvChannelList[1].callSign", iter.GetValue().callSign, "exampleCSign"));
-        VerifyOrReturn(CheckValueAsString("tvChannelList[1].affiliateCallSign", iter.GetValue().affiliateCallSign, "exampleASign"));
+        VerifyOrReturn(CheckValueAsString("tvChannelList[1].name", iter.GetValue().name, chip::CharSpan("exampleName", 11)));
+        VerifyOrReturn(
+            CheckValueAsString("tvChannelList[1].callSign", iter.GetValue().callSign, chip::CharSpan("exampleCSign", 12)));
+        VerifyOrReturn(CheckValueAsString("tvChannelList[1].affiliateCallSign", iter.GetValue().affiliateCallSign,
+                                          chip::CharSpan("exampleASign", 12)));
         VerifyOrReturn(CheckNoMoreListItems<decltype(tvChannelList)>("tvChannelList", iter, 2));
         NextTest();
     }
@@ -26318,13 +26322,15 @@ private:
         VerifyOrReturn(CheckNextListItemDecodes<decltype(mediaInputList)>("mediaInputList", iter, 0));
         VerifyOrReturn(CheckValue<>("mediaInputList[0].index", iter.GetValue().index, 1));
         VerifyOrReturn(CheckValue<>("mediaInputList[0].inputType", iter.GetValue().inputType, 4));
-        VerifyOrReturn(CheckValueAsString("mediaInputList[0].name", iter.GetValue().name, "exampleName"));
-        VerifyOrReturn(CheckValueAsString("mediaInputList[0].description", iter.GetValue().description, "exampleDescription"));
+        VerifyOrReturn(CheckValueAsString("mediaInputList[0].name", iter.GetValue().name, chip::CharSpan("exampleName", 11)));
+        VerifyOrReturn(CheckValueAsString("mediaInputList[0].description", iter.GetValue().description,
+                                          chip::CharSpan("exampleDescription", 18)));
         VerifyOrReturn(CheckNextListItemDecodes<decltype(mediaInputList)>("mediaInputList", iter, 1));
         VerifyOrReturn(CheckValue<>("mediaInputList[1].index", iter.GetValue().index, 2));
         VerifyOrReturn(CheckValue<>("mediaInputList[1].inputType", iter.GetValue().inputType, 4));
-        VerifyOrReturn(CheckValueAsString("mediaInputList[1].name", iter.GetValue().name, "exampleName"));
-        VerifyOrReturn(CheckValueAsString("mediaInputList[1].description", iter.GetValue().description, "exampleDescription"));
+        VerifyOrReturn(CheckValueAsString("mediaInputList[1].name", iter.GetValue().name, chip::CharSpan("exampleName", 11)));
+        VerifyOrReturn(CheckValueAsString("mediaInputList[1].description", iter.GetValue().description,
+                                          chip::CharSpan("exampleDescription", 18)));
         VerifyOrReturn(CheckNoMoreListItems<decltype(mediaInputList)>("mediaInputList", iter, 2));
         NextTest();
     }
@@ -26425,7 +26431,7 @@ private:
 
         RequestType request;
         request.index = 1;
-        request.name  = chip::Span<const char>("newName", strlen("newName"));
+        request.name  = chip::Span<const char>("newNamegarbage: not in length on purpose", 7);
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<TV_MediaInputCluster *>(context))->OnSuccessResponse_5();
@@ -26829,12 +26835,12 @@ public:
             err = TestReadAttributeOctetStringDefaultValue_88();
             break;
         case 89:
-            ChipLogProgress(chipTool, " ***** Test Step 89 : Write attribute OCTET_STRING\n");
-            err = TestWriteAttributeOctetString_89();
+            ChipLogProgress(chipTool, " ***** Test Step 89 : Write attribute OCTET_STRING with embedded null\n");
+            err = TestWriteAttributeOctetStringWithEmbeddedNull_89();
             break;
         case 90:
-            ChipLogProgress(chipTool, " ***** Test Step 90 : Read attribute OCTET_STRING\n");
-            err = TestReadAttributeOctetString_90();
+            ChipLogProgress(chipTool, " ***** Test Step 90 : Read attribute OCTET_STRING with embedded null\n");
+            err = TestReadAttributeOctetStringWithEmbeddedNull_90();
             break;
         case 91:
             ChipLogProgress(chipTool, " ***** Test Step 91 : Write attribute OCTET_STRING\n");
@@ -26849,136 +26855,144 @@ public:
             err = TestWriteAttributeOctetString_93();
             break;
         case 94:
-            ChipLogProgress(chipTool, " ***** Test Step 94 : Read attribute LONG_OCTET_STRING Default Value\n");
-            err = TestReadAttributeLongOctetStringDefaultValue_94();
+            ChipLogProgress(chipTool, " ***** Test Step 94 : Read attribute OCTET_STRING\n");
+            err = TestReadAttributeOctetString_94();
             break;
         case 95:
-            ChipLogProgress(chipTool, " ***** Test Step 95 : Write attribute LONG_OCTET_STRING\n");
-            err = TestWriteAttributeLongOctetString_95();
+            ChipLogProgress(chipTool, " ***** Test Step 95 : Write attribute OCTET_STRING\n");
+            err = TestWriteAttributeOctetString_95();
             break;
         case 96:
-            ChipLogProgress(chipTool, " ***** Test Step 96 : Read attribute LONG_OCTET_STRING\n");
-            err = TestReadAttributeLongOctetString_96();
+            ChipLogProgress(chipTool, " ***** Test Step 96 : Read attribute LONG_OCTET_STRING Default Value\n");
+            err = TestReadAttributeLongOctetStringDefaultValue_96();
             break;
         case 97:
             ChipLogProgress(chipTool, " ***** Test Step 97 : Write attribute LONG_OCTET_STRING\n");
             err = TestWriteAttributeLongOctetString_97();
             break;
         case 98:
-            ChipLogProgress(chipTool, " ***** Test Step 98 : Read attribute CHAR_STRING Default Value\n");
-            err = TestReadAttributeCharStringDefaultValue_98();
+            ChipLogProgress(chipTool, " ***** Test Step 98 : Read attribute LONG_OCTET_STRING\n");
+            err = TestReadAttributeLongOctetString_98();
             break;
         case 99:
-            ChipLogProgress(chipTool, " ***** Test Step 99 : Write attribute CHAR_STRING\n");
-            err = TestWriteAttributeCharString_99();
+            ChipLogProgress(chipTool, " ***** Test Step 99 : Write attribute LONG_OCTET_STRING\n");
+            err = TestWriteAttributeLongOctetString_99();
             break;
         case 100:
-            ChipLogProgress(chipTool, " ***** Test Step 100 : Write attribute CHAR_STRING - Value too long\n");
-            err = TestWriteAttributeCharStringValueTooLong_100();
+            ChipLogProgress(chipTool, " ***** Test Step 100 : Read attribute CHAR_STRING Default Value\n");
+            err = TestReadAttributeCharStringDefaultValue_100();
             break;
         case 101:
-            ChipLogProgress(chipTool, " ***** Test Step 101 : Write attribute CHAR_STRING - Empty\n");
-            err = TestWriteAttributeCharStringEmpty_101();
+            ChipLogProgress(chipTool, " ***** Test Step 101 : Write attribute CHAR_STRING\n");
+            err = TestWriteAttributeCharString_101();
             break;
         case 102:
-            ChipLogProgress(chipTool, " ***** Test Step 102 : Read attribute LONG_CHAR_STRING Default Value\n");
-            err = TestReadAttributeLongCharStringDefaultValue_102();
+            ChipLogProgress(chipTool, " ***** Test Step 102 : Write attribute CHAR_STRING - Value too long\n");
+            err = TestWriteAttributeCharStringValueTooLong_102();
             break;
         case 103:
-            ChipLogProgress(chipTool, " ***** Test Step 103 : Write attribute LONG_CHAR_STRING\n");
-            err = TestWriteAttributeLongCharString_103();
+            ChipLogProgress(chipTool, " ***** Test Step 103 : Write attribute CHAR_STRING - Empty\n");
+            err = TestWriteAttributeCharStringEmpty_103();
             break;
         case 104:
-            ChipLogProgress(chipTool, " ***** Test Step 104 : Read attribute LONG_CHAR_STRING\n");
-            err = TestReadAttributeLongCharString_104();
+            ChipLogProgress(chipTool, " ***** Test Step 104 : Read attribute LONG_CHAR_STRING Default Value\n");
+            err = TestReadAttributeLongCharStringDefaultValue_104();
             break;
         case 105:
             ChipLogProgress(chipTool, " ***** Test Step 105 : Write attribute LONG_CHAR_STRING\n");
             err = TestWriteAttributeLongCharString_105();
             break;
         case 106:
-            ChipLogProgress(chipTool, " ***** Test Step 106 : Read attribute LIST\n");
-            err = TestReadAttributeList_106();
+            ChipLogProgress(chipTool, " ***** Test Step 106 : Read attribute LONG_CHAR_STRING\n");
+            err = TestReadAttributeLongCharString_106();
             break;
         case 107:
-            ChipLogProgress(chipTool, " ***** Test Step 107 : Read attribute LIST_OCTET_STRING\n");
-            err = TestReadAttributeListOctetString_107();
+            ChipLogProgress(chipTool, " ***** Test Step 107 : Write attribute LONG_CHAR_STRING\n");
+            err = TestWriteAttributeLongCharString_107();
             break;
         case 108:
-            ChipLogProgress(chipTool, " ***** Test Step 108 : Read attribute LIST_STRUCT_OCTET_STRING\n");
-            err = TestReadAttributeListStructOctetString_108();
+            ChipLogProgress(chipTool, " ***** Test Step 108 : Read attribute LIST\n");
+            err = TestReadAttributeList_108();
             break;
         case 109:
-            ChipLogProgress(chipTool, " ***** Test Step 109 : Read attribute EPOCH_US Default Value\n");
-            err = TestReadAttributeEpochUsDefaultValue_109();
+            ChipLogProgress(chipTool, " ***** Test Step 109 : Read attribute LIST_OCTET_STRING\n");
+            err = TestReadAttributeListOctetString_109();
             break;
         case 110:
-            ChipLogProgress(chipTool, " ***** Test Step 110 : Write attribute EPOCH_US Max Value\n");
-            err = TestWriteAttributeEpochUsMaxValue_110();
+            ChipLogProgress(chipTool, " ***** Test Step 110 : Read attribute LIST_STRUCT_OCTET_STRING\n");
+            err = TestReadAttributeListStructOctetString_110();
             break;
         case 111:
-            ChipLogProgress(chipTool, " ***** Test Step 111 : Read attribute EPOCH_US Max Value\n");
-            err = TestReadAttributeEpochUsMaxValue_111();
+            ChipLogProgress(chipTool, " ***** Test Step 111 : Read attribute EPOCH_US Default Value\n");
+            err = TestReadAttributeEpochUsDefaultValue_111();
             break;
         case 112:
-            ChipLogProgress(chipTool, " ***** Test Step 112 : Write attribute EPOCH_US Min Value\n");
-            err = TestWriteAttributeEpochUsMinValue_112();
+            ChipLogProgress(chipTool, " ***** Test Step 112 : Write attribute EPOCH_US Max Value\n");
+            err = TestWriteAttributeEpochUsMaxValue_112();
             break;
         case 113:
-            ChipLogProgress(chipTool, " ***** Test Step 113 : Read attribute EPOCH_US Min Value\n");
-            err = TestReadAttributeEpochUsMinValue_113();
+            ChipLogProgress(chipTool, " ***** Test Step 113 : Read attribute EPOCH_US Max Value\n");
+            err = TestReadAttributeEpochUsMaxValue_113();
             break;
         case 114:
-            ChipLogProgress(chipTool, " ***** Test Step 114 : Read attribute EPOCH_S Default Value\n");
-            err = TestReadAttributeEpochSDefaultValue_114();
+            ChipLogProgress(chipTool, " ***** Test Step 114 : Write attribute EPOCH_US Min Value\n");
+            err = TestWriteAttributeEpochUsMinValue_114();
             break;
         case 115:
-            ChipLogProgress(chipTool, " ***** Test Step 115 : Write attribute EPOCH_S Max Value\n");
-            err = TestWriteAttributeEpochSMaxValue_115();
+            ChipLogProgress(chipTool, " ***** Test Step 115 : Read attribute EPOCH_US Min Value\n");
+            err = TestReadAttributeEpochUsMinValue_115();
             break;
         case 116:
-            ChipLogProgress(chipTool, " ***** Test Step 116 : Read attribute EPOCH_S Max Value\n");
-            err = TestReadAttributeEpochSMaxValue_116();
+            ChipLogProgress(chipTool, " ***** Test Step 116 : Read attribute EPOCH_S Default Value\n");
+            err = TestReadAttributeEpochSDefaultValue_116();
             break;
         case 117:
-            ChipLogProgress(chipTool, " ***** Test Step 117 : Write attribute EPOCH_S Min Value\n");
-            err = TestWriteAttributeEpochSMinValue_117();
+            ChipLogProgress(chipTool, " ***** Test Step 117 : Write attribute EPOCH_S Max Value\n");
+            err = TestWriteAttributeEpochSMaxValue_117();
             break;
         case 118:
-            ChipLogProgress(chipTool, " ***** Test Step 118 : Read attribute EPOCH_S Min Value\n");
-            err = TestReadAttributeEpochSMinValue_118();
+            ChipLogProgress(chipTool, " ***** Test Step 118 : Read attribute EPOCH_S Max Value\n");
+            err = TestReadAttributeEpochSMaxValue_118();
             break;
         case 119:
-            ChipLogProgress(chipTool, " ***** Test Step 119 : Read attribute UNSUPPORTED\n");
-            err = TestReadAttributeUnsupported_119();
+            ChipLogProgress(chipTool, " ***** Test Step 119 : Write attribute EPOCH_S Min Value\n");
+            err = TestWriteAttributeEpochSMinValue_119();
             break;
         case 120:
-            ChipLogProgress(chipTool, " ***** Test Step 120 : Writeattribute UNSUPPORTED\n");
-            err = TestWriteattributeUnsupported_120();
+            ChipLogProgress(chipTool, " ***** Test Step 120 : Read attribute EPOCH_S Min Value\n");
+            err = TestReadAttributeEpochSMinValue_120();
             break;
         case 121:
-            ChipLogProgress(chipTool, " ***** Test Step 121 : Send Test Command to unsupported endpoint\n");
-            err = TestSendTestCommandToUnsupportedEndpoint_121();
+            ChipLogProgress(chipTool, " ***** Test Step 121 : Read attribute UNSUPPORTED\n");
+            err = TestReadAttributeUnsupported_121();
             break;
         case 122:
-            ChipLogProgress(chipTool, " ***** Test Step 122 : Read attribute vendor_id Default Value\n");
-            err = TestReadAttributeVendorIdDefaultValue_122();
+            ChipLogProgress(chipTool, " ***** Test Step 122 : Writeattribute UNSUPPORTED\n");
+            err = TestWriteattributeUnsupported_122();
             break;
         case 123:
-            ChipLogProgress(chipTool, " ***** Test Step 123 : Write attribute vendor_id\n");
-            err = TestWriteAttributeVendorId_123();
+            ChipLogProgress(chipTool, " ***** Test Step 123 : Send Test Command to unsupported endpoint\n");
+            err = TestSendTestCommandToUnsupportedEndpoint_123();
             break;
         case 124:
-            ChipLogProgress(chipTool, " ***** Test Step 124 : Read attribute vendor_id\n");
-            err = TestReadAttributeVendorId_124();
+            ChipLogProgress(chipTool, " ***** Test Step 124 : Read attribute vendor_id Default Value\n");
+            err = TestReadAttributeVendorIdDefaultValue_124();
             break;
         case 125:
-            ChipLogProgress(chipTool, " ***** Test Step 125 : Restore attribute vendor_id\n");
-            err = TestRestoreAttributeVendorId_125();
+            ChipLogProgress(chipTool, " ***** Test Step 125 : Write attribute vendor_id\n");
+            err = TestWriteAttributeVendorId_125();
             break;
         case 126:
-            ChipLogProgress(chipTool, " ***** Test Step 126 : Send a command with a vendor_id and enum\n");
-            err = TestSendACommandWithAVendorIdAndEnum_126();
+            ChipLogProgress(chipTool, " ***** Test Step 126 : Read attribute vendor_id\n");
+            err = TestReadAttributeVendorId_126();
+            break;
+        case 127:
+            ChipLogProgress(chipTool, " ***** Test Step 127 : Restore attribute vendor_id\n");
+            err = TestRestoreAttributeVendorId_127();
+            break;
+        case 128:
+            ChipLogProgress(chipTool, " ***** Test Step 128 : Send a command with a vendor_id and enum\n");
+            err = TestSendACommandWithAVendorIdAndEnum_128();
             break;
         }
 
@@ -26991,7 +27005,7 @@ public:
 
 private:
     std::atomic_uint16_t mTestIndex;
-    const uint16_t mTestCount = 127;
+    const uint16_t mTestCount = 129;
 
     static void OnFailureCallback_5(void * context, EmberAfStatus status)
     {
@@ -27777,9 +27791,9 @@ private:
         (static_cast<TestCluster *>(context))->OnFailureResponse_94(chip::to_underlying(status));
     }
 
-    static void OnSuccessCallback_94(void * context, chip::ByteSpan longOctetString)
+    static void OnSuccessCallback_94(void * context, chip::ByteSpan octetString)
     {
-        (static_cast<TestCluster *>(context))->OnSuccessResponse_94(longOctetString);
+        (static_cast<TestCluster *>(context))->OnSuccessResponse_94(octetString);
     }
 
     static void OnFailureCallback_95(void * context, EmberAfStatus status)
@@ -27811,9 +27825,9 @@ private:
         (static_cast<TestCluster *>(context))->OnFailureResponse_98(chip::to_underlying(status));
     }
 
-    static void OnSuccessCallback_98(void * context, chip::CharSpan charString)
+    static void OnSuccessCallback_98(void * context, chip::ByteSpan longOctetString)
     {
-        (static_cast<TestCluster *>(context))->OnSuccessResponse_98(charString);
+        (static_cast<TestCluster *>(context))->OnSuccessResponse_98(longOctetString);
     }
 
     static void OnFailureCallback_99(void * context, EmberAfStatus status)
@@ -27828,7 +27842,10 @@ private:
         (static_cast<TestCluster *>(context))->OnFailureResponse_100(chip::to_underlying(status));
     }
 
-    static void OnSuccessCallback_100(void * context) { (static_cast<TestCluster *>(context))->OnSuccessResponse_100(); }
+    static void OnSuccessCallback_100(void * context, chip::CharSpan charString)
+    {
+        (static_cast<TestCluster *>(context))->OnSuccessResponse_100(charString);
+    }
 
     static void OnFailureCallback_101(void * context, EmberAfStatus status)
     {
@@ -27842,10 +27859,7 @@ private:
         (static_cast<TestCluster *>(context))->OnFailureResponse_102(chip::to_underlying(status));
     }
 
-    static void OnSuccessCallback_102(void * context, chip::CharSpan longCharString)
-    {
-        (static_cast<TestCluster *>(context))->OnSuccessResponse_102(longCharString);
-    }
+    static void OnSuccessCallback_102(void * context) { (static_cast<TestCluster *>(context))->OnSuccessResponse_102(); }
 
     static void OnFailureCallback_103(void * context, EmberAfStatus status)
     {
@@ -27876,9 +27890,9 @@ private:
         (static_cast<TestCluster *>(context))->OnFailureResponse_106(chip::to_underlying(status));
     }
 
-    static void OnSuccessCallback_106(void * context, const chip::app::DataModel::DecodableList<uint8_t> & listInt8u)
+    static void OnSuccessCallback_106(void * context, chip::CharSpan longCharString)
     {
-        (static_cast<TestCluster *>(context))->OnSuccessResponse_106(listInt8u);
+        (static_cast<TestCluster *>(context))->OnSuccessResponse_106(longCharString);
     }
 
     static void OnFailureCallback_107(void * context, EmberAfStatus status)
@@ -27886,22 +27900,16 @@ private:
         (static_cast<TestCluster *>(context))->OnFailureResponse_107(chip::to_underlying(status));
     }
 
-    static void OnSuccessCallback_107(void * context, const chip::app::DataModel::DecodableList<chip::ByteSpan> & listOctetString)
-    {
-        (static_cast<TestCluster *>(context))->OnSuccessResponse_107(listOctetString);
-    }
+    static void OnSuccessCallback_107(void * context) { (static_cast<TestCluster *>(context))->OnSuccessResponse_107(); }
 
     static void OnFailureCallback_108(void * context, EmberAfStatus status)
     {
         (static_cast<TestCluster *>(context))->OnFailureResponse_108(chip::to_underlying(status));
     }
 
-    static void OnSuccessCallback_108(
-        void * context,
-        const chip::app::DataModel::DecodableList<chip::app::Clusters::TestCluster::Structs::TestListStructOctet::DecodableType> &
-            listStructOctetString)
+    static void OnSuccessCallback_108(void * context, const chip::app::DataModel::DecodableList<uint8_t> & listInt8u)
     {
-        (static_cast<TestCluster *>(context))->OnSuccessResponse_108(listStructOctetString);
+        (static_cast<TestCluster *>(context))->OnSuccessResponse_108(listInt8u);
     }
 
     static void OnFailureCallback_109(void * context, EmberAfStatus status)
@@ -27909,9 +27917,9 @@ private:
         (static_cast<TestCluster *>(context))->OnFailureResponse_109(chip::to_underlying(status));
     }
 
-    static void OnSuccessCallback_109(void * context, uint64_t epochUs)
+    static void OnSuccessCallback_109(void * context, const chip::app::DataModel::DecodableList<chip::ByteSpan> & listOctetString)
     {
-        (static_cast<TestCluster *>(context))->OnSuccessResponse_109(epochUs);
+        (static_cast<TestCluster *>(context))->OnSuccessResponse_109(listOctetString);
     }
 
     static void OnFailureCallback_110(void * context, EmberAfStatus status)
@@ -27919,7 +27927,13 @@ private:
         (static_cast<TestCluster *>(context))->OnFailureResponse_110(chip::to_underlying(status));
     }
 
-    static void OnSuccessCallback_110(void * context) { (static_cast<TestCluster *>(context))->OnSuccessResponse_110(); }
+    static void OnSuccessCallback_110(
+        void * context,
+        const chip::app::DataModel::DecodableList<chip::app::Clusters::TestCluster::Structs::TestListStructOctet::DecodableType> &
+            listStructOctetString)
+    {
+        (static_cast<TestCluster *>(context))->OnSuccessResponse_110(listStructOctetString);
+    }
 
     static void OnFailureCallback_111(void * context, EmberAfStatus status)
     {
@@ -27953,17 +27967,17 @@ private:
         (static_cast<TestCluster *>(context))->OnFailureResponse_114(chip::to_underlying(status));
     }
 
-    static void OnSuccessCallback_114(void * context, uint32_t epochS)
-    {
-        (static_cast<TestCluster *>(context))->OnSuccessResponse_114(epochS);
-    }
+    static void OnSuccessCallback_114(void * context) { (static_cast<TestCluster *>(context))->OnSuccessResponse_114(); }
 
     static void OnFailureCallback_115(void * context, EmberAfStatus status)
     {
         (static_cast<TestCluster *>(context))->OnFailureResponse_115(chip::to_underlying(status));
     }
 
-    static void OnSuccessCallback_115(void * context) { (static_cast<TestCluster *>(context))->OnSuccessResponse_115(); }
+    static void OnSuccessCallback_115(void * context, uint64_t epochUs)
+    {
+        (static_cast<TestCluster *>(context))->OnSuccessResponse_115(epochUs);
+    }
 
     static void OnFailureCallback_116(void * context, EmberAfStatus status)
     {
@@ -27997,34 +28011,34 @@ private:
         (static_cast<TestCluster *>(context))->OnFailureResponse_119(chip::to_underlying(status));
     }
 
-    static void OnSuccessCallback_119(void * context, bool unsupported)
-    {
-        (static_cast<TestCluster *>(context))->OnSuccessResponse_119(unsupported);
-    }
+    static void OnSuccessCallback_119(void * context) { (static_cast<TestCluster *>(context))->OnSuccessResponse_119(); }
 
     static void OnFailureCallback_120(void * context, EmberAfStatus status)
     {
         (static_cast<TestCluster *>(context))->OnFailureResponse_120(chip::to_underlying(status));
     }
 
-    static void OnSuccessCallback_120(void * context) { (static_cast<TestCluster *>(context))->OnSuccessResponse_120(); }
+    static void OnSuccessCallback_120(void * context, uint32_t epochS)
+    {
+        (static_cast<TestCluster *>(context))->OnSuccessResponse_120(epochS);
+    }
+
+    static void OnFailureCallback_121(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestCluster *>(context))->OnFailureResponse_121(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_121(void * context, bool unsupported)
+    {
+        (static_cast<TestCluster *>(context))->OnSuccessResponse_121(unsupported);
+    }
 
     static void OnFailureCallback_122(void * context, EmberAfStatus status)
     {
         (static_cast<TestCluster *>(context))->OnFailureResponse_122(chip::to_underlying(status));
     }
 
-    static void OnSuccessCallback_122(void * context, chip::VendorId vendorId)
-    {
-        (static_cast<TestCluster *>(context))->OnSuccessResponse_122(vendorId);
-    }
-
-    static void OnFailureCallback_123(void * context, EmberAfStatus status)
-    {
-        (static_cast<TestCluster *>(context))->OnFailureResponse_123(chip::to_underlying(status));
-    }
-
-    static void OnSuccessCallback_123(void * context) { (static_cast<TestCluster *>(context))->OnSuccessResponse_123(); }
+    static void OnSuccessCallback_122(void * context) { (static_cast<TestCluster *>(context))->OnSuccessResponse_122(); }
 
     static void OnFailureCallback_124(void * context, EmberAfStatus status)
     {
@@ -28042,6 +28056,23 @@ private:
     }
 
     static void OnSuccessCallback_125(void * context) { (static_cast<TestCluster *>(context))->OnSuccessResponse_125(); }
+
+    static void OnFailureCallback_126(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestCluster *>(context))->OnFailureResponse_126(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_126(void * context, chip::VendorId vendorId)
+    {
+        (static_cast<TestCluster *>(context))->OnSuccessResponse_126(vendorId);
+    }
+
+    static void OnFailureCallback_127(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestCluster *>(context))->OnFailureResponse_127(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_127(void * context) { (static_cast<TestCluster *>(context))->OnSuccessResponse_127(); }
 
     //
     // Tests methods
@@ -29564,17 +29595,17 @@ private:
 
     void OnSuccessResponse_88(chip::ByteSpan octetString)
     {
-        VerifyOrReturn(CheckValueAsString("octetString", octetString, ""));
+        VerifyOrReturn(CheckValueAsString("octetString", octetString, chip::ByteSpan(chip::Uint8::from_const_char(""), 0)));
         NextTest();
     }
 
-    CHIP_ERROR TestWriteAttributeOctetString_89()
+    CHIP_ERROR TestWriteAttributeOctetStringWithEmbeddedNull_89()
     {
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
         chip::ByteSpan octetStringArgument;
-        octetStringArgument = chip::ByteSpan(chip::Uint8::from_const_char("TestValue"), strlen("TestValue"));
+        octetStringArgument = chip::ByteSpan(chip::Uint8::from_const_char("Tes\x00ti\x00nggarbage: not in length on purpose"), 9);
 
         return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::OctetString::TypeInfo>(
             octetStringArgument, this, OnSuccessCallback_89, OnFailureCallback_89);
@@ -29584,7 +29615,7 @@ private:
 
     void OnSuccessResponse_89() { NextTest(); }
 
-    CHIP_ERROR TestReadAttributeOctetString_90()
+    CHIP_ERROR TestReadAttributeOctetStringWithEmbeddedNull_90()
     {
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
@@ -29597,7 +29628,8 @@ private:
 
     void OnSuccessResponse_90(chip::ByteSpan octetString)
     {
-        VerifyOrReturn(CheckValueAsString("octetString", octetString, "TestValue"));
+        VerifyOrReturn(
+            CheckValueAsString("octetString", octetString, chip::ByteSpan(chip::Uint8::from_const_char("Tes\x00ti\x00ng"), 9)));
         NextTest();
     }
 
@@ -29607,16 +29639,15 @@ private:
         cluster.Associate(mDevice, 1);
 
         chip::ByteSpan octetStringArgument;
-        octetStringArgument =
-            chip::ByteSpan(chip::Uint8::from_const_char("TestValueLongerThan10"), strlen("TestValueLongerThan10"));
+        octetStringArgument = chip::ByteSpan(chip::Uint8::from_const_char("TestValuegarbage: not in length on purpose"), 9);
 
         return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::OctetString::TypeInfo>(
             octetStringArgument, this, OnSuccessCallback_91, OnFailureCallback_91);
     }
 
-    void OnFailureResponse_91(uint8_t status) { NextTest(); }
+    void OnFailureResponse_91(uint8_t status) { ThrowFailureResponse(); }
 
-    void OnSuccessResponse_91() { ThrowSuccessResponse(); }
+    void OnSuccessResponse_91() { NextTest(); }
 
     CHIP_ERROR TestReadAttributeOctetString_92()
     {
@@ -29631,7 +29662,8 @@ private:
 
     void OnSuccessResponse_92(chip::ByteSpan octetString)
     {
-        VerifyOrReturn(CheckValueAsString("octetString", octetString, "TestValue"));
+        VerifyOrReturn(
+            CheckValueAsString("octetString", octetString, chip::ByteSpan(chip::Uint8::from_const_char("TestValue"), 9)));
         NextTest();
     }
 
@@ -29641,57 +29673,52 @@ private:
         cluster.Associate(mDevice, 1);
 
         chip::ByteSpan octetStringArgument;
-        octetStringArgument = chip::ByteSpan(chip::Uint8::from_const_char(""), strlen(""));
+        octetStringArgument =
+            chip::ByteSpan(chip::Uint8::from_const_char("TestValueLongerThan10garbage: not in length on purpose"), 21);
 
         return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::OctetString::TypeInfo>(
             octetStringArgument, this, OnSuccessCallback_93, OnFailureCallback_93);
     }
 
-    void OnFailureResponse_93(uint8_t status) { ThrowFailureResponse(); }
+    void OnFailureResponse_93(uint8_t status) { NextTest(); }
 
-    void OnSuccessResponse_93() { NextTest(); }
+    void OnSuccessResponse_93() { ThrowSuccessResponse(); }
 
-    CHIP_ERROR TestReadAttributeLongOctetStringDefaultValue_94()
+    CHIP_ERROR TestReadAttributeOctetString_94()
     {
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::LongOctetString::TypeInfo>(
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::OctetString::TypeInfo>(
             this, OnSuccessCallback_94, OnFailureCallback_94);
     }
 
     void OnFailureResponse_94(uint8_t status) { ThrowFailureResponse(); }
 
-    void OnSuccessResponse_94(chip::ByteSpan longOctetString)
+    void OnSuccessResponse_94(chip::ByteSpan octetString)
     {
-        VerifyOrReturn(CheckValueAsString("longOctetString", longOctetString, ""));
+        VerifyOrReturn(
+            CheckValueAsString("octetString", octetString, chip::ByteSpan(chip::Uint8::from_const_char("TestValue"), 9)));
         NextTest();
     }
 
-    CHIP_ERROR TestWriteAttributeLongOctetString_95()
+    CHIP_ERROR TestWriteAttributeOctetString_95()
     {
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        chip::ByteSpan longOctetStringArgument;
-        longOctetStringArgument = chip::ByteSpan(
-            chip::Uint8::from_const_char(
-                "111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111"
-                "111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111"
-                "111111111111111111111111111111111111111111111111111111111111111111111111"),
-            strlen("111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111"
-                   "111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111"
-                   "111111111111111111111111111111111111111111111111111111111111111111111111111111"));
+        chip::ByteSpan octetStringArgument;
+        octetStringArgument = chip::ByteSpan(chip::Uint8::from_const_char("garbage: not in length on purpose"), 0);
 
-        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::LongOctetString::TypeInfo>(
-            longOctetStringArgument, this, OnSuccessCallback_95, OnFailureCallback_95);
+        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::OctetString::TypeInfo>(
+            octetStringArgument, this, OnSuccessCallback_95, OnFailureCallback_95);
     }
 
     void OnFailureResponse_95(uint8_t status) { ThrowFailureResponse(); }
 
     void OnSuccessResponse_95() { NextTest(); }
 
-    CHIP_ERROR TestReadAttributeLongOctetString_96()
+    CHIP_ERROR TestReadAttributeLongOctetStringDefaultValue_96()
     {
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
@@ -29704,11 +29731,7 @@ private:
 
     void OnSuccessResponse_96(chip::ByteSpan longOctetString)
     {
-        VerifyOrReturn(CheckValueAsString(
-            "longOctetString", longOctetString,
-            "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111"
-            "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111"
-            "1111111111111111111111111111111111111111111111111111111111111111"));
+        VerifyOrReturn(CheckValueAsString("longOctetString", longOctetString, chip::ByteSpan(chip::Uint8::from_const_char(""), 0)));
         NextTest();
     }
 
@@ -29718,7 +29741,12 @@ private:
         cluster.Associate(mDevice, 1);
 
         chip::ByteSpan longOctetStringArgument;
-        longOctetStringArgument = chip::ByteSpan(chip::Uint8::from_const_char(""), strlen(""));
+        longOctetStringArgument = chip::ByteSpan(
+            chip::Uint8::from_const_char(
+                "111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111"
+                "111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111"
+                "111111111111111111111111111111111111111111111111111111111111111111111111garbage: not in length on purpose"),
+            300);
 
         return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::LongOctetString::TypeInfo>(
             longOctetStringArgument, this, OnSuccessCallback_97, OnFailureCallback_97);
@@ -29728,62 +29756,70 @@ private:
 
     void OnSuccessResponse_97() { NextTest(); }
 
-    CHIP_ERROR TestReadAttributeCharStringDefaultValue_98()
+    CHIP_ERROR TestReadAttributeLongOctetString_98()
     {
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::CharString::TypeInfo>(this, OnSuccessCallback_98,
-                                                                                                         OnFailureCallback_98);
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::LongOctetString::TypeInfo>(
+            this, OnSuccessCallback_98, OnFailureCallback_98);
     }
 
     void OnFailureResponse_98(uint8_t status) { ThrowFailureResponse(); }
 
-    void OnSuccessResponse_98(chip::CharSpan charString)
+    void OnSuccessResponse_98(chip::ByteSpan longOctetString)
     {
-        VerifyOrReturn(CheckValueAsString("charString", charString, ""));
+        VerifyOrReturn(CheckValueAsString(
+            "longOctetString", longOctetString,
+            chip::ByteSpan(
+                chip::Uint8::from_const_char(
+                    "11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111"
+                    "11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111"
+                    "11111111111111111111111111111111111111111111111111111111111111111111111111111111"),
+                300)));
         NextTest();
     }
 
-    CHIP_ERROR TestWriteAttributeCharString_99()
+    CHIP_ERROR TestWriteAttributeLongOctetString_99()
     {
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        chip::CharSpan charStringArgument;
-        charStringArgument = chip::Span<const char>("☉T☉", strlen("☉T☉"));
+        chip::ByteSpan longOctetStringArgument;
+        longOctetStringArgument = chip::ByteSpan(chip::Uint8::from_const_char("garbage: not in length on purpose"), 0);
 
-        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::CharString::TypeInfo>(
-            charStringArgument, this, OnSuccessCallback_99, OnFailureCallback_99);
+        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::LongOctetString::TypeInfo>(
+            longOctetStringArgument, this, OnSuccessCallback_99, OnFailureCallback_99);
     }
 
     void OnFailureResponse_99(uint8_t status) { ThrowFailureResponse(); }
 
     void OnSuccessResponse_99() { NextTest(); }
 
-    CHIP_ERROR TestWriteAttributeCharStringValueTooLong_100()
+    CHIP_ERROR TestReadAttributeCharStringDefaultValue_100()
     {
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        chip::CharSpan charStringArgument;
-        charStringArgument = chip::Span<const char>("☉TestValueLongerThan10☉", strlen("☉TestValueLongerThan10☉"));
-
-        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::CharString::TypeInfo>(
-            charStringArgument, this, OnSuccessCallback_100, OnFailureCallback_100);
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::CharString::TypeInfo>(
+            this, OnSuccessCallback_100, OnFailureCallback_100);
     }
 
-    void OnFailureResponse_100(uint8_t status) { NextTest(); }
+    void OnFailureResponse_100(uint8_t status) { ThrowFailureResponse(); }
 
-    void OnSuccessResponse_100() { ThrowSuccessResponse(); }
+    void OnSuccessResponse_100(chip::CharSpan charString)
+    {
+        VerifyOrReturn(CheckValueAsString("charString", charString, chip::CharSpan("", 0)));
+        NextTest();
+    }
 
-    CHIP_ERROR TestWriteAttributeCharStringEmpty_101()
+    CHIP_ERROR TestWriteAttributeCharString_101()
     {
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
         chip::CharSpan charStringArgument;
-        charStringArgument = chip::Span<const char>("", strlen(""));
+        charStringArgument = chip::Span<const char>("☉T☉garbage: not in length on purpose", 3);
 
         return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::CharString::TypeInfo>(
             charStringArgument, this, OnSuccessCallback_101, OnFailureCallback_101);
@@ -29793,46 +29829,39 @@ private:
 
     void OnSuccessResponse_101() { NextTest(); }
 
-    CHIP_ERROR TestReadAttributeLongCharStringDefaultValue_102()
+    CHIP_ERROR TestWriteAttributeCharStringValueTooLong_102()
     {
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::LongCharString::TypeInfo>(
-            this, OnSuccessCallback_102, OnFailureCallback_102);
+        chip::CharSpan charStringArgument;
+        charStringArgument = chip::Span<const char>("☉TestValueLongerThan10☉garbage: not in length on purpose", 23);
+
+        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::CharString::TypeInfo>(
+            charStringArgument, this, OnSuccessCallback_102, OnFailureCallback_102);
     }
 
-    void OnFailureResponse_102(uint8_t status) { ThrowFailureResponse(); }
+    void OnFailureResponse_102(uint8_t status) { NextTest(); }
 
-    void OnSuccessResponse_102(chip::CharSpan longCharString)
-    {
-        VerifyOrReturn(CheckValueAsString("longCharString", longCharString, ""));
-        NextTest();
-    }
+    void OnSuccessResponse_102() { ThrowSuccessResponse(); }
 
-    CHIP_ERROR TestWriteAttributeLongCharString_103()
+    CHIP_ERROR TestWriteAttributeCharStringEmpty_103()
     {
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        chip::CharSpan longCharStringArgument;
-        longCharStringArgument = chip::Span<const char>(
-            "☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉"
-            "☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉"
-            "☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉",
-            strlen("☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉"
-                   "☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉"
-                   "☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉"));
+        chip::CharSpan charStringArgument;
+        charStringArgument = chip::Span<const char>("garbage: not in length on purpose", 0);
 
-        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::LongCharString::TypeInfo>(
-            longCharStringArgument, this, OnSuccessCallback_103, OnFailureCallback_103);
+        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::CharString::TypeInfo>(
+            charStringArgument, this, OnSuccessCallback_103, OnFailureCallback_103);
     }
 
     void OnFailureResponse_103(uint8_t status) { ThrowFailureResponse(); }
 
     void OnSuccessResponse_103() { NextTest(); }
 
-    CHIP_ERROR TestReadAttributeLongCharString_104()
+    CHIP_ERROR TestReadAttributeLongCharStringDefaultValue_104()
     {
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
@@ -29845,11 +29874,7 @@ private:
 
     void OnSuccessResponse_104(chip::CharSpan longCharString)
     {
-        VerifyOrReturn(CheckValueAsString(
-            "longCharString", longCharString,
-            "☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉"
-            "☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉"
-            "☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉"));
+        VerifyOrReturn(CheckValueAsString("longCharString", longCharString, chip::CharSpan("", 0)));
         NextTest();
     }
 
@@ -29859,7 +29884,11 @@ private:
         cluster.Associate(mDevice, 1);
 
         chip::CharSpan longCharStringArgument;
-        longCharStringArgument = chip::Span<const char>("", strlen(""));
+        longCharStringArgument = chip::Span<const char>(
+            "☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉"
+            "☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉"
+            "☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉garbage: not in length on purpose",
+            300);
 
         return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::LongCharString::TypeInfo>(
             longCharStringArgument, this, OnSuccessCallback_105, OnFailureCallback_105);
@@ -29869,18 +29898,56 @@ private:
 
     void OnSuccessResponse_105() { NextTest(); }
 
-    CHIP_ERROR TestReadAttributeList_106()
+    CHIP_ERROR TestReadAttributeLongCharString_106()
     {
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::ListInt8u::TypeInfo>(this, OnSuccessCallback_106,
-                                                                                                        OnFailureCallback_106);
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::LongCharString::TypeInfo>(
+            this, OnSuccessCallback_106, OnFailureCallback_106);
     }
 
     void OnFailureResponse_106(uint8_t status) { ThrowFailureResponse(); }
 
-    void OnSuccessResponse_106(const chip::app::DataModel::DecodableList<uint8_t> & listInt8u)
+    void OnSuccessResponse_106(chip::CharSpan longCharString)
+    {
+        VerifyOrReturn(CheckValueAsString(
+            "longCharString", longCharString,
+            chip::CharSpan("☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉"
+                           "☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉"
+                           "☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉",
+                           300)));
+        NextTest();
+    }
+
+    CHIP_ERROR TestWriteAttributeLongCharString_107()
+    {
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, 1);
+
+        chip::CharSpan longCharStringArgument;
+        longCharStringArgument = chip::Span<const char>("garbage: not in length on purpose", 0);
+
+        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::LongCharString::TypeInfo>(
+            longCharStringArgument, this, OnSuccessCallback_107, OnFailureCallback_107);
+    }
+
+    void OnFailureResponse_107(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_107() { NextTest(); }
+
+    CHIP_ERROR TestReadAttributeList_108()
+    {
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, 1);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::ListInt8u::TypeInfo>(this, OnSuccessCallback_108,
+                                                                                                        OnFailureCallback_108);
+    }
+
+    void OnFailureResponse_108(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_108(const chip::app::DataModel::DecodableList<uint8_t> & listInt8u)
     {
         auto iter = listInt8u.begin();
         VerifyOrReturn(CheckNextListItemDecodes<decltype(listInt8u)>("listInt8u", iter, 0));
@@ -29895,98 +29962,73 @@ private:
         NextTest();
     }
 
-    CHIP_ERROR TestReadAttributeListOctetString_107()
+    CHIP_ERROR TestReadAttributeListOctetString_109()
     {
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
         return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::ListOctetString::TypeInfo>(
-            this, OnSuccessCallback_107, OnFailureCallback_107);
+            this, OnSuccessCallback_109, OnFailureCallback_109);
     }
 
-    void OnFailureResponse_107(uint8_t status) { ThrowFailureResponse(); }
+    void OnFailureResponse_109(uint8_t status) { ThrowFailureResponse(); }
 
-    void OnSuccessResponse_107(const chip::app::DataModel::DecodableList<chip::ByteSpan> & listOctetString)
+    void OnSuccessResponse_109(const chip::app::DataModel::DecodableList<chip::ByteSpan> & listOctetString)
     {
         auto iter = listOctetString.begin();
         VerifyOrReturn(CheckNextListItemDecodes<decltype(listOctetString)>("listOctetString", iter, 0));
-        VerifyOrReturn(CheckValueAsString("listOctetString[0]", iter.GetValue(), "Test0"));
+        VerifyOrReturn(
+            CheckValueAsString("listOctetString[0]", iter.GetValue(), chip::ByteSpan(chip::Uint8::from_const_char("Test0"), 5)));
         VerifyOrReturn(CheckNextListItemDecodes<decltype(listOctetString)>("listOctetString", iter, 1));
-        VerifyOrReturn(CheckValueAsString("listOctetString[1]", iter.GetValue(), "Test1"));
+        VerifyOrReturn(
+            CheckValueAsString("listOctetString[1]", iter.GetValue(), chip::ByteSpan(chip::Uint8::from_const_char("Test1"), 5)));
         VerifyOrReturn(CheckNextListItemDecodes<decltype(listOctetString)>("listOctetString", iter, 2));
-        VerifyOrReturn(CheckValueAsString("listOctetString[2]", iter.GetValue(), "Test2"));
+        VerifyOrReturn(
+            CheckValueAsString("listOctetString[2]", iter.GetValue(), chip::ByteSpan(chip::Uint8::from_const_char("Test2"), 5)));
         VerifyOrReturn(CheckNextListItemDecodes<decltype(listOctetString)>("listOctetString", iter, 3));
-        VerifyOrReturn(CheckValueAsString("listOctetString[3]", iter.GetValue(), "Test3"));
+        VerifyOrReturn(
+            CheckValueAsString("listOctetString[3]", iter.GetValue(), chip::ByteSpan(chip::Uint8::from_const_char("Test3"), 5)));
         VerifyOrReturn(CheckNoMoreListItems<decltype(listOctetString)>("listOctetString", iter, 4));
         NextTest();
     }
 
-    CHIP_ERROR TestReadAttributeListStructOctetString_108()
+    CHIP_ERROR TestReadAttributeListStructOctetString_110()
     {
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
         return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::ListStructOctetString::TypeInfo>(
-            this, OnSuccessCallback_108, OnFailureCallback_108);
+            this, OnSuccessCallback_110, OnFailureCallback_110);
     }
 
-    void OnFailureResponse_108(uint8_t status) { ThrowFailureResponse(); }
+    void OnFailureResponse_110(uint8_t status) { ThrowFailureResponse(); }
 
-    void OnSuccessResponse_108(
+    void OnSuccessResponse_110(
         const chip::app::DataModel::DecodableList<chip::app::Clusters::TestCluster::Structs::TestListStructOctet::DecodableType> &
             listStructOctetString)
     {
         auto iter = listStructOctetString.begin();
         VerifyOrReturn(CheckNextListItemDecodes<decltype(listStructOctetString)>("listStructOctetString", iter, 0));
         VerifyOrReturn(CheckValue<>("listStructOctetString[0].fabricIndex", iter.GetValue().fabricIndex, 0ULL));
-        VerifyOrReturn(CheckValueAsString("listStructOctetString[0].operationalCert", iter.GetValue().operationalCert, "Test0"));
+        VerifyOrReturn(CheckValueAsString("listStructOctetString[0].operationalCert", iter.GetValue().operationalCert,
+                                          chip::ByteSpan(chip::Uint8::from_const_char("Test0"), 5)));
         VerifyOrReturn(CheckNextListItemDecodes<decltype(listStructOctetString)>("listStructOctetString", iter, 1));
         VerifyOrReturn(CheckValue<>("listStructOctetString[1].fabricIndex", iter.GetValue().fabricIndex, 1ULL));
-        VerifyOrReturn(CheckValueAsString("listStructOctetString[1].operationalCert", iter.GetValue().operationalCert, "Test1"));
+        VerifyOrReturn(CheckValueAsString("listStructOctetString[1].operationalCert", iter.GetValue().operationalCert,
+                                          chip::ByteSpan(chip::Uint8::from_const_char("Test1"), 5)));
         VerifyOrReturn(CheckNextListItemDecodes<decltype(listStructOctetString)>("listStructOctetString", iter, 2));
         VerifyOrReturn(CheckValue<>("listStructOctetString[2].fabricIndex", iter.GetValue().fabricIndex, 2ULL));
-        VerifyOrReturn(CheckValueAsString("listStructOctetString[2].operationalCert", iter.GetValue().operationalCert, "Test2"));
+        VerifyOrReturn(CheckValueAsString("listStructOctetString[2].operationalCert", iter.GetValue().operationalCert,
+                                          chip::ByteSpan(chip::Uint8::from_const_char("Test2"), 5)));
         VerifyOrReturn(CheckNextListItemDecodes<decltype(listStructOctetString)>("listStructOctetString", iter, 3));
         VerifyOrReturn(CheckValue<>("listStructOctetString[3].fabricIndex", iter.GetValue().fabricIndex, 3ULL));
-        VerifyOrReturn(CheckValueAsString("listStructOctetString[3].operationalCert", iter.GetValue().operationalCert, "Test3"));
+        VerifyOrReturn(CheckValueAsString("listStructOctetString[3].operationalCert", iter.GetValue().operationalCert,
+                                          chip::ByteSpan(chip::Uint8::from_const_char("Test3"), 5)));
         VerifyOrReturn(CheckNoMoreListItems<decltype(listStructOctetString)>("listStructOctetString", iter, 4));
         NextTest();
     }
 
-    CHIP_ERROR TestReadAttributeEpochUsDefaultValue_109()
-    {
-        chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
-
-        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::EpochUs::TypeInfo>(this, OnSuccessCallback_109,
-                                                                                                      OnFailureCallback_109);
-    }
-
-    void OnFailureResponse_109(uint8_t status) { ThrowFailureResponse(); }
-
-    void OnSuccessResponse_109(uint64_t epochUs)
-    {
-        VerifyOrReturn(CheckValue<uint64_t>("epochUs", epochUs, 0ULL));
-        NextTest();
-    }
-
-    CHIP_ERROR TestWriteAttributeEpochUsMaxValue_110()
-    {
-        chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
-
-        uint64_t epochUsArgument;
-        epochUsArgument = 18446744073709551615ULL;
-
-        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::EpochUs::TypeInfo>(
-            epochUsArgument, this, OnSuccessCallback_110, OnFailureCallback_110);
-    }
-
-    void OnFailureResponse_110(uint8_t status) { ThrowFailureResponse(); }
-
-    void OnSuccessResponse_110() { NextTest(); }
-
-    CHIP_ERROR TestReadAttributeEpochUsMaxValue_111()
+    CHIP_ERROR TestReadAttributeEpochUsDefaultValue_111()
     {
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
@@ -29999,17 +30041,17 @@ private:
 
     void OnSuccessResponse_111(uint64_t epochUs)
     {
-        VerifyOrReturn(CheckValue<uint64_t>("epochUs", epochUs, 18446744073709551615ULL));
+        VerifyOrReturn(CheckValue<uint64_t>("epochUs", epochUs, 0ULL));
         NextTest();
     }
 
-    CHIP_ERROR TestWriteAttributeEpochUsMinValue_112()
+    CHIP_ERROR TestWriteAttributeEpochUsMaxValue_112()
     {
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
         uint64_t epochUsArgument;
-        epochUsArgument = 0ULL;
+        epochUsArgument = 18446744073709551615ULL;
 
         return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::EpochUs::TypeInfo>(
             epochUsArgument, this, OnSuccessCallback_112, OnFailureCallback_112);
@@ -30019,7 +30061,7 @@ private:
 
     void OnSuccessResponse_112() { NextTest(); }
 
-    CHIP_ERROR TestReadAttributeEpochUsMinValue_113()
+    CHIP_ERROR TestReadAttributeEpochUsMaxValue_113()
     {
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
@@ -30032,44 +30074,44 @@ private:
 
     void OnSuccessResponse_113(uint64_t epochUs)
     {
-        VerifyOrReturn(CheckValue<uint64_t>("epochUs", epochUs, 0ULL));
+        VerifyOrReturn(CheckValue<uint64_t>("epochUs", epochUs, 18446744073709551615ULL));
         NextTest();
     }
 
-    CHIP_ERROR TestReadAttributeEpochSDefaultValue_114()
+    CHIP_ERROR TestWriteAttributeEpochUsMinValue_114()
     {
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::EpochS::TypeInfo>(this, OnSuccessCallback_114,
-                                                                                                     OnFailureCallback_114);
+        uint64_t epochUsArgument;
+        epochUsArgument = 0ULL;
+
+        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::EpochUs::TypeInfo>(
+            epochUsArgument, this, OnSuccessCallback_114, OnFailureCallback_114);
     }
 
     void OnFailureResponse_114(uint8_t status) { ThrowFailureResponse(); }
 
-    void OnSuccessResponse_114(uint32_t epochS)
-    {
-        VerifyOrReturn(CheckValue<uint32_t>("epochS", epochS, 0UL));
-        NextTest();
-    }
+    void OnSuccessResponse_114() { NextTest(); }
 
-    CHIP_ERROR TestWriteAttributeEpochSMaxValue_115()
+    CHIP_ERROR TestReadAttributeEpochUsMinValue_115()
     {
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
-        uint32_t epochSArgument;
-        epochSArgument = 4294967295UL;
-
-        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::EpochS::TypeInfo>(
-            epochSArgument, this, OnSuccessCallback_115, OnFailureCallback_115);
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::EpochUs::TypeInfo>(this, OnSuccessCallback_115,
+                                                                                                      OnFailureCallback_115);
     }
 
     void OnFailureResponse_115(uint8_t status) { ThrowFailureResponse(); }
 
-    void OnSuccessResponse_115() { NextTest(); }
+    void OnSuccessResponse_115(uint64_t epochUs)
+    {
+        VerifyOrReturn(CheckValue<uint64_t>("epochUs", epochUs, 0ULL));
+        NextTest();
+    }
 
-    CHIP_ERROR TestReadAttributeEpochSMaxValue_116()
+    CHIP_ERROR TestReadAttributeEpochSDefaultValue_116()
     {
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
@@ -30082,17 +30124,17 @@ private:
 
     void OnSuccessResponse_116(uint32_t epochS)
     {
-        VerifyOrReturn(CheckValue<uint32_t>("epochS", epochS, 4294967295UL));
+        VerifyOrReturn(CheckValue<uint32_t>("epochS", epochS, 0UL));
         NextTest();
     }
 
-    CHIP_ERROR TestWriteAttributeEpochSMinValue_117()
+    CHIP_ERROR TestWriteAttributeEpochSMaxValue_117()
     {
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
         uint32_t epochSArgument;
-        epochSArgument = 0UL;
+        epochSArgument = 4294967295UL;
 
         return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::EpochS::TypeInfo>(
             epochSArgument, this, OnSuccessCallback_117, OnFailureCallback_117);
@@ -30102,7 +30144,7 @@ private:
 
     void OnSuccessResponse_117() { NextTest(); }
 
-    CHIP_ERROR TestReadAttributeEpochSMinValue_118()
+    CHIP_ERROR TestReadAttributeEpochSMaxValue_118()
     {
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
@@ -30115,31 +30157,64 @@ private:
 
     void OnSuccessResponse_118(uint32_t epochS)
     {
+        VerifyOrReturn(CheckValue<uint32_t>("epochS", epochS, 4294967295UL));
+        NextTest();
+    }
+
+    CHIP_ERROR TestWriteAttributeEpochSMinValue_119()
+    {
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, 1);
+
+        uint32_t epochSArgument;
+        epochSArgument = 0UL;
+
+        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::EpochS::TypeInfo>(
+            epochSArgument, this, OnSuccessCallback_119, OnFailureCallback_119);
+    }
+
+    void OnFailureResponse_119(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_119() { NextTest(); }
+
+    CHIP_ERROR TestReadAttributeEpochSMinValue_120()
+    {
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, 1);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::EpochS::TypeInfo>(this, OnSuccessCallback_120,
+                                                                                                     OnFailureCallback_120);
+    }
+
+    void OnFailureResponse_120(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_120(uint32_t epochS)
+    {
         VerifyOrReturn(CheckValue<uint32_t>("epochS", epochS, 0UL));
         NextTest();
     }
 
-    CHIP_ERROR TestReadAttributeUnsupported_119()
+    CHIP_ERROR TestReadAttributeUnsupported_121()
     {
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
         return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Unsupported::TypeInfo>(
-            this, OnSuccessCallback_119, OnFailureCallback_119);
+            this, OnSuccessCallback_121, OnFailureCallback_121);
     }
 
-    void OnFailureResponse_119(uint8_t status)
+    void OnFailureResponse_121(uint8_t status)
     {
         (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
     }
 
-    void OnSuccessResponse_119(bool unsupported)
+    void OnSuccessResponse_121(bool unsupported)
     {
         VerifyOrReturn(CheckValue<bool>("unsupported", unsupported, 0));
         NextTest();
     }
 
-    CHIP_ERROR TestWriteattributeUnsupported_120()
+    CHIP_ERROR TestWriteattributeUnsupported_122()
     {
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
@@ -30148,17 +30223,17 @@ private:
         unsupportedArgument = 0;
 
         return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::Unsupported::TypeInfo>(
-            unsupportedArgument, this, OnSuccessCallback_120, OnFailureCallback_120);
+            unsupportedArgument, this, OnSuccessCallback_122, OnFailureCallback_122);
     }
 
-    void OnFailureResponse_120(uint8_t status)
+    void OnFailureResponse_122(uint8_t status)
     {
         (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE) ? NextTest() : ThrowFailureResponse();
     }
 
-    void OnSuccessResponse_120() { NextTest(); }
+    void OnSuccessResponse_122() { NextTest(); }
 
-    CHIP_ERROR TestSendTestCommandToUnsupportedEndpoint_121()
+    CHIP_ERROR TestSendTestCommandToUnsupportedEndpoint_123()
     {
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 200);
@@ -30168,53 +30243,20 @@ private:
         RequestType request;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
-            (static_cast<TestCluster *>(context))->OnSuccessResponse_121();
+            (static_cast<TestCluster *>(context))->OnSuccessResponse_123();
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
-            (static_cast<TestCluster *>(context))->OnFailureResponse_121(status);
+            (static_cast<TestCluster *>(context))->OnFailureResponse_123(status);
         };
         return cluster.InvokeCommand(request, this, success, failure);
     }
 
-    void OnFailureResponse_121(uint8_t status) { NextTest(); }
+    void OnFailureResponse_123(uint8_t status) { NextTest(); }
 
-    void OnSuccessResponse_121() { ThrowSuccessResponse(); }
+    void OnSuccessResponse_123() { ThrowSuccessResponse(); }
 
-    CHIP_ERROR TestReadAttributeVendorIdDefaultValue_122()
-    {
-        chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
-
-        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::VendorId::TypeInfo>(this, OnSuccessCallback_122,
-                                                                                                       OnFailureCallback_122);
-    }
-
-    void OnFailureResponse_122(uint8_t status) { ThrowFailureResponse(); }
-
-    void OnSuccessResponse_122(chip::VendorId vendorId)
-    {
-        VerifyOrReturn(CheckValue<chip::VendorId>("vendorId", vendorId, 0U));
-        NextTest();
-    }
-
-    CHIP_ERROR TestWriteAttributeVendorId_123()
-    {
-        chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, 1);
-
-        chip::VendorId vendorIdArgument;
-        vendorIdArgument = static_cast<chip::VendorId>(17);
-
-        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::VendorId::TypeInfo>(
-            vendorIdArgument, this, OnSuccessCallback_123, OnFailureCallback_123);
-    }
-
-    void OnFailureResponse_123(uint8_t status) { ThrowFailureResponse(); }
-
-    void OnSuccessResponse_123() { NextTest(); }
-
-    CHIP_ERROR TestReadAttributeVendorId_124()
+    CHIP_ERROR TestReadAttributeVendorIdDefaultValue_124()
     {
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
@@ -30227,17 +30269,17 @@ private:
 
     void OnSuccessResponse_124(chip::VendorId vendorId)
     {
-        VerifyOrReturn(CheckValue<chip::VendorId>("vendorId", vendorId, 17U));
+        VerifyOrReturn(CheckValue<chip::VendorId>("vendorId", vendorId, 0U));
         NextTest();
     }
 
-    CHIP_ERROR TestRestoreAttributeVendorId_125()
+    CHIP_ERROR TestWriteAttributeVendorId_125()
     {
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
         chip::VendorId vendorIdArgument;
-        vendorIdArgument = static_cast<chip::VendorId>(0);
+        vendorIdArgument = static_cast<chip::VendorId>(17);
 
         return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::VendorId::TypeInfo>(
             vendorIdArgument, this, OnSuccessCallback_125, OnFailureCallback_125);
@@ -30247,7 +30289,40 @@ private:
 
     void OnSuccessResponse_125() { NextTest(); }
 
-    CHIP_ERROR TestSendACommandWithAVendorIdAndEnum_126()
+    CHIP_ERROR TestReadAttributeVendorId_126()
+    {
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, 1);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::VendorId::TypeInfo>(this, OnSuccessCallback_126,
+                                                                                                       OnFailureCallback_126);
+    }
+
+    void OnFailureResponse_126(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_126(chip::VendorId vendorId)
+    {
+        VerifyOrReturn(CheckValue<chip::VendorId>("vendorId", vendorId, 17U));
+        NextTest();
+    }
+
+    CHIP_ERROR TestRestoreAttributeVendorId_127()
+    {
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, 1);
+
+        chip::VendorId vendorIdArgument;
+        vendorIdArgument = static_cast<chip::VendorId>(0);
+
+        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::VendorId::TypeInfo>(
+            vendorIdArgument, this, OnSuccessCallback_127, OnFailureCallback_127);
+    }
+
+    void OnFailureResponse_127(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_127() { NextTest(); }
+
+    CHIP_ERROR TestSendACommandWithAVendorIdAndEnum_128()
     {
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, 1);
@@ -30259,18 +30334,18 @@ private:
         request.arg2 = static_cast<chip::app::Clusters::TestCluster::SimpleEnum>(101);
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
-            (static_cast<TestCluster *>(context))->OnSuccessResponse_126(data.arg1, data.arg2);
+            (static_cast<TestCluster *>(context))->OnSuccessResponse_128(data.arg1, data.arg2);
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
-            (static_cast<TestCluster *>(context))->OnFailureResponse_126(status);
+            (static_cast<TestCluster *>(context))->OnFailureResponse_128(status);
         };
         return cluster.InvokeCommand(request, this, success, failure);
     }
 
-    void OnFailureResponse_126(uint8_t status) { ThrowFailureResponse(); }
+    void OnFailureResponse_128(uint8_t status) { ThrowFailureResponse(); }
 
-    void OnSuccessResponse_126(chip::VendorId arg1, chip::app::Clusters::TestCluster::SimpleEnum arg2)
+    void OnSuccessResponse_128(chip::VendorId arg1, chip::app::Clusters::TestCluster::SimpleEnum arg2)
     {
         VerifyOrReturn(CheckValue<chip::VendorId>("arg1", arg1, 20003U));
 
@@ -30386,8 +30461,8 @@ private:
         request.arg1.a = 0;
         request.arg1.b = true;
         request.arg1.c = static_cast<chip::app::Clusters::TestCluster::SimpleEnum>(2);
-        request.arg1.d = chip::ByteSpan(chip::Uint8::from_const_char("octet_string"), strlen("octet_string"));
-        request.arg1.e = chip::Span<const char>("char_string", strlen("char_string"));
+        request.arg1.d = chip::ByteSpan(chip::Uint8::from_const_char("octet_stringgarbage: not in length on purpose"), 12);
+        request.arg1.e = chip::Span<const char>("char_stringgarbage: not in length on purpose", 11);
         request.arg1.f = static_cast<chip::BitFlags<chip::app::Clusters::TestCluster::SimpleBitmap>>(1);
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -30420,8 +30495,8 @@ private:
         request.arg1.a = 0;
         request.arg1.b = false;
         request.arg1.c = static_cast<chip::app::Clusters::TestCluster::SimpleEnum>(2);
-        request.arg1.d = chip::ByteSpan(chip::Uint8::from_const_char("octet_string"), strlen("octet_string"));
-        request.arg1.e = chip::Span<const char>("char_string", strlen("char_string"));
+        request.arg1.d = chip::ByteSpan(chip::Uint8::from_const_char("octet_stringgarbage: not in length on purpose"), 12);
+        request.arg1.e = chip::Span<const char>("char_stringgarbage: not in length on purpose", 11);
         request.arg1.f = static_cast<chip::BitFlags<chip::app::Clusters::TestCluster::SimpleBitmap>>(1);
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
@@ -30623,15 +30698,15 @@ private:
         arg1List[0].a = 0;
         arg1List[0].b = true;
         arg1List[0].c = static_cast<chip::app::Clusters::TestCluster::SimpleEnum>(2);
-        arg1List[0].d = chip::ByteSpan(chip::Uint8::from_const_char("first_octet_string"), strlen("first_octet_string"));
-        arg1List[0].e = chip::Span<const char>("first_char_string", strlen("first_char_string"));
+        arg1List[0].d = chip::ByteSpan(chip::Uint8::from_const_char("first_octet_stringgarbage: not in length on purpose"), 18);
+        arg1List[0].e = chip::Span<const char>("first_char_stringgarbage: not in length on purpose", 17);
         arg1List[0].f = static_cast<chip::BitFlags<chip::app::Clusters::TestCluster::SimpleBitmap>>(1);
 
         arg1List[1].a = 1;
         arg1List[1].b = true;
         arg1List[1].c = static_cast<chip::app::Clusters::TestCluster::SimpleEnum>(3);
-        arg1List[1].d = chip::ByteSpan(chip::Uint8::from_const_char("second_octet_string"), strlen("second_octet_string"));
-        arg1List[1].e = chip::Span<const char>("second_char_string", strlen("second_char_string"));
+        arg1List[1].d = chip::ByteSpan(chip::Uint8::from_const_char("second_octet_stringgarbage: not in length on purpose"), 19);
+        arg1List[1].e = chip::Span<const char>("second_char_stringgarbage: not in length on purpose", 18);
         arg1List[1].f = static_cast<chip::BitFlags<chip::app::Clusters::TestCluster::SimpleBitmap>>(1);
 
         request.arg1 = arg1List;
@@ -30668,15 +30743,15 @@ private:
         arg1List[0].a = 1;
         arg1List[0].b = true;
         arg1List[0].c = static_cast<chip::app::Clusters::TestCluster::SimpleEnum>(3);
-        arg1List[0].d = chip::ByteSpan(chip::Uint8::from_const_char("second_octet_string"), strlen("second_octet_string"));
-        arg1List[0].e = chip::Span<const char>("second_char_string", strlen("second_char_string"));
+        arg1List[0].d = chip::ByteSpan(chip::Uint8::from_const_char("second_octet_stringgarbage: not in length on purpose"), 19);
+        arg1List[0].e = chip::Span<const char>("second_char_stringgarbage: not in length on purpose", 18);
         arg1List[0].f = static_cast<chip::BitFlags<chip::app::Clusters::TestCluster::SimpleBitmap>>(1);
 
         arg1List[1].a = 0;
         arg1List[1].b = false;
         arg1List[1].c = static_cast<chip::app::Clusters::TestCluster::SimpleEnum>(2);
-        arg1List[1].d = chip::ByteSpan(chip::Uint8::from_const_char("first_octet_string"), strlen("first_octet_string"));
-        arg1List[1].e = chip::Span<const char>("first_char_string", strlen("first_char_string"));
+        arg1List[1].d = chip::ByteSpan(chip::Uint8::from_const_char("first_octet_stringgarbage: not in length on purpose"), 18);
+        arg1List[1].e = chip::Span<const char>("first_char_stringgarbage: not in length on purpose", 17);
         arg1List[1].f = static_cast<chip::BitFlags<chip::app::Clusters::TestCluster::SimpleBitmap>>(1);
 
         request.arg1 = arg1List;
@@ -31414,7 +31489,7 @@ private:
 
     void OnSuccessResponse_0(chip::CharSpan location)
     {
-        VerifyOrReturn(CheckValueAsString("location", location, ""));
+        VerifyOrReturn(CheckValueAsString("location", location, chip::CharSpan("", 0)));
         NextTest();
     }
 
@@ -31424,7 +31499,7 @@ private:
         cluster.Associate(mDevice, 0);
 
         chip::CharSpan locationArgument;
-        locationArgument = chip::Span<const char>("us", strlen("us"));
+        locationArgument = chip::Span<const char>("usgarbage: not in length on purpose", 2);
 
         return cluster.WriteAttribute<chip::app::Clusters::Basic::Attributes::Location::TypeInfo>(
             locationArgument, this, OnSuccessCallback_1, OnFailureCallback_1);
@@ -31447,7 +31522,7 @@ private:
 
     void OnSuccessResponse_2(chip::CharSpan location)
     {
-        VerifyOrReturn(CheckValueAsString("location", location, "us"));
+        VerifyOrReturn(CheckValueAsString("location", location, chip::CharSpan("us", 2)));
         NextTest();
     }
 
@@ -31457,7 +31532,7 @@ private:
         cluster.Associate(mDevice, 0);
 
         chip::CharSpan locationArgument;
-        locationArgument = chip::Span<const char>("", strlen(""));
+        locationArgument = chip::Span<const char>("garbage: not in length on purpose", 0);
 
         return cluster.WriteAttribute<chip::app::Clusters::Basic::Attributes::Location::TypeInfo>(
             locationArgument, this, OnSuccessCallback_3, OnFailureCallback_3);
@@ -31894,7 +31969,7 @@ private:
 
     void OnSuccessResponse_3(chip::CharSpan description)
     {
-        VerifyOrReturn(CheckValueAsString("description", description, "Coffee"));
+        VerifyOrReturn(CheckValueAsString("description", description, chip::CharSpan("Coffee", 6)));
         NextTest();
     }
 
@@ -31915,15 +31990,15 @@ private:
     {
         auto iter = supportedModes.begin();
         VerifyOrReturn(CheckNextListItemDecodes<decltype(supportedModes)>("supportedModes", iter, 0));
-        VerifyOrReturn(CheckValueAsString("supportedModes[0].label", iter.GetValue().label, "Black"));
+        VerifyOrReturn(CheckValueAsString("supportedModes[0].label", iter.GetValue().label, chip::CharSpan("Black", 5)));
         VerifyOrReturn(CheckValue<>("supportedModes[0].mode", iter.GetValue().mode, 0));
         VerifyOrReturn(CheckValue<>("supportedModes[0].semanticTag", iter.GetValue().semanticTag, 0UL));
         VerifyOrReturn(CheckNextListItemDecodes<decltype(supportedModes)>("supportedModes", iter, 1));
-        VerifyOrReturn(CheckValueAsString("supportedModes[1].label", iter.GetValue().label, "Cappuccino"));
+        VerifyOrReturn(CheckValueAsString("supportedModes[1].label", iter.GetValue().label, chip::CharSpan("Cappuccino", 10)));
         VerifyOrReturn(CheckValue<>("supportedModes[1].mode", iter.GetValue().mode, 4));
         VerifyOrReturn(CheckValue<>("supportedModes[1].semanticTag", iter.GetValue().semanticTag, 0UL));
         VerifyOrReturn(CheckNextListItemDecodes<decltype(supportedModes)>("supportedModes", iter, 2));
-        VerifyOrReturn(CheckValueAsString("supportedModes[2].label", iter.GetValue().label, "Espresso"));
+        VerifyOrReturn(CheckValueAsString("supportedModes[2].label", iter.GetValue().label, chip::CharSpan("Espresso", 8)));
         VerifyOrReturn(CheckValue<>("supportedModes[2].mode", iter.GetValue().mode, 7));
         VerifyOrReturn(CheckValue<>("supportedModes[2].semanticTag", iter.GetValue().semanticTag, 0UL));
         VerifyOrReturn(CheckNoMoreListItems<decltype(supportedModes)>("supportedModes", iter, 3));


### PR DESCRIPTION
This adds garbage to the ends of all the strings and octet strings
being sent in yaml tests, and makes sure that garbage is not included
in the length, so the span is correct.  The idea is to catch cases
where someone uses a span's pointer without checking its length.

This also adds a way to embed a 0 byte in an octet string (by using
\x00 in the yaml string) and adds support for both sending and
checking for such values.

#### Problem
No testing of octet string with embedded null.

#### Change overview
Add support for it, and a test.

#### Testing
Manual inspection of the generated test code.