### PR TITLE
Do not dispatch packet to Device/DeviceController

### DIFF
--- a/examples/all-clusters-app/esp32/main/main.cpp
+++ b/examples/all-clusters-app/esp32/main/main.cpp
@@ -498,7 +498,6 @@ WiFiWidget pairingWindowLED;
 class AppCallbacks : public AppDelegate
 {
 public:
-    void OnReceiveError() override { statusLED1.BlinkOnError(); }
     void OnRendezvousStarted() override { bluetoothLED.Set(true); }
     void OnRendezvousStopped() override
     {

--- a/src/app/DeviceProxy.h
+++ b/src/app/DeviceProxy.h
@@ -104,39 +104,4 @@ protected:
     uint32_t mMrpActiveInterval = CHIP_CONFIG_MRP_DEFAULT_ACTIVE_RETRY_INTERVAL;
 };
 
-/**
- * This class defines an interface for an object that the user of Device
- * can register as a delegate. The delegate object will be called by the
- * Device when a new message or status update is received from the corresponding
- * CHIP device.
- */
-class DLL_EXPORT DeviceStatusDelegate
-{
-public:
-    virtual ~DeviceStatusDelegate() {}
-
-    /**
-     * @brief
-     *   Called when a message is received from the device.
-     *
-     * @param[in] msg Received message buffer.
-     */
-    virtual void OnMessage(System::PacketBufferHandle && msg) = 0;
-
-    /**
-     * @brief
-     *   Called when response to OpenPairingWindow is received from the device.
-     *
-     * @param[in] status CHIP_NO_ERROR on success, or corresponding error.
-     */
-    virtual void OnPairingWindowOpenStatus(CHIP_ERROR status){};
-
-    /**
-     * @brief
-     *   Called when device status is updated.
-     *
-     */
-    virtual void OnStatusChange(void){};
-};
-
 } // namespace chip

--- a/src/app/OperationalDeviceProxy.cpp
+++ b/src/app/OperationalDeviceProxy.cpp
@@ -262,15 +262,7 @@ void OperationalDeviceProxy::Clear()
 {
     mCASESession.Clear();
 
-    mState          = State::Uninitialized;
-    mStatusDelegate = nullptr;
-    if (mInitParams.exchangeMgr)
-    {
-        // Ensure that any exchange contexts we have open get closed now,
-        // because we don't want them to call back in to us after this
-        // point.
-        mInitParams.exchangeMgr->CloseAllContextsForDelegate(this);
-    }
+    mState      = State::Uninitialized;
     mInitParams = DeviceProxyInitParams();
 }
 
@@ -282,34 +274,12 @@ void OperationalDeviceProxy::OnConnectionExpired(SessionHandle session)
     mSecureSession.ClearValue();
 }
 
-CHIP_ERROR OperationalDeviceProxy::OnMessageReceived(Messaging::ExchangeContext * exchange, const PayloadHeader & payloadHeader,
-                                                     System::PacketBufferHandle && msgBuf)
-{
-    if (mState == State::SecureConnected)
-    {
-        if (mStatusDelegate != nullptr)
-        {
-            mStatusDelegate->OnMessage(std::move(msgBuf));
-        }
-    }
-    return CHIP_NO_ERROR;
-}
-
 CHIP_ERROR OperationalDeviceProxy::ShutdownSubscriptions()
 {
     return app::InteractionModelEngine::GetInstance()->ShutdownSubscriptions(mInitParams.fabricInfo->GetFabricIndex(),
                                                                              GetDeviceId());
 }
 
-OperationalDeviceProxy::~OperationalDeviceProxy()
-{
-    if (mInitParams.exchangeMgr)
-    {
-        // Ensure that any exchange contexts we have open get closed now,
-        // because we don't want them to call back in to us after this
-        // point.
-        mInitParams.exchangeMgr->CloseAllContextsForDelegate(this);
-    }
-}
+OperationalDeviceProxy::~OperationalDeviceProxy() {}
 
 } // namespace chip

