### PR TITLE
esp32: fix different NDEBUG definitions in the examples and the library

### DIFF
--- a/config/esp32/components/chip/CMakeLists.txt
+++ b/config/esp32/components/chip/CMakeLists.txt
@@ -39,6 +39,16 @@ if (CONFIG_OPENTHREAD_ENABLED)
     list(APPEND CHIP_REQURIE_COMPONENTS openthread)
 endif()
 
+if (NOT CMAKE_BUILD_EARLY_EXPANSION)
+    if (CONFIG_COMPILER_OPTIMIZATION_DEFAULT OR CONFIG_COMPILER_OPTIMIZATION_NONE)
+        set(is_debug TRUE)
+    else()
+        if (NOT CONFIG_COMPILER_OPTIMIZATION_ASSERTIONS_DISABLE)
+            message(FATAL_ERROR "CONFIG_COMPILER_OPTIMIZATION_ASSERTIONS_DISABLE shall be set")
+        endif()
+    endif()
+endif()
+
 idf_component_register(SRCS chip.c chip.cpp
                        PRIV_REQUIRES ${CHIP_REQURIE_COMPONENTS})
 
@@ -62,7 +72,7 @@ chip_gn_arg_append("esp32_ar"              "\"${CMAKE_AR}\"")
 chip_gn_arg_append("esp32_cc"              "\"${CMAKE_C_COMPILER}\"")
 chip_gn_arg_append("esp32_cxx"             "\"${CMAKE_CXX_COMPILER}\"")
 chip_gn_arg_append("esp32_cpu"             "\"esp32\"")
-chip_gn_arg_bool("is_debug"                is_debug)
+chip_gn_arg_bool("is_debug"                ${is_debug})
 
 if(CONFIG_BT_ENABLED)
 chip_gn_arg_append("chip_config_network_layer_ble"           "true")


### PR DESCRIPTION


#### Problem

The debug level was not correctly synchronized between ESP-IDF and the
connectedhomeip library.

The different `NDEBUG` definitions are causing wrong `vtable` offest in [ConfigurationManager](https://github.com/project-chip/connectedhomeip/blob/master/src/include/platform/ConfigurationManager.h#L112).


#### Change overview

Set the gn `is_debug` option based on the IDF debug level.

#### Testing

Build & run. The `ConfigurationManager` is calling the correct functions now.

