### PR TITLE
Do not compile rpc variant for nrf5340 (does not compile without pigw…

### DIFF
--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -135,10 +135,12 @@ def NrfTargets():
     for target in targets:
         yield target.Extend('lock', app=NrfApp.LOCK)
         yield target.Extend('light', app=NrfApp.LIGHT)
-        yield target.Extend('light-rpc', app=NrfApp.LIGHT, enable_rpcs=True)
         yield target.Extend('shell', app=NrfApp.SHELL)
         yield target.Extend('pump', app=NrfApp.PUMP)
         yield target.Extend('pump-controller', app=NrfApp.PUMP_CONTROLLER)
+
+    # NRF5340 does not compile with rpcs right now (requires pigweed fix)
+    yield targets[1].Extend('light-rpc', app=NrfApp.LIGHT, enable_rpcs=True)
 
 
 def AndroidTargets():

--- a/scripts/build/testdata/all_targets_except_host.txt
+++ b/scripts/build/testdata/all_targets_except_host.txt
@@ -28,7 +28,6 @@ nrf-nrf52840-pump
 nrf-nrf52840-pump-controller
 nrf-nrf52840-shell
 nrf-nrf5340-light
-nrf-nrf5340-light-rpc
 nrf-nrf5340-lock
 nrf-nrf5340-pump
 nrf-nrf5340-pump-controller

--- a/scripts/build/testdata/build_all_except_host.txt
+++ b/scripts/build/testdata/build_all_except_host.txt
@@ -253,11 +253,6 @@ bash -c 'source "$ZEPHYR_BASE/zephyr-env.sh";
 export GNUARMEMB_TOOLCHAIN_PATH="$PW_PIGWEED_CIPD_INSTALL_DIR";
 west build --cmake-only -d {out}/nrf-nrf5340-light -b nrf5340dk_nrf5340_cpuapp {root}/examples/lighting-app/nrfconnect'
 
-# Generating nrf-nrf5340-light-rpc
-bash -c 'source "$ZEPHYR_BASE/zephyr-env.sh";
-export GNUARMEMB_TOOLCHAIN_PATH="$PW_PIGWEED_CIPD_INSTALL_DIR";
-west build --cmake-only -d {out}/nrf-nrf5340-light-rpc -b nrf5340dk_nrf5340_cpuapp {root}/examples/lighting-app/nrfconnect -- -DOVERLAY_CONFIG=rpc.overlay'
-
 # Generating nrf-nrf5340-lock
 bash -c 'source "$ZEPHYR_BASE/zephyr-env.sh";
 export GNUARMEMB_TOOLCHAIN_PATH="$PW_PIGWEED_CIPD_INSTALL_DIR";
@@ -514,9 +509,6 @@ ninja -C {out}/nrf-nrf52840-shell
 
 # Building nrf-nrf5340-light
 ninja -C {out}/nrf-nrf5340-light
-
-# Building nrf-nrf5340-light-rpc
-ninja -C {out}/nrf-nrf5340-light-rpc
 
 # Building nrf-nrf5340-lock
 ninja -C {out}/nrf-nrf5340-lock


### PR DESCRIPTION
…eed update)

#### Problem
```
/workspace/out/nrf-nrf5340-light-rpc/zephyr && /pwenv/cipd/python/bin/cmake -E echo
Step #1 - "CompileAll": 2021-11-10 19:48:41 INFO    /pwenv/cipd/pigweed/bin/../lib/gcc/arm-none-eabi/10.2.1/../../../../arm-none-eabi/bin/ld.bfd: error: libbutton_service.nanopb.a(button_service.pb.c.obj): conflicting CPU architectures 17/2
Step #1 - "CompileAll": 2021-11-10 19:48:41 INFO    /pwenv/cipd/pigweed/bin/../lib/gcc/arm-none-eabi/10.2.1/../../../../arm-none-eabi/bin/ld.bfd: failed to merge target specific data of file libbutton_service.nanopb.a(button_service.pb.c.obj)
Step #1 - "CompileAll": 2021-11-10 19:48:41 INFO    /pwenv/cipd/pigweed/bin/../lib/gcc/arm-none-eabi/10.2.1/../../../../arm-none-eabi/bin/ld.bfd: error: libdevice_service.nanopb.a(device_service.pb.c.obj): conflicting CPU architectures 17/2
....
```

#### Change contents:

disable the rpc variant for nrf5340

