### PR TITLE
Add RIO patch location to lwip doc.

### DIFF
--- a/docs/discussion/lwip_ipv6.md
+++ b/docs/discussion/lwip_ipv6.md
@@ -17,7 +17,7 @@ need to incorporate this into their own middleware
 
 -   write a RIO patch, upstream to lwip
     -   Ensure patch is RFC compliant (especially re: expiry)
-- UPDATE: Patch is available at https://savannah.nongnu.org/patch/?10114
+-   UPDATE: Patch is available at https://savannah.nongnu.org/patch/?10114
 
 ## Address Scopes
 

--- a/docs/discussion/lwip_ipv6.md
+++ b/docs/discussion/lwip_ipv6.md
@@ -17,6 +17,7 @@ need to incorporate this into their own middleware
 
 -   write a RIO patch, upstream to lwip
     -   Ensure patch is RFC compliant (especially re: expiry)
+- UPDATE: Patch is available at https://savannah.nongnu.org/patch/?10114
 
 ## Address Scopes
 


### PR DESCRIPTION
#### Problem
Lwip doc not updated with location of RIO patch

#### Change overview
Adds link to RIO patch in lwip doc

#### Testing
Not tested - just a doc. 
