### PR TITLE
[Android] Support list attribute nullable/optionals

### DIFF
--- a/src/controller/java/CHIPDefaultCallbacks.cpp
+++ b/src/controller/java/CHIPDefaultCallbacks.cpp
@@ -27,7 +27,7 @@ chip::CHIPDefaultSuccessCallback::~CHIPDefaultSuccessCallback()
     JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
     if (env == nullptr)
     {
-        ChipLogError(Zcl, "Could not create global reference for Java callback");
+        ChipLogError(Zcl, "Could not delete global reference for Java callback");
         return;
     }
     env->DeleteGlobalRef(javaCallbackRef);

--- a/src/controller/java/templates/CHIPClusters-JNI.zapt
+++ b/src/controller/java/templates/CHIPClusters-JNI.zapt
@@ -76,7 +76,7 @@ class CHIP{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}Callba
             javaCallbackRef = cppCallback->javaCallbackRef;
             VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-            err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "({{#chip_cluster_response_arguments}}{{#if isArray}}{{else if (isOctetString type)}}[B{{else if (isShortString type)}}Ljava/lang/String;{{else}}{{asJniSignature type}}{{/if}}{{/chip_cluster_response_arguments}})V", &javaMethod);
+            err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "({{#chip_cluster_response_arguments}}{{#if isArray}}{{else if (isOctetString type)}}[B{{else if (isShortString type)}}Ljava/lang/String;{{else}}{{asJniSignature type false}}{{/if}}{{/chip_cluster_response_arguments}})V", &javaMethod);
             SuccessOrExit(err);
 
             {{#chip_cluster_response_arguments}}
@@ -146,7 +146,7 @@ JNI_METHOD(jlong, {{asUpperCamelCase name}}Cluster, initWithDevice)(JNIEnv * env
 }
 
 {{#chip_cluster_commands}}
-JNI_METHOD(void, {{asUpperCamelCase ../name}}Cluster, {{asLowerCamelCase name}})(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback{{#chip_cluster_command_arguments_with_structs_expanded}}, {{asJniBasicType type}} {{asLowerCamelCase label}}{{/chip_cluster_command_arguments_with_structs_expanded}})
+JNI_METHOD(void, {{asUpperCamelCase ../name}}Cluster, {{asLowerCamelCase name}})(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback{{#chip_cluster_command_arguments_with_structs_expanded}}, {{asJniBasicType type false}} {{asLowerCamelCase label}}{{/chip_cluster_command_arguments_with_structs_expanded}})
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -173,7 +173,8 @@ JNI_METHOD(void, {{asUpperCamelCase ../name}}Cluster, {{asLowerCamelCase name}})
     cppCluster = reinterpret_cast<{{asUpperCamelCase ../name}}Cluster *>(clusterPtr);
     VerifyOrExit(cppCluster != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
 
-    err = cppCluster->{{asCamelCased name false}}(onSuccess->Cancel(), onFailure->Cancel(){{#chip_cluster_command_arguments_with_structs_expanded}}, {{#if_chip_enum type}}static_cast<{{chipType}}>({{asLowerCamelCase label}}){{else if (isOctetString type)}}{{asUnderlyingZclType type}}((const uint8_t*) {{asLowerCamelCase label}}Arr.data(), {{asLowerCamelCase label}}Arr.size()){{else if (isCharString type)}}chip::CharSpan({{asLowerCamelCase label}}Str.c_str(), strlen({{asLowerCamelCase label}}Str.c_str())){{else}}{{asLowerCamelCase label}}{{/if_chip_enum}}{{/chip_cluster_command_arguments_with_structs_expanded}});
+    err = cppCluster->{{asCamelCased name false}}(onSuccess->Cancel(), onFailure->Cancel()
+    {{#chip_cluster_command_arguments_with_structs_expanded}}, {{#if_chip_enum type}}static_cast<{{chipType}}>({{asLowerCamelCase label}}){{else if (isOctetString type)}}{{asUnderlyingZclType type}}((const uint8_t*) {{asLowerCamelCase label}}Arr.data(), {{asLowerCamelCase label}}Arr.size()){{else if (isCharString type)}}chip::CharSpan({{asLowerCamelCase label}}Str.c_str(), strlen({{asLowerCamelCase label}}Str.c_str())){{else}}{{asLowerCamelCase label}}{{/if_chip_enum}}{{/chip_cluster_command_arguments_with_structs_expanded}});
     SuccessOrExit(err);
 
 exit: 
@@ -202,7 +203,7 @@ exit:
 {{#chip_server_cluster_attributes}}
 {{#if isWritableAttribute}}
 
-JNI_METHOD(void, {{asUpperCamelCase ../name}}Cluster, write{{asUpperCamelCase name}}Attribute)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, {{asJniBasicType type}} value)
+JNI_METHOD(void, {{asUpperCamelCase ../name}}Cluster, write{{asUpperCamelCase name}}Attribute)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, {{asJniBasicType type false}} value)
 {
     chip::DeviceLayer::StackLock lock;
     std::unique_ptr<CHIPDefaultSuccessCallback, void (*)(CHIPDefaultSuccessCallback *)> onSuccess(Platform::New<CHIPDefaultSuccessCallback>(callback), Platform::Delete<CHIPDefaultSuccessCallback>);

--- a/src/controller/java/templates/CHIPReadCallbacks-src.zapt
+++ b/src/controller/java/templates/CHIPReadCallbacks-src.zapt
@@ -26,6 +26,16 @@ CHIP{{chipCallback.name}}AttributeCallback::CHIP{{chipCallback.name}}AttributeCa
     }
 }
 
+CHIP{{chipCallback.name}}AttributeCallback::~CHIP{{chipCallback.name}}AttributeCallback() {
+    JNIEnv * env = chip::JniReferences::GetInstance().GetEnvForCurrentThread();
+    if (env == nullptr)
+    {
+        ChipLogError(Zcl, "Could not delete global reference for Java callback");
+        return;
+    }
+    env->DeleteGlobalRef(javaCallbackRef);
+}
+
 void CHIP{{chipCallback.name}}AttributeCallback::CallbackFn(void * context, {{chipCallback.type}} value)
 {
     chip::DeviceLayer::StackUnlock unlock;
@@ -43,7 +53,7 @@ void CHIP{{chipCallback.name}}AttributeCallback::CallbackFn(void * context, {{ch
     jmethodID javaMethod;
     {{#unless (isStrEqual chipCallback.name "OctetString")}}
     {{#unless (isStrEqual chipCallback.name "CharString")}}
-    err = chip::JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "({{convertCTypeToJniSignature chipCallback.type}})V", &javaMethod);
+    err = chip::JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "({{convertCTypeToJniSignature chipCallback.type false}})V", &javaMethod);
     VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Could not find onSuccess method"));
     env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<{{convertBasicCTypeToJniType chipCallback.type}}>(value));
     {{/unless}}
@@ -89,6 +99,16 @@ CHIP{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}AttributeCallback::
     }
 }
 
+CHIP{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}AttributeCallback::~CHIP{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}AttributeCallback() {
+    JNIEnv * env = chip::JniReferences::GetInstance().GetEnvForCurrentThread();
+    if (env == nullptr)
+    {
+        ChipLogError(Zcl, "Could not delete global reference for Java callback");
+        return;
+    }
+    env->DeleteGlobalRef(javaCallbackRef);
+}
+
 void CHIP{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}AttributeCallback::CallbackFn(void * context, {{zapTypeToDecodableClusterObjectType type ns=parent.name isArgument=true}} list)
 {
     chip::DeviceLayer::StackUnlock unlock;
@@ -124,7 +144,7 @@ void CHIP{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}AttributeCallb
     VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Could not find class chip/devicecontroller/ChipClusters${{asUpperCamelCase parent.name}}Cluster${{asUpperCamelCase name}}Attribute"));
     chip::JniClass attributeJniClass(attributeClass);
     jmethodID attributeCtor = env->GetMethodID(attributeClass, "<init>"
-        , "({{#chip_attribute_list_entryTypes}}{{#if isOptional}}{{! TODO: Add support for optional types here }}{{else if isNullable}}{{! TODO: Add support for nullable types here }}{{else if isArray}}{{! TODO: Add support for lists here }}{{else if isStruct}}{{! TODO: Add support for structs here }}{{else if (isString type)}}{{#if (isOctetString type)}}[B{{else}}Ljava/lang/String;{{/if}}{{else}}{{asJniSignature type}}{{/if}}{{/chip_attribute_list_entryTypes}})V");
+        , "({{#chip_attribute_list_entryTypes}}{{#if isArray}}{{! TODO: Add support for lists here }}{{else if isStruct}}{{! TODO: Add support for structs here }}{{else if isOptional}}Ljava/util/Optional;{{else if (isString type)}}{{#if (isOctetString type)}}[B{{else}}Ljava/lang/String;{{/if}}{{else}}{{asJniSignature type true}}{{/if}}{{/chip_attribute_list_entryTypes}})V");
     VerifyOrReturn(attributeCtor != nullptr, ChipLogError(Zcl, "Could not find {{asUpperCamelCase name}}Attribute constructor"));
     {{/if}}
 
@@ -135,35 +155,93 @@ void CHIP{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}AttributeCallb
         {{#if isStruct}}
         (void)entry; {{! In case all our struct members are not supported yet }}
         {{#chip_attribute_list_entryTypes}}
+        {{#unless isArray}}
+        {{#unless isStruct}}
+        bool {{asLowerCamelCase name}}Null = false;
+        bool {{asLowerCamelCase name}}HasValue = true;
+        {{#if isNullable}}
+        {{#unless isOptional}}
+        {{chipType}} {{asLowerCamelCase name}}Value;
+        {{asLowerCamelCase name}}Null = entry.{{asLowerCamelCase name}}.IsNull();
+        if (!{{asLowerCamelCase name}}Null) {
+            {{asLowerCamelCase name}}Value = entry.{{asLowerCamelCase name}}.Value();
+        }
+        {{/unless}}
+        {{/if}}
+
         {{#if isOptional}}
-        {{! TODO: Add support for optional types here }}
-        {{else if isNullable}}
-        {{! TODO: Add support for nullable types here }}
-        {{else if isArray}}
+        {{chipType}} {{asLowerCamelCase name}}Value;
+        {{#if isNullable}}
+        {{asLowerCamelCase name}}HasValue = entry.{{asLowerCamelCase name}}.HasValue();
+        if ({{asLowerCamelCase name}}HasValue) {
+            auto {{asLowerCamelCase name}}ValueFromOptional = entry.{{asLowerCamelCase name}}.Value();
+            {{asLowerCamelCase name}}Null = {{asLowerCamelCase name}}ValueFromOptional.IsNull();
+            if (!{{asLowerCamelCase name}}Null) {
+                {{asLowerCamelCase name}}Value = {{asLowerCamelCase name}}ValueFromOptional.Value();
+            }
+        }
+        {{else}}
+        {{asLowerCamelCase name}}HasValue = entry.{{asLowerCamelCase name}}.HasValue();
+        if ({{asLowerCamelCase name}}HasValue) {
+            {{asLowerCamelCase name}}Value = entry.{{asLowerCamelCase name}}.Value();
+        }
+        {{/if}}
+        {{/if}}
+
+        {{#unless isOptional}}
+        {{#unless isNullable}}
+        {{chipType}} {{asLowerCamelCase name}}Value = entry.{{asLowerCamelCase name}};
+        {{/unless}}
+        {{/unless}}
+
+        {{/unless}}
+        {{/unless}}
+
+        {{#if isArray}}
         {{! TODO: Add support for lists here }}
         {{else if isStruct}}
         {{! TODO: Add support for structs here }}
         {{else if (isOctetString type)}}
-        jbyteArray {{asLowerCamelCase name}} = env->NewByteArray(entry.{{asLowerCamelCase name}}.size());
-        env->SetByteArrayRegion({{asLowerCamelCase name}}, 0, entry.{{asLowerCamelCase name}}.size(), reinterpret_cast<const jbyte *>(entry.{{asLowerCamelCase name}}.data()));
+        jbyteArray {{asLowerCamelCase name}} = nullptr;
+        if (!{{asLowerCamelCase name}}Null && {{asLowerCamelCase name}}HasValue) {
+            {{asLowerCamelCase name}} = env->NewByteArray({{asLowerCamelCase name}}Value.size());
+            env->SetByteArrayRegion({{asLowerCamelCase name}}, 0, {{asLowerCamelCase name}}Value.size(), reinterpret_cast<const jbyte *>({{asLowerCamelCase name}}Value.data()));
+        }
         {{else if (isCharString type)}}
-        chip::UtfString {{asLowerCamelCase name}}Str(env, entry.{{asLowerCamelCase name}});
-        jstring {{asLowerCamelCase name}}({{asLowerCamelCase name}}Str.jniValue());
+        jstring {{asLowerCamelCase name}} = nullptr;
+        chip::UtfString {{asLowerCamelCase name}}Str(env, {{asLowerCamelCase name}}Value);
+        if (!{{asLowerCamelCase name}}Null && {{asLowerCamelCase name}}HasValue) {
+            {{asLowerCamelCase name}} = jstring({{asLowerCamelCase name}}Str.jniValue());
+        }
         {{else}}
-        {{asJniBasicType type}} {{asLowerCamelCase name}} = entry.{{asLowerCamelCase name}};
+        jobject {{asLowerCamelCase name}} = nullptr;
+        if (!{{asLowerCamelCase name}}Null && {{asLowerCamelCase name}}HasValue) {
+            jclass {{asLowerCamelCase name}}EntryCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/{{asJavaBasicTypeForZclType type true}}", {{asLowerCamelCase name}}EntryCls);
+            chip::JniClass {{asLowerCamelCase name}}JniClass({{asLowerCamelCase name}}EntryCls);
+            jmethodID {{asLowerCamelCase name}}EntryTypeCtor = env->GetMethodID({{asLowerCamelCase name}}EntryCls, "<init>", "({{asJniSignature type false}})V");
+            {{asLowerCamelCase name}} = env->NewObject({{asLowerCamelCase name}}EntryCls, {{asLowerCamelCase name}}EntryTypeCtor, {{asLowerCamelCase name}}Value);
+        }
+        {{/if}}
+
+        {{#if isOptional}}
+        {{#unless isArray}}
+        {{#unless isStruct}}
+        jobject {{asLowerCamelCase name}}Optional = nullptr;
+        chip::JniReferences::GetInstance().CreateOptional({{asLowerCamelCase name}}, {{asLowerCamelCase name}}Optional);
+        {{/unless}}
+        {{/unless}}
         {{/if}}
         {{/chip_attribute_list_entryTypes}}
 
         jobject attributeObj = env->NewObject(attributeClass, attributeCtor
             {{#chip_attribute_list_entryTypes}}
-            {{#if isOptional}}
-            {{! TODO: Add support for optional types here }}
-            {{else if isNullable}}
-            {{! TODO: Add support for nullable types here }}
-            {{else if isArray}}
+            {{#if isArray}}
             {{! TODO: Add support for lists here }}
             {{else if isStruct}}
             {{! TODO: Add support for structs here }}
+            {{else isOptional}}
+            , {{asLowerCamelCase name}}Optional
             {{else}}
             , {{asLowerCamelCase name}}
             {{/if}}
@@ -173,19 +251,53 @@ void CHIP{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}AttributeCallb
 
         env->CallBooleanMethod(arrayListObj, arrayListAddMethod, attributeObj);
         {{else}}
-        {{#if (isOctetString type)}}
-        jbyteArray {{asLowerCamelCase name}} = env->NewByteArray(entry.size());
-        env->SetByteArrayRegion({{asLowerCamelCase name}}, 0, entry.size(), reinterpret_cast<const jbyte *>(entry.data()));
-        {{else if (isCharString type)}}
-        chip::UtfString {{asLowerCamelCase name}}Str(env, entry);
-        jstring {{asLowerCamelCase name}}({{asLowerCamelCase name}}Str.jniValue());
+        bool entryNull = false;
+        {{#unless isArray}}
+        {{#unless isStruct}}
+        {{#if isNullable}}
+        {{chipType}} entryValue;
+        entryNull = entry.IsNull();
+        if (!entryNull) {
+            entryValue = entry.Value();
+        }
         {{else}}
-        jclass entryTypeCls;
-        chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/{{asJavaBasicTypeForZclType type true}}", entryTypeCls);
-        jmethodID entryTypeCtor = env->GetMethodID(entryTypeCls, "<init>", "({{asJniSignature type}})V");
-        jobject {{asLowerCamelCase name}} = env->NewObject(entryTypeCls, entryTypeCtor, entry);
+        {{chipType}} entryValue = entry;
         {{/if}}
-        env->CallBooleanMethod(arrayListObj, arrayListAddMethod, {{asLowerCamelCase name}});
+        {{/unless}}
+        {{/unless}}
+
+        {{#if isStruct}}
+        {{! TODO: Add support for structs here }}
+        {{else if (isOctetString type)}}
+        jbyteArray entryObject = nullptr;
+        if (!entryNull) {
+            entryObject = env->NewByteArray(entryValue.size());
+            env->SetByteArrayRegion(entryObject, 0, entryValue.size(), reinterpret_cast<const jbyte *>(entryValue.data()));
+        }
+        {{else if (isCharString type)}}
+        jstring entryObject = nullptr;
+        chip::UtfString entryStr(env, entryValue);
+        if (!entryNull) {
+            entryObject = jstring(entryStr.jniValue());
+        }
+        {{else}}
+        jobject entryObject = nullptr;
+        if (!entryNull) {
+            jclass entryTypeCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/{{asJavaBasicTypeForZclType type true}}", entryTypeCls);
+            chip::JniClass jniClass(entryTypeCls);
+            jmethodID entryTypeCtor = env->GetMethodID(entryTypeCls, "<init>", "({{asJniSignature type false}})V");
+            entryObject = env->NewObject(entryTypeCls, entryTypeCtor, entryValue);
+        }
+        {{/if}}
+
+        {{#if isOptional}}
+        jobject entryOptional = nullptr;
+        chip::JniReferences::GetInstance().CreateOptional(entryObject, entryOptional);
+        env->CallBooleanMethod(arrayListObj, arrayListAddMethod, entryOptional);
+        {{else}}
+        env->CallBooleanMethod(arrayListObj, arrayListAddMethod, entryObject);
+        {{/if}}
         {{/if}}
     }
     VerifyOrReturn(iter.GetStatus() == CHIP_NO_ERROR, ChipLogError(Zcl, "Error decoding {{asUpperCamelCase name}}Attribute value: %" CHIP_ERROR_FORMAT, iter.GetStatus().Format()));

--- a/src/controller/java/templates/CHIPReadCallbacks.zapt
+++ b/src/controller/java/templates/CHIPReadCallbacks.zapt
@@ -9,6 +9,8 @@ class CHIP{{chipCallback.name}}AttributeCallback : public chip::Callback::Callba
 public:
     CHIP{{chipCallback.name}}AttributeCallback(jobject javaCallback, bool keepAlive = false);
 
+    ~CHIP{{chipCallback.name}}AttributeCallback();
+
     static void maybeDestroy(CHIP{{chipCallback.name}}AttributeCallback * callback) {
         if (!callback->keepAlive) {
             callback->Cancel();
@@ -32,6 +34,8 @@ class CHIP{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}AttributeCall
 {
 public:
     CHIP{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}AttributeCallback(jobject javaCallback);
+
+    ~CHIP{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}AttributeCallback();
 
     static void CallbackFn(void * context, {{zapTypeToDecodableClusterObjectType type ns=parent.name isArgument=true}} list);
 

--- a/src/controller/java/templates/ChipClusters-java.zapt
+++ b/src/controller/java/templates/ChipClusters-java.zapt
@@ -3,7 +3,9 @@
 
 package chip.devicecontroller;
 
+import androidx.annotation.Nullable;
 import java.util.List;
+import java.util.Optional;
 
 public class ChipClusters {
 
@@ -110,48 +112,51 @@ public class ChipClusters {
   {{#if isStruct}}
     public static class {{asUpperCamelCase name}}Attribute {
     {{#chip_attribute_list_entryTypes}}
-      {{#if isOptional}}
-      {{! TODO: Add support for optional types here }}
-      {{else if isNullable}}
-      {{! TODO: Add support for nullable types here }}
-      {{else if isArray}}
+      {{#if isNullable}}
+      {{! 'unless' blocks are temporary until optional array / struct implemented }}
+      {{#unless isArray}}
+      {{#unless isStruct}}
+      @Nullable
+      {{/unless}}
+      {{/unless}}
+      {{/if}}
+      {{#if isArray}}
       {{! TODO: Add support for lists here }}
       {{else if isStruct}}
       {{! TODO: Add support for structs here }}
       {{else if (isOctetString type)}}
-      public byte[] {{asLowerCamelCase name}};
+      public {{#if isOptional}}Optional<{{/if}}byte[]{{#if isOptional}}>{{/if}} {{asLowerCamelCase name}};
       {{else if (isCharString type)}}
-      public String {{asLowerCamelCase name}};
+      public {{#if isOptional}}Optional<{{/if}}String{{#if isOptional}}>{{/if}} {{asLowerCamelCase name}};
       {{else}}
-      public {{asJavaBasicType label type}} {{asLowerCamelCase name}};
+      public {{#if isOptional}}Optional<{{/if}}{{asJavaBoxedType label type}}{{#if isOptional}}>{{/if}} {{asLowerCamelCase name}};
       {{/if}}
     {{/chip_attribute_list_entryTypes}}
 
       public {{asUpperCamelCase name}}Attribute(
         {{#chip_attribute_list_entryTypes}}
-        {{#if isOptional}}
-        {{! TODO: Add support for optional types here }}
-        {{else if isNullable}}
-        {{! TODO: Add support for nullable types here }}
-        {{else if isArray}}
+        {{#if isNullable}}
+        {{#unless isArray}}
+        {{#unless isStruct}}
+        @Nullable
+        {{/unless}}
+        {{/unless}}
+        {{/if}}
+        {{#if isArray}}
         {{! TODO: Add support for lists here }}
         {{else if isStruct}}
         {{! TODO: Add support for structs here }}
         {{else if (isOctetString type)}}
-        byte[] {{asLowerCamelCase name}}{{#not_last}},{{/not_last}}
+        {{#if isOptional}}Optional<{{/if}}byte[]{{#if isOptional}}>{{/if}} {{asLowerCamelCase name}} {{#notLastSupportedEntryTypes ..}},{{/notLastSupportedEntryTypes}}
         {{else if (isCharString type)}}
-        String {{asLowerCamelCase name}}{{#not_last}},{{/not_last}}
+        {{#if isOptional}}Optional<{{/if}}String{{#if isOptional}}>{{/if}} {{asLowerCamelCase name}} {{#notLastSupportedEntryTypes ..}},{{/notLastSupportedEntryTypes}}
         {{else}}
-        {{asJavaBasicType label type}} {{asLowerCamelCase name}}{{#not_last}},{{/not_last}}
+        {{#if isOptional}}Optional<{{/if}}{{asJavaBoxedType label type}}{{#if isOptional}}>{{/if}} {{asLowerCamelCase name}} {{#notLastSupportedEntryTypes ..}},{{/notLastSupportedEntryTypes}}
         {{/if}}
         {{/chip_attribute_list_entryTypes}}
       ) {
         {{#chip_attribute_list_entryTypes}}
-        {{#if isOptional}}
-        {{! TODO: Add support for optional types here }}
-        {{else if isNullable}}
-        {{! TODO: Add support for nullable types here }}
-        {{else if isArray}}
+        {{#if isArray}}
         {{! TODO: Add support for lists here }}
         {{else if isStruct}}
         {{! TODO: Add support for structs here }}
@@ -207,12 +212,33 @@ public class ChipClusters {
       {{#if isStruct}}
       {{asUpperCamelCase name}}Attribute
       {{else}}
+        {{#if isNullable}}
+        {{#unless isArray}}
+        {{#unless isStruct}}
+        @Nullable
+        {{/unless}}
+        {{/unless}}
+        {{/if}}
+        {{#if isOptional}}
+        {{#unless isArray}}
+        {{#unless isStruct}}
+        Optional<
+        {{/unless}}
+        {{/unless}}
+        {{/if}}
         {{#if (isOctetString type)}}
         byte[]
         {{else if (isCharString type)}}
         // Add String field here after ByteSpan is properly emitted in C++ layer
         {{else}}
         {{asJavaBasicTypeForZclType type true}}
+        {{/if}}
+        {{#if isOptional}}
+        {{#unless isArray}}
+        {{#unless isStruct}}
+        >
+        {{/unless}}
+        {{/unless}}
         {{/if}}
       {{/if}}
       > valueList);

--- a/src/controller/java/templates/helper.js
+++ b/src/controller/java/templates/helper.js
@@ -99,13 +99,16 @@ function asJavaBoxedType(type)
   }
 }
 
-function asJniBasicType(type)
+function asJniBasicType(type, useBoxedTypes)
 {
   if (StringHelper.isOctetString(type)) {
     return 'jbyteArray';
   } else if (StringHelper.isCharString(type)) {
     return 'jstring';
   } else {
+    if (useBoxedTypes) {
+      return 'jobject';
+    }
     return convertBasicCTypeToJniType(ChipTypesHelper.asBasicType(this.chipType));
   }
 }
@@ -145,13 +148,13 @@ function asJniBasicTypeForZclType(type)
   return templateUtil.templatePromise(this.global, promise)
 }
 
-function asJniSignature(type)
+function asJniSignature(type, useBoxedTypes)
 {
   function fn(pkgId)
   {
     const options = { 'hash' : {} };
     return zclHelper.asUnderlyingZclType.call(this, type, options).then(zclType => {
-      return convertCTypeToJniSignature(ChipTypesHelper.asBasicType(zclType));
+      return convertCTypeToJniSignature(ChipTypesHelper.asBasicType(zclType), useBoxedTypes);
     })
   }
 
@@ -162,9 +165,15 @@ function asJniSignature(type)
   return templateUtil.templatePromise(this.global, promise)
 }
 
-function convertCTypeToJniSignature(cType)
+function convertCTypeToJniSignature(cType, useBoxedTypes)
 {
-  const javaType = convertBasicCTypeToJavaType(cType);
+  let javaType;
+  if (useBoxedTypes) {
+    javaType = convertBasicCTypeToJavaBoxedType(cType);
+  } else {
+    javaType = convertBasicCTypeToJavaType(cType);
+  }
+
   switch (javaType) {
   case 'int':
     return 'I';
@@ -172,6 +181,12 @@ function convertCTypeToJniSignature(cType)
     return 'J';
   case 'boolean':
     return 'Z';
+  case 'Boolean':
+    return 'Ljava/lang/Boolean;';
+  case 'Integer':
+    return 'Ljava/lang/Integer;';
+  case 'Long':
+    return 'Ljava/lang/Long;';
   default:
     error = 'Unhandled Java type ' + javaType + ' for C type ' + cType;
     throw error;
@@ -187,6 +202,22 @@ function convertAttributeCallbackTypeToJavaName(cType)
     return 'CharString';
   } else {
     return convertBasicCTypeToJavaBoxedType(cType);
+  }
+}
+
+function notLastSupportedEntryTypes(context, options)
+{
+  if (context.items.length == 0) {
+    return
+  }
+
+  let lastIndex = context.items.length - 1;
+  while (context.items[lastIndex].isStruct || context.items[lastIndex].isArray) {
+    lastIndex--;
+  }
+
+  if (this.index != lastIndex) {
+    return options.fn(this);
   }
 }
 
@@ -228,3 +259,4 @@ exports.convertCTypeToJniSignature             = convertCTypeToJniSignature;
 exports.convertBasicCTypeToJavaBoxedType       = convertBasicCTypeToJavaBoxedType;
 exports.convertAttributeCallbackTypeToJavaName = convertAttributeCallbackTypeToJavaName;
 exports.omitCommaForFirstNonStatusCommand      = omitCommaForFirstNonStatusCommand;
+exports.notLastSupportedEntryTypes             = notLastSupportedEntryTypes;

--- a/src/controller/java/zap-generated/CHIPReadCallbacks.cpp
+++ b/src/controller/java/zap-generated/CHIPReadCallbacks.cpp
@@ -42,6 +42,17 @@ CHIPBooleanAttributeCallback::CHIPBooleanAttributeCallback(jobject javaCallback,
     }
 }
 
+CHIPBooleanAttributeCallback::~CHIPBooleanAttributeCallback()
+{
+    JNIEnv * env = chip::JniReferences::GetInstance().GetEnvForCurrentThread();
+    if (env == nullptr)
+    {
+        ChipLogError(Zcl, "Could not delete global reference for Java callback");
+        return;
+    }
+    env->DeleteGlobalRef(javaCallbackRef);
+}
+
 void CHIPBooleanAttributeCallback::CallbackFn(void * context, bool value)
 {
     chip::DeviceLayer::StackUnlock unlock;
@@ -78,6 +89,17 @@ CHIPCharStringAttributeCallback::CHIPCharStringAttributeCallback(jobject javaCal
     {
         ChipLogError(Zcl, "Could not create global reference for Java callback");
     }
+}
+
+CHIPCharStringAttributeCallback::~CHIPCharStringAttributeCallback()
+{
+    JNIEnv * env = chip::JniReferences::GetInstance().GetEnvForCurrentThread();
+    if (env == nullptr)
+    {
+        ChipLogError(Zcl, "Could not delete global reference for Java callback");
+        return;
+    }
+    env->DeleteGlobalRef(javaCallbackRef);
 }
 
 void CHIPCharStringAttributeCallback::CallbackFn(void * context, const chip::CharSpan value)
@@ -121,6 +143,17 @@ CHIPInt8sAttributeCallback::CHIPInt8sAttributeCallback(jobject javaCallback, boo
     }
 }
 
+CHIPInt8sAttributeCallback::~CHIPInt8sAttributeCallback()
+{
+    JNIEnv * env = chip::JniReferences::GetInstance().GetEnvForCurrentThread();
+    if (env == nullptr)
+    {
+        ChipLogError(Zcl, "Could not delete global reference for Java callback");
+        return;
+    }
+    env->DeleteGlobalRef(javaCallbackRef);
+}
+
 void CHIPInt8sAttributeCallback::CallbackFn(void * context, int8_t value)
 {
     chip::DeviceLayer::StackUnlock unlock;
@@ -157,6 +190,17 @@ CHIPInt8uAttributeCallback::CHIPInt8uAttributeCallback(jobject javaCallback, boo
     {
         ChipLogError(Zcl, "Could not create global reference for Java callback");
     }
+}
+
+CHIPInt8uAttributeCallback::~CHIPInt8uAttributeCallback()
+{
+    JNIEnv * env = chip::JniReferences::GetInstance().GetEnvForCurrentThread();
+    if (env == nullptr)
+    {
+        ChipLogError(Zcl, "Could not delete global reference for Java callback");
+        return;
+    }
+    env->DeleteGlobalRef(javaCallbackRef);
 }
 
 void CHIPInt8uAttributeCallback::CallbackFn(void * context, uint8_t value)
@@ -197,6 +241,17 @@ CHIPInt16sAttributeCallback::CHIPInt16sAttributeCallback(jobject javaCallback, b
     }
 }
 
+CHIPInt16sAttributeCallback::~CHIPInt16sAttributeCallback()
+{
+    JNIEnv * env = chip::JniReferences::GetInstance().GetEnvForCurrentThread();
+    if (env == nullptr)
+    {
+        ChipLogError(Zcl, "Could not delete global reference for Java callback");
+        return;
+    }
+    env->DeleteGlobalRef(javaCallbackRef);
+}
+
 void CHIPInt16sAttributeCallback::CallbackFn(void * context, int16_t value)
 {
     chip::DeviceLayer::StackUnlock unlock;
@@ -233,6 +288,17 @@ CHIPInt16uAttributeCallback::CHIPInt16uAttributeCallback(jobject javaCallback, b
     {
         ChipLogError(Zcl, "Could not create global reference for Java callback");
     }
+}
+
+CHIPInt16uAttributeCallback::~CHIPInt16uAttributeCallback()
+{
+    JNIEnv * env = chip::JniReferences::GetInstance().GetEnvForCurrentThread();
+    if (env == nullptr)
+    {
+        ChipLogError(Zcl, "Could not delete global reference for Java callback");
+        return;
+    }
+    env->DeleteGlobalRef(javaCallbackRef);
 }
 
 void CHIPInt16uAttributeCallback::CallbackFn(void * context, uint16_t value)
@@ -273,6 +339,17 @@ CHIPInt32sAttributeCallback::CHIPInt32sAttributeCallback(jobject javaCallback, b
     }
 }
 
+CHIPInt32sAttributeCallback::~CHIPInt32sAttributeCallback()
+{
+    JNIEnv * env = chip::JniReferences::GetInstance().GetEnvForCurrentThread();
+    if (env == nullptr)
+    {
+        ChipLogError(Zcl, "Could not delete global reference for Java callback");
+        return;
+    }
+    env->DeleteGlobalRef(javaCallbackRef);
+}
+
 void CHIPInt32sAttributeCallback::CallbackFn(void * context, int32_t value)
 {
     chip::DeviceLayer::StackUnlock unlock;
@@ -309,6 +386,17 @@ CHIPInt32uAttributeCallback::CHIPInt32uAttributeCallback(jobject javaCallback, b
     {
         ChipLogError(Zcl, "Could not create global reference for Java callback");
     }
+}
+
+CHIPInt32uAttributeCallback::~CHIPInt32uAttributeCallback()
+{
+    JNIEnv * env = chip::JniReferences::GetInstance().GetEnvForCurrentThread();
+    if (env == nullptr)
+    {
+        ChipLogError(Zcl, "Could not delete global reference for Java callback");
+        return;
+    }
+    env->DeleteGlobalRef(javaCallbackRef);
 }
 
 void CHIPInt32uAttributeCallback::CallbackFn(void * context, uint32_t value)
@@ -349,6 +437,17 @@ CHIPInt64sAttributeCallback::CHIPInt64sAttributeCallback(jobject javaCallback, b
     }
 }
 
+CHIPInt64sAttributeCallback::~CHIPInt64sAttributeCallback()
+{
+    JNIEnv * env = chip::JniReferences::GetInstance().GetEnvForCurrentThread();
+    if (env == nullptr)
+    {
+        ChipLogError(Zcl, "Could not delete global reference for Java callback");
+        return;
+    }
+    env->DeleteGlobalRef(javaCallbackRef);
+}
+
 void CHIPInt64sAttributeCallback::CallbackFn(void * context, int64_t value)
 {
     chip::DeviceLayer::StackUnlock unlock;
@@ -387,6 +486,17 @@ CHIPInt64uAttributeCallback::CHIPInt64uAttributeCallback(jobject javaCallback, b
     }
 }
 
+CHIPInt64uAttributeCallback::~CHIPInt64uAttributeCallback()
+{
+    JNIEnv * env = chip::JniReferences::GetInstance().GetEnvForCurrentThread();
+    if (env == nullptr)
+    {
+        ChipLogError(Zcl, "Could not delete global reference for Java callback");
+        return;
+    }
+    env->DeleteGlobalRef(javaCallbackRef);
+}
+
 void CHIPInt64uAttributeCallback::CallbackFn(void * context, uint64_t value)
 {
     chip::DeviceLayer::StackUnlock unlock;
@@ -423,6 +533,17 @@ CHIPOctetStringAttributeCallback::CHIPOctetStringAttributeCallback(jobject javaC
     {
         ChipLogError(Zcl, "Could not create global reference for Java callback");
     }
+}
+
+CHIPOctetStringAttributeCallback::~CHIPOctetStringAttributeCallback()
+{
+    JNIEnv * env = chip::JniReferences::GetInstance().GetEnvForCurrentThread();
+    if (env == nullptr)
+    {
+        ChipLogError(Zcl, "Could not delete global reference for Java callback");
+        return;
+    }
+    env->DeleteGlobalRef(javaCallbackRef);
 }
 
 void CHIPOctetStringAttributeCallback::CallbackFn(void * context, const chip::ByteSpan value)
@@ -471,6 +592,17 @@ CHIPApplicationLauncherApplicationLauncherListAttributeCallback::CHIPApplication
     }
 }
 
+CHIPApplicationLauncherApplicationLauncherListAttributeCallback::~CHIPApplicationLauncherApplicationLauncherListAttributeCallback()
+{
+    JNIEnv * env = chip::JniReferences::GetInstance().GetEnvForCurrentThread();
+    if (env == nullptr)
+    {
+        ChipLogError(Zcl, "Could not delete global reference for Java callback");
+        return;
+    }
+    env->DeleteGlobalRef(javaCallbackRef);
+}
+
 void CHIPApplicationLauncherApplicationLauncherListAttributeCallback::CallbackFn(
     void * context, const chip::app::DataModel::DecodableList<uint16_t> & list)
 {
@@ -507,12 +639,21 @@ void CHIPApplicationLauncherApplicationLauncherListAttributeCallback::CallbackFn
     auto iter = list.begin();
     while (iter.Next())
     {
-        auto & entry = iter.GetValue();
-        jclass entryTypeCls;
-        chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Integer", entryTypeCls);
-        jmethodID entryTypeCtor         = env->GetMethodID(entryTypeCls, "<init>", "(I)V");
-        jobject applicationLauncherList = env->NewObject(entryTypeCls, entryTypeCtor, entry);
-        env->CallBooleanMethod(arrayListObj, arrayListAddMethod, applicationLauncherList);
+        auto & entry        = iter.GetValue();
+        bool entryNull      = false;
+        uint16_t entryValue = entry;
+
+        jobject entryObject = nullptr;
+        if (!entryNull)
+        {
+            jclass entryTypeCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Integer", entryTypeCls);
+            chip::JniClass jniClass(entryTypeCls);
+            jmethodID entryTypeCtor = env->GetMethodID(entryTypeCls, "<init>", "(I)V");
+            entryObject             = env->NewObject(entryTypeCls, entryTypeCtor, entryValue);
+        }
+
+        env->CallBooleanMethod(arrayListObj, arrayListAddMethod, entryObject);
     }
     VerifyOrReturn(
         iter.GetStatus() == CHIP_NO_ERROR,
@@ -537,6 +678,17 @@ CHIPAudioOutputAudioOutputListAttributeCallback::CHIPAudioOutputAudioOutputListA
     {
         ChipLogError(Zcl, "Could not create global reference for Java callback");
     }
+}
+
+CHIPAudioOutputAudioOutputListAttributeCallback::~CHIPAudioOutputAudioOutputListAttributeCallback()
+{
+    JNIEnv * env = chip::JniReferences::GetInstance().GetEnvForCurrentThread();
+    if (env == nullptr)
+    {
+        ChipLogError(Zcl, "Could not delete global reference for Java callback");
+        return;
+    }
+    env->DeleteGlobalRef(javaCallbackRef);
 }
 
 void CHIPAudioOutputAudioOutputListAttributeCallback::CallbackFn(
@@ -580,7 +732,8 @@ void CHIPAudioOutputAudioOutputListAttributeCallback::CallbackFn(
         err == CHIP_NO_ERROR,
         ChipLogError(Zcl, "Could not find class chip/devicecontroller/ChipClusters$AudioOutputCluster$AudioOutputListAttribute"));
     chip::JniClass attributeJniClass(attributeClass);
-    jmethodID attributeCtor = env->GetMethodID(attributeClass, "<init>", "(IILjava/lang/String;)V");
+    jmethodID attributeCtor =
+        env->GetMethodID(attributeClass, "<init>", "(Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;)V");
     VerifyOrReturn(attributeCtor != nullptr, ChipLogError(Zcl, "Could not find AudioOutputListAttribute constructor"));
 
     auto iter = list.begin();
@@ -588,10 +741,47 @@ void CHIPAudioOutputAudioOutputListAttributeCallback::CallbackFn(
     {
         auto & entry = iter.GetValue();
         (void) entry;
-        jint index      = entry.index;
-        jint outputType = entry.outputType;
-        chip::UtfString nameStr(env, entry.name);
-        jstring name(nameStr.jniValue());
+        bool indexNull     = false;
+        bool indexHasValue = true;
+
+        uint8_t indexValue = entry.index;
+
+        jobject index = nullptr;
+        if (!indexNull && indexHasValue)
+        {
+            jclass indexEntryCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Integer", indexEntryCls);
+            chip::JniClass indexJniClass(indexEntryCls);
+            jmethodID indexEntryTypeCtor = env->GetMethodID(indexEntryCls, "<init>", "(I)V");
+            index                        = env->NewObject(indexEntryCls, indexEntryTypeCtor, indexValue);
+        }
+
+        bool outputTypeNull     = false;
+        bool outputTypeHasValue = true;
+
+        uint8_t outputTypeValue = entry.outputType;
+
+        jobject outputType = nullptr;
+        if (!outputTypeNull && outputTypeHasValue)
+        {
+            jclass outputTypeEntryCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Integer", outputTypeEntryCls);
+            chip::JniClass outputTypeJniClass(outputTypeEntryCls);
+            jmethodID outputTypeEntryTypeCtor = env->GetMethodID(outputTypeEntryCls, "<init>", "(I)V");
+            outputType                        = env->NewObject(outputTypeEntryCls, outputTypeEntryTypeCtor, outputTypeValue);
+        }
+
+        bool nameNull     = false;
+        bool nameHasValue = true;
+
+        chip::CharSpan nameValue = entry.name;
+
+        jstring name = nullptr;
+        chip::UtfString nameStr(env, nameValue);
+        if (!nameNull && nameHasValue)
+        {
+            name = jstring(nameStr.jniValue());
+        }
 
         jobject attributeObj = env->NewObject(attributeClass, attributeCtor, index, outputType, name);
         VerifyOrReturn(attributeObj != nullptr, ChipLogError(Zcl, "Could not create AudioOutputListAttribute object"));
@@ -621,6 +811,17 @@ CHIPBridgedActionsActionListAttributeCallback::CHIPBridgedActionsActionListAttri
     {
         ChipLogError(Zcl, "Could not create global reference for Java callback");
     }
+}
+
+CHIPBridgedActionsActionListAttributeCallback::~CHIPBridgedActionsActionListAttributeCallback()
+{
+    JNIEnv * env = chip::JniReferences::GetInstance().GetEnvForCurrentThread();
+    if (env == nullptr)
+    {
+        ChipLogError(Zcl, "Could not delete global reference for Java callback");
+        return;
+    }
+    env->DeleteGlobalRef(javaCallbackRef);
 }
 
 void CHIPBridgedActionsActionListAttributeCallback::CallbackFn(
@@ -664,7 +865,9 @@ void CHIPBridgedActionsActionListAttributeCallback::CallbackFn(
         err == CHIP_NO_ERROR,
         ChipLogError(Zcl, "Could not find class chip/devicecontroller/ChipClusters$BridgedActionsCluster$ActionListAttribute"));
     chip::JniClass attributeJniClass(attributeClass);
-    jmethodID attributeCtor = env->GetMethodID(attributeClass, "<init>", "(ILjava/lang/String;IIII)V");
+    jmethodID attributeCtor = env->GetMethodID(
+        attributeClass, "<init>",
+        "(Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;)V");
     VerifyOrReturn(attributeCtor != nullptr, ChipLogError(Zcl, "Could not find ActionListAttribute constructor"));
 
     auto iter = list.begin();
@@ -672,13 +875,92 @@ void CHIPBridgedActionsActionListAttributeCallback::CallbackFn(
     {
         auto & entry = iter.GetValue();
         (void) entry;
-        jint actionID = entry.actionID;
-        chip::UtfString nameStr(env, entry.name);
-        jstring name(nameStr.jniValue());
-        jint type              = entry.type;
-        jint endpointListID    = entry.endpointListID;
-        jint supportedCommands = entry.supportedCommands;
-        jint status            = entry.status;
+        bool actionIDNull     = false;
+        bool actionIDHasValue = true;
+
+        uint16_t actionIDValue = entry.actionID;
+
+        jobject actionID = nullptr;
+        if (!actionIDNull && actionIDHasValue)
+        {
+            jclass actionIDEntryCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Integer", actionIDEntryCls);
+            chip::JniClass actionIDJniClass(actionIDEntryCls);
+            jmethodID actionIDEntryTypeCtor = env->GetMethodID(actionIDEntryCls, "<init>", "(I)V");
+            actionID                        = env->NewObject(actionIDEntryCls, actionIDEntryTypeCtor, actionIDValue);
+        }
+
+        bool nameNull     = false;
+        bool nameHasValue = true;
+
+        chip::CharSpan nameValue = entry.name;
+
+        jstring name = nullptr;
+        chip::UtfString nameStr(env, nameValue);
+        if (!nameNull && nameHasValue)
+        {
+            name = jstring(nameStr.jniValue());
+        }
+
+        bool typeNull     = false;
+        bool typeHasValue = true;
+
+        uint8_t typeValue = entry.type;
+
+        jobject type = nullptr;
+        if (!typeNull && typeHasValue)
+        {
+            jclass typeEntryCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Integer", typeEntryCls);
+            chip::JniClass typeJniClass(typeEntryCls);
+            jmethodID typeEntryTypeCtor = env->GetMethodID(typeEntryCls, "<init>", "(I)V");
+            type                        = env->NewObject(typeEntryCls, typeEntryTypeCtor, typeValue);
+        }
+
+        bool endpointListIDNull     = false;
+        bool endpointListIDHasValue = true;
+
+        uint16_t endpointListIDValue = entry.endpointListID;
+
+        jobject endpointListID = nullptr;
+        if (!endpointListIDNull && endpointListIDHasValue)
+        {
+            jclass endpointListIDEntryCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Integer", endpointListIDEntryCls);
+            chip::JniClass endpointListIDJniClass(endpointListIDEntryCls);
+            jmethodID endpointListIDEntryTypeCtor = env->GetMethodID(endpointListIDEntryCls, "<init>", "(I)V");
+            endpointListID = env->NewObject(endpointListIDEntryCls, endpointListIDEntryTypeCtor, endpointListIDValue);
+        }
+
+        bool supportedCommandsNull     = false;
+        bool supportedCommandsHasValue = true;
+
+        uint16_t supportedCommandsValue = entry.supportedCommands;
+
+        jobject supportedCommands = nullptr;
+        if (!supportedCommandsNull && supportedCommandsHasValue)
+        {
+            jclass supportedCommandsEntryCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Integer", supportedCommandsEntryCls);
+            chip::JniClass supportedCommandsJniClass(supportedCommandsEntryCls);
+            jmethodID supportedCommandsEntryTypeCtor = env->GetMethodID(supportedCommandsEntryCls, "<init>", "(I)V");
+            supportedCommands = env->NewObject(supportedCommandsEntryCls, supportedCommandsEntryTypeCtor, supportedCommandsValue);
+        }
+
+        bool statusNull     = false;
+        bool statusHasValue = true;
+
+        uint8_t statusValue = entry.status;
+
+        jobject status = nullptr;
+        if (!statusNull && statusHasValue)
+        {
+            jclass statusEntryCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Integer", statusEntryCls);
+            chip::JniClass statusJniClass(statusEntryCls);
+            jmethodID statusEntryTypeCtor = env->GetMethodID(statusEntryCls, "<init>", "(I)V");
+            status                        = env->NewObject(statusEntryCls, statusEntryTypeCtor, statusValue);
+        }
 
         jobject attributeObj =
             env->NewObject(attributeClass, attributeCtor, actionID, name, type, endpointListID, supportedCommands, status);
@@ -708,6 +990,17 @@ CHIPBridgedActionsEndpointListAttributeCallback::CHIPBridgedActionsEndpointListA
     {
         ChipLogError(Zcl, "Could not create global reference for Java callback");
     }
+}
+
+CHIPBridgedActionsEndpointListAttributeCallback::~CHIPBridgedActionsEndpointListAttributeCallback()
+{
+    JNIEnv * env = chip::JniReferences::GetInstance().GetEnvForCurrentThread();
+    if (env == nullptr)
+    {
+        ChipLogError(Zcl, "Could not delete global reference for Java callback");
+        return;
+    }
+    env->DeleteGlobalRef(javaCallbackRef);
 }
 
 void CHIPBridgedActionsEndpointListAttributeCallback::CallbackFn(
@@ -752,7 +1045,8 @@ void CHIPBridgedActionsEndpointListAttributeCallback::CallbackFn(
         err == CHIP_NO_ERROR,
         ChipLogError(Zcl, "Could not find class chip/devicecontroller/ChipClusters$BridgedActionsCluster$EndpointListAttribute"));
     chip::JniClass attributeJniClass(attributeClass);
-    jmethodID attributeCtor = env->GetMethodID(attributeClass, "<init>", "(ILjava/lang/String;I[B)V");
+    jmethodID attributeCtor =
+        env->GetMethodID(attributeClass, "<init>", "(Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Integer;[B)V");
     VerifyOrReturn(attributeCtor != nullptr, ChipLogError(Zcl, "Could not find EndpointListAttribute constructor"));
 
     auto iter = list.begin();
@@ -760,12 +1054,59 @@ void CHIPBridgedActionsEndpointListAttributeCallback::CallbackFn(
     {
         auto & entry = iter.GetValue();
         (void) entry;
-        jint endpointListID = entry.endpointListID;
-        chip::UtfString nameStr(env, entry.name);
-        jstring name(nameStr.jniValue());
-        jint type            = entry.type;
-        jbyteArray endpoints = env->NewByteArray(entry.endpoints.size());
-        env->SetByteArrayRegion(endpoints, 0, entry.endpoints.size(), reinterpret_cast<const jbyte *>(entry.endpoints.data()));
+        bool endpointListIDNull     = false;
+        bool endpointListIDHasValue = true;
+
+        uint16_t endpointListIDValue = entry.endpointListID;
+
+        jobject endpointListID = nullptr;
+        if (!endpointListIDNull && endpointListIDHasValue)
+        {
+            jclass endpointListIDEntryCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Integer", endpointListIDEntryCls);
+            chip::JniClass endpointListIDJniClass(endpointListIDEntryCls);
+            jmethodID endpointListIDEntryTypeCtor = env->GetMethodID(endpointListIDEntryCls, "<init>", "(I)V");
+            endpointListID = env->NewObject(endpointListIDEntryCls, endpointListIDEntryTypeCtor, endpointListIDValue);
+        }
+
+        bool nameNull     = false;
+        bool nameHasValue = true;
+
+        chip::CharSpan nameValue = entry.name;
+
+        jstring name = nullptr;
+        chip::UtfString nameStr(env, nameValue);
+        if (!nameNull && nameHasValue)
+        {
+            name = jstring(nameStr.jniValue());
+        }
+
+        bool typeNull     = false;
+        bool typeHasValue = true;
+
+        uint8_t typeValue = entry.type;
+
+        jobject type = nullptr;
+        if (!typeNull && typeHasValue)
+        {
+            jclass typeEntryCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Integer", typeEntryCls);
+            chip::JniClass typeJniClass(typeEntryCls);
+            jmethodID typeEntryTypeCtor = env->GetMethodID(typeEntryCls, "<init>", "(I)V");
+            type                        = env->NewObject(typeEntryCls, typeEntryTypeCtor, typeValue);
+        }
+
+        bool endpointsNull     = false;
+        bool endpointsHasValue = true;
+
+        chip::ByteSpan endpointsValue = entry.endpoints;
+
+        jbyteArray endpoints = nullptr;
+        if (!endpointsNull && endpointsHasValue)
+        {
+            endpoints = env->NewByteArray(endpointsValue.size());
+            env->SetByteArrayRegion(endpoints, 0, endpointsValue.size(), reinterpret_cast<const jbyte *>(endpointsValue.data()));
+        }
 
         jobject attributeObj = env->NewObject(attributeClass, attributeCtor, endpointListID, name, type, endpoints);
         VerifyOrReturn(attributeObj != nullptr, ChipLogError(Zcl, "Could not create EndpointListAttribute object"));
@@ -794,6 +1135,17 @@ CHIPContentLauncherAcceptsHeaderListAttributeCallback::CHIPContentLauncherAccept
     {
         ChipLogError(Zcl, "Could not create global reference for Java callback");
     }
+}
+
+CHIPContentLauncherAcceptsHeaderListAttributeCallback::~CHIPContentLauncherAcceptsHeaderListAttributeCallback()
+{
+    JNIEnv * env = chip::JniReferences::GetInstance().GetEnvForCurrentThread();
+    if (env == nullptr)
+    {
+        ChipLogError(Zcl, "Could not delete global reference for Java callback");
+        return;
+    }
+    env->DeleteGlobalRef(javaCallbackRef);
 }
 
 void CHIPContentLauncherAcceptsHeaderListAttributeCallback::CallbackFn(
@@ -832,10 +1184,18 @@ void CHIPContentLauncherAcceptsHeaderListAttributeCallback::CallbackFn(
     auto iter = list.begin();
     while (iter.Next())
     {
-        auto & entry                 = iter.GetValue();
-        jbyteArray acceptsHeaderList = env->NewByteArray(entry.size());
-        env->SetByteArrayRegion(acceptsHeaderList, 0, entry.size(), reinterpret_cast<const jbyte *>(entry.data()));
-        env->CallBooleanMethod(arrayListObj, arrayListAddMethod, acceptsHeaderList);
+        auto & entry              = iter.GetValue();
+        bool entryNull            = false;
+        chip::ByteSpan entryValue = entry;
+
+        jbyteArray entryObject = nullptr;
+        if (!entryNull)
+        {
+            entryObject = env->NewByteArray(entryValue.size());
+            env->SetByteArrayRegion(entryObject, 0, entryValue.size(), reinterpret_cast<const jbyte *>(entryValue.data()));
+        }
+
+        env->CallBooleanMethod(arrayListObj, arrayListAddMethod, entryObject);
     }
     VerifyOrReturn(
         iter.GetStatus() == CHIP_NO_ERROR,
@@ -861,6 +1221,17 @@ CHIPContentLauncherSupportedStreamingTypesAttributeCallback::CHIPContentLauncher
     {
         ChipLogError(Zcl, "Could not create global reference for Java callback");
     }
+}
+
+CHIPContentLauncherSupportedStreamingTypesAttributeCallback::~CHIPContentLauncherSupportedStreamingTypesAttributeCallback()
+{
+    JNIEnv * env = chip::JniReferences::GetInstance().GetEnvForCurrentThread();
+    if (env == nullptr)
+    {
+        ChipLogError(Zcl, "Could not delete global reference for Java callback");
+        return;
+    }
+    env->DeleteGlobalRef(javaCallbackRef);
 }
 
 void CHIPContentLauncherSupportedStreamingTypesAttributeCallback::CallbackFn(
@@ -900,12 +1271,21 @@ void CHIPContentLauncherSupportedStreamingTypesAttributeCallback::CallbackFn(
     auto iter = list.begin();
     while (iter.Next())
     {
-        auto & entry = iter.GetValue();
-        jclass entryTypeCls;
-        chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Integer", entryTypeCls);
-        jmethodID entryTypeCtor         = env->GetMethodID(entryTypeCls, "<init>", "(I)V");
-        jobject supportedStreamingTypes = env->NewObject(entryTypeCls, entryTypeCtor, entry);
-        env->CallBooleanMethod(arrayListObj, arrayListAddMethod, supportedStreamingTypes);
+        auto & entry       = iter.GetValue();
+        bool entryNull     = false;
+        uint8_t entryValue = entry;
+
+        jobject entryObject = nullptr;
+        if (!entryNull)
+        {
+            jclass entryTypeCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Integer", entryTypeCls);
+            chip::JniClass jniClass(entryTypeCls);
+            jmethodID entryTypeCtor = env->GetMethodID(entryTypeCls, "<init>", "(I)V");
+            entryObject             = env->NewObject(entryTypeCls, entryTypeCtor, entryValue);
+        }
+
+        env->CallBooleanMethod(arrayListObj, arrayListAddMethod, entryObject);
     }
     VerifyOrReturn(
         iter.GetStatus() == CHIP_NO_ERROR,
@@ -930,6 +1310,17 @@ CHIPDescriptorDeviceListAttributeCallback::CHIPDescriptorDeviceListAttributeCall
     {
         ChipLogError(Zcl, "Could not create global reference for Java callback");
     }
+}
+
+CHIPDescriptorDeviceListAttributeCallback::~CHIPDescriptorDeviceListAttributeCallback()
+{
+    JNIEnv * env = chip::JniReferences::GetInstance().GetEnvForCurrentThread();
+    if (env == nullptr)
+    {
+        ChipLogError(Zcl, "Could not delete global reference for Java callback");
+        return;
+    }
+    env->DeleteGlobalRef(javaCallbackRef);
 }
 
 void CHIPDescriptorDeviceListAttributeCallback::CallbackFn(
@@ -973,7 +1364,7 @@ void CHIPDescriptorDeviceListAttributeCallback::CallbackFn(
         err == CHIP_NO_ERROR,
         ChipLogError(Zcl, "Could not find class chip/devicecontroller/ChipClusters$DescriptorCluster$DeviceListAttribute"));
     chip::JniClass attributeJniClass(attributeClass);
-    jmethodID attributeCtor = env->GetMethodID(attributeClass, "<init>", "(JI)V");
+    jmethodID attributeCtor = env->GetMethodID(attributeClass, "<init>", "(Ljava/lang/Long;Ljava/lang/Integer;)V");
     VerifyOrReturn(attributeCtor != nullptr, ChipLogError(Zcl, "Could not find DeviceListAttribute constructor"));
 
     auto iter = list.begin();
@@ -981,8 +1372,35 @@ void CHIPDescriptorDeviceListAttributeCallback::CallbackFn(
     {
         auto & entry = iter.GetValue();
         (void) entry;
-        jlong type    = entry.type;
-        jint revision = entry.revision;
+        bool typeNull     = false;
+        bool typeHasValue = true;
+
+        chip::DeviceTypeId typeValue = entry.type;
+
+        jobject type = nullptr;
+        if (!typeNull && typeHasValue)
+        {
+            jclass typeEntryCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Long", typeEntryCls);
+            chip::JniClass typeJniClass(typeEntryCls);
+            jmethodID typeEntryTypeCtor = env->GetMethodID(typeEntryCls, "<init>", "(J)V");
+            type                        = env->NewObject(typeEntryCls, typeEntryTypeCtor, typeValue);
+        }
+
+        bool revisionNull     = false;
+        bool revisionHasValue = true;
+
+        uint16_t revisionValue = entry.revision;
+
+        jobject revision = nullptr;
+        if (!revisionNull && revisionHasValue)
+        {
+            jclass revisionEntryCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Integer", revisionEntryCls);
+            chip::JniClass revisionJniClass(revisionEntryCls);
+            jmethodID revisionEntryTypeCtor = env->GetMethodID(revisionEntryCls, "<init>", "(I)V");
+            revision                        = env->NewObject(revisionEntryCls, revisionEntryTypeCtor, revisionValue);
+        }
 
         jobject attributeObj = env->NewObject(attributeClass, attributeCtor, type, revision);
         VerifyOrReturn(attributeObj != nullptr, ChipLogError(Zcl, "Could not create DeviceListAttribute object"));
@@ -1011,6 +1429,17 @@ CHIPDescriptorServerListAttributeCallback::CHIPDescriptorServerListAttributeCall
     {
         ChipLogError(Zcl, "Could not create global reference for Java callback");
     }
+}
+
+CHIPDescriptorServerListAttributeCallback::~CHIPDescriptorServerListAttributeCallback()
+{
+    JNIEnv * env = chip::JniReferences::GetInstance().GetEnvForCurrentThread();
+    if (env == nullptr)
+    {
+        ChipLogError(Zcl, "Could not delete global reference for Java callback");
+        return;
+    }
+    env->DeleteGlobalRef(javaCallbackRef);
 }
 
 void CHIPDescriptorServerListAttributeCallback::CallbackFn(void * context,
@@ -1049,12 +1478,21 @@ void CHIPDescriptorServerListAttributeCallback::CallbackFn(void * context,
     auto iter = list.begin();
     while (iter.Next())
     {
-        auto & entry = iter.GetValue();
-        jclass entryTypeCls;
-        chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Long", entryTypeCls);
-        jmethodID entryTypeCtor = env->GetMethodID(entryTypeCls, "<init>", "(J)V");
-        jobject serverList      = env->NewObject(entryTypeCls, entryTypeCtor, entry);
-        env->CallBooleanMethod(arrayListObj, arrayListAddMethod, serverList);
+        auto & entry               = iter.GetValue();
+        bool entryNull             = false;
+        chip::ClusterId entryValue = entry;
+
+        jobject entryObject = nullptr;
+        if (!entryNull)
+        {
+            jclass entryTypeCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Long", entryTypeCls);
+            chip::JniClass jniClass(entryTypeCls);
+            jmethodID entryTypeCtor = env->GetMethodID(entryTypeCls, "<init>", "(J)V");
+            entryObject             = env->NewObject(entryTypeCls, entryTypeCtor, entryValue);
+        }
+
+        env->CallBooleanMethod(arrayListObj, arrayListAddMethod, entryObject);
     }
     VerifyOrReturn(iter.GetStatus() == CHIP_NO_ERROR,
                    ChipLogError(Zcl, "Error decoding ServerListAttribute value: %" CHIP_ERROR_FORMAT, iter.GetStatus().Format()));
@@ -1078,6 +1516,17 @@ CHIPDescriptorClientListAttributeCallback::CHIPDescriptorClientListAttributeCall
     {
         ChipLogError(Zcl, "Could not create global reference for Java callback");
     }
+}
+
+CHIPDescriptorClientListAttributeCallback::~CHIPDescriptorClientListAttributeCallback()
+{
+    JNIEnv * env = chip::JniReferences::GetInstance().GetEnvForCurrentThread();
+    if (env == nullptr)
+    {
+        ChipLogError(Zcl, "Could not delete global reference for Java callback");
+        return;
+    }
+    env->DeleteGlobalRef(javaCallbackRef);
 }
 
 void CHIPDescriptorClientListAttributeCallback::CallbackFn(void * context,
@@ -1116,12 +1565,21 @@ void CHIPDescriptorClientListAttributeCallback::CallbackFn(void * context,
     auto iter = list.begin();
     while (iter.Next())
     {
-        auto & entry = iter.GetValue();
-        jclass entryTypeCls;
-        chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Long", entryTypeCls);
-        jmethodID entryTypeCtor = env->GetMethodID(entryTypeCls, "<init>", "(J)V");
-        jobject clientList      = env->NewObject(entryTypeCls, entryTypeCtor, entry);
-        env->CallBooleanMethod(arrayListObj, arrayListAddMethod, clientList);
+        auto & entry               = iter.GetValue();
+        bool entryNull             = false;
+        chip::ClusterId entryValue = entry;
+
+        jobject entryObject = nullptr;
+        if (!entryNull)
+        {
+            jclass entryTypeCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Long", entryTypeCls);
+            chip::JniClass jniClass(entryTypeCls);
+            jmethodID entryTypeCtor = env->GetMethodID(entryTypeCls, "<init>", "(J)V");
+            entryObject             = env->NewObject(entryTypeCls, entryTypeCtor, entryValue);
+        }
+
+        env->CallBooleanMethod(arrayListObj, arrayListAddMethod, entryObject);
     }
     VerifyOrReturn(iter.GetStatus() == CHIP_NO_ERROR,
                    ChipLogError(Zcl, "Error decoding ClientListAttribute value: %" CHIP_ERROR_FORMAT, iter.GetStatus().Format()));
@@ -1145,6 +1603,17 @@ CHIPDescriptorPartsListAttributeCallback::CHIPDescriptorPartsListAttributeCallba
     {
         ChipLogError(Zcl, "Could not create global reference for Java callback");
     }
+}
+
+CHIPDescriptorPartsListAttributeCallback::~CHIPDescriptorPartsListAttributeCallback()
+{
+    JNIEnv * env = chip::JniReferences::GetInstance().GetEnvForCurrentThread();
+    if (env == nullptr)
+    {
+        ChipLogError(Zcl, "Could not delete global reference for Java callback");
+        return;
+    }
+    env->DeleteGlobalRef(javaCallbackRef);
 }
 
 void CHIPDescriptorPartsListAttributeCallback::CallbackFn(void * context,
@@ -1183,12 +1652,21 @@ void CHIPDescriptorPartsListAttributeCallback::CallbackFn(void * context,
     auto iter = list.begin();
     while (iter.Next())
     {
-        auto & entry = iter.GetValue();
-        jclass entryTypeCls;
-        chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Integer", entryTypeCls);
-        jmethodID entryTypeCtor = env->GetMethodID(entryTypeCls, "<init>", "(I)V");
-        jobject partsList       = env->NewObject(entryTypeCls, entryTypeCtor, entry);
-        env->CallBooleanMethod(arrayListObj, arrayListAddMethod, partsList);
+        auto & entry                = iter.GetValue();
+        bool entryNull              = false;
+        chip::EndpointId entryValue = entry;
+
+        jobject entryObject = nullptr;
+        if (!entryNull)
+        {
+            jclass entryTypeCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Integer", entryTypeCls);
+            chip::JniClass jniClass(entryTypeCls);
+            jmethodID entryTypeCtor = env->GetMethodID(entryTypeCls, "<init>", "(I)V");
+            entryObject             = env->NewObject(entryTypeCls, entryTypeCtor, entryValue);
+        }
+
+        env->CallBooleanMethod(arrayListObj, arrayListAddMethod, entryObject);
     }
     VerifyOrReturn(iter.GetStatus() == CHIP_NO_ERROR,
                    ChipLogError(Zcl, "Error decoding PartsListAttribute value: %" CHIP_ERROR_FORMAT, iter.GetStatus().Format()));
@@ -1212,6 +1690,17 @@ CHIPFixedLabelLabelListAttributeCallback::CHIPFixedLabelLabelListAttributeCallba
     {
         ChipLogError(Zcl, "Could not create global reference for Java callback");
     }
+}
+
+CHIPFixedLabelLabelListAttributeCallback::~CHIPFixedLabelLabelListAttributeCallback()
+{
+    JNIEnv * env = chip::JniReferences::GetInstance().GetEnvForCurrentThread();
+    if (env == nullptr)
+    {
+        ChipLogError(Zcl, "Could not delete global reference for Java callback");
+        return;
+    }
+    env->DeleteGlobalRef(javaCallbackRef);
 }
 
 void CHIPFixedLabelLabelListAttributeCallback::CallbackFn(
@@ -1263,10 +1752,29 @@ void CHIPFixedLabelLabelListAttributeCallback::CallbackFn(
     {
         auto & entry = iter.GetValue();
         (void) entry;
-        chip::UtfString labelStr(env, entry.label);
-        jstring label(labelStr.jniValue());
-        chip::UtfString valueStr(env, entry.value);
-        jstring value(valueStr.jniValue());
+        bool labelNull     = false;
+        bool labelHasValue = true;
+
+        chip::CharSpan labelValue = entry.label;
+
+        jstring label = nullptr;
+        chip::UtfString labelStr(env, labelValue);
+        if (!labelNull && labelHasValue)
+        {
+            label = jstring(labelStr.jniValue());
+        }
+
+        bool valueNull     = false;
+        bool valueHasValue = true;
+
+        chip::CharSpan valueValue = entry.value;
+
+        jstring value = nullptr;
+        chip::UtfString valueStr(env, valueValue);
+        if (!valueNull && valueHasValue)
+        {
+            value = jstring(valueStr.jniValue());
+        }
 
         jobject attributeObj = env->NewObject(attributeClass, attributeCtor, label, value);
         VerifyOrReturn(attributeObj != nullptr, ChipLogError(Zcl, "Could not create LabelListAttribute object"));
@@ -1296,6 +1804,18 @@ CHIPGeneralCommissioningBasicCommissioningInfoListAttributeCallback::
     {
         ChipLogError(Zcl, "Could not create global reference for Java callback");
     }
+}
+
+CHIPGeneralCommissioningBasicCommissioningInfoListAttributeCallback::
+    ~CHIPGeneralCommissioningBasicCommissioningInfoListAttributeCallback()
+{
+    JNIEnv * env = chip::JniReferences::GetInstance().GetEnvForCurrentThread();
+    if (env == nullptr)
+    {
+        ChipLogError(Zcl, "Could not delete global reference for Java callback");
+        return;
+    }
+    env->DeleteGlobalRef(javaCallbackRef);
 }
 
 void CHIPGeneralCommissioningBasicCommissioningInfoListAttributeCallback::CallbackFn(
@@ -1342,7 +1862,7 @@ void CHIPGeneralCommissioningBasicCommissioningInfoListAttributeCallback::Callba
                      "Could not find class "
                      "chip/devicecontroller/ChipClusters$GeneralCommissioningCluster$BasicCommissioningInfoListAttribute"));
     chip::JniClass attributeJniClass(attributeClass);
-    jmethodID attributeCtor = env->GetMethodID(attributeClass, "<init>", "(J)V");
+    jmethodID attributeCtor = env->GetMethodID(attributeClass, "<init>", "(Ljava/lang/Long;)V");
     VerifyOrReturn(attributeCtor != nullptr, ChipLogError(Zcl, "Could not find BasicCommissioningInfoListAttribute constructor"));
 
     auto iter = list.begin();
@@ -1350,7 +1870,21 @@ void CHIPGeneralCommissioningBasicCommissioningInfoListAttributeCallback::Callba
     {
         auto & entry = iter.GetValue();
         (void) entry;
-        jlong failSafeExpiryLengthMs = entry.failSafeExpiryLengthMs;
+        bool failSafeExpiryLengthMsNull     = false;
+        bool failSafeExpiryLengthMsHasValue = true;
+
+        uint32_t failSafeExpiryLengthMsValue = entry.failSafeExpiryLengthMs;
+
+        jobject failSafeExpiryLengthMs = nullptr;
+        if (!failSafeExpiryLengthMsNull && failSafeExpiryLengthMsHasValue)
+        {
+            jclass failSafeExpiryLengthMsEntryCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Long", failSafeExpiryLengthMsEntryCls);
+            chip::JniClass failSafeExpiryLengthMsJniClass(failSafeExpiryLengthMsEntryCls);
+            jmethodID failSafeExpiryLengthMsEntryTypeCtor = env->GetMethodID(failSafeExpiryLengthMsEntryCls, "<init>", "(J)V");
+            failSafeExpiryLengthMs =
+                env->NewObject(failSafeExpiryLengthMsEntryCls, failSafeExpiryLengthMsEntryTypeCtor, failSafeExpiryLengthMsValue);
+        }
 
         jobject attributeObj = env->NewObject(attributeClass, attributeCtor, failSafeExpiryLengthMs);
         VerifyOrReturn(attributeObj != nullptr, ChipLogError(Zcl, "Could not create BasicCommissioningInfoListAttribute object"));
@@ -1381,6 +1915,17 @@ CHIPGeneralDiagnosticsNetworkInterfacesAttributeCallback::CHIPGeneralDiagnostics
     {
         ChipLogError(Zcl, "Could not create global reference for Java callback");
     }
+}
+
+CHIPGeneralDiagnosticsNetworkInterfacesAttributeCallback::~CHIPGeneralDiagnosticsNetworkInterfacesAttributeCallback()
+{
+    JNIEnv * env = chip::JniReferences::GetInstance().GetEnvForCurrentThread();
+    if (env == nullptr)
+    {
+        ChipLogError(Zcl, "Could not delete global reference for Java callback");
+        return;
+    }
+    env->DeleteGlobalRef(javaCallbackRef);
 }
 
 void CHIPGeneralDiagnosticsNetworkInterfacesAttributeCallback::CallbackFn(
@@ -1426,7 +1971,9 @@ void CHIPGeneralDiagnosticsNetworkInterfacesAttributeCallback::CallbackFn(
         ChipLogError(
             Zcl, "Could not find class chip/devicecontroller/ChipClusters$GeneralDiagnosticsCluster$NetworkInterfacesAttribute"));
     chip::JniClass attributeJniClass(attributeClass);
-    jmethodID attributeCtor = env->GetMethodID(attributeClass, "<init>", "(Ljava/lang/String;ZZZ[BI)V");
+    jmethodID attributeCtor =
+        env->GetMethodID(attributeClass, "<init>",
+                         "(Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;[BLjava/lang/Integer;)V");
     VerifyOrReturn(attributeCtor != nullptr, ChipLogError(Zcl, "Could not find NetworkInterfacesAttribute constructor"));
 
     auto iter = list.begin();
@@ -1434,15 +1981,96 @@ void CHIPGeneralDiagnosticsNetworkInterfacesAttributeCallback::CallbackFn(
     {
         auto & entry = iter.GetValue();
         (void) entry;
-        chip::UtfString nameStr(env, entry.name);
-        jstring name(nameStr.jniValue());
-        jboolean fabricConnected                 = entry.fabricConnected;
-        jboolean offPremiseServicesReachableIPv4 = entry.offPremiseServicesReachableIPv4;
-        jboolean offPremiseServicesReachableIPv6 = entry.offPremiseServicesReachableIPv6;
-        jbyteArray hardwareAddress               = env->NewByteArray(entry.hardwareAddress.size());
-        env->SetByteArrayRegion(hardwareAddress, 0, entry.hardwareAddress.size(),
-                                reinterpret_cast<const jbyte *>(entry.hardwareAddress.data()));
-        jint type = entry.type;
+        bool nameNull     = false;
+        bool nameHasValue = true;
+
+        chip::CharSpan nameValue = entry.name;
+
+        jstring name = nullptr;
+        chip::UtfString nameStr(env, nameValue);
+        if (!nameNull && nameHasValue)
+        {
+            name = jstring(nameStr.jniValue());
+        }
+
+        bool fabricConnectedNull     = false;
+        bool fabricConnectedHasValue = true;
+
+        bool fabricConnectedValue = entry.fabricConnected;
+
+        jobject fabricConnected = nullptr;
+        if (!fabricConnectedNull && fabricConnectedHasValue)
+        {
+            jclass fabricConnectedEntryCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Boolean", fabricConnectedEntryCls);
+            chip::JniClass fabricConnectedJniClass(fabricConnectedEntryCls);
+            jmethodID fabricConnectedEntryTypeCtor = env->GetMethodID(fabricConnectedEntryCls, "<init>", "(Z)V");
+            fabricConnected = env->NewObject(fabricConnectedEntryCls, fabricConnectedEntryTypeCtor, fabricConnectedValue);
+        }
+
+        bool offPremiseServicesReachableIPv4Null     = false;
+        bool offPremiseServicesReachableIPv4HasValue = true;
+
+        bool offPremiseServicesReachableIPv4Value = entry.offPremiseServicesReachableIPv4;
+
+        jobject offPremiseServicesReachableIPv4 = nullptr;
+        if (!offPremiseServicesReachableIPv4Null && offPremiseServicesReachableIPv4HasValue)
+        {
+            jclass offPremiseServicesReachableIPv4EntryCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Boolean", offPremiseServicesReachableIPv4EntryCls);
+            chip::JniClass offPremiseServicesReachableIPv4JniClass(offPremiseServicesReachableIPv4EntryCls);
+            jmethodID offPremiseServicesReachableIPv4EntryTypeCtor =
+                env->GetMethodID(offPremiseServicesReachableIPv4EntryCls, "<init>", "(Z)V");
+            offPremiseServicesReachableIPv4 =
+                env->NewObject(offPremiseServicesReachableIPv4EntryCls, offPremiseServicesReachableIPv4EntryTypeCtor,
+                               offPremiseServicesReachableIPv4Value);
+        }
+
+        bool offPremiseServicesReachableIPv6Null     = false;
+        bool offPremiseServicesReachableIPv6HasValue = true;
+
+        bool offPremiseServicesReachableIPv6Value = entry.offPremiseServicesReachableIPv6;
+
+        jobject offPremiseServicesReachableIPv6 = nullptr;
+        if (!offPremiseServicesReachableIPv6Null && offPremiseServicesReachableIPv6HasValue)
+        {
+            jclass offPremiseServicesReachableIPv6EntryCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Boolean", offPremiseServicesReachableIPv6EntryCls);
+            chip::JniClass offPremiseServicesReachableIPv6JniClass(offPremiseServicesReachableIPv6EntryCls);
+            jmethodID offPremiseServicesReachableIPv6EntryTypeCtor =
+                env->GetMethodID(offPremiseServicesReachableIPv6EntryCls, "<init>", "(Z)V");
+            offPremiseServicesReachableIPv6 =
+                env->NewObject(offPremiseServicesReachableIPv6EntryCls, offPremiseServicesReachableIPv6EntryTypeCtor,
+                               offPremiseServicesReachableIPv6Value);
+        }
+
+        bool hardwareAddressNull     = false;
+        bool hardwareAddressHasValue = true;
+
+        chip::ByteSpan hardwareAddressValue = entry.hardwareAddress;
+
+        jbyteArray hardwareAddress = nullptr;
+        if (!hardwareAddressNull && hardwareAddressHasValue)
+        {
+            hardwareAddress = env->NewByteArray(hardwareAddressValue.size());
+            env->SetByteArrayRegion(hardwareAddress, 0, hardwareAddressValue.size(),
+                                    reinterpret_cast<const jbyte *>(hardwareAddressValue.data()));
+        }
+
+        bool typeNull     = false;
+        bool typeHasValue = true;
+
+        uint8_t typeValue = entry.type;
+
+        jobject type = nullptr;
+        if (!typeNull && typeHasValue)
+        {
+            jclass typeEntryCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Integer", typeEntryCls);
+            chip::JniClass typeJniClass(typeEntryCls);
+            jmethodID typeEntryTypeCtor = env->GetMethodID(typeEntryCls, "<init>", "(I)V");
+            type                        = env->NewObject(typeEntryCls, typeEntryTypeCtor, typeValue);
+        }
 
         jobject attributeObj = env->NewObject(attributeClass, attributeCtor, name, fabricConnected, offPremiseServicesReachableIPv4,
                                               offPremiseServicesReachableIPv6, hardwareAddress, type);
@@ -1473,6 +2101,17 @@ CHIPGroupKeyManagementGroupsAttributeCallback::CHIPGroupKeyManagementGroupsAttri
     {
         ChipLogError(Zcl, "Could not create global reference for Java callback");
     }
+}
+
+CHIPGroupKeyManagementGroupsAttributeCallback::~CHIPGroupKeyManagementGroupsAttributeCallback()
+{
+    JNIEnv * env = chip::JniReferences::GetInstance().GetEnvForCurrentThread();
+    if (env == nullptr)
+    {
+        ChipLogError(Zcl, "Could not delete global reference for Java callback");
+        return;
+    }
+    env->DeleteGlobalRef(javaCallbackRef);
 }
 
 void CHIPGroupKeyManagementGroupsAttributeCallback::CallbackFn(
@@ -1516,7 +2155,8 @@ void CHIPGroupKeyManagementGroupsAttributeCallback::CallbackFn(
         err == CHIP_NO_ERROR,
         ChipLogError(Zcl, "Could not find class chip/devicecontroller/ChipClusters$GroupKeyManagementCluster$GroupsAttribute"));
     chip::JniClass attributeJniClass(attributeClass);
-    jmethodID attributeCtor = env->GetMethodID(attributeClass, "<init>", "(III)V");
+    jmethodID attributeCtor =
+        env->GetMethodID(attributeClass, "<init>", "(Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;)V");
     VerifyOrReturn(attributeCtor != nullptr, ChipLogError(Zcl, "Could not find GroupsAttribute constructor"));
 
     auto iter = list.begin();
@@ -1524,9 +2164,50 @@ void CHIPGroupKeyManagementGroupsAttributeCallback::CallbackFn(
     {
         auto & entry = iter.GetValue();
         (void) entry;
-        jint vendorId         = entry.vendorId;
-        jint vendorGroupId    = entry.vendorGroupId;
-        jint groupKeySetIndex = entry.groupKeySetIndex;
+        bool vendorIdNull     = false;
+        bool vendorIdHasValue = true;
+
+        uint16_t vendorIdValue = entry.vendorId;
+
+        jobject vendorId = nullptr;
+        if (!vendorIdNull && vendorIdHasValue)
+        {
+            jclass vendorIdEntryCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Integer", vendorIdEntryCls);
+            chip::JniClass vendorIdJniClass(vendorIdEntryCls);
+            jmethodID vendorIdEntryTypeCtor = env->GetMethodID(vendorIdEntryCls, "<init>", "(I)V");
+            vendorId                        = env->NewObject(vendorIdEntryCls, vendorIdEntryTypeCtor, vendorIdValue);
+        }
+
+        bool vendorGroupIdNull     = false;
+        bool vendorGroupIdHasValue = true;
+
+        uint16_t vendorGroupIdValue = entry.vendorGroupId;
+
+        jobject vendorGroupId = nullptr;
+        if (!vendorGroupIdNull && vendorGroupIdHasValue)
+        {
+            jclass vendorGroupIdEntryCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Integer", vendorGroupIdEntryCls);
+            chip::JniClass vendorGroupIdJniClass(vendorGroupIdEntryCls);
+            jmethodID vendorGroupIdEntryTypeCtor = env->GetMethodID(vendorGroupIdEntryCls, "<init>", "(I)V");
+            vendorGroupId = env->NewObject(vendorGroupIdEntryCls, vendorGroupIdEntryTypeCtor, vendorGroupIdValue);
+        }
+
+        bool groupKeySetIndexNull     = false;
+        bool groupKeySetIndexHasValue = true;
+
+        uint16_t groupKeySetIndexValue = entry.groupKeySetIndex;
+
+        jobject groupKeySetIndex = nullptr;
+        if (!groupKeySetIndexNull && groupKeySetIndexHasValue)
+        {
+            jclass groupKeySetIndexEntryCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Integer", groupKeySetIndexEntryCls);
+            chip::JniClass groupKeySetIndexJniClass(groupKeySetIndexEntryCls);
+            jmethodID groupKeySetIndexEntryTypeCtor = env->GetMethodID(groupKeySetIndexEntryCls, "<init>", "(I)V");
+            groupKeySetIndex = env->NewObject(groupKeySetIndexEntryCls, groupKeySetIndexEntryTypeCtor, groupKeySetIndexValue);
+        }
 
         jobject attributeObj = env->NewObject(attributeClass, attributeCtor, vendorId, vendorGroupId, groupKeySetIndex);
         VerifyOrReturn(attributeObj != nullptr, ChipLogError(Zcl, "Could not create GroupsAttribute object"));
@@ -1555,6 +2236,17 @@ CHIPGroupKeyManagementGroupKeysAttributeCallback::CHIPGroupKeyManagementGroupKey
     {
         ChipLogError(Zcl, "Could not create global reference for Java callback");
     }
+}
+
+CHIPGroupKeyManagementGroupKeysAttributeCallback::~CHIPGroupKeyManagementGroupKeysAttributeCallback()
+{
+    JNIEnv * env = chip::JniReferences::GetInstance().GetEnvForCurrentThread();
+    if (env == nullptr)
+    {
+        ChipLogError(Zcl, "Could not delete global reference for Java callback");
+        return;
+    }
+    env->DeleteGlobalRef(javaCallbackRef);
 }
 
 void CHIPGroupKeyManagementGroupKeysAttributeCallback::CallbackFn(
@@ -1598,7 +2290,8 @@ void CHIPGroupKeyManagementGroupKeysAttributeCallback::CallbackFn(
         err == CHIP_NO_ERROR,
         ChipLogError(Zcl, "Could not find class chip/devicecontroller/ChipClusters$GroupKeyManagementCluster$GroupKeysAttribute"));
     chip::JniClass attributeJniClass(attributeClass);
-    jmethodID attributeCtor = env->GetMethodID(attributeClass, "<init>", "(II[BJI)V");
+    jmethodID attributeCtor = env->GetMethodID(attributeClass, "<init>",
+                                               "(Ljava/lang/Integer;Ljava/lang/Integer;[BLjava/lang/Long;Ljava/lang/Integer;)V");
     VerifyOrReturn(attributeCtor != nullptr, ChipLogError(Zcl, "Could not find GroupKeysAttribute constructor"));
 
     auto iter = list.begin();
@@ -1606,13 +2299,80 @@ void CHIPGroupKeyManagementGroupKeysAttributeCallback::CallbackFn(
     {
         auto & entry = iter.GetValue();
         (void) entry;
-        jint vendorId           = entry.vendorId;
-        jint groupKeyIndex      = entry.groupKeyIndex;
-        jbyteArray groupKeyRoot = env->NewByteArray(entry.groupKeyRoot.size());
-        env->SetByteArrayRegion(groupKeyRoot, 0, entry.groupKeyRoot.size(),
-                                reinterpret_cast<const jbyte *>(entry.groupKeyRoot.data()));
-        jlong groupKeyEpochStartTime = entry.groupKeyEpochStartTime;
-        jint groupKeySecurityPolicy  = entry.groupKeySecurityPolicy;
+        bool vendorIdNull     = false;
+        bool vendorIdHasValue = true;
+
+        uint16_t vendorIdValue = entry.vendorId;
+
+        jobject vendorId = nullptr;
+        if (!vendorIdNull && vendorIdHasValue)
+        {
+            jclass vendorIdEntryCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Integer", vendorIdEntryCls);
+            chip::JniClass vendorIdJniClass(vendorIdEntryCls);
+            jmethodID vendorIdEntryTypeCtor = env->GetMethodID(vendorIdEntryCls, "<init>", "(I)V");
+            vendorId                        = env->NewObject(vendorIdEntryCls, vendorIdEntryTypeCtor, vendorIdValue);
+        }
+
+        bool groupKeyIndexNull     = false;
+        bool groupKeyIndexHasValue = true;
+
+        uint16_t groupKeyIndexValue = entry.groupKeyIndex;
+
+        jobject groupKeyIndex = nullptr;
+        if (!groupKeyIndexNull && groupKeyIndexHasValue)
+        {
+            jclass groupKeyIndexEntryCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Integer", groupKeyIndexEntryCls);
+            chip::JniClass groupKeyIndexJniClass(groupKeyIndexEntryCls);
+            jmethodID groupKeyIndexEntryTypeCtor = env->GetMethodID(groupKeyIndexEntryCls, "<init>", "(I)V");
+            groupKeyIndex = env->NewObject(groupKeyIndexEntryCls, groupKeyIndexEntryTypeCtor, groupKeyIndexValue);
+        }
+
+        bool groupKeyRootNull     = false;
+        bool groupKeyRootHasValue = true;
+
+        chip::ByteSpan groupKeyRootValue = entry.groupKeyRoot;
+
+        jbyteArray groupKeyRoot = nullptr;
+        if (!groupKeyRootNull && groupKeyRootHasValue)
+        {
+            groupKeyRoot = env->NewByteArray(groupKeyRootValue.size());
+            env->SetByteArrayRegion(groupKeyRoot, 0, groupKeyRootValue.size(),
+                                    reinterpret_cast<const jbyte *>(groupKeyRootValue.data()));
+        }
+
+        bool groupKeyEpochStartTimeNull     = false;
+        bool groupKeyEpochStartTimeHasValue = true;
+
+        uint64_t groupKeyEpochStartTimeValue = entry.groupKeyEpochStartTime;
+
+        jobject groupKeyEpochStartTime = nullptr;
+        if (!groupKeyEpochStartTimeNull && groupKeyEpochStartTimeHasValue)
+        {
+            jclass groupKeyEpochStartTimeEntryCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Long", groupKeyEpochStartTimeEntryCls);
+            chip::JniClass groupKeyEpochStartTimeJniClass(groupKeyEpochStartTimeEntryCls);
+            jmethodID groupKeyEpochStartTimeEntryTypeCtor = env->GetMethodID(groupKeyEpochStartTimeEntryCls, "<init>", "(J)V");
+            groupKeyEpochStartTime =
+                env->NewObject(groupKeyEpochStartTimeEntryCls, groupKeyEpochStartTimeEntryTypeCtor, groupKeyEpochStartTimeValue);
+        }
+
+        bool groupKeySecurityPolicyNull     = false;
+        bool groupKeySecurityPolicyHasValue = true;
+
+        uint8_t groupKeySecurityPolicyValue = entry.groupKeySecurityPolicy;
+
+        jobject groupKeySecurityPolicy = nullptr;
+        if (!groupKeySecurityPolicyNull && groupKeySecurityPolicyHasValue)
+        {
+            jclass groupKeySecurityPolicyEntryCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Integer", groupKeySecurityPolicyEntryCls);
+            chip::JniClass groupKeySecurityPolicyJniClass(groupKeySecurityPolicyEntryCls);
+            jmethodID groupKeySecurityPolicyEntryTypeCtor = env->GetMethodID(groupKeySecurityPolicyEntryCls, "<init>", "(I)V");
+            groupKeySecurityPolicy =
+                env->NewObject(groupKeySecurityPolicyEntryCls, groupKeySecurityPolicyEntryTypeCtor, groupKeySecurityPolicyValue);
+        }
 
         jobject attributeObj = env->NewObject(attributeClass, attributeCtor, vendorId, groupKeyIndex, groupKeyRoot,
                                               groupKeyEpochStartTime, groupKeySecurityPolicy);
@@ -1642,6 +2402,17 @@ CHIPMediaInputMediaInputListAttributeCallback::CHIPMediaInputMediaInputListAttri
     {
         ChipLogError(Zcl, "Could not create global reference for Java callback");
     }
+}
+
+CHIPMediaInputMediaInputListAttributeCallback::~CHIPMediaInputMediaInputListAttributeCallback()
+{
+    JNIEnv * env = chip::JniReferences::GetInstance().GetEnvForCurrentThread();
+    if (env == nullptr)
+    {
+        ChipLogError(Zcl, "Could not delete global reference for Java callback");
+        return;
+    }
+    env->DeleteGlobalRef(javaCallbackRef);
 }
 
 void CHIPMediaInputMediaInputListAttributeCallback::CallbackFn(
@@ -1685,7 +2456,8 @@ void CHIPMediaInputMediaInputListAttributeCallback::CallbackFn(
         err == CHIP_NO_ERROR,
         ChipLogError(Zcl, "Could not find class chip/devicecontroller/ChipClusters$MediaInputCluster$MediaInputListAttribute"));
     chip::JniClass attributeJniClass(attributeClass);
-    jmethodID attributeCtor = env->GetMethodID(attributeClass, "<init>", "(IILjava/lang/String;Ljava/lang/String;)V");
+    jmethodID attributeCtor =
+        env->GetMethodID(attributeClass, "<init>", "(Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;)V");
     VerifyOrReturn(attributeCtor != nullptr, ChipLogError(Zcl, "Could not find MediaInputListAttribute constructor"));
 
     auto iter = list.begin();
@@ -1693,12 +2465,59 @@ void CHIPMediaInputMediaInputListAttributeCallback::CallbackFn(
     {
         auto & entry = iter.GetValue();
         (void) entry;
-        jint index     = entry.index;
-        jint inputType = entry.inputType;
-        chip::UtfString nameStr(env, entry.name);
-        jstring name(nameStr.jniValue());
-        chip::UtfString descriptionStr(env, entry.description);
-        jstring description(descriptionStr.jniValue());
+        bool indexNull     = false;
+        bool indexHasValue = true;
+
+        uint8_t indexValue = entry.index;
+
+        jobject index = nullptr;
+        if (!indexNull && indexHasValue)
+        {
+            jclass indexEntryCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Integer", indexEntryCls);
+            chip::JniClass indexJniClass(indexEntryCls);
+            jmethodID indexEntryTypeCtor = env->GetMethodID(indexEntryCls, "<init>", "(I)V");
+            index                        = env->NewObject(indexEntryCls, indexEntryTypeCtor, indexValue);
+        }
+
+        bool inputTypeNull     = false;
+        bool inputTypeHasValue = true;
+
+        uint8_t inputTypeValue = entry.inputType;
+
+        jobject inputType = nullptr;
+        if (!inputTypeNull && inputTypeHasValue)
+        {
+            jclass inputTypeEntryCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Integer", inputTypeEntryCls);
+            chip::JniClass inputTypeJniClass(inputTypeEntryCls);
+            jmethodID inputTypeEntryTypeCtor = env->GetMethodID(inputTypeEntryCls, "<init>", "(I)V");
+            inputType                        = env->NewObject(inputTypeEntryCls, inputTypeEntryTypeCtor, inputTypeValue);
+        }
+
+        bool nameNull     = false;
+        bool nameHasValue = true;
+
+        chip::CharSpan nameValue = entry.name;
+
+        jstring name = nullptr;
+        chip::UtfString nameStr(env, nameValue);
+        if (!nameNull && nameHasValue)
+        {
+            name = jstring(nameStr.jniValue());
+        }
+
+        bool descriptionNull     = false;
+        bool descriptionHasValue = true;
+
+        chip::CharSpan descriptionValue = entry.description;
+
+        jstring description = nullptr;
+        chip::UtfString descriptionStr(env, descriptionValue);
+        if (!descriptionNull && descriptionHasValue)
+        {
+            description = jstring(descriptionStr.jniValue());
+        }
 
         jobject attributeObj = env->NewObject(attributeClass, attributeCtor, index, inputType, name, description);
         VerifyOrReturn(attributeObj != nullptr, ChipLogError(Zcl, "Could not create MediaInputListAttribute object"));
@@ -1728,6 +2547,17 @@ CHIPModeSelectSupportedModesAttributeCallback::CHIPModeSelectSupportedModesAttri
     {
         ChipLogError(Zcl, "Could not create global reference for Java callback");
     }
+}
+
+CHIPModeSelectSupportedModesAttributeCallback::~CHIPModeSelectSupportedModesAttributeCallback()
+{
+    JNIEnv * env = chip::JniReferences::GetInstance().GetEnvForCurrentThread();
+    if (env == nullptr)
+    {
+        ChipLogError(Zcl, "Could not delete global reference for Java callback");
+        return;
+    }
+    env->DeleteGlobalRef(javaCallbackRef);
 }
 
 void CHIPModeSelectSupportedModesAttributeCallback::CallbackFn(
@@ -1771,7 +2601,8 @@ void CHIPModeSelectSupportedModesAttributeCallback::CallbackFn(
         err == CHIP_NO_ERROR,
         ChipLogError(Zcl, "Could not find class chip/devicecontroller/ChipClusters$ModeSelectCluster$SupportedModesAttribute"));
     chip::JniClass attributeJniClass(attributeClass);
-    jmethodID attributeCtor = env->GetMethodID(attributeClass, "<init>", "(Ljava/lang/String;IJ)V");
+    jmethodID attributeCtor =
+        env->GetMethodID(attributeClass, "<init>", "(Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Long;)V");
     VerifyOrReturn(attributeCtor != nullptr, ChipLogError(Zcl, "Could not find SupportedModesAttribute constructor"));
 
     auto iter = list.begin();
@@ -1779,10 +2610,47 @@ void CHIPModeSelectSupportedModesAttributeCallback::CallbackFn(
     {
         auto & entry = iter.GetValue();
         (void) entry;
-        chip::UtfString labelStr(env, entry.label);
-        jstring label(labelStr.jniValue());
-        jint mode         = entry.mode;
-        jlong semanticTag = entry.semanticTag;
+        bool labelNull     = false;
+        bool labelHasValue = true;
+
+        chip::CharSpan labelValue = entry.label;
+
+        jstring label = nullptr;
+        chip::UtfString labelStr(env, labelValue);
+        if (!labelNull && labelHasValue)
+        {
+            label = jstring(labelStr.jniValue());
+        }
+
+        bool modeNull     = false;
+        bool modeHasValue = true;
+
+        uint8_t modeValue = entry.mode;
+
+        jobject mode = nullptr;
+        if (!modeNull && modeHasValue)
+        {
+            jclass modeEntryCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Integer", modeEntryCls);
+            chip::JniClass modeJniClass(modeEntryCls);
+            jmethodID modeEntryTypeCtor = env->GetMethodID(modeEntryCls, "<init>", "(I)V");
+            mode                        = env->NewObject(modeEntryCls, modeEntryTypeCtor, modeValue);
+        }
+
+        bool semanticTagNull     = false;
+        bool semanticTagHasValue = true;
+
+        uint32_t semanticTagValue = entry.semanticTag;
+
+        jobject semanticTag = nullptr;
+        if (!semanticTagNull && semanticTagHasValue)
+        {
+            jclass semanticTagEntryCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Long", semanticTagEntryCls);
+            chip::JniClass semanticTagJniClass(semanticTagEntryCls);
+            jmethodID semanticTagEntryTypeCtor = env->GetMethodID(semanticTagEntryCls, "<init>", "(J)V");
+            semanticTag                        = env->NewObject(semanticTagEntryCls, semanticTagEntryTypeCtor, semanticTagValue);
+        }
 
         jobject attributeObj = env->NewObject(attributeClass, attributeCtor, label, mode, semanticTag);
         VerifyOrReturn(attributeObj != nullptr, ChipLogError(Zcl, "Could not create SupportedModesAttribute object"));
@@ -1813,6 +2681,17 @@ CHIPOperationalCredentialsFabricsListAttributeCallback::CHIPOperationalCredentia
     {
         ChipLogError(Zcl, "Could not create global reference for Java callback");
     }
+}
+
+CHIPOperationalCredentialsFabricsListAttributeCallback::~CHIPOperationalCredentialsFabricsListAttributeCallback()
+{
+    JNIEnv * env = chip::JniReferences::GetInstance().GetEnvForCurrentThread();
+    if (env == nullptr)
+    {
+        ChipLogError(Zcl, "Could not delete global reference for Java callback");
+        return;
+    }
+    env->DeleteGlobalRef(javaCallbackRef);
 }
 
 void CHIPOperationalCredentialsFabricsListAttributeCallback::CallbackFn(
@@ -1858,7 +2737,8 @@ void CHIPOperationalCredentialsFabricsListAttributeCallback::CallbackFn(
         ChipLogError(Zcl,
                      "Could not find class chip/devicecontroller/ChipClusters$OperationalCredentialsCluster$FabricsListAttribute"));
     chip::JniClass attributeJniClass(attributeClass);
-    jmethodID attributeCtor = env->GetMethodID(attributeClass, "<init>", "(I[BIJJLjava/lang/String;)V");
+    jmethodID attributeCtor = env->GetMethodID(
+        attributeClass, "<init>", "(Ljava/lang/Integer;[BLjava/lang/Integer;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/String;)V");
     VerifyOrReturn(attributeCtor != nullptr, ChipLogError(Zcl, "Could not find FabricsListAttribute constructor"));
 
     auto iter = list.begin();
@@ -1866,15 +2746,90 @@ void CHIPOperationalCredentialsFabricsListAttributeCallback::CallbackFn(
     {
         auto & entry = iter.GetValue();
         (void) entry;
-        jint fabricIndex         = entry.fabricIndex;
-        jbyteArray rootPublicKey = env->NewByteArray(entry.rootPublicKey.size());
-        env->SetByteArrayRegion(rootPublicKey, 0, entry.rootPublicKey.size(),
-                                reinterpret_cast<const jbyte *>(entry.rootPublicKey.data()));
-        jint vendorId  = entry.vendorId;
-        jlong fabricId = entry.fabricId;
-        jlong nodeId   = entry.nodeId;
-        chip::UtfString labelStr(env, entry.label);
-        jstring label(labelStr.jniValue());
+        bool fabricIndexNull     = false;
+        bool fabricIndexHasValue = true;
+
+        uint8_t fabricIndexValue = entry.fabricIndex;
+
+        jobject fabricIndex = nullptr;
+        if (!fabricIndexNull && fabricIndexHasValue)
+        {
+            jclass fabricIndexEntryCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Integer", fabricIndexEntryCls);
+            chip::JniClass fabricIndexJniClass(fabricIndexEntryCls);
+            jmethodID fabricIndexEntryTypeCtor = env->GetMethodID(fabricIndexEntryCls, "<init>", "(I)V");
+            fabricIndex                        = env->NewObject(fabricIndexEntryCls, fabricIndexEntryTypeCtor, fabricIndexValue);
+        }
+
+        bool rootPublicKeyNull     = false;
+        bool rootPublicKeyHasValue = true;
+
+        chip::ByteSpan rootPublicKeyValue = entry.rootPublicKey;
+
+        jbyteArray rootPublicKey = nullptr;
+        if (!rootPublicKeyNull && rootPublicKeyHasValue)
+        {
+            rootPublicKey = env->NewByteArray(rootPublicKeyValue.size());
+            env->SetByteArrayRegion(rootPublicKey, 0, rootPublicKeyValue.size(),
+                                    reinterpret_cast<const jbyte *>(rootPublicKeyValue.data()));
+        }
+
+        bool vendorIdNull     = false;
+        bool vendorIdHasValue = true;
+
+        uint16_t vendorIdValue = entry.vendorId;
+
+        jobject vendorId = nullptr;
+        if (!vendorIdNull && vendorIdHasValue)
+        {
+            jclass vendorIdEntryCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Integer", vendorIdEntryCls);
+            chip::JniClass vendorIdJniClass(vendorIdEntryCls);
+            jmethodID vendorIdEntryTypeCtor = env->GetMethodID(vendorIdEntryCls, "<init>", "(I)V");
+            vendorId                        = env->NewObject(vendorIdEntryCls, vendorIdEntryTypeCtor, vendorIdValue);
+        }
+
+        bool fabricIdNull     = false;
+        bool fabricIdHasValue = true;
+
+        chip::FabricId fabricIdValue = entry.fabricId;
+
+        jobject fabricId = nullptr;
+        if (!fabricIdNull && fabricIdHasValue)
+        {
+            jclass fabricIdEntryCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Long", fabricIdEntryCls);
+            chip::JniClass fabricIdJniClass(fabricIdEntryCls);
+            jmethodID fabricIdEntryTypeCtor = env->GetMethodID(fabricIdEntryCls, "<init>", "(J)V");
+            fabricId                        = env->NewObject(fabricIdEntryCls, fabricIdEntryTypeCtor, fabricIdValue);
+        }
+
+        bool nodeIdNull     = false;
+        bool nodeIdHasValue = true;
+
+        chip::NodeId nodeIdValue = entry.nodeId;
+
+        jobject nodeId = nullptr;
+        if (!nodeIdNull && nodeIdHasValue)
+        {
+            jclass nodeIdEntryCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Long", nodeIdEntryCls);
+            chip::JniClass nodeIdJniClass(nodeIdEntryCls);
+            jmethodID nodeIdEntryTypeCtor = env->GetMethodID(nodeIdEntryCls, "<init>", "(J)V");
+            nodeId                        = env->NewObject(nodeIdEntryCls, nodeIdEntryTypeCtor, nodeIdValue);
+        }
+
+        bool labelNull     = false;
+        bool labelHasValue = true;
+
+        chip::CharSpan labelValue = entry.label;
+
+        jstring label = nullptr;
+        chip::UtfString labelStr(env, labelValue);
+        if (!labelNull && labelHasValue)
+        {
+            label = jstring(labelStr.jniValue());
+        }
 
         jobject attributeObj =
             env->NewObject(attributeClass, attributeCtor, fabricIndex, rootPublicKey, vendorId, fabricId, nodeId, label);
@@ -1905,6 +2860,18 @@ CHIPOperationalCredentialsTrustedRootCertificatesAttributeCallback::
     {
         ChipLogError(Zcl, "Could not create global reference for Java callback");
     }
+}
+
+CHIPOperationalCredentialsTrustedRootCertificatesAttributeCallback::
+    ~CHIPOperationalCredentialsTrustedRootCertificatesAttributeCallback()
+{
+    JNIEnv * env = chip::JniReferences::GetInstance().GetEnvForCurrentThread();
+    if (env == nullptr)
+    {
+        ChipLogError(Zcl, "Could not delete global reference for Java callback");
+        return;
+    }
+    env->DeleteGlobalRef(javaCallbackRef);
 }
 
 void CHIPOperationalCredentialsTrustedRootCertificatesAttributeCallback::CallbackFn(
@@ -1943,10 +2910,18 @@ void CHIPOperationalCredentialsTrustedRootCertificatesAttributeCallback::Callbac
     auto iter = list.begin();
     while (iter.Next())
     {
-        auto & entry                       = iter.GetValue();
-        jbyteArray trustedRootCertificates = env->NewByteArray(entry.size());
-        env->SetByteArrayRegion(trustedRootCertificates, 0, entry.size(), reinterpret_cast<const jbyte *>(entry.data()));
-        env->CallBooleanMethod(arrayListObj, arrayListAddMethod, trustedRootCertificates);
+        auto & entry              = iter.GetValue();
+        bool entryNull            = false;
+        chip::ByteSpan entryValue = entry;
+
+        jbyteArray entryObject = nullptr;
+        if (!entryNull)
+        {
+            entryObject = env->NewByteArray(entryValue.size());
+            env->SetByteArrayRegion(entryObject, 0, entryValue.size(), reinterpret_cast<const jbyte *>(entryValue.data()));
+        }
+
+        env->CallBooleanMethod(arrayListObj, arrayListAddMethod, entryObject);
     }
     VerifyOrReturn(
         iter.GetStatus() == CHIP_NO_ERROR,
@@ -1971,6 +2946,17 @@ CHIPPowerSourceActiveBatteryFaultsAttributeCallback::CHIPPowerSourceActiveBatter
     {
         ChipLogError(Zcl, "Could not create global reference for Java callback");
     }
+}
+
+CHIPPowerSourceActiveBatteryFaultsAttributeCallback::~CHIPPowerSourceActiveBatteryFaultsAttributeCallback()
+{
+    JNIEnv * env = chip::JniReferences::GetInstance().GetEnvForCurrentThread();
+    if (env == nullptr)
+    {
+        ChipLogError(Zcl, "Could not delete global reference for Java callback");
+        return;
+    }
+    env->DeleteGlobalRef(javaCallbackRef);
 }
 
 void CHIPPowerSourceActiveBatteryFaultsAttributeCallback::CallbackFn(void * context,
@@ -2009,12 +2995,21 @@ void CHIPPowerSourceActiveBatteryFaultsAttributeCallback::CallbackFn(void * cont
     auto iter = list.begin();
     while (iter.Next())
     {
-        auto & entry = iter.GetValue();
-        jclass entryTypeCls;
-        chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Integer", entryTypeCls);
-        jmethodID entryTypeCtor     = env->GetMethodID(entryTypeCls, "<init>", "(I)V");
-        jobject activeBatteryFaults = env->NewObject(entryTypeCls, entryTypeCtor, entry);
-        env->CallBooleanMethod(arrayListObj, arrayListAddMethod, activeBatteryFaults);
+        auto & entry       = iter.GetValue();
+        bool entryNull     = false;
+        uint8_t entryValue = entry;
+
+        jobject entryObject = nullptr;
+        if (!entryNull)
+        {
+            jclass entryTypeCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Integer", entryTypeCls);
+            chip::JniClass jniClass(entryTypeCls);
+            jmethodID entryTypeCtor = env->GetMethodID(entryTypeCls, "<init>", "(I)V");
+            entryObject             = env->NewObject(entryTypeCls, entryTypeCtor, entryValue);
+        }
+
+        env->CallBooleanMethod(arrayListObj, arrayListAddMethod, entryObject);
     }
     VerifyOrReturn(
         iter.GetStatus() == CHIP_NO_ERROR,
@@ -2039,6 +3034,17 @@ CHIPTvChannelTvChannelListAttributeCallback::CHIPTvChannelTvChannelListAttribute
     {
         ChipLogError(Zcl, "Could not create global reference for Java callback");
     }
+}
+
+CHIPTvChannelTvChannelListAttributeCallback::~CHIPTvChannelTvChannelListAttributeCallback()
+{
+    JNIEnv * env = chip::JniReferences::GetInstance().GetEnvForCurrentThread();
+    if (env == nullptr)
+    {
+        ChipLogError(Zcl, "Could not delete global reference for Java callback");
+        return;
+    }
+    env->DeleteGlobalRef(javaCallbackRef);
 }
 
 void CHIPTvChannelTvChannelListAttributeCallback::CallbackFn(
@@ -2083,7 +3089,8 @@ void CHIPTvChannelTvChannelListAttributeCallback::CallbackFn(
         ChipLogError(Zcl, "Could not find class chip/devicecontroller/ChipClusters$TvChannelCluster$TvChannelListAttribute"));
     chip::JniClass attributeJniClass(attributeClass);
     jmethodID attributeCtor =
-        env->GetMethodID(attributeClass, "<init>", "(IILjava/lang/String;Ljava/lang/String;Ljava/lang/String;)V");
+        env->GetMethodID(attributeClass, "<init>",
+                         "(Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V");
     VerifyOrReturn(attributeCtor != nullptr, ChipLogError(Zcl, "Could not find TvChannelListAttribute constructor"));
 
     auto iter = list.begin();
@@ -2091,14 +3098,71 @@ void CHIPTvChannelTvChannelListAttributeCallback::CallbackFn(
     {
         auto & entry = iter.GetValue();
         (void) entry;
-        jint majorNumber = entry.majorNumber;
-        jint minorNumber = entry.minorNumber;
-        chip::UtfString nameStr(env, entry.name);
-        jstring name(nameStr.jniValue());
-        chip::UtfString callSignStr(env, entry.callSign);
-        jstring callSign(callSignStr.jniValue());
-        chip::UtfString affiliateCallSignStr(env, entry.affiliateCallSign);
-        jstring affiliateCallSign(affiliateCallSignStr.jniValue());
+        bool majorNumberNull     = false;
+        bool majorNumberHasValue = true;
+
+        uint16_t majorNumberValue = entry.majorNumber;
+
+        jobject majorNumber = nullptr;
+        if (!majorNumberNull && majorNumberHasValue)
+        {
+            jclass majorNumberEntryCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Integer", majorNumberEntryCls);
+            chip::JniClass majorNumberJniClass(majorNumberEntryCls);
+            jmethodID majorNumberEntryTypeCtor = env->GetMethodID(majorNumberEntryCls, "<init>", "(I)V");
+            majorNumber                        = env->NewObject(majorNumberEntryCls, majorNumberEntryTypeCtor, majorNumberValue);
+        }
+
+        bool minorNumberNull     = false;
+        bool minorNumberHasValue = true;
+
+        uint16_t minorNumberValue = entry.minorNumber;
+
+        jobject minorNumber = nullptr;
+        if (!minorNumberNull && minorNumberHasValue)
+        {
+            jclass minorNumberEntryCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Integer", minorNumberEntryCls);
+            chip::JniClass minorNumberJniClass(minorNumberEntryCls);
+            jmethodID minorNumberEntryTypeCtor = env->GetMethodID(minorNumberEntryCls, "<init>", "(I)V");
+            minorNumber                        = env->NewObject(minorNumberEntryCls, minorNumberEntryTypeCtor, minorNumberValue);
+        }
+
+        bool nameNull     = false;
+        bool nameHasValue = true;
+
+        chip::CharSpan nameValue = entry.name;
+
+        jstring name = nullptr;
+        chip::UtfString nameStr(env, nameValue);
+        if (!nameNull && nameHasValue)
+        {
+            name = jstring(nameStr.jniValue());
+        }
+
+        bool callSignNull     = false;
+        bool callSignHasValue = true;
+
+        chip::CharSpan callSignValue = entry.callSign;
+
+        jstring callSign = nullptr;
+        chip::UtfString callSignStr(env, callSignValue);
+        if (!callSignNull && callSignHasValue)
+        {
+            callSign = jstring(callSignStr.jniValue());
+        }
+
+        bool affiliateCallSignNull     = false;
+        bool affiliateCallSignHasValue = true;
+
+        chip::CharSpan affiliateCallSignValue = entry.affiliateCallSign;
+
+        jstring affiliateCallSign = nullptr;
+        chip::UtfString affiliateCallSignStr(env, affiliateCallSignValue);
+        if (!affiliateCallSignNull && affiliateCallSignHasValue)
+        {
+            affiliateCallSign = jstring(affiliateCallSignStr.jniValue());
+        }
 
         jobject attributeObj =
             env->NewObject(attributeClass, attributeCtor, majorNumber, minorNumber, name, callSign, affiliateCallSign);
@@ -2130,6 +3194,17 @@ CHIPTargetNavigatorTargetNavigatorListAttributeCallback::CHIPTargetNavigatorTarg
     {
         ChipLogError(Zcl, "Could not create global reference for Java callback");
     }
+}
+
+CHIPTargetNavigatorTargetNavigatorListAttributeCallback::~CHIPTargetNavigatorTargetNavigatorListAttributeCallback()
+{
+    JNIEnv * env = chip::JniReferences::GetInstance().GetEnvForCurrentThread();
+    if (env == nullptr)
+    {
+        ChipLogError(Zcl, "Could not delete global reference for Java callback");
+        return;
+    }
+    env->DeleteGlobalRef(javaCallbackRef);
 }
 
 void CHIPTargetNavigatorTargetNavigatorListAttributeCallback::CallbackFn(
@@ -2175,7 +3250,7 @@ void CHIPTargetNavigatorTargetNavigatorListAttributeCallback::CallbackFn(
         ChipLogError(
             Zcl, "Could not find class chip/devicecontroller/ChipClusters$TargetNavigatorCluster$TargetNavigatorListAttribute"));
     chip::JniClass attributeJniClass(attributeClass);
-    jmethodID attributeCtor = env->GetMethodID(attributeClass, "<init>", "(ILjava/lang/String;)V");
+    jmethodID attributeCtor = env->GetMethodID(attributeClass, "<init>", "(Ljava/lang/Integer;Ljava/lang/String;)V");
     VerifyOrReturn(attributeCtor != nullptr, ChipLogError(Zcl, "Could not find TargetNavigatorListAttribute constructor"));
 
     auto iter = list.begin();
@@ -2183,9 +3258,32 @@ void CHIPTargetNavigatorTargetNavigatorListAttributeCallback::CallbackFn(
     {
         auto & entry = iter.GetValue();
         (void) entry;
-        jint identifier = entry.identifier;
-        chip::UtfString nameStr(env, entry.name);
-        jstring name(nameStr.jniValue());
+        bool identifierNull     = false;
+        bool identifierHasValue = true;
+
+        uint8_t identifierValue = entry.identifier;
+
+        jobject identifier = nullptr;
+        if (!identifierNull && identifierHasValue)
+        {
+            jclass identifierEntryCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Integer", identifierEntryCls);
+            chip::JniClass identifierJniClass(identifierEntryCls);
+            jmethodID identifierEntryTypeCtor = env->GetMethodID(identifierEntryCls, "<init>", "(I)V");
+            identifier                        = env->NewObject(identifierEntryCls, identifierEntryTypeCtor, identifierValue);
+        }
+
+        bool nameNull     = false;
+        bool nameHasValue = true;
+
+        chip::CharSpan nameValue = entry.name;
+
+        jstring name = nullptr;
+        chip::UtfString nameStr(env, nameValue);
+        if (!nameNull && nameHasValue)
+        {
+            name = jstring(nameStr.jniValue());
+        }
 
         jobject attributeObj = env->NewObject(attributeClass, attributeCtor, identifier, name);
         VerifyOrReturn(attributeObj != nullptr, ChipLogError(Zcl, "Could not create TargetNavigatorListAttribute object"));
@@ -2215,6 +3313,17 @@ CHIPTestClusterListInt8uAttributeCallback::CHIPTestClusterListInt8uAttributeCall
     {
         ChipLogError(Zcl, "Could not create global reference for Java callback");
     }
+}
+
+CHIPTestClusterListInt8uAttributeCallback::~CHIPTestClusterListInt8uAttributeCallback()
+{
+    JNIEnv * env = chip::JniReferences::GetInstance().GetEnvForCurrentThread();
+    if (env == nullptr)
+    {
+        ChipLogError(Zcl, "Could not delete global reference for Java callback");
+        return;
+    }
+    env->DeleteGlobalRef(javaCallbackRef);
 }
 
 void CHIPTestClusterListInt8uAttributeCallback::CallbackFn(void * context,
@@ -2253,12 +3362,21 @@ void CHIPTestClusterListInt8uAttributeCallback::CallbackFn(void * context,
     auto iter = list.begin();
     while (iter.Next())
     {
-        auto & entry = iter.GetValue();
-        jclass entryTypeCls;
-        chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Integer", entryTypeCls);
-        jmethodID entryTypeCtor = env->GetMethodID(entryTypeCls, "<init>", "(I)V");
-        jobject listInt8u       = env->NewObject(entryTypeCls, entryTypeCtor, entry);
-        env->CallBooleanMethod(arrayListObj, arrayListAddMethod, listInt8u);
+        auto & entry       = iter.GetValue();
+        bool entryNull     = false;
+        uint8_t entryValue = entry;
+
+        jobject entryObject = nullptr;
+        if (!entryNull)
+        {
+            jclass entryTypeCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Integer", entryTypeCls);
+            chip::JniClass jniClass(entryTypeCls);
+            jmethodID entryTypeCtor = env->GetMethodID(entryTypeCls, "<init>", "(I)V");
+            entryObject             = env->NewObject(entryTypeCls, entryTypeCtor, entryValue);
+        }
+
+        env->CallBooleanMethod(arrayListObj, arrayListAddMethod, entryObject);
     }
     VerifyOrReturn(iter.GetStatus() == CHIP_NO_ERROR,
                    ChipLogError(Zcl, "Error decoding ListInt8uAttribute value: %" CHIP_ERROR_FORMAT, iter.GetStatus().Format()));
@@ -2282,6 +3400,17 @@ CHIPTestClusterListOctetStringAttributeCallback::CHIPTestClusterListOctetStringA
     {
         ChipLogError(Zcl, "Could not create global reference for Java callback");
     }
+}
+
+CHIPTestClusterListOctetStringAttributeCallback::~CHIPTestClusterListOctetStringAttributeCallback()
+{
+    JNIEnv * env = chip::JniReferences::GetInstance().GetEnvForCurrentThread();
+    if (env == nullptr)
+    {
+        ChipLogError(Zcl, "Could not delete global reference for Java callback");
+        return;
+    }
+    env->DeleteGlobalRef(javaCallbackRef);
 }
 
 void CHIPTestClusterListOctetStringAttributeCallback::CallbackFn(void * context,
@@ -2320,10 +3449,18 @@ void CHIPTestClusterListOctetStringAttributeCallback::CallbackFn(void * context,
     auto iter = list.begin();
     while (iter.Next())
     {
-        auto & entry               = iter.GetValue();
-        jbyteArray listOctetString = env->NewByteArray(entry.size());
-        env->SetByteArrayRegion(listOctetString, 0, entry.size(), reinterpret_cast<const jbyte *>(entry.data()));
-        env->CallBooleanMethod(arrayListObj, arrayListAddMethod, listOctetString);
+        auto & entry              = iter.GetValue();
+        bool entryNull            = false;
+        chip::ByteSpan entryValue = entry;
+
+        jbyteArray entryObject = nullptr;
+        if (!entryNull)
+        {
+            entryObject = env->NewByteArray(entryValue.size());
+            env->SetByteArrayRegion(entryObject, 0, entryValue.size(), reinterpret_cast<const jbyte *>(entryValue.data()));
+        }
+
+        env->CallBooleanMethod(arrayListObj, arrayListAddMethod, entryObject);
     }
     VerifyOrReturn(
         iter.GetStatus() == CHIP_NO_ERROR,
@@ -2348,6 +3485,17 @@ CHIPTestClusterListStructOctetStringAttributeCallback::CHIPTestClusterListStruct
     {
         ChipLogError(Zcl, "Could not create global reference for Java callback");
     }
+}
+
+CHIPTestClusterListStructOctetStringAttributeCallback::~CHIPTestClusterListStructOctetStringAttributeCallback()
+{
+    JNIEnv * env = chip::JniReferences::GetInstance().GetEnvForCurrentThread();
+    if (env == nullptr)
+    {
+        ChipLogError(Zcl, "Could not delete global reference for Java callback");
+        return;
+    }
+    env->DeleteGlobalRef(javaCallbackRef);
 }
 
 void CHIPTestClusterListStructOctetStringAttributeCallback::CallbackFn(
@@ -2392,7 +3540,7 @@ void CHIPTestClusterListStructOctetStringAttributeCallback::CallbackFn(
         ChipLogError(Zcl,
                      "Could not find class chip/devicecontroller/ChipClusters$TestClusterCluster$ListStructOctetStringAttribute"));
     chip::JniClass attributeJniClass(attributeClass);
-    jmethodID attributeCtor = env->GetMethodID(attributeClass, "<init>", "(J[B)V");
+    jmethodID attributeCtor = env->GetMethodID(attributeClass, "<init>", "(Ljava/lang/Long;[B)V");
     VerifyOrReturn(attributeCtor != nullptr, ChipLogError(Zcl, "Could not find ListStructOctetStringAttribute constructor"));
 
     auto iter = list.begin();
@@ -2400,10 +3548,33 @@ void CHIPTestClusterListStructOctetStringAttributeCallback::CallbackFn(
     {
         auto & entry = iter.GetValue();
         (void) entry;
-        jlong fabricIndex          = entry.fabricIndex;
-        jbyteArray operationalCert = env->NewByteArray(entry.operationalCert.size());
-        env->SetByteArrayRegion(operationalCert, 0, entry.operationalCert.size(),
-                                reinterpret_cast<const jbyte *>(entry.operationalCert.data()));
+        bool fabricIndexNull     = false;
+        bool fabricIndexHasValue = true;
+
+        uint64_t fabricIndexValue = entry.fabricIndex;
+
+        jobject fabricIndex = nullptr;
+        if (!fabricIndexNull && fabricIndexHasValue)
+        {
+            jclass fabricIndexEntryCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Long", fabricIndexEntryCls);
+            chip::JniClass fabricIndexJniClass(fabricIndexEntryCls);
+            jmethodID fabricIndexEntryTypeCtor = env->GetMethodID(fabricIndexEntryCls, "<init>", "(J)V");
+            fabricIndex                        = env->NewObject(fabricIndexEntryCls, fabricIndexEntryTypeCtor, fabricIndexValue);
+        }
+
+        bool operationalCertNull     = false;
+        bool operationalCertHasValue = true;
+
+        chip::ByteSpan operationalCertValue = entry.operationalCert;
+
+        jbyteArray operationalCert = nullptr;
+        if (!operationalCertNull && operationalCertHasValue)
+        {
+            operationalCert = env->NewByteArray(operationalCertValue.size());
+            env->SetByteArrayRegion(operationalCert, 0, operationalCertValue.size(),
+                                    reinterpret_cast<const jbyte *>(operationalCertValue.data()));
+        }
 
         jobject attributeObj = env->NewObject(attributeClass, attributeCtor, fabricIndex, operationalCert);
         VerifyOrReturn(attributeObj != nullptr, ChipLogError(Zcl, "Could not create ListStructOctetStringAttribute object"));
@@ -2434,6 +3605,17 @@ CHIPTestClusterListNullablesAndOptionalsStructAttributeCallback::CHIPTestCluster
     {
         ChipLogError(Zcl, "Could not create global reference for Java callback");
     }
+}
+
+CHIPTestClusterListNullablesAndOptionalsStructAttributeCallback::~CHIPTestClusterListNullablesAndOptionalsStructAttributeCallback()
+{
+    JNIEnv * env = chip::JniReferences::GetInstance().GetEnvForCurrentThread();
+    if (env == nullptr)
+    {
+        ChipLogError(Zcl, "Could not delete global reference for Java callback");
+        return;
+    }
+    env->DeleteGlobalRef(javaCallbackRef);
 }
 
 void CHIPTestClusterListNullablesAndOptionalsStructAttributeCallback::CallbackFn(
@@ -2480,7 +3662,9 @@ void CHIPTestClusterListNullablesAndOptionalsStructAttributeCallback::CallbackFn
             Zcl,
             "Could not find class chip/devicecontroller/ChipClusters$TestClusterCluster$ListNullablesAndOptionalsStructAttribute"));
     chip::JniClass attributeJniClass(attributeClass);
-    jmethodID attributeCtor = env->GetMethodID(attributeClass, "<init>", "()V");
+    jmethodID attributeCtor = env->GetMethodID(
+        attributeClass, "<init>",
+        "(Ljava/lang/Integer;Ljava/util/Optional;Ljava/util/Optional;Ljava/lang/String;Ljava/util/Optional;Ljava/util/Optional;)V");
     VerifyOrReturn(attributeCtor != nullptr,
                    ChipLogError(Zcl, "Could not find ListNullablesAndOptionalsStructAttribute constructor"));
 
@@ -2489,8 +3673,138 @@ void CHIPTestClusterListNullablesAndOptionalsStructAttributeCallback::CallbackFn
     {
         auto & entry = iter.GetValue();
         (void) entry;
+        bool nullableIntNull     = false;
+        bool nullableIntHasValue = true;
+        uint16_t nullableIntValue;
+        nullableIntNull = entry.nullableInt.IsNull();
+        if (!nullableIntNull)
+        {
+            nullableIntValue = entry.nullableInt.Value();
+        }
 
-        jobject attributeObj = env->NewObject(attributeClass, attributeCtor);
+        jobject nullableInt = nullptr;
+        if (!nullableIntNull && nullableIntHasValue)
+        {
+            jclass nullableIntEntryCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Integer", nullableIntEntryCls);
+            chip::JniClass nullableIntJniClass(nullableIntEntryCls);
+            jmethodID nullableIntEntryTypeCtor = env->GetMethodID(nullableIntEntryCls, "<init>", "(I)V");
+            nullableInt                        = env->NewObject(nullableIntEntryCls, nullableIntEntryTypeCtor, nullableIntValue);
+        }
+
+        bool optionalIntNull     = false;
+        bool optionalIntHasValue = true;
+
+        uint16_t optionalIntValue;
+        optionalIntHasValue = entry.optionalInt.HasValue();
+        if (optionalIntHasValue)
+        {
+            optionalIntValue = entry.optionalInt.Value();
+        }
+
+        jobject optionalInt = nullptr;
+        if (!optionalIntNull && optionalIntHasValue)
+        {
+            jclass optionalIntEntryCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Integer", optionalIntEntryCls);
+            chip::JniClass optionalIntJniClass(optionalIntEntryCls);
+            jmethodID optionalIntEntryTypeCtor = env->GetMethodID(optionalIntEntryCls, "<init>", "(I)V");
+            optionalInt                        = env->NewObject(optionalIntEntryCls, optionalIntEntryTypeCtor, optionalIntValue);
+        }
+
+        jobject optionalIntOptional = nullptr;
+        chip::JniReferences::GetInstance().CreateOptional(optionalInt, optionalIntOptional);
+        bool nullableOptionalIntNull     = false;
+        bool nullableOptionalIntHasValue = true;
+
+        uint16_t nullableOptionalIntValue;
+        nullableOptionalIntHasValue = entry.nullableOptionalInt.HasValue();
+        if (nullableOptionalIntHasValue)
+        {
+            auto nullableOptionalIntValueFromOptional = entry.nullableOptionalInt.Value();
+            nullableOptionalIntNull                   = nullableOptionalIntValueFromOptional.IsNull();
+            if (!nullableOptionalIntNull)
+            {
+                nullableOptionalIntValue = nullableOptionalIntValueFromOptional.Value();
+            }
+        }
+
+        jobject nullableOptionalInt = nullptr;
+        if (!nullableOptionalIntNull && nullableOptionalIntHasValue)
+        {
+            jclass nullableOptionalIntEntryCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Integer", nullableOptionalIntEntryCls);
+            chip::JniClass nullableOptionalIntJniClass(nullableOptionalIntEntryCls);
+            jmethodID nullableOptionalIntEntryTypeCtor = env->GetMethodID(nullableOptionalIntEntryCls, "<init>", "(I)V");
+            nullableOptionalInt =
+                env->NewObject(nullableOptionalIntEntryCls, nullableOptionalIntEntryTypeCtor, nullableOptionalIntValue);
+        }
+
+        jobject nullableOptionalIntOptional = nullptr;
+        chip::JniReferences::GetInstance().CreateOptional(nullableOptionalInt, nullableOptionalIntOptional);
+        bool nullableStringNull     = false;
+        bool nullableStringHasValue = true;
+        chip::CharSpan nullableStringValue;
+        nullableStringNull = entry.nullableString.IsNull();
+        if (!nullableStringNull)
+        {
+            nullableStringValue = entry.nullableString.Value();
+        }
+
+        jstring nullableString = nullptr;
+        chip::UtfString nullableStringStr(env, nullableStringValue);
+        if (!nullableStringNull && nullableStringHasValue)
+        {
+            nullableString = jstring(nullableStringStr.jniValue());
+        }
+
+        bool optionalStringNull     = false;
+        bool optionalStringHasValue = true;
+
+        chip::CharSpan optionalStringValue;
+        optionalStringHasValue = entry.optionalString.HasValue();
+        if (optionalStringHasValue)
+        {
+            optionalStringValue = entry.optionalString.Value();
+        }
+
+        jstring optionalString = nullptr;
+        chip::UtfString optionalStringStr(env, optionalStringValue);
+        if (!optionalStringNull && optionalStringHasValue)
+        {
+            optionalString = jstring(optionalStringStr.jniValue());
+        }
+
+        jobject optionalStringOptional = nullptr;
+        chip::JniReferences::GetInstance().CreateOptional(optionalString, optionalStringOptional);
+        bool nullableOptionalStringNull     = false;
+        bool nullableOptionalStringHasValue = true;
+
+        chip::CharSpan nullableOptionalStringValue;
+        nullableOptionalStringHasValue = entry.nullableOptionalString.HasValue();
+        if (nullableOptionalStringHasValue)
+        {
+            auto nullableOptionalStringValueFromOptional = entry.nullableOptionalString.Value();
+            nullableOptionalStringNull                   = nullableOptionalStringValueFromOptional.IsNull();
+            if (!nullableOptionalStringNull)
+            {
+                nullableOptionalStringValue = nullableOptionalStringValueFromOptional.Value();
+            }
+        }
+
+        jstring nullableOptionalString = nullptr;
+        chip::UtfString nullableOptionalStringStr(env, nullableOptionalStringValue);
+        if (!nullableOptionalStringNull && nullableOptionalStringHasValue)
+        {
+            nullableOptionalString = jstring(nullableOptionalStringStr.jniValue());
+        }
+
+        jobject nullableOptionalStringOptional = nullptr;
+        chip::JniReferences::GetInstance().CreateOptional(nullableOptionalString, nullableOptionalStringOptional);
+
+        jobject attributeObj =
+            env->NewObject(attributeClass, attributeCtor, nullableInt, optionalIntOptional, nullableOptionalIntOptional,
+                           nullableString, optionalStringOptional, nullableOptionalStringOptional);
         VerifyOrReturn(attributeObj != nullptr,
                        ChipLogError(Zcl, "Could not create ListNullablesAndOptionalsStructAttribute object"));
 
@@ -2520,6 +3834,17 @@ CHIPThreadNetworkDiagnosticsNeighborTableListAttributeCallback::CHIPThreadNetwor
     {
         ChipLogError(Zcl, "Could not create global reference for Java callback");
     }
+}
+
+CHIPThreadNetworkDiagnosticsNeighborTableListAttributeCallback::~CHIPThreadNetworkDiagnosticsNeighborTableListAttributeCallback()
+{
+    JNIEnv * env = chip::JniReferences::GetInstance().GetEnvForCurrentThread();
+    if (env == nullptr)
+    {
+        ChipLogError(Zcl, "Could not delete global reference for Java callback");
+        return;
+    }
+    env->DeleteGlobalRef(javaCallbackRef);
 }
 
 void CHIPThreadNetworkDiagnosticsNeighborTableListAttributeCallback::CallbackFn(
@@ -2566,7 +3891,11 @@ void CHIPThreadNetworkDiagnosticsNeighborTableListAttributeCallback::CallbackFn(
             Zcl,
             "Could not find class chip/devicecontroller/ChipClusters$ThreadNetworkDiagnosticsCluster$NeighborTableListAttribute"));
     chip::JniClass attributeJniClass(attributeClass);
-    jmethodID attributeCtor = env->GetMethodID(attributeClass, "<init>", "(JJIJJIIIIIZZZZ)V");
+    jmethodID attributeCtor =
+        env->GetMethodID(attributeClass, "<init>",
+                         "(Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/"
+                         "Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/"
+                         "Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;)V");
     VerifyOrReturn(attributeCtor != nullptr, ChipLogError(Zcl, "Could not find NeighborTableListAttribute constructor"));
 
     auto iter = list.begin();
@@ -2574,20 +3903,215 @@ void CHIPThreadNetworkDiagnosticsNeighborTableListAttributeCallback::CallbackFn(
     {
         auto & entry = iter.GetValue();
         (void) entry;
-        jlong extAddress          = entry.extAddress;
-        jlong age                 = entry.age;
-        jint rloc16               = entry.rloc16;
-        jlong linkFrameCounter    = entry.linkFrameCounter;
-        jlong mleFrameCounter     = entry.mleFrameCounter;
-        jint lqi                  = entry.lqi;
-        jint averageRssi          = entry.averageRssi;
-        jint lastRssi             = entry.lastRssi;
-        jint frameErrorRate       = entry.frameErrorRate;
-        jint messageErrorRate     = entry.messageErrorRate;
-        jboolean rxOnWhenIdle     = entry.rxOnWhenIdle;
-        jboolean fullThreadDevice = entry.fullThreadDevice;
-        jboolean fullNetworkData  = entry.fullNetworkData;
-        jboolean isChild          = entry.isChild;
+        bool extAddressNull     = false;
+        bool extAddressHasValue = true;
+
+        uint64_t extAddressValue = entry.extAddress;
+
+        jobject extAddress = nullptr;
+        if (!extAddressNull && extAddressHasValue)
+        {
+            jclass extAddressEntryCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Long", extAddressEntryCls);
+            chip::JniClass extAddressJniClass(extAddressEntryCls);
+            jmethodID extAddressEntryTypeCtor = env->GetMethodID(extAddressEntryCls, "<init>", "(J)V");
+            extAddress                        = env->NewObject(extAddressEntryCls, extAddressEntryTypeCtor, extAddressValue);
+        }
+
+        bool ageNull     = false;
+        bool ageHasValue = true;
+
+        uint32_t ageValue = entry.age;
+
+        jobject age = nullptr;
+        if (!ageNull && ageHasValue)
+        {
+            jclass ageEntryCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Long", ageEntryCls);
+            chip::JniClass ageJniClass(ageEntryCls);
+            jmethodID ageEntryTypeCtor = env->GetMethodID(ageEntryCls, "<init>", "(J)V");
+            age                        = env->NewObject(ageEntryCls, ageEntryTypeCtor, ageValue);
+        }
+
+        bool rloc16Null     = false;
+        bool rloc16HasValue = true;
+
+        uint16_t rloc16Value = entry.rloc16;
+
+        jobject rloc16 = nullptr;
+        if (!rloc16Null && rloc16HasValue)
+        {
+            jclass rloc16EntryCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Integer", rloc16EntryCls);
+            chip::JniClass rloc16JniClass(rloc16EntryCls);
+            jmethodID rloc16EntryTypeCtor = env->GetMethodID(rloc16EntryCls, "<init>", "(I)V");
+            rloc16                        = env->NewObject(rloc16EntryCls, rloc16EntryTypeCtor, rloc16Value);
+        }
+
+        bool linkFrameCounterNull     = false;
+        bool linkFrameCounterHasValue = true;
+
+        uint32_t linkFrameCounterValue = entry.linkFrameCounter;
+
+        jobject linkFrameCounter = nullptr;
+        if (!linkFrameCounterNull && linkFrameCounterHasValue)
+        {
+            jclass linkFrameCounterEntryCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Long", linkFrameCounterEntryCls);
+            chip::JniClass linkFrameCounterJniClass(linkFrameCounterEntryCls);
+            jmethodID linkFrameCounterEntryTypeCtor = env->GetMethodID(linkFrameCounterEntryCls, "<init>", "(J)V");
+            linkFrameCounter = env->NewObject(linkFrameCounterEntryCls, linkFrameCounterEntryTypeCtor, linkFrameCounterValue);
+        }
+
+        bool mleFrameCounterNull     = false;
+        bool mleFrameCounterHasValue = true;
+
+        uint32_t mleFrameCounterValue = entry.mleFrameCounter;
+
+        jobject mleFrameCounter = nullptr;
+        if (!mleFrameCounterNull && mleFrameCounterHasValue)
+        {
+            jclass mleFrameCounterEntryCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Long", mleFrameCounterEntryCls);
+            chip::JniClass mleFrameCounterJniClass(mleFrameCounterEntryCls);
+            jmethodID mleFrameCounterEntryTypeCtor = env->GetMethodID(mleFrameCounterEntryCls, "<init>", "(J)V");
+            mleFrameCounter = env->NewObject(mleFrameCounterEntryCls, mleFrameCounterEntryTypeCtor, mleFrameCounterValue);
+        }
+
+        bool lqiNull     = false;
+        bool lqiHasValue = true;
+
+        uint8_t lqiValue = entry.lqi;
+
+        jobject lqi = nullptr;
+        if (!lqiNull && lqiHasValue)
+        {
+            jclass lqiEntryCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Integer", lqiEntryCls);
+            chip::JniClass lqiJniClass(lqiEntryCls);
+            jmethodID lqiEntryTypeCtor = env->GetMethodID(lqiEntryCls, "<init>", "(I)V");
+            lqi                        = env->NewObject(lqiEntryCls, lqiEntryTypeCtor, lqiValue);
+        }
+
+        bool averageRssiNull     = false;
+        bool averageRssiHasValue = true;
+
+        int8_t averageRssiValue = entry.averageRssi;
+
+        jobject averageRssi = nullptr;
+        if (!averageRssiNull && averageRssiHasValue)
+        {
+            jclass averageRssiEntryCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Integer", averageRssiEntryCls);
+            chip::JniClass averageRssiJniClass(averageRssiEntryCls);
+            jmethodID averageRssiEntryTypeCtor = env->GetMethodID(averageRssiEntryCls, "<init>", "(I)V");
+            averageRssi                        = env->NewObject(averageRssiEntryCls, averageRssiEntryTypeCtor, averageRssiValue);
+        }
+
+        bool lastRssiNull     = false;
+        bool lastRssiHasValue = true;
+
+        int8_t lastRssiValue = entry.lastRssi;
+
+        jobject lastRssi = nullptr;
+        if (!lastRssiNull && lastRssiHasValue)
+        {
+            jclass lastRssiEntryCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Integer", lastRssiEntryCls);
+            chip::JniClass lastRssiJniClass(lastRssiEntryCls);
+            jmethodID lastRssiEntryTypeCtor = env->GetMethodID(lastRssiEntryCls, "<init>", "(I)V");
+            lastRssi                        = env->NewObject(lastRssiEntryCls, lastRssiEntryTypeCtor, lastRssiValue);
+        }
+
+        bool frameErrorRateNull     = false;
+        bool frameErrorRateHasValue = true;
+
+        uint8_t frameErrorRateValue = entry.frameErrorRate;
+
+        jobject frameErrorRate = nullptr;
+        if (!frameErrorRateNull && frameErrorRateHasValue)
+        {
+            jclass frameErrorRateEntryCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Integer", frameErrorRateEntryCls);
+            chip::JniClass frameErrorRateJniClass(frameErrorRateEntryCls);
+            jmethodID frameErrorRateEntryTypeCtor = env->GetMethodID(frameErrorRateEntryCls, "<init>", "(I)V");
+            frameErrorRate = env->NewObject(frameErrorRateEntryCls, frameErrorRateEntryTypeCtor, frameErrorRateValue);
+        }
+
+        bool messageErrorRateNull     = false;
+        bool messageErrorRateHasValue = true;
+
+        uint8_t messageErrorRateValue = entry.messageErrorRate;
+
+        jobject messageErrorRate = nullptr;
+        if (!messageErrorRateNull && messageErrorRateHasValue)
+        {
+            jclass messageErrorRateEntryCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Integer", messageErrorRateEntryCls);
+            chip::JniClass messageErrorRateJniClass(messageErrorRateEntryCls);
+            jmethodID messageErrorRateEntryTypeCtor = env->GetMethodID(messageErrorRateEntryCls, "<init>", "(I)V");
+            messageErrorRate = env->NewObject(messageErrorRateEntryCls, messageErrorRateEntryTypeCtor, messageErrorRateValue);
+        }
+
+        bool rxOnWhenIdleNull     = false;
+        bool rxOnWhenIdleHasValue = true;
+
+        bool rxOnWhenIdleValue = entry.rxOnWhenIdle;
+
+        jobject rxOnWhenIdle = nullptr;
+        if (!rxOnWhenIdleNull && rxOnWhenIdleHasValue)
+        {
+            jclass rxOnWhenIdleEntryCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Boolean", rxOnWhenIdleEntryCls);
+            chip::JniClass rxOnWhenIdleJniClass(rxOnWhenIdleEntryCls);
+            jmethodID rxOnWhenIdleEntryTypeCtor = env->GetMethodID(rxOnWhenIdleEntryCls, "<init>", "(Z)V");
+            rxOnWhenIdle = env->NewObject(rxOnWhenIdleEntryCls, rxOnWhenIdleEntryTypeCtor, rxOnWhenIdleValue);
+        }
+
+        bool fullThreadDeviceNull     = false;
+        bool fullThreadDeviceHasValue = true;
+
+        bool fullThreadDeviceValue = entry.fullThreadDevice;
+
+        jobject fullThreadDevice = nullptr;
+        if (!fullThreadDeviceNull && fullThreadDeviceHasValue)
+        {
+            jclass fullThreadDeviceEntryCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Boolean", fullThreadDeviceEntryCls);
+            chip::JniClass fullThreadDeviceJniClass(fullThreadDeviceEntryCls);
+            jmethodID fullThreadDeviceEntryTypeCtor = env->GetMethodID(fullThreadDeviceEntryCls, "<init>", "(Z)V");
+            fullThreadDevice = env->NewObject(fullThreadDeviceEntryCls, fullThreadDeviceEntryTypeCtor, fullThreadDeviceValue);
+        }
+
+        bool fullNetworkDataNull     = false;
+        bool fullNetworkDataHasValue = true;
+
+        bool fullNetworkDataValue = entry.fullNetworkData;
+
+        jobject fullNetworkData = nullptr;
+        if (!fullNetworkDataNull && fullNetworkDataHasValue)
+        {
+            jclass fullNetworkDataEntryCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Boolean", fullNetworkDataEntryCls);
+            chip::JniClass fullNetworkDataJniClass(fullNetworkDataEntryCls);
+            jmethodID fullNetworkDataEntryTypeCtor = env->GetMethodID(fullNetworkDataEntryCls, "<init>", "(Z)V");
+            fullNetworkData = env->NewObject(fullNetworkDataEntryCls, fullNetworkDataEntryTypeCtor, fullNetworkDataValue);
+        }
+
+        bool isChildNull     = false;
+        bool isChildHasValue = true;
+
+        bool isChildValue = entry.isChild;
+
+        jobject isChild = nullptr;
+        if (!isChildNull && isChildHasValue)
+        {
+            jclass isChildEntryCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Boolean", isChildEntryCls);
+            chip::JniClass isChildJniClass(isChildEntryCls);
+            jmethodID isChildEntryTypeCtor = env->GetMethodID(isChildEntryCls, "<init>", "(Z)V");
+            isChild                        = env->NewObject(isChildEntryCls, isChildEntryTypeCtor, isChildValue);
+        }
 
         jobject attributeObj = env->NewObject(attributeClass, attributeCtor, extAddress, age, rloc16, linkFrameCounter,
                                               mleFrameCounter, lqi, averageRssi, lastRssi, frameErrorRate, messageErrorRate,
@@ -2620,6 +4144,17 @@ CHIPThreadNetworkDiagnosticsRouteTableListAttributeCallback::CHIPThreadNetworkDi
     {
         ChipLogError(Zcl, "Could not create global reference for Java callback");
     }
+}
+
+CHIPThreadNetworkDiagnosticsRouteTableListAttributeCallback::~CHIPThreadNetworkDiagnosticsRouteTableListAttributeCallback()
+{
+    JNIEnv * env = chip::JniReferences::GetInstance().GetEnvForCurrentThread();
+    if (env == nullptr)
+    {
+        ChipLogError(Zcl, "Could not delete global reference for Java callback");
+        return;
+    }
+    env->DeleteGlobalRef(javaCallbackRef);
 }
 
 void CHIPThreadNetworkDiagnosticsRouteTableListAttributeCallback::CallbackFn(
@@ -2666,7 +4201,10 @@ void CHIPThreadNetworkDiagnosticsRouteTableListAttributeCallback::CallbackFn(
             Zcl,
             "Could not find class chip/devicecontroller/ChipClusters$ThreadNetworkDiagnosticsCluster$RouteTableListAttribute"));
     chip::JniClass attributeJniClass(attributeClass);
-    jmethodID attributeCtor = env->GetMethodID(attributeClass, "<init>", "(JIIIIIIIZZ)V");
+    jmethodID attributeCtor =
+        env->GetMethodID(attributeClass, "<init>",
+                         "(Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/"
+                         "Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;)V");
     VerifyOrReturn(attributeCtor != nullptr, ChipLogError(Zcl, "Could not find RouteTableListAttribute constructor"));
 
     auto iter = list.begin();
@@ -2674,16 +4212,155 @@ void CHIPThreadNetworkDiagnosticsRouteTableListAttributeCallback::CallbackFn(
     {
         auto & entry = iter.GetValue();
         (void) entry;
-        jlong extAddress         = entry.extAddress;
-        jint rloc16              = entry.rloc16;
-        jint routerId            = entry.routerId;
-        jint nextHop             = entry.nextHop;
-        jint pathCost            = entry.pathCost;
-        jint LQIIn               = entry.LQIIn;
-        jint LQIOut              = entry.LQIOut;
-        jint age                 = entry.age;
-        jboolean allocated       = entry.allocated;
-        jboolean linkEstablished = entry.linkEstablished;
+        bool extAddressNull     = false;
+        bool extAddressHasValue = true;
+
+        uint64_t extAddressValue = entry.extAddress;
+
+        jobject extAddress = nullptr;
+        if (!extAddressNull && extAddressHasValue)
+        {
+            jclass extAddressEntryCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Long", extAddressEntryCls);
+            chip::JniClass extAddressJniClass(extAddressEntryCls);
+            jmethodID extAddressEntryTypeCtor = env->GetMethodID(extAddressEntryCls, "<init>", "(J)V");
+            extAddress                        = env->NewObject(extAddressEntryCls, extAddressEntryTypeCtor, extAddressValue);
+        }
+
+        bool rloc16Null     = false;
+        bool rloc16HasValue = true;
+
+        uint16_t rloc16Value = entry.rloc16;
+
+        jobject rloc16 = nullptr;
+        if (!rloc16Null && rloc16HasValue)
+        {
+            jclass rloc16EntryCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Integer", rloc16EntryCls);
+            chip::JniClass rloc16JniClass(rloc16EntryCls);
+            jmethodID rloc16EntryTypeCtor = env->GetMethodID(rloc16EntryCls, "<init>", "(I)V");
+            rloc16                        = env->NewObject(rloc16EntryCls, rloc16EntryTypeCtor, rloc16Value);
+        }
+
+        bool routerIdNull     = false;
+        bool routerIdHasValue = true;
+
+        uint8_t routerIdValue = entry.routerId;
+
+        jobject routerId = nullptr;
+        if (!routerIdNull && routerIdHasValue)
+        {
+            jclass routerIdEntryCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Integer", routerIdEntryCls);
+            chip::JniClass routerIdJniClass(routerIdEntryCls);
+            jmethodID routerIdEntryTypeCtor = env->GetMethodID(routerIdEntryCls, "<init>", "(I)V");
+            routerId                        = env->NewObject(routerIdEntryCls, routerIdEntryTypeCtor, routerIdValue);
+        }
+
+        bool nextHopNull     = false;
+        bool nextHopHasValue = true;
+
+        uint8_t nextHopValue = entry.nextHop;
+
+        jobject nextHop = nullptr;
+        if (!nextHopNull && nextHopHasValue)
+        {
+            jclass nextHopEntryCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Integer", nextHopEntryCls);
+            chip::JniClass nextHopJniClass(nextHopEntryCls);
+            jmethodID nextHopEntryTypeCtor = env->GetMethodID(nextHopEntryCls, "<init>", "(I)V");
+            nextHop                        = env->NewObject(nextHopEntryCls, nextHopEntryTypeCtor, nextHopValue);
+        }
+
+        bool pathCostNull     = false;
+        bool pathCostHasValue = true;
+
+        uint8_t pathCostValue = entry.pathCost;
+
+        jobject pathCost = nullptr;
+        if (!pathCostNull && pathCostHasValue)
+        {
+            jclass pathCostEntryCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Integer", pathCostEntryCls);
+            chip::JniClass pathCostJniClass(pathCostEntryCls);
+            jmethodID pathCostEntryTypeCtor = env->GetMethodID(pathCostEntryCls, "<init>", "(I)V");
+            pathCost                        = env->NewObject(pathCostEntryCls, pathCostEntryTypeCtor, pathCostValue);
+        }
+
+        bool LQIInNull     = false;
+        bool LQIInHasValue = true;
+
+        uint8_t LQIInValue = entry.LQIIn;
+
+        jobject LQIIn = nullptr;
+        if (!LQIInNull && LQIInHasValue)
+        {
+            jclass LQIInEntryCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Integer", LQIInEntryCls);
+            chip::JniClass LQIInJniClass(LQIInEntryCls);
+            jmethodID LQIInEntryTypeCtor = env->GetMethodID(LQIInEntryCls, "<init>", "(I)V");
+            LQIIn                        = env->NewObject(LQIInEntryCls, LQIInEntryTypeCtor, LQIInValue);
+        }
+
+        bool LQIOutNull     = false;
+        bool LQIOutHasValue = true;
+
+        uint8_t LQIOutValue = entry.LQIOut;
+
+        jobject LQIOut = nullptr;
+        if (!LQIOutNull && LQIOutHasValue)
+        {
+            jclass LQIOutEntryCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Integer", LQIOutEntryCls);
+            chip::JniClass LQIOutJniClass(LQIOutEntryCls);
+            jmethodID LQIOutEntryTypeCtor = env->GetMethodID(LQIOutEntryCls, "<init>", "(I)V");
+            LQIOut                        = env->NewObject(LQIOutEntryCls, LQIOutEntryTypeCtor, LQIOutValue);
+        }
+
+        bool ageNull     = false;
+        bool ageHasValue = true;
+
+        uint8_t ageValue = entry.age;
+
+        jobject age = nullptr;
+        if (!ageNull && ageHasValue)
+        {
+            jclass ageEntryCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Integer", ageEntryCls);
+            chip::JniClass ageJniClass(ageEntryCls);
+            jmethodID ageEntryTypeCtor = env->GetMethodID(ageEntryCls, "<init>", "(I)V");
+            age                        = env->NewObject(ageEntryCls, ageEntryTypeCtor, ageValue);
+        }
+
+        bool allocatedNull     = false;
+        bool allocatedHasValue = true;
+
+        bool allocatedValue = entry.allocated;
+
+        jobject allocated = nullptr;
+        if (!allocatedNull && allocatedHasValue)
+        {
+            jclass allocatedEntryCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Boolean", allocatedEntryCls);
+            chip::JniClass allocatedJniClass(allocatedEntryCls);
+            jmethodID allocatedEntryTypeCtor = env->GetMethodID(allocatedEntryCls, "<init>", "(Z)V");
+            allocated                        = env->NewObject(allocatedEntryCls, allocatedEntryTypeCtor, allocatedValue);
+        }
+
+        bool linkEstablishedNull     = false;
+        bool linkEstablishedHasValue = true;
+
+        bool linkEstablishedValue = entry.linkEstablished;
+
+        jobject linkEstablished = nullptr;
+        if (!linkEstablishedNull && linkEstablishedHasValue)
+        {
+            jclass linkEstablishedEntryCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Boolean", linkEstablishedEntryCls);
+            chip::JniClass linkEstablishedJniClass(linkEstablishedEntryCls);
+            jmethodID linkEstablishedEntryTypeCtor = env->GetMethodID(linkEstablishedEntryCls, "<init>", "(Z)V");
+            linkEstablished = env->NewObject(linkEstablishedEntryCls, linkEstablishedEntryTypeCtor, linkEstablishedValue);
+        }
 
         jobject attributeObj = env->NewObject(attributeClass, attributeCtor, extAddress, rloc16, routerId, nextHop, pathCost, LQIIn,
                                               LQIOut, age, allocated, linkEstablished);
@@ -2715,6 +4392,17 @@ CHIPThreadNetworkDiagnosticsSecurityPolicyAttributeCallback::CHIPThreadNetworkDi
     {
         ChipLogError(Zcl, "Could not create global reference for Java callback");
     }
+}
+
+CHIPThreadNetworkDiagnosticsSecurityPolicyAttributeCallback::~CHIPThreadNetworkDiagnosticsSecurityPolicyAttributeCallback()
+{
+    JNIEnv * env = chip::JniReferences::GetInstance().GetEnvForCurrentThread();
+    if (env == nullptr)
+    {
+        ChipLogError(Zcl, "Could not delete global reference for Java callback");
+        return;
+    }
+    env->DeleteGlobalRef(javaCallbackRef);
 }
 
 void CHIPThreadNetworkDiagnosticsSecurityPolicyAttributeCallback::CallbackFn(
@@ -2761,7 +4449,7 @@ void CHIPThreadNetworkDiagnosticsSecurityPolicyAttributeCallback::CallbackFn(
             Zcl,
             "Could not find class chip/devicecontroller/ChipClusters$ThreadNetworkDiagnosticsCluster$SecurityPolicyAttribute"));
     chip::JniClass attributeJniClass(attributeClass);
-    jmethodID attributeCtor = env->GetMethodID(attributeClass, "<init>", "(II)V");
+    jmethodID attributeCtor = env->GetMethodID(attributeClass, "<init>", "(Ljava/lang/Integer;Ljava/lang/Integer;)V");
     VerifyOrReturn(attributeCtor != nullptr, ChipLogError(Zcl, "Could not find SecurityPolicyAttribute constructor"));
 
     auto iter = list.begin();
@@ -2769,8 +4457,35 @@ void CHIPThreadNetworkDiagnosticsSecurityPolicyAttributeCallback::CallbackFn(
     {
         auto & entry = iter.GetValue();
         (void) entry;
-        jint rotationTime = entry.rotationTime;
-        jint flags        = entry.flags;
+        bool rotationTimeNull     = false;
+        bool rotationTimeHasValue = true;
+
+        uint16_t rotationTimeValue = entry.rotationTime;
+
+        jobject rotationTime = nullptr;
+        if (!rotationTimeNull && rotationTimeHasValue)
+        {
+            jclass rotationTimeEntryCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Integer", rotationTimeEntryCls);
+            chip::JniClass rotationTimeJniClass(rotationTimeEntryCls);
+            jmethodID rotationTimeEntryTypeCtor = env->GetMethodID(rotationTimeEntryCls, "<init>", "(I)V");
+            rotationTime = env->NewObject(rotationTimeEntryCls, rotationTimeEntryTypeCtor, rotationTimeValue);
+        }
+
+        bool flagsNull     = false;
+        bool flagsHasValue = true;
+
+        uint16_t flagsValue = entry.flags;
+
+        jobject flags = nullptr;
+        if (!flagsNull && flagsHasValue)
+        {
+            jclass flagsEntryCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Integer", flagsEntryCls);
+            chip::JniClass flagsJniClass(flagsEntryCls);
+            jmethodID flagsEntryTypeCtor = env->GetMethodID(flagsEntryCls, "<init>", "(I)V");
+            flags                        = env->NewObject(flagsEntryCls, flagsEntryTypeCtor, flagsValue);
+        }
 
         jobject attributeObj = env->NewObject(attributeClass, attributeCtor, rotationTime, flags);
         VerifyOrReturn(attributeObj != nullptr, ChipLogError(Zcl, "Could not create SecurityPolicyAttribute object"));
@@ -2801,6 +4516,18 @@ CHIPThreadNetworkDiagnosticsOperationalDatasetComponentsAttributeCallback::
     {
         ChipLogError(Zcl, "Could not create global reference for Java callback");
     }
+}
+
+CHIPThreadNetworkDiagnosticsOperationalDatasetComponentsAttributeCallback::
+    ~CHIPThreadNetworkDiagnosticsOperationalDatasetComponentsAttributeCallback()
+{
+    JNIEnv * env = chip::JniReferences::GetInstance().GetEnvForCurrentThread();
+    if (env == nullptr)
+    {
+        ChipLogError(Zcl, "Could not delete global reference for Java callback");
+        return;
+    }
+    env->DeleteGlobalRef(javaCallbackRef);
 }
 
 void CHIPThreadNetworkDiagnosticsOperationalDatasetComponentsAttributeCallback::CallbackFn(
@@ -2848,7 +4575,10 @@ void CHIPThreadNetworkDiagnosticsOperationalDatasetComponentsAttributeCallback::
                      "Could not find class "
                      "chip/devicecontroller/ChipClusters$ThreadNetworkDiagnosticsCluster$OperationalDatasetComponentsAttribute"));
     chip::JniClass attributeJniClass(attributeClass);
-    jmethodID attributeCtor = env->GetMethodID(attributeClass, "<init>", "(ZZZZZZZZZZZZ)V");
+    jmethodID attributeCtor = env->GetMethodID(
+        attributeClass, "<init>",
+        "(Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/"
+        "lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;)V");
     VerifyOrReturn(attributeCtor != nullptr, ChipLogError(Zcl, "Could not find OperationalDatasetComponentsAttribute constructor"));
 
     auto iter = list.begin();
@@ -2856,18 +4586,192 @@ void CHIPThreadNetworkDiagnosticsOperationalDatasetComponentsAttributeCallback::
     {
         auto & entry = iter.GetValue();
         (void) entry;
-        jboolean activeTimestampPresent  = entry.activeTimestampPresent;
-        jboolean pendingTimestampPresent = entry.pendingTimestampPresent;
-        jboolean masterKeyPresent        = entry.masterKeyPresent;
-        jboolean networkNamePresent      = entry.networkNamePresent;
-        jboolean extendedPanIdPresent    = entry.extendedPanIdPresent;
-        jboolean meshLocalPrefixPresent  = entry.meshLocalPrefixPresent;
-        jboolean delayPresent            = entry.delayPresent;
-        jboolean panIdPresent            = entry.panIdPresent;
-        jboolean channelPresent          = entry.channelPresent;
-        jboolean pskcPresent             = entry.pskcPresent;
-        jboolean securityPolicyPresent   = entry.securityPolicyPresent;
-        jboolean channelMaskPresent      = entry.channelMaskPresent;
+        bool activeTimestampPresentNull     = false;
+        bool activeTimestampPresentHasValue = true;
+
+        bool activeTimestampPresentValue = entry.activeTimestampPresent;
+
+        jobject activeTimestampPresent = nullptr;
+        if (!activeTimestampPresentNull && activeTimestampPresentHasValue)
+        {
+            jclass activeTimestampPresentEntryCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Boolean", activeTimestampPresentEntryCls);
+            chip::JniClass activeTimestampPresentJniClass(activeTimestampPresentEntryCls);
+            jmethodID activeTimestampPresentEntryTypeCtor = env->GetMethodID(activeTimestampPresentEntryCls, "<init>", "(Z)V");
+            activeTimestampPresent =
+                env->NewObject(activeTimestampPresentEntryCls, activeTimestampPresentEntryTypeCtor, activeTimestampPresentValue);
+        }
+
+        bool pendingTimestampPresentNull     = false;
+        bool pendingTimestampPresentHasValue = true;
+
+        bool pendingTimestampPresentValue = entry.pendingTimestampPresent;
+
+        jobject pendingTimestampPresent = nullptr;
+        if (!pendingTimestampPresentNull && pendingTimestampPresentHasValue)
+        {
+            jclass pendingTimestampPresentEntryCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Boolean", pendingTimestampPresentEntryCls);
+            chip::JniClass pendingTimestampPresentJniClass(pendingTimestampPresentEntryCls);
+            jmethodID pendingTimestampPresentEntryTypeCtor = env->GetMethodID(pendingTimestampPresentEntryCls, "<init>", "(Z)V");
+            pendingTimestampPresent =
+                env->NewObject(pendingTimestampPresentEntryCls, pendingTimestampPresentEntryTypeCtor, pendingTimestampPresentValue);
+        }
+
+        bool masterKeyPresentNull     = false;
+        bool masterKeyPresentHasValue = true;
+
+        bool masterKeyPresentValue = entry.masterKeyPresent;
+
+        jobject masterKeyPresent = nullptr;
+        if (!masterKeyPresentNull && masterKeyPresentHasValue)
+        {
+            jclass masterKeyPresentEntryCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Boolean", masterKeyPresentEntryCls);
+            chip::JniClass masterKeyPresentJniClass(masterKeyPresentEntryCls);
+            jmethodID masterKeyPresentEntryTypeCtor = env->GetMethodID(masterKeyPresentEntryCls, "<init>", "(Z)V");
+            masterKeyPresent = env->NewObject(masterKeyPresentEntryCls, masterKeyPresentEntryTypeCtor, masterKeyPresentValue);
+        }
+
+        bool networkNamePresentNull     = false;
+        bool networkNamePresentHasValue = true;
+
+        bool networkNamePresentValue = entry.networkNamePresent;
+
+        jobject networkNamePresent = nullptr;
+        if (!networkNamePresentNull && networkNamePresentHasValue)
+        {
+            jclass networkNamePresentEntryCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Boolean", networkNamePresentEntryCls);
+            chip::JniClass networkNamePresentJniClass(networkNamePresentEntryCls);
+            jmethodID networkNamePresentEntryTypeCtor = env->GetMethodID(networkNamePresentEntryCls, "<init>", "(Z)V");
+            networkNamePresent =
+                env->NewObject(networkNamePresentEntryCls, networkNamePresentEntryTypeCtor, networkNamePresentValue);
+        }
+
+        bool extendedPanIdPresentNull     = false;
+        bool extendedPanIdPresentHasValue = true;
+
+        bool extendedPanIdPresentValue = entry.extendedPanIdPresent;
+
+        jobject extendedPanIdPresent = nullptr;
+        if (!extendedPanIdPresentNull && extendedPanIdPresentHasValue)
+        {
+            jclass extendedPanIdPresentEntryCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Boolean", extendedPanIdPresentEntryCls);
+            chip::JniClass extendedPanIdPresentJniClass(extendedPanIdPresentEntryCls);
+            jmethodID extendedPanIdPresentEntryTypeCtor = env->GetMethodID(extendedPanIdPresentEntryCls, "<init>", "(Z)V");
+            extendedPanIdPresent =
+                env->NewObject(extendedPanIdPresentEntryCls, extendedPanIdPresentEntryTypeCtor, extendedPanIdPresentValue);
+        }
+
+        bool meshLocalPrefixPresentNull     = false;
+        bool meshLocalPrefixPresentHasValue = true;
+
+        bool meshLocalPrefixPresentValue = entry.meshLocalPrefixPresent;
+
+        jobject meshLocalPrefixPresent = nullptr;
+        if (!meshLocalPrefixPresentNull && meshLocalPrefixPresentHasValue)
+        {
+            jclass meshLocalPrefixPresentEntryCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Boolean", meshLocalPrefixPresentEntryCls);
+            chip::JniClass meshLocalPrefixPresentJniClass(meshLocalPrefixPresentEntryCls);
+            jmethodID meshLocalPrefixPresentEntryTypeCtor = env->GetMethodID(meshLocalPrefixPresentEntryCls, "<init>", "(Z)V");
+            meshLocalPrefixPresent =
+                env->NewObject(meshLocalPrefixPresentEntryCls, meshLocalPrefixPresentEntryTypeCtor, meshLocalPrefixPresentValue);
+        }
+
+        bool delayPresentNull     = false;
+        bool delayPresentHasValue = true;
+
+        bool delayPresentValue = entry.delayPresent;
+
+        jobject delayPresent = nullptr;
+        if (!delayPresentNull && delayPresentHasValue)
+        {
+            jclass delayPresentEntryCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Boolean", delayPresentEntryCls);
+            chip::JniClass delayPresentJniClass(delayPresentEntryCls);
+            jmethodID delayPresentEntryTypeCtor = env->GetMethodID(delayPresentEntryCls, "<init>", "(Z)V");
+            delayPresent = env->NewObject(delayPresentEntryCls, delayPresentEntryTypeCtor, delayPresentValue);
+        }
+
+        bool panIdPresentNull     = false;
+        bool panIdPresentHasValue = true;
+
+        bool panIdPresentValue = entry.panIdPresent;
+
+        jobject panIdPresent = nullptr;
+        if (!panIdPresentNull && panIdPresentHasValue)
+        {
+            jclass panIdPresentEntryCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Boolean", panIdPresentEntryCls);
+            chip::JniClass panIdPresentJniClass(panIdPresentEntryCls);
+            jmethodID panIdPresentEntryTypeCtor = env->GetMethodID(panIdPresentEntryCls, "<init>", "(Z)V");
+            panIdPresent = env->NewObject(panIdPresentEntryCls, panIdPresentEntryTypeCtor, panIdPresentValue);
+        }
+
+        bool channelPresentNull     = false;
+        bool channelPresentHasValue = true;
+
+        bool channelPresentValue = entry.channelPresent;
+
+        jobject channelPresent = nullptr;
+        if (!channelPresentNull && channelPresentHasValue)
+        {
+            jclass channelPresentEntryCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Boolean", channelPresentEntryCls);
+            chip::JniClass channelPresentJniClass(channelPresentEntryCls);
+            jmethodID channelPresentEntryTypeCtor = env->GetMethodID(channelPresentEntryCls, "<init>", "(Z)V");
+            channelPresent = env->NewObject(channelPresentEntryCls, channelPresentEntryTypeCtor, channelPresentValue);
+        }
+
+        bool pskcPresentNull     = false;
+        bool pskcPresentHasValue = true;
+
+        bool pskcPresentValue = entry.pskcPresent;
+
+        jobject pskcPresent = nullptr;
+        if (!pskcPresentNull && pskcPresentHasValue)
+        {
+            jclass pskcPresentEntryCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Boolean", pskcPresentEntryCls);
+            chip::JniClass pskcPresentJniClass(pskcPresentEntryCls);
+            jmethodID pskcPresentEntryTypeCtor = env->GetMethodID(pskcPresentEntryCls, "<init>", "(Z)V");
+            pskcPresent                        = env->NewObject(pskcPresentEntryCls, pskcPresentEntryTypeCtor, pskcPresentValue);
+        }
+
+        bool securityPolicyPresentNull     = false;
+        bool securityPolicyPresentHasValue = true;
+
+        bool securityPolicyPresentValue = entry.securityPolicyPresent;
+
+        jobject securityPolicyPresent = nullptr;
+        if (!securityPolicyPresentNull && securityPolicyPresentHasValue)
+        {
+            jclass securityPolicyPresentEntryCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Boolean", securityPolicyPresentEntryCls);
+            chip::JniClass securityPolicyPresentJniClass(securityPolicyPresentEntryCls);
+            jmethodID securityPolicyPresentEntryTypeCtor = env->GetMethodID(securityPolicyPresentEntryCls, "<init>", "(Z)V");
+            securityPolicyPresent =
+                env->NewObject(securityPolicyPresentEntryCls, securityPolicyPresentEntryTypeCtor, securityPolicyPresentValue);
+        }
+
+        bool channelMaskPresentNull     = false;
+        bool channelMaskPresentHasValue = true;
+
+        bool channelMaskPresentValue = entry.channelMaskPresent;
+
+        jobject channelMaskPresent = nullptr;
+        if (!channelMaskPresentNull && channelMaskPresentHasValue)
+        {
+            jclass channelMaskPresentEntryCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Boolean", channelMaskPresentEntryCls);
+            chip::JniClass channelMaskPresentJniClass(channelMaskPresentEntryCls);
+            jmethodID channelMaskPresentEntryTypeCtor = env->GetMethodID(channelMaskPresentEntryCls, "<init>", "(Z)V");
+            channelMaskPresent =
+                env->NewObject(channelMaskPresentEntryCls, channelMaskPresentEntryTypeCtor, channelMaskPresentValue);
+        }
 
         jobject attributeObj =
             env->NewObject(attributeClass, attributeCtor, activeTimestampPresent, pendingTimestampPresent, masterKeyPresent,
@@ -2901,6 +4805,18 @@ CHIPThreadNetworkDiagnosticsActiveNetworkFaultsListAttributeCallback::
     {
         ChipLogError(Zcl, "Could not create global reference for Java callback");
     }
+}
+
+CHIPThreadNetworkDiagnosticsActiveNetworkFaultsListAttributeCallback::
+    ~CHIPThreadNetworkDiagnosticsActiveNetworkFaultsListAttributeCallback()
+{
+    JNIEnv * env = chip::JniReferences::GetInstance().GetEnvForCurrentThread();
+    if (env == nullptr)
+    {
+        ChipLogError(Zcl, "Could not delete global reference for Java callback");
+        return;
+    }
+    env->DeleteGlobalRef(javaCallbackRef);
 }
 
 void CHIPThreadNetworkDiagnosticsActiveNetworkFaultsListAttributeCallback::CallbackFn(
@@ -2939,12 +4855,21 @@ void CHIPThreadNetworkDiagnosticsActiveNetworkFaultsListAttributeCallback::Callb
     auto iter = list.begin();
     while (iter.Next())
     {
-        auto & entry = iter.GetValue();
-        jclass entryTypeCls;
-        chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Integer", entryTypeCls);
-        jmethodID entryTypeCtor         = env->GetMethodID(entryTypeCls, "<init>", "(I)V");
-        jobject activeNetworkFaultsList = env->NewObject(entryTypeCls, entryTypeCtor, entry);
-        env->CallBooleanMethod(arrayListObj, arrayListAddMethod, activeNetworkFaultsList);
+        auto & entry       = iter.GetValue();
+        bool entryNull     = false;
+        uint8_t entryValue = entry;
+
+        jobject entryObject = nullptr;
+        if (!entryNull)
+        {
+            jclass entryTypeCls;
+            chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Integer", entryTypeCls);
+            chip::JniClass jniClass(entryTypeCls);
+            jmethodID entryTypeCtor = env->GetMethodID(entryTypeCls, "<init>", "(I)V");
+            entryObject             = env->NewObject(entryTypeCls, entryTypeCtor, entryValue);
+        }
+
+        env->CallBooleanMethod(arrayListObj, arrayListAddMethod, entryObject);
     }
     VerifyOrReturn(
         iter.GetStatus() == CHIP_NO_ERROR,

--- a/src/controller/java/zap-generated/CHIPReadCallbacks.h
+++ b/src/controller/java/zap-generated/CHIPReadCallbacks.h
@@ -25,6 +25,8 @@ class CHIPBooleanAttributeCallback : public chip::Callback::Callback<BooleanAttr
 public:
     CHIPBooleanAttributeCallback(jobject javaCallback, bool keepAlive = false);
 
+    ~CHIPBooleanAttributeCallback();
+
     static void maybeDestroy(CHIPBooleanAttributeCallback * callback)
     {
         if (!callback->keepAlive)
@@ -45,6 +47,8 @@ class CHIPCharStringAttributeCallback : public chip::Callback::Callback<CharStri
 {
 public:
     CHIPCharStringAttributeCallback(jobject javaCallback, bool keepAlive = false);
+
+    ~CHIPCharStringAttributeCallback();
 
     static void maybeDestroy(CHIPCharStringAttributeCallback * callback)
     {
@@ -67,6 +71,8 @@ class CHIPInt8sAttributeCallback : public chip::Callback::Callback<Int8sAttribut
 public:
     CHIPInt8sAttributeCallback(jobject javaCallback, bool keepAlive = false);
 
+    ~CHIPInt8sAttributeCallback();
+
     static void maybeDestroy(CHIPInt8sAttributeCallback * callback)
     {
         if (!callback->keepAlive)
@@ -87,6 +93,8 @@ class CHIPInt8uAttributeCallback : public chip::Callback::Callback<Int8uAttribut
 {
 public:
     CHIPInt8uAttributeCallback(jobject javaCallback, bool keepAlive = false);
+
+    ~CHIPInt8uAttributeCallback();
 
     static void maybeDestroy(CHIPInt8uAttributeCallback * callback)
     {
@@ -109,6 +117,8 @@ class CHIPInt16sAttributeCallback : public chip::Callback::Callback<Int16sAttrib
 public:
     CHIPInt16sAttributeCallback(jobject javaCallback, bool keepAlive = false);
 
+    ~CHIPInt16sAttributeCallback();
+
     static void maybeDestroy(CHIPInt16sAttributeCallback * callback)
     {
         if (!callback->keepAlive)
@@ -129,6 +139,8 @@ class CHIPInt16uAttributeCallback : public chip::Callback::Callback<Int16uAttrib
 {
 public:
     CHIPInt16uAttributeCallback(jobject javaCallback, bool keepAlive = false);
+
+    ~CHIPInt16uAttributeCallback();
 
     static void maybeDestroy(CHIPInt16uAttributeCallback * callback)
     {
@@ -151,6 +163,8 @@ class CHIPInt32sAttributeCallback : public chip::Callback::Callback<Int32sAttrib
 public:
     CHIPInt32sAttributeCallback(jobject javaCallback, bool keepAlive = false);
 
+    ~CHIPInt32sAttributeCallback();
+
     static void maybeDestroy(CHIPInt32sAttributeCallback * callback)
     {
         if (!callback->keepAlive)
@@ -171,6 +185,8 @@ class CHIPInt32uAttributeCallback : public chip::Callback::Callback<Int32uAttrib
 {
 public:
     CHIPInt32uAttributeCallback(jobject javaCallback, bool keepAlive = false);
+
+    ~CHIPInt32uAttributeCallback();
 
     static void maybeDestroy(CHIPInt32uAttributeCallback * callback)
     {
@@ -193,6 +209,8 @@ class CHIPInt64sAttributeCallback : public chip::Callback::Callback<Int64sAttrib
 public:
     CHIPInt64sAttributeCallback(jobject javaCallback, bool keepAlive = false);
 
+    ~CHIPInt64sAttributeCallback();
+
     static void maybeDestroy(CHIPInt64sAttributeCallback * callback)
     {
         if (!callback->keepAlive)
@@ -214,6 +232,8 @@ class CHIPInt64uAttributeCallback : public chip::Callback::Callback<Int64uAttrib
 public:
     CHIPInt64uAttributeCallback(jobject javaCallback, bool keepAlive = false);
 
+    ~CHIPInt64uAttributeCallback();
+
     static void maybeDestroy(CHIPInt64uAttributeCallback * callback)
     {
         if (!callback->keepAlive)
@@ -234,6 +254,8 @@ class CHIPOctetStringAttributeCallback : public chip::Callback::Callback<OctetSt
 {
 public:
     CHIPOctetStringAttributeCallback(jobject javaCallback, bool keepAlive = false);
+
+    ~CHIPOctetStringAttributeCallback();
 
     static void maybeDestroy(CHIPOctetStringAttributeCallback * callback)
     {
@@ -257,6 +279,8 @@ class CHIPApplicationLauncherApplicationLauncherListAttributeCallback
 public:
     CHIPApplicationLauncherApplicationLauncherListAttributeCallback(jobject javaCallback);
 
+    ~CHIPApplicationLauncherApplicationLauncherListAttributeCallback();
+
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<uint16_t> & list);
 
 private:
@@ -268,6 +292,8 @@ class CHIPAudioOutputAudioOutputListAttributeCallback
 {
 public:
     CHIPAudioOutputAudioOutputListAttributeCallback(jobject javaCallback);
+
+    ~CHIPAudioOutputAudioOutputListAttributeCallback();
 
     static void CallbackFn(
         void * context,
@@ -282,6 +308,8 @@ class CHIPBridgedActionsActionListAttributeCallback : public chip::Callback::Cal
 {
 public:
     CHIPBridgedActionsActionListAttributeCallback(jobject javaCallback);
+
+    ~CHIPBridgedActionsActionListAttributeCallback();
 
     static void CallbackFn(
         void * context,
@@ -298,6 +326,8 @@ class CHIPBridgedActionsEndpointListAttributeCallback
 public:
     CHIPBridgedActionsEndpointListAttributeCallback(jobject javaCallback);
 
+    ~CHIPBridgedActionsEndpointListAttributeCallback();
+
     static void CallbackFn(
         void * context,
         const chip::app::DataModel::DecodableList<chip::app::Clusters::BridgedActions::Structs::EndpointListStruct::DecodableType> &
@@ -313,6 +343,8 @@ class CHIPContentLauncherAcceptsHeaderListAttributeCallback
 public:
     CHIPContentLauncherAcceptsHeaderListAttributeCallback(jobject javaCallback);
 
+    ~CHIPContentLauncherAcceptsHeaderListAttributeCallback();
+
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::ByteSpan> & list);
 
 private:
@@ -324,6 +356,8 @@ class CHIPContentLauncherSupportedStreamingTypesAttributeCallback
 {
 public:
     CHIPContentLauncherSupportedStreamingTypesAttributeCallback(jobject javaCallback);
+
+    ~CHIPContentLauncherSupportedStreamingTypesAttributeCallback();
 
     static void
     CallbackFn(void * context,
@@ -338,6 +372,8 @@ class CHIPDescriptorDeviceListAttributeCallback : public chip::Callback::Callbac
 public:
     CHIPDescriptorDeviceListAttributeCallback(jobject javaCallback);
 
+    ~CHIPDescriptorDeviceListAttributeCallback();
+
     static void CallbackFn(
         void * context,
         const chip::app::DataModel::DecodableList<chip::app::Clusters::Descriptor::Structs::DeviceType::DecodableType> & list);
@@ -351,6 +387,8 @@ class CHIPDescriptorServerListAttributeCallback : public chip::Callback::Callbac
 public:
     CHIPDescriptorServerListAttributeCallback(jobject javaCallback);
 
+    ~CHIPDescriptorServerListAttributeCallback();
+
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::ClusterId> & list);
 
 private:
@@ -361,6 +399,8 @@ class CHIPDescriptorClientListAttributeCallback : public chip::Callback::Callbac
 {
 public:
     CHIPDescriptorClientListAttributeCallback(jobject javaCallback);
+
+    ~CHIPDescriptorClientListAttributeCallback();
 
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::ClusterId> & list);
 
@@ -373,6 +413,8 @@ class CHIPDescriptorPartsListAttributeCallback : public chip::Callback::Callback
 public:
     CHIPDescriptorPartsListAttributeCallback(jobject javaCallback);
 
+    ~CHIPDescriptorPartsListAttributeCallback();
+
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::EndpointId> & list);
 
 private:
@@ -383,6 +425,8 @@ class CHIPFixedLabelLabelListAttributeCallback : public chip::Callback::Callback
 {
 public:
     CHIPFixedLabelLabelListAttributeCallback(jobject javaCallback);
+
+    ~CHIPFixedLabelLabelListAttributeCallback();
 
     static void CallbackFn(
         void * context,
@@ -397,6 +441,8 @@ class CHIPGeneralCommissioningBasicCommissioningInfoListAttributeCallback
 {
 public:
     CHIPGeneralCommissioningBasicCommissioningInfoListAttributeCallback(jobject javaCallback);
+
+    ~CHIPGeneralCommissioningBasicCommissioningInfoListAttributeCallback();
 
     static void
     CallbackFn(void * context,
@@ -413,6 +459,8 @@ class CHIPGeneralDiagnosticsNetworkInterfacesAttributeCallback
 public:
     CHIPGeneralDiagnosticsNetworkInterfacesAttributeCallback(jobject javaCallback);
 
+    ~CHIPGeneralDiagnosticsNetworkInterfacesAttributeCallback();
+
     static void CallbackFn(void * context,
                            const chip::app::DataModel::DecodableList<
                                chip::app::Clusters::GeneralDiagnostics::Structs::NetworkInterfaceType::DecodableType> & list);
@@ -425,6 +473,8 @@ class CHIPGroupKeyManagementGroupsAttributeCallback : public chip::Callback::Cal
 {
 public:
     CHIPGroupKeyManagementGroupsAttributeCallback(jobject javaCallback);
+
+    ~CHIPGroupKeyManagementGroupsAttributeCallback();
 
     static void CallbackFn(
         void * context,
@@ -441,6 +491,8 @@ class CHIPGroupKeyManagementGroupKeysAttributeCallback
 public:
     CHIPGroupKeyManagementGroupKeysAttributeCallback(jobject javaCallback);
 
+    ~CHIPGroupKeyManagementGroupKeysAttributeCallback();
+
     static void CallbackFn(
         void * context,
         const chip::app::DataModel::DecodableList<chip::app::Clusters::GroupKeyManagement::Structs::GroupKey::DecodableType> &
@@ -455,6 +507,8 @@ class CHIPMediaInputMediaInputListAttributeCallback : public chip::Callback::Cal
 public:
     CHIPMediaInputMediaInputListAttributeCallback(jobject javaCallback);
 
+    ~CHIPMediaInputMediaInputListAttributeCallback();
+
     static void CallbackFn(
         void * context,
         const chip::app::DataModel::DecodableList<chip::app::Clusters::MediaInput::Structs::MediaInputInfo::DecodableType> & list);
@@ -467,6 +521,8 @@ class CHIPModeSelectSupportedModesAttributeCallback : public chip::Callback::Cal
 {
 public:
     CHIPModeSelectSupportedModesAttributeCallback(jobject javaCallback);
+
+    ~CHIPModeSelectSupportedModesAttributeCallback();
 
     static void CallbackFn(
         void * context,
@@ -483,6 +539,8 @@ class CHIPOperationalCredentialsFabricsListAttributeCallback
 public:
     CHIPOperationalCredentialsFabricsListAttributeCallback(jobject javaCallback);
 
+    ~CHIPOperationalCredentialsFabricsListAttributeCallback();
+
     static void CallbackFn(void * context,
                            const chip::app::DataModel::DecodableList<
                                chip::app::Clusters::OperationalCredentials::Structs::FabricDescriptor::DecodableType> & list);
@@ -497,6 +555,8 @@ class CHIPOperationalCredentialsTrustedRootCertificatesAttributeCallback
 public:
     CHIPOperationalCredentialsTrustedRootCertificatesAttributeCallback(jobject javaCallback);
 
+    ~CHIPOperationalCredentialsTrustedRootCertificatesAttributeCallback();
+
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::ByteSpan> & list);
 
 private:
@@ -509,6 +569,8 @@ class CHIPPowerSourceActiveBatteryFaultsAttributeCallback
 public:
     CHIPPowerSourceActiveBatteryFaultsAttributeCallback(jobject javaCallback);
 
+    ~CHIPPowerSourceActiveBatteryFaultsAttributeCallback();
+
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<uint8_t> & list);
 
 private:
@@ -519,6 +581,8 @@ class CHIPTvChannelTvChannelListAttributeCallback : public chip::Callback::Callb
 {
 public:
     CHIPTvChannelTvChannelListAttributeCallback(jobject javaCallback);
+
+    ~CHIPTvChannelTvChannelListAttributeCallback();
 
     static void CallbackFn(
         void * context,
@@ -534,6 +598,8 @@ class CHIPTargetNavigatorTargetNavigatorListAttributeCallback
 public:
     CHIPTargetNavigatorTargetNavigatorListAttributeCallback(jobject javaCallback);
 
+    ~CHIPTargetNavigatorTargetNavigatorListAttributeCallback();
+
     static void CallbackFn(void * context,
                            const chip::app::DataModel::DecodableList<
                                chip::app::Clusters::TargetNavigator::Structs::NavigateTargetTargetInfo::DecodableType> & list);
@@ -547,6 +613,8 @@ class CHIPTestClusterListInt8uAttributeCallback : public chip::Callback::Callbac
 public:
     CHIPTestClusterListInt8uAttributeCallback(jobject javaCallback);
 
+    ~CHIPTestClusterListInt8uAttributeCallback();
+
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<uint8_t> & list);
 
 private:
@@ -559,6 +627,8 @@ class CHIPTestClusterListOctetStringAttributeCallback
 public:
     CHIPTestClusterListOctetStringAttributeCallback(jobject javaCallback);
 
+    ~CHIPTestClusterListOctetStringAttributeCallback();
+
     static void CallbackFn(void * context, const chip::app::DataModel::DecodableList<chip::ByteSpan> & list);
 
 private:
@@ -570,6 +640,8 @@ class CHIPTestClusterListStructOctetStringAttributeCallback
 {
 public:
     CHIPTestClusterListStructOctetStringAttributeCallback(jobject javaCallback);
+
+    ~CHIPTestClusterListStructOctetStringAttributeCallback();
 
     static void CallbackFn(
         void * context,
@@ -586,6 +658,8 @@ class CHIPTestClusterListNullablesAndOptionalsStructAttributeCallback
 public:
     CHIPTestClusterListNullablesAndOptionalsStructAttributeCallback(jobject javaCallback);
 
+    ~CHIPTestClusterListNullablesAndOptionalsStructAttributeCallback();
+
     static void CallbackFn(void * context,
                            const chip::app::DataModel::DecodableList<
                                chip::app::Clusters::TestCluster::Structs::NullablesAndOptionalsStruct::DecodableType> & list);
@@ -599,6 +673,8 @@ class CHIPThreadNetworkDiagnosticsNeighborTableListAttributeCallback
 {
 public:
     CHIPThreadNetworkDiagnosticsNeighborTableListAttributeCallback(jobject javaCallback);
+
+    ~CHIPThreadNetworkDiagnosticsNeighborTableListAttributeCallback();
 
     static void CallbackFn(void * context,
                            const chip::app::DataModel::DecodableList<
@@ -614,6 +690,8 @@ class CHIPThreadNetworkDiagnosticsRouteTableListAttributeCallback
 public:
     CHIPThreadNetworkDiagnosticsRouteTableListAttributeCallback(jobject javaCallback);
 
+    ~CHIPThreadNetworkDiagnosticsRouteTableListAttributeCallback();
+
     static void CallbackFn(void * context,
                            const chip::app::DataModel::DecodableList<
                                chip::app::Clusters::ThreadNetworkDiagnostics::Structs::RouteTable::DecodableType> & list);
@@ -627,6 +705,8 @@ class CHIPThreadNetworkDiagnosticsSecurityPolicyAttributeCallback
 {
 public:
     CHIPThreadNetworkDiagnosticsSecurityPolicyAttributeCallback(jobject javaCallback);
+
+    ~CHIPThreadNetworkDiagnosticsSecurityPolicyAttributeCallback();
 
     static void CallbackFn(void * context,
                            const chip::app::DataModel::DecodableList<
@@ -642,6 +722,8 @@ class CHIPThreadNetworkDiagnosticsOperationalDatasetComponentsAttributeCallback
 public:
     CHIPThreadNetworkDiagnosticsOperationalDatasetComponentsAttributeCallback(jobject javaCallback);
 
+    ~CHIPThreadNetworkDiagnosticsOperationalDatasetComponentsAttributeCallback();
+
     static void
     CallbackFn(void * context,
                const chip::app::DataModel::DecodableList<
@@ -656,6 +738,8 @@ class CHIPThreadNetworkDiagnosticsActiveNetworkFaultsListAttributeCallback
 {
 public:
     CHIPThreadNetworkDiagnosticsActiveNetworkFaultsListAttributeCallback(jobject javaCallback);
+
+    ~CHIPThreadNetworkDiagnosticsActiveNetworkFaultsListAttributeCallback();
 
     static void
     CallbackFn(void * context,

--- a/src/controller/java/zap-generated/chip/devicecontroller/ChipClusters.java
+++ b/src/controller/java/zap-generated/chip/devicecontroller/ChipClusters.java
@@ -19,7 +19,9 @@
 
 package chip.devicecontroller;
 
+import androidx.annotation.Nullable;
 import java.util.List;
+import java.util.Optional;
 
 public class ChipClusters {
 
@@ -362,11 +364,11 @@ public class ChipClusters {
         long chipClusterPtr, DefaultClusterCallback callback, int index);
 
     public static class AudioOutputListAttribute {
-      public int index;
-      public int outputType;
+      public Integer index;
+      public Integer outputType;
       public String name;
 
-      public AudioOutputListAttribute(int index, int outputType, String name) {
+      public AudioOutputListAttribute(Integer index, Integer outputType, String name) {
         this.index = index;
         this.outputType = outputType;
         this.name = name;
@@ -948,20 +950,20 @@ public class ChipClusters {
         long chipClusterPtr, DefaultClusterCallback callback, int actionID, long invokeID);
 
     public static class ActionListAttribute {
-      public int actionID;
+      public Integer actionID;
       public String name;
-      public int type;
-      public int endpointListID;
-      public int supportedCommands;
-      public int status;
+      public Integer type;
+      public Integer endpointListID;
+      public Integer supportedCommands;
+      public Integer status;
 
       public ActionListAttribute(
-          int actionID,
+          Integer actionID,
           String name,
-          int type,
-          int endpointListID,
-          int supportedCommands,
-          int status) {
+          Integer type,
+          Integer endpointListID,
+          Integer supportedCommands,
+          Integer status) {
         this.actionID = actionID;
         this.name = name;
         this.type = type;
@@ -1008,12 +1010,13 @@ public class ChipClusters {
     }
 
     public static class EndpointListAttribute {
-      public int endpointListID;
+      public Integer endpointListID;
       public String name;
-      public int type;
+      public Integer type;
       public byte[] endpoints;
 
-      public EndpointListAttribute(int endpointListID, String name, int type, byte[] endpoints) {
+      public EndpointListAttribute(
+          Integer endpointListID, String name, Integer type, byte[] endpoints) {
         this.endpointListID = endpointListID;
         this.name = name;
         this.type = type;
@@ -2268,10 +2271,10 @@ public class ChipClusters {
     public native long initWithDevice(long devicePtr, int endpointId);
 
     public static class DeviceListAttribute {
-      public long type;
-      public int revision;
+      public Long type;
+      public Integer revision;
 
-      public DeviceListAttribute(long type, int revision) {
+      public DeviceListAttribute(Long type, Integer revision) {
         this.type = type;
         this.revision = revision;
       }
@@ -3204,9 +3207,9 @@ public class ChipClusters {
     }
 
     public static class BasicCommissioningInfoListAttribute {
-      public long failSafeExpiryLengthMs;
+      public Long failSafeExpiryLengthMs;
 
-      public BasicCommissioningInfoListAttribute(long failSafeExpiryLengthMs) {
+      public BasicCommissioningInfoListAttribute(Long failSafeExpiryLengthMs) {
         this.failSafeExpiryLengthMs = failSafeExpiryLengthMs;
       }
 
@@ -3271,19 +3274,19 @@ public class ChipClusters {
 
     public static class NetworkInterfacesAttribute {
       public String name;
-      public boolean fabricConnected;
-      public boolean offPremiseServicesReachableIPv4;
-      public boolean offPremiseServicesReachableIPv6;
+      public Boolean fabricConnected;
+      public Boolean offPremiseServicesReachableIPv4;
+      public Boolean offPremiseServicesReachableIPv6;
       public byte[] hardwareAddress;
-      public int type;
+      public Integer type;
 
       public NetworkInterfacesAttribute(
           String name,
-          boolean fabricConnected,
-          boolean offPremiseServicesReachableIPv4,
-          boolean offPremiseServicesReachableIPv6,
+          Boolean fabricConnected,
+          Boolean offPremiseServicesReachableIPv4,
+          Boolean offPremiseServicesReachableIPv6,
           byte[] hardwareAddress,
-          int type) {
+          Integer type) {
         this.name = name;
         this.fabricConnected = fabricConnected;
         this.offPremiseServicesReachableIPv4 = offPremiseServicesReachableIPv4;
@@ -3392,11 +3395,11 @@ public class ChipClusters {
     public native long initWithDevice(long devicePtr, int endpointId);
 
     public static class GroupsAttribute {
-      public int vendorId;
-      public int vendorGroupId;
-      public int groupKeySetIndex;
+      public Integer vendorId;
+      public Integer vendorGroupId;
+      public Integer groupKeySetIndex;
 
-      public GroupsAttribute(int vendorId, int vendorGroupId, int groupKeySetIndex) {
+      public GroupsAttribute(Integer vendorId, Integer vendorGroupId, Integer groupKeySetIndex) {
         this.vendorId = vendorId;
         this.vendorGroupId = vendorGroupId;
         this.groupKeySetIndex = groupKeySetIndex;
@@ -3428,18 +3431,18 @@ public class ChipClusters {
     }
 
     public static class GroupKeysAttribute {
-      public int vendorId;
-      public int groupKeyIndex;
+      public Integer vendorId;
+      public Integer groupKeyIndex;
       public byte[] groupKeyRoot;
-      public long groupKeyEpochStartTime;
-      public int groupKeySecurityPolicy;
+      public Long groupKeyEpochStartTime;
+      public Integer groupKeySecurityPolicy;
 
       public GroupKeysAttribute(
-          int vendorId,
-          int groupKeyIndex,
+          Integer vendorId,
+          Integer groupKeyIndex,
           byte[] groupKeyRoot,
-          long groupKeyEpochStartTime,
-          int groupKeySecurityPolicy) {
+          Long groupKeyEpochStartTime,
+          Integer groupKeySecurityPolicy) {
         this.vendorId = vendorId;
         this.groupKeyIndex = groupKeyIndex;
         this.groupKeyRoot = groupKeyRoot;
@@ -4123,12 +4126,13 @@ public class ChipClusters {
     private native void showInputStatus(long chipClusterPtr, DefaultClusterCallback callback);
 
     public static class MediaInputListAttribute {
-      public int index;
-      public int inputType;
+      public Integer index;
+      public Integer inputType;
       public String name;
       public String description;
 
-      public MediaInputListAttribute(int index, int inputType, String name, String description) {
+      public MediaInputListAttribute(
+          Integer index, Integer inputType, String name, String description) {
         this.index = index;
         this.inputType = inputType;
         this.name = name;
@@ -4423,10 +4427,10 @@ public class ChipClusters {
 
     public static class SupportedModesAttribute {
       public String label;
-      public int mode;
-      public long semanticTag;
+      public Integer mode;
+      public Long semanticTag;
 
-      public SupportedModesAttribute(String label, int mode, long semanticTag) {
+      public SupportedModesAttribute(String label, Integer mode, Long semanticTag) {
         this.label = label;
         this.mode = mode;
         this.semanticTag = semanticTag;
@@ -5228,19 +5232,19 @@ public class ChipClusters {
     }
 
     public static class FabricsListAttribute {
-      public int fabricIndex;
+      public Integer fabricIndex;
       public byte[] rootPublicKey;
-      public int vendorId;
-      public long fabricId;
-      public long nodeId;
+      public Integer vendorId;
+      public Long fabricId;
+      public Long nodeId;
       public String label;
 
       public FabricsListAttribute(
-          int fabricIndex,
+          Integer fabricIndex,
           byte[] rootPublicKey,
-          int vendorId,
-          long fabricId,
-          long nodeId,
+          Integer vendorId,
+          Long fabricId,
+          Long nodeId,
           String label) {
         this.fabricIndex = fabricIndex;
         this.rootPublicKey = rootPublicKey;
@@ -6127,15 +6131,15 @@ public class ChipClusters {
     }
 
     public static class TvChannelListAttribute {
-      public int majorNumber;
-      public int minorNumber;
+      public Integer majorNumber;
+      public Integer minorNumber;
       public String name;
       public String callSign;
       public String affiliateCallSign;
 
       public TvChannelListAttribute(
-          int majorNumber,
-          int minorNumber,
+          Integer majorNumber,
+          Integer minorNumber,
           String name,
           String callSign,
           String affiliateCallSign) {
@@ -6234,10 +6238,10 @@ public class ChipClusters {
     }
 
     public static class TargetNavigatorListAttribute {
-      public int identifier;
+      public Integer identifier;
       public String name;
 
-      public TargetNavigatorListAttribute(int identifier, String name) {
+      public TargetNavigatorListAttribute(Integer identifier, String name) {
         this.identifier = identifier;
         this.name = name;
       }
@@ -6511,10 +6515,10 @@ public class ChipClusters {
     }
 
     public static class ListStructOctetStringAttribute {
-      public long fabricIndex;
+      public Long fabricIndex;
       public byte[] operationalCert;
 
-      public ListStructOctetStringAttribute(long fabricIndex, byte[] operationalCert) {
+      public ListStructOctetStringAttribute(Long fabricIndex, byte[] operationalCert) {
         this.fabricIndex = fabricIndex;
         this.operationalCert = operationalCert;
       }
@@ -6549,8 +6553,27 @@ public class ChipClusters {
     }
 
     public static class ListNullablesAndOptionalsStructAttribute {
+      @Nullable public Integer nullableInt;
+      public Optional<Integer> optionalInt;
+      @Nullable public Optional<Integer> nullableOptionalInt;
+      @Nullable public String nullableString;
+      public Optional<String> optionalString;
+      @Nullable public Optional<String> nullableOptionalString;
 
-      public ListNullablesAndOptionalsStructAttribute() {}
+      public ListNullablesAndOptionalsStructAttribute(
+          @Nullable Integer nullableInt,
+          Optional<Integer> optionalInt,
+          @Nullable Optional<Integer> nullableOptionalInt,
+          @Nullable String nullableString,
+          Optional<String> optionalString,
+          @Nullable Optional<String> nullableOptionalString) {
+        this.nullableInt = nullableInt;
+        this.optionalInt = optionalInt;
+        this.nullableOptionalInt = nullableOptionalInt;
+        this.nullableString = nullableString;
+        this.optionalString = optionalString;
+        this.nullableOptionalString = nullableOptionalString;
+      }
 
       @Override
       public String toString() {
@@ -7269,36 +7292,36 @@ public class ChipClusters {
     private native void resetCounts(long chipClusterPtr, DefaultClusterCallback callback);
 
     public static class NeighborTableListAttribute {
-      public long extAddress;
-      public long age;
-      public int rloc16;
-      public long linkFrameCounter;
-      public long mleFrameCounter;
-      public int lqi;
-      public int averageRssi;
-      public int lastRssi;
-      public int frameErrorRate;
-      public int messageErrorRate;
-      public boolean rxOnWhenIdle;
-      public boolean fullThreadDevice;
-      public boolean fullNetworkData;
-      public boolean isChild;
+      public Long extAddress;
+      public Long age;
+      public Integer rloc16;
+      public Long linkFrameCounter;
+      public Long mleFrameCounter;
+      public Integer lqi;
+      public Integer averageRssi;
+      public Integer lastRssi;
+      public Integer frameErrorRate;
+      public Integer messageErrorRate;
+      public Boolean rxOnWhenIdle;
+      public Boolean fullThreadDevice;
+      public Boolean fullNetworkData;
+      public Boolean isChild;
 
       public NeighborTableListAttribute(
-          long extAddress,
-          long age,
-          int rloc16,
-          long linkFrameCounter,
-          long mleFrameCounter,
-          int lqi,
-          int averageRssi,
-          int lastRssi,
-          int frameErrorRate,
-          int messageErrorRate,
-          boolean rxOnWhenIdle,
-          boolean fullThreadDevice,
-          boolean fullNetworkData,
-          boolean isChild) {
+          Long extAddress,
+          Long age,
+          Integer rloc16,
+          Long linkFrameCounter,
+          Long mleFrameCounter,
+          Integer lqi,
+          Integer averageRssi,
+          Integer lastRssi,
+          Integer frameErrorRate,
+          Integer messageErrorRate,
+          Boolean rxOnWhenIdle,
+          Boolean fullThreadDevice,
+          Boolean fullNetworkData,
+          Boolean isChild) {
         this.extAddress = extAddress;
         this.age = age;
         this.rloc16 = rloc16;
@@ -7385,28 +7408,28 @@ public class ChipClusters {
     }
 
     public static class RouteTableListAttribute {
-      public long extAddress;
-      public int rloc16;
-      public int routerId;
-      public int nextHop;
-      public int pathCost;
-      public int LQIIn;
-      public int LQIOut;
-      public int age;
-      public boolean allocated;
-      public boolean linkEstablished;
+      public Long extAddress;
+      public Integer rloc16;
+      public Integer routerId;
+      public Integer nextHop;
+      public Integer pathCost;
+      public Integer LQIIn;
+      public Integer LQIOut;
+      public Integer age;
+      public Boolean allocated;
+      public Boolean linkEstablished;
 
       public RouteTableListAttribute(
-          long extAddress,
-          int rloc16,
-          int routerId,
-          int nextHop,
-          int pathCost,
-          int LQIIn,
-          int LQIOut,
-          int age,
-          boolean allocated,
-          boolean linkEstablished) {
+          Long extAddress,
+          Integer rloc16,
+          Integer routerId,
+          Integer nextHop,
+          Integer pathCost,
+          Integer LQIIn,
+          Integer LQIOut,
+          Integer age,
+          Boolean allocated,
+          Boolean linkEstablished) {
         this.extAddress = extAddress;
         this.rloc16 = rloc16;
         this.routerId = routerId;
@@ -7473,10 +7496,10 @@ public class ChipClusters {
     }
 
     public static class SecurityPolicyAttribute {
-      public int rotationTime;
-      public int flags;
+      public Integer rotationTime;
+      public Integer flags;
 
-      public SecurityPolicyAttribute(int rotationTime, int flags) {
+      public SecurityPolicyAttribute(Integer rotationTime, Integer flags) {
         this.rotationTime = rotationTime;
         this.flags = flags;
       }
@@ -7503,32 +7526,32 @@ public class ChipClusters {
     }
 
     public static class OperationalDatasetComponentsAttribute {
-      public boolean activeTimestampPresent;
-      public boolean pendingTimestampPresent;
-      public boolean masterKeyPresent;
-      public boolean networkNamePresent;
-      public boolean extendedPanIdPresent;
-      public boolean meshLocalPrefixPresent;
-      public boolean delayPresent;
-      public boolean panIdPresent;
-      public boolean channelPresent;
-      public boolean pskcPresent;
-      public boolean securityPolicyPresent;
-      public boolean channelMaskPresent;
+      public Boolean activeTimestampPresent;
+      public Boolean pendingTimestampPresent;
+      public Boolean masterKeyPresent;
+      public Boolean networkNamePresent;
+      public Boolean extendedPanIdPresent;
+      public Boolean meshLocalPrefixPresent;
+      public Boolean delayPresent;
+      public Boolean panIdPresent;
+      public Boolean channelPresent;
+      public Boolean pskcPresent;
+      public Boolean securityPolicyPresent;
+      public Boolean channelMaskPresent;
 
       public OperationalDatasetComponentsAttribute(
-          boolean activeTimestampPresent,
-          boolean pendingTimestampPresent,
-          boolean masterKeyPresent,
-          boolean networkNamePresent,
-          boolean extendedPanIdPresent,
-          boolean meshLocalPrefixPresent,
-          boolean delayPresent,
-          boolean panIdPresent,
-          boolean channelPresent,
-          boolean pskcPresent,
-          boolean securityPolicyPresent,
-          boolean channelMaskPresent) {
+          Boolean activeTimestampPresent,
+          Boolean pendingTimestampPresent,
+          Boolean masterKeyPresent,
+          Boolean networkNamePresent,
+          Boolean extendedPanIdPresent,
+          Boolean meshLocalPrefixPresent,
+          Boolean delayPresent,
+          Boolean panIdPresent,
+          Boolean channelPresent,
+          Boolean pskcPresent,
+          Boolean securityPolicyPresent,
+          Boolean channelMaskPresent) {
         this.activeTimestampPresent = activeTimestampPresent;
         this.pendingTimestampPresent = pendingTimestampPresent;
         this.masterKeyPresent = masterKeyPresent;

--- a/src/lib/support/JniReferences.h
+++ b/src/lib/support/JniReferences.h
@@ -21,6 +21,7 @@
 #include <lib/core/CHIPError.h>
 #include <lib/support/CodeUtils.h>
 #include <pthread.h>
+#include <string>
 
 namespace chip {
 class JniReferences
@@ -36,11 +37,6 @@ public:
         static JniReferences jniReferences;
         return jniReferences;
     }
-
-    /**
-     * Returns a stack lock to be shared by all controller JNI code.
-     */
-    pthread_mutex_t * GetStackLock();
 
     /**
      * Set the JavaVM.
@@ -80,10 +76,15 @@ public:
 
     void ThrowError(JNIEnv * env, jclass exceptionCls, CHIP_ERROR errToThrow);
 
+    /**
+     * Creates a java.util.Optional wrapping the specified jobject. If the wrapped jobject is null, an empty
+     * Optional will be returned.
+     */
+    CHIP_ERROR CreateOptional(jobject objectToWrap, jobject & outOptional);
+
 private:
     JniReferences() {}
 
-    pthread_mutex_t mStackLock = PTHREAD_MUTEX_INITIALIZER;
     JavaVM * mJvm              = nullptr;
     jobject mClassLoader       = nullptr;
     jmethodID mFindClassMethod = nullptr;

--- a/src/lib/support/JniTypeWrappers.h
+++ b/src/lib/support/JniTypeWrappers.h
@@ -50,7 +50,10 @@ public:
     ~JniByteArray() { mEnv->ReleaseByteArrayElements(mArray, mData, 0); }
 
     const jbyte * data() const { return mData; }
-    chip::ByteSpan byteSpan() const { return chip::ByteSpan(reinterpret_cast<const uint8_t *>(data()), size()); }
+    chip::ByteSpan byteSpan() const
+    {
+        return chip::ByteSpan(reinterpret_cast<const uint8_t *>(data()), static_cast<size_t>(size()));
+    }
     jsize size() const { return mDataLength; }
 
 private:


### PR DESCRIPTION
#### Problem
* Nullable / optional support doesn't exist in Android clusters code

#### Change overview
* Process nullables and optionals in list attributes.
  * DataModel::Nullable -> `@Nullable`, and null is passed to the Java layer when needed
  * chip::Optional -> `java.util.Optional`, and if a DataModel::Nullable wrapped by chip::Optional is null, an empty `java.util.Optional` is used.

#### Testing
* Manual test using TestCluster
