### PR TITLE
Build minmdns examples with build_examples.py

### DIFF
--- a/examples/minimal-mdns/AllInterfaceListener.h
+++ b/examples/minimal-mdns/AllInterfaceListener.h
@@ -39,7 +39,7 @@ public:
         if (mState == State::kIpV4)
         {
 #if INET_CONFIG_ENABLE_IPV4
-            *id   = Inet::InterfaceId::Null();
+            *id   = chip::Inet::InterfaceId::Null();
             *type = chip::Inet::IPAddressType::kIPv4;
 #endif
             mState = State::kIpV6;
@@ -113,7 +113,7 @@ private:
             return true;
         }
 
-        printf("Usable interface: %s (%d)\n", name, static_cast<int>(mIterator.GetInterfaceId()));
+        printf("Usable interface: %s\n", name);
 
         return false;
     }

--- a/examples/minimal-mdns/client.cpp
+++ b/examples/minimal-mdns/client.cpp
@@ -186,7 +186,10 @@ public:
         char addr[32];
         info->SrcAddress.ToString(addr, sizeof(addr));
 
-        printf("QUERY from: %-15s on port %d, via interface %d\n", addr, info->SrcPort, info->Interface);
+        char ifName[64];
+        VerifyOrDie(info->Interface.GetInterfaceName(ifName, sizeof(ifName)) == CHIP_NO_ERROR);
+
+        printf("QUERY from: %-15s on port %d, via interface %s\n", addr, info->SrcPort, ifName);
         Report("QUERY: ", data);
     }
 
@@ -195,7 +198,10 @@ public:
         char addr[32];
         info->SrcAddress.ToString(addr, sizeof(addr));
 
-        printf("RESPONSE from: %-15s on port %d, via interface %d\n", addr, info->SrcPort, info->Interface);
+        char ifName[64];
+        VerifyOrDie(info->Interface.GetInterfaceName(ifName, sizeof(ifName)) == CHIP_NO_ERROR);
+
+        printf("RESPONSE from: %-15s on port %d, via interface %s\n", addr, info->SrcPort, ifName);
         Report("RESPONSE: ", data);
     }
 
@@ -328,7 +334,7 @@ int main(int argc, char ** args)
     BroadcastPacket(&mdnsServer);
 
     err = DeviceLayer::SystemLayer().StartTimer(
-        gOptions.runtimeMs,
+        chip::System::Clock::Milliseconds32(gOptions.runtimeMs),
         [](System::Layer *, void *) {
             DeviceLayer::PlatformMgr().StopEventLoopTask();
             DeviceLayer::PlatformMgr().Shutdown();

--- a/examples/minimal-mdns/server.cpp
+++ b/examples/minimal-mdns/server.cpp
@@ -115,7 +115,10 @@ public:
         char addr[INET6_ADDRSTRLEN];
         info->SrcAddress.ToString(addr, sizeof(addr));
 
-        printf("QUERY from: %-15s on port %d, via interface %d\n", addr, info->SrcPort, info->Interface);
+        char ifName[64];
+        VerifyOrDie(info->Interface.GetInterfaceName(ifName, sizeof(ifName)) == CHIP_NO_ERROR);
+
+        printf("QUERY from: %-15s on port %d, via interface %s\n", addr, info->SrcPort, ifName);
         Report("QUERY: ", data);
 
         mCurrentSource = info;
@@ -131,7 +134,10 @@ public:
         char addr[INET6_ADDRSTRLEN];
         info->SrcAddress.ToString(addr, sizeof(addr));
 
-        printf("RESPONSE from: %-15s on port %d, via interface %d\n", addr, info->SrcPort, info->Interface);
+        char ifName[64];
+        VerifyOrDie(info->Interface.GetInterfaceName(ifName, sizeof(ifName)) == CHIP_NO_ERROR);
+
+        printf("RESPONSE from: %-15s on port %d, via interface %s\n", addr, info->SrcPort, ifName);
     }
 
     // ParserDelegate

--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -110,6 +110,7 @@ def HostTargets():
             'all-clusters', app=HostApp.ALL_CLUSTERS))
         app_targets.append(target.Extend('chip-tool', app=HostApp.CHIP_TOOL))
         app_targets.append(target.Extend('thermostat', app=HostApp.THERMOSTAT))
+        app_targets.append(target.Extend('minmdns', app=HostApp.MIN_MDNS))
         app_targets.append(target.Extend(
             'rpc-console', app=HostApp.RPC_CONSOLE))
 

--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -105,14 +105,17 @@ def HostTargets():
         targets.append(target.Extend('arm64', board=HostBoard.ARM64))
 
     app_targets = []
+
+    # RPC console compilation only for native
+    app_targets.append(
+        targets[0].Extend('rpc-console', app=HostApp.RPC_CONSOLE))
+
     for target in targets:
         app_targets.append(target.Extend(
             'all-clusters', app=HostApp.ALL_CLUSTERS))
         app_targets.append(target.Extend('chip-tool', app=HostApp.CHIP_TOOL))
         app_targets.append(target.Extend('thermostat', app=HostApp.THERMOSTAT))
         app_targets.append(target.Extend('minmdns', app=HostApp.MIN_MDNS))
-        app_targets.append(target.Extend(
-            'rpc-console', app=HostApp.RPC_CONSOLE))
 
     for target in app_targets:
         yield target

--- a/scripts/build/builders/host.py
+++ b/scripts/build/builders/host.py
@@ -151,9 +151,9 @@ class HostBuilder(GnBuilder):
             if os.path.isdir(path):
                 for root, dirs, files in os.walk(path):
                     for file in files:
-                       outputs.update({
-                           file: os.path.join(root, file)
-                       })
+                        outputs.update({
+                            file: os.path.join(root, file)
+                        })
             else:
                 outputs.update({
                     name: os.path.join(self.output_dir, name)

--- a/scripts/build/builders/host.py
+++ b/scripts/build/builders/host.py
@@ -43,23 +43,23 @@ class HostApp(Enum):
 
     def OutputNames(self):
         if self == HostApp.ALL_CLUSTERS:
-            return ['chip-all-clusters-app', 'chip-all-clusters-app.map']
+            yield 'chip-all-clusters-app' 
+            yield 'chip-all-clusters-app.map'
         elif self == HostApp.CHIP_TOOL:
-            return ['chip-tool', 'chip-tool.map']
+            yield 'chip-tool' 
+            yield 'chip-tool.map'
         elif self == HostApp.THERMOSTAT:
-            return ['thermostat-app', 'thermostat-app.map']
+            yield 'thermostat-app'
+            yield 'thermostat-app.map'
         elif self == HostApp.RPC_CONSOLE:
-            return ['chip_rpc_console_wheels']
+            yield 'chip_rpc_console_wheels'
         elif self == HostApp.MIN_MDNS:
-            return [
-                'mdns-advertiser',
-                'mdns-advertiser.map',
-                'minimal-mdns-client',
-                'minimal-mdns-client.map',
-                'minimal-mdns-server',
-                'minimal-mdns-server.map',
-            ]
-            return 'FIXME' # FIXME: multiple names?
+            yield 'mdns-advertiser'
+            yield 'mdns-advertiser.map'
+            yield 'minimal-mdns-client'
+            yield 'minimal-mdns-client.map'
+            yield 'minimal-mdns-server'
+            yield 'minimal-mdns-server.map'
         else:
             raise Exception('Unknown app type: %r' % self)
 

--- a/scripts/build/builders/host.py
+++ b/scripts/build/builders/host.py
@@ -25,6 +25,7 @@ class HostApp(Enum):
     CHIP_TOOL = auto()
     THERMOSTAT = auto()
     RPC_CONSOLE = auto()
+    MIN_MDNS = auto()
 
     def ExamplePath(self):
         if self == HostApp.ALL_CLUSTERS:
@@ -35,6 +36,8 @@ class HostApp(Enum):
             return 'thermostat/linux'
         elif self == HostApp.RPC_CONSOLE:
             return 'common/pigweed/rpc_console'
+        if self == HostApp.MIN_MDNS:
+            return 'minimal-mdns'
         else:
             raise Exception('Unknown app type: %r' % self)
 
@@ -47,6 +50,8 @@ class HostApp(Enum):
             return 'thermostat-app'
         elif self == HostApp.RPC_CONSOLE:
             return 'rpc-console'
+        elif self == HostApp.MIN_MDNS:
+            return 'FIXME' # FIXME: multiple names?
         else:
             raise Exception('Unknown app type: %r' % self)
 

--- a/scripts/build/builders/host.py
+++ b/scripts/build/builders/host.py
@@ -152,7 +152,7 @@ class HostBuilder(GnBuilder):
     def build_outputs(self):
         outputs = {}
 
-        for name in self.app.OutputNames:
+        for name in self.app.OutputNames():
             outputs.update({
                 name: os.path.join(self.output_dir, name)
             })

--- a/scripts/build/builders/host.py
+++ b/scripts/build/builders/host.py
@@ -43,10 +43,10 @@ class HostApp(Enum):
 
     def OutputNames(self):
         if self == HostApp.ALL_CLUSTERS:
-            yield 'chip-all-clusters-app' 
+            yield 'chip-all-clusters-app'
             yield 'chip-all-clusters-app.map'
         elif self == HostApp.CHIP_TOOL:
-            yield 'chip-tool' 
+            yield 'chip-tool'
             yield 'chip-tool.map'
         elif self == HostApp.THERMOSTAT:
             yield 'thermostat-app'

--- a/scripts/build/testdata/build_linux_on_x64.txt
+++ b/scripts/build/testdata/build_linux_on_x64.txt
@@ -21,10 +21,20 @@ bash -c '
 PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
  gn gen --check --fail-on-unused-args --root={root}/examples/chip-tool '"'"'--args=chip_inet_config_enable_ipv4=false target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-chip-tool-ipv6only'
 
+# Generating linux-arm64-minmdns
+bash -c '
+PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
+ gn gen --check --fail-on-unused-args --root={root}/examples/minimal-mdns '"'"'--args=target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-minmdns'
+
+# Generating linux-arm64-minmdns-ipv6only
+bash -c '
+PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
+ gn gen --check --fail-on-unused-args --root={root}/examples/minimal-mdns '"'"'--args=chip_inet_config_enable_ipv4=false target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-minmdns-ipv6only'
+
 # Generating linux-arm64-rpc-console
 bash -c '
 PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
- gn gen --check --fail-on-unused-args --root={root}/examples/common/pigweed/rpc_console '"'"'--args=target_cpu="arm64" is_clang=true'"'"' {out}/linux-arm64-rpc-console'
+ gn gen --check --fail-on-unused-args --root={root}/examples/common/pigweed/rpc_console '"'"'--args=target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-rpc-console'
 
 # Generating linux-arm64-thermostat
 bash -c '
@@ -48,6 +58,12 @@ gn gen --check --fail-on-unused-args --root={root}/examples/chip-tool {out}/linu
 # Generating linux-x64-chip-tool-ipv6only
 gn gen --check --fail-on-unused-args --root={root}/examples/chip-tool --args=chip_inet_config_enable_ipv4=false {out}/linux-x64-chip-tool-ipv6only
 
+# Generating linux-x64-minmdns
+gn gen --check --fail-on-unused-args --root={root}/examples/minimal-mdns {out}/linux-x64-minmdns
+
+# Generating linux-x64-minmdns-ipv6only
+gn gen --check --fail-on-unused-args --root={root}/examples/minimal-mdns --args=chip_inet_config_enable_ipv4=false {out}/linux-x64-minmdns-ipv6only
+
 # Generating linux-x64-rpc-console
 gn gen --check --fail-on-unused-args --root={root}/examples/common/pigweed/rpc_console {out}/linux-x64-rpc-console
 
@@ -69,6 +85,12 @@ ninja -C {out}/linux-arm64-chip-tool
 # Building linux-arm64-chip-tool-ipv6only
 ninja -C {out}/linux-arm64-chip-tool-ipv6only
 
+# Building linux-arm64-minmdns
+ninja -C {out}/linux-arm64-minmdns
+
+# Building linux-arm64-minmdns-ipv6only
+ninja -C {out}/linux-arm64-minmdns-ipv6only
+
 # Building linux-arm64-rpc-console
 ninja -C {out}/linux-arm64-rpc-console
 
@@ -89,6 +111,12 @@ ninja -C {out}/linux-x64-chip-tool
 
 # Building linux-x64-chip-tool-ipv6only
 ninja -C {out}/linux-x64-chip-tool-ipv6only
+
+# Building linux-x64-minmdns
+ninja -C {out}/linux-x64-minmdns
+
+# Building linux-x64-minmdns-ipv6only
+ninja -C {out}/linux-x64-minmdns-ipv6only
 
 # Building linux-x64-rpc-console
 ninja -C {out}/linux-x64-rpc-console

--- a/scripts/build/testdata/build_linux_on_x64.txt
+++ b/scripts/build/testdata/build_linux_on_x64.txt
@@ -31,11 +31,6 @@ bash -c '
 PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
  gn gen --check --fail-on-unused-args --root={root}/examples/minimal-mdns '"'"'--args=chip_inet_config_enable_ipv4=false target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-minmdns-ipv6only'
 
-# Generating linux-arm64-rpc-console
-bash -c '
-PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
- gn gen --check --fail-on-unused-args --root={root}/examples/common/pigweed/rpc_console '"'"'--args=target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-rpc-console'
-
 # Generating linux-arm64-thermostat
 bash -c '
 PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
@@ -90,9 +85,6 @@ ninja -C {out}/linux-arm64-minmdns
 
 # Building linux-arm64-minmdns-ipv6only
 ninja -C {out}/linux-arm64-minmdns-ipv6only
-
-# Building linux-arm64-rpc-console
-ninja -C {out}/linux-arm64-rpc-console
 
 # Building linux-arm64-thermostat
 ninja -C {out}/linux-arm64-thermostat


### PR DESCRIPTION
#### Problem
Minmdns examples do not build at all and became stale

#### Change overview
Adds `build_examples.py` support for minmdns builds, fixes builds

#### Testing

```
./scripts/build/build_examples.py --target-glob '*minmdns*' build --copy-artifacts-to ./out/artifacts
```

```
/scripts/build/build_examples.py --target-glob 'linux*' build --copy-artifacts-to ./out/artifacts/
```

CI unit test (validatese build examples commands)