### PR TITLE
[chip-tool] Restart address update on failure

### DIFF
--- a/examples/chip-tool/commands/pairing/PairingCommand.cpp
+++ b/examples/chip-tool/commands/pairing/PairingCommand.cpp
@@ -425,11 +425,13 @@ CHIP_ERROR PairingCommand::UpdateNetworkAddress()
 void PairingCommand::OnAddressUpdateComplete(NodeId nodeId, CHIP_ERROR err)
 {
     ChipLogProgress(chipTool, "OnAddressUpdateComplete: %" PRIx64 ": %s", nodeId, ErrorStr(err));
-    if (err != CHIP_NO_ERROR && nodeId == mNodeId)
+    if (err != CHIP_NO_ERROR)
     {
-        // Set exit status only if the address update failed.
-        // Otherwise wait for OnCommissioningComplete() callback.
-        SetCommandExitStatus(err);
+        // For some devices, it may take more time to appear on the network and become discoverable
+        // over DNS-SD, so don't give up on failure and restart the address update. Note that this
+        // will not be repeated endlessly as each chip-tool command has a timeout (in the case of
+        // the `pairing` command it equals 120s).
+        UpdateNetworkAddress();
     }
 }
 


### PR DESCRIPTION
#### Problem
For some devices, it may take more time to appear on the network and become discoverable over DNS-SD. Some users reported issues with `chip-tool` failing to discover an address of a Thread Sleepy End Device because of certain delays in an SRP update processing. Consequently, they had to restart the entire commissioning to move on.

#### Change overview
Don't give up on the address resolution failure and restart the address update.

#### Testing
Tested using `chip-tool` and a Thread device by manually delaying the OTBR start.
