### PR TITLE
[chip-tool] Specify optional arguments name instead of relying on the argument position

### DIFF
--- a/examples/chip-tool/commands/common/Command.cpp
+++ b/examples/chip-tool/commands/common/Command.cpp
@@ -32,33 +32,69 @@
 #include <lib/support/ScopedBuffer.h>
 #include <lib/support/logging/CHIPLogging.h>
 
+constexpr const char * kOptionalArgumentPrefix = "--";
+constexpr size_t kOptionalArgumentPrefixLength = 2;
+
 bool Command::InitArguments(int argc, char ** argv)
 {
     bool isValidCommand = false;
-    size_t argsCount    = mArgs.size();
 
-    size_t argsOptionalCount = 0;
-    for (size_t i = 0; i < argsCount; i++)
+    size_t argvExtraArgsCount = (size_t) argc;
+    size_t mandatoryArgsCount = 0;
+    size_t optionalArgsCount  = 0;
+    for (size_t i = 0; i < mArgs.size(); i++)
     {
         if (mArgs[i].optional)
         {
-            argsOptionalCount++;
+            optionalArgsCount++;
+        }
+        else
+        {
+            mandatoryArgsCount++;
+            argvExtraArgsCount--;
         }
     }
 
-    VerifyOrExit((size_t)(argc) >= (argsCount - argsOptionalCount) && (size_t)(argc) <= argsCount,
-                 ChipLogError(chipTool, "InitArgs: Wrong arguments number: %d instead of %zu", argc, argsCount));
+    VerifyOrExit((size_t)(argc) >= mandatoryArgsCount && (argvExtraArgsCount == 0 || (argvExtraArgsCount && optionalArgsCount)),
+                 ChipLogError(chipTool, "InitArgs: Wrong arguments number: %d instead of %zu", argc, mandatoryArgsCount));
 
-    for (size_t i = 0; i < (size_t) argc; i++)
+    // Initialize mandatory arguments
+    for (size_t i = 0; i < mandatoryArgsCount; i++)
     {
-        if (!InitArgument(i, argv[i]))
+        char * arg = argv[i];
+        if (!InitArgument(i, arg))
         {
             ExitNow();
         }
     }
 
-    for (size_t i = (size_t) argc; i < argsCount; i++)
+    // Initialize optional arguments
+    // Optional arguments expect a name and a value, so i is increased by 2 on every step.
+    for (size_t i = mandatoryArgsCount; i < (size_t) argc; i += 2)
     {
+        bool found = false;
+        for (size_t j = mandatoryArgsCount; j < mandatoryArgsCount + optionalArgsCount; j++)
+        {
+            // optional arguments starts with kOptionalArgumentPrefix
+            if (strlen(argv[i]) <= kOptionalArgumentPrefixLength &&
+                strncmp(argv[i], kOptionalArgumentPrefix, kOptionalArgumentPrefixLength) != 0)
+            {
+                continue;
+            }
+
+            if (strcmp(argv[i] + strlen(kOptionalArgumentPrefix), mArgs[j].name) == 0)
+            {
+                found = true;
+
+                VerifyOrExit((size_t) argc > (i + 1),
+                             ChipLogError(chipTool, "InitArgs: Optional argument %s missing value.", argv[i]));
+                if (!InitArgument(j, argv[i + 1]))
+                {
+                    ExitNow();
+                }
+            }
+        }
+        VerifyOrExit(found, ChipLogError(chipTool, "InitArgs: Optional argument %s does not exist.", argv[i]));
     }
 
     isValidCommand = true;

--- a/examples/chip-tool/commands/common/Commands.cpp
+++ b/examples/chip-tool/commands/common/Commands.cpp
@@ -258,7 +258,7 @@ void Commands::ShowCommand(std::string executable, std::string clusterName, Comm
         bool isOptional = command->GetArgumentIsOptional(i);
         if (isOptional)
         {
-            arguments += "[";
+            arguments += "[--";
         }
         arguments += command->GetArgumentName(i);
         if (isOptional)

--- a/scripts/tests/test_suites.sh
+++ b/scripts/tests/test_suites.sh
@@ -251,7 +251,7 @@ for j in "${iter_array[@]}"; do
         echo "          * Pairing to device"
         ${tool_run_prefix} "${test_case_wrapper[@]}" out/debug/standalone/chip-tool pairing qrcode "$node_id" MT:D8XA0CQM00KA0648G00 | tee "$pairing_log_file"
         echo "          * Starting test run: $i"
-        ${tool_run_prefix} "${test_case_wrapper[@]}" out/debug/standalone/chip-tool tests "$i" "$node_id" "$delay" | tee "$chip_tool_log_file"
+        ${tool_run_prefix} "${test_case_wrapper[@]}" out/debug/standalone/chip-tool tests "$i" "$node_id" --delayInMs "$delay" | tee "$chip_tool_log_file"
         # Prevent cleanup trying to kill a process we already killed.
         temp_background_pid=$background_pid
         background_pid=0


### PR DESCRIPTION
#### Problem

Assuming a `chip-tool` command has argument `A`, `B` and `C` where `B` and `C` are optionals, if one want to provide only `A` and `C`, it can not be done without providing `B` as well.

#### Change overview
 * Make optional argument specified using the configured name.
