### PR TITLE
Refactor/Split ExchangeMgrDelegate

### DIFF
--- a/src/app/CASESessionManager.cpp
+++ b/src/app/CASESessionManager.cpp
@@ -111,18 +111,12 @@ CHIP_ERROR CASESessionManager::GetPeerAddress(NodeId nodeId, Transport::PeerAddr
     return CHIP_NO_ERROR;
 }
 
-void CASESessionManager::OnNewConnection(SessionHandle sessionHandle, Messaging::ExchangeManager * mgr)
-{
-    // TODO Update the MRP params based on the MRP params extracted from CASE, when this is available.
-}
-
-void CASESessionManager::OnConnectionExpired(SessionHandle sessionHandle, Messaging::ExchangeManager * mgr)
+void CASESessionManager::OnSessionReleased(SessionHandle sessionHandle)
 {
     OperationalDeviceProxy * session = FindSession(sessionHandle);
-    VerifyOrReturn(session != nullptr,
-                   ChipLogDetail(Controller, "OnConnectionExpired was called for unknown device, ignoring it."));
+    VerifyOrReturn(session != nullptr, ChipLogDetail(Controller, "OnSessionReleased was called for unknown device, ignoring it."));
 
-    session->OnConnectionExpired(sessionHandle);
+    session->OnSessionReleased(sessionHandle);
 }
 
 OperationalDeviceProxy * CASESessionManager::FindSession(SessionHandle session)

--- a/src/app/CASESessionManager.h
+++ b/src/app/CASESessionManager.h
@@ -23,7 +23,7 @@
 #include <lib/core/CHIPCore.h>
 #include <lib/dnssd/DnssdCache.h>
 #include <lib/support/Pool.h>
-#include <messaging/ExchangeMgrDelegate.h>
+#include <transport/SessionDelegate.h>
 
 #include <lib/dnssd/Resolver.h>
 
@@ -43,7 +43,7 @@ struct CASESessionManagerConfig
  * 4. During session establishment, trigger node ID resolution (if needed), and update the DNS-SD cache (if resolution is
  * successful)
  */
-class CASESessionManager : public Messaging::ExchangeMgrDelegate, public Dnssd::ResolverDelegate
+class CASESessionManager : public SessionReleaseDelegate, public Dnssd::ResolverDelegate
 {
 public:
     CASESessionManager() = delete;
@@ -91,9 +91,8 @@ public:
      */
     CHIP_ERROR GetPeerAddress(NodeId nodeId, Transport::PeerAddress & addr);
 
-    //////////// ExchangeMgrDelegate Implementation ///////////////
-    void OnNewConnection(SessionHandle session, Messaging::ExchangeManager * mgr) override;
-    void OnConnectionExpired(SessionHandle session, Messaging::ExchangeManager * mgr) override;
+    //////////// SessionReleaseDelegate Implementation ///////////////
+    void OnSessionReleased(SessionHandle session) override;
 
     //////////// ResolverDelegate Implementation ///////////////
     void OnNodeIdResolved(const Dnssd::ResolvedNodeData & nodeData) override;

--- a/src/app/DeviceProxy.h
+++ b/src/app/DeviceProxy.h
@@ -43,12 +43,6 @@ public:
     DeviceProxy() {}
 
     /**
-     *   Called when a connection is closing.
-     *   The object releases all resources associated with the connection.
-     */
-    virtual void OnConnectionExpired(SessionHandle session) = 0;
-
-    /**
      *  Mark any open session with the device as expired.
      */
     virtual CHIP_ERROR Disconnect() = 0;

--- a/src/app/OperationalDeviceProxy.cpp
+++ b/src/app/OperationalDeviceProxy.cpp
@@ -229,6 +229,7 @@ void OperationalDeviceProxy::OnSessionEstablished()
     VerifyOrReturn(mState != State::Uninitialized,
                    ChipLogError(Controller, "OnSessionEstablished was called while the device was not initialized"));
 
+    // TODO Update the MRP params based on the MRP params extracted from CASE, when this is available.
     CHIP_ERROR err = mInitParams.sessionManager->NewPairing(
         Optional<Transport::PeerAddress>::Value(mDeviceAddress), mPeerId.GetNodeId(), &mCASESession,
         CryptoContext::SessionRole::kInitiator, mInitParams.fabricInfo->GetFabricIndex());
@@ -267,7 +268,7 @@ void OperationalDeviceProxy::Clear()
     mInitParams = DeviceProxyInitParams();
 }
 
-void OperationalDeviceProxy::OnConnectionExpired(SessionHandle session)
+void OperationalDeviceProxy::OnSessionReleased(SessionHandle session)
 {
     VerifyOrReturn(mSecureSession.HasValue() && mSecureSession.Value() == session,
                    ChipLogDetail(Controller, "Connection expired, but it doesn't match the current session"));

--- a/src/app/OperationalDeviceProxy.h
+++ b/src/app/OperationalDeviceProxy.h
@@ -69,7 +69,7 @@ class OperationalDeviceProxy;
 typedef void (*OnDeviceConnected)(void * context, DeviceProxy * device);
 typedef void (*OnDeviceConnectionFailure)(void * context, NodeId deviceId, CHIP_ERROR error);
 
-class DLL_EXPORT OperationalDeviceProxy : public DeviceProxy, public SessionEstablishmentDelegate
+class DLL_EXPORT OperationalDeviceProxy : public DeviceProxy, SessionReleaseDelegate, public SessionEstablishmentDelegate
 {
 public:
     virtual ~OperationalDeviceProxy();
@@ -113,7 +113,7 @@ public:
      *   Called when a connection is closing.
      *   The object releases all resources associated with the connection.
      */
-    void OnConnectionExpired(SessionHandle session) override;
+    void OnSessionReleased(SessionHandle session) override;
 
     void OnNodeIdResolved(const Dnssd::ResolvedNodeData & nodeResolutionData)
     {

--- a/src/channel/Manager.h
+++ b/src/channel/Manager.h
@@ -34,10 +34,13 @@ class ChannelContext;
  *  @brief
  *    This class is used to manage Channel Contexts with other CHIP nodes.
  */
-class DLL_EXPORT ChannelManager : public ExchangeMgrDelegate
+class DLL_EXPORT ChannelManager : public SessionCreationDelegate
 {
 public:
-    ChannelManager(ExchangeManager * exchangeManager) : mExchangeManager(exchangeManager) { exchangeManager->SetDelegate(this); }
+    ChannelManager(ExchangeManager * exchangeManager) : mExchangeManager(exchangeManager)
+    {
+        exchangeManager->GetSessionManager()->RegisterCreationDelegate(*this);
+    }
     ChannelManager(const ChannelManager &) = delete;
     ChannelManager operator=(const ChannelManager &) = delete;
 
@@ -58,24 +61,12 @@ public:
         });
     }
 
-    void OnNewConnection(SessionHandle session, ExchangeManager * mgr) override
+    void OnNewSession(SessionHandle session) override
     {
         mChannelContexts.ForEachActiveObject([&](ChannelContext * context) {
-            if (context->MatchesSession(session, mgr->GetSessionManager()))
+            if (context->MatchesSession(session, mExchangeManager->GetSessionManager()))
             {
                 context->OnNewConnection(session);
-                return false;
-            }
-            return true;
-        });
-    }
-
-    void OnConnectionExpired(SessionHandle session, ExchangeManager * mgr) override
-    {
-        mChannelContexts.ForEachActiveObject([&](ChannelContext * context) {
-            if (context->MatchesSession(session, mgr->GetSessionManager()))
-            {
-                context->OnConnectionExpired(session);
                 return false;
             }
             return true;

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -48,7 +48,6 @@
 #include <lib/support/SerializableIntegerSet.h>
 #include <lib/support/Span.h>
 #include <messaging/ExchangeMgr.h>
-#include <messaging/ExchangeMgrDelegate.h>
 #include <protocols/secure_channel/MessageCounterManager.h>
 #include <protocols/secure_channel/RendezvousParameters.h>
 #include <protocols/user_directed_commissioning/UserDirectedCommissioning.h>
@@ -187,7 +186,7 @@ typedef void (*OnOpenCommissioningWindow)(void * context, NodeId deviceId, CHIP_
  *   and device pairing information for individual devices). Alternatively, this class can retrieve the
  *   relevant information when the application tries to communicate with the device
  */
-class DLL_EXPORT DeviceController : public Messaging::ExchangeMgrDelegate,
+class DLL_EXPORT DeviceController : public SessionReleaseDelegate,
 #if CHIP_DEVICE_CONFIG_ENABLE_DNSSD
                                     public AbstractDnssdDiscoveryController,
 #endif
@@ -376,9 +375,8 @@ protected:
 
     uint16_t mVendorId;
 
-    //////////// ExchangeMgrDelegate Implementation ///////////////
-    void OnNewConnection(SessionHandle session, Messaging::ExchangeManager * mgr) override {}
-    void OnConnectionExpired(SessionHandle session, Messaging::ExchangeManager * mgr) override;
+    //////////// SessionReleaseDelegate Implementation ///////////////
+    void OnSessionReleased(SessionHandle session) override;
 
 #if CHIP_DEVICE_CONFIG_ENABLE_DNSSD
     //////////// ResolverDelegate Implementation ///////////////
@@ -412,12 +410,12 @@ private:
  *   will be stored.
  */
 class DLL_EXPORT DeviceCommissioner : public DeviceController,
+                                      public SessionCreationDelegate,
 #if CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY // make this commissioner discoverable
                                       public Protocols::UserDirectedCommissioning::InstanceNameResolver,
                                       public Protocols::UserDirectedCommissioning::UserConfirmationProvider,
 #endif
                                       public SessionEstablishmentDelegate
-
 {
 public:
     DeviceCommissioner();
@@ -624,9 +622,10 @@ private:
 
     void OnSessionEstablishmentTimeout();
 
-    //////////// ExchangeMgrDelegate Implementation ///////////////
-    void OnNewConnection(SessionHandle session, Messaging::ExchangeManager * mgr) override;
-    void OnConnectionExpired(SessionHandle session, Messaging::ExchangeManager * mgr) override;
+    //////////// SessionCreationDelegate Implementation ///////////////
+    void OnNewSession(SessionHandle session) override;
+    //////////// SessionReleaseDelegate Implementation ///////////////
+    void OnSessionReleased(SessionHandle session) override;
 
     static void OnSessionEstablishmentTimeoutCallback(System::Layer * aLayer, void * aAppState);
 

--- a/src/controller/CommissioneeDeviceProxy.cpp
+++ b/src/controller/CommissioneeDeviceProxy.cpp
@@ -92,7 +92,7 @@ void CommissioneeDeviceProxy::OnNewConnection(SessionHandle session)
     mSecureSession.SetValue(session);
 }
 
-void CommissioneeDeviceProxy::OnConnectionExpired(SessionHandle session)
+void CommissioneeDeviceProxy::OnSessionReleased(SessionHandle session)
 {
     VerifyOrReturn(mSecureSession.HasValue() && mSecureSession.Value() == session,
                    ChipLogDetail(Controller, "Connection expired, but it doesn't match the current session"));

--- a/src/controller/CommissioneeDeviceProxy.h
+++ b/src/controller/CommissioneeDeviceProxy.h
@@ -79,7 +79,7 @@ struct ControllerDeviceInitParams
     Controller::DeviceControllerInteractionModelDelegate * imDelegate = nullptr;
 };
 
-class CommissioneeDeviceProxy : public DeviceProxy
+class CommissioneeDeviceProxy : public DeviceProxy, public SessionReleaseDelegate
 {
 public:
     ~CommissioneeDeviceProxy();
@@ -165,13 +165,13 @@ public:
 
     /**
      * @brief
-     *   Called when a connection is closing.
+     *   Called when the associated session is released
      *
      *   The receiver should release all resources associated with the connection.
      *
      * @param session A handle to the secure session
      */
-    void OnConnectionExpired(SessionHandle session) override;
+    void OnSessionReleased(SessionHandle session) override;
 
     /**
      *  In case there exists an open session to the device, mark it as expired.

--- a/src/controller/tests/data_model/TestRead.cpp
+++ b/src/controller/tests/data_model/TestRead.cpp
@@ -235,7 +235,7 @@ void TestReadInteraction::TestReadTimeout(nlTestSuite * apSuite, void * apContex
     NL_TEST_ASSERT(apSuite, chip::app::InteractionModelEngine::GetInstance()->GetNumActiveReadClients() == 1);
     NL_TEST_ASSERT(apSuite, ctx.GetExchangeManager().GetNumActiveExchanges() == 2);
 
-    ctx.GetExchangeManager().OnConnectionExpired(ctx.GetSessionBobToAlice());
+    ctx.GetExchangeManager().ExpireExchangesForSession(ctx.GetSessionBobToAlice());
 
     ctx.DrainAndServiceIO();
 
@@ -251,7 +251,7 @@ void TestReadInteraction::TestReadTimeout(nlTestSuite * apSuite, void * apContex
     chip::app::InteractionModelEngine::GetInstance()->GetReportingEngine().Run();
     ctx.DrainAndServiceIO();
 
-    ctx.GetExchangeManager().OnConnectionExpired(ctx.GetSessionAliceToBob());
+    ctx.GetExchangeManager().ExpireExchangesForSession(ctx.GetSessionAliceToBob());
 
     NL_TEST_ASSERT(apSuite, chip::app::InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers() == 0);
 

--- a/src/lib/core/CHIPConfig.h
+++ b/src/lib/core/CHIPConfig.h
@@ -2674,5 +2674,23 @@ extern const char CHIP_NON_PRODUCTION_MARKER[];
 #endif
 
 /**
+ * @def CHIP_CONFIG_MAX_SESSION_CREATION_DELEGATES
+ *
+ * @brief Defines the max number of SessionCreationDelegates
+ */
+#ifndef CHIP_CONFIG_MAX_SESSION_CREATION_DELEGATES
+#define CHIP_CONFIG_MAX_SESSION_CREATION_DELEGATES 2
+#endif
+
+/**
+ * @def CHIP_CONFIG_MAX_SESSION_RELEASE_DELEGATES
+ *
+ * @brief Defines the max number of SessionReleaseDelegate
+ */
+#ifndef CHIP_CONFIG_MAX_SESSION_RELEASE_DELEGATES
+#define CHIP_CONFIG_MAX_SESSION_RELEASE_DELEGATES 2
+#endif
+
+/**
  * @}
  */

--- a/src/messaging/BUILD.gn
+++ b/src/messaging/BUILD.gn
@@ -42,7 +42,6 @@ static_library("messaging") {
     "ExchangeMessageDispatch.h",
     "ExchangeMgr.cpp",
     "ExchangeMgr.h",
-    "ExchangeMgrDelegate.h",
     "Flags.h",
     "ReliableMessageContext.cpp",
     "ReliableMessageContext.h",

--- a/src/messaging/ExchangeMgr.cpp
+++ b/src/messaging/ExchangeMgr.cpp
@@ -59,7 +59,7 @@ namespace Messaging {
  *    prior to use.
  *
  */
-ExchangeManager::ExchangeManager() : mDelegate(nullptr), mReliableMessageMgr(mContextPool)
+ExchangeManager::ExchangeManager() : mReliableMessageMgr(mContextPool)
 {
     mState = State::kState_NotInitialized;
 }
@@ -83,7 +83,8 @@ CHIP_ERROR ExchangeManager::Init(SessionManager * sessionManager)
         handler.Reset();
     }
 
-    sessionManager->SetDelegate(this);
+    sessionManager->RegisterReleaseDelegate(*this);
+    sessionManager->SetMessageDelegate(this);
 
     mReliableMessageMgr.Init(sessionManager->SystemLayer(), sessionManager);
     ReturnErrorOnFailure(mDefaultExchangeDispatch.Init(mSessionManager));
@@ -105,7 +106,8 @@ CHIP_ERROR ExchangeManager::Shutdown()
 
     if (mSessionManager != nullptr)
     {
-        mSessionManager->SetDelegate(nullptr);
+        mSessionManager->SetMessageDelegate(nullptr);
+        mSessionManager->UnregisterReleaseDelegate(*this);
         mSessionManager = nullptr;
     }
 
@@ -150,16 +152,6 @@ CHIP_ERROR ExchangeManager::UnregisterUnsolicitedMessageHandlerForProtocol(Proto
 CHIP_ERROR ExchangeManager::UnregisterUnsolicitedMessageHandlerForType(Protocols::Id protocolId, uint8_t msgType)
 {
     return UnregisterUMH(protocolId, static_cast<int16_t>(msgType));
-}
-
-void ExchangeManager::OnReceiveError(CHIP_ERROR error, const Transport::PeerAddress & source)
-{
-#if CHIP_ERROR_LOGGING
-    char srcAddressStr[Transport::PeerAddress::kMaxToStringSize];
-    source.ToString(srcAddressStr);
-
-    ChipLogError(ExchangeManager, "Error receiving message from %s: %s", srcAddressStr, ErrorStr(error));
-#endif // CHIP_ERROR_LOGGING
 }
 
 CHIP_ERROR ExchangeManager::RegisterUMH(Protocols::Id protocolId, int16_t msgType, ExchangeDelegate * delegate)
@@ -326,21 +318,13 @@ void ExchangeManager::OnMessageReceived(const PacketHeader & packetHeader, const
     }
 }
 
-void ExchangeManager::OnNewConnection(SessionHandle session)
+void ExchangeManager::OnSessionReleased(SessionHandle session)
 {
-    if (mDelegate != nullptr)
-    {
-        mDelegate->OnNewConnection(session, this);
-    }
+    ExpireExchangesForSession(session);
 }
 
-void ExchangeManager::OnConnectionExpired(SessionHandle session)
+void ExchangeManager::ExpireExchangesForSession(SessionHandle session)
 {
-    if (mDelegate != nullptr)
-    {
-        mDelegate->OnConnectionExpired(session, this);
-    }
-
     mContextPool.ForEachActiveObject([&](auto * ec) {
         if (ec->mSession.HasValue() && ec->mSession.Value() == session)
         {

--- a/src/messaging/tests/TestExchangeMgr.cpp
+++ b/src/messaging/tests/TestExchangeMgr.cpp
@@ -124,7 +124,7 @@ void CheckSessionExpirationBasics(nlTestSuite * inSuite, void * inContext)
     ExchangeContext * ec1 = ctx.NewExchangeToBob(&sendDelegate);
 
     // Expire the session this exchange is supposedly on.
-    ctx.GetExchangeManager().OnConnectionExpired(ec1->GetSessionHandle());
+    ctx.GetExchangeManager().ExpireExchangesForSession(ec1->GetSessionHandle());
 
     MockAppDelegate receiveDelegate;
     CHIP_ERROR err =
@@ -154,7 +154,7 @@ void CheckSessionExpirationTimeout(nlTestSuite * inSuite, void * inContext)
 
     // Expire the session this exchange is supposedly on.  This should close the
     // exchange.
-    ctx.GetExchangeManager().OnConnectionExpired(ec1->GetSessionHandle());
+    ctx.GetExchangeManager().ExpireExchangesForSession(ec1->GetSessionHandle());
     NL_TEST_ASSERT(inSuite, sendDelegate.IsOnResponseTimeoutCalled);
 }
 

--- a/src/transport/BUILD.gn
+++ b/src/transport/BUILD.gn
@@ -26,18 +26,23 @@ static_library("transport") {
     "FabricTable.h",
     "MessageCounter.cpp",
     "MessageCounter.h",
+    "MessageCounterManagerInterface.h",
     "PeerMessageCounter.h",
     "SecureMessageCodec.cpp",
     "SecureMessageCodec.h",
     "SecureSession.h",
     "SecureSessionTable.h",
+    "SessionDelegate.h",
     "SessionHandle.cpp",
     "SessionHandle.h",
     "SessionManager.cpp",
     "SessionManager.h",
+    "SessionMessageCounter.h",
+    "SessionMessageDelegate.h",
     "TransportMgr.h",
     "TransportMgrBase.cpp",
     "TransportMgrBase.h",
+    "UnauthenticatedSessionTable.h",
   ]
 
   cflags = [ "-Wconversion" ]

--- a/src/transport/SessionDelegate.h
+++ b/src/transport/SessionDelegate.h
@@ -1,5 +1,4 @@
 /*
- *
  *    Copyright (c) 2021 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,45 +14,38 @@
  *    limitations under the License.
  */
 
-/**
- *    @file
- *      This file defines the classes corresponding to CHIP Exchange Manager Delegate.
- *
- */
-
 #pragma once
 
-#include <system/SystemPacketBuffer.h>
-#include <transport/SessionManager.h>
+#include <transport/SessionHandle.h>
 
 namespace chip {
-namespace Messaging {
 
-class ExchangeManager;
-
-class DLL_EXPORT ExchangeMgrDelegate
+class DLL_EXPORT SessionCreationDelegate
 {
 public:
-    virtual ~ExchangeMgrDelegate() {}
+    virtual ~SessionCreationDelegate() {}
 
     /**
      * @brief
-     *   Called when a new pairing is being established
+     *   Called when a new session is being established
      *
      * @param session   The handle to the secure session
-     * @param mgr       A pointer to the ExchangeManager
      */
-    virtual void OnNewConnection(SessionHandle session, ExchangeManager * mgr) {}
-
-    /**
-     * @brief
-     *   Called when a connection is closing
-     *
-     * @param session   The handle to the secure session
-     * @param mgr       A pointer to the ExchangeManager
-     */
-    virtual void OnConnectionExpired(SessionHandle session, ExchangeManager * mgr) {}
+    virtual void OnNewSession(SessionHandle session) = 0;
 };
 
-} // namespace Messaging
+class DLL_EXPORT SessionReleaseDelegate
+{
+public:
+    virtual ~SessionReleaseDelegate() {}
+
+    /**
+     * @brief
+     *   Called when a session is releasing
+     *
+     * @param session   The handle to the secure session
+     */
+    virtual void OnSessionReleased(SessionHandle session) = 0;
+};
+
 } // namespace chip

--- a/src/transport/SessionMessageDelegate.h
+++ b/src/transport/SessionMessageDelegate.h
@@ -1,0 +1,58 @@
+/*
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <transport/SessionHandle.h>
+
+namespace chip {
+
+/**
+ * @brief
+ *   This class provides a skeleton for the callback functions. The functions will be
+ *   called by SecureSssionMgrBase object on specific events. If the user of SessionManager
+ *   is interested in receiving these callbacks, they can specialize this class and handle
+ *   each trigger in their implementation of this class.
+ */
+class DLL_EXPORT SessionMessageDelegate
+{
+public:
+    virtual ~SessionMessageDelegate() {}
+
+    enum class DuplicateMessage : uint8_t
+    {
+        Yes,
+        No,
+    };
+
+    /**
+     * @brief
+     *   Called when a new message is received. The function must internally release the
+     *   msgBuf after processing it.
+     *
+     * @param packetHeader  The message header
+     * @param payloadHeader The payload header
+     * @param session       The handle to the secure session
+     * @param source        The sender's address
+     * @param isDuplicate   The message is a duplicate of previously received message
+     * @param msgBuf        The received message
+     */
+    virtual void OnMessageReceived(const PacketHeader & packetHeader, const PayloadHeader & payloadHeader, SessionHandle session,
+                                   const Transport::PeerAddress & source, DuplicateMessage isDuplicate,
+                                   System::PacketBufferHandle && msgBuf) = 0;
+};
+
+} // namespace chip


### PR DESCRIPTION
#### Problem
`SessionManageDelegate` and `ExchangeMgrDelegate` do not fit their role.

#### Change overview
There are totally 4 callbacks in `SessionManageDelegate`:
* OnNewConnection
* OnConnectionExpired
* OnMessageReceived
* OnReceiveError

`ExchangeMgrDelegate` duplicate 2 callbacks:
* OnNewConnection
* OnConnectionExpired

This shouldn't be how these callback works.

In This PR, these callbacks will be split into 3 delegate classes:
* `SessionCreationDelegate::OnNewSession`: device controller is the only receiver now, exchange manager doesn't need this event.
* `SessionReleaseDelegate::OnSessionReleased`: everything holding a session should be the receiver of this event, including `ExchangeManager`, `DeviceController`, 
* `SessionMessageDelegate::OnMessageReceived`: `ExchangeManager` is the only receiver, all messages are handled by the `ExchangeManager`

`OnReceiveError` event is removed, we log all error path inside `SessionManager` the event is not needed for applications.

#### Testing
Verified using unit-tests.