### PR TITLE
Fix unit tests for build_examples.py

### DIFF
--- a/scripts/build/testdata/all_targets_except_host.txt
+++ b/scripts/build/testdata/all_targets_except_host.txt
@@ -23,8 +23,8 @@ esp32-devkitc-shell
 esp32-devkitc-temperature-measurement
 esp32-m5stack-all-clusters
 esp32-m5stack-all-clusters-ipv6only
-esp32-m5stack-all-clusters-rpc
-esp32-m5stack-all-clusters-rpc-ipv6only
+esp32-m5stack-all-clusters-rpc (NOGLOB: Generate error in v4.4 IDF SDK)
+esp32-m5stack-all-clusters-rpc-ipv6only (NOGLOB: Generate error in v4.4 IDF SDK)
 infineon-p6-all-clusters
 infineon-p6-lock
 mbed-CY8CPROTO_062_4343W-all-clusters-debug (NOGLOB: Compile only for debugging purpose - https://os.mbed.com/docs/mbed-os/latest/program-setup/build-profiles-and-rules.html)

--- a/scripts/build/testdata/glob_star_targets_except_host.txt
+++ b/scripts/build/testdata/glob_star_targets_except_host.txt
@@ -23,8 +23,6 @@ esp32-devkitc-shell
 esp32-devkitc-temperature-measurement
 esp32-m5stack-all-clusters
 esp32-m5stack-all-clusters-ipv6only
-esp32-m5stack-all-clusters-rpc
-esp32-m5stack-all-clusters-rpc-ipv6only
 infineon-p6-all-clusters
 infineon-p6-lock
 mbed-CY8CPROTO_062_4343W-all-clusters-release


### PR DESCRIPTION
#### Problem
Unit tests were not updated when rpc builds were blacklisted for esp32