### PR TITLE
Fix for 'Verhoeff code is not using tables as const causing unnecessa…

### DIFF
--- a/src/lib/support/verhoeff/Verhoeff.cpp
+++ b/src/lib/support/verhoeff/Verhoeff.cpp
@@ -52,7 +52,7 @@ int Verhoeff::DihedralInvert(int val, int n)
     return val;
 }
 
-int Verhoeff::Permute(int val, uint8_t * permTable, int permTableLen, uint64_t iterCount)
+int Verhoeff::Permute(int val, const uint8_t * permTable, int permTableLen, uint64_t iterCount)
 {
     val = val % permTableLen;
     if (iterCount == 0)

--- a/src/lib/support/verhoeff/Verhoeff.h
+++ b/src/lib/support/verhoeff/Verhoeff.h
@@ -66,8 +66,8 @@ private:
     Verhoeff10()  = delete;
     ~Verhoeff10() = delete;
 
-    static uint8_t sMultiplyTable[];
-    static uint8_t sPermTable[];
+    static const uint8_t sMultiplyTable[];
+    static const uint8_t sPermTable[];
 };
 
 // Verhoeff16 -- Implements Verhoeff's check-digit algorithm for base-16 (hex) strings.
@@ -103,8 +103,8 @@ private:
     Verhoeff16()  = delete;
     ~Verhoeff16() = delete;
 
-    static uint8_t sMultiplyTable[];
-    static uint8_t sPermTable[];
+    static const uint8_t sMultiplyTable[];
+    static const uint8_t sPermTable[];
 };
 
 // Verhoeff32 -- Implements Verhoeff's check-digit algorithm for base-32 strings.
@@ -142,10 +142,10 @@ private:
     Verhoeff32()  = delete;
     ~Verhoeff32() = delete;
 
-    static uint8_t sMultiplyTable[];
-    static uint8_t sPermTable[];
-    static int8_t sCharToValTable[];
-    static char sValToCharTable[];
+    static const uint8_t sMultiplyTable[];
+    static const uint8_t sPermTable[];
+    static const int8_t sCharToValTable[];
+    static const char sValToCharTable[];
 };
 
 // Verhoeff36 -- Implements Verhoeff's check-digit algorithm for base-36 strings.
@@ -177,10 +177,10 @@ private:
     Verhoeff36()  = delete;
     ~Verhoeff36() = delete;
 
-    static uint8_t sMultiplyTable[];
-    static uint8_t sPermTable[];
-    static int8_t sCharToValTable[];
-    static char sValToCharTable[];
+    static const uint8_t sMultiplyTable[];
+    static const uint8_t sPermTable[];
+    static const int8_t sCharToValTable[];
+    static const char sValToCharTable[];
 };
 
 // Verhoeff -- Implements core functions for Verhoeff's algorithm.
@@ -190,5 +190,5 @@ class Verhoeff
 public:
     static int DihedralMultiply(int x, int y, int n);
     static int DihedralInvert(int val, int n);
-    static int Permute(int val, uint8_t * permTable, int permTableLen, uint64_t iterCount);
+    static int Permute(int val, const uint8_t * permTable, int permTableLen, uint64_t iterCount);
 };

--- a/src/lib/support/verhoeff/Verhoeff10.cpp
+++ b/src/lib/support/verhoeff/Verhoeff10.cpp
@@ -30,7 +30,7 @@
 
 #ifndef VERHOEFF10_NO_MULTIPLY_TABLE
 
-uint8_t Verhoeff10::sMultiplyTable[] = {
+const uint8_t Verhoeff10::sMultiplyTable[] = {
     0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4, 0, 6, 7, 8, 9, 5, 2, 3, 4, 0, 1, 7, 8, 9, 5, 6, 3, 4, 0, 1,
     2, 8, 9, 5, 6, 7, 4, 0, 1, 2, 3, 9, 5, 6, 7, 8, 5, 9, 8, 7, 6, 0, 4, 3, 2, 1, 6, 5, 9, 8, 7, 1, 0, 4,
     3, 2, 7, 6, 5, 9, 8, 2, 1, 0, 4, 3, 8, 7, 6, 5, 9, 3, 2, 1, 0, 4, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0,
@@ -38,7 +38,7 @@ uint8_t Verhoeff10::sMultiplyTable[] = {
 
 #endif
 
-uint8_t Verhoeff10::sPermTable[] = { 1, 5, 7, 6, 2, 8, 3, 0, 9, 4 };
+const uint8_t Verhoeff10::sPermTable[] = { 1, 5, 7, 6, 2, 8, 3, 0, 9, 4 };
 
 char Verhoeff10::ComputeCheckChar(const char * str)
 {

--- a/src/lib/support/verhoeff/Verhoeff16.cpp
+++ b/src/lib/support/verhoeff/Verhoeff16.cpp
@@ -29,7 +29,7 @@
 
 #ifndef VERHOEFF16_NO_MULTIPLY_TABLE
 
-uint8_t Verhoeff16::sMultiplyTable[] = {
+const uint8_t Verhoeff16::sMultiplyTable[] = {
     0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15, 1,  2,  3,  4,  5,  6,  7,  0,  9,  10, 11, 12, 13, 14, 15, 8,
     2,  3,  4,  5,  6,  7,  0,  1,  10, 11, 12, 13, 14, 15, 8,  9,  3,  4,  5,  6,  7,  0,  1,  2,  11, 12, 13, 14, 15, 8,  9,  10,
     4,  5,  6,  7,  0,  1,  2,  3,  12, 13, 14, 15, 8,  9,  10, 11, 5,  6,  7,  0,  1,  2,  3,  4,  13, 14, 15, 8,  9,  10, 11, 12,
@@ -42,7 +42,7 @@ uint8_t Verhoeff16::sMultiplyTable[] = {
 
 #endif // VERHOEFF16_NO_MULTIPLY_TABLE
 
-uint8_t Verhoeff16::sPermTable[] = { 4, 7, 5, 14, 8, 12, 15, 0, 2, 11, 3, 13, 10, 6, 9, 1 };
+const uint8_t Verhoeff16::sPermTable[] = { 4, 7, 5, 14, 8, 12, 15, 0, 2, 11, 3, 13, 10, 6, 9, 1 };
 
 char Verhoeff16::ComputeCheckChar(const char * str)
 {

--- a/src/lib/support/verhoeff/Verhoeff32.cpp
+++ b/src/lib/support/verhoeff/Verhoeff32.cpp
@@ -32,7 +32,7 @@
 
 #ifndef VERHOEFF32_NO_MULTIPLY_TABLE
 
-uint8_t Verhoeff32::sMultiplyTable[] = {
+const uint8_t Verhoeff32::sMultiplyTable[] = {
     0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
     1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15, 0,  17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 16,
     2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15, 0,  1,  18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 16, 17,
@@ -69,19 +69,19 @@ uint8_t Verhoeff32::sMultiplyTable[] = {
 
 #endif // VERHOEFF32_NO_MULTIPLY_TABLE
 
-uint8_t Verhoeff32::sPermTable[] = {
+const uint8_t Verhoeff32::sPermTable[] = {
     // Detects all single digit and adjacent transposition errors, and 97.076613% of jump transposition errors.
     7, 2, 1, 30, 16, 20, 27, 11, 31, 6, 8, 13, 29, 5, 10, 21, 22, 3, 24, 0, 23, 25, 12, 9, 28, 14, 4, 15, 17, 18, 19, 26,
 };
 
-int8_t Verhoeff32::sCharToValTable[] = {
+const int8_t Verhoeff32::sCharToValTable[] = {
     // NOTE: table starts at ASCII 30h
     0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  -1, -1, -1, -1, -1, -1, -1, 10, 11, 12, 13, 14, 15, 16, 17,
     -1, 18, 19, 20, 21, 22, -1, 23, -1, 24, 25, 26, 27, 28, 29, 30, 31, -1, -1, -1, -1, -1, -1, -1, 10,
     11, 12, 13, 14, 15, 16, 17, -1, 18, 19, 20, 21, 22, -1, 23, -1, 24, 25, 26, 27, 28, 29, 30, 31
 };
 
-char Verhoeff32::sValToCharTable[] = "0123456789ABCDEFGHJKLMNPRSTUVWXY";
+const char Verhoeff32::sValToCharTable[] = "0123456789ABCDEFGHJKLMNPRSTUVWXY";
 
 char Verhoeff32::ComputeCheckChar(const char * str)
 {

--- a/src/lib/support/verhoeff/Verhoeff36.cpp
+++ b/src/lib/support/verhoeff/Verhoeff36.cpp
@@ -31,7 +31,7 @@
 
 #ifndef VERHOEFF36_NO_MULTIPLY_TABLE
 
-uint8_t Verhoeff36::sMultiplyTable[] = {
+const uint8_t Verhoeff36::sMultiplyTable[] = {
     0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
     32, 33, 34, 35, 1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15, 16, 17, 0,  19, 20, 21, 22, 23, 24, 25, 26, 27, 28,
     29, 30, 31, 32, 33, 34, 35, 18, 2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15, 16, 17, 0,  1,  20, 21, 22, 23, 24, 25,
@@ -77,17 +77,17 @@ uint8_t Verhoeff36::sMultiplyTable[] = {
 
 #endif // VERHOEFF36_NO_MULTIPLY_TABLE
 
-uint8_t Verhoeff36::sPermTable[] = { 29, 0,  32, 11, 35, 20, 7,  27, 2,  4,  19, 28, 30, 1,  5,  12, 3,  9,
-                                     16, 22, 6,  33, 8,  24, 26, 21, 14, 10, 34, 31, 15, 25, 17, 13, 23, 18 };
+const uint8_t Verhoeff36::sPermTable[] = { 29, 0,  32, 11, 35, 20, 7,  27, 2,  4,  19, 28, 30, 1,  5,  12, 3,  9,
+                                           16, 22, 6,  33, 8,  24, 26, 21, 14, 10, 34, 31, 15, 25, 17, 13, 23, 18 };
 
-int8_t Verhoeff36::sCharToValTable[] = {
+const int8_t Verhoeff36::sCharToValTable[] = {
     // NOTE: table starts at ASCII 30h
     0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  -1, -1, -1, -1, -1, -1, -1, 10, 11, 12, 13, 14, 15, 16, 17,
     18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, -1, -1, -1, -1, -1, -1, 10,
     11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35
 };
 
-char Verhoeff36::sValToCharTable[] = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+const char Verhoeff36::sValToCharTable[] = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
 
 char Verhoeff36::ComputeCheckChar(const char * str)
 {


### PR DESCRIPTION
…ry RAM use #9564'

#### Problem
What is being fixed?
* Optimize RAM use

#### Change overview
Const specifier were added to lookup tables to move them to flash section.

#### Testing
How was this tested? (at least one bullet point required)
* Compared memory footprint before and after the change
* Sanity runtime test