--- a/src/app/OperationalDeviceProxy.h
+++ b/src/app/OperationalDeviceProxy.h
@@ -42,8 +42,6 @@
 
 namespace chip {
 
-class DeviceStatusDelegate;
-
 struct DeviceProxyInitParams
 {
     SessionManager * sessionManager          = nullptr;
@@ -59,7 +57,7 @@ class OperationalDeviceProxy;
 typedef void (*OnDeviceConnected)(void * context, DeviceProxy * device);
 typedef void (*OnDeviceConnectionFailure)(void * context, NodeId deviceId, CHIP_ERROR error);
 
-class DLL_EXPORT OperationalDeviceProxy : public DeviceProxy, Messaging::ExchangeDelegate, public SessionEstablishmentDelegate
+class DLL_EXPORT OperationalDeviceProxy : public DeviceProxy, public SessionEstablishmentDelegate
 {
 public:
     virtual ~OperationalDeviceProxy();
@@ -128,16 +126,6 @@ public:
        onFailureCallback, app::TLVDataFilter tlvDataFilter = nullptr) override; void CancelIMResponseHandler(void * commandObj)
        override;
     */
-    /**
-     * @brief
-     *   This function is called when a message is received from the corresponding
-     *   device. The message ownership is transferred to the function, and it is expected
-     *   to release the message buffer before returning.
-     */
-    CHIP_ERROR OnMessageReceived(Messaging::ExchangeContext * exchange, const PayloadHeader & payloadHeader,
-                                 System::PacketBufferHandle && msgBuf) override;
-
-    void OnResponseTimeout(Messaging::ExchangeContext * ec) override {}
 
     /**
      *   Update data of the device.
@@ -146,13 +134,6 @@ public:
      *   will load the device settings first, before making the changes.
      */
     CHIP_ERROR UpdateDeviceData(const Transport::PeerAddress & addr, uint32_t mrpIdleInterval, uint32_t mrpActiveInterval);
-
-    /**
-     *   Set the delegate object which will be called when a message is received.
-     *   The user of this Device object must reset the delegate (by calling
-     *   SetDelegate(nullptr)) before releasing their delegate object.
-     */
-    void SetDelegate(DeviceStatusDelegate * delegate) { mStatusDelegate = delegate; }
 
     PeerId GetPeerId() const { return mPeerId; }
 
@@ -196,7 +177,6 @@ private:
 
     State mState = State::Uninitialized;
 
-    DeviceStatusDelegate * mStatusDelegate = nullptr;
     Optional<SessionHandle> mSecureSession = Optional<SessionHandle>::Missing();
 
     uint8_t mSequenceNumber = 0;

--- a/src/app/server/AppDelegate.h
+++ b/src/app/server/AppDelegate.h
@@ -26,7 +26,6 @@ class AppDelegate
 {
 public:
     virtual ~AppDelegate() {}
-    virtual void OnReceiveError() {}
     virtual void OnRendezvousStarted() {}
     virtual void OnRendezvousStopped() {}
     virtual void OnPairingWindowOpened() {}

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -72,7 +72,6 @@ Server Server::sServer;
 
 CHIP_ERROR Server::Init(AppDelegate * delegate, uint16_t secureServicePort, uint16_t unsecureServicePort)
 {
-    mAppDelegate          = delegate;
     mSecuredServicePort   = secureServicePort;
     mUnsecuredServicePort = unsecureServicePort;
 
@@ -161,11 +160,6 @@ CHIP_ERROR Server::Init(AppDelegate * delegate, uint16_t secureServicePort, uint
     // StartServer only enables commissioning mode if device has not been commissioned
     app::DnssdServer::Instance().StartServer();
 #endif
-
-    // TODO @pan-apple Use IM protocol ID.
-    // Register to receive unsolicited legacy ZCL messages from the exchange manager.
-    err = mExchangeMgr.RegisterUnsolicitedMessageHandlerForProtocol(Protocols::TempZCL::Id, this);
-    SuccessOrExit(err);
 
     err = mCASEServer.ListenForSessionEstablishment(&mExchangeMgr, &mTransports, chip::DeviceLayer::ConnectivityMgr().GetBleLayer(),
                                                     &mSessions, &mFabrics, &mSessionIDAllocator);
@@ -257,26 +251,6 @@ exit:
         mFabrics.ReleaseFabricIndex(kMinValidFabricIndex);
     }
     return err;
-}
-
-CHIP_ERROR Server::OnMessageReceived(Messaging::ExchangeContext * exchangeContext, const PayloadHeader & payloadHeader,
-                                     System::PacketBufferHandle && buffer)
-{
-    CHIP_ERROR err = CHIP_NO_ERROR;
-    VerifyOrReturnError(!buffer.IsNull(), err = CHIP_ERROR_INVALID_ARGUMENT);
-    // TODO: BDX messages will also be possible in the future.
-    HandleDataModelMessage(exchangeContext, std::move(buffer));
-
-    return err;
-}
-
-void Server::OnResponseTimeout(Messaging::ExchangeContext * ec)
-{
-    ChipLogProgress(AppServer, "Failed to receive response");
-    if (mAppDelegate != nullptr)
-    {
-        mAppDelegate->OnReceiveError();
-    }
 }
 
 } // namespace chip

--- a/src/app/server/Server.h
+++ b/src/app/server/Server.h
@@ -50,7 +50,7 @@ using ServerTransportMgr = chip::TransportMgr<chip::Transport::UDP
 #endif
                                               >;
 
-class Server : public Messaging::ExchangeDelegate
+class Server
 {
 public:
     CHIP_ERROR Init(AppDelegate * delegate = nullptr, uint16_t secureServicePort = CHIP_PORT,
@@ -129,13 +129,6 @@ private:
 
         CHIP_ERROR SyncDelete(FabricIndex fabricIndex, const char * key) override { return SyncDeleteKeyValue(key); };
     };
-
-    // Messaging::ExchangeDelegate
-    CHIP_ERROR OnMessageReceived(Messaging::ExchangeContext * exchangeContext, const PayloadHeader & payloadHeader,
-                                 System::PacketBufferHandle && buffer) override;
-    void OnResponseTimeout(Messaging::ExchangeContext * ec) override;
-
-    AppDelegate * mAppDelegate = nullptr;
 
 #if CONFIG_NETWORK_LAYER_BLE
     Ble::BleLayer * mBleLayer = nullptr;

--- a/src/app/tests/TestCommissionManager.cpp
+++ b/src/app/tests/TestCommissionManager.cpp
@@ -34,7 +34,6 @@ using chip::Server;
 
 // Mock function for linking
 void InitDataModelHandler(chip::Messaging::ExchangeManager * exchangeMgr) {}
-void HandleDataModelMessage(chip::Messaging::ExchangeContext * exchange, chip::System::PacketBufferHandle && buffer) {}
 
 namespace {
 

--- a/src/app/util/DataModelHandler.cpp
+++ b/src/app/util/DataModelHandler.cpp
@@ -51,37 +51,3 @@ void InitDataModelHandler(chip::Messaging::ExchangeManager * exchangeManager)
 #endif
 #endif
 }
-
-void HandleDataModelMessage(Messaging::ExchangeContext * exchange, System::PacketBufferHandle && buffer)
-{
-#ifdef USE_ZAP_CONFIG
-    EmberApsFrame frame;
-    bool ok = extractApsFrame(buffer->Start(), buffer->DataLength(), &frame) > 0;
-    if (ok)
-    {
-        ChipLogDetail(Zcl, "APS frame processing success!");
-    }
-    else
-    {
-        ChipLogDetail(Zcl, "APS frame processing failure!");
-        return;
-    }
-
-    uint8_t * message;
-    uint16_t messageLen = extractMessage(buffer->Start(), buffer->DataLength(), &message);
-    ok                  = emberAfProcessMessage(&frame,
-                               0, // type
-                               message, messageLen,
-                               exchange, // source identifier
-                               NULL);
-
-    if (ok)
-    {
-        ChipLogDetail(Zcl, "Data model processing success!");
-    }
-    else
-    {
-        ChipLogDetail(Zcl, "Data model processing failure!");
-    }
-#endif
-}

--- a/src/app/util/DataModelHandler.h
+++ b/src/app/util/DataModelHandler.h
@@ -33,14 +33,3 @@
  *
  */
 void InitDataModelHandler(chip::Messaging::ExchangeManager * exchangeMgr);
-
-/**
- * Handle a message that should be processed via our data model processing
- * codepath.
- *
- * @param [in] exchange The exchange on which the message was received.
- * @param [in] buffer The buffer holding the message.  This function guarantees
- *                    that it will free the buffer before returning.
- *
- */
-void HandleDataModelMessage(chip::Messaging::ExchangeContext * exchange, chip::System::PacketBufferHandle && buffer);

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -133,8 +133,6 @@ CHIP_ERROR DeviceController::Init(ControllerInitParams params)
 
     // TODO Exchange Mgr needs to be able to track multiple delegates. Delegate API should be able to query for the right delegate
     // to handle events.
-    ReturnErrorOnFailure(
-        params.systemState->ExchangeMgr()->RegisterUnsolicitedMessageHandlerForProtocol(Protocols::TempZCL::Id, this));
     params.systemState->ExchangeMgr()->SetDelegate(this);
 
 #if CHIP_DEVICE_CONFIG_ENABLE_DNSSD
@@ -301,29 +299,6 @@ CHIP_ERROR DeviceController::UpdateDevice(NodeId deviceId)
 #else
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 #endif // CHIP_DEVICE_CONFIG_ENABLE_DNSSD
-}
-
-CHIP_ERROR DeviceController::OnMessageReceived(Messaging::ExchangeContext * ec, const PayloadHeader & payloadHeader,
-                                               System::PacketBufferHandle && msgBuf)
-{
-    OperationalDeviceProxy * device = nullptr;
-
-    VerifyOrExit(mState == State::Initialized, ChipLogError(Controller, "OnMessageReceived was called in incorrect state"));
-    VerifyOrExit(ec != nullptr, ChipLogError(Controller, "OnMessageReceived was called with null exchange"));
-
-    device = FindOperationalDevice(ec->GetSessionHandle());
-    VerifyOrExit(device != nullptr, ChipLogError(Controller, "OnMessageReceived was called for unknown device object"));
-
-    device->OnMessageReceived(ec, payloadHeader, std::move(msgBuf));
-
-exit:
-    return CHIP_NO_ERROR;
-}
-
-void DeviceController::OnResponseTimeout(Messaging::ExchangeContext * ec)
-{
-    ChipLogProgress(Controller, "Time out! failed to receive response from Exchange: " ChipLogFormatExchange,
-                    ChipLogValueExchange(ec));
 }
 
 void DeviceController::OnNewConnection(SessionHandle session, Messaging::ExchangeManager * mgr) {}

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -186,8 +186,7 @@ typedef void (*OnOpenCommissioningWindow)(void * context, NodeId deviceId, CHIP_
  *   and device pairing information for individual devices). Alternatively, this class can retrieve the
  *   relevant information when the application tries to communicate with the device
  */
-class DLL_EXPORT DeviceController : public Messaging::ExchangeDelegate,
-                                    public Messaging::ExchangeMgrDelegate,
+class DLL_EXPORT DeviceController : public Messaging::ExchangeMgrDelegate,
 #if CHIP_DEVICE_CONFIG_ENABLE_DNSSD
                                     public AbstractDnssdDiscoveryController,
 #endif
@@ -402,11 +401,6 @@ protected:
 #endif // CHIP_DEVICE_CONFIG_ENABLE_DNSSD
 
 private:
-    //////////// ExchangeDelegate Implementation ///////////////
-    CHIP_ERROR OnMessageReceived(Messaging::ExchangeContext * ec, const PayloadHeader & payloadHeader,
-                                 System::PacketBufferHandle && msgBuf) override;
-    void OnResponseTimeout(Messaging::ExchangeContext * ec) override;
-
     OperationalDeviceProxy * FindOperationalDevice(SessionHandle session);
     OperationalDeviceProxy * FindOperationalDevice(NodeId id);
     void ReleaseOperationalDevice(OperationalDeviceProxy * device);

--- a/src/controller/CommissioneeDeviceProxy.h
+++ b/src/controller/CommissioneeDeviceProxy.h
@@ -37,7 +37,6 @@
 #include <lib/core/CHIPCore.h>
 #include <lib/support/DLLUtil.h>
 #include <messaging/ExchangeContext.h>
-#include <messaging/ExchangeDelegate.h>
 #include <messaging/ExchangeMgr.h>
 #include <messaging/Flags.h>
 #include <protocols/secure_channel/PASESession.h>
@@ -53,8 +52,6 @@
 #endif
 
 namespace chip {
-
-class DeviceStatusDelegate;
 
 constexpr size_t kOpCSRNonceLength       = 32;
 constexpr size_t kAttestationNonceLength = 32;
@@ -82,22 +79,12 @@ struct ControllerDeviceInitParams
     Controller::DeviceControllerInteractionModelDelegate * imDelegate = nullptr;
 };
 
-class CommissioneeDeviceProxy : public DeviceProxy, Messaging::ExchangeDelegate
+class CommissioneeDeviceProxy : public DeviceProxy
 {
 public:
     ~CommissioneeDeviceProxy();
     CommissioneeDeviceProxy() {}
     CommissioneeDeviceProxy(const CommissioneeDeviceProxy &) = delete;
-
-    /**
-     * @brief
-     *   Set the delegate object which will be called when a message is received.
-     *   The user of this Device object must reset the delegate (by calling
-     *   SetDelegate(nullptr)) before releasing their delegate object.
-     *
-     * @param[in] delegate   The pointer to the delegate object.
-     */
-    void SetDelegate(DeviceStatusDelegate * delegate) { mStatusDelegate = delegate; }
 
     /**
      * @brief
@@ -185,27 +172,6 @@ public:
      * @param session A handle to the secure session
      */
     void OnConnectionExpired(SessionHandle session) override;
-
-    /**
-     * @brief
-     *   This function is called when a message is received from the corresponding CHIP
-     *   device. The message ownership is transferred to the function, and it is expected
-     *   to release the message buffer before returning.
-     *
-     * @param[in] exchange      The exchange context the message was received
-     *                          on.  The Device guarantees that it will call
-     *                          Close() on exchange when it's done processing
-     *                          the message.
-     * @param[in] payloadHeader Reference to payload header in the message
-     * @param[in] msgBuf        The message buffer
-     */
-    CHIP_ERROR OnMessageReceived(Messaging::ExchangeContext * exchange, const PayloadHeader & payloadHeader,
-                                 System::PacketBufferHandle && msgBuf) override;
-
-    /**
-     * @brief ExchangeDelegate implementation of OnResponseTimeout.
-     */
-    void OnResponseTimeout(Messaging::ExchangeContext * exchange) override;
 
     /**
      *  In case there exists an open session to the device, mark it as expired.
@@ -334,8 +300,6 @@ private:
 #endif
 
     PASESession mPairing;
-
-    DeviceStatusDelegate * mStatusDelegate = nullptr;
 
     SessionManager * mSessionManager = nullptr;
 

--- a/src/controller/EmptyDataModelHandler.cpp
+++ b/src/controller/EmptyDataModelHandler.cpp
@@ -25,6 +25,3 @@
 #include <app/util/DataModelHandler.h>
 
 __attribute__((weak)) void InitDataModelHandler(chip::Messaging::ExchangeManager * exchangeMgr) {}
-__attribute__((weak)) void HandleDataModelMessage(chip::Messaging::ExchangeContext * exchange,
-                                                  chip::System::PacketBufferHandle && buffer)
-{}

--- a/src/controller/java/AndroidDeviceControllerWrapper.cpp
+++ b/src/controller/java/AndroidDeviceControllerWrapper.cpp
@@ -327,10 +327,6 @@ CHIP_ERROR AndroidDeviceControllerWrapper::InitializeOperationalCredentialsIssue
     return CHIP_NO_ERROR;
 }
 
-void AndroidDeviceControllerWrapper::OnMessage(chip::System::PacketBufferHandle && msg) {}
-
-void AndroidDeviceControllerWrapper::OnStatusChange(void) {}
-
 CHIP_ERROR AndroidDeviceControllerWrapper::SyncGetKeyValue(const char * key, void * value, uint16_t & size)
 {
     ChipLogProgress(chipTool, "KVS: Getting key %s", key);

--- a/src/controller/java/AndroidDeviceControllerWrapper.h
+++ b/src/controller/java/AndroidDeviceControllerWrapper.h
@@ -35,7 +35,6 @@
  * Generally it contains the DeviceController class itself, plus any related delegates/callbacks.
  */
 class AndroidDeviceControllerWrapper : public chip::Controller::DevicePairingDelegate,
-                                       public chip::DeviceStatusDelegate,
                                        public chip::Controller::OperationalCredentialsDelegate,
                                        public chip::PersistentStorageDelegate,
                                        public chip::FabricStorage
@@ -69,10 +68,6 @@ public:
     }
 
     void SetFabricIdForNextNOCRequest(chip::FabricId fabricId) override { mNextFabricId = fabricId; }
-
-    // DeviceStatusDelegate implementation
-    void OnMessage(chip::System::PacketBufferHandle && msg) override;
-    void OnStatusChange(void) override;
 
     // PersistentStorageDelegate implementation
     CHIP_ERROR SyncSetKeyValue(const char * key, const void * value, uint16_t size) override;


### PR DESCRIPTION
#### Problem
All messages should be handled by protocols via exchange manager. But legacy codes routes message to device controller.

#### Change overview
Do not dispatch packet to Device/DeviceController

#### Testing
Verified using unit-tests.