### PR TITLE
Add API to find if an endpoint of given index contains the ZCL server.

### DIFF
--- a/src/app/util/af.h
+++ b/src/app/util/af.h
@@ -148,6 +148,17 @@ bool emberAfContainsServerWithMfgCode(chip::EndpointId endpoint, chip::ClusterId
 bool emberAfContainsServer(chip::EndpointId endpoint, chip::ClusterId clusterId);
 
 /**
+ * @brief Returns true if endpoint of given index contains the ZCL server with specified id.
+ *
+ * This function returns true if
+ * the endpoint of given index contains server of a given cluster.
+ * If this function is used with a manufacturer specific clusterId
+ * then this will return the first cluster that it finds in the Cluster table.
+ * and will not return any other clusters that share that id.
+ */
+bool emberAfContainsServerFromIndex(uint16_t index, chip::ClusterId clusterId);
+
+/**
  * @brief Returns true if endpoint contains cluster client.
  *
  * This function returns true if

--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -798,6 +798,20 @@ bool emberAfContainsClient(EndpointId endpoint, ClusterId clusterId)
     return (emberAfFindClusterWithMfgCode(endpoint, clusterId, CLUSTER_MASK_CLIENT, EMBER_AF_NULL_MANUFACTURER_CODE) != NULL);
 }
 
+// This will find the first server that has the clusterId given from the index of endpoint, regardless of mfgCode.
+bool emberAfContainsServerFromIndex(uint16_t index, ClusterId clusterId)
+{
+    if (index == 0xFFFF)
+    {
+        return false;
+    }
+    else
+    {
+        return emberAfFindClusterInTypeWithMfgCode(emAfEndpoints[index].endpointType, clusterId, CLUSTER_MASK_SERVER,
+                                                   EMBER_AF_NULL_MANUFACTURER_CODE);
+    }
+}
+
 // Finds the cluster that matches endpoint, clusterId, direction, and manufacturerCode.
 EmberAfCluster * emberAfFindClusterWithMfgCode(EndpointId endpoint, ClusterId clusterId, EmberAfClusterMask mask,
                                                uint16_t manufacturerCode)


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* Currently, we only have the API to find if an endpoint contains the ZCL server from its endpointID.

#### Change overview
Add API to find if an endpoint of given index contains the ZCL server.

#### Testing
How was this tested? (at least one bullet point required)
* currently, no unit test for util functions in app, test manually by repalcing the endpointID with endpointIndex 
