### PR TITLE
fix for efr32 mg12 multi-admin

### DIFF
--- a/examples/platform/efr32/init_efrPlatform.cpp
+++ b/examples/platform/efr32/init_efrPlatform.cpp
@@ -53,6 +53,7 @@ extern "C" {
 
 #include "init_efrPlatform.h"
 #include "sl_component_catalog.h"
+#include "sl_mbedtls.h"
 #include "sl_system_init.h"
 
 #if DISPLAY_ENABLED
@@ -64,6 +65,7 @@ void initAntenna(void);
 void init_efrPlatform(void)
 {
     sl_system_init();
+    sl_mbedtls_init();
 
 #if DISPLAY_ENABLED
     initLCD();

--- a/third_party/efr32_sdk/efr32_sdk.gni
+++ b/third_party/efr32_sdk/efr32_sdk.gni
@@ -137,6 +137,9 @@ template("efr32_sdk") {
       "CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI=1",
       "__HEAP_SIZE=0",
       "SL_CATALOG_FREERTOS_KERNEL_PRESENT=1",
+      "MBEDTLS_THREADING_C=1",
+      "MBEDTLS_THREADING_ALT=1",
+      "SL_THREADING_ALT=1",
 
       #"__STACK_SIZE=0",
     ]


### PR DESCRIPTION
#### Problem
* Multi admin was failing on mg12 when trying to complete commissioning with the 2nd controller

#### Change overview
* Added missing defines and init function to properly init mbedtls for efr32 sdk

#### Testing
* Manual testing with mg12 to validate fix
* Manual testing with mg24 to validate no regressions were caused