### PR TITLE
Uncomment the <tag> bits in window covering.

### DIFF
--- a/src/app/zap-templates/zcl/data-model/chip/window-covering.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/window-covering.xml
@@ -21,12 +21,10 @@ limitations under the License.
     <define>WINDOW_COVERING_CLUSTER</define>
     <client tick="false" init="false">true</client>
     <server tick="false" init="false">true</server>
-    <!-- TODO: <tag> support seems to be broken in ZAP, leading to database
-         constraint errors
     <tag name="LF" description="Lift Control"/>
     <tag name="TL" description="Tilt Control"/>
     <tag name="PA" description="Position Aware"/>
-    <tag name="ABS" description="Absolute Positioning"/> -->
+    <tag name="ABS" description="Absolute Positioning"/>
     <globalAttribute side="server" code="0xFFFC" value="0x0001">
       <featureBit tag="LF" bit="0">true</featureBit>
       <featureBit tag="TL" bit="1">false</featureBit>


### PR DESCRIPTION
https://github.com/project-chip/zap/pull/274 should have fixed the problem that caused them to be commented out.

Fixes https://github.com/project-chip/connectedhomeip/issues/11056
Fixes https://github.com/project-chip/connectedhomeip/issues/11057

#### Problem
Part of the XML commented out when it doesn't need to be.

#### Change overview
Uncomment it.

#### Testing
Reran codegen.  No changes, no failures.