### PR TITLE
[YAML] Add saveAs keyword for response fields and command arguments

### DIFF
--- a/examples/chip-tool/commands/tests/TestCommand.h
+++ b/examples/chip-tool/commands/tests/TestCommand.h
@@ -96,7 +96,14 @@ protected:
     {
         if (current == expected)
         {
-            Exit(std::string(itemName) + " value == notValue: " + std::to_string(current) + " == " + std::to_string(expected));
+            if (std::is_same<T, const chip::Span<const uint8_t>>::value || std::is_same<T, const chip::Span<const char>>::value)
+            {
+                Exit(std::string(itemName) + " value == notValue");
+            }
+            else
+            {
+                Exit(std::string(itemName) + " value == notValue: " + std::to_string(current) + " == " + std::to_string(expected));
+            }
             return false;
         }
 

--- a/examples/chip-tool/templates/partials/test_cluster.zapt
+++ b/examples/chip-tool/templates/partials/test_cluster.zapt
@@ -49,6 +49,14 @@ class {{filename}}: public TestCommand
     std::atomic_uint16_t mTestIndex;
     const uint16_t mTestCount = {{totalTests}};
 
+    {{#chip_tests_items}}
+    {{#chip_tests_item_response_parameters}}
+    {{#if saveAs}}
+    {{chipType}} {{saveAs}};
+    {{/if}}
+    {{/chip_tests_item_response_parameters}}
+    {{/chip_tests_items}}
+
     {{#*inline "failureCallback"}}mOnFailureCallback_{{index}}{{/inline}}
     {{#*inline "successCallback"}}mOnSuccessCallback_{{index}}{{/inline}}
     {{#*inline "failureResponse"}}OnFailureCallback_{{index}}{{/inline}}
@@ -230,6 +238,10 @@ class {{filename}}: public TestCommand
               {{~#if expectedConstraints.minValue}}VerifyOrReturn(CheckConstraintMinValue<{{chipType}}>("{{>item}}", {{>item}}, {{expectedConstraints.minValue}}));{{/if}}
               {{~#if expectedConstraints.maxValue}}VerifyOrReturn(CheckConstraintMaxValue<{{chipType}}>("{{>item}}", {{>item}}, {{expectedConstraints.maxValue}}));{{/if}}
               {{~#if expectedConstraints.notValue}}VerifyOrReturn(CheckConstraintNotValue<{{chipType}}>("{{>item}}", {{>item}}, {{expectedConstraints.notValue}}));{{/if}}
+            {{/if}}
+
+            {{#if saveAs}}
+            {{saveAs}} = {{>item}};
             {{/if}}
           {{/chip_tests_item_response_parameters}}
         {{#unless async}}NextTest();{{/unless}}

--- a/examples/chip-tool/templates/partials/test_cluster_command_value.zapt
+++ b/examples/chip-tool/templates/partials/test_cluster_command_value.zapt
@@ -39,7 +39,7 @@
       {{#if_is_bitmap type}}
       static_cast<{{zapTypeToEncodableClusterObjectType type ns=ns}}>({{definedValue}});
       {{else}}
-      {{definedValue}}{{asTypeLiteralSuffix type}};
+      {{asTypeLiteralSuffix definedValue type}};
       {{/if_is_bitmap}}
     {{/if_chip_enum}}
   {{/if_is_struct}}

--- a/examples/chip-tool/templates/partials/test_cluster_value_equals.zapt
+++ b/examples/chip-tool/templates/partials/test_cluster_value_equals.zapt
@@ -31,7 +31,7 @@
     VerifyOrReturn(CheckValue
       {{~#if (isOctetString type)}}AsString("{{label}}", {{actual}}, chip::ByteSpan(chip::Uint8::from_const_char("{{octetStringEscapedForCLiteral expected}}"), {{expected.length}}))
       {{else if (isCharString type)}}AsString("{{label}}", {{actual}}, chip::CharSpan("{{expected}}", {{expected.length}}))
-      {{else}}<{{chipType}}>("{{label}}", {{actual}}, {{expected}}{{asTypeLiteralSuffix type}})
+      {{else}}<{{chipType}}>("{{label}}", {{actual}}, {{asTypeLiteralSuffix expected type}})
       {{/if}}
     );
   {{/if_is_struct}}

--- a/examples/chip-tool/templates/tests.js
+++ b/examples/chip-tool/templates/tests.js
@@ -182,6 +182,7 @@ function getTests()
     'TestConstraints',
     'TestDelayCommands',
     'TestLogCommands',
+    'TestSaveAs',
     'TestDescriptorCluster',
     'TestBasicInformation',
     'TestIdentifyCluster',

--- a/src/app/tests/suites/TestConstraints.yaml
+++ b/src/app/tests/suites/TestConstraints.yaml
@@ -47,3 +47,9 @@ tests:
       response:
           constraints:
               notValue: 6
+
+    - label: "Write attribute INT32U Value Back to Default Value"
+      command: "writeAttribute"
+      attribute: "int32u"
+      arguments:
+          value: 0

--- a/src/app/tests/suites/TestSaveAs.yaml
+++ b/src/app/tests/suites/TestSaveAs.yaml
@@ -1,0 +1,673 @@
+# Copyright (c) 2021 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Test Cluster Tests
+
+config:
+    cluster: "Test Cluster"
+    endpoint: 1
+
+tests:
+    - label: "Send Test Add Arguments Command"
+      command: "testAddArguments"
+      arguments:
+          values:
+              - name: "arg1"
+                value: 3
+              - name: "arg2"
+                value: 17
+      response:
+          values:
+              - name: "returnValue"
+                saveAs: TestAddArgumentDefaultValue
+                value: 20
+
+    - label: "Send Test Add Arguments Command"
+      command: "testAddArguments"
+      arguments:
+          values:
+              - name: "arg1"
+                value: 3
+              - name: "arg2"
+                value: 17
+      response:
+          values:
+              - name: "returnValue"
+                value: TestAddArgumentDefaultValue
+
+    - label: "Send Test Add Arguments Command"
+      command: "testAddArguments"
+      arguments:
+          values:
+              - name: "arg1"
+                value: 3
+              - name: "arg2"
+                value: TestAddArgumentDefaultValue
+      response:
+          values:
+              - name: "returnValue"
+                constraints:
+                    notValue: TestAddArgumentDefaultValue
+
+    # Tests for Boolean attribute
+
+    - label: "Read attribute BOOLEAN Default Value"
+      command: "readAttribute"
+      attribute: "boolean"
+      response:
+          saveAs: readAttributeBooleanDefaultValue
+          value: 0
+
+    - label: "Write attribute BOOLEAN Not Default Value"
+      command: "writeAttribute"
+      attribute: "boolean"
+      arguments:
+          value: 1
+
+    - label: "Read attribute BOOLEAN Not Default Value"
+      command: "readAttribute"
+      attribute: "boolean"
+      response:
+          constraints:
+              notValue: readAttributeBooleanDefaultValue
+
+    - label: "Write attribute BOOLEAN DefaultValue"
+      command: "writeAttribute"
+      attribute: "boolean"
+      arguments:
+          value: readAttributeBooleanDefaultValue
+
+    - label: "Read attribute BOOLEAN False"
+      command: "readAttribute"
+      attribute: "boolean"
+      response:
+          value: readAttributeBooleanDefaultValue
+
+    # Tests for Bitmap8 attribute
+
+    - label: "Read attribute BITMAP8 Default Value"
+      command: "readAttribute"
+      attribute: "bitmap8"
+      response:
+          saveAs: readAttributeBitmap8DefaultValue
+          value: 0
+
+    - label: "Write attribute BITMAP8 Not Default Value"
+      command: "writeAttribute"
+      attribute: "bitmap8"
+      arguments:
+          value: 1
+
+    - label: "Read attribute BITMAP8 Not Default Value"
+      command: "readAttribute"
+      attribute: "bitmap8"
+      response:
+          constraints:
+              notValue: readAttributeBitmap8DefaultValue
+
+    - label: "Write attribute BITMAP8 Default Value"
+      command: "writeAttribute"
+      attribute: "bitmap8"
+      arguments:
+          value: readAttributeBitmap8DefaultValue
+
+    - label: "Read attribute BITMAP8 Default Value"
+      command: "readAttribute"
+      attribute: "bitmap8"
+      response:
+          value: readAttributeBitmap8DefaultValue
+
+    # Tests for Bitmap16 attribute
+
+    - label: "Read attribute BITMAP16 Default Value"
+      command: "readAttribute"
+      attribute: "bitmap16"
+      response:
+          saveAs: readAttributeBitmap16DefaultValue
+          value: 0
+
+    - label: "Write attribute BITMAP16 Not Default Value"
+      command: "writeAttribute"
+      attribute: "bitmap16"
+      arguments:
+          value: 1
+
+    - label: "Read attribute BITMAP16 Not Default Value"
+      command: "readAttribute"
+      attribute: "bitmap16"
+      response:
+          constraints:
+              notValue: readAttributeBitmap16DefaultValue
+
+    - label: "Write attribute BITMAP16 Default Value"
+      command: "writeAttribute"
+      attribute: "bitmap16"
+      arguments:
+          value: readAttributeBitmap16DefaultValue
+
+    - label: "Read attribute BITMAP16 Default Value"
+      command: "readAttribute"
+      attribute: "bitmap16"
+      response:
+          value: readAttributeBitmap16DefaultValue
+
+    # Tests for Bitmap32 attribute
+
+    - label: "Read attribute BITMAP32 Default Value"
+      command: "readAttribute"
+      attribute: "bitmap32"
+      response:
+          saveAs: readAttributeBitmap32DefaultValue
+          value: 0
+
+    - label: "Write attribute BITMAP32 Not Default Value"
+      command: "writeAttribute"
+      attribute: "bitmap32"
+      arguments:
+          value: 1
+
+    - label: "Read attribute BITMAP32 Not Default Value"
+      command: "readAttribute"
+      attribute: "bitmap32"
+      response:
+          constraints:
+              notValue: readAttributeBitmap32DefaultValue
+
+    - label: "Write attribute BITMAP32 Default Value"
+      command: "writeAttribute"
+      attribute: "bitmap32"
+      arguments:
+          value: readAttributeBitmap32DefaultValue
+
+    - label: "Read attribute BITMAP32 Default Value"
+      command: "readAttribute"
+      attribute: "bitmap32"
+      response:
+          value: readAttributeBitmap32DefaultValue
+
+    # Tests for Bitmap64 attribute
+
+    - label: "Read attribute BITMAP64 Default Value"
+      command: "readAttribute"
+      attribute: "bitmap64"
+      response:
+          saveAs: readAttributeBitmap64DefaultValue
+          value: 0
+
+    - label: "Write attribute BITMAP64 Not Default Value"
+      command: "writeAttribute"
+      attribute: "bitmap64"
+      arguments:
+          value: 1
+
+    - label: "Read attribute BITMAP64 Default Value"
+      command: "readAttribute"
+      attribute: "bitmap64"
+      response:
+          constraints:
+              notValue: readAttributeBitmap64DefaultValue
+
+    - label: "Write attribute BITMAP64 Default Value"
+      command: "writeAttribute"
+      attribute: "bitmap64"
+      arguments:
+          value: readAttributeBitmap64DefaultValue
+
+    - label: "Read attribute BITMAP64 Default Value"
+      command: "readAttribute"
+      attribute: "bitmap64"
+      response:
+          value: readAttributeBitmap64DefaultValue
+
+    # Tests for UInt8 attribute
+
+    - label: "Read attribute INT8U Default Value"
+      command: "readAttribute"
+      attribute: "int8u"
+      response:
+          saveAs: readAttributeInt8uDefaultValue
+          value: 0
+
+    - label: "Write attribute INT8U Not Default Value"
+      command: "writeAttribute"
+      attribute: "int8u"
+      arguments:
+          value: 1
+
+    - label: "Read attribute INT8U Not Default Value"
+      command: "readAttribute"
+      attribute: "int8u"
+      response:
+          constraints:
+              notValue: readAttributeInt8uDefaultValue
+
+    - label: "Write attribute INT8U Default Value"
+      command: "writeAttribute"
+      attribute: "int8u"
+      arguments:
+          value: readAttributeInt8uDefaultValue
+
+    - label: "Read attribute INT8U Default Value"
+      command: "readAttribute"
+      attribute: "int8u"
+      response:
+          value: readAttributeInt8uDefaultValue
+
+    # Tests for UInt16 attribute
+
+    - label: "Read attribute INT16U Default Value"
+      command: "readAttribute"
+      attribute: "int16u"
+      response:
+          saveAs: readAttributeInt16uDefaultValue
+          value: 0
+
+    - label: "Write attribute INT16U Not Default Value"
+      command: "writeAttribute"
+      attribute: "int16u"
+      arguments:
+          value: 1
+
+    - label: "Read attribute INT16U Not Default Value"
+      command: "readAttribute"
+      attribute: "int16u"
+      response:
+          constraints:
+              notValue: readAttributeInt16uDefaultValue
+
+    - label: "Write attribute INT16U Default Value"
+      command: "writeAttribute"
+      attribute: "int16u"
+      arguments:
+          value: readAttributeInt16uDefaultValue
+
+    - label: "Read attribute INT16U Default Value"
+      command: "readAttribute"
+      attribute: "int16u"
+      response:
+          value: readAttributeInt16uDefaultValue
+
+    # Tests for UInt32 attribute
+
+    - label: "Read attribute INT32U Default Value"
+      command: "readAttribute"
+      attribute: "int32u"
+      response:
+          saveAs: readAttributeInt32uDefaultValue
+          value: 0
+
+    - label: "Write attribute INT32U Not Default Value"
+      command: "writeAttribute"
+      attribute: "int32u"
+      arguments:
+          value: 1
+
+    - label: "Read attribute INT32U Not Default Value"
+      command: "readAttribute"
+      attribute: "int32u"
+      response:
+          constraints:
+              notValue: readAttributeInt32uDefaultValue
+
+    - label: "Write attribute INT32U Default Value"
+      command: "writeAttribute"
+      attribute: "int32u"
+      arguments:
+          value: readAttributeInt32uDefaultValue
+
+    - label: "Read attribute INT32U Default Value"
+      command: "readAttribute"
+      attribute: "int32u"
+      response:
+          value: readAttributeInt32uDefaultValue
+
+    # Tests for UInt64 attribute
+
+    - label: "Read attribute INT64U Default Value"
+      command: "readAttribute"
+      attribute: "int64u"
+      response:
+          saveAs: readAttributeInt64uDefaultValue
+          value: 0
+
+    - label: "Write attribute INT64U Not Default Value"
+      command: "writeAttribute"
+      attribute: "int64u"
+      arguments:
+          value: 1
+
+    - label: "Read attribute INT64U Not Default Value"
+      command: "readAttribute"
+      attribute: "int64u"
+      response:
+          constraints:
+              notValue: readAttributeInt64uDefaultValue
+
+    - label: "Write attribute INT64U Default Value"
+      command: "writeAttribute"
+      attribute: "int64u"
+      arguments:
+          value: readAttributeInt64uDefaultValue
+
+    - label: "Read attribute INT64U Default Value"
+      command: "readAttribute"
+      attribute: "int64u"
+      response:
+          value: readAttributeInt64uDefaultValue
+
+    # Tests for Int8 attribute
+
+    - label: "Read attribute INT8S Default Value"
+      command: "readAttribute"
+      attribute: "int8s"
+      response:
+          saveAs: readAttributeInt8sDefaultValue
+          value: 0
+
+    - label: "Write attribute INT8S Not Default Value"
+      command: "writeAttribute"
+      attribute: "int8s"
+      arguments:
+          value: 1
+
+    - label: "Read attribute INT8S Not Default Value"
+      command: "readAttribute"
+      attribute: "int8s"
+      response:
+          constraints:
+              notValue: readAttributeInt8sDefaultValue
+
+    - label: "Write attribute INT8S Default Value"
+      command: "writeAttribute"
+      attribute: "int8s"
+      arguments:
+          value: readAttributeInt8sDefaultValue
+
+    - label: "Read attribute INT8S Default Value"
+      command: "readAttribute"
+      attribute: "int8s"
+      response:
+          value: readAttributeInt8sDefaultValue
+
+    # Tests for Int16 attribute
+
+    - label: "Read attribute INT16S Default Value"
+      command: "readAttribute"
+      attribute: "int16s"
+      response:
+          saveAs: readAttributeInt16sDefaultValue
+          value: 0
+
+    - label: "Write attribute INT16S Not Default Value"
+      command: "writeAttribute"
+      attribute: "int16s"
+      arguments:
+          value: 1
+
+    - label: "Read attribute INT16S Not Default Value"
+      command: "readAttribute"
+      attribute: "int16s"
+      response:
+          constraints:
+              notValue: readAttributeInt16sDefaultValue
+
+    - label: "Write attribute INT16S Default Value"
+      command: "writeAttribute"
+      attribute: "int16s"
+      arguments:
+          value: readAttributeInt16sDefaultValue
+
+    - label: "Read attribute INT16S Default Value"
+      command: "readAttribute"
+      attribute: "int16s"
+      response:
+          value: readAttributeInt16sDefaultValue
+
+    # Tests for Int32 attribute
+
+    - label: "Read attribute INT32S Default Value"
+      command: "readAttribute"
+      attribute: "int32s"
+      response:
+          saveAs: readAttributeInt32sDefaultValue
+          value: 0
+
+    - label: "Write attribute INT32S Not Default Value"
+      command: "writeAttribute"
+      attribute: "int32s"
+      arguments:
+          value: 1
+
+    - label: "Read attribute INT32S Not Default Value"
+      command: "readAttribute"
+      attribute: "int32s"
+      response:
+          constraints:
+              notValue: readAttributeInt32sDefaultValue
+
+    - label: "Write attribute INT32S Default Value"
+      command: "writeAttribute"
+      attribute: "int32s"
+      arguments:
+          value: readAttributeInt32sDefaultValue
+
+    - label: "Read attribute INT32S Default Value"
+      command: "readAttribute"
+      attribute: "int32s"
+      response:
+          value: readAttributeInt32sDefaultValue
+
+    # Tests for Int64 attribute
+
+    - label: "Read attribute INT64S Default Value"
+      command: "readAttribute"
+      attribute: "int64s"
+      response:
+          saveAs: readAttributeInt64sDefaultValue
+          value: 0
+
+    - label: "Write attribute INTS Not Default Value"
+      command: "writeAttribute"
+      attribute: "int64s"
+      arguments:
+          value: 1
+
+    - label: "Read attribute INT64S Not Default Value"
+      command: "readAttribute"
+      attribute: "int64s"
+      response:
+          constraints:
+              notValue: readAttributeInt64sDefaultValue
+
+    - label: "Write attribute INT64S Default Value"
+      command: "writeAttribute"
+      attribute: "int64s"
+      arguments:
+          value: readAttributeInt64sDefaultValue
+
+    - label: "Read attribute INT64S Default Value"
+      command: "readAttribute"
+      attribute: "int64s"
+      response:
+          value: readAttributeInt64sDefaultValue
+
+    # Tests for Enum8 attribute
+
+    - label: "Read attribute ENUM8 Default Value"
+      command: "readAttribute"
+      attribute: "enum8"
+      response:
+          saveAs: readAttributeEnum8DefaultValue
+          value: 0
+
+    - label: "Write attribute ENUM8 Not Default Value"
+      command: "writeAttribute"
+      attribute: "enum8"
+      arguments:
+          value: 1
+
+    - label: "Read attribute ENUM8 Not Default Value"
+      command: "readAttribute"
+      attribute: "enum8"
+      response:
+          constraints:
+              notValue: readAttributeEnum8DefaultValue
+
+    - label: "Write attribute ENUM8 Default Value"
+      command: "writeAttribute"
+      attribute: "enum8"
+      arguments:
+          value: readAttributeEnum8DefaultValue
+
+    - label: "Read attribute ENUM8 Default Value"
+      command: "readAttribute"
+      attribute: "enum8"
+      response:
+          value: readAttributeEnum8DefaultValue
+
+    # Tests for Enum16 attribute
+
+    - label: "Read attribute ENUM16 Default Value"
+      command: "readAttribute"
+      attribute: "enum16"
+      response:
+          saveAs: readAttributeEnum16DefaultValue
+          value: 0
+
+    - label: "Write attribute ENUM16 Not Default Value"
+      command: "writeAttribute"
+      attribute: "enum16"
+      arguments:
+          value: 1
+
+    - label: "Read attribute ENUM16 Not Default Value"
+      command: "readAttribute"
+      attribute: "enum16"
+      response:
+          constraints:
+              notValue: readAttributeEnum16DefaultValue
+
+    - label: "Write attribute ENUM16 Default Value"
+      command: "writeAttribute"
+      attribute: "enum16"
+      arguments:
+          value: readAttributeEnum16DefaultValue
+
+    - label: "Read attribute ENUM16 Default Value"
+      command: "readAttribute"
+      attribute: "enum16"
+      response:
+          value: readAttributeEnum16DefaultValue
+
+    # Tests for Epoch Microseconds
+
+    - label: "Read attribute EPOCH_US Default Value"
+      command: "readAttribute"
+      attribute: "epoch_us"
+      response:
+          saveAs: readAttributeEpochUSDefaultValue
+          value: 0
+
+    - label: "Write attribute EPOCH_US Not Default Value"
+      command: "writeAttribute"
+      attribute: "epoch_us"
+      arguments:
+          value: 1
+
+    - label: "Read attribute EPOCH_US Not Default Value"
+      command: "readAttribute"
+      attribute: "epoch_us"
+      response:
+          constraints:
+              notValue: readAttributeEpochUSDefaultValue
+
+    - label: "Write attribute EPOCH_US Default Value"
+      command: "writeAttribute"
+      attribute: "epoch_us"
+      arguments:
+          value: readAttributeEpochUSDefaultValue
+
+    - label: "Read attribute EPOCH_US Default Value"
+      command: "readAttribute"
+      attribute: "epoch_us"
+      response:
+          value: readAttributeEpochUSDefaultValue
+
+    # Tests for Epoch Seconds
+
+    - label: "Read attribute EPOCH_S Default Value"
+      command: "readAttribute"
+      attribute: "epoch_s"
+      response:
+          saveAs: readAttributeEpochSDefaultValue
+          value: 0
+
+    - label: "Write attribute EPOCH_S Not Default Value"
+      command: "writeAttribute"
+      attribute: "epoch_s"
+      arguments:
+          value: 1
+
+    - label: "Read attribute EPOCH_S Not Default Value"
+      command: "readAttribute"
+      attribute: "epoch_s"
+      response:
+          constraints:
+              notValue: readAttributeEpochSDefaultValue
+
+    - label: "Write attribute EPOCH_S Default Value"
+      command: "writeAttribute"
+      attribute: "epoch_s"
+      arguments:
+          value: readAttributeEpochSDefaultValue
+
+    - label: "Read attribute EPOCH_S Default Value"
+      command: "readAttribute"
+      attribute: "epoch_s"
+      response:
+          value: readAttributeEpochSDefaultValue
+
+    # Tests for vendor id
+
+    - label: "Read attribute vendor_id Default Value"
+      command: "readAttribute"
+      attribute: "vendor_id"
+      response:
+          saveAs: readAttributeVendorIdDefaultValue
+          value: 0
+
+    - label: "Write attribute vendor_id Not Default Value"
+      command: "writeAttribute"
+      attribute: "vendor_id"
+      arguments:
+          value: 1
+
+    - label: "Read attribute vendor_id Not Default Value"
+      command: "readAttribute"
+      attribute: "vendor_id"
+      response:
+          constraints:
+              notValue: readAttributeVendorIdDefaultValue
+
+    - label: "Write attribute vendor_id Default Value"
+      command: "writeAttribute"
+      attribute: "vendor_id"
+      arguments:
+          value: readAttributeVendorIdDefaultValue
+
+    - label: "Read attribute vendor_id Default Value"
+      command: "readAttribute"
+      attribute: "vendor_id"
+      response:
+          value: readAttributeVendorIdDefaultValue

--- a/src/app/zap-templates/common/ClusterTestGeneration.js
+++ b/src/app/zap-templates/common/ClusterTestGeneration.js
@@ -44,6 +44,7 @@ const kResponseName      = 'response';
 const kDisabledName      = 'disabled';
 const kResponseErrorName = 'error';
 const kPICSName          = 'PICS';
+const kSaveAsName        = 'saveAs';
 
 class NullObject {
   toString()
@@ -198,6 +199,9 @@ function setDefaultResponse(test)
   const defaultResponseConstraints = {};
   setDefault(test[kResponseName], kConstraintsName, defaultResponseConstraints);
 
+  const defaultResponseSaveAs = '';
+  setDefault(test[kResponseName], kSaveAsName, defaultResponseSaveAs);
+
   const hasResponseValue              = 'value' in test[kResponseName];
   const hasResponseError              = 'error' in test[kResponseName];
   const hasResponseConstraints        = 'constraints' in test[kResponseName] && Object.keys(test[kResponseName].constraints).length;
@@ -242,11 +246,13 @@ function setDefaultResponse(test)
   }
 
   if (hasResponseValue) {
-    test[kResponseName].values.push({ name : test.attribute, value : test[kResponseName].value });
+    test[kResponseName].values.push(
+        { name : test.attribute, value : test[kResponseName].value, saveAs : test[kResponseName].saveAs });
   }
 
   if (hasResponseConstraints) {
-    test[kResponseName].values.push({ name : test.attribute, constraints : test[kResponseName].constraints });
+    test[kResponseName].values.push(
+        { name : test.attribute, constraints : test[kResponseName].constraints, saveAs : test[kResponseName].saveAs });
   }
 
   delete test[kResponseName].value;
@@ -570,6 +576,10 @@ function chip_tests_item_response_parameters(options)
         if ('constraints' in expected) {
           responseArg.hasExpectedConstraints = true;
           responseArg.expectedConstraints    = expected.constraints;
+        }
+
+        if ('saveAs' in expected) {
+          responseArg.saveAs = expected.saveAs;
         }
       }
 

--- a/src/app/zap-templates/templates/app/helper.js
+++ b/src/app/zap-templates/templates/app/helper.js
@@ -263,8 +263,9 @@ function asPrintFormat(type)
   return templateUtil.templatePromise(this.global, promise)
 }
 
-function asTypeLiteralSuffix(type)
+function asTypeLiteralSuffix(value, type)
 {
+  const valueIsANumber = !isNaN(value);
   function fn(pkgId)
   {
     const options = { 'hash' : {} };
@@ -272,17 +273,17 @@ function asTypeLiteralSuffix(type)
       const basicType = ChipTypesHelper.asBasicType(zclType);
       switch (basicType) {
       case 'int32_t':
-        return 'L';
+        return value + (valueIsANumber ? 'L' : '');
       case 'int64_t':
-        return 'LL';
+        return value + (valueIsANumber ? 'LL' : '');
       case 'uint16_t':
-        return 'U';
+        return value + (valueIsANumber ? 'U' : '');
       case 'uint32_t':
-        return 'UL';
+        return value + (valueIsANumber ? 'UL' : '');
       case 'uint64_t':
-        return 'ULL';
+        return value + (valueIsANumber ? 'ULL' : '');
       default:
-        return '';
+        return value;
       }
     })
   }

--- a/src/darwin/Framework/CHIP/templates/partials/check_test_value.zapt
+++ b/src/darwin/Framework/CHIP/templates/partials/check_test_value.zapt
@@ -37,7 +37,7 @@
     {{else if (isCharString type)}}
       XCTAssertTrue([{{actual}} isEqualToString:@"{{expected}}"]);
     {{else}}
-      XCTAssertEqual([{{actual}} {{asObjectiveCNumberType "" type true}}Value], {{expected}}{{asTypeLiteralSuffix type}});
+      XCTAssertEqual([{{actual}} {{asObjectiveCNumberType "" type true}}Value], {{asTypeLiteralSuffix expected type}});
     {{/if}}
   {{/if_is_struct}}
 {{/if}}

--- a/src/darwin/Framework/CHIP/templates/partials/test_cluster.zapt
+++ b/src/darwin/Framework/CHIP/templates/partials/test_cluster.zapt
@@ -3,6 +3,11 @@
 {{#if async}}
 bool testSendCluster{{parent.filename}}_{{asTestIndex index}}_{{asUpperCamelCase command}}_Fulfilled = false;
 {{/if}}
+{{#chip_tests_item_response_parameters}}
+{{#if saveAs}}
+{{asBasicType chipType}} {{saveAs}};
+{{/if}}
+{{/chip_tests_item_response_parameters}}
 - (void)testSendCluster{{parent.filename}}_{{asTestIndex index}}_{{asUpperCamelCase command}}
 {
     {{#unless async}}
@@ -45,7 +50,7 @@ bool testSendCluster{{parent.filename}}_{{asTestIndex index}}_{{asUpperCamelCase
     NSString * {{asLowerCamelCase name}}Argument= @"{{definedValue}}";
     {{/if}}
     {{else}}
-    {{asObjectiveCBasicType type}} {{asLowerCamelCase name}}Argument = {{definedValue}}{{asTypeLiteralSuffix type}};
+    {{asObjectiveCBasicType type}} {{asLowerCamelCase name}}Argument = {{asTypeLiteralSuffix definedValue type}};
     {{/if}}
     {{/chip_tests_item_parameters}}
     [cluster subscribeAttribute{{asUpperCamelCase attribute}}WithMinInterval:minIntervalArgument
@@ -89,6 +94,9 @@ bool testSendCluster{{parent.filename}}_{{asTestIndex index}}_{{asUpperCamelCase
         {
           {{> actualValue}}
           {{>check_test_value actual="actualValue" expected=expectedValue cluster=../cluster}}
+          {{#if saveAs}}
+          {{saveAs}} = [actualValue {{asObjectiveCNumberType "" type true}}Value];
+          {{/if}}
         }
         {{/if}}
         {{#if hasExpectedConstraints}}

--- a/src/darwin/Framework/CHIP/templates/partials/test_value.zapt
+++ b/src/darwin/Framework/CHIP/templates/partials/test_value.zapt
@@ -29,6 +29,6 @@
   {{else if (isOctetString type)}}
     {{target}} = [[NSData alloc] initWithBytes:"{{octetStringEscapedForCLiteral definedValue}}" length:{{definedValue.length}}];
   {{else}}
-    {{target}} = [NSNumber numberWith{{asObjectiveCNumberType definedValue type false}}:{{definedValue}}{{asTypeLiteralSuffix type}}];
+    {{target}} = [NSNumber numberWith{{asObjectiveCNumberType definedValue type false}}:{{asTypeLiteralSuffix definedValue type}}];
   {{/if_is_struct}}
 {{/if}}

--- a/src/darwin/Framework/CHIP/templates/templates.json
+++ b/src/darwin/Framework/CHIP/templates/templates.json
@@ -3,6 +3,7 @@
     "version": "chip-v1",
     "helpers": [
         "../../../../../src/app/zap-templates/partials/helper.js",
+        "../../../../../src/app/zap-templates/common/ChipTypesHelper.js",
         "../../../../../src/app/zap-templates/common/StringHelper.js",
         "../../../../../src/app/zap-templates/templates/app/helper.js",
         "../../../../../src/app/zap-templates/templates/chip/helper.js",

--- a/src/darwin/Framework/CHIP/templates/tests.js
+++ b/src/darwin/Framework/CHIP/templates/tests.js
@@ -163,6 +163,7 @@ function getTests()
 
   const Others = [
     'TestCluster',
+    'TestSaveAs',
     'TestConstraints',
     'TestDelayCommands',
     'TestDescriptorCluster',

--- a/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
+++ b/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
@@ -23757,7 +23757,7 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     id nullableInt64sArgument;
-    nullableInt64sArgument = [NSNumber numberWithLongLong:-9223372036854775807LL - 1LL];
+    nullableInt64sArgument = [NSNumber numberWithLongLong:-9223372036854775807LL - 1];
     [cluster writeAttributeNullableInt64sWithValue:nullableInt64sArgument
                                  completionHandler:^(NSError * _Nullable err) {
                                      NSLog(@"Write attribute NULLABLE_INT64S Invalid Value Error: %@", err);
@@ -24441,6 +24441,2220 @@ CHIPDevice * GetConnectedDevice()
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 
+uint8_t TestAddArgumentDefaultValue;
+- (void)testSendClusterTestSaveAs_000000_TestAddArguments
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Send Test Add Arguments Command"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    __auto_type * params = [[CHIPTestClusterClusterTestAddArgumentsParams alloc] init];
+    params.arg1 = [NSNumber numberWithUnsignedChar:3];
+    params.arg2 = [NSNumber numberWithUnsignedChar:17];
+    [cluster testAddArgumentsWithParams:params
+                      completionHandler:^(
+                          CHIPTestClusterClusterTestAddArgumentsResponseParams * _Nullable values, NSError * _Nullable err) {
+                          NSLog(@"Send Test Add Arguments Command Error: %@", err);
+
+                          XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+                          {
+                              id actualValue = values.returnValue;
+                              XCTAssertEqual([actualValue unsignedCharValue], 20);
+                              TestAddArgumentDefaultValue = [actualValue unsignedCharValue];
+                          }
+
+                          [expectation fulfill];
+                      }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestSaveAs_000001_TestAddArguments
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Send Test Add Arguments Command"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    __auto_type * params = [[CHIPTestClusterClusterTestAddArgumentsParams alloc] init];
+    params.arg1 = [NSNumber numberWithUnsignedChar:3];
+    params.arg2 = [NSNumber numberWithUnsignedChar:17];
+    [cluster testAddArgumentsWithParams:params
+                      completionHandler:^(
+                          CHIPTestClusterClusterTestAddArgumentsResponseParams * _Nullable values, NSError * _Nullable err) {
+                          NSLog(@"Send Test Add Arguments Command Error: %@", err);
+
+                          XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+                          {
+                              id actualValue = values.returnValue;
+                              XCTAssertEqual([actualValue unsignedCharValue], TestAddArgumentDefaultValue);
+                          }
+
+                          [expectation fulfill];
+                      }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestSaveAs_000002_TestAddArguments
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Send Test Add Arguments Command"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    __auto_type * params = [[CHIPTestClusterClusterTestAddArgumentsParams alloc] init];
+    params.arg1 = [NSNumber numberWithUnsignedChar:3];
+    params.arg2 = [NSNumber numberWithUnsignedChar:TestAddArgumentDefaultValue];
+    [cluster testAddArgumentsWithParams:params
+                      completionHandler:^(
+                          CHIPTestClusterClusterTestAddArgumentsResponseParams * _Nullable values, NSError * _Nullable err) {
+                          NSLog(@"Send Test Add Arguments Command Error: %@", err);
+
+                          XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+                          {
+                              id actualValue = values.returnValue;
+                              XCTAssertNotEqual([actualValue unsignedCharValue], TestAddArgumentDefaultValue);
+                          }
+
+                          [expectation fulfill];
+                      }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+bool readAttributeBooleanDefaultValue;
+- (void)testSendClusterTestSaveAs_000003_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute BOOLEAN Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeBooleanWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"Read attribute BOOLEAN Default Value Error: %@", err);
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        {
+            id actualValue = value;
+            XCTAssertEqual([actualValue boolValue], 0);
+            readAttributeBooleanDefaultValue = [actualValue boolValue];
+        }
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestSaveAs_000004_WriteAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute BOOLEAN Not Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    id booleanArgument;
+    booleanArgument = [NSNumber numberWithBool:1];
+    [cluster writeAttributeBooleanWithValue:booleanArgument
+                          completionHandler:^(NSError * _Nullable err) {
+                              NSLog(@"Write attribute BOOLEAN Not Default Value Error: %@", err);
+
+                              XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+                              [expectation fulfill];
+                          }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestSaveAs_000005_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute BOOLEAN Not Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeBooleanWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"Read attribute BOOLEAN Not Default Value Error: %@", err);
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        {
+            id actualValue = value;
+            XCTAssertNotEqual([actualValue boolValue], readAttributeBooleanDefaultValue);
+        }
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestSaveAs_000006_WriteAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute BOOLEAN DefaultValue"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    id booleanArgument;
+    booleanArgument = [NSNumber numberWithBool:readAttributeBooleanDefaultValue];
+    [cluster writeAttributeBooleanWithValue:booleanArgument
+                          completionHandler:^(NSError * _Nullable err) {
+                              NSLog(@"Write attribute BOOLEAN DefaultValue Error: %@", err);
+
+                              XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+                              [expectation fulfill];
+                          }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestSaveAs_000007_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute BOOLEAN False"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeBooleanWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"Read attribute BOOLEAN False Error: %@", err);
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        {
+            id actualValue = value;
+            XCTAssertEqual([actualValue boolValue], readAttributeBooleanDefaultValue);
+        }
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+uint8_t readAttributeBitmap8DefaultValue;
+- (void)testSendClusterTestSaveAs_000008_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute BITMAP8 Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeBitmap8WithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"Read attribute BITMAP8 Default Value Error: %@", err);
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        {
+            id actualValue = value;
+            XCTAssertEqual([actualValue unsignedCharValue], 0);
+            readAttributeBitmap8DefaultValue = [actualValue unsignedCharValue];
+        }
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestSaveAs_000009_WriteAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute BITMAP8 Not Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    id bitmap8Argument;
+    bitmap8Argument = [NSNumber numberWithUnsignedChar:1];
+    [cluster writeAttributeBitmap8WithValue:bitmap8Argument
+                          completionHandler:^(NSError * _Nullable err) {
+                              NSLog(@"Write attribute BITMAP8 Not Default Value Error: %@", err);
+
+                              XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+                              [expectation fulfill];
+                          }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestSaveAs_000010_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute BITMAP8 Not Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeBitmap8WithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"Read attribute BITMAP8 Not Default Value Error: %@", err);
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        {
+            id actualValue = value;
+            XCTAssertNotEqual([actualValue unsignedCharValue], readAttributeBitmap8DefaultValue);
+        }
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestSaveAs_000011_WriteAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute BITMAP8 Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    id bitmap8Argument;
+    bitmap8Argument = [NSNumber numberWithUnsignedChar:readAttributeBitmap8DefaultValue];
+    [cluster writeAttributeBitmap8WithValue:bitmap8Argument
+                          completionHandler:^(NSError * _Nullable err) {
+                              NSLog(@"Write attribute BITMAP8 Default Value Error: %@", err);
+
+                              XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+                              [expectation fulfill];
+                          }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestSaveAs_000012_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute BITMAP8 Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeBitmap8WithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"Read attribute BITMAP8 Default Value Error: %@", err);
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        {
+            id actualValue = value;
+            XCTAssertEqual([actualValue unsignedCharValue], readAttributeBitmap8DefaultValue);
+        }
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+uint16_t readAttributeBitmap16DefaultValue;
+- (void)testSendClusterTestSaveAs_000013_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute BITMAP16 Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeBitmap16WithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"Read attribute BITMAP16 Default Value Error: %@", err);
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        {
+            id actualValue = value;
+            XCTAssertEqual([actualValue unsignedShortValue], 0U);
+            readAttributeBitmap16DefaultValue = [actualValue unsignedShortValue];
+        }
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestSaveAs_000014_WriteAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute BITMAP16 Not Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    id bitmap16Argument;
+    bitmap16Argument = [NSNumber numberWithUnsignedShort:1U];
+    [cluster writeAttributeBitmap16WithValue:bitmap16Argument
+                           completionHandler:^(NSError * _Nullable err) {
+                               NSLog(@"Write attribute BITMAP16 Not Default Value Error: %@", err);
+
+                               XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+                               [expectation fulfill];
+                           }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestSaveAs_000015_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute BITMAP16 Not Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeBitmap16WithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"Read attribute BITMAP16 Not Default Value Error: %@", err);
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        {
+            id actualValue = value;
+            XCTAssertNotEqual([actualValue unsignedShortValue], readAttributeBitmap16DefaultValue);
+        }
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestSaveAs_000016_WriteAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute BITMAP16 Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    id bitmap16Argument;
+    bitmap16Argument = [NSNumber numberWithUnsignedShort:readAttributeBitmap16DefaultValue];
+    [cluster writeAttributeBitmap16WithValue:bitmap16Argument
+                           completionHandler:^(NSError * _Nullable err) {
+                               NSLog(@"Write attribute BITMAP16 Default Value Error: %@", err);
+
+                               XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+                               [expectation fulfill];
+                           }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestSaveAs_000017_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute BITMAP16 Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeBitmap16WithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"Read attribute BITMAP16 Default Value Error: %@", err);
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        {
+            id actualValue = value;
+            XCTAssertEqual([actualValue unsignedShortValue], readAttributeBitmap16DefaultValue);
+        }
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+uint32_t readAttributeBitmap32DefaultValue;
+- (void)testSendClusterTestSaveAs_000018_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute BITMAP32 Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeBitmap32WithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"Read attribute BITMAP32 Default Value Error: %@", err);
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        {
+            id actualValue = value;
+            XCTAssertEqual([actualValue unsignedIntValue], 0UL);
+            readAttributeBitmap32DefaultValue = [actualValue unsignedIntValue];
+        }
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestSaveAs_000019_WriteAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute BITMAP32 Not Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    id bitmap32Argument;
+    bitmap32Argument = [NSNumber numberWithUnsignedInt:1UL];
+    [cluster writeAttributeBitmap32WithValue:bitmap32Argument
+                           completionHandler:^(NSError * _Nullable err) {
+                               NSLog(@"Write attribute BITMAP32 Not Default Value Error: %@", err);
+
+                               XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+                               [expectation fulfill];
+                           }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestSaveAs_000020_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute BITMAP32 Not Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeBitmap32WithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"Read attribute BITMAP32 Not Default Value Error: %@", err);
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        {
+            id actualValue = value;
+            XCTAssertNotEqual([actualValue unsignedIntValue], readAttributeBitmap32DefaultValue);
+        }
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestSaveAs_000021_WriteAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute BITMAP32 Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    id bitmap32Argument;
+    bitmap32Argument = [NSNumber numberWithUnsignedInt:readAttributeBitmap32DefaultValue];
+    [cluster writeAttributeBitmap32WithValue:bitmap32Argument
+                           completionHandler:^(NSError * _Nullable err) {
+                               NSLog(@"Write attribute BITMAP32 Default Value Error: %@", err);
+
+                               XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+                               [expectation fulfill];
+                           }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestSaveAs_000022_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute BITMAP32 Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeBitmap32WithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"Read attribute BITMAP32 Default Value Error: %@", err);
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        {
+            id actualValue = value;
+            XCTAssertEqual([actualValue unsignedIntValue], readAttributeBitmap32DefaultValue);
+        }
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+uint64_t readAttributeBitmap64DefaultValue;
+- (void)testSendClusterTestSaveAs_000023_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute BITMAP64 Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeBitmap64WithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"Read attribute BITMAP64 Default Value Error: %@", err);
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        {
+            id actualValue = value;
+            XCTAssertEqual([actualValue unsignedLongLongValue], 0ULL);
+            readAttributeBitmap64DefaultValue = [actualValue unsignedLongLongValue];
+        }
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestSaveAs_000024_WriteAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute BITMAP64 Not Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    id bitmap64Argument;
+    bitmap64Argument = [NSNumber numberWithUnsignedLongLong:1ULL];
+    [cluster writeAttributeBitmap64WithValue:bitmap64Argument
+                           completionHandler:^(NSError * _Nullable err) {
+                               NSLog(@"Write attribute BITMAP64 Not Default Value Error: %@", err);
+
+                               XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+                               [expectation fulfill];
+                           }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestSaveAs_000025_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute BITMAP64 Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeBitmap64WithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"Read attribute BITMAP64 Default Value Error: %@", err);
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        {
+            id actualValue = value;
+            XCTAssertNotEqual([actualValue unsignedLongLongValue], readAttributeBitmap64DefaultValue);
+        }
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestSaveAs_000026_WriteAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute BITMAP64 Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    id bitmap64Argument;
+    bitmap64Argument = [NSNumber numberWithUnsignedLongLong:readAttributeBitmap64DefaultValue];
+    [cluster writeAttributeBitmap64WithValue:bitmap64Argument
+                           completionHandler:^(NSError * _Nullable err) {
+                               NSLog(@"Write attribute BITMAP64 Default Value Error: %@", err);
+
+                               XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+                               [expectation fulfill];
+                           }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestSaveAs_000027_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute BITMAP64 Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeBitmap64WithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"Read attribute BITMAP64 Default Value Error: %@", err);
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        {
+            id actualValue = value;
+            XCTAssertEqual([actualValue unsignedLongLongValue], readAttributeBitmap64DefaultValue);
+        }
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+uint8_t readAttributeInt8uDefaultValue;
+- (void)testSendClusterTestSaveAs_000028_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute INT8U Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeInt8uWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"Read attribute INT8U Default Value Error: %@", err);
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        {
+            id actualValue = value;
+            XCTAssertEqual([actualValue unsignedCharValue], 0);
+            readAttributeInt8uDefaultValue = [actualValue unsignedCharValue];
+        }
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestSaveAs_000029_WriteAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute INT8U Not Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    id int8uArgument;
+    int8uArgument = [NSNumber numberWithUnsignedChar:1];
+    [cluster writeAttributeInt8uWithValue:int8uArgument
+                        completionHandler:^(NSError * _Nullable err) {
+                            NSLog(@"Write attribute INT8U Not Default Value Error: %@", err);
+
+                            XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+                            [expectation fulfill];
+                        }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestSaveAs_000030_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute INT8U Not Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeInt8uWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"Read attribute INT8U Not Default Value Error: %@", err);
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        {
+            id actualValue = value;
+            XCTAssertNotEqual([actualValue unsignedCharValue], readAttributeInt8uDefaultValue);
+        }
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestSaveAs_000031_WriteAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute INT8U Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    id int8uArgument;
+    int8uArgument = [NSNumber numberWithUnsignedChar:readAttributeInt8uDefaultValue];
+    [cluster writeAttributeInt8uWithValue:int8uArgument
+                        completionHandler:^(NSError * _Nullable err) {
+                            NSLog(@"Write attribute INT8U Default Value Error: %@", err);
+
+                            XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+                            [expectation fulfill];
+                        }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestSaveAs_000032_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute INT8U Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeInt8uWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"Read attribute INT8U Default Value Error: %@", err);
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        {
+            id actualValue = value;
+            XCTAssertEqual([actualValue unsignedCharValue], readAttributeInt8uDefaultValue);
+        }
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+uint16_t readAttributeInt16uDefaultValue;
+- (void)testSendClusterTestSaveAs_000033_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute INT16U Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeInt16uWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"Read attribute INT16U Default Value Error: %@", err);
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        {
+            id actualValue = value;
+            XCTAssertEqual([actualValue unsignedShortValue], 0U);
+            readAttributeInt16uDefaultValue = [actualValue unsignedShortValue];
+        }
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestSaveAs_000034_WriteAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute INT16U Not Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    id int16uArgument;
+    int16uArgument = [NSNumber numberWithUnsignedShort:1U];
+    [cluster writeAttributeInt16uWithValue:int16uArgument
+                         completionHandler:^(NSError * _Nullable err) {
+                             NSLog(@"Write attribute INT16U Not Default Value Error: %@", err);
+
+                             XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+                             [expectation fulfill];
+                         }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestSaveAs_000035_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute INT16U Not Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeInt16uWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"Read attribute INT16U Not Default Value Error: %@", err);
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        {
+            id actualValue = value;
+            XCTAssertNotEqual([actualValue unsignedShortValue], readAttributeInt16uDefaultValue);
+        }
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestSaveAs_000036_WriteAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute INT16U Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    id int16uArgument;
+    int16uArgument = [NSNumber numberWithUnsignedShort:readAttributeInt16uDefaultValue];
+    [cluster writeAttributeInt16uWithValue:int16uArgument
+                         completionHandler:^(NSError * _Nullable err) {
+                             NSLog(@"Write attribute INT16U Default Value Error: %@", err);
+
+                             XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+                             [expectation fulfill];
+                         }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestSaveAs_000037_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute INT16U Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeInt16uWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"Read attribute INT16U Default Value Error: %@", err);
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        {
+            id actualValue = value;
+            XCTAssertEqual([actualValue unsignedShortValue], readAttributeInt16uDefaultValue);
+        }
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+uint32_t readAttributeInt32uDefaultValue;
+- (void)testSendClusterTestSaveAs_000038_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute INT32U Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeInt32uWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"Read attribute INT32U Default Value Error: %@", err);
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        {
+            id actualValue = value;
+            XCTAssertEqual([actualValue unsignedIntValue], 0UL);
+            readAttributeInt32uDefaultValue = [actualValue unsignedIntValue];
+        }
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestSaveAs_000039_WriteAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute INT32U Not Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    id int32uArgument;
+    int32uArgument = [NSNumber numberWithUnsignedInt:1UL];
+    [cluster writeAttributeInt32uWithValue:int32uArgument
+                         completionHandler:^(NSError * _Nullable err) {
+                             NSLog(@"Write attribute INT32U Not Default Value Error: %@", err);
+
+                             XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+                             [expectation fulfill];
+                         }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestSaveAs_000040_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute INT32U Not Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeInt32uWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"Read attribute INT32U Not Default Value Error: %@", err);
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        {
+            id actualValue = value;
+            XCTAssertNotEqual([actualValue unsignedIntValue], readAttributeInt32uDefaultValue);
+        }
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestSaveAs_000041_WriteAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute INT32U Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    id int32uArgument;
+    int32uArgument = [NSNumber numberWithUnsignedInt:readAttributeInt32uDefaultValue];
+    [cluster writeAttributeInt32uWithValue:int32uArgument
+                         completionHandler:^(NSError * _Nullable err) {
+                             NSLog(@"Write attribute INT32U Default Value Error: %@", err);
+
+                             XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+                             [expectation fulfill];
+                         }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestSaveAs_000042_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute INT32U Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeInt32uWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"Read attribute INT32U Default Value Error: %@", err);
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        {
+            id actualValue = value;
+            XCTAssertEqual([actualValue unsignedIntValue], readAttributeInt32uDefaultValue);
+        }
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+uint64_t readAttributeInt64uDefaultValue;
+- (void)testSendClusterTestSaveAs_000043_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute INT64U Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeInt64uWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"Read attribute INT64U Default Value Error: %@", err);
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        {
+            id actualValue = value;
+            XCTAssertEqual([actualValue unsignedLongLongValue], 0ULL);
+            readAttributeInt64uDefaultValue = [actualValue unsignedLongLongValue];
+        }
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestSaveAs_000044_WriteAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute INT64U Not Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    id int64uArgument;
+    int64uArgument = [NSNumber numberWithUnsignedLongLong:1ULL];
+    [cluster writeAttributeInt64uWithValue:int64uArgument
+                         completionHandler:^(NSError * _Nullable err) {
+                             NSLog(@"Write attribute INT64U Not Default Value Error: %@", err);
+
+                             XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+                             [expectation fulfill];
+                         }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestSaveAs_000045_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute INT64U Not Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeInt64uWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"Read attribute INT64U Not Default Value Error: %@", err);
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        {
+            id actualValue = value;
+            XCTAssertNotEqual([actualValue unsignedLongLongValue], readAttributeInt64uDefaultValue);
+        }
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestSaveAs_000046_WriteAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute INT64U Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    id int64uArgument;
+    int64uArgument = [NSNumber numberWithUnsignedLongLong:readAttributeInt64uDefaultValue];
+    [cluster writeAttributeInt64uWithValue:int64uArgument
+                         completionHandler:^(NSError * _Nullable err) {
+                             NSLog(@"Write attribute INT64U Default Value Error: %@", err);
+
+                             XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+                             [expectation fulfill];
+                         }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestSaveAs_000047_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute INT64U Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeInt64uWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"Read attribute INT64U Default Value Error: %@", err);
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        {
+            id actualValue = value;
+            XCTAssertEqual([actualValue unsignedLongLongValue], readAttributeInt64uDefaultValue);
+        }
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+int8_t readAttributeInt8sDefaultValue;
+- (void)testSendClusterTestSaveAs_000048_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute INT8S Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeInt8sWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"Read attribute INT8S Default Value Error: %@", err);
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        {
+            id actualValue = value;
+            XCTAssertEqual([actualValue charValue], 0);
+            readAttributeInt8sDefaultValue = [actualValue charValue];
+        }
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestSaveAs_000049_WriteAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute INT8S Not Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    id int8sArgument;
+    int8sArgument = [NSNumber numberWithChar:1];
+    [cluster writeAttributeInt8sWithValue:int8sArgument
+                        completionHandler:^(NSError * _Nullable err) {
+                            NSLog(@"Write attribute INT8S Not Default Value Error: %@", err);
+
+                            XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+                            [expectation fulfill];
+                        }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestSaveAs_000050_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute INT8S Not Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeInt8sWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"Read attribute INT8S Not Default Value Error: %@", err);
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        {
+            id actualValue = value;
+            XCTAssertNotEqual([actualValue charValue], readAttributeInt8sDefaultValue);
+        }
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestSaveAs_000051_WriteAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute INT8S Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    id int8sArgument;
+    int8sArgument = [NSNumber numberWithChar:readAttributeInt8sDefaultValue];
+    [cluster writeAttributeInt8sWithValue:int8sArgument
+                        completionHandler:^(NSError * _Nullable err) {
+                            NSLog(@"Write attribute INT8S Default Value Error: %@", err);
+
+                            XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+                            [expectation fulfill];
+                        }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestSaveAs_000052_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute INT8S Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeInt8sWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"Read attribute INT8S Default Value Error: %@", err);
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        {
+            id actualValue = value;
+            XCTAssertEqual([actualValue charValue], readAttributeInt8sDefaultValue);
+        }
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+int16_t readAttributeInt16sDefaultValue;
+- (void)testSendClusterTestSaveAs_000053_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute INT16S Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeInt16sWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"Read attribute INT16S Default Value Error: %@", err);
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        {
+            id actualValue = value;
+            XCTAssertEqual([actualValue shortValue], 0);
+            readAttributeInt16sDefaultValue = [actualValue shortValue];
+        }
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestSaveAs_000054_WriteAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute INT16S Not Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    id int16sArgument;
+    int16sArgument = [NSNumber numberWithShort:1];
+    [cluster writeAttributeInt16sWithValue:int16sArgument
+                         completionHandler:^(NSError * _Nullable err) {
+                             NSLog(@"Write attribute INT16S Not Default Value Error: %@", err);
+
+                             XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+                             [expectation fulfill];
+                         }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestSaveAs_000055_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute INT16S Not Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeInt16sWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"Read attribute INT16S Not Default Value Error: %@", err);
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        {
+            id actualValue = value;
+            XCTAssertNotEqual([actualValue shortValue], readAttributeInt16sDefaultValue);
+        }
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestSaveAs_000056_WriteAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute INT16S Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    id int16sArgument;
+    int16sArgument = [NSNumber numberWithShort:readAttributeInt16sDefaultValue];
+    [cluster writeAttributeInt16sWithValue:int16sArgument
+                         completionHandler:^(NSError * _Nullable err) {
+                             NSLog(@"Write attribute INT16S Default Value Error: %@", err);
+
+                             XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+                             [expectation fulfill];
+                         }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestSaveAs_000057_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute INT16S Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeInt16sWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"Read attribute INT16S Default Value Error: %@", err);
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        {
+            id actualValue = value;
+            XCTAssertEqual([actualValue shortValue], readAttributeInt16sDefaultValue);
+        }
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+int32_t readAttributeInt32sDefaultValue;
+- (void)testSendClusterTestSaveAs_000058_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute INT32S Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeInt32sWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"Read attribute INT32S Default Value Error: %@", err);
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        {
+            id actualValue = value;
+            XCTAssertEqual([actualValue intValue], 0L);
+            readAttributeInt32sDefaultValue = [actualValue intValue];
+        }
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestSaveAs_000059_WriteAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute INT32S Not Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    id int32sArgument;
+    int32sArgument = [NSNumber numberWithInt:1L];
+    [cluster writeAttributeInt32sWithValue:int32sArgument
+                         completionHandler:^(NSError * _Nullable err) {
+                             NSLog(@"Write attribute INT32S Not Default Value Error: %@", err);
+
+                             XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+                             [expectation fulfill];
+                         }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestSaveAs_000060_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute INT32S Not Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeInt32sWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"Read attribute INT32S Not Default Value Error: %@", err);
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        {
+            id actualValue = value;
+            XCTAssertNotEqual([actualValue intValue], readAttributeInt32sDefaultValue);
+        }
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestSaveAs_000061_WriteAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute INT32S Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    id int32sArgument;
+    int32sArgument = [NSNumber numberWithInt:readAttributeInt32sDefaultValue];
+    [cluster writeAttributeInt32sWithValue:int32sArgument
+                         completionHandler:^(NSError * _Nullable err) {
+                             NSLog(@"Write attribute INT32S Default Value Error: %@", err);
+
+                             XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+                             [expectation fulfill];
+                         }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestSaveAs_000062_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute INT32S Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeInt32sWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"Read attribute INT32S Default Value Error: %@", err);
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        {
+            id actualValue = value;
+            XCTAssertEqual([actualValue intValue], readAttributeInt32sDefaultValue);
+        }
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+int64_t readAttributeInt64sDefaultValue;
+- (void)testSendClusterTestSaveAs_000063_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute INT64S Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeInt64sWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"Read attribute INT64S Default Value Error: %@", err);
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        {
+            id actualValue = value;
+            XCTAssertEqual([actualValue longLongValue], 0LL);
+            readAttributeInt64sDefaultValue = [actualValue longLongValue];
+        }
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestSaveAs_000064_WriteAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute INTS Not Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    id int64sArgument;
+    int64sArgument = [NSNumber numberWithLongLong:1LL];
+    [cluster writeAttributeInt64sWithValue:int64sArgument
+                         completionHandler:^(NSError * _Nullable err) {
+                             NSLog(@"Write attribute INTS Not Default Value Error: %@", err);
+
+                             XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+                             [expectation fulfill];
+                         }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestSaveAs_000065_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute INT64S Not Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeInt64sWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"Read attribute INT64S Not Default Value Error: %@", err);
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        {
+            id actualValue = value;
+            XCTAssertNotEqual([actualValue longLongValue], readAttributeInt64sDefaultValue);
+        }
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestSaveAs_000066_WriteAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute INT64S Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    id int64sArgument;
+    int64sArgument = [NSNumber numberWithLongLong:readAttributeInt64sDefaultValue];
+    [cluster writeAttributeInt64sWithValue:int64sArgument
+                         completionHandler:^(NSError * _Nullable err) {
+                             NSLog(@"Write attribute INT64S Default Value Error: %@", err);
+
+                             XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+                             [expectation fulfill];
+                         }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestSaveAs_000067_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute INT64S Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeInt64sWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"Read attribute INT64S Default Value Error: %@", err);
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        {
+            id actualValue = value;
+            XCTAssertEqual([actualValue longLongValue], readAttributeInt64sDefaultValue);
+        }
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+uint8_t readAttributeEnum8DefaultValue;
+- (void)testSendClusterTestSaveAs_000068_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute ENUM8 Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeEnum8WithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"Read attribute ENUM8 Default Value Error: %@", err);
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        {
+            id actualValue = value;
+            XCTAssertEqual([actualValue unsignedCharValue], 0);
+            readAttributeEnum8DefaultValue = [actualValue unsignedCharValue];
+        }
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestSaveAs_000069_WriteAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute ENUM8 Not Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    id enum8Argument;
+    enum8Argument = [NSNumber numberWithUnsignedChar:1];
+    [cluster writeAttributeEnum8WithValue:enum8Argument
+                        completionHandler:^(NSError * _Nullable err) {
+                            NSLog(@"Write attribute ENUM8 Not Default Value Error: %@", err);
+
+                            XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+                            [expectation fulfill];
+                        }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestSaveAs_000070_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute ENUM8 Not Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeEnum8WithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"Read attribute ENUM8 Not Default Value Error: %@", err);
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        {
+            id actualValue = value;
+            XCTAssertNotEqual([actualValue unsignedCharValue], readAttributeEnum8DefaultValue);
+        }
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestSaveAs_000071_WriteAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute ENUM8 Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    id enum8Argument;
+    enum8Argument = [NSNumber numberWithUnsignedChar:readAttributeEnum8DefaultValue];
+    [cluster writeAttributeEnum8WithValue:enum8Argument
+                        completionHandler:^(NSError * _Nullable err) {
+                            NSLog(@"Write attribute ENUM8 Default Value Error: %@", err);
+
+                            XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+                            [expectation fulfill];
+                        }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestSaveAs_000072_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute ENUM8 Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeEnum8WithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"Read attribute ENUM8 Default Value Error: %@", err);
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        {
+            id actualValue = value;
+            XCTAssertEqual([actualValue unsignedCharValue], readAttributeEnum8DefaultValue);
+        }
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+uint16_t readAttributeEnum16DefaultValue;
+- (void)testSendClusterTestSaveAs_000073_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute ENUM16 Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeEnum16WithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"Read attribute ENUM16 Default Value Error: %@", err);
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        {
+            id actualValue = value;
+            XCTAssertEqual([actualValue unsignedShortValue], 0U);
+            readAttributeEnum16DefaultValue = [actualValue unsignedShortValue];
+        }
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestSaveAs_000074_WriteAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute ENUM16 Not Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    id enum16Argument;
+    enum16Argument = [NSNumber numberWithUnsignedShort:1U];
+    [cluster writeAttributeEnum16WithValue:enum16Argument
+                         completionHandler:^(NSError * _Nullable err) {
+                             NSLog(@"Write attribute ENUM16 Not Default Value Error: %@", err);
+
+                             XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+                             [expectation fulfill];
+                         }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestSaveAs_000075_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute ENUM16 Not Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeEnum16WithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"Read attribute ENUM16 Not Default Value Error: %@", err);
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        {
+            id actualValue = value;
+            XCTAssertNotEqual([actualValue unsignedShortValue], readAttributeEnum16DefaultValue);
+        }
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestSaveAs_000076_WriteAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute ENUM16 Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    id enum16Argument;
+    enum16Argument = [NSNumber numberWithUnsignedShort:readAttributeEnum16DefaultValue];
+    [cluster writeAttributeEnum16WithValue:enum16Argument
+                         completionHandler:^(NSError * _Nullable err) {
+                             NSLog(@"Write attribute ENUM16 Default Value Error: %@", err);
+
+                             XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+                             [expectation fulfill];
+                         }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestSaveAs_000077_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute ENUM16 Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeEnum16WithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"Read attribute ENUM16 Default Value Error: %@", err);
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        {
+            id actualValue = value;
+            XCTAssertEqual([actualValue unsignedShortValue], readAttributeEnum16DefaultValue);
+        }
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+uint64_t readAttributeEpochUSDefaultValue;
+- (void)testSendClusterTestSaveAs_000078_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute EPOCH_US Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeEpochUsWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"Read attribute EPOCH_US Default Value Error: %@", err);
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        {
+            id actualValue = value;
+            XCTAssertEqual([actualValue unsignedLongLongValue], 0ULL);
+            readAttributeEpochUSDefaultValue = [actualValue unsignedLongLongValue];
+        }
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestSaveAs_000079_WriteAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute EPOCH_US Not Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    id epochUsArgument;
+    epochUsArgument = [NSNumber numberWithUnsignedLongLong:1ULL];
+    [cluster writeAttributeEpochUsWithValue:epochUsArgument
+                          completionHandler:^(NSError * _Nullable err) {
+                              NSLog(@"Write attribute EPOCH_US Not Default Value Error: %@", err);
+
+                              XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+                              [expectation fulfill];
+                          }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestSaveAs_000080_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute EPOCH_US Not Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeEpochUsWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"Read attribute EPOCH_US Not Default Value Error: %@", err);
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        {
+            id actualValue = value;
+            XCTAssertNotEqual([actualValue unsignedLongLongValue], readAttributeEpochUSDefaultValue);
+        }
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestSaveAs_000081_WriteAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute EPOCH_US Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    id epochUsArgument;
+    epochUsArgument = [NSNumber numberWithUnsignedLongLong:readAttributeEpochUSDefaultValue];
+    [cluster writeAttributeEpochUsWithValue:epochUsArgument
+                          completionHandler:^(NSError * _Nullable err) {
+                              NSLog(@"Write attribute EPOCH_US Default Value Error: %@", err);
+
+                              XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+                              [expectation fulfill];
+                          }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestSaveAs_000082_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute EPOCH_US Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeEpochUsWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"Read attribute EPOCH_US Default Value Error: %@", err);
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        {
+            id actualValue = value;
+            XCTAssertEqual([actualValue unsignedLongLongValue], readAttributeEpochUSDefaultValue);
+        }
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+uint32_t readAttributeEpochSDefaultValue;
+- (void)testSendClusterTestSaveAs_000083_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute EPOCH_S Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeEpochSWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"Read attribute EPOCH_S Default Value Error: %@", err);
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        {
+            id actualValue = value;
+            XCTAssertEqual([actualValue unsignedIntValue], 0UL);
+            readAttributeEpochSDefaultValue = [actualValue unsignedIntValue];
+        }
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestSaveAs_000084_WriteAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute EPOCH_S Not Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    id epochSArgument;
+    epochSArgument = [NSNumber numberWithUnsignedInt:1UL];
+    [cluster writeAttributeEpochSWithValue:epochSArgument
+                         completionHandler:^(NSError * _Nullable err) {
+                             NSLog(@"Write attribute EPOCH_S Not Default Value Error: %@", err);
+
+                             XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+                             [expectation fulfill];
+                         }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestSaveAs_000085_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute EPOCH_S Not Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeEpochSWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"Read attribute EPOCH_S Not Default Value Error: %@", err);
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        {
+            id actualValue = value;
+            XCTAssertNotEqual([actualValue unsignedIntValue], readAttributeEpochSDefaultValue);
+        }
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestSaveAs_000086_WriteAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute EPOCH_S Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    id epochSArgument;
+    epochSArgument = [NSNumber numberWithUnsignedInt:readAttributeEpochSDefaultValue];
+    [cluster writeAttributeEpochSWithValue:epochSArgument
+                         completionHandler:^(NSError * _Nullable err) {
+                             NSLog(@"Write attribute EPOCH_S Default Value Error: %@", err);
+
+                             XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+                             [expectation fulfill];
+                         }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestSaveAs_000087_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute EPOCH_S Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeEpochSWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"Read attribute EPOCH_S Default Value Error: %@", err);
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        {
+            id actualValue = value;
+            XCTAssertEqual([actualValue unsignedIntValue], readAttributeEpochSDefaultValue);
+        }
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+uint16_t readAttributeVendorIdDefaultValue;
+- (void)testSendClusterTestSaveAs_000088_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute vendor_id Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeVendorIdWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"Read attribute vendor_id Default Value Error: %@", err);
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        {
+            id actualValue = value;
+            XCTAssertEqual([actualValue unsignedShortValue], 0U);
+            readAttributeVendorIdDefaultValue = [actualValue unsignedShortValue];
+        }
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestSaveAs_000089_WriteAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute vendor_id Not Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    id vendorIdArgument;
+    vendorIdArgument = [NSNumber numberWithUnsignedShort:1U];
+    [cluster writeAttributeVendorIdWithValue:vendorIdArgument
+                           completionHandler:^(NSError * _Nullable err) {
+                               NSLog(@"Write attribute vendor_id Not Default Value Error: %@", err);
+
+                               XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+                               [expectation fulfill];
+                           }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestSaveAs_000090_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute vendor_id Not Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeVendorIdWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"Read attribute vendor_id Not Default Value Error: %@", err);
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        {
+            id actualValue = value;
+            XCTAssertNotEqual([actualValue unsignedShortValue], readAttributeVendorIdDefaultValue);
+        }
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestSaveAs_000091_WriteAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute vendor_id Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    id vendorIdArgument;
+    vendorIdArgument = [NSNumber numberWithUnsignedShort:readAttributeVendorIdDefaultValue];
+    [cluster writeAttributeVendorIdWithValue:vendorIdArgument
+                           completionHandler:^(NSError * _Nullable err) {
+                               NSLog(@"Write attribute vendor_id Default Value Error: %@", err);
+
+                               XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+                               [expectation fulfill];
+                           }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestSaveAs_000092_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute vendor_id Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeVendorIdWithCompletionHandler:^(NSNumber * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"Read attribute vendor_id Default Value Error: %@", err);
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        {
+            id actualValue = value;
+            XCTAssertEqual([actualValue unsignedShortValue], readAttributeVendorIdDefaultValue);
+        }
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+
 - (void)testSendClusterTestConstraints_000000_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute INT32U Value"];
@@ -24532,6 +26746,28 @@ CHIPDevice * GetConnectedDevice()
 
         [expectation fulfill];
     }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestConstraints_000004_WriteAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute INT32U Value Back to Default Value"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    id int32uArgument;
+    int32uArgument = [NSNumber numberWithUnsignedInt:0UL];
+    [cluster writeAttributeInt32uWithValue:int32uArgument
+                         completionHandler:^(NSError * _Nullable err) {
+                             NSLog(@"Write attribute INT32U Value Back to Default Value Error: %@", err);
+
+                             XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+                             [expectation fulfill];
+                         }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }

--- a/src/lib/support/Span.h
+++ b/src/lib/support/Span.h
@@ -75,6 +75,12 @@ public:
 
     // Allow data_equal for spans that are over the same type up to const-ness.
     template <class U, typename = std::enable_if_t<std::is_same<std::remove_const_t<T>, std::remove_const_t<U>>::value>>
+    bool operator==(const Span<U> & other) const
+    {
+        return data_equal(other);
+    }
+
+    template <class U, typename = std::enable_if_t<std::is_same<std::remove_const_t<T>, std::remove_const_t<U>>::value>>
     bool data_equal(const Span<U> & other) const
     {
         return (size() == other.size()) && (empty() || (memcmp(data(), other.data(), size() * sizeof(T)) == 0));

--- a/zzz_generated/chip-tool/zap-generated/test/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/test/Commands.h
@@ -124,6 +124,7 @@ private:
     void OnSuccessResponse_0(uint16_t clusterRevision)
     {
         VerifyOrReturn(CheckValue<uint16_t>("clusterRevision", clusterRevision, 1U));
+
         NextTest();
     }
 
@@ -159,6 +160,7 @@ private:
     void OnSuccessResponse_2(uint16_t clusterRevision)
     {
         VerifyOrReturn(CheckValue<uint16_t>("clusterRevision", clusterRevision, 1U));
+
         NextTest();
     }
 };
@@ -373,6 +375,7 @@ private:
     void OnSuccessResponse_0(bool outOfService)
     {
         VerifyOrReturn(CheckValue<bool>("outOfService", outOfService, 0));
+
         NextTest();
     }
 
@@ -391,6 +394,7 @@ private:
     void OnSuccessResponse_1(bool outOfService)
     {
         VerifyOrReturn(CheckConstraintType("outOfService", "", "bool"));
+
         NextTest();
     }
 
@@ -426,6 +430,7 @@ private:
     void OnSuccessResponse_3(bool outOfService)
     {
         VerifyOrReturn(CheckValue<bool>("outOfService", outOfService, 0));
+
         NextTest();
     }
 
@@ -444,6 +449,7 @@ private:
     void OnSuccessResponse_4(bool presentValue)
     {
         VerifyOrReturn(CheckConstraintType("presentValue", "", "bool"));
+
         NextTest();
     }
 
@@ -479,6 +485,7 @@ private:
     void OnSuccessResponse_6(bool presentValue)
     {
         VerifyOrReturn(CheckValue<bool>("presentValue", presentValue, 0));
+
         NextTest();
     }
 
@@ -497,6 +504,7 @@ private:
     void OnSuccessResponse_7(uint8_t statusFlags)
     {
         VerifyOrReturn(CheckValue<uint8_t>("statusFlags", statusFlags, 0));
+
         NextTest();
     }
 
@@ -516,6 +524,7 @@ private:
     {
         VerifyOrReturn(CheckConstraintType("statusFlags", "", "map8"));
         VerifyOrReturn(CheckConstraintMaxValue<uint8_t>("statusFlags", statusFlags, 15));
+
         NextTest();
     }
 
@@ -551,6 +560,7 @@ private:
     void OnSuccessResponse_10(uint8_t statusFlags)
     {
         VerifyOrReturn(CheckValue<uint8_t>("statusFlags", statusFlags, 0));
+
         NextTest();
     }
 };
@@ -729,6 +739,7 @@ private:
     void OnSuccessResponse_0(bool presentValue)
     {
         VerifyOrReturn(CheckValue<bool>("presentValue", presentValue, 0));
+
         NextTest();
     }
 
@@ -747,6 +758,7 @@ private:
     void OnSuccessResponse_1(bool outOfService)
     {
         VerifyOrReturn(CheckValue<bool>("outOfService", outOfService, 0));
+
         NextTest();
     }
 
@@ -765,6 +777,7 @@ private:
     void OnSuccessResponse_2(uint8_t statusFlags)
     {
         VerifyOrReturn(CheckValue<uint8_t>("statusFlags", statusFlags, 0));
+
         NextTest();
     }
 
@@ -783,6 +796,7 @@ private:
     void OnSuccessResponse_3(bool presentValue)
     {
         VerifyOrReturn(CheckValue<bool>("presentValue", presentValue, 0));
+
         NextTest();
     }
 
@@ -801,6 +815,7 @@ private:
     void OnSuccessResponse_4(bool outOfService)
     {
         VerifyOrReturn(CheckValue<bool>("outOfService", outOfService, 0));
+
         NextTest();
     }
 
@@ -819,6 +834,7 @@ private:
     void OnSuccessResponse_5(uint8_t statusFlags)
     {
         VerifyOrReturn(CheckValue<uint8_t>("statusFlags", statusFlags, 0));
+
         NextTest();
     }
 
@@ -837,6 +853,7 @@ private:
     void OnSuccessResponse_6(uint8_t statusFlags)
     {
         VerifyOrReturn(CheckValue<uint8_t>("statusFlags", statusFlags, 0));
+
         NextTest();
     }
 
@@ -855,6 +872,7 @@ private:
     void OnSuccessResponse_7(uint8_t statusFlags)
     {
         VerifyOrReturn(CheckValue<uint8_t>("statusFlags", statusFlags, 0));
+
         NextTest();
     }
 };
@@ -961,6 +979,7 @@ private:
     void OnSuccessResponse_0(uint16_t clusterRevision)
     {
         VerifyOrReturn(CheckValue<uint16_t>("clusterRevision", clusterRevision, 1U));
+
         NextTest();
     }
 
@@ -996,6 +1015,7 @@ private:
     void OnSuccessResponse_2(uint16_t clusterRevision)
     {
         VerifyOrReturn(CheckValue<uint16_t>("clusterRevision", clusterRevision, 1U));
+
         NextTest();
     }
 };
@@ -1116,6 +1136,7 @@ private:
     void OnSuccessResponse_0(bool stateValue)
     {
         VerifyOrReturn(CheckValue<bool>("stateValue", stateValue, 0));
+
         NextTest();
     }
 
@@ -1134,6 +1155,7 @@ private:
     void OnSuccessResponse_1(bool stateValue)
     {
         VerifyOrReturn(CheckConstraintType("stateValue", "", "bool"));
+
         NextTest();
     }
 
@@ -1169,6 +1191,7 @@ private:
     void OnSuccessResponse_3(bool stateValue)
     {
         VerifyOrReturn(CheckValue<bool>("stateValue", stateValue, 0));
+
         NextTest();
     }
 };
@@ -3234,6 +3257,7 @@ private:
     void OnSuccessResponse_0(uint8_t currentHue)
     {
         VerifyOrReturn(CheckValue<uint8_t>("currentHue", currentHue, 0));
+
         NextTest();
     }
 
@@ -3253,6 +3277,7 @@ private:
     {
         VerifyOrReturn(CheckConstraintType("currentHue", "", "uint8"));
         VerifyOrReturn(CheckConstraintMaxValue<uint8_t>("currentHue", currentHue, 254));
+
         NextTest();
     }
 
@@ -3288,6 +3313,7 @@ private:
     void OnSuccessResponse_3(uint8_t currentHue)
     {
         VerifyOrReturn(CheckValue<uint8_t>("currentHue", currentHue, 0));
+
         NextTest();
     }
 
@@ -3306,6 +3332,7 @@ private:
     void OnSuccessResponse_4(uint8_t currentSaturation)
     {
         VerifyOrReturn(CheckValue<uint8_t>("currentSaturation", currentSaturation, 0));
+
         NextTest();
     }
 
@@ -3325,6 +3352,7 @@ private:
     {
         VerifyOrReturn(CheckConstraintType("currentSaturation", "", "uint8"));
         VerifyOrReturn(CheckConstraintMaxValue<uint8_t>("currentSaturation", currentSaturation, 254));
+
         NextTest();
     }
 
@@ -3360,6 +3388,7 @@ private:
     void OnSuccessResponse_7(uint8_t currentSaturation)
     {
         VerifyOrReturn(CheckValue<uint8_t>("currentSaturation", currentSaturation, 0));
+
         NextTest();
     }
 
@@ -3378,6 +3407,7 @@ private:
     void OnSuccessResponse_8(uint16_t currentX)
     {
         VerifyOrReturn(CheckValue<uint16_t>("currentX", currentX, 24939U));
+
         NextTest();
     }
 
@@ -3397,6 +3427,7 @@ private:
     {
         VerifyOrReturn(CheckConstraintType("currentX", "", "uint16"));
         VerifyOrReturn(CheckConstraintMaxValue<uint16_t>("currentX", currentX, 65279));
+
         NextTest();
     }
 
@@ -3432,6 +3463,7 @@ private:
     void OnSuccessResponse_11(uint16_t currentX)
     {
         VerifyOrReturn(CheckValue<uint16_t>("currentX", currentX, 24939U));
+
         NextTest();
     }
 
@@ -3450,6 +3482,7 @@ private:
     void OnSuccessResponse_12(uint16_t currentY)
     {
         VerifyOrReturn(CheckValue<uint16_t>("currentY", currentY, 24701U));
+
         NextTest();
     }
 
@@ -3469,6 +3502,7 @@ private:
     {
         VerifyOrReturn(CheckConstraintType("currentY", "", "uint16"));
         VerifyOrReturn(CheckConstraintMaxValue<uint16_t>("currentY", currentY, 65279));
+
         NextTest();
     }
 
@@ -3504,6 +3538,7 @@ private:
     void OnSuccessResponse_15(uint16_t currentY)
     {
         VerifyOrReturn(CheckValue<uint16_t>("currentY", currentY, 24701U));
+
         NextTest();
     }
 
@@ -3523,6 +3558,7 @@ private:
     {
         VerifyOrReturn(CheckConstraintType("colorTemperature", "", "uint16"));
         VerifyOrReturn(CheckConstraintMaxValue<uint16_t>("colorTemperature", colorTemperature, 65279));
+
         NextTest();
     }
 
@@ -3542,6 +3578,7 @@ private:
     {
         VerifyOrReturn(CheckConstraintType("colorMode", "", "enum8"));
         VerifyOrReturn(CheckConstraintMaxValue<uint8_t>("colorMode", colorMode, 2));
+
         NextTest();
     }
 
@@ -3560,6 +3597,7 @@ private:
     void OnSuccessResponse_18(uint8_t colorControlOptions)
     {
         VerifyOrReturn(CheckValue<uint8_t>("colorControlOptions", colorControlOptions, 0));
+
         NextTest();
     }
 
@@ -3578,6 +3616,7 @@ private:
     void OnSuccessResponse_19(uint8_t colorControlOptions)
     {
         VerifyOrReturn(CheckConstraintType("colorControlOptions", "", "map8"));
+
         NextTest();
     }
 
@@ -3613,6 +3652,7 @@ private:
     void OnSuccessResponse_21(uint8_t colorControlOptions)
     {
         VerifyOrReturn(CheckValue<uint8_t>("colorControlOptions", colorControlOptions, 0));
+
         NextTest();
     }
 
@@ -3631,6 +3671,7 @@ private:
     void OnSuccessResponse_22(uint16_t enhancedCurrentHue)
     {
         VerifyOrReturn(CheckValue<uint16_t>("enhancedCurrentHue", enhancedCurrentHue, 0U));
+
         NextTest();
     }
 
@@ -3649,6 +3690,7 @@ private:
     void OnSuccessResponse_23(uint16_t enhancedCurrentHue)
     {
         VerifyOrReturn(CheckConstraintType("enhancedCurrentHue", "", "uint16"));
+
         NextTest();
     }
 
@@ -3684,6 +3726,7 @@ private:
     void OnSuccessResponse_25(uint16_t enhancedCurrentHue)
     {
         VerifyOrReturn(CheckValue<uint16_t>("enhancedCurrentHue", enhancedCurrentHue, 0U));
+
         NextTest();
     }
 
@@ -3702,6 +3745,7 @@ private:
     void OnSuccessResponse_26(uint8_t enhancedColorMode)
     {
         VerifyOrReturn(CheckConstraintType("enhancedColorMode", "", "enum8"));
+
         NextTest();
     }
 
@@ -3720,6 +3764,7 @@ private:
     void OnSuccessResponse_27(uint8_t colorLoopActive)
     {
         VerifyOrReturn(CheckValue<uint8_t>("colorLoopActive", colorLoopActive, 0));
+
         NextTest();
     }
 
@@ -3738,6 +3783,7 @@ private:
     void OnSuccessResponse_28(uint8_t colorLoopActive)
     {
         VerifyOrReturn(CheckConstraintType("colorLoopActive", "", "uint8"));
+
         NextTest();
     }
 
@@ -3773,6 +3819,7 @@ private:
     void OnSuccessResponse_30(uint8_t colorLoopActive)
     {
         VerifyOrReturn(CheckValue<uint8_t>("colorLoopActive", colorLoopActive, 0));
+
         NextTest();
     }
 
@@ -3791,6 +3838,7 @@ private:
     void OnSuccessResponse_31(uint8_t colorLoopDirection)
     {
         VerifyOrReturn(CheckValue<uint8_t>("colorLoopDirection", colorLoopDirection, 0));
+
         NextTest();
     }
 
@@ -3809,6 +3857,7 @@ private:
     void OnSuccessResponse_32(uint8_t colorLoopDirection)
     {
         VerifyOrReturn(CheckConstraintType("colorLoopDirection", "", "uint8"));
+
         NextTest();
     }
 
@@ -3844,6 +3893,7 @@ private:
     void OnSuccessResponse_34(uint8_t colorLoopDirection)
     {
         VerifyOrReturn(CheckValue<uint8_t>("colorLoopDirection", colorLoopDirection, 0));
+
         NextTest();
     }
 
@@ -3862,6 +3912,7 @@ private:
     void OnSuccessResponse_35(uint16_t colorLoopTime)
     {
         VerifyOrReturn(CheckValue<uint16_t>("colorLoopTime", colorLoopTime, 25U));
+
         NextTest();
     }
 
@@ -3880,6 +3931,7 @@ private:
     void OnSuccessResponse_36(uint16_t colorLoopTime)
     {
         VerifyOrReturn(CheckConstraintType("colorLoopTime", "", "uint16"));
+
         NextTest();
     }
 
@@ -3915,6 +3967,7 @@ private:
     void OnSuccessResponse_38(uint16_t colorLoopTime)
     {
         VerifyOrReturn(CheckValue<uint16_t>("colorLoopTime", colorLoopTime, 25U));
+
         NextTest();
     }
 
@@ -3933,6 +3986,7 @@ private:
     void OnSuccessResponse_39(uint16_t colorLoopStartEnhancedHue)
     {
         VerifyOrReturn(CheckValue<uint16_t>("colorLoopStartEnhancedHue", colorLoopStartEnhancedHue, 8960U));
+
         NextTest();
     }
 
@@ -3951,6 +4005,7 @@ private:
     void OnSuccessResponse_40(uint16_t colorLoopStartEnhancedHue)
     {
         VerifyOrReturn(CheckConstraintType("colorLoopStartEnhancedHue", "", "uint16"));
+
         NextTest();
     }
 
@@ -3986,6 +4041,7 @@ private:
     void OnSuccessResponse_42(uint16_t colorLoopStartEnhancedHue)
     {
         VerifyOrReturn(CheckValue<uint16_t>("colorLoopStartEnhancedHue", colorLoopStartEnhancedHue, 8960U));
+
         NextTest();
     }
 
@@ -4004,6 +4060,7 @@ private:
     void OnSuccessResponse_43(uint16_t colorLoopStoredEnhancedHue)
     {
         VerifyOrReturn(CheckValue<uint16_t>("colorLoopStoredEnhancedHue", colorLoopStoredEnhancedHue, 0U));
+
         NextTest();
     }
 
@@ -4022,6 +4079,7 @@ private:
     void OnSuccessResponse_44(uint16_t colorLoopStoredEnhancedHue)
     {
         VerifyOrReturn(CheckConstraintType("colorLoopStoredEnhancedHue", "", "uint16"));
+
         NextTest();
     }
 
@@ -4057,6 +4115,7 @@ private:
     void OnSuccessResponse_46(uint16_t colorLoopStoredEnhancedHue)
     {
         VerifyOrReturn(CheckValue<uint16_t>("colorLoopStoredEnhancedHue", colorLoopStoredEnhancedHue, 0U));
+
         NextTest();
     }
 
@@ -4075,6 +4134,7 @@ private:
     void OnSuccessResponse_47(uint16_t colorCapabilities)
     {
         VerifyOrReturn(CheckValue<uint16_t>("colorCapabilities", colorCapabilities, 0U));
+
         NextTest();
     }
 
@@ -4094,6 +4154,7 @@ private:
     {
         VerifyOrReturn(CheckConstraintType("colorCapabilities", "", "map16"));
         VerifyOrReturn(CheckConstraintMaxValue<uint16_t>("colorCapabilities", colorCapabilities, 65279));
+
         NextTest();
     }
 
@@ -4129,6 +4190,7 @@ private:
     void OnSuccessResponse_50(uint16_t colorCapabilities)
     {
         VerifyOrReturn(CheckValue<uint16_t>("colorCapabilities", colorCapabilities, 0U));
+
         NextTest();
     }
 
@@ -4147,6 +4209,7 @@ private:
     void OnSuccessResponse_51(uint16_t colorTempPhysicalMin)
     {
         VerifyOrReturn(CheckValue<uint16_t>("colorTempPhysicalMin", colorTempPhysicalMin, 0U));
+
         NextTest();
     }
 
@@ -4166,6 +4229,7 @@ private:
     {
         VerifyOrReturn(CheckConstraintType("colorTempPhysicalMin", "", "uint16"));
         VerifyOrReturn(CheckConstraintMaxValue<uint16_t>("colorTempPhysicalMin", colorTempPhysicalMin, 65279));
+
         NextTest();
     }
 
@@ -4201,6 +4265,7 @@ private:
     void OnSuccessResponse_54(uint16_t colorTempPhysicalMin)
     {
         VerifyOrReturn(CheckValue<uint16_t>("colorTempPhysicalMin", colorTempPhysicalMin, 0U));
+
         NextTest();
     }
 
@@ -4219,6 +4284,7 @@ private:
     void OnSuccessResponse_55(uint16_t colorTempPhysicalMax)
     {
         VerifyOrReturn(CheckValue<uint16_t>("colorTempPhysicalMax", colorTempPhysicalMax, 65279U));
+
         NextTest();
     }
 
@@ -4238,6 +4304,7 @@ private:
     {
         VerifyOrReturn(CheckConstraintType("colorTempPhysicalMax", "", "uint16"));
         VerifyOrReturn(CheckConstraintMaxValue<uint16_t>("colorTempPhysicalMax", colorTempPhysicalMax, 65279));
+
         NextTest();
     }
 
@@ -4273,6 +4340,7 @@ private:
     void OnSuccessResponse_58(uint16_t colorTempPhysicalMax)
     {
         VerifyOrReturn(CheckValue<uint16_t>("colorTempPhysicalMax", colorTempPhysicalMax, 65279U));
+
         NextTest();
     }
 
@@ -4291,6 +4359,7 @@ private:
     void OnSuccessResponse_59(uint16_t coupleColorTempToLevelMinMireds)
     {
         VerifyOrReturn(CheckConstraintType("coupleColorTempToLevelMinMireds", "", "uint16"));
+
         NextTest();
     }
 
@@ -4326,6 +4395,7 @@ private:
     void OnSuccessResponse_61(uint16_t coupleColorTempToLevelMinMireds)
     {
         VerifyOrReturn(CheckValue<uint16_t>("coupleColorTempToLevelMinMireds", coupleColorTempToLevelMinMireds, 0U));
+
         NextTest();
     }
 
@@ -4345,6 +4415,7 @@ private:
     {
         VerifyOrReturn(CheckConstraintType("startUpColorTemperatureMireds", "", "uint16"));
         VerifyOrReturn(CheckConstraintMaxValue<uint16_t>("startUpColorTemperatureMireds", startUpColorTemperatureMireds, 65279));
+
         NextTest();
     }
 
@@ -4380,6 +4451,7 @@ private:
     void OnSuccessResponse_64(uint16_t startUpColorTemperatureMireds)
     {
         VerifyOrReturn(CheckValue<uint16_t>("startUpColorTemperatureMireds", startUpColorTemperatureMireds, 0U));
+
         NextTest();
     }
 
@@ -4398,6 +4470,7 @@ private:
     void OnSuccessResponse_65(uint16_t remainingTime)
     {
         VerifyOrReturn(CheckValue<uint16_t>("remainingTime", remainingTime, 0U));
+
         NextTest();
     }
 
@@ -4417,6 +4490,7 @@ private:
     {
         VerifyOrReturn(CheckConstraintType("remainingTime", "", "uint16"));
         VerifyOrReturn(CheckConstraintMaxValue<uint16_t>("remainingTime", remainingTime, 254));
+
         NextTest();
     }
 
@@ -4452,6 +4526,7 @@ private:
     void OnSuccessResponse_68(uint16_t remainingTime)
     {
         VerifyOrReturn(CheckValue<uint16_t>("remainingTime", remainingTime, 0U));
+
         NextTest();
     }
 
@@ -4471,6 +4546,7 @@ private:
     {
         VerifyOrReturn(CheckConstraintType("driftCompensation", "", "enum8"));
         VerifyOrReturn(CheckConstraintMaxValue<uint8_t>("driftCompensation", driftCompensation, 4));
+
         NextTest();
     }
 
@@ -4506,6 +4582,7 @@ private:
     void OnSuccessResponse_71(uint8_t driftCompensation)
     {
         VerifyOrReturn(CheckValue<uint8_t>("driftCompensation", driftCompensation, 0));
+
         NextTest();
     }
 
@@ -4525,6 +4602,7 @@ private:
     {
         VerifyOrReturn(CheckConstraintType("compensationText", "", "string"));
         VerifyOrReturn(CheckConstraintMaxLength("compensationText", compensationText.size(), 254));
+
         NextTest();
     }
 
@@ -4544,6 +4622,7 @@ private:
     {
         VerifyOrReturn(CheckConstraintType("numberOfPrimaries", "", "uint8"));
         VerifyOrReturn(CheckConstraintMaxValue<uint8_t>("numberOfPrimaries", numberOfPrimaries, 6));
+
         NextTest();
     }
 
@@ -4579,6 +4658,7 @@ private:
     void OnSuccessResponse_75(uint8_t numberOfPrimaries)
     {
         VerifyOrReturn(CheckValue<uint8_t>("numberOfPrimaries", numberOfPrimaries, 0));
+
         NextTest();
     }
 
@@ -4598,6 +4678,7 @@ private:
     {
         VerifyOrReturn(CheckConstraintType("primary1X", "", "uint16"));
         VerifyOrReturn(CheckConstraintMaxValue<uint16_t>("primary1X", primary1X, 65279));
+
         NextTest();
     }
 
@@ -4633,6 +4714,7 @@ private:
     void OnSuccessResponse_78(uint16_t primary1X)
     {
         VerifyOrReturn(CheckValue<uint16_t>("primary1X", primary1X, 0U));
+
         NextTest();
     }
 
@@ -4652,6 +4734,7 @@ private:
     {
         VerifyOrReturn(CheckConstraintType("primary1Y", "", "uint16"));
         VerifyOrReturn(CheckConstraintMaxValue<uint16_t>("primary1Y", primary1Y, 65279));
+
         NextTest();
     }
 
@@ -4687,6 +4770,7 @@ private:
     void OnSuccessResponse_81(uint16_t primary1Y)
     {
         VerifyOrReturn(CheckValue<uint16_t>("primary1Y", primary1Y, 0U));
+
         NextTest();
     }
 
@@ -4705,6 +4789,7 @@ private:
     void OnSuccessResponse_82(uint8_t primary1Intensity)
     {
         VerifyOrReturn(CheckConstraintType("primary1Intensity", "", "uint8"));
+
         NextTest();
     }
 
@@ -4724,6 +4809,7 @@ private:
     {
         VerifyOrReturn(CheckConstraintType("primary2X", "", "uint16"));
         VerifyOrReturn(CheckConstraintMaxValue<uint16_t>("primary2X", primary2X, 65279));
+
         NextTest();
     }
 
@@ -4759,6 +4845,7 @@ private:
     void OnSuccessResponse_85(uint16_t primary2X)
     {
         VerifyOrReturn(CheckValue<uint16_t>("primary2X", primary2X, 0U));
+
         NextTest();
     }
 
@@ -4778,6 +4865,7 @@ private:
     {
         VerifyOrReturn(CheckConstraintType("primary2Y", "", "uint16"));
         VerifyOrReturn(CheckConstraintMaxValue<uint16_t>("primary2Y", primary2Y, 65279));
+
         NextTest();
     }
 
@@ -4813,6 +4901,7 @@ private:
     void OnSuccessResponse_88(uint16_t primary2Y)
     {
         VerifyOrReturn(CheckValue<uint16_t>("primary2Y", primary2Y, 0U));
+
         NextTest();
     }
 
@@ -4831,6 +4920,7 @@ private:
     void OnSuccessResponse_89(uint8_t primary2Intensity)
     {
         VerifyOrReturn(CheckConstraintType("primary2Intensity", "", "uint8"));
+
         NextTest();
     }
 
@@ -4850,6 +4940,7 @@ private:
     {
         VerifyOrReturn(CheckConstraintType("primary3X", "", "uint16"));
         VerifyOrReturn(CheckConstraintMaxValue<uint16_t>("primary3X", primary3X, 65279));
+
         NextTest();
     }
 
@@ -4885,6 +4976,7 @@ private:
     void OnSuccessResponse_92(uint16_t primary3X)
     {
         VerifyOrReturn(CheckValue<uint16_t>("primary3X", primary3X, 0U));
+
         NextTest();
     }
 
@@ -4904,6 +4996,7 @@ private:
     {
         VerifyOrReturn(CheckConstraintType("primary3Y", "", "uint16"));
         VerifyOrReturn(CheckConstraintMaxValue<uint16_t>("primary3Y", primary3Y, 65279));
+
         NextTest();
     }
 
@@ -4939,6 +5032,7 @@ private:
     void OnSuccessResponse_95(uint16_t primary3Y)
     {
         VerifyOrReturn(CheckValue<uint16_t>("primary3Y", primary3Y, 0U));
+
         NextTest();
     }
 
@@ -4957,6 +5051,7 @@ private:
     void OnSuccessResponse_96(uint8_t primary3Intensity)
     {
         VerifyOrReturn(CheckConstraintType("primary3Intensity", "", "uint8"));
+
         NextTest();
     }
 
@@ -4976,6 +5071,7 @@ private:
     {
         VerifyOrReturn(CheckConstraintType("primary4X", "", "uint16"));
         VerifyOrReturn(CheckConstraintMaxValue<uint16_t>("primary4X", primary4X, 65279));
+
         NextTest();
     }
 
@@ -5011,6 +5107,7 @@ private:
     void OnSuccessResponse_99(uint16_t primary4X)
     {
         VerifyOrReturn(CheckValue<uint16_t>("primary4X", primary4X, 0U));
+
         NextTest();
     }
 
@@ -5030,6 +5127,7 @@ private:
     {
         VerifyOrReturn(CheckConstraintType("primary4Y", "", "uint16"));
         VerifyOrReturn(CheckConstraintMaxValue<uint16_t>("primary4Y", primary4Y, 65279));
+
         NextTest();
     }
 
@@ -5065,6 +5163,7 @@ private:
     void OnSuccessResponse_102(uint16_t primary4Y)
     {
         VerifyOrReturn(CheckValue<uint16_t>("primary4Y", primary4Y, 0U));
+
         NextTest();
     }
 
@@ -5083,6 +5182,7 @@ private:
     void OnSuccessResponse_103(uint8_t primary4Intensity)
     {
         VerifyOrReturn(CheckConstraintType("primary4Intensity", "", "uint8"));
+
         NextTest();
     }
 
@@ -5102,6 +5202,7 @@ private:
     {
         VerifyOrReturn(CheckConstraintType("primary5X", "", "uint16"));
         VerifyOrReturn(CheckConstraintMaxValue<uint16_t>("primary5X", primary5X, 65279));
+
         NextTest();
     }
 
@@ -5137,6 +5238,7 @@ private:
     void OnSuccessResponse_106(uint16_t primary5X)
     {
         VerifyOrReturn(CheckValue<uint16_t>("primary5X", primary5X, 0U));
+
         NextTest();
     }
 
@@ -5156,6 +5258,7 @@ private:
     {
         VerifyOrReturn(CheckConstraintType("primary5Y", "", "uint16"));
         VerifyOrReturn(CheckConstraintMaxValue<uint16_t>("primary5Y", primary5Y, 65279));
+
         NextTest();
     }
 
@@ -5191,6 +5294,7 @@ private:
     void OnSuccessResponse_109(uint16_t primary5Y)
     {
         VerifyOrReturn(CheckValue<uint16_t>("primary5Y", primary5Y, 0U));
+
         NextTest();
     }
 
@@ -5209,6 +5313,7 @@ private:
     void OnSuccessResponse_110(uint8_t primary5Intensity)
     {
         VerifyOrReturn(CheckConstraintType("primary5Intensity", "", "uint8"));
+
         NextTest();
     }
 
@@ -5228,6 +5333,7 @@ private:
     {
         VerifyOrReturn(CheckConstraintType("primary6X", "", "uint16"));
         VerifyOrReturn(CheckConstraintMaxValue<uint16_t>("primary6X", primary6X, 65279));
+
         NextTest();
     }
 
@@ -5263,6 +5369,7 @@ private:
     void OnSuccessResponse_113(uint16_t primary6X)
     {
         VerifyOrReturn(CheckValue<uint16_t>("primary6X", primary6X, 0U));
+
         NextTest();
     }
 
@@ -5282,6 +5389,7 @@ private:
     {
         VerifyOrReturn(CheckConstraintType("primary6Y", "", "uint16"));
         VerifyOrReturn(CheckConstraintMaxValue<uint16_t>("primary6Y", primary6Y, 65279));
+
         NextTest();
     }
 
@@ -5317,6 +5425,7 @@ private:
     void OnSuccessResponse_116(uint16_t primary6Y)
     {
         VerifyOrReturn(CheckValue<uint16_t>("primary6Y", primary6Y, 0U));
+
         NextTest();
     }
 
@@ -5335,6 +5444,7 @@ private:
     void OnSuccessResponse_117(uint8_t primary6Intensity)
     {
         VerifyOrReturn(CheckConstraintType("primary6Intensity", "", "uint8"));
+
         NextTest();
     }
 
@@ -5354,6 +5464,7 @@ private:
     {
         VerifyOrReturn(CheckConstraintType("whitePointX", "", "uint16"));
         VerifyOrReturn(CheckConstraintMaxValue<uint16_t>("whitePointX", whitePointX, 65279));
+
         NextTest();
     }
 
@@ -5389,6 +5500,7 @@ private:
     void OnSuccessResponse_120(uint16_t whitePointX)
     {
         VerifyOrReturn(CheckValue<uint16_t>("whitePointX", whitePointX, 0U));
+
         NextTest();
     }
 
@@ -5408,6 +5520,7 @@ private:
     {
         VerifyOrReturn(CheckConstraintType("whitePointY", "", "uint16"));
         VerifyOrReturn(CheckConstraintMaxValue<uint16_t>("whitePointY", whitePointY, 65279));
+
         NextTest();
     }
 
@@ -5443,6 +5556,7 @@ private:
     void OnSuccessResponse_123(uint16_t whitePointY)
     {
         VerifyOrReturn(CheckValue<uint16_t>("whitePointY", whitePointY, 0U));
+
         NextTest();
     }
 
@@ -5462,6 +5576,7 @@ private:
     {
         VerifyOrReturn(CheckConstraintType("colorPointRX", "", "uint16"));
         VerifyOrReturn(CheckConstraintMaxValue<uint16_t>("colorPointRX", colorPointRX, 65279));
+
         NextTest();
     }
 
@@ -5497,6 +5612,7 @@ private:
     void OnSuccessResponse_126(uint16_t colorPointRX)
     {
         VerifyOrReturn(CheckValue<uint16_t>("colorPointRX", colorPointRX, 0U));
+
         NextTest();
     }
 
@@ -5516,6 +5632,7 @@ private:
     {
         VerifyOrReturn(CheckConstraintType("colorPointRY", "", "uint16"));
         VerifyOrReturn(CheckConstraintMaxValue<uint16_t>("colorPointRY", colorPointRY, 65279));
+
         NextTest();
     }
 
@@ -5551,6 +5668,7 @@ private:
     void OnSuccessResponse_129(uint16_t colorPointRY)
     {
         VerifyOrReturn(CheckValue<uint16_t>("colorPointRY", colorPointRY, 0U));
+
         NextTest();
     }
 
@@ -5569,6 +5687,7 @@ private:
     void OnSuccessResponse_130(uint8_t colorPointRIntensity)
     {
         VerifyOrReturn(CheckConstraintType("colorPointRIntensity", "", "uint8"));
+
         NextTest();
     }
 
@@ -5588,6 +5707,7 @@ private:
     {
         VerifyOrReturn(CheckConstraintType("colorPointGX", "", "uint16"));
         VerifyOrReturn(CheckConstraintMaxValue<uint16_t>("colorPointGX", colorPointGX, 65279));
+
         NextTest();
     }
 
@@ -5623,6 +5743,7 @@ private:
     void OnSuccessResponse_133(uint16_t colorPointGX)
     {
         VerifyOrReturn(CheckValue<uint16_t>("colorPointGX", colorPointGX, 0U));
+
         NextTest();
     }
 
@@ -5642,6 +5763,7 @@ private:
     {
         VerifyOrReturn(CheckConstraintType("colorPointGY", "", "uint16"));
         VerifyOrReturn(CheckConstraintMaxValue<uint16_t>("colorPointGY", colorPointGY, 65279));
+
         NextTest();
     }
 
@@ -5677,6 +5799,7 @@ private:
     void OnSuccessResponse_136(uint16_t colorPointGY)
     {
         VerifyOrReturn(CheckValue<uint16_t>("colorPointGY", colorPointGY, 0U));
+
         NextTest();
     }
 
@@ -5695,6 +5818,7 @@ private:
     void OnSuccessResponse_137(uint8_t colorPointGIntensity)
     {
         VerifyOrReturn(CheckConstraintType("colorPointGIntensity", "", "uint8"));
+
         NextTest();
     }
 
@@ -5714,6 +5838,7 @@ private:
     {
         VerifyOrReturn(CheckConstraintType("colorPointBX", "", "uint16"));
         VerifyOrReturn(CheckConstraintMaxValue<uint16_t>("colorPointBX", colorPointBX, 65279));
+
         NextTest();
     }
 
@@ -5749,6 +5874,7 @@ private:
     void OnSuccessResponse_140(uint16_t colorPointBX)
     {
         VerifyOrReturn(CheckValue<uint16_t>("colorPointBX", colorPointBX, 0U));
+
         NextTest();
     }
 
@@ -5768,6 +5894,7 @@ private:
     {
         VerifyOrReturn(CheckConstraintType("colorPointBY", "", "uint16"));
         VerifyOrReturn(CheckConstraintMaxValue<uint16_t>("colorPointBY", colorPointBY, 65279));
+
         NextTest();
     }
 
@@ -5803,6 +5930,7 @@ private:
     void OnSuccessResponse_143(uint16_t colorPointBY)
     {
         VerifyOrReturn(CheckValue<uint16_t>("colorPointBY", colorPointBY, 0U));
+
         NextTest();
     }
 
@@ -5821,6 +5949,7 @@ private:
     void OnSuccessResponse_144(uint8_t colorPointBIntensity)
     {
         VerifyOrReturn(CheckConstraintType("colorPointBIntensity", "", "uint8"));
+
         NextTest();
     }
 };
@@ -5962,6 +6091,7 @@ private:
     void OnSuccessResponse_1(bool onOff)
     {
         VerifyOrReturn(CheckValue<bool>("onOff", onOff, 1));
+
         NextTest();
     }
 
@@ -6115,6 +6245,7 @@ private:
     void OnSuccessResponse_7(bool onOff)
     {
         VerifyOrReturn(CheckValue<bool>("onOff", onOff, 0));
+
         NextTest();
     }
 };
@@ -6256,6 +6387,7 @@ private:
     void OnSuccessResponse_1(bool onOff)
     {
         VerifyOrReturn(CheckValue<bool>("onOff", onOff, 1));
+
         NextTest();
     }
 
@@ -6405,6 +6537,7 @@ private:
     void OnSuccessResponse_7(bool onOff)
     {
         VerifyOrReturn(CheckValue<bool>("onOff", onOff, 0));
+
         NextTest();
     }
 };
@@ -6538,6 +6671,7 @@ private:
     void OnSuccessResponse_1(bool onOff)
     {
         VerifyOrReturn(CheckValue<bool>("onOff", onOff, 1));
+
         NextTest();
     }
 
@@ -6635,6 +6769,7 @@ private:
     void OnSuccessResponse_5(bool onOff)
     {
         VerifyOrReturn(CheckValue<bool>("onOff", onOff, 0));
+
         NextTest();
     }
 };
@@ -6764,6 +6899,7 @@ private:
     void OnSuccessResponse_1(bool onOff)
     {
         VerifyOrReturn(CheckValue<bool>("onOff", onOff, 1));
+
         NextTest();
     }
 
@@ -6832,6 +6968,7 @@ private:
     void OnSuccessResponse_4(bool onOff)
     {
         VerifyOrReturn(CheckValue<bool>("onOff", onOff, 0));
+
         NextTest();
     }
 };
@@ -6965,6 +7102,7 @@ private:
     void OnSuccessResponse_1(bool onOff)
     {
         VerifyOrReturn(CheckValue<bool>("onOff", onOff, 1));
+
         NextTest();
     }
 
@@ -7060,6 +7198,7 @@ private:
     void OnSuccessResponse_5(bool onOff)
     {
         VerifyOrReturn(CheckValue<bool>("onOff", onOff, 0));
+
         NextTest();
     }
 };
@@ -7193,6 +7332,7 @@ private:
     void OnSuccessResponse_1(bool onOff)
     {
         VerifyOrReturn(CheckValue<bool>("onOff", onOff, 1));
+
         NextTest();
     }
 
@@ -7290,6 +7430,7 @@ private:
     void OnSuccessResponse_5(bool onOff)
     {
         VerifyOrReturn(CheckValue<bool>("onOff", onOff, 0));
+
         NextTest();
     }
 };
@@ -7419,6 +7560,7 @@ private:
     void OnSuccessResponse_1(bool onOff)
     {
         VerifyOrReturn(CheckValue<bool>("onOff", onOff, 1));
+
         NextTest();
     }
 
@@ -7488,6 +7630,7 @@ private:
     void OnSuccessResponse_4(bool onOff)
     {
         VerifyOrReturn(CheckValue<bool>("onOff", onOff, 0));
+
         NextTest();
     }
 };
@@ -7617,6 +7760,7 @@ private:
     void OnSuccessResponse_1(bool onOff)
     {
         VerifyOrReturn(CheckValue<bool>("onOff", onOff, 1));
+
         NextTest();
     }
 
@@ -7686,6 +7830,7 @@ private:
     void OnSuccessResponse_4(bool onOff)
     {
         VerifyOrReturn(CheckValue<bool>("onOff", onOff, 0));
+
         NextTest();
     }
 };
@@ -7819,6 +7964,7 @@ private:
     void OnSuccessResponse_1(bool onOff)
     {
         VerifyOrReturn(CheckValue<bool>("onOff", onOff, 1));
+
         NextTest();
     }
 
@@ -7912,6 +8058,7 @@ private:
     void OnSuccessResponse_5(bool onOff)
     {
         VerifyOrReturn(CheckValue<bool>("onOff", onOff, 0));
+
         NextTest();
     }
 };
@@ -8041,6 +8188,7 @@ private:
     void OnSuccessResponse_1(bool onOff)
     {
         VerifyOrReturn(CheckValue<bool>("onOff", onOff, 1));
+
         NextTest();
     }
 
@@ -8110,6 +8258,7 @@ private:
     void OnSuccessResponse_4(bool onOff)
     {
         VerifyOrReturn(CheckValue<bool>("onOff", onOff, 0));
+
         NextTest();
     }
 };
@@ -8239,6 +8388,7 @@ private:
     void OnSuccessResponse_1(bool onOff)
     {
         VerifyOrReturn(CheckValue<bool>("onOff", onOff, 1));
+
         NextTest();
     }
 
@@ -8307,6 +8457,7 @@ private:
     void OnSuccessResponse_4(bool onOff)
     {
         VerifyOrReturn(CheckValue<bool>("onOff", onOff, 0));
+
         NextTest();
     }
 };
@@ -8444,6 +8595,7 @@ private:
     void OnSuccessResponse_1(bool onOff)
     {
         VerifyOrReturn(CheckValue<bool>("onOff", onOff, 1));
+
         NextTest();
     }
 
@@ -8572,6 +8724,7 @@ private:
     void OnSuccessResponse_6(bool onOff)
     {
         VerifyOrReturn(CheckValue<bool>("onOff", onOff, 0));
+
         NextTest();
     }
 };
@@ -8705,6 +8858,7 @@ private:
     void OnSuccessResponse_1(bool onOff)
     {
         VerifyOrReturn(CheckValue<bool>("onOff", onOff, 1));
+
         NextTest();
     }
 
@@ -8806,6 +8960,7 @@ private:
     void OnSuccessResponse_5(bool onOff)
     {
         VerifyOrReturn(CheckValue<bool>("onOff", onOff, 0));
+
         NextTest();
     }
 };
@@ -8950,6 +9105,7 @@ private:
     void OnSuccessResponse_1(bool onOff)
     {
         VerifyOrReturn(CheckValue<bool>("onOff", onOff, 1));
+
         NextTest();
     }
 
@@ -8996,6 +9152,7 @@ private:
     void OnSuccessResponse_3(uint16_t remainingTime)
     {
         VerifyOrReturn(CheckValue<uint16_t>("remainingTime", remainingTime, 1U));
+
         NextTest();
     }
 
@@ -9037,6 +9194,7 @@ private:
     void OnSuccessResponse_5(bool onOff)
     {
         VerifyOrReturn(CheckValue<bool>("onOff", onOff, 0));
+
         NextTest();
     }
 };
@@ -9178,6 +9336,7 @@ private:
     void OnSuccessResponse_1(bool onOff)
     {
         VerifyOrReturn(CheckValue<bool>("onOff", onOff, 1));
+
         NextTest();
     }
 
@@ -9327,6 +9486,7 @@ private:
     void OnSuccessResponse_7(bool onOff)
     {
         VerifyOrReturn(CheckValue<bool>("onOff", onOff, 0));
+
         NextTest();
     }
 };
@@ -9460,6 +9620,7 @@ private:
     void OnSuccessResponse_1(bool onOff)
     {
         VerifyOrReturn(CheckValue<bool>("onOff", onOff, 1));
+
         NextTest();
     }
 
@@ -9557,6 +9718,7 @@ private:
     void OnSuccessResponse_5(bool onOff)
     {
         VerifyOrReturn(CheckValue<bool>("onOff", onOff, 0));
+
         NextTest();
     }
 };
@@ -9686,6 +9848,7 @@ private:
     void OnSuccessResponse_1(bool onOff)
     {
         VerifyOrReturn(CheckValue<bool>("onOff", onOff, 1));
+
         NextTest();
     }
 
@@ -9755,6 +9918,7 @@ private:
     void OnSuccessResponse_4(bool onOff)
     {
         VerifyOrReturn(CheckValue<bool>("onOff", onOff, 0));
+
         NextTest();
     }
 };
@@ -10008,6 +10172,7 @@ private:
     void OnSuccessResponse_1(bool onOff)
     {
         VerifyOrReturn(CheckValue<bool>("onOff", onOff, 1));
+
         NextTest();
     }
 
@@ -10056,6 +10221,7 @@ private:
     void OnSuccessResponse_3(uint8_t colorLoopDirection)
     {
         VerifyOrReturn(CheckValue<uint8_t>("colorLoopDirection", colorLoopDirection, 1));
+
         NextTest();
     }
 
@@ -10074,6 +10240,7 @@ private:
     void OnSuccessResponse_4(uint16_t colorLoopTime)
     {
         VerifyOrReturn(CheckValue<uint16_t>("colorLoopTime", colorLoopTime, 100U));
+
         NextTest();
     }
 
@@ -10092,6 +10259,7 @@ private:
     void OnSuccessResponse_5(uint16_t colorLoopStartEnhancedHue)
     {
         VerifyOrReturn(CheckValue<uint16_t>("colorLoopStartEnhancedHue", colorLoopStartEnhancedHue, 500U));
+
         NextTest();
     }
 
@@ -10110,6 +10278,7 @@ private:
     void OnSuccessResponse_6(uint8_t colorLoopActive)
     {
         VerifyOrReturn(CheckValue<uint8_t>("colorLoopActive", colorLoopActive, 0));
+
         NextTest();
     }
 
@@ -10158,6 +10327,7 @@ private:
     void OnSuccessResponse_8(uint8_t colorLoopActive)
     {
         VerifyOrReturn(CheckValue<uint8_t>("colorLoopActive", colorLoopActive, 1));
+
         NextTest();
     }
 
@@ -10206,6 +10376,7 @@ private:
     void OnSuccessResponse_10(uint8_t colorLoopDirection)
     {
         VerifyOrReturn(CheckValue<uint8_t>("colorLoopDirection", colorLoopDirection, 0));
+
         NextTest();
     }
 
@@ -10224,6 +10395,7 @@ private:
     void OnSuccessResponse_11(uint16_t colorLoopTime)
     {
         VerifyOrReturn(CheckValue<uint16_t>("colorLoopTime", colorLoopTime, 3500U));
+
         NextTest();
     }
 
@@ -10272,6 +10444,7 @@ private:
     void OnSuccessResponse_13(uint8_t colorLoopDirection)
     {
         VerifyOrReturn(CheckValue<uint8_t>("colorLoopDirection", colorLoopDirection, 1));
+
         NextTest();
     }
 
@@ -10313,6 +10486,7 @@ private:
     void OnSuccessResponse_15(bool onOff)
     {
         VerifyOrReturn(CheckValue<bool>("onOff", onOff, 0));
+
         NextTest();
     }
 };
@@ -10716,6 +10890,7 @@ private:
     void OnSuccessResponse_1(bool onOff)
     {
         VerifyOrReturn(CheckValue<bool>("onOff", onOff, 1));
+
         NextTest();
     }
 
@@ -10764,6 +10939,7 @@ private:
     void OnSuccessResponse_3(uint8_t colorLoopActive)
     {
         VerifyOrReturn(CheckValue<uint8_t>("colorLoopActive", colorLoopActive, 0));
+
         NextTest();
     }
 
@@ -10812,6 +10988,7 @@ private:
     void OnSuccessResponse_5(uint8_t colorLoopDirection)
     {
         VerifyOrReturn(CheckValue<uint8_t>("colorLoopDirection", colorLoopDirection, 0));
+
         NextTest();
     }
 
@@ -10860,6 +11037,7 @@ private:
     void OnSuccessResponse_7(uint16_t colorLoopTime)
     {
         VerifyOrReturn(CheckValue<uint16_t>("colorLoopTime", colorLoopTime, 30U));
+
         NextTest();
     }
 
@@ -10908,6 +11086,7 @@ private:
     void OnSuccessResponse_9(uint16_t colorLoopStartEnhancedHue)
     {
         VerifyOrReturn(CheckValue<uint16_t>("colorLoopStartEnhancedHue", colorLoopStartEnhancedHue, 160U));
+
         NextTest();
     }
 
@@ -10956,6 +11135,7 @@ private:
     void OnSuccessResponse_11(uint8_t colorLoopActive)
     {
         VerifyOrReturn(CheckValue<uint8_t>("colorLoopActive", colorLoopActive, 1));
+
         NextTest();
     }
 
@@ -11004,6 +11184,7 @@ private:
     void OnSuccessResponse_13(uint8_t colorLoopActive)
     {
         VerifyOrReturn(CheckValue<uint8_t>("colorLoopActive", colorLoopActive, 0));
+
         NextTest();
     }
 
@@ -11052,6 +11233,7 @@ private:
     void OnSuccessResponse_15(uint8_t colorLoopDirection)
     {
         VerifyOrReturn(CheckValue<uint8_t>("colorLoopDirection", colorLoopDirection, 1));
+
         NextTest();
     }
 
@@ -11100,6 +11282,7 @@ private:
     void OnSuccessResponse_17(uint8_t colorLoopActive)
     {
         VerifyOrReturn(CheckValue<uint8_t>("colorLoopActive", colorLoopActive, 1));
+
         NextTest();
     }
 
@@ -11148,6 +11331,7 @@ private:
     void OnSuccessResponse_19(uint8_t colorLoopActive)
     {
         VerifyOrReturn(CheckValue<uint8_t>("colorLoopActive", colorLoopActive, 0));
+
         NextTest();
     }
 
@@ -11196,6 +11380,7 @@ private:
     void OnSuccessResponse_22(uint16_t enhancedCurrentHue)
     {
         VerifyOrReturn(CheckValue<uint16_t>("enhancedCurrentHue", enhancedCurrentHue, 40960U));
+
         NextTest();
     }
 
@@ -11244,6 +11429,7 @@ private:
     void OnSuccessResponse_24(uint8_t colorLoopDirection)
     {
         VerifyOrReturn(CheckValue<uint8_t>("colorLoopDirection", colorLoopDirection, 0));
+
         NextTest();
     }
 
@@ -11292,6 +11478,7 @@ private:
     void OnSuccessResponse_26(uint8_t colorLoopActive)
     {
         VerifyOrReturn(CheckValue<uint8_t>("colorLoopActive", colorLoopActive, 1));
+
         NextTest();
     }
 
@@ -11340,6 +11527,7 @@ private:
     void OnSuccessResponse_28(uint8_t colorLoopActive)
     {
         VerifyOrReturn(CheckValue<uint8_t>("colorLoopActive", colorLoopActive, 0));
+
         NextTest();
     }
 
@@ -11388,6 +11576,7 @@ private:
     void OnSuccessResponse_30(uint8_t colorLoopDirection)
     {
         VerifyOrReturn(CheckValue<uint8_t>("colorLoopDirection", colorLoopDirection, 1));
+
         NextTest();
     }
 
@@ -11436,6 +11625,7 @@ private:
     void OnSuccessResponse_32(uint8_t colorLoopActive)
     {
         VerifyOrReturn(CheckValue<uint8_t>("colorLoopActive", colorLoopActive, 1));
+
         NextTest();
     }
 
@@ -11484,6 +11674,7 @@ private:
     void OnSuccessResponse_34(uint8_t colorLoopActive)
     {
         VerifyOrReturn(CheckValue<uint8_t>("colorLoopActive", colorLoopActive, 0));
+
         NextTest();
     }
 
@@ -11732,6 +11923,7 @@ private:
     void OnSuccessResponse_1(bool onOff)
     {
         VerifyOrReturn(CheckValue<bool>("onOff", onOff, 1));
+
         NextTest();
     }
 
@@ -11780,6 +11972,7 @@ private:
     void OnSuccessResponse_3(uint8_t colorLoopActive)
     {
         VerifyOrReturn(CheckValue<uint8_t>("colorLoopActive", colorLoopActive, 0));
+
         NextTest();
     }
 
@@ -11798,6 +11991,7 @@ private:
     void OnSuccessResponse_4(uint8_t colorLoopDirection)
     {
         VerifyOrReturn(CheckValue<uint8_t>("colorLoopDirection", colorLoopDirection, 0));
+
         NextTest();
     }
 
@@ -11816,6 +12010,7 @@ private:
     void OnSuccessResponse_5(uint16_t colorLoopTime)
     {
         VerifyOrReturn(CheckValue<uint16_t>("colorLoopTime", colorLoopTime, 30U));
+
         NextTest();
     }
 
@@ -11834,6 +12029,7 @@ private:
     void OnSuccessResponse_6(uint16_t colorLoopStartEnhancedHue)
     {
         VerifyOrReturn(CheckValue<uint16_t>("colorLoopStartEnhancedHue", colorLoopStartEnhancedHue, 160U));
+
         NextTest();
     }
 
@@ -11882,6 +12078,7 @@ private:
     void OnSuccessResponse_8(uint8_t colorLoopActive)
     {
         VerifyOrReturn(CheckValue<uint8_t>("colorLoopActive", colorLoopActive, 1));
+
         NextTest();
     }
 
@@ -11930,6 +12127,7 @@ private:
     void OnSuccessResponse_10(uint8_t colorLoopDirection)
     {
         VerifyOrReturn(CheckValue<uint8_t>("colorLoopDirection", colorLoopDirection, 1));
+
         NextTest();
     }
 
@@ -11978,6 +12176,7 @@ private:
     void OnSuccessResponse_12(uint8_t colorLoopActive)
     {
         VerifyOrReturn(CheckValue<uint8_t>("colorLoopActive", colorLoopActive, 0));
+
         NextTest();
     }
 
@@ -12226,6 +12425,7 @@ private:
     void OnSuccessResponse_1(bool onOff)
     {
         VerifyOrReturn(CheckValue<bool>("onOff", onOff, 1));
+
         NextTest();
     }
 
@@ -12274,6 +12474,7 @@ private:
     void OnSuccessResponse_3(uint8_t colorLoopActive)
     {
         VerifyOrReturn(CheckValue<uint8_t>("colorLoopActive", colorLoopActive, 0));
+
         NextTest();
     }
 
@@ -12292,6 +12493,7 @@ private:
     void OnSuccessResponse_4(uint8_t colorLoopDirection)
     {
         VerifyOrReturn(CheckValue<uint8_t>("colorLoopDirection", colorLoopDirection, 0));
+
         NextTest();
     }
 
@@ -12310,6 +12512,7 @@ private:
     void OnSuccessResponse_5(uint16_t colorLoopTime)
     {
         VerifyOrReturn(CheckValue<uint16_t>("colorLoopTime", colorLoopTime, 30U));
+
         NextTest();
     }
 
@@ -12328,6 +12531,7 @@ private:
     void OnSuccessResponse_6(uint16_t colorLoopStartEnhancedHue)
     {
         VerifyOrReturn(CheckValue<uint16_t>("colorLoopStartEnhancedHue", colorLoopStartEnhancedHue, 160U));
+
         NextTest();
     }
 
@@ -12376,6 +12580,7 @@ private:
     void OnSuccessResponse_8(uint8_t colorLoopActive)
     {
         VerifyOrReturn(CheckValue<uint8_t>("colorLoopActive", colorLoopActive, 1));
+
         NextTest();
     }
 
@@ -12424,6 +12629,7 @@ private:
     void OnSuccessResponse_10(uint16_t colorLoopTime)
     {
         VerifyOrReturn(CheckValue<uint16_t>("colorLoopTime", colorLoopTime, 60U));
+
         NextTest();
     }
 
@@ -12472,6 +12678,7 @@ private:
     void OnSuccessResponse_12(uint8_t colorLoopActive)
     {
         VerifyOrReturn(CheckValue<uint8_t>("colorLoopActive", colorLoopActive, 0));
+
         NextTest();
     }
 
@@ -12827,6 +13034,7 @@ private:
     void OnSuccessResponse_0(uint16_t interactionModelVersion)
     {
         VerifyOrReturn(CheckConstraintType("interactionModelVersion", "", "uint16"));
+
         NextTest();
     }
 
@@ -12846,6 +13054,7 @@ private:
     {
         VerifyOrReturn(CheckConstraintType("vendorName", "", "string"));
         VerifyOrReturn(CheckConstraintMaxLength("vendorName", vendorName.size(), 32));
+
         NextTest();
     }
 
@@ -12864,6 +13073,7 @@ private:
     void OnSuccessResponse_2(uint16_t vendorID)
     {
         VerifyOrReturn(CheckConstraintType("vendorID", "", "uint16"));
+
         NextTest();
     }
 
@@ -12883,6 +13093,7 @@ private:
     {
         VerifyOrReturn(CheckConstraintType("productName", "", "string"));
         VerifyOrReturn(CheckConstraintMaxLength("productName", productName.size(), 32));
+
         NextTest();
     }
 
@@ -12901,6 +13112,7 @@ private:
     void OnSuccessResponse_4(uint16_t productID)
     {
         VerifyOrReturn(CheckConstraintType("productID", "", "uint16"));
+
         NextTest();
     }
 
@@ -12920,6 +13132,7 @@ private:
     {
         VerifyOrReturn(CheckConstraintType("nodeLabel", "", "string"));
         VerifyOrReturn(CheckConstraintMaxLength("nodeLabel", nodeLabel.size(), 32));
+
         NextTest();
     }
 
@@ -12940,6 +13153,7 @@ private:
         VerifyOrReturn(CheckConstraintType("location", "", "string"));
         VerifyOrReturn(CheckConstraintFormat("location", "", "ISO 3166-1 alpha-2"));
         VerifyOrReturn(CheckConstraintMaxLength("location", location.size(), 2));
+
         NextTest();
     }
 
@@ -12958,6 +13172,7 @@ private:
     void OnSuccessResponse_7(uint16_t hardwareVersion)
     {
         VerifyOrReturn(CheckConstraintType("hardwareVersion", "", "uint16"));
+
         NextTest();
     }
 
@@ -12978,6 +13193,7 @@ private:
         VerifyOrReturn(CheckConstraintType("hardwareVersionString", "", "string"));
         VerifyOrReturn(CheckConstraintMinLength("hardwareVersionString", hardwareVersionString.size(), 1));
         VerifyOrReturn(CheckConstraintMaxLength("hardwareVersionString", hardwareVersionString.size(), 64));
+
         NextTest();
     }
 
@@ -12996,6 +13212,7 @@ private:
     void OnSuccessResponse_9(uint32_t softwareVersion)
     {
         VerifyOrReturn(CheckConstraintType("softwareVersion", "", "uint32"));
+
         NextTest();
     }
 
@@ -13017,6 +13234,7 @@ private:
         VerifyOrReturn(CheckConstraintFormat("softwareVersionString", "", "ASCII"));
         VerifyOrReturn(CheckConstraintMinLength("softwareVersionString", softwareVersionString.size(), 1));
         VerifyOrReturn(CheckConstraintMaxLength("softwareVersionString", softwareVersionString.size(), 64));
+
         NextTest();
     }
 
@@ -13041,6 +13259,7 @@ private:
         VerifyOrReturn(CheckConstraintFormat("manufacturingDate", "", "ISO 8601"));
         VerifyOrReturn(CheckConstraintMinLength("manufacturingDate", manufacturingDate.size(), 8));
         VerifyOrReturn(CheckConstraintMaxLength("manufacturingDate", manufacturingDate.size(), 16));
+
         NextTest();
     }
 
@@ -13063,6 +13282,7 @@ private:
     {
         VerifyOrReturn(CheckConstraintType("partNumber", "", "string"));
         VerifyOrReturn(CheckConstraintMaxLength("partNumber", partNumber.size(), 32));
+
         NextTest();
     }
 
@@ -13086,6 +13306,7 @@ private:
         VerifyOrReturn(CheckConstraintType("productURL", "", "string"));
         VerifyOrReturn(CheckConstraintFormat("productURL", "", "RFC3986"));
         VerifyOrReturn(CheckConstraintMaxLength("productURL", productURL.size(), 256));
+
         NextTest();
     }
 
@@ -13108,6 +13329,7 @@ private:
     {
         VerifyOrReturn(CheckConstraintType("productLabel", "", "string"));
         VerifyOrReturn(CheckConstraintMaxLength("productLabel", productLabel.size(), 64));
+
         NextTest();
     }
 
@@ -13130,6 +13352,7 @@ private:
     {
         VerifyOrReturn(CheckConstraintType("serialNumber", "", "string"));
         VerifyOrReturn(CheckConstraintMaxLength("serialNumber", serialNumber.size(), 32));
+
         NextTest();
     }
 
@@ -13151,6 +13374,7 @@ private:
     void OnSuccessResponse_16(bool localConfigDisabled)
     {
         VerifyOrReturn(CheckConstraintType("localConfigDisabled", "", "boolean"));
+
         NextTest();
     }
 
@@ -13172,6 +13396,7 @@ private:
     void OnSuccessResponse_17(bool reachable)
     {
         VerifyOrReturn(CheckConstraintType("reachable", "", "boolean"));
+
         NextTest();
     }
 
@@ -13194,6 +13419,7 @@ private:
     {
         VerifyOrReturn(CheckConstraintType("uniqueID", "", "string"));
         VerifyOrReturn(CheckConstraintMaxLength("uniqueID", uniqueID.size(), 32));
+
         NextTest();
     }
 };
@@ -13371,6 +13597,7 @@ private:
         auto iter = fabricsList.begin();
         VerifyOrReturn(CheckNextListItemDecodes<decltype(fabricsList)>("fabricsList", iter, 0));
         VerifyOrReturn(CheckNoMoreListItems<decltype(fabricsList)>("fabricsList", iter, 1));
+
         NextTest();
     }
 
@@ -13389,6 +13616,7 @@ private:
     void OnSuccessResponse_1(uint8_t supportedFabrics)
     {
         VerifyOrReturn(CheckValue<uint8_t>("supportedFabrics", supportedFabrics, 16));
+
         NextTest();
     }
 
@@ -13407,6 +13635,7 @@ private:
     void OnSuccessResponse_2(uint8_t commissionedFabrics)
     {
         VerifyOrReturn(CheckValue<uint8_t>("commissionedFabrics", commissionedFabrics, 1));
+
         NextTest();
     }
 
@@ -13425,6 +13654,7 @@ private:
     void OnSuccessResponse_3(const chip::app::DataModel::DecodableList<chip::ByteSpan> & trustedRootCertificates)
     {
         VerifyOrReturn(CheckConstraintType("trustedRootCertificates", "", "list"));
+
         NextTest();
     }
 };
@@ -13531,6 +13761,7 @@ private:
     void OnSuccessResponse_0(uint16_t clusterRevision)
     {
         VerifyOrReturn(CheckValue<uint16_t>("clusterRevision", clusterRevision, 3U));
+
         NextTest();
     }
 
@@ -13566,6 +13797,7 @@ private:
     void OnSuccessResponse_2(uint16_t clusterRevision)
     {
         VerifyOrReturn(CheckValue<uint16_t>("clusterRevision", clusterRevision, 3U));
+
         NextTest();
     }
 };
@@ -13815,6 +14047,7 @@ private:
     void OnSuccessResponse_0(int16_t measuredValue)
     {
         VerifyOrReturn(CheckConstraintType("measuredValue", "", "uint16"));
+
         NextTest();
     }
 
@@ -13833,6 +14066,7 @@ private:
     void OnSuccessResponse_1(int16_t minMeasuredValue)
     {
         VerifyOrReturn(CheckConstraintType("minMeasuredValue", "", "uint16"));
+
         NextTest();
     }
 
@@ -13851,6 +14085,7 @@ private:
     void OnSuccessResponse_2(int16_t maxMeasuredValue)
     {
         VerifyOrReturn(CheckConstraintType("maxMeasuredValue", "", "uint16"));
+
         NextTest();
     }
 
@@ -13903,6 +14138,7 @@ private:
     void OnSuccessResponse_5(int16_t measuredValue)
     {
         VerifyOrReturn(CheckConstraintType("measuredValue", "", "uint16"));
+
         NextTest();
     }
 
@@ -13921,6 +14157,7 @@ private:
     void OnSuccessResponse_6(int16_t minMeasuredValue)
     {
         VerifyOrReturn(CheckConstraintType("minMeasuredValue", "", "uint16"));
+
         NextTest();
     }
 
@@ -13939,6 +14176,7 @@ private:
     void OnSuccessResponse_7(int16_t maxMeasuredValue)
     {
         VerifyOrReturn(CheckConstraintType("maxMeasuredValue", "", "uint16"));
+
         NextTest();
     }
 };
@@ -14033,6 +14271,7 @@ private:
     void OnSuccessResponse_0(int16_t measuredValue)
     {
         VerifyOrReturn(CheckConstraintType("measuredValue", "", "uint16"));
+
         NextTest();
     }
 
@@ -14051,6 +14290,7 @@ private:
     void OnSuccessResponse_1(int16_t measuredValue)
     {
         VerifyOrReturn(CheckConstraintType("measuredValue", "", "uint16"));
+
         NextTest();
     }
 };
@@ -14157,6 +14397,7 @@ private:
     void OnSuccessResponse_0(uint16_t clusterRevision)
     {
         VerifyOrReturn(CheckValue<uint16_t>("clusterRevision", clusterRevision, 2U));
+
         NextTest();
     }
 
@@ -14192,6 +14433,7 @@ private:
     void OnSuccessResponse_2(uint16_t clusterRevision)
     {
         VerifyOrReturn(CheckValue<uint16_t>("clusterRevision", clusterRevision, 2U));
+
         NextTest();
     }
 };
@@ -14437,6 +14679,7 @@ private:
     void OnSuccessResponse_0(uint8_t currentLevel)
     {
         VerifyOrReturn(CheckValue<uint8_t>("currentLevel", currentLevel, 0));
+
         NextTest();
     }
 
@@ -14484,6 +14727,7 @@ private:
     void OnSuccessResponse_3(uint8_t currentLevel)
     {
         VerifyOrReturn(CheckValue<uint8_t>("currentLevel", currentLevel, 64));
+
         NextTest();
     }
 
@@ -14531,6 +14775,7 @@ private:
     void OnSuccessResponse_6(uint8_t currentLevel)
     {
         VerifyOrReturn(CheckValue<uint8_t>("currentLevel", currentLevel, 128));
+
         NextTest();
     }
 
@@ -14549,6 +14794,7 @@ private:
     void OnSuccessResponse_7(uint16_t onOffTransitionTime)
     {
         VerifyOrReturn(CheckValue<uint16_t>("onOffTransitionTime", onOffTransitionTime, 0U));
+
         NextTest();
     }
 
@@ -14596,6 +14842,7 @@ private:
     void OnSuccessResponse_10(uint8_t currentLevel)
     {
         VerifyOrReturn(CheckValue<uint8_t>("currentLevel", currentLevel, 254));
+
         NextTest();
     }
 
@@ -14824,6 +15071,7 @@ private:
     void OnSuccessResponse_0(uint8_t currentLevel)
     {
         VerifyOrReturn(CheckValue<uint8_t>("currentLevel", currentLevel, 0));
+
         NextTest();
     }
 
@@ -14842,6 +15090,7 @@ private:
     void OnSuccessResponse_1(uint8_t maxLevel)
     {
         VerifyOrReturn(CheckValue<uint8_t>("maxLevel", maxLevel, 255));
+
         NextTest();
     }
 
@@ -14889,6 +15138,7 @@ private:
     void OnSuccessResponse_4(uint8_t currentLevel)
     {
         VerifyOrReturn(CheckValue<uint8_t>("currentLevel", currentLevel, 255));
+
         NextTest();
     }
 
@@ -14907,6 +15157,7 @@ private:
     void OnSuccessResponse_5(uint8_t minLevel)
     {
         VerifyOrReturn(CheckValue<uint8_t>("minLevel", minLevel, 0));
+
         NextTest();
     }
 
@@ -14954,6 +15205,7 @@ private:
     void OnSuccessResponse_8(uint8_t currentLevel)
     {
         VerifyOrReturn(CheckValue<uint8_t>("currentLevel", currentLevel, 0));
+
         NextTest();
     }
 
@@ -14989,6 +15241,7 @@ private:
     void OnSuccessResponse_10(uint8_t defaultMoveRate)
     {
         VerifyOrReturn(CheckValue<uint8_t>("defaultMoveRate", defaultMoveRate, 20));
+
         NextTest();
     }
 
@@ -15036,6 +15289,7 @@ private:
     void OnSuccessResponse_13(uint8_t currentLevel)
     {
         VerifyOrReturn(CheckConstraintNotValue<uint8_t>("currentLevel", currentLevel, 255));
+
         NextTest();
     }
 };
@@ -15229,6 +15483,7 @@ private:
     void OnSuccessResponse_3(uint8_t currentLevel)
     {
         VerifyOrReturn(CheckValue<uint8_t>("currentLevel", currentLevel, 128));
+
         NextTest();
     }
 
@@ -15277,6 +15532,7 @@ private:
     void OnSuccessResponse_6(uint8_t currentLevel)
     {
         VerifyOrReturn(CheckValue<uint8_t>("currentLevel", currentLevel, 64));
+
         NextTest();
     }
 
@@ -15325,6 +15581,7 @@ private:
     void OnSuccessResponse_9(uint8_t currentLevel)
     {
         VerifyOrReturn(CheckValue<uint8_t>("currentLevel", currentLevel, 128));
+
         NextTest();
     }
 
@@ -16326,6 +16583,7 @@ private:
     void OnSuccessResponse_0(uint16_t clusterRevision)
     {
         VerifyOrReturn(CheckValue<uint16_t>("clusterRevision", clusterRevision, 2U));
+
         NextTest();
     }
 
@@ -16531,6 +16789,7 @@ private:
     {
         VerifyOrReturn(CheckConstraintType("occupancy", "", "map8"));
         VerifyOrReturn(CheckConstraintMaxValue<uint8_t>("occupancy", occupancy, 1));
+
         NextTest();
     }
 
@@ -16566,6 +16825,7 @@ private:
     void OnSuccessResponse_2(uint8_t occupancy)
     {
         VerifyOrReturn(CheckValue<uint8_t>("occupancy", occupancy, 0));
+
         NextTest();
     }
 
@@ -16585,6 +16845,7 @@ private:
     {
         VerifyOrReturn(CheckConstraintType("occupancySensorType", "", "enum8"));
         VerifyOrReturn(CheckConstraintMaxValue<uint8_t>("occupancySensorType", occupancySensorType, 3));
+
         NextTest();
     }
 
@@ -16620,6 +16881,7 @@ private:
     void OnSuccessResponse_5(uint8_t occupancySensorType)
     {
         VerifyOrReturn(CheckValue<uint8_t>("occupancySensorType", occupancySensorType, 0));
+
         NextTest();
     }
 
@@ -16640,6 +16902,7 @@ private:
         VerifyOrReturn(CheckConstraintType("occupancySensorTypeBitmap", "", "map8"));
         VerifyOrReturn(CheckConstraintMinValue<uint8_t>("occupancySensorTypeBitmap", occupancySensorTypeBitmap, 1));
         VerifyOrReturn(CheckConstraintMaxValue<uint8_t>("occupancySensorTypeBitmap", occupancySensorTypeBitmap, 7));
+
         NextTest();
     }
 
@@ -16675,6 +16938,7 @@ private:
     void OnSuccessResponse_8(uint8_t occupancySensorTypeBitmap)
     {
         VerifyOrReturn(CheckValue<uint8_t>("occupancySensorTypeBitmap", occupancySensorTypeBitmap, 1));
+
         NextTest();
     }
 };
@@ -16769,6 +17033,7 @@ private:
     void OnSuccessResponse_0(uint8_t occupancy)
     {
         VerifyOrReturn(CheckConstraintType("occupancy", "", "map8"));
+
         NextTest();
     }
 
@@ -16787,6 +17052,7 @@ private:
     void OnSuccessResponse_1(uint8_t occupancy)
     {
         VerifyOrReturn(CheckConstraintType("occupancy", "", "map8"));
+
         NextTest();
     }
 };
@@ -16932,6 +17198,7 @@ private:
     void OnSuccessResponse_0(uint16_t clusterRevision)
     {
         VerifyOrReturn(CheckValue<uint16_t>("clusterRevision", clusterRevision, 4U));
+
         NextTest();
     }
 
@@ -16967,6 +17234,7 @@ private:
     void OnSuccessResponse_2(uint16_t clusterRevision)
     {
         VerifyOrReturn(CheckValue<uint16_t>("clusterRevision", clusterRevision, 4U));
+
         NextTest();
     }
 
@@ -16985,6 +17253,7 @@ private:
     void OnSuccessResponse_3(uint32_t featureMap)
     {
         VerifyOrReturn(CheckValue<uint32_t>("featureMap", featureMap, 0UL));
+
         NextTest();
     }
 
@@ -17020,6 +17289,7 @@ private:
     void OnSuccessResponse_5(uint32_t featureMap)
     {
         VerifyOrReturn(CheckValue<uint32_t>("featureMap", featureMap, 0UL));
+
         NextTest();
     }
 };
@@ -17245,6 +17515,7 @@ private:
     void OnSuccessResponse_0(bool onOff)
     {
         VerifyOrReturn(CheckValue<bool>("onOff", onOff, 0));
+
         NextTest();
     }
 
@@ -17263,6 +17534,7 @@ private:
     void OnSuccessResponse_1(bool onOff)
     {
         VerifyOrReturn(CheckValue<bool>("onOff", onOff, 0));
+
         NextTest();
     }
 
@@ -17281,6 +17553,7 @@ private:
     void OnSuccessResponse_2(bool globalSceneControl)
     {
         VerifyOrReturn(CheckValue<bool>("globalSceneControl", globalSceneControl, 1));
+
         NextTest();
     }
 
@@ -17299,6 +17572,7 @@ private:
     void OnSuccessResponse_3(uint16_t onTime)
     {
         VerifyOrReturn(CheckValue<uint16_t>("onTime", onTime, 0U));
+
         NextTest();
     }
 
@@ -17317,6 +17591,7 @@ private:
     void OnSuccessResponse_4(uint16_t offWaitTime)
     {
         VerifyOrReturn(CheckValue<uint16_t>("offWaitTime", offWaitTime, 0U));
+
         NextTest();
     }
 
@@ -17335,6 +17610,7 @@ private:
     void OnSuccessResponse_5(uint8_t startUpOnOff)
     {
         VerifyOrReturn(CheckValue<uint8_t>("startUpOnOff", startUpOnOff, 0));
+
         NextTest();
     }
 
@@ -17404,6 +17680,7 @@ private:
     void OnSuccessResponse_9(uint16_t onTime)
     {
         VerifyOrReturn(CheckValue<uint16_t>("onTime", onTime, 0U));
+
         NextTest();
     }
 
@@ -17422,6 +17699,7 @@ private:
     void OnSuccessResponse_10(uint16_t offWaitTime)
     {
         VerifyOrReturn(CheckValue<uint16_t>("offWaitTime", offWaitTime, 0U));
+
         NextTest();
     }
 
@@ -17440,6 +17718,7 @@ private:
     void OnSuccessResponse_11(uint8_t startUpOnOff)
     {
         VerifyOrReturn(CheckValue<uint8_t>("startUpOnOff", startUpOnOff, 0));
+
         NextTest();
     }
 };
@@ -17655,6 +17934,7 @@ private:
     void OnSuccessResponse_1(bool onOff)
     {
         VerifyOrReturn(CheckValue<bool>("onOff", onOff, 0));
+
         NextTest();
     }
 
@@ -17696,6 +17976,7 @@ private:
     void OnSuccessResponse_3(bool onOff)
     {
         VerifyOrReturn(CheckValue<bool>("onOff", onOff, 1));
+
         NextTest();
     }
 
@@ -17737,6 +18018,7 @@ private:
     void OnSuccessResponse_5(bool onOff)
     {
         VerifyOrReturn(CheckValue<bool>("onOff", onOff, 0));
+
         NextTest();
     }
 
@@ -17778,6 +18060,7 @@ private:
     void OnSuccessResponse_7(bool onOff)
     {
         VerifyOrReturn(CheckValue<bool>("onOff", onOff, 1));
+
         NextTest();
     }
 
@@ -17819,6 +18102,7 @@ private:
     void OnSuccessResponse_9(bool onOff)
     {
         VerifyOrReturn(CheckValue<bool>("onOff", onOff, 0));
+
         NextTest();
     }
 
@@ -17860,6 +18144,7 @@ private:
     void OnSuccessResponse_11(bool onOff)
     {
         VerifyOrReturn(CheckValue<bool>("onOff", onOff, 1));
+
         NextTest();
     }
 
@@ -17901,6 +18186,7 @@ private:
     void OnSuccessResponse_13(bool onOff)
     {
         VerifyOrReturn(CheckValue<bool>("onOff", onOff, 0));
+
         NextTest();
     }
 };
@@ -18506,6 +18792,7 @@ private:
     void OnSuccessResponse_2(bool onOff)
     {
         VerifyOrReturn(CheckValue<bool>("onOff", onOff, 1));
+
         NextTest();
     }
 
@@ -18524,6 +18811,7 @@ private:
     void OnSuccessResponse_3(bool globalSceneControl)
     {
         VerifyOrReturn(CheckValue<bool>("globalSceneControl", globalSceneControl, 1));
+
         NextTest();
     }
 
@@ -18567,6 +18855,7 @@ private:
     void OnSuccessResponse_6(bool onOff)
     {
         VerifyOrReturn(CheckValue<bool>("onOff", onOff, 1));
+
         NextTest();
     }
 
@@ -18585,6 +18874,7 @@ private:
     void OnSuccessResponse_7(bool globalSceneControl)
     {
         VerifyOrReturn(CheckValue<bool>("globalSceneControl", globalSceneControl, 1));
+
         NextTest();
     }
 
@@ -18628,6 +18918,7 @@ private:
     void OnSuccessResponse_10(bool onOff)
     {
         VerifyOrReturn(CheckValue<bool>("onOff", onOff, 1));
+
         NextTest();
     }
 
@@ -18646,6 +18937,7 @@ private:
     void OnSuccessResponse_11(bool globalSceneControl)
     {
         VerifyOrReturn(CheckValue<bool>("globalSceneControl", globalSceneControl, 1));
+
         NextTest();
     }
 
@@ -18664,6 +18956,7 @@ private:
     void OnSuccessResponse_12(uint16_t onTime)
     {
         VerifyOrReturn(CheckValue<uint16_t>("onTime", onTime, 0U));
+
         NextTest();
     }
 
@@ -18682,6 +18975,7 @@ private:
     void OnSuccessResponse_13(uint16_t offWaitTime)
     {
         VerifyOrReturn(CheckValue<uint16_t>("offWaitTime", offWaitTime, 0U));
+
         NextTest();
     }
 
@@ -18723,6 +19017,7 @@ private:
     void OnSuccessResponse_15(bool onOff)
     {
         VerifyOrReturn(CheckValue<bool>("onOff", onOff, 1));
+
         NextTest();
     }
 
@@ -18741,6 +19036,7 @@ private:
     void OnSuccessResponse_16(uint16_t onTime)
     {
         VerifyOrReturn(CheckValue<uint16_t>("onTime", onTime, 0U));
+
         NextTest();
     }
 
@@ -18759,6 +19055,7 @@ private:
     void OnSuccessResponse_17(uint16_t offWaitTime)
     {
         VerifyOrReturn(CheckValue<uint16_t>("offWaitTime", offWaitTime, 0U));
+
         NextTest();
     }
 
@@ -18800,6 +19097,7 @@ private:
     void OnSuccessResponse_19(bool onOff)
     {
         VerifyOrReturn(CheckValue<bool>("onOff", onOff, 0));
+
         NextTest();
     }
 
@@ -18818,6 +19116,7 @@ private:
     void OnSuccessResponse_20(uint16_t onTime)
     {
         VerifyOrReturn(CheckValue<uint16_t>("onTime", onTime, 0U));
+
         NextTest();
     }
 
@@ -18836,6 +19135,7 @@ private:
     void OnSuccessResponse_21(bool onOff)
     {
         VerifyOrReturn(CheckValue<bool>("onOff", onOff, 0));
+
         NextTest();
     }
 
@@ -18854,6 +19154,7 @@ private:
     void OnSuccessResponse_22(uint16_t onTime)
     {
         VerifyOrReturn(CheckValue<uint16_t>("onTime", onTime, 0U));
+
         NextTest();
     }
 
@@ -18872,6 +19173,7 @@ private:
     void OnSuccessResponse_23(uint16_t offWaitTime)
     {
         VerifyOrReturn(CheckValue<uint16_t>("offWaitTime", offWaitTime, 0U));
+
         NextTest();
     }
 
@@ -18913,6 +19215,7 @@ private:
     void OnSuccessResponse_25(uint16_t onTime)
     {
         VerifyOrReturn(CheckValue<uint16_t>("onTime", onTime, 0U));
+
         NextTest();
     }
 
@@ -18931,6 +19234,7 @@ private:
     void OnSuccessResponse_26(uint16_t offWaitTime)
     {
         VerifyOrReturn(CheckValue<uint16_t>("offWaitTime", offWaitTime, 0U));
+
         NextTest();
     }
 
@@ -18972,6 +19276,7 @@ private:
     void OnSuccessResponse_28(bool onOff)
     {
         VerifyOrReturn(CheckValue<bool>("onOff", onOff, 0));
+
         NextTest();
     }
 
@@ -18990,6 +19295,7 @@ private:
     void OnSuccessResponse_29(uint16_t onTime)
     {
         VerifyOrReturn(CheckValue<uint16_t>("onTime", onTime, 0U));
+
         NextTest();
     }
 
@@ -19008,6 +19314,7 @@ private:
     void OnSuccessResponse_30(bool onOff)
     {
         VerifyOrReturn(CheckValue<bool>("onOff", onOff, 0));
+
         NextTest();
     }
 
@@ -19026,6 +19333,7 @@ private:
     void OnSuccessResponse_31(uint16_t onTime)
     {
         VerifyOrReturn(CheckValue<uint16_t>("onTime", onTime, 0U));
+
         NextTest();
     }
 
@@ -19067,6 +19375,7 @@ private:
     void OnSuccessResponse_33(bool onOff)
     {
         VerifyOrReturn(CheckValue<bool>("onOff", onOff, 1));
+
         NextTest();
     }
 
@@ -19085,6 +19394,7 @@ private:
     void OnSuccessResponse_34(uint16_t onTime)
     {
         VerifyOrReturn(CheckValue<uint16_t>("onTime", onTime, 0U));
+
         NextTest();
     }
 
@@ -19103,6 +19413,7 @@ private:
     void OnSuccessResponse_35(uint16_t offWaitTime)
     {
         VerifyOrReturn(CheckValue<uint16_t>("offWaitTime", offWaitTime, 0U));
+
         NextTest();
     }
 
@@ -19144,6 +19455,7 @@ private:
     void OnSuccessResponse_37(bool onOff)
     {
         VerifyOrReturn(CheckValue<bool>("onOff", onOff, 0));
+
         NextTest();
     }
 
@@ -19162,6 +19474,7 @@ private:
     void OnSuccessResponse_38(uint16_t onTime)
     {
         VerifyOrReturn(CheckValue<uint16_t>("onTime", onTime, 0U));
+
         NextTest();
     }
 
@@ -19180,6 +19493,7 @@ private:
     void OnSuccessResponse_39(bool onOff)
     {
         VerifyOrReturn(CheckValue<bool>("onOff", onOff, 0));
+
         NextTest();
     }
 
@@ -19198,6 +19512,7 @@ private:
     void OnSuccessResponse_40(uint16_t onTime)
     {
         VerifyOrReturn(CheckValue<uint16_t>("onTime", onTime, 0U));
+
         NextTest();
     }
 
@@ -19216,6 +19531,7 @@ private:
     void OnSuccessResponse_41(uint16_t offWaitTime)
     {
         VerifyOrReturn(CheckValue<uint16_t>("offWaitTime", offWaitTime, 0U));
+
         NextTest();
     }
 
@@ -19234,6 +19550,7 @@ private:
     void OnSuccessResponse_42(bool onOff)
     {
         VerifyOrReturn(CheckValue<bool>("onOff", onOff, 0));
+
         NextTest();
     }
 
@@ -19252,6 +19569,7 @@ private:
     void OnSuccessResponse_43(uint16_t onTime)
     {
         VerifyOrReturn(CheckValue<uint16_t>("onTime", onTime, 0U));
+
         NextTest();
     }
 
@@ -19270,6 +19588,7 @@ private:
     void OnSuccessResponse_44(uint16_t offWaitTime)
     {
         VerifyOrReturn(CheckValue<uint16_t>("offWaitTime", offWaitTime, 0U));
+
         NextTest();
     }
 
@@ -19413,6 +19732,7 @@ private:
     void OnSuccessResponse_0(uint16_t clusterRevision)
     {
         VerifyOrReturn(CheckValue<uint16_t>("clusterRevision", clusterRevision, 2U));
+
         NextTest();
     }
 
@@ -19431,6 +19751,7 @@ private:
     void OnSuccessResponse_1(uint16_t clusterRevision)
     {
         VerifyOrReturn(CheckConstraintType("clusterRevision", "", "uint16"));
+
         NextTest();
     }
 
@@ -19466,6 +19787,7 @@ private:
     void OnSuccessResponse_3(uint16_t clusterRevision)
     {
         VerifyOrReturn(CheckValue<uint16_t>("clusterRevision", clusterRevision, 2U));
+
         NextTest();
     }
 };
@@ -19649,6 +19971,7 @@ private:
     void OnSuccessResponse_0(int16_t measuredValue)
     {
         VerifyOrReturn(CheckConstraintType("measuredValue", "", "int16"));
+
         NextTest();
     }
 
@@ -19684,6 +20007,7 @@ private:
     void OnSuccessResponse_2(int16_t measuredValue)
     {
         VerifyOrReturn(CheckValue<int16_t>("measuredValue", measuredValue, 0));
+
         NextTest();
     }
 
@@ -19702,6 +20026,7 @@ private:
     void OnSuccessResponse_3(int16_t minMeasuredValue)
     {
         VerifyOrReturn(CheckConstraintType("minMeasuredValue", "", "int16"));
+
         NextTest();
     }
 
@@ -19737,6 +20062,7 @@ private:
     void OnSuccessResponse_5(int16_t minMeasuredValue)
     {
         VerifyOrReturn(CheckValue<int16_t>("minMeasuredValue", minMeasuredValue, 0));
+
         NextTest();
     }
 
@@ -19755,6 +20081,7 @@ private:
     void OnSuccessResponse_6(int16_t maxMeasuredValue)
     {
         VerifyOrReturn(CheckConstraintType("maxMeasuredValue", "", "int16"));
+
         NextTest();
     }
 
@@ -19790,6 +20117,7 @@ private:
     void OnSuccessResponse_8(int16_t maxMeasuredValue)
     {
         VerifyOrReturn(CheckValue<int16_t>("maxMeasuredValue", maxMeasuredValue, 0));
+
         NextTest();
     }
 };
@@ -20045,6 +20373,7 @@ private:
     void OnSuccessResponse_0(int16_t maxPressure)
     {
         VerifyOrReturn(CheckConstraintType("maxPressure", "", "int16"));
+
         NextTest();
     }
 
@@ -20064,6 +20393,7 @@ private:
     void OnSuccessResponse_1(uint8_t effectiveOperationMode)
     {
         VerifyOrReturn(CheckConstraintType("effectiveOperationMode", "", "enum8"));
+
         NextTest();
     }
 
@@ -20082,6 +20412,7 @@ private:
     void OnSuccessResponse_2(uint8_t effectiveControlMode)
     {
         VerifyOrReturn(CheckConstraintType("effectiveControlMode", "", "enum8"));
+
         NextTest();
     }
 
@@ -20100,6 +20431,7 @@ private:
     void OnSuccessResponse_3(int16_t capacity)
     {
         VerifyOrReturn(CheckConstraintType("capacity", "", "int16"));
+
         NextTest();
     }
 
@@ -20118,6 +20450,7 @@ private:
     void OnSuccessResponse_4(int16_t maxPressure)
     {
         VerifyOrReturn(CheckConstraintType("maxPressure", "", "int16"));
+
         NextTest();
     }
 
@@ -20137,6 +20470,7 @@ private:
     void OnSuccessResponse_5(uint8_t effectiveOperationMode)
     {
         VerifyOrReturn(CheckConstraintType("effectiveOperationMode", "", "enum8"));
+
         NextTest();
     }
 
@@ -20155,6 +20489,7 @@ private:
     void OnSuccessResponse_6(uint8_t effectiveControlMode)
     {
         VerifyOrReturn(CheckConstraintType("effectiveControlMode", "", "enum8"));
+
         NextTest();
     }
 
@@ -20173,6 +20508,7 @@ private:
     void OnSuccessResponse_7(int16_t capacity)
     {
         VerifyOrReturn(CheckConstraintType("capacity", "", "int16"));
+
         NextTest();
     }
 };
@@ -20414,6 +20750,7 @@ private:
     void OnSuccessResponse_1(uint8_t effectiveOperationMode)
     {
         VerifyOrReturn(CheckValue<uint8_t>("effectiveOperationMode", effectiveOperationMode, 0));
+
         NextTest();
     }
 };
@@ -20585,6 +20922,7 @@ private:
     void OnSuccessResponse_0(uint16_t measuredValue)
     {
         VerifyOrReturn(CheckConstraintType("measuredValue", "", "uint16"));
+
         NextTest();
     }
 
@@ -20604,6 +20942,7 @@ private:
     {
         VerifyOrReturn(CheckConstraintType("minMeasuredValue", "", "uint16"));
         VerifyOrReturn(CheckConstraintMaxValue<uint16_t>("minMeasuredValue", minMeasuredValue, 9999));
+
         NextTest();
     }
 };
@@ -20698,6 +21037,7 @@ private:
     void OnSuccessResponse_0(uint16_t measuredValue)
     {
         VerifyOrReturn(CheckConstraintType("measuredValue", "", "uint16"));
+
         NextTest();
     }
 
@@ -20716,6 +21056,7 @@ private:
     void OnSuccessResponse_1(uint16_t measuredValue)
     {
         VerifyOrReturn(CheckConstraintType("measuredValue", "", "uint16"));
+
         NextTest();
     }
 };
@@ -20822,6 +21163,7 @@ private:
     void OnSuccessResponse_0(uint16_t clusterRevision)
     {
         VerifyOrReturn(CheckValue<uint16_t>("clusterRevision", clusterRevision, 3U));
+
         NextTest();
     }
 
@@ -20857,6 +21199,7 @@ private:
     void OnSuccessResponse_2(uint16_t clusterRevision)
     {
         VerifyOrReturn(CheckValue<uint16_t>("clusterRevision", clusterRevision, 3U));
+
         NextTest();
     }
 };
@@ -20937,6 +21280,7 @@ private:
     void OnSuccessResponse_0(int16_t measuredValue)
     {
         VerifyOrReturn(CheckConstraintType("measuredValue", "", "int16"));
+
         NextTest();
     }
 };
@@ -21031,6 +21375,7 @@ private:
     void OnSuccessResponse_0(int16_t measuredValue)
     {
         VerifyOrReturn(CheckConstraintType("measuredValue", "", "uint16"));
+
         NextTest();
     }
 
@@ -21049,6 +21394,7 @@ private:
     void OnSuccessResponse_1(int16_t measuredValue)
     {
         VerifyOrReturn(CheckConstraintType("measuredValue", "", "uint16"));
+
         NextTest();
     }
 };
@@ -22030,6 +22376,7 @@ private:
     void OnSuccessResponse_0(int16_t localTemperature)
     {
         VerifyOrReturn(CheckConstraintType("localTemperature", "", "int16"));
+
         NextTest();
     }
 
@@ -22048,6 +22395,7 @@ private:
     void OnSuccessResponse_1(int16_t absMinHeatSetpointLimit)
     {
         VerifyOrReturn(CheckValue<int16_t>("absMinHeatSetpointLimit", absMinHeatSetpointLimit, 700));
+
         NextTest();
     }
 
@@ -22068,6 +22416,7 @@ private:
         VerifyOrReturn(CheckConstraintType("absMinHeatSetpointLimit", "", "int16"));
         VerifyOrReturn(CheckConstraintMinValue<int16_t>("absMinHeatSetpointLimit", absMinHeatSetpointLimit, 700));
         VerifyOrReturn(CheckConstraintMaxValue<int16_t>("absMinHeatSetpointLimit", absMinHeatSetpointLimit, 3000));
+
         NextTest();
     }
 
@@ -22103,6 +22452,7 @@ private:
     void OnSuccessResponse_4(int16_t absMinHeatSetpointLimit)
     {
         VerifyOrReturn(CheckValue<int16_t>("absMinHeatSetpointLimit", absMinHeatSetpointLimit, 700));
+
         NextTest();
     }
 
@@ -22121,6 +22471,7 @@ private:
     void OnSuccessResponse_5(int16_t absMaxHeatSetpointLimit)
     {
         VerifyOrReturn(CheckValue<int16_t>("absMaxHeatSetpointLimit", absMaxHeatSetpointLimit, 3000));
+
         NextTest();
     }
 
@@ -22141,6 +22492,7 @@ private:
         VerifyOrReturn(CheckConstraintType("absMaxHeatSetpointLimit", "", "int16"));
         VerifyOrReturn(CheckConstraintMinValue<int16_t>("absMaxHeatSetpointLimit", absMaxHeatSetpointLimit, 700));
         VerifyOrReturn(CheckConstraintMaxValue<int16_t>("absMaxHeatSetpointLimit", absMaxHeatSetpointLimit, 3000));
+
         NextTest();
     }
 
@@ -22176,6 +22528,7 @@ private:
     void OnSuccessResponse_8(int16_t absMaxHeatSetpointLimit)
     {
         VerifyOrReturn(CheckValue<int16_t>("absMaxHeatSetpointLimit", absMaxHeatSetpointLimit, 3000));
+
         NextTest();
     }
 
@@ -22194,6 +22547,7 @@ private:
     void OnSuccessResponse_9(int16_t absMinCoolSetpointLimit)
     {
         VerifyOrReturn(CheckValue<int16_t>("absMinCoolSetpointLimit", absMinCoolSetpointLimit, 1600));
+
         NextTest();
     }
 
@@ -22214,6 +22568,7 @@ private:
         VerifyOrReturn(CheckConstraintType("absMinCoolSetpointLimit", "", "int16"));
         VerifyOrReturn(CheckConstraintMinValue<int16_t>("absMinCoolSetpointLimit", absMinCoolSetpointLimit, 1600));
         VerifyOrReturn(CheckConstraintMaxValue<int16_t>("absMinCoolSetpointLimit", absMinCoolSetpointLimit, 3200));
+
         NextTest();
     }
 
@@ -22249,6 +22604,7 @@ private:
     void OnSuccessResponse_12(int16_t absMinCoolSetpointLimit)
     {
         VerifyOrReturn(CheckValue<int16_t>("absMinCoolSetpointLimit", absMinCoolSetpointLimit, 1600));
+
         NextTest();
     }
 
@@ -22267,6 +22623,7 @@ private:
     void OnSuccessResponse_13(int16_t absMaxCoolSetpointLimit)
     {
         VerifyOrReturn(CheckValue<int16_t>("absMaxCoolSetpointLimit", absMaxCoolSetpointLimit, 3200));
+
         NextTest();
     }
 
@@ -22287,6 +22644,7 @@ private:
         VerifyOrReturn(CheckConstraintType("absMaxCoolSetpointLimit", "", "int16"));
         VerifyOrReturn(CheckConstraintMinValue<int16_t>("absMaxCoolSetpointLimit", absMaxCoolSetpointLimit, 1600));
         VerifyOrReturn(CheckConstraintMaxValue<int16_t>("absMaxCoolSetpointLimit", absMaxCoolSetpointLimit, 3200));
+
         NextTest();
     }
 
@@ -22322,6 +22680,7 @@ private:
     void OnSuccessResponse_16(int16_t absMaxCoolSetpointLimit)
     {
         VerifyOrReturn(CheckValue<int16_t>("absMaxCoolSetpointLimit", absMaxCoolSetpointLimit, 3200));
+
         NextTest();
     }
 
@@ -22340,6 +22699,7 @@ private:
     void OnSuccessResponse_17(int16_t occupiedCoolingSetpoint)
     {
         VerifyOrReturn(CheckValue<int16_t>("occupiedCoolingSetpoint", occupiedCoolingSetpoint, 2600));
+
         NextTest();
     }
 
@@ -22360,6 +22720,7 @@ private:
         VerifyOrReturn(CheckConstraintType("occupiedCoolingSetpoint", "", "int16"));
         VerifyOrReturn(CheckConstraintMinValue<int16_t>("occupiedCoolingSetpoint", occupiedCoolingSetpoint, 1600));
         VerifyOrReturn(CheckConstraintMaxValue<int16_t>("occupiedCoolingSetpoint", occupiedCoolingSetpoint, 2600));
+
         NextTest();
     }
 
@@ -22395,6 +22756,7 @@ private:
     void OnSuccessResponse_20(int16_t occupiedCoolingSetpoint)
     {
         VerifyOrReturn(CheckValue<int16_t>("occupiedCoolingSetpoint", occupiedCoolingSetpoint, 2600));
+
         NextTest();
     }
 
@@ -22413,6 +22775,7 @@ private:
     void OnSuccessResponse_21(int16_t occupiedHeatingSetpoint)
     {
         VerifyOrReturn(CheckValue<int16_t>("occupiedHeatingSetpoint", occupiedHeatingSetpoint, 2000));
+
         NextTest();
     }
 
@@ -22433,6 +22796,7 @@ private:
         VerifyOrReturn(CheckConstraintType("occupiedHeatingSetpoint", "", "int16"));
         VerifyOrReturn(CheckConstraintMinValue<int16_t>("occupiedHeatingSetpoint", occupiedHeatingSetpoint, 700));
         VerifyOrReturn(CheckConstraintMaxValue<int16_t>("occupiedHeatingSetpoint", occupiedHeatingSetpoint, 2600));
+
         NextTest();
     }
 
@@ -22468,6 +22832,7 @@ private:
     void OnSuccessResponse_24(int16_t occupiedHeatingSetpoint)
     {
         VerifyOrReturn(CheckValue<int16_t>("occupiedHeatingSetpoint", occupiedHeatingSetpoint, 2000));
+
         NextTest();
     }
 
@@ -22486,6 +22851,7 @@ private:
     void OnSuccessResponse_25(int16_t minHeatSetpointLimit)
     {
         VerifyOrReturn(CheckValue<int16_t>("minHeatSetpointLimit", minHeatSetpointLimit, 700));
+
         NextTest();
     }
 
@@ -22506,6 +22872,7 @@ private:
         VerifyOrReturn(CheckConstraintType("minHeatSetpointLimit", "", "int16"));
         VerifyOrReturn(CheckConstraintMinValue<int16_t>("minHeatSetpointLimit", minHeatSetpointLimit, 700));
         VerifyOrReturn(CheckConstraintMaxValue<int16_t>("minHeatSetpointLimit", minHeatSetpointLimit, 3000));
+
         NextTest();
     }
 
@@ -22541,6 +22908,7 @@ private:
     void OnSuccessResponse_28(int16_t minHeatSetpointLimit)
     {
         VerifyOrReturn(CheckValue<int16_t>("minHeatSetpointLimit", minHeatSetpointLimit, 700));
+
         NextTest();
     }
 
@@ -22559,6 +22927,7 @@ private:
     void OnSuccessResponse_29(int16_t maxHeatSetpointLimit)
     {
         VerifyOrReturn(CheckValue<int16_t>("maxHeatSetpointLimit", maxHeatSetpointLimit, 3000));
+
         NextTest();
     }
 
@@ -22579,6 +22948,7 @@ private:
         VerifyOrReturn(CheckConstraintType("maxHeatSetpointLimit", "", "int16"));
         VerifyOrReturn(CheckConstraintMinValue<int16_t>("maxHeatSetpointLimit", maxHeatSetpointLimit, 700));
         VerifyOrReturn(CheckConstraintMaxValue<int16_t>("maxHeatSetpointLimit", maxHeatSetpointLimit, 3000));
+
         NextTest();
     }
 
@@ -22614,6 +22984,7 @@ private:
     void OnSuccessResponse_32(int16_t maxHeatSetpointLimit)
     {
         VerifyOrReturn(CheckValue<int16_t>("maxHeatSetpointLimit", maxHeatSetpointLimit, 3000));
+
         NextTest();
     }
 
@@ -22632,6 +23003,7 @@ private:
     void OnSuccessResponse_33(int16_t minCoolSetpointLimit)
     {
         VerifyOrReturn(CheckValue<int16_t>("minCoolSetpointLimit", minCoolSetpointLimit, 1600));
+
         NextTest();
     }
 
@@ -22652,6 +23024,7 @@ private:
         VerifyOrReturn(CheckConstraintType("minCoolSetpointLimit", "", "int16"));
         VerifyOrReturn(CheckConstraintMinValue<int16_t>("minCoolSetpointLimit", minCoolSetpointLimit, 1600));
         VerifyOrReturn(CheckConstraintMaxValue<int16_t>("minCoolSetpointLimit", minCoolSetpointLimit, 3200));
+
         NextTest();
     }
 
@@ -22687,6 +23060,7 @@ private:
     void OnSuccessResponse_36(int16_t minCoolSetpointLimit)
     {
         VerifyOrReturn(CheckValue<int16_t>("minCoolSetpointLimit", minCoolSetpointLimit, 1600));
+
         NextTest();
     }
 
@@ -22705,6 +23079,7 @@ private:
     void OnSuccessResponse_37(int16_t maxCoolSetpointLimit)
     {
         VerifyOrReturn(CheckValue<int16_t>("maxCoolSetpointLimit", maxCoolSetpointLimit, 3200));
+
         NextTest();
     }
 
@@ -22725,6 +23100,7 @@ private:
         VerifyOrReturn(CheckConstraintType("maxCoolSetpointLimit", "", "int16"));
         VerifyOrReturn(CheckConstraintMinValue<int16_t>("maxCoolSetpointLimit", maxCoolSetpointLimit, 1600));
         VerifyOrReturn(CheckConstraintMaxValue<int16_t>("maxCoolSetpointLimit", maxCoolSetpointLimit, 3200));
+
         NextTest();
     }
 
@@ -22760,6 +23136,7 @@ private:
     void OnSuccessResponse_40(int16_t maxCoolSetpointLimit)
     {
         VerifyOrReturn(CheckValue<int16_t>("maxCoolSetpointLimit", maxCoolSetpointLimit, 3200));
+
         NextTest();
     }
 
@@ -22778,6 +23155,7 @@ private:
     void OnSuccessResponse_41(uint8_t controlSequenceOfOperation)
     {
         VerifyOrReturn(CheckValue<uint8_t>("controlSequenceOfOperation", controlSequenceOfOperation, 4));
+
         NextTest();
     }
 
@@ -22797,6 +23175,7 @@ private:
     {
         VerifyOrReturn(CheckConstraintType("controlSequenceOfOperation", "", "enum8"));
         VerifyOrReturn(CheckConstraintMaxValue<uint8_t>("controlSequenceOfOperation", controlSequenceOfOperation, 5));
+
         NextTest();
     }
 
@@ -22832,6 +23211,7 @@ private:
     void OnSuccessResponse_44(uint8_t controlSequenceOfOperation)
     {
         VerifyOrReturn(CheckValue<uint8_t>("controlSequenceOfOperation", controlSequenceOfOperation, 4));
+
         NextTest();
     }
 
@@ -22850,6 +23230,7 @@ private:
     void OnSuccessResponse_45(uint8_t systemMode)
     {
         VerifyOrReturn(CheckValue<uint8_t>("systemMode", systemMode, 1));
+
         NextTest();
     }
 
@@ -22869,6 +23250,7 @@ private:
     {
         VerifyOrReturn(CheckConstraintType("systemMode", "", "enum8"));
         VerifyOrReturn(CheckConstraintMaxValue<uint8_t>("systemMode", systemMode, 9));
+
         NextTest();
     }
 
@@ -22904,6 +23286,7 @@ private:
     void OnSuccessResponse_48(uint8_t systemMode)
     {
         VerifyOrReturn(CheckValue<uint8_t>("systemMode", systemMode, 1));
+
         NextTest();
     }
 
@@ -22922,6 +23305,7 @@ private:
     void OnSuccessResponse_49(int8_t minSetpointDeadBand)
     {
         VerifyOrReturn(CheckValue<int8_t>("minSetpointDeadBand", minSetpointDeadBand, 25));
+
         NextTest();
     }
 
@@ -22941,6 +23325,7 @@ private:
     {
         VerifyOrReturn(CheckConstraintType("minSetpointDeadBand", "", "int8"));
         VerifyOrReturn(CheckConstraintMaxValue<int8_t>("minSetpointDeadBand", minSetpointDeadBand, 25));
+
         NextTest();
     }
 
@@ -22976,6 +23361,7 @@ private:
     void OnSuccessResponse_52(int8_t minSetpointDeadBand)
     {
         VerifyOrReturn(CheckValue<int8_t>("minSetpointDeadBand", minSetpointDeadBand, 25));
+
         NextTest();
     }
 
@@ -22995,6 +23381,7 @@ private:
     {
         VerifyOrReturn(CheckConstraintType("startOfWeek", "", "enum8"));
         VerifyOrReturn(CheckConstraintMaxValue<uint8_t>("startOfWeek", startOfWeek, 6));
+
         NextTest();
     }
 
@@ -23030,6 +23417,7 @@ private:
     void OnSuccessResponse_55(uint8_t startOfWeek)
     {
         VerifyOrReturn(CheckValue<uint8_t>("startOfWeek", startOfWeek, 0));
+
         NextTest();
     }
 
@@ -23048,6 +23436,7 @@ private:
     void OnSuccessResponse_56(uint8_t numberOfWeeklyTransitions)
     {
         VerifyOrReturn(CheckConstraintType("numberOfWeeklyTransitions", "", "uint8"));
+
         NextTest();
     }
 
@@ -23083,6 +23472,7 @@ private:
     void OnSuccessResponse_58(uint8_t numberOfDailyTransitions)
     {
         VerifyOrReturn(CheckConstraintType("numberOfDailyTransitions", "", "uint8"));
+
         NextTest();
     }
 
@@ -23814,6 +24204,7 @@ private:
     void OnSuccessResponse_0(int16_t occupiedCoolingSetpoint)
     {
         VerifyOrReturn(CheckValue<int16_t>("occupiedCoolingSetpoint", occupiedCoolingSetpoint, 2600));
+
         NextTest();
     }
 
@@ -23849,6 +24240,7 @@ private:
     void OnSuccessResponse_2(int16_t occupiedCoolingSetpoint)
     {
         VerifyOrReturn(CheckValue<int16_t>("occupiedCoolingSetpoint", occupiedCoolingSetpoint, 2000));
+
         NextTest();
     }
 
@@ -23901,6 +24293,7 @@ private:
     void OnSuccessResponse_5(int16_t occupiedHeatingSetpoint)
     {
         VerifyOrReturn(CheckValue<int16_t>("occupiedHeatingSetpoint", occupiedHeatingSetpoint, 2000));
+
         NextTest();
     }
 
@@ -23936,6 +24329,7 @@ private:
     void OnSuccessResponse_7(int16_t occupiedHeatingSetpoint)
     {
         VerifyOrReturn(CheckValue<int16_t>("occupiedHeatingSetpoint", occupiedHeatingSetpoint, 2100));
+
         NextTest();
     }
 
@@ -23988,6 +24382,7 @@ private:
     void OnSuccessResponse_10(int16_t minHeatSetpointLimit)
     {
         VerifyOrReturn(CheckValue<int16_t>("minHeatSetpointLimit", minHeatSetpointLimit, 700));
+
         NextTest();
     }
 
@@ -24023,6 +24418,7 @@ private:
     void OnSuccessResponse_12(int16_t minHeatSetpointLimit)
     {
         VerifyOrReturn(CheckValue<int16_t>("minHeatSetpointLimit", minHeatSetpointLimit, 2000));
+
         NextTest();
     }
 
@@ -24075,6 +24471,7 @@ private:
     void OnSuccessResponse_15(int16_t maxHeatSetpointLimit)
     {
         VerifyOrReturn(CheckValue<int16_t>("maxHeatSetpointLimit", maxHeatSetpointLimit, 3000));
+
         NextTest();
     }
 
@@ -24110,6 +24507,7 @@ private:
     void OnSuccessResponse_17(int16_t maxHeatSetpointLimit)
     {
         VerifyOrReturn(CheckValue<int16_t>("maxHeatSetpointLimit", maxHeatSetpointLimit, 2000));
+
         NextTest();
     }
 
@@ -24162,6 +24560,7 @@ private:
     void OnSuccessResponse_20(int16_t minCoolSetpointLimit)
     {
         VerifyOrReturn(CheckValue<int16_t>("minCoolSetpointLimit", minCoolSetpointLimit, 1600));
+
         NextTest();
     }
 
@@ -24197,6 +24596,7 @@ private:
     void OnSuccessResponse_22(int16_t minCoolSetpointLimit)
     {
         VerifyOrReturn(CheckValue<int16_t>("minCoolSetpointLimit", minCoolSetpointLimit, 2000));
+
         NextTest();
     }
 
@@ -24249,6 +24649,7 @@ private:
     void OnSuccessResponse_25(int16_t maxCoolSetpointLimit)
     {
         VerifyOrReturn(CheckValue<int16_t>("maxCoolSetpointLimit", maxCoolSetpointLimit, 3200));
+
         NextTest();
     }
 
@@ -24284,6 +24685,7 @@ private:
     void OnSuccessResponse_27(int16_t maxCoolSetpointLimit)
     {
         VerifyOrReturn(CheckValue<int16_t>("maxCoolSetpointLimit", maxCoolSetpointLimit, 2000));
+
         NextTest();
     }
 
@@ -24472,6 +24874,7 @@ private:
     void OnSuccessResponse_38(uint8_t controlSequenceOfOperation)
     {
         VerifyOrReturn(CheckValue<uint8_t>("controlSequenceOfOperation", controlSequenceOfOperation, 4));
+
         NextTest();
     }
 
@@ -24507,6 +24910,7 @@ private:
     void OnSuccessResponse_40(uint8_t controlSequenceOfOperation)
     {
         VerifyOrReturn(CheckValue<uint8_t>("controlSequenceOfOperation", controlSequenceOfOperation, 2));
+
         NextTest();
     }
 
@@ -24989,6 +25393,7 @@ private:
     void OnSuccessResponse_0(uint8_t temperatureDisplayMode)
     {
         VerifyOrReturn(CheckValue<uint8_t>("temperatureDisplayMode", temperatureDisplayMode, 0));
+
         NextTest();
     }
 
@@ -25008,6 +25413,7 @@ private:
     void OnSuccessResponse_1(uint8_t temperatureDisplayMode)
     {
         VerifyOrReturn(CheckConstraintType("temperatureDisplayMode", "", "enum8"));
+
         NextTest();
     }
 
@@ -25045,6 +25451,7 @@ private:
     void OnSuccessResponse_3(uint8_t temperatureDisplayMode)
     {
         VerifyOrReturn(CheckValue<uint8_t>("temperatureDisplayMode", temperatureDisplayMode, 0));
+
         NextTest();
     }
 
@@ -25064,6 +25471,7 @@ private:
     void OnSuccessResponse_4(uint8_t temperatureDisplayMode)
     {
         VerifyOrReturn(CheckConstraintType("temperatureDisplayMode", "", "enum8"));
+
         NextTest();
     }
 
@@ -25083,6 +25491,7 @@ private:
     void OnSuccessResponse_5(uint8_t keypadLockout)
     {
         VerifyOrReturn(CheckValue<uint8_t>("keypadLockout", keypadLockout, 0));
+
         NextTest();
     }
 
@@ -25102,6 +25511,7 @@ private:
     void OnSuccessResponse_6(uint8_t keypadLockout)
     {
         VerifyOrReturn(CheckConstraintType("keypadLockout", "", "enum8"));
+
         NextTest();
     }
 
@@ -25139,6 +25549,7 @@ private:
     void OnSuccessResponse_8(uint8_t keypadLockout)
     {
         VerifyOrReturn(CheckValue<uint8_t>("keypadLockout", keypadLockout, 0));
+
         NextTest();
     }
 
@@ -25158,6 +25569,7 @@ private:
     void OnSuccessResponse_9(uint8_t keypadLockout)
     {
         VerifyOrReturn(CheckConstraintType("keypadLockout", "", "enum8"));
+
         NextTest();
     }
 
@@ -25177,6 +25589,7 @@ private:
     void OnSuccessResponse_10(uint8_t scheduleProgrammingVisibility)
     {
         VerifyOrReturn(CheckValue<uint8_t>("scheduleProgrammingVisibility", scheduleProgrammingVisibility, 0));
+
         NextTest();
     }
 
@@ -25196,6 +25609,7 @@ private:
     void OnSuccessResponse_11(uint8_t scheduleProgrammingVisibility)
     {
         VerifyOrReturn(CheckConstraintType("scheduleProgrammingVisibility", "", "enum8"));
+
         NextTest();
     }
 
@@ -25233,6 +25647,7 @@ private:
     void OnSuccessResponse_13(uint8_t scheduleProgrammingVisibility)
     {
         VerifyOrReturn(CheckValue<uint8_t>("scheduleProgrammingVisibility", scheduleProgrammingVisibility, 0));
+
         NextTest();
     }
 
@@ -25252,6 +25667,7 @@ private:
     void OnSuccessResponse_14(uint8_t scheduleProgrammingVisibility)
     {
         VerifyOrReturn(CheckConstraintType("scheduleProgrammingVisibility", "", "enum8"));
+
         NextTest();
     }
 };
@@ -25698,6 +26114,7 @@ private:
     void OnSuccessResponse_0(uint16_t clusterRevision)
     {
         VerifyOrReturn(CheckValue<uint16_t>("clusterRevision", clusterRevision, 1U));
+
         NextTest();
     }
 
@@ -25733,6 +26150,7 @@ private:
     void OnSuccessResponse_2(uint16_t clusterRevision)
     {
         VerifyOrReturn(CheckValue<uint16_t>("clusterRevision", clusterRevision, 1U));
+
         NextTest();
     }
 };
@@ -25881,6 +26299,7 @@ private:
         VerifyOrReturn(CheckConstraintType("clusterRevision", "", "uint16"));
         VerifyOrReturn(CheckConstraintMinValue<uint16_t>("clusterRevision", clusterRevision, 5));
         VerifyOrReturn(CheckConstraintMaxValue<uint16_t>("clusterRevision", clusterRevision, 200));
+
         NextTest();
     }
 
@@ -25917,6 +26336,7 @@ private:
     {
         VerifyOrReturn(CheckConstraintType("clusterRevision", "", "uint16"));
         VerifyOrReturn(CheckConstraintNotValue<uint16_t>("clusterRevision", clusterRevision, 201));
+
         NextTest();
     }
 
@@ -25936,6 +26356,7 @@ private:
     {
         VerifyOrReturn(CheckConstraintType("featureMap", "", "uint32"));
         VerifyOrReturn(CheckConstraintMaxValue<uint32_t>("featureMap", featureMap, 32768));
+
         NextTest();
     }
 
@@ -25972,6 +26393,7 @@ private:
     {
         VerifyOrReturn(CheckConstraintType("featureMap", "", "uint32"));
         VerifyOrReturn(CheckConstraintNotValue<uint32_t>("featureMap", featureMap, 32769));
+
         NextTest();
     }
 };
@@ -26774,6 +27196,7 @@ private:
     {
         VerifyOrReturn(CheckConstraintType("type", "", "enum8"));
         VerifyOrReturn(CheckConstraintMaxValue<uint8_t>("type", type, 9));
+
         NextTest();
     }
 
@@ -26810,6 +27233,7 @@ private:
     {
         VerifyOrReturn(CheckConstraintType("type", "", "enum8"));
         VerifyOrReturn(CheckConstraintNotValue<uint8_t>("type", type, 250));
+
         NextTest();
     }
 
@@ -26829,6 +27253,7 @@ private:
     {
         VerifyOrReturn(CheckConstraintType("configStatus", "", "map8"));
         VerifyOrReturn(CheckConstraintMaxValue<uint8_t>("configStatus", configStatus, 63));
+
         NextTest();
     }
 
@@ -26865,6 +27290,7 @@ private:
     {
         VerifyOrReturn(CheckConstraintType("configStatus", "", "map8"));
         VerifyOrReturn(CheckConstraintNotValue<uint8_t>("configStatus", configStatus, 128));
+
         NextTest();
     }
 
@@ -26884,6 +27310,7 @@ private:
     {
         VerifyOrReturn(CheckConstraintType("operationalStatus", "", "map8"));
         VerifyOrReturn(CheckConstraintMaxValue<uint8_t>("operationalStatus", operationalStatus, 63));
+
         NextTest();
     }
 
@@ -26920,6 +27347,7 @@ private:
     {
         VerifyOrReturn(CheckConstraintType("operationalStatus", "", "map8"));
         VerifyOrReturn(CheckConstraintNotValue<uint8_t>("operationalStatus", operationalStatus, 128));
+
         NextTest();
     }
 
@@ -26939,6 +27367,7 @@ private:
     {
         VerifyOrReturn(CheckConstraintType("endProductType", "", "enum8"));
         VerifyOrReturn(CheckConstraintMaxValue<uint8_t>("endProductType", endProductType, 23));
+
         NextTest();
     }
 
@@ -26975,6 +27404,7 @@ private:
     {
         VerifyOrReturn(CheckConstraintType("endProductType", "", "enum8"));
         VerifyOrReturn(CheckConstraintNotValue<uint8_t>("endProductType", endProductType, 250));
+
         NextTest();
     }
 
@@ -26994,6 +27424,7 @@ private:
     {
         VerifyOrReturn(CheckConstraintType("mode", "", "map8"));
         VerifyOrReturn(CheckConstraintMaxValue<uint8_t>("mode", mode, 15));
+
         NextTest();
     }
 
@@ -27029,6 +27460,7 @@ private:
     void OnSuccessResponse_14(uint8_t mode)
     {
         VerifyOrReturn(CheckValue<uint8_t>("mode", mode, 8));
+
         NextTest();
     }
 
@@ -27049,6 +27481,7 @@ private:
         VerifyOrReturn(CheckConstraintType("targetPositionLiftPercent100ths", "", "uint16"));
         VerifyOrReturn(
             CheckConstraintMaxValue<uint16_t>("targetPositionLiftPercent100ths", targetPositionLiftPercent100ths, 10000));
+
         NextTest();
     }
 
@@ -27086,6 +27519,7 @@ private:
         VerifyOrReturn(CheckConstraintType("targetPositionLiftPercent100ths", "", "uint16"));
         VerifyOrReturn(
             CheckConstraintNotValue<uint16_t>("targetPositionLiftPercent100ths", targetPositionLiftPercent100ths, 20000));
+
         NextTest();
     }
 
@@ -27106,6 +27540,7 @@ private:
         VerifyOrReturn(CheckConstraintType("targetPositionTiltPercent100ths", "", "uint16"));
         VerifyOrReturn(
             CheckConstraintMaxValue<uint16_t>("targetPositionTiltPercent100ths", targetPositionTiltPercent100ths, 10000));
+
         NextTest();
     }
 
@@ -27143,6 +27578,7 @@ private:
         VerifyOrReturn(CheckConstraintType("targetPositionTiltPercent100ths", "", "uint16"));
         VerifyOrReturn(
             CheckConstraintNotValue<uint16_t>("targetPositionTiltPercent100ths", targetPositionTiltPercent100ths, 20000));
+
         NextTest();
     }
 
@@ -27163,6 +27599,7 @@ private:
         VerifyOrReturn(CheckConstraintType("currentPositionLiftPercent100ths", "", "uint16"));
         VerifyOrReturn(
             CheckConstraintMaxValue<uint16_t>("currentPositionLiftPercent100ths", currentPositionLiftPercent100ths, 10000));
+
         NextTest();
     }
 
@@ -27200,6 +27637,7 @@ private:
         VerifyOrReturn(CheckConstraintType("currentPositionLiftPercent100ths", "", "uint16"));
         VerifyOrReturn(
             CheckConstraintNotValue<uint16_t>("currentPositionLiftPercent100ths", currentPositionLiftPercent100ths, 20000));
+
         NextTest();
     }
 
@@ -27220,6 +27658,7 @@ private:
         VerifyOrReturn(CheckConstraintType("currentPositionTiltPercent100ths", "", "uint16"));
         VerifyOrReturn(
             CheckConstraintMaxValue<uint16_t>("currentPositionTiltPercent100ths", currentPositionTiltPercent100ths, 10000));
+
         NextTest();
     }
 
@@ -27257,6 +27696,7 @@ private:
         VerifyOrReturn(CheckConstraintType("currentPositionTiltPercent100ths", "", "uint16"));
         VerifyOrReturn(
             CheckConstraintNotValue<uint16_t>("currentPositionTiltPercent100ths", currentPositionTiltPercent100ths, 20000));
+
         NextTest();
     }
 
@@ -27276,6 +27716,7 @@ private:
     {
         VerifyOrReturn(CheckConstraintType("installedOpenLimitLift", "", "uint16"));
         VerifyOrReturn(CheckConstraintMaxValue<uint16_t>("installedOpenLimitLift", installedOpenLimitLift, 65535));
+
         NextTest();
     }
 
@@ -27312,6 +27753,7 @@ private:
     {
         VerifyOrReturn(CheckConstraintType("installedOpenLimitLift", "", "uint16"));
         VerifyOrReturn(CheckConstraintMaxValue<uint16_t>("installedOpenLimitLift", installedOpenLimitLift, 65535));
+
         NextTest();
     }
 
@@ -27331,6 +27773,7 @@ private:
     {
         VerifyOrReturn(CheckConstraintType("installedClosedLimitLift", "", "uint16"));
         VerifyOrReturn(CheckConstraintMaxValue<uint16_t>("installedClosedLimitLift", installedClosedLimitLift, 65535));
+
         NextTest();
     }
 
@@ -27367,6 +27810,7 @@ private:
     {
         VerifyOrReturn(CheckConstraintType("installedClosedLimitLift", "", "uint16"));
         VerifyOrReturn(CheckConstraintMaxValue<uint16_t>("installedClosedLimitLift", installedClosedLimitLift, 65535));
+
         NextTest();
     }
 
@@ -27386,6 +27830,7 @@ private:
     {
         VerifyOrReturn(CheckConstraintType("installedOpenLimitTilt", "", "uint16"));
         VerifyOrReturn(CheckConstraintMaxValue<uint16_t>("installedOpenLimitTilt", installedOpenLimitTilt, 65535));
+
         NextTest();
     }
 
@@ -27422,6 +27867,7 @@ private:
     {
         VerifyOrReturn(CheckConstraintType("installedOpenLimitTilt", "", "uint16"));
         VerifyOrReturn(CheckConstraintMaxValue<uint16_t>("installedOpenLimitTilt", installedOpenLimitTilt, 65535));
+
         NextTest();
     }
 
@@ -27441,6 +27887,7 @@ private:
     {
         VerifyOrReturn(CheckConstraintType("installedClosedLimitTilt", "", "uint16"));
         VerifyOrReturn(CheckConstraintMaxValue<uint16_t>("installedClosedLimitTilt", installedClosedLimitTilt, 65535));
+
         NextTest();
     }
 
@@ -27477,6 +27924,7 @@ private:
     {
         VerifyOrReturn(CheckConstraintType("installedClosedLimitTilt", "", "uint16"));
         VerifyOrReturn(CheckConstraintMaxValue<uint16_t>("installedClosedLimitTilt", installedClosedLimitTilt, 65535));
+
         NextTest();
     }
 
@@ -27496,6 +27944,7 @@ private:
     {
         VerifyOrReturn(CheckConstraintType("safetyStatus", "", "map16"));
         VerifyOrReturn(CheckConstraintMaxValue<uint16_t>("safetyStatus", safetyStatus, 2047));
+
         NextTest();
     }
 
@@ -27532,6 +27981,7 @@ private:
     {
         VerifyOrReturn(CheckConstraintType("safetyStatus", "", "map16"));
         VerifyOrReturn(CheckConstraintNotValue<uint16_t>("safetyStatus", safetyStatus, 4096));
+
         NextTest();
     }
 
@@ -27551,6 +28001,7 @@ private:
     {
         VerifyOrReturn(CheckConstraintType("currentPositionLift", "", "uint16"));
         VerifyOrReturn(CheckConstraintMaxValue<uint16_t>("currentPositionLift", currentPositionLift, 65535));
+
         NextTest();
     }
 
@@ -27587,6 +28038,7 @@ private:
     {
         VerifyOrReturn(CheckConstraintType("currentPositionLift", "", "uint16"));
         VerifyOrReturn(CheckConstraintMaxValue<uint16_t>("currentPositionLift", currentPositionLift, 65535));
+
         NextTest();
     }
 
@@ -27606,6 +28058,7 @@ private:
     {
         VerifyOrReturn(CheckConstraintType("currentPositionTilt", "", "uint16"));
         VerifyOrReturn(CheckConstraintMaxValue<uint16_t>("currentPositionTilt", currentPositionTilt, 65535));
+
         NextTest();
     }
 
@@ -27642,6 +28095,7 @@ private:
     {
         VerifyOrReturn(CheckConstraintType("currentPositionTilt", "", "uint16"));
         VerifyOrReturn(CheckConstraintMaxValue<uint16_t>("currentPositionTilt", currentPositionTilt, 65535));
+
         NextTest();
     }
 
@@ -27661,6 +28115,7 @@ private:
     {
         VerifyOrReturn(CheckConstraintType("currentPositionLiftPercentage", "", "uint8"));
         VerifyOrReturn(CheckConstraintMaxValue<uint8_t>("currentPositionLiftPercentage", currentPositionLiftPercentage, 100));
+
         NextTest();
     }
 
@@ -27697,6 +28152,7 @@ private:
     {
         VerifyOrReturn(CheckConstraintType("currentPositionLiftPercentage", "", "uint8"));
         VerifyOrReturn(CheckConstraintNotValue<uint8_t>("currentPositionLiftPercentage", currentPositionLiftPercentage, 200));
+
         NextTest();
     }
 
@@ -27716,6 +28172,7 @@ private:
     {
         VerifyOrReturn(CheckConstraintType("currentPositionTiltPercentage", "", "uint8"));
         VerifyOrReturn(CheckConstraintMaxValue<uint8_t>("currentPositionTiltPercentage", currentPositionTiltPercentage, 100));
+
         NextTest();
     }
 
@@ -27752,6 +28209,7 @@ private:
     {
         VerifyOrReturn(CheckConstraintType("currentPositionTiltPercentage", "", "uint8"));
         VerifyOrReturn(CheckConstraintNotValue<uint8_t>("currentPositionTiltPercentage", currentPositionTiltPercentage, 200));
+
         NextTest();
     }
 };
@@ -27894,6 +28352,7 @@ private:
     void OnSuccessResponse_0(uint8_t type)
     {
         VerifyOrReturn(CheckValue<uint8_t>("type", type, 0));
+
         NextTest();
     }
 
@@ -27913,6 +28372,7 @@ private:
     {
         VerifyOrReturn(CheckConstraintType("type", "", "enum8"));
         VerifyOrReturn(CheckConstraintMaxValue<uint8_t>("type", type, 9));
+
         NextTest();
     }
 };
@@ -28007,6 +28467,7 @@ private:
     void OnSuccessResponse_0(uint8_t endProductType)
     {
         VerifyOrReturn(CheckValue<uint8_t>("endProductType", endProductType, 0));
+
         NextTest();
     }
 
@@ -28026,6 +28487,7 @@ private:
     {
         VerifyOrReturn(CheckConstraintType("endProductType", "", "enum8"));
         VerifyOrReturn(CheckConstraintMaxValue<uint8_t>("endProductType", endProductType, 23));
+
         NextTest();
     }
 };
@@ -28160,6 +28622,7 @@ private:
     void OnSuccessResponse_2(uint8_t operationalStatus)
     {
         VerifyOrReturn(CheckValue<uint8_t>("operationalStatus", operationalStatus, 0));
+
         NextTest();
     }
 };
@@ -28294,6 +28757,7 @@ private:
     void OnSuccessResponse_2(uint8_t operationalStatus)
     {
         VerifyOrReturn(CheckValue<uint8_t>("operationalStatus", operationalStatus, 0));
+
         NextTest();
     }
 };
@@ -28428,6 +28892,7 @@ private:
     void OnSuccessResponse_2(uint8_t operationalStatus)
     {
         VerifyOrReturn(CheckValue<uint8_t>("operationalStatus", operationalStatus, 0));
+
         NextTest();
     }
 };
@@ -28524,6 +28989,7 @@ private:
         VerifyOrReturn(CheckValue<>("targetNavigatorList[1].identifier", iter.GetValue().identifier, 2));
         VerifyOrReturn(CheckValueAsString("targetNavigatorList[1].name", iter.GetValue().name, chip::CharSpan("exampleName", 11)));
         VerifyOrReturn(CheckNoMoreListItems<decltype(targetNavigatorList)>("targetNavigatorList", iter, 2));
+
         NextTest();
     }
 
@@ -28655,6 +29121,7 @@ private:
         VerifyOrReturn(CheckValue<>("audioOutputList[2].outputType", iter.GetValue().outputType, 0));
         VerifyOrReturn(CheckValueAsString("audioOutputList[2].name", iter.GetValue().name, chip::CharSpan("exampleName", 11)));
         VerifyOrReturn(CheckNoMoreListItems<decltype(audioOutputList)>("audioOutputList", iter, 3));
+
         NextTest();
     }
 
@@ -28821,6 +29288,7 @@ private:
         VerifyOrReturn(CheckNextListItemDecodes<decltype(applicationLauncherList)>("applicationLauncherList", iter, 1));
         VerifyOrReturn(CheckValue<uint16_t>("applicationLauncherList[1]", iter.GetValue(), 456U));
         VerifyOrReturn(CheckNoMoreListItems<decltype(applicationLauncherList)>("applicationLauncherList", iter, 2));
+
         NextTest();
     }
 
@@ -28869,6 +29337,7 @@ private:
     void OnSuccessResponse_2(uint8_t catalogVendorId)
     {
         VerifyOrReturn(CheckValue<uint8_t>("catalogVendorId", catalogVendorId, 0));
+
         NextTest();
     }
 
@@ -28887,6 +29356,7 @@ private:
     void OnSuccessResponse_3(uint8_t applicationId)
     {
         VerifyOrReturn(CheckValue<uint8_t>("applicationId", applicationId, 0));
+
         NextTest();
     }
 };
@@ -29148,6 +29618,7 @@ private:
     void OnSuccessResponse_0(chip::CharSpan wakeOnLanMacAddress)
     {
         VerifyOrReturn(CheckValueAsString("wakeOnLanMacAddress", wakeOnLanMacAddress, chip::CharSpan("00:00:00:00:00", 14)));
+
         NextTest();
     }
 };
@@ -29284,6 +29755,7 @@ private:
     void OnSuccessResponse_1(uint16_t vendorId)
     {
         VerifyOrReturn(CheckValue<uint16_t>("vendorId", vendorId, 1U));
+
         NextTest();
     }
 
@@ -29302,6 +29774,7 @@ private:
     void OnSuccessResponse_2(uint16_t productId)
     {
         VerifyOrReturn(CheckValue<uint16_t>("productId", productId, 1U));
+
         NextTest();
     }
 
@@ -29320,6 +29793,7 @@ private:
     void OnSuccessResponse_3(uint16_t catalogVendorId)
     {
         VerifyOrReturn(CheckValue<uint16_t>("catalogVendorId", catalogVendorId, 1U));
+
         NextTest();
     }
 };
@@ -29439,6 +29913,7 @@ private:
     void OnSuccessResponse_0(chip::app::Clusters::MediaPlayback::MediaPlaybackStatus mediaPlaybackStatus)
     {
         VerifyOrReturn(CheckValue<uint8_t>("mediaPlaybackStatus", mediaPlaybackStatus, 0));
+
         NextTest();
     }
 
@@ -29466,6 +29941,7 @@ private:
     void OnSuccessResponse_1(chip::app::Clusters::MediaPlayback::MediaPlaybackStatus mediaPlaybackStatus)
     {
         VerifyOrReturn(CheckValue<uint8_t>("mediaPlaybackStatus", mediaPlaybackStatus, 0));
+
         NextTest();
     }
 
@@ -29493,6 +29969,7 @@ private:
     void OnSuccessResponse_2(chip::app::Clusters::MediaPlayback::MediaPlaybackStatus mediaPlaybackStatus)
     {
         VerifyOrReturn(CheckValue<uint8_t>("mediaPlaybackStatus", mediaPlaybackStatus, 0));
+
         NextTest();
     }
 
@@ -29520,6 +29997,7 @@ private:
     void OnSuccessResponse_3(chip::app::Clusters::MediaPlayback::MediaPlaybackStatus mediaPlaybackStatus)
     {
         VerifyOrReturn(CheckValue<uint8_t>("mediaPlaybackStatus", mediaPlaybackStatus, 0));
+
         NextTest();
     }
 
@@ -29547,6 +30025,7 @@ private:
     void OnSuccessResponse_4(chip::app::Clusters::MediaPlayback::MediaPlaybackStatus mediaPlaybackStatus)
     {
         VerifyOrReturn(CheckValue<uint8_t>("mediaPlaybackStatus", mediaPlaybackStatus, 0));
+
         NextTest();
     }
 
@@ -29574,6 +30053,7 @@ private:
     void OnSuccessResponse_5(chip::app::Clusters::MediaPlayback::MediaPlaybackStatus mediaPlaybackStatus)
     {
         VerifyOrReturn(CheckValue<uint8_t>("mediaPlaybackStatus", mediaPlaybackStatus, 0));
+
         NextTest();
     }
 
@@ -29601,6 +30081,7 @@ private:
     void OnSuccessResponse_6(chip::app::Clusters::MediaPlayback::MediaPlaybackStatus mediaPlaybackStatus)
     {
         VerifyOrReturn(CheckValue<uint8_t>("mediaPlaybackStatus", mediaPlaybackStatus, 0));
+
         NextTest();
     }
 
@@ -29628,6 +30109,7 @@ private:
     void OnSuccessResponse_7(chip::app::Clusters::MediaPlayback::MediaPlaybackStatus mediaPlaybackStatus)
     {
         VerifyOrReturn(CheckValue<uint8_t>("mediaPlaybackStatus", mediaPlaybackStatus, 0));
+
         NextTest();
     }
 
@@ -29656,6 +30138,7 @@ private:
     void OnSuccessResponse_8(chip::app::Clusters::MediaPlayback::MediaPlaybackStatus mediaPlaybackStatus)
     {
         VerifyOrReturn(CheckValue<uint8_t>("mediaPlaybackStatus", mediaPlaybackStatus, 0));
+
         NextTest();
     }
 
@@ -29684,6 +30167,7 @@ private:
     void OnSuccessResponse_9(chip::app::Clusters::MediaPlayback::MediaPlaybackStatus mediaPlaybackStatus)
     {
         VerifyOrReturn(CheckValue<uint8_t>("mediaPlaybackStatus", mediaPlaybackStatus, 0));
+
         NextTest();
     }
 
@@ -29712,6 +30196,7 @@ private:
     void OnSuccessResponse_10(chip::app::Clusters::MediaPlayback::MediaPlaybackStatus mediaPlaybackStatus)
     {
         VerifyOrReturn(CheckValue<uint8_t>("mediaPlaybackStatus", mediaPlaybackStatus, 0));
+
         NextTest();
     }
 };
@@ -29822,6 +30307,7 @@ private:
         VerifyOrReturn(CheckValueAsString("tvChannelList[1].affiliateCallSign", iter.GetValue().affiliateCallSign,
                                           chip::CharSpan("exampleASign", 12)));
         VerifyOrReturn(CheckNoMoreListItems<decltype(tvChannelList)>("tvChannelList", iter, 2));
+
         NextTest();
     }
 
@@ -30074,6 +30560,7 @@ private:
         VerifyOrReturn(CheckValueAsString("mediaInputList[1].description", iter.GetValue().description,
                                           chip::CharSpan("exampleDescription", 18)));
         VerifyOrReturn(CheckNoMoreListItems<decltype(mediaInputList)>("mediaInputList", iter, 2));
+
         NextTest();
     }
 
@@ -30116,6 +30603,7 @@ private:
     void OnSuccessResponse_2(uint8_t currentMediaInput)
     {
         VerifyOrReturn(CheckValue<uint8_t>("currentMediaInput", currentMediaInput, 1));
+
         NextTest();
     }
 
@@ -33248,6 +33736,7 @@ private:
     void OnSuccessResponse_2(uint8_t returnValue)
     {
         VerifyOrReturn(CheckValue<uint8_t>("returnValue", returnValue, 7));
+
         NextTest();
     }
 
@@ -33277,6 +33766,7 @@ private:
     void OnSuccessResponse_3(uint8_t returnValue)
     {
         VerifyOrReturn(CheckValue<uint8_t>("returnValue", returnValue, 20));
+
         NextTest();
     }
 
@@ -33320,6 +33810,7 @@ private:
     void OnSuccessResponse_5(bool boolean)
     {
         VerifyOrReturn(CheckValue<bool>("boolean", boolean, 0));
+
         NextTest();
     }
 
@@ -33355,6 +33846,7 @@ private:
     void OnSuccessResponse_7(bool boolean)
     {
         VerifyOrReturn(CheckValue<bool>("boolean", boolean, 1));
+
         NextTest();
     }
 
@@ -33390,6 +33882,7 @@ private:
     void OnSuccessResponse_9(bool boolean)
     {
         VerifyOrReturn(CheckValue<bool>("boolean", boolean, 0));
+
         NextTest();
     }
 
@@ -33408,6 +33901,7 @@ private:
     void OnSuccessResponse_10(uint8_t bitmap8)
     {
         VerifyOrReturn(CheckValue<uint8_t>("bitmap8", bitmap8, 0));
+
         NextTest();
     }
 
@@ -33443,6 +33937,7 @@ private:
     void OnSuccessResponse_12(uint8_t bitmap8)
     {
         VerifyOrReturn(CheckValue<uint8_t>("bitmap8", bitmap8, 255));
+
         NextTest();
     }
 
@@ -33478,6 +33973,7 @@ private:
     void OnSuccessResponse_14(uint8_t bitmap8)
     {
         VerifyOrReturn(CheckValue<uint8_t>("bitmap8", bitmap8, 0));
+
         NextTest();
     }
 
@@ -33496,6 +33992,7 @@ private:
     void OnSuccessResponse_15(uint16_t bitmap16)
     {
         VerifyOrReturn(CheckValue<uint16_t>("bitmap16", bitmap16, 0U));
+
         NextTest();
     }
 
@@ -33531,6 +34028,7 @@ private:
     void OnSuccessResponse_17(uint16_t bitmap16)
     {
         VerifyOrReturn(CheckValue<uint16_t>("bitmap16", bitmap16, 65535U));
+
         NextTest();
     }
 
@@ -33566,6 +34064,7 @@ private:
     void OnSuccessResponse_19(uint16_t bitmap16)
     {
         VerifyOrReturn(CheckValue<uint16_t>("bitmap16", bitmap16, 0U));
+
         NextTest();
     }
 
@@ -33584,6 +34083,7 @@ private:
     void OnSuccessResponse_20(uint32_t bitmap32)
     {
         VerifyOrReturn(CheckValue<uint32_t>("bitmap32", bitmap32, 0UL));
+
         NextTest();
     }
 
@@ -33619,6 +34119,7 @@ private:
     void OnSuccessResponse_22(uint32_t bitmap32)
     {
         VerifyOrReturn(CheckValue<uint32_t>("bitmap32", bitmap32, 4294967295UL));
+
         NextTest();
     }
 
@@ -33654,6 +34155,7 @@ private:
     void OnSuccessResponse_24(uint32_t bitmap32)
     {
         VerifyOrReturn(CheckValue<uint32_t>("bitmap32", bitmap32, 0UL));
+
         NextTest();
     }
 
@@ -33672,6 +34174,7 @@ private:
     void OnSuccessResponse_25(uint64_t bitmap64)
     {
         VerifyOrReturn(CheckValue<uint64_t>("bitmap64", bitmap64, 0ULL));
+
         NextTest();
     }
 
@@ -33707,6 +34210,7 @@ private:
     void OnSuccessResponse_27(uint64_t bitmap64)
     {
         VerifyOrReturn(CheckValue<uint64_t>("bitmap64", bitmap64, 18446744073709551615ULL));
+
         NextTest();
     }
 
@@ -33742,6 +34246,7 @@ private:
     void OnSuccessResponse_29(uint64_t bitmap64)
     {
         VerifyOrReturn(CheckValue<uint64_t>("bitmap64", bitmap64, 0ULL));
+
         NextTest();
     }
 
@@ -33760,6 +34265,7 @@ private:
     void OnSuccessResponse_30(uint8_t int8u)
     {
         VerifyOrReturn(CheckValue<uint8_t>("int8u", int8u, 0));
+
         NextTest();
     }
 
@@ -33795,6 +34301,7 @@ private:
     void OnSuccessResponse_32(uint8_t int8u)
     {
         VerifyOrReturn(CheckValue<uint8_t>("int8u", int8u, 255));
+
         NextTest();
     }
 
@@ -33830,6 +34337,7 @@ private:
     void OnSuccessResponse_34(uint8_t int8u)
     {
         VerifyOrReturn(CheckValue<uint8_t>("int8u", int8u, 0));
+
         NextTest();
     }
 
@@ -33848,6 +34356,7 @@ private:
     void OnSuccessResponse_35(uint16_t int16u)
     {
         VerifyOrReturn(CheckValue<uint16_t>("int16u", int16u, 0U));
+
         NextTest();
     }
 
@@ -33883,6 +34392,7 @@ private:
     void OnSuccessResponse_37(uint16_t int16u)
     {
         VerifyOrReturn(CheckValue<uint16_t>("int16u", int16u, 65535U));
+
         NextTest();
     }
 
@@ -33918,6 +34428,7 @@ private:
     void OnSuccessResponse_39(uint16_t int16u)
     {
         VerifyOrReturn(CheckValue<uint16_t>("int16u", int16u, 0U));
+
         NextTest();
     }
 
@@ -33936,6 +34447,7 @@ private:
     void OnSuccessResponse_40(uint32_t int32u)
     {
         VerifyOrReturn(CheckValue<uint32_t>("int32u", int32u, 0UL));
+
         NextTest();
     }
 
@@ -33971,6 +34483,7 @@ private:
     void OnSuccessResponse_42(uint32_t int32u)
     {
         VerifyOrReturn(CheckValue<uint32_t>("int32u", int32u, 4294967295UL));
+
         NextTest();
     }
 
@@ -34006,6 +34519,7 @@ private:
     void OnSuccessResponse_44(uint32_t int32u)
     {
         VerifyOrReturn(CheckValue<uint32_t>("int32u", int32u, 0UL));
+
         NextTest();
     }
 
@@ -34024,6 +34538,7 @@ private:
     void OnSuccessResponse_45(uint64_t int64u)
     {
         VerifyOrReturn(CheckValue<uint64_t>("int64u", int64u, 0ULL));
+
         NextTest();
     }
 
@@ -34059,6 +34574,7 @@ private:
     void OnSuccessResponse_47(uint64_t int64u)
     {
         VerifyOrReturn(CheckValue<uint64_t>("int64u", int64u, 18446744073709551615ULL));
+
         NextTest();
     }
 
@@ -34094,6 +34610,7 @@ private:
     void OnSuccessResponse_49(uint64_t int64u)
     {
         VerifyOrReturn(CheckValue<uint64_t>("int64u", int64u, 0ULL));
+
         NextTest();
     }
 
@@ -34112,6 +34629,7 @@ private:
     void OnSuccessResponse_50(int8_t int8s)
     {
         VerifyOrReturn(CheckValue<int8_t>("int8s", int8s, 0));
+
         NextTest();
     }
 
@@ -34147,6 +34665,7 @@ private:
     void OnSuccessResponse_52(int8_t int8s)
     {
         VerifyOrReturn(CheckValue<int8_t>("int8s", int8s, 127));
+
         NextTest();
     }
 
@@ -34182,6 +34701,7 @@ private:
     void OnSuccessResponse_54(int8_t int8s)
     {
         VerifyOrReturn(CheckValue<int8_t>("int8s", int8s, -128));
+
         NextTest();
     }
 
@@ -34217,6 +34737,7 @@ private:
     void OnSuccessResponse_56(int8_t int8s)
     {
         VerifyOrReturn(CheckValue<int8_t>("int8s", int8s, 0));
+
         NextTest();
     }
 
@@ -34235,6 +34756,7 @@ private:
     void OnSuccessResponse_57(int16_t int16s)
     {
         VerifyOrReturn(CheckValue<int16_t>("int16s", int16s, 0));
+
         NextTest();
     }
 
@@ -34270,6 +34792,7 @@ private:
     void OnSuccessResponse_59(int16_t int16s)
     {
         VerifyOrReturn(CheckValue<int16_t>("int16s", int16s, 32767));
+
         NextTest();
     }
 
@@ -34305,6 +34828,7 @@ private:
     void OnSuccessResponse_61(int16_t int16s)
     {
         VerifyOrReturn(CheckValue<int16_t>("int16s", int16s, -32768));
+
         NextTest();
     }
 
@@ -34340,6 +34864,7 @@ private:
     void OnSuccessResponse_63(int16_t int16s)
     {
         VerifyOrReturn(CheckValue<int16_t>("int16s", int16s, 0));
+
         NextTest();
     }
 
@@ -34358,6 +34883,7 @@ private:
     void OnSuccessResponse_64(int32_t int32s)
     {
         VerifyOrReturn(CheckValue<int32_t>("int32s", int32s, 0L));
+
         NextTest();
     }
 
@@ -34393,6 +34919,7 @@ private:
     void OnSuccessResponse_66(int32_t int32s)
     {
         VerifyOrReturn(CheckValue<int32_t>("int32s", int32s, 2147483647L));
+
         NextTest();
     }
 
@@ -34428,6 +34955,7 @@ private:
     void OnSuccessResponse_68(int32_t int32s)
     {
         VerifyOrReturn(CheckValue<int32_t>("int32s", int32s, -2147483648L));
+
         NextTest();
     }
 
@@ -34463,6 +34991,7 @@ private:
     void OnSuccessResponse_70(int32_t int32s)
     {
         VerifyOrReturn(CheckValue<int32_t>("int32s", int32s, 0L));
+
         NextTest();
     }
 
@@ -34481,6 +35010,7 @@ private:
     void OnSuccessResponse_71(int64_t int64s)
     {
         VerifyOrReturn(CheckValue<int64_t>("int64s", int64s, 0LL));
+
         NextTest();
     }
 
@@ -34516,6 +35046,7 @@ private:
     void OnSuccessResponse_73(int64_t int64s)
     {
         VerifyOrReturn(CheckValue<int64_t>("int64s", int64s, 9223372036854775807LL));
+
         NextTest();
     }
 
@@ -34551,6 +35082,7 @@ private:
     void OnSuccessResponse_75(int64_t int64s)
     {
         VerifyOrReturn(CheckValue<int64_t>("int64s", int64s, -9223372036854775807LL));
+
         NextTest();
     }
 
@@ -34586,6 +35118,7 @@ private:
     void OnSuccessResponse_77(int64_t int64s)
     {
         VerifyOrReturn(CheckValue<int64_t>("int64s", int64s, 0LL));
+
         NextTest();
     }
 
@@ -34604,6 +35137,7 @@ private:
     void OnSuccessResponse_78(uint8_t enum8)
     {
         VerifyOrReturn(CheckValue<uint8_t>("enum8", enum8, 0));
+
         NextTest();
     }
 
@@ -34639,6 +35173,7 @@ private:
     void OnSuccessResponse_80(uint8_t enum8)
     {
         VerifyOrReturn(CheckValue<uint8_t>("enum8", enum8, 255));
+
         NextTest();
     }
 
@@ -34674,6 +35209,7 @@ private:
     void OnSuccessResponse_82(uint8_t enum8)
     {
         VerifyOrReturn(CheckValue<uint8_t>("enum8", enum8, 0));
+
         NextTest();
     }
 
@@ -34692,6 +35228,7 @@ private:
     void OnSuccessResponse_83(uint16_t enum16)
     {
         VerifyOrReturn(CheckValue<uint16_t>("enum16", enum16, 0U));
+
         NextTest();
     }
 
@@ -34727,6 +35264,7 @@ private:
     void OnSuccessResponse_85(uint16_t enum16)
     {
         VerifyOrReturn(CheckValue<uint16_t>("enum16", enum16, 65535U));
+
         NextTest();
     }
 
@@ -34762,6 +35300,7 @@ private:
     void OnSuccessResponse_87(uint16_t enum16)
     {
         VerifyOrReturn(CheckValue<uint16_t>("enum16", enum16, 0U));
+
         NextTest();
     }
 
@@ -34780,6 +35319,7 @@ private:
     void OnSuccessResponse_88(chip::ByteSpan octetString)
     {
         VerifyOrReturn(CheckValueAsString("octetString", octetString, chip::ByteSpan(chip::Uint8::from_const_char(""), 0)));
+
         NextTest();
     }
 
@@ -34816,6 +35356,7 @@ private:
     {
         VerifyOrReturn(
             CheckValueAsString("octetString", octetString, chip::ByteSpan(chip::Uint8::from_const_char("Tes\x00ti\x00ng"), 9)));
+
         NextTest();
     }
 
@@ -34852,6 +35393,7 @@ private:
     {
         VerifyOrReturn(
             CheckValueAsString("octetString", octetString, chip::ByteSpan(chip::Uint8::from_const_char("TestValue"), 9)));
+
         NextTest();
     }
 
@@ -34889,6 +35431,7 @@ private:
     {
         VerifyOrReturn(
             CheckValueAsString("octetString", octetString, chip::ByteSpan(chip::Uint8::from_const_char("TestValue"), 9)));
+
         NextTest();
     }
 
@@ -34924,6 +35467,7 @@ private:
     void OnSuccessResponse_96(chip::ByteSpan longOctetString)
     {
         VerifyOrReturn(CheckValueAsString("longOctetString", longOctetString, chip::ByteSpan(chip::Uint8::from_const_char(""), 0)));
+
         NextTest();
     }
 
@@ -34971,6 +35515,7 @@ private:
                     "11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111"
                     "11111111111111111111111111111111111111111111111111111111111111111111111111111111"),
                 300)));
+
         NextTest();
     }
 
@@ -35006,6 +35551,7 @@ private:
     void OnSuccessResponse_100(chip::CharSpan charString)
     {
         VerifyOrReturn(CheckValueAsString("charString", charString, chip::CharSpan("", 0)));
+
         NextTest();
     }
 
@@ -35075,6 +35621,7 @@ private:
     void OnSuccessResponse_104(chip::CharSpan longCharString)
     {
         VerifyOrReturn(CheckValueAsString("longCharString", longCharString, chip::CharSpan("", 0)));
+
         NextTest();
     }
 
@@ -35119,6 +35666,7 @@ private:
                            "☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉"
                            "☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉",
                            300)));
+
         NextTest();
     }
 
@@ -35154,6 +35702,7 @@ private:
     void OnSuccessResponse_108(uint64_t epochUs)
     {
         VerifyOrReturn(CheckValue<uint64_t>("epochUs", epochUs, 0ULL));
+
         NextTest();
     }
 
@@ -35189,6 +35738,7 @@ private:
     void OnSuccessResponse_110(uint64_t epochUs)
     {
         VerifyOrReturn(CheckValue<uint64_t>("epochUs", epochUs, 18446744073709551615ULL));
+
         NextTest();
     }
 
@@ -35224,6 +35774,7 @@ private:
     void OnSuccessResponse_112(uint64_t epochUs)
     {
         VerifyOrReturn(CheckValue<uint64_t>("epochUs", epochUs, 0ULL));
+
         NextTest();
     }
 
@@ -35242,6 +35793,7 @@ private:
     void OnSuccessResponse_113(uint32_t epochS)
     {
         VerifyOrReturn(CheckValue<uint32_t>("epochS", epochS, 0UL));
+
         NextTest();
     }
 
@@ -35277,6 +35829,7 @@ private:
     void OnSuccessResponse_115(uint32_t epochS)
     {
         VerifyOrReturn(CheckValue<uint32_t>("epochS", epochS, 4294967295UL));
+
         NextTest();
     }
 
@@ -35312,6 +35865,7 @@ private:
     void OnSuccessResponse_117(uint32_t epochS)
     {
         VerifyOrReturn(CheckValue<uint32_t>("epochS", epochS, 0UL));
+
         NextTest();
     }
 
@@ -35333,6 +35887,7 @@ private:
     void OnSuccessResponse_118(bool unsupported)
     {
         VerifyOrReturn(CheckValue<bool>("unsupported", unsupported, 0));
+
         NextTest();
     }
 
@@ -35394,6 +35949,7 @@ private:
     void OnSuccessResponse_121(chip::VendorId vendorId)
     {
         VerifyOrReturn(CheckValue<chip::VendorId>("vendorId", vendorId, 0U));
+
         NextTest();
     }
 
@@ -35429,6 +35985,7 @@ private:
     void OnSuccessResponse_123(chip::VendorId vendorId)
     {
         VerifyOrReturn(CheckValue<chip::VendorId>("vendorId", vendorId, 17U));
+
         NextTest();
     }
 
@@ -35477,6 +36034,7 @@ private:
         VerifyOrReturn(CheckValue<chip::VendorId>("arg1", arg1, 20003U));
 
         VerifyOrReturn(CheckValue<uint8_t>("arg2", arg2, 101));
+
         NextTest();
     }
 
@@ -35511,6 +36069,7 @@ private:
     void OnSuccessResponse_126(bool value)
     {
         VerifyOrReturn(CheckValue<bool>("value", value, true));
+
         NextTest();
     }
 
@@ -35545,6 +36104,7 @@ private:
     void OnSuccessResponse_127(bool value)
     {
         VerifyOrReturn(CheckValue<bool>("value", value, false));
+
         NextTest();
     }
 
@@ -35584,6 +36144,7 @@ private:
     void OnSuccessResponse_128(bool value)
     {
         VerifyOrReturn(CheckValue<bool>("value", value, true));
+
         NextTest();
     }
 
@@ -35624,6 +36185,7 @@ private:
     void OnSuccessResponse_129(bool value)
     {
         VerifyOrReturn(CheckValue<bool>("value", value, false));
+
         NextTest();
     }
 
@@ -35682,6 +36244,7 @@ private:
         VerifyOrReturn(CheckNextListItemDecodes<decltype(arg1)>("arg1", iter, 8));
         VerifyOrReturn(CheckValue<uint8_t>("arg1[8]", iter.GetValue(), 1));
         VerifyOrReturn(CheckNoMoreListItems<decltype(arg1)>("arg1", iter, 9));
+
         NextTest();
     }
 
@@ -35712,6 +36275,7 @@ private:
     {
         auto iter = arg1.begin();
         VerifyOrReturn(CheckNoMoreListItems<decltype(arg1)>("arg1", iter, 0));
+
         NextTest();
     }
 
@@ -35757,6 +36321,7 @@ private:
     void OnSuccessResponse_132(bool value)
     {
         VerifyOrReturn(CheckValue<bool>("value", value, true));
+
         NextTest();
     }
 
@@ -35802,6 +36367,7 @@ private:
     void OnSuccessResponse_133(bool value)
     {
         VerifyOrReturn(CheckValue<bool>("value", value, false));
+
         NextTest();
     }
 
@@ -35852,6 +36418,7 @@ private:
         VerifyOrReturn(CheckNextListItemDecodes<decltype(listInt8u)>("listInt8u", iter, 3));
         VerifyOrReturn(CheckValue<uint8_t>("listInt8u[3]", iter.GetValue(), 4));
         VerifyOrReturn(CheckNoMoreListItems<decltype(listInt8u)>("listInt8u", iter, 4));
+
         NextTest();
     }
 
@@ -35906,6 +36473,7 @@ private:
         VerifyOrReturn(
             CheckValueAsString("listOctetString[3]", iter.GetValue(), chip::ByteSpan(chip::Uint8::from_const_char("Test3"), 5)));
         VerifyOrReturn(CheckNoMoreListItems<decltype(listOctetString)>("listOctetString", iter, 4));
+
         NextTest();
     }
 
@@ -35980,6 +36548,7 @@ private:
         VerifyOrReturn(CheckValueAsString("listStructOctetString[3].operationalCert", iter.GetValue().operationalCert,
                                           chip::ByteSpan(chip::Uint8::from_const_char("Test3"), 5)));
         VerifyOrReturn(CheckNoMoreListItems<decltype(listStructOctetString)>("listStructOctetString", iter, 4));
+
         NextTest();
     }
 
@@ -36020,6 +36589,7 @@ private:
         VerifyOrReturn(CheckValuePresent("originalValue", originalValue));
         VerifyOrReturn(CheckValueNonNull("originalValue.Value()", originalValue.Value()));
         VerifyOrReturn(CheckValue<uint8_t>("originalValue.Value().Value()", originalValue.Value().Value(), 5));
+
         NextTest();
     }
 
@@ -36085,6 +36655,7 @@ private:
     void OnSuccessResponse_143(const chip::app::DataModel::Nullable<bool> & nullableBoolean)
     {
         VerifyOrReturn(CheckValueNull("nullableBoolean", nullableBoolean));
+
         NextTest();
     }
 
@@ -36121,6 +36692,7 @@ private:
     {
         VerifyOrReturn(CheckValueNonNull("nullableBoolean", nullableBoolean));
         VerifyOrReturn(CheckValue<bool>("nullableBoolean.Value()", nullableBoolean.Value(), true));
+
         NextTest();
     }
 
@@ -36157,6 +36729,7 @@ private:
     {
         VerifyOrReturn(CheckValueNonNull("nullableBitmap8", nullableBitmap8));
         VerifyOrReturn(CheckValue<uint8_t>("nullableBitmap8.Value()", nullableBitmap8.Value(), 254));
+
         NextTest();
     }
 
@@ -36193,6 +36766,7 @@ private:
     {
         VerifyOrReturn(CheckValueNonNull("nullableBitmap8", nullableBitmap8));
         VerifyOrReturn(CheckValue<uint8_t>("nullableBitmap8.Value()", nullableBitmap8.Value(), 254));
+
         NextTest();
     }
 
@@ -36228,6 +36802,7 @@ private:
     void OnSuccessResponse_151(const chip::app::DataModel::Nullable<uint8_t> & nullableBitmap8)
     {
         VerifyOrReturn(CheckValueNull("nullableBitmap8", nullableBitmap8));
+
         NextTest();
     }
 
@@ -36264,6 +36839,7 @@ private:
     {
         VerifyOrReturn(CheckValueNonNull("nullableBitmap16", nullableBitmap16));
         VerifyOrReturn(CheckValue<uint16_t>("nullableBitmap16.Value()", nullableBitmap16.Value(), 65534U));
+
         NextTest();
     }
 
@@ -36300,6 +36876,7 @@ private:
     {
         VerifyOrReturn(CheckValueNonNull("nullableBitmap16", nullableBitmap16));
         VerifyOrReturn(CheckValue<uint16_t>("nullableBitmap16.Value()", nullableBitmap16.Value(), 65534U));
+
         NextTest();
     }
 
@@ -36335,6 +36912,7 @@ private:
     void OnSuccessResponse_157(const chip::app::DataModel::Nullable<uint16_t> & nullableBitmap16)
     {
         VerifyOrReturn(CheckValueNull("nullableBitmap16", nullableBitmap16));
+
         NextTest();
     }
 
@@ -36371,6 +36949,7 @@ private:
     {
         VerifyOrReturn(CheckValueNonNull("nullableBitmap32", nullableBitmap32));
         VerifyOrReturn(CheckValue<uint32_t>("nullableBitmap32.Value()", nullableBitmap32.Value(), 4294967294UL));
+
         NextTest();
     }
 
@@ -36407,6 +36986,7 @@ private:
     {
         VerifyOrReturn(CheckValueNonNull("nullableBitmap32", nullableBitmap32));
         VerifyOrReturn(CheckValue<uint32_t>("nullableBitmap32.Value()", nullableBitmap32.Value(), 4294967294UL));
+
         NextTest();
     }
 
@@ -36442,6 +37022,7 @@ private:
     void OnSuccessResponse_163(const chip::app::DataModel::Nullable<uint32_t> & nullableBitmap32)
     {
         VerifyOrReturn(CheckValueNull("nullableBitmap32", nullableBitmap32));
+
         NextTest();
     }
 
@@ -36478,6 +37059,7 @@ private:
     {
         VerifyOrReturn(CheckValueNonNull("nullableBitmap64", nullableBitmap64));
         VerifyOrReturn(CheckValue<uint64_t>("nullableBitmap64.Value()", nullableBitmap64.Value(), 18446744073709551614ULL));
+
         NextTest();
     }
 
@@ -36514,6 +37096,7 @@ private:
     {
         VerifyOrReturn(CheckValueNonNull("nullableBitmap64", nullableBitmap64));
         VerifyOrReturn(CheckValue<uint64_t>("nullableBitmap64.Value()", nullableBitmap64.Value(), 18446744073709551614ULL));
+
         NextTest();
     }
 
@@ -36549,6 +37132,7 @@ private:
     void OnSuccessResponse_169(const chip::app::DataModel::Nullable<uint64_t> & nullableBitmap64)
     {
         VerifyOrReturn(CheckValueNull("nullableBitmap64", nullableBitmap64));
+
         NextTest();
     }
 
@@ -36585,6 +37169,7 @@ private:
     {
         VerifyOrReturn(CheckValueNonNull("nullableInt8u", nullableInt8u));
         VerifyOrReturn(CheckValue<uint8_t>("nullableInt8u.Value()", nullableInt8u.Value(), 254));
+
         NextTest();
     }
 
@@ -36621,6 +37206,7 @@ private:
     {
         VerifyOrReturn(CheckValueNonNull("nullableInt8u", nullableInt8u));
         VerifyOrReturn(CheckValue<uint8_t>("nullableInt8u.Value()", nullableInt8u.Value(), 254));
+
         NextTest();
     }
 
@@ -36656,6 +37242,7 @@ private:
     void OnSuccessResponse_175(const chip::app::DataModel::Nullable<uint8_t> & nullableInt8u)
     {
         VerifyOrReturn(CheckValueNull("nullableInt8u", nullableInt8u));
+
         NextTest();
     }
 
@@ -36692,6 +37279,7 @@ private:
     {
         VerifyOrReturn(CheckValueNonNull("nullableInt16u", nullableInt16u));
         VerifyOrReturn(CheckValue<uint16_t>("nullableInt16u.Value()", nullableInt16u.Value(), 65534U));
+
         NextTest();
     }
 
@@ -36728,6 +37316,7 @@ private:
     {
         VerifyOrReturn(CheckValueNonNull("nullableInt16u", nullableInt16u));
         VerifyOrReturn(CheckValue<uint16_t>("nullableInt16u.Value()", nullableInt16u.Value(), 65534U));
+
         NextTest();
     }
 
@@ -36763,6 +37352,7 @@ private:
     void OnSuccessResponse_181(const chip::app::DataModel::Nullable<uint16_t> & nullableInt16u)
     {
         VerifyOrReturn(CheckValueNull("nullableInt16u", nullableInt16u));
+
         NextTest();
     }
 
@@ -36799,6 +37389,7 @@ private:
     {
         VerifyOrReturn(CheckValueNonNull("nullableInt32u", nullableInt32u));
         VerifyOrReturn(CheckValue<uint32_t>("nullableInt32u.Value()", nullableInt32u.Value(), 4294967294UL));
+
         NextTest();
     }
 
@@ -36835,6 +37426,7 @@ private:
     {
         VerifyOrReturn(CheckValueNonNull("nullableInt32u", nullableInt32u));
         VerifyOrReturn(CheckValue<uint32_t>("nullableInt32u.Value()", nullableInt32u.Value(), 4294967294UL));
+
         NextTest();
     }
 
@@ -36870,6 +37462,7 @@ private:
     void OnSuccessResponse_187(const chip::app::DataModel::Nullable<uint32_t> & nullableInt32u)
     {
         VerifyOrReturn(CheckValueNull("nullableInt32u", nullableInt32u));
+
         NextTest();
     }
 
@@ -36906,6 +37499,7 @@ private:
     {
         VerifyOrReturn(CheckValueNonNull("nullableInt64u", nullableInt64u));
         VerifyOrReturn(CheckValue<uint64_t>("nullableInt64u.Value()", nullableInt64u.Value(), 18446744073709551614ULL));
+
         NextTest();
     }
 
@@ -36942,6 +37536,7 @@ private:
     {
         VerifyOrReturn(CheckValueNonNull("nullableInt64u", nullableInt64u));
         VerifyOrReturn(CheckValue<uint64_t>("nullableInt64u.Value()", nullableInt64u.Value(), 18446744073709551614ULL));
+
         NextTest();
     }
 
@@ -36977,6 +37572,7 @@ private:
     void OnSuccessResponse_193(const chip::app::DataModel::Nullable<uint64_t> & nullableInt64u)
     {
         VerifyOrReturn(CheckValueNull("nullableInt64u", nullableInt64u));
+
         NextTest();
     }
 
@@ -37013,6 +37609,7 @@ private:
     {
         VerifyOrReturn(CheckValueNonNull("nullableInt8s", nullableInt8s));
         VerifyOrReturn(CheckValue<int8_t>("nullableInt8s.Value()", nullableInt8s.Value(), -127));
+
         NextTest();
     }
 
@@ -37049,6 +37646,7 @@ private:
     {
         VerifyOrReturn(CheckValueNonNull("nullableInt8s", nullableInt8s));
         VerifyOrReturn(CheckValue<int8_t>("nullableInt8s.Value()", nullableInt8s.Value(), -127));
+
         NextTest();
     }
 
@@ -37084,6 +37682,7 @@ private:
     void OnSuccessResponse_199(const chip::app::DataModel::Nullable<int8_t> & nullableInt8s)
     {
         VerifyOrReturn(CheckValueNull("nullableInt8s", nullableInt8s));
+
         NextTest();
     }
 
@@ -37120,6 +37719,7 @@ private:
     {
         VerifyOrReturn(CheckValueNonNull("nullableInt16s", nullableInt16s));
         VerifyOrReturn(CheckValue<int16_t>("nullableInt16s.Value()", nullableInt16s.Value(), -32767));
+
         NextTest();
     }
 
@@ -37156,6 +37756,7 @@ private:
     {
         VerifyOrReturn(CheckValueNonNull("nullableInt16s", nullableInt16s));
         VerifyOrReturn(CheckValue<int16_t>("nullableInt16s.Value()", nullableInt16s.Value(), -32767));
+
         NextTest();
     }
 
@@ -37191,6 +37792,7 @@ private:
     void OnSuccessResponse_205(const chip::app::DataModel::Nullable<int16_t> & nullableInt16s)
     {
         VerifyOrReturn(CheckValueNull("nullableInt16s", nullableInt16s));
+
         NextTest();
     }
 
@@ -37227,6 +37829,7 @@ private:
     {
         VerifyOrReturn(CheckValueNonNull("nullableInt32s", nullableInt32s));
         VerifyOrReturn(CheckValue<int32_t>("nullableInt32s.Value()", nullableInt32s.Value(), -2147483647L));
+
         NextTest();
     }
 
@@ -37263,6 +37866,7 @@ private:
     {
         VerifyOrReturn(CheckValueNonNull("nullableInt32s", nullableInt32s));
         VerifyOrReturn(CheckValue<int32_t>("nullableInt32s.Value()", nullableInt32s.Value(), -2147483647L));
+
         NextTest();
     }
 
@@ -37298,6 +37902,7 @@ private:
     void OnSuccessResponse_211(const chip::app::DataModel::Nullable<int32_t> & nullableInt32s)
     {
         VerifyOrReturn(CheckValueNull("nullableInt32s", nullableInt32s));
+
         NextTest();
     }
 
@@ -37334,6 +37939,7 @@ private:
     {
         VerifyOrReturn(CheckValueNonNull("nullableInt64s", nullableInt64s));
         VerifyOrReturn(CheckValue<int64_t>("nullableInt64s.Value()", nullableInt64s.Value(), -9223372036854775807LL));
+
         NextTest();
     }
 
@@ -37344,7 +37950,7 @@ private:
         cluster.Associate(mDevice, endpoint);
 
         chip::app::DataModel::Nullable<int64_t> nullableInt64sArgument;
-        nullableInt64sArgument.SetNonNull() = -9223372036854775807LL - 1LL;
+        nullableInt64sArgument.SetNonNull() = -9223372036854775807LL - 1;
 
         return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt64s::TypeInfo>(
             nullableInt64sArgument, this, OnSuccessCallback_214, OnFailureCallback_214);
@@ -37370,6 +37976,7 @@ private:
     {
         VerifyOrReturn(CheckValueNonNull("nullableInt64s", nullableInt64s));
         VerifyOrReturn(CheckValue<int64_t>("nullableInt64s.Value()", nullableInt64s.Value(), -9223372036854775807LL));
+
         NextTest();
     }
 
@@ -37405,6 +38012,7 @@ private:
     void OnSuccessResponse_217(const chip::app::DataModel::Nullable<int64_t> & nullableInt64s)
     {
         VerifyOrReturn(CheckValueNull("nullableInt64s", nullableInt64s));
+
         NextTest();
     }
 
@@ -37441,6 +38049,7 @@ private:
     {
         VerifyOrReturn(CheckValueNonNull("nullableEnum8", nullableEnum8));
         VerifyOrReturn(CheckValue<uint8_t>("nullableEnum8.Value()", nullableEnum8.Value(), 254));
+
         NextTest();
     }
 
@@ -37477,6 +38086,7 @@ private:
     {
         VerifyOrReturn(CheckValueNonNull("nullableEnum8", nullableEnum8));
         VerifyOrReturn(CheckValue<uint8_t>("nullableEnum8.Value()", nullableEnum8.Value(), 254));
+
         NextTest();
     }
 
@@ -37512,6 +38122,7 @@ private:
     void OnSuccessResponse_223(const chip::app::DataModel::Nullable<uint8_t> & nullableEnum8)
     {
         VerifyOrReturn(CheckValueNull("nullableEnum8", nullableEnum8));
+
         NextTest();
     }
 
@@ -37548,6 +38159,7 @@ private:
     {
         VerifyOrReturn(CheckValueNonNull("nullableEnum16", nullableEnum16));
         VerifyOrReturn(CheckValue<uint16_t>("nullableEnum16.Value()", nullableEnum16.Value(), 65534U));
+
         NextTest();
     }
 
@@ -37584,6 +38196,7 @@ private:
     {
         VerifyOrReturn(CheckValueNonNull("nullableEnum16", nullableEnum16));
         VerifyOrReturn(CheckValue<uint16_t>("nullableEnum16.Value()", nullableEnum16.Value(), 65534U));
+
         NextTest();
     }
 
@@ -37619,6 +38232,7 @@ private:
     void OnSuccessResponse_229(const chip::app::DataModel::Nullable<uint16_t> & nullableEnum16)
     {
         VerifyOrReturn(CheckValueNull("nullableEnum16", nullableEnum16));
+
         NextTest();
     }
 
@@ -37639,6 +38253,7 @@ private:
         VerifyOrReturn(CheckValueNonNull("nullableOctetString", nullableOctetString));
         VerifyOrReturn(CheckValueAsString("nullableOctetString.Value()", nullableOctetString.Value(),
                                           chip::ByteSpan(chip::Uint8::from_const_char(""), 0)));
+
         NextTest();
     }
 
@@ -37677,6 +38292,7 @@ private:
         VerifyOrReturn(CheckValueNonNull("nullableOctetString", nullableOctetString));
         VerifyOrReturn(CheckValueAsString("nullableOctetString.Value()", nullableOctetString.Value(),
                                           chip::ByteSpan(chip::Uint8::from_const_char("TestValue"), 9)));
+
         NextTest();
     }
 
@@ -37712,6 +38328,7 @@ private:
     void OnSuccessResponse_234(const chip::app::DataModel::Nullable<chip::ByteSpan> & nullableOctetString)
     {
         VerifyOrReturn(CheckValueNull("nullableOctetString", nullableOctetString));
+
         NextTest();
     }
 
@@ -37750,6 +38367,7 @@ private:
         VerifyOrReturn(CheckValueNonNull("nullableOctetString", nullableOctetString));
         VerifyOrReturn(CheckValueAsString("nullableOctetString.Value()", nullableOctetString.Value(),
                                           chip::ByteSpan(chip::Uint8::from_const_char(""), 0)));
+
         NextTest();
     }
 
@@ -37769,6 +38387,7 @@ private:
     {
         VerifyOrReturn(CheckValueNonNull("nullableCharString", nullableCharString));
         VerifyOrReturn(CheckValueAsString("nullableCharString.Value()", nullableCharString.Value(), chip::CharSpan("", 0)));
+
         NextTest();
     }
 
@@ -37821,6 +38440,7 @@ private:
     void OnSuccessResponse_240(const chip::app::DataModel::Nullable<chip::CharSpan> & nullableCharString)
     {
         VerifyOrReturn(CheckValueNull("nullableCharString", nullableCharString));
+
         NextTest();
     }
 
@@ -37857,6 +38477,7 @@ private:
     {
         VerifyOrReturn(CheckValueNonNull("nullableCharString", nullableCharString));
         VerifyOrReturn(CheckValueAsString("nullableCharString.Value()", nullableCharString.Value(), chip::CharSpan("", 0)));
+
         NextTest();
     }
 
@@ -37959,6 +38580,7 @@ private:
 
         VerifyOrReturn(CheckValuePresent("originalValue", originalValue));
         VerifyOrReturn(CheckValueNull("originalValue.Value()", originalValue.Value()));
+
         NextTest();
     }
 };
@@ -38009,6 +38631,10 @@ public:
             ChipLogProgress(chipTool, " ***** Test Step 3 : Read attribute INT32U Value NotValue Constraints\n");
             err = TestReadAttributeInt32uValueNotValueConstraints_3();
             break;
+        case 4:
+            ChipLogProgress(chipTool, " ***** Test Step 4 : Write attribute INT32U Value Back to Default Value\n");
+            err = TestWriteAttributeInt32uValueBackToDefaultValue_4();
+            break;
         }
 
         if (CHIP_NO_ERROR != err)
@@ -38020,7 +38646,7 @@ public:
 
 private:
     std::atomic_uint16_t mTestIndex;
-    const uint16_t mTestCount = 4;
+    const uint16_t mTestCount = 5;
 
     static void OnFailureCallback_0(void * context, EmberAfStatus status)
     {
@@ -38059,6 +38685,13 @@ private:
         (static_cast<TestConstraints *>(context))->OnSuccessResponse_3(int32u);
     }
 
+    static void OnFailureCallback_4(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestConstraints *>(context))->OnFailureResponse_4(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_4(void * context) { (static_cast<TestConstraints *>(context))->OnSuccessResponse_4(); }
+
     //
     // Tests methods
     //
@@ -38095,6 +38728,7 @@ private:
     void OnSuccessResponse_1(uint32_t int32u)
     {
         VerifyOrReturn(CheckConstraintMinValue<uint32_t>("int32u", int32u, 5));
+
         NextTest();
     }
 
@@ -38113,6 +38747,7 @@ private:
     void OnSuccessResponse_2(uint32_t int32u)
     {
         VerifyOrReturn(CheckConstraintMaxValue<uint32_t>("int32u", int32u, 5));
+
         NextTest();
     }
 
@@ -38131,8 +38766,26 @@ private:
     void OnSuccessResponse_3(uint32_t int32u)
     {
         VerifyOrReturn(CheckConstraintNotValue<uint32_t>("int32u", int32u, 6));
+
         NextTest();
     }
+
+    CHIP_ERROR TestWriteAttributeInt32uValueBackToDefaultValue_4()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        uint32_t int32uArgument;
+        int32uArgument = 0UL;
+
+        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::Int32u::TypeInfo>(
+            int32uArgument, this, OnSuccessCallback_4, OnFailureCallback_4);
+    }
+
+    void OnFailureResponse_4(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_4() { NextTest(); }
 };
 
 class TestDelayCommands : public TestCommand
@@ -38241,6 +38894,2985 @@ private:
     //
 
     CHIP_ERROR TestLogASimpleMessage_0() { return Log("This is a simple message"); }
+};
+
+class TestSaveAs : public TestCommand
+{
+public:
+    TestSaveAs() : TestCommand("TestSaveAs"), mTestIndex(0) {}
+
+    /////////// TestCommand Interface /////////
+    void NextTest() override
+    {
+        CHIP_ERROR err = CHIP_NO_ERROR;
+
+        if (0 == mTestIndex)
+        {
+            ChipLogProgress(chipTool, " **** Test Start: TestSaveAs\n");
+        }
+
+        if (mTestCount == mTestIndex)
+        {
+            ChipLogProgress(chipTool, " **** Test Complete: TestSaveAs\n");
+            SetCommandExitStatus(CHIP_NO_ERROR);
+            return;
+        }
+
+        Wait();
+
+        // Ensure we increment mTestIndex before we start running the relevant
+        // command.  That way if we lose the timeslice after we send the message
+        // but before our function call returns, we won't end up with an
+        // incorrect mTestIndex value observed when we get the response.
+        switch (mTestIndex++)
+        {
+        case 0:
+            ChipLogProgress(chipTool, " ***** Test Step 0 : Send Test Add Arguments Command\n");
+            err = TestSendTestAddArgumentsCommand_0();
+            break;
+        case 1:
+            ChipLogProgress(chipTool, " ***** Test Step 1 : Send Test Add Arguments Command\n");
+            err = TestSendTestAddArgumentsCommand_1();
+            break;
+        case 2:
+            ChipLogProgress(chipTool, " ***** Test Step 2 : Send Test Add Arguments Command\n");
+            err = TestSendTestAddArgumentsCommand_2();
+            break;
+        case 3:
+            ChipLogProgress(chipTool, " ***** Test Step 3 : Read attribute BOOLEAN Default Value\n");
+            err = TestReadAttributeBooleanDefaultValue_3();
+            break;
+        case 4:
+            ChipLogProgress(chipTool, " ***** Test Step 4 : Write attribute BOOLEAN Not Default Value\n");
+            err = TestWriteAttributeBooleanNotDefaultValue_4();
+            break;
+        case 5:
+            ChipLogProgress(chipTool, " ***** Test Step 5 : Read attribute BOOLEAN Not Default Value\n");
+            err = TestReadAttributeBooleanNotDefaultValue_5();
+            break;
+        case 6:
+            ChipLogProgress(chipTool, " ***** Test Step 6 : Write attribute BOOLEAN DefaultValue\n");
+            err = TestWriteAttributeBooleanDefaultValue_6();
+            break;
+        case 7:
+            ChipLogProgress(chipTool, " ***** Test Step 7 : Read attribute BOOLEAN False\n");
+            err = TestReadAttributeBooleanFalse_7();
+            break;
+        case 8:
+            ChipLogProgress(chipTool, " ***** Test Step 8 : Read attribute BITMAP8 Default Value\n");
+            err = TestReadAttributeBitmap8DefaultValue_8();
+            break;
+        case 9:
+            ChipLogProgress(chipTool, " ***** Test Step 9 : Write attribute BITMAP8 Not Default Value\n");
+            err = TestWriteAttributeBitmap8NotDefaultValue_9();
+            break;
+        case 10:
+            ChipLogProgress(chipTool, " ***** Test Step 10 : Read attribute BITMAP8 Not Default Value\n");
+            err = TestReadAttributeBitmap8NotDefaultValue_10();
+            break;
+        case 11:
+            ChipLogProgress(chipTool, " ***** Test Step 11 : Write attribute BITMAP8 Default Value\n");
+            err = TestWriteAttributeBitmap8DefaultValue_11();
+            break;
+        case 12:
+            ChipLogProgress(chipTool, " ***** Test Step 12 : Read attribute BITMAP8 Default Value\n");
+            err = TestReadAttributeBitmap8DefaultValue_12();
+            break;
+        case 13:
+            ChipLogProgress(chipTool, " ***** Test Step 13 : Read attribute BITMAP16 Default Value\n");
+            err = TestReadAttributeBitmap16DefaultValue_13();
+            break;
+        case 14:
+            ChipLogProgress(chipTool, " ***** Test Step 14 : Write attribute BITMAP16 Not Default Value\n");
+            err = TestWriteAttributeBitmap16NotDefaultValue_14();
+            break;
+        case 15:
+            ChipLogProgress(chipTool, " ***** Test Step 15 : Read attribute BITMAP16 Not Default Value\n");
+            err = TestReadAttributeBitmap16NotDefaultValue_15();
+            break;
+        case 16:
+            ChipLogProgress(chipTool, " ***** Test Step 16 : Write attribute BITMAP16 Default Value\n");
+            err = TestWriteAttributeBitmap16DefaultValue_16();
+            break;
+        case 17:
+            ChipLogProgress(chipTool, " ***** Test Step 17 : Read attribute BITMAP16 Default Value\n");
+            err = TestReadAttributeBitmap16DefaultValue_17();
+            break;
+        case 18:
+            ChipLogProgress(chipTool, " ***** Test Step 18 : Read attribute BITMAP32 Default Value\n");
+            err = TestReadAttributeBitmap32DefaultValue_18();
+            break;
+        case 19:
+            ChipLogProgress(chipTool, " ***** Test Step 19 : Write attribute BITMAP32 Not Default Value\n");
+            err = TestWriteAttributeBitmap32NotDefaultValue_19();
+            break;
+        case 20:
+            ChipLogProgress(chipTool, " ***** Test Step 20 : Read attribute BITMAP32 Not Default Value\n");
+            err = TestReadAttributeBitmap32NotDefaultValue_20();
+            break;
+        case 21:
+            ChipLogProgress(chipTool, " ***** Test Step 21 : Write attribute BITMAP32 Default Value\n");
+            err = TestWriteAttributeBitmap32DefaultValue_21();
+            break;
+        case 22:
+            ChipLogProgress(chipTool, " ***** Test Step 22 : Read attribute BITMAP32 Default Value\n");
+            err = TestReadAttributeBitmap32DefaultValue_22();
+            break;
+        case 23:
+            ChipLogProgress(chipTool, " ***** Test Step 23 : Read attribute BITMAP64 Default Value\n");
+            err = TestReadAttributeBitmap64DefaultValue_23();
+            break;
+        case 24:
+            ChipLogProgress(chipTool, " ***** Test Step 24 : Write attribute BITMAP64 Not Default Value\n");
+            err = TestWriteAttributeBitmap64NotDefaultValue_24();
+            break;
+        case 25:
+            ChipLogProgress(chipTool, " ***** Test Step 25 : Read attribute BITMAP64 Default Value\n");
+            err = TestReadAttributeBitmap64DefaultValue_25();
+            break;
+        case 26:
+            ChipLogProgress(chipTool, " ***** Test Step 26 : Write attribute BITMAP64 Default Value\n");
+            err = TestWriteAttributeBitmap64DefaultValue_26();
+            break;
+        case 27:
+            ChipLogProgress(chipTool, " ***** Test Step 27 : Read attribute BITMAP64 Default Value\n");
+            err = TestReadAttributeBitmap64DefaultValue_27();
+            break;
+        case 28:
+            ChipLogProgress(chipTool, " ***** Test Step 28 : Read attribute INT8U Default Value\n");
+            err = TestReadAttributeInt8uDefaultValue_28();
+            break;
+        case 29:
+            ChipLogProgress(chipTool, " ***** Test Step 29 : Write attribute INT8U Not Default Value\n");
+            err = TestWriteAttributeInt8uNotDefaultValue_29();
+            break;
+        case 30:
+            ChipLogProgress(chipTool, " ***** Test Step 30 : Read attribute INT8U Not Default Value\n");
+            err = TestReadAttributeInt8uNotDefaultValue_30();
+            break;
+        case 31:
+            ChipLogProgress(chipTool, " ***** Test Step 31 : Write attribute INT8U Default Value\n");
+            err = TestWriteAttributeInt8uDefaultValue_31();
+            break;
+        case 32:
+            ChipLogProgress(chipTool, " ***** Test Step 32 : Read attribute INT8U Default Value\n");
+            err = TestReadAttributeInt8uDefaultValue_32();
+            break;
+        case 33:
+            ChipLogProgress(chipTool, " ***** Test Step 33 : Read attribute INT16U Default Value\n");
+            err = TestReadAttributeInt16uDefaultValue_33();
+            break;
+        case 34:
+            ChipLogProgress(chipTool, " ***** Test Step 34 : Write attribute INT16U Not Default Value\n");
+            err = TestWriteAttributeInt16uNotDefaultValue_34();
+            break;
+        case 35:
+            ChipLogProgress(chipTool, " ***** Test Step 35 : Read attribute INT16U Not Default Value\n");
+            err = TestReadAttributeInt16uNotDefaultValue_35();
+            break;
+        case 36:
+            ChipLogProgress(chipTool, " ***** Test Step 36 : Write attribute INT16U Default Value\n");
+            err = TestWriteAttributeInt16uDefaultValue_36();
+            break;
+        case 37:
+            ChipLogProgress(chipTool, " ***** Test Step 37 : Read attribute INT16U Default Value\n");
+            err = TestReadAttributeInt16uDefaultValue_37();
+            break;
+        case 38:
+            ChipLogProgress(chipTool, " ***** Test Step 38 : Read attribute INT32U Default Value\n");
+            err = TestReadAttributeInt32uDefaultValue_38();
+            break;
+        case 39:
+            ChipLogProgress(chipTool, " ***** Test Step 39 : Write attribute INT32U Not Default Value\n");
+            err = TestWriteAttributeInt32uNotDefaultValue_39();
+            break;
+        case 40:
+            ChipLogProgress(chipTool, " ***** Test Step 40 : Read attribute INT32U Not Default Value\n");
+            err = TestReadAttributeInt32uNotDefaultValue_40();
+            break;
+        case 41:
+            ChipLogProgress(chipTool, " ***** Test Step 41 : Write attribute INT32U Default Value\n");
+            err = TestWriteAttributeInt32uDefaultValue_41();
+            break;
+        case 42:
+            ChipLogProgress(chipTool, " ***** Test Step 42 : Read attribute INT32U Default Value\n");
+            err = TestReadAttributeInt32uDefaultValue_42();
+            break;
+        case 43:
+            ChipLogProgress(chipTool, " ***** Test Step 43 : Read attribute INT64U Default Value\n");
+            err = TestReadAttributeInt64uDefaultValue_43();
+            break;
+        case 44:
+            ChipLogProgress(chipTool, " ***** Test Step 44 : Write attribute INT64U Not Default Value\n");
+            err = TestWriteAttributeInt64uNotDefaultValue_44();
+            break;
+        case 45:
+            ChipLogProgress(chipTool, " ***** Test Step 45 : Read attribute INT64U Not Default Value\n");
+            err = TestReadAttributeInt64uNotDefaultValue_45();
+            break;
+        case 46:
+            ChipLogProgress(chipTool, " ***** Test Step 46 : Write attribute INT64U Default Value\n");
+            err = TestWriteAttributeInt64uDefaultValue_46();
+            break;
+        case 47:
+            ChipLogProgress(chipTool, " ***** Test Step 47 : Read attribute INT64U Default Value\n");
+            err = TestReadAttributeInt64uDefaultValue_47();
+            break;
+        case 48:
+            ChipLogProgress(chipTool, " ***** Test Step 48 : Read attribute INT8S Default Value\n");
+            err = TestReadAttributeInt8sDefaultValue_48();
+            break;
+        case 49:
+            ChipLogProgress(chipTool, " ***** Test Step 49 : Write attribute INT8S Not Default Value\n");
+            err = TestWriteAttributeInt8sNotDefaultValue_49();
+            break;
+        case 50:
+            ChipLogProgress(chipTool, " ***** Test Step 50 : Read attribute INT8S Not Default Value\n");
+            err = TestReadAttributeInt8sNotDefaultValue_50();
+            break;
+        case 51:
+            ChipLogProgress(chipTool, " ***** Test Step 51 : Write attribute INT8S Default Value\n");
+            err = TestWriteAttributeInt8sDefaultValue_51();
+            break;
+        case 52:
+            ChipLogProgress(chipTool, " ***** Test Step 52 : Read attribute INT8S Default Value\n");
+            err = TestReadAttributeInt8sDefaultValue_52();
+            break;
+        case 53:
+            ChipLogProgress(chipTool, " ***** Test Step 53 : Read attribute INT16S Default Value\n");
+            err = TestReadAttributeInt16sDefaultValue_53();
+            break;
+        case 54:
+            ChipLogProgress(chipTool, " ***** Test Step 54 : Write attribute INT16S Not Default Value\n");
+            err = TestWriteAttributeInt16sNotDefaultValue_54();
+            break;
+        case 55:
+            ChipLogProgress(chipTool, " ***** Test Step 55 : Read attribute INT16S Not Default Value\n");
+            err = TestReadAttributeInt16sNotDefaultValue_55();
+            break;
+        case 56:
+            ChipLogProgress(chipTool, " ***** Test Step 56 : Write attribute INT16S Default Value\n");
+            err = TestWriteAttributeInt16sDefaultValue_56();
+            break;
+        case 57:
+            ChipLogProgress(chipTool, " ***** Test Step 57 : Read attribute INT16S Default Value\n");
+            err = TestReadAttributeInt16sDefaultValue_57();
+            break;
+        case 58:
+            ChipLogProgress(chipTool, " ***** Test Step 58 : Read attribute INT32S Default Value\n");
+            err = TestReadAttributeInt32sDefaultValue_58();
+            break;
+        case 59:
+            ChipLogProgress(chipTool, " ***** Test Step 59 : Write attribute INT32S Not Default Value\n");
+            err = TestWriteAttributeInt32sNotDefaultValue_59();
+            break;
+        case 60:
+            ChipLogProgress(chipTool, " ***** Test Step 60 : Read attribute INT32S Not Default Value\n");
+            err = TestReadAttributeInt32sNotDefaultValue_60();
+            break;
+        case 61:
+            ChipLogProgress(chipTool, " ***** Test Step 61 : Write attribute INT32S Default Value\n");
+            err = TestWriteAttributeInt32sDefaultValue_61();
+            break;
+        case 62:
+            ChipLogProgress(chipTool, " ***** Test Step 62 : Read attribute INT32S Default Value\n");
+            err = TestReadAttributeInt32sDefaultValue_62();
+            break;
+        case 63:
+            ChipLogProgress(chipTool, " ***** Test Step 63 : Read attribute INT64S Default Value\n");
+            err = TestReadAttributeInt64sDefaultValue_63();
+            break;
+        case 64:
+            ChipLogProgress(chipTool, " ***** Test Step 64 : Write attribute INTS Not Default Value\n");
+            err = TestWriteAttributeIntsNotDefaultValue_64();
+            break;
+        case 65:
+            ChipLogProgress(chipTool, " ***** Test Step 65 : Read attribute INT64S Not Default Value\n");
+            err = TestReadAttributeInt64sNotDefaultValue_65();
+            break;
+        case 66:
+            ChipLogProgress(chipTool, " ***** Test Step 66 : Write attribute INT64S Default Value\n");
+            err = TestWriteAttributeInt64sDefaultValue_66();
+            break;
+        case 67:
+            ChipLogProgress(chipTool, " ***** Test Step 67 : Read attribute INT64S Default Value\n");
+            err = TestReadAttributeInt64sDefaultValue_67();
+            break;
+        case 68:
+            ChipLogProgress(chipTool, " ***** Test Step 68 : Read attribute ENUM8 Default Value\n");
+            err = TestReadAttributeEnum8DefaultValue_68();
+            break;
+        case 69:
+            ChipLogProgress(chipTool, " ***** Test Step 69 : Write attribute ENUM8 Not Default Value\n");
+            err = TestWriteAttributeEnum8NotDefaultValue_69();
+            break;
+        case 70:
+            ChipLogProgress(chipTool, " ***** Test Step 70 : Read attribute ENUM8 Not Default Value\n");
+            err = TestReadAttributeEnum8NotDefaultValue_70();
+            break;
+        case 71:
+            ChipLogProgress(chipTool, " ***** Test Step 71 : Write attribute ENUM8 Default Value\n");
+            err = TestWriteAttributeEnum8DefaultValue_71();
+            break;
+        case 72:
+            ChipLogProgress(chipTool, " ***** Test Step 72 : Read attribute ENUM8 Default Value\n");
+            err = TestReadAttributeEnum8DefaultValue_72();
+            break;
+        case 73:
+            ChipLogProgress(chipTool, " ***** Test Step 73 : Read attribute ENUM16 Default Value\n");
+            err = TestReadAttributeEnum16DefaultValue_73();
+            break;
+        case 74:
+            ChipLogProgress(chipTool, " ***** Test Step 74 : Write attribute ENUM16 Not Default Value\n");
+            err = TestWriteAttributeEnum16NotDefaultValue_74();
+            break;
+        case 75:
+            ChipLogProgress(chipTool, " ***** Test Step 75 : Read attribute ENUM16 Not Default Value\n");
+            err = TestReadAttributeEnum16NotDefaultValue_75();
+            break;
+        case 76:
+            ChipLogProgress(chipTool, " ***** Test Step 76 : Write attribute ENUM16 Default Value\n");
+            err = TestWriteAttributeEnum16DefaultValue_76();
+            break;
+        case 77:
+            ChipLogProgress(chipTool, " ***** Test Step 77 : Read attribute ENUM16 Default Value\n");
+            err = TestReadAttributeEnum16DefaultValue_77();
+            break;
+        case 78:
+            ChipLogProgress(chipTool, " ***** Test Step 78 : Read attribute EPOCH_US Default Value\n");
+            err = TestReadAttributeEpochUsDefaultValue_78();
+            break;
+        case 79:
+            ChipLogProgress(chipTool, " ***** Test Step 79 : Write attribute EPOCH_US Not Default Value\n");
+            err = TestWriteAttributeEpochUsNotDefaultValue_79();
+            break;
+        case 80:
+            ChipLogProgress(chipTool, " ***** Test Step 80 : Read attribute EPOCH_US Not Default Value\n");
+            err = TestReadAttributeEpochUsNotDefaultValue_80();
+            break;
+        case 81:
+            ChipLogProgress(chipTool, " ***** Test Step 81 : Write attribute EPOCH_US Default Value\n");
+            err = TestWriteAttributeEpochUsDefaultValue_81();
+            break;
+        case 82:
+            ChipLogProgress(chipTool, " ***** Test Step 82 : Read attribute EPOCH_US Default Value\n");
+            err = TestReadAttributeEpochUsDefaultValue_82();
+            break;
+        case 83:
+            ChipLogProgress(chipTool, " ***** Test Step 83 : Read attribute EPOCH_S Default Value\n");
+            err = TestReadAttributeEpochSDefaultValue_83();
+            break;
+        case 84:
+            ChipLogProgress(chipTool, " ***** Test Step 84 : Write attribute EPOCH_S Not Default Value\n");
+            err = TestWriteAttributeEpochSNotDefaultValue_84();
+            break;
+        case 85:
+            ChipLogProgress(chipTool, " ***** Test Step 85 : Read attribute EPOCH_S Not Default Value\n");
+            err = TestReadAttributeEpochSNotDefaultValue_85();
+            break;
+        case 86:
+            ChipLogProgress(chipTool, " ***** Test Step 86 : Write attribute EPOCH_S Default Value\n");
+            err = TestWriteAttributeEpochSDefaultValue_86();
+            break;
+        case 87:
+            ChipLogProgress(chipTool, " ***** Test Step 87 : Read attribute EPOCH_S Default Value\n");
+            err = TestReadAttributeEpochSDefaultValue_87();
+            break;
+        case 88:
+            ChipLogProgress(chipTool, " ***** Test Step 88 : Read attribute vendor_id Default Value\n");
+            err = TestReadAttributeVendorIdDefaultValue_88();
+            break;
+        case 89:
+            ChipLogProgress(chipTool, " ***** Test Step 89 : Write attribute vendor_id Not Default Value\n");
+            err = TestWriteAttributeVendorIdNotDefaultValue_89();
+            break;
+        case 90:
+            ChipLogProgress(chipTool, " ***** Test Step 90 : Read attribute vendor_id Not Default Value\n");
+            err = TestReadAttributeVendorIdNotDefaultValue_90();
+            break;
+        case 91:
+            ChipLogProgress(chipTool, " ***** Test Step 91 : Write attribute vendor_id Default Value\n");
+            err = TestWriteAttributeVendorIdDefaultValue_91();
+            break;
+        case 92:
+            ChipLogProgress(chipTool, " ***** Test Step 92 : Read attribute vendor_id Default Value\n");
+            err = TestReadAttributeVendorIdDefaultValue_92();
+            break;
+        }
+
+        if (CHIP_NO_ERROR != err)
+        {
+            ChipLogError(chipTool, " ***** Test Failure: %s\n", chip::ErrorStr(err));
+            SetCommandExitStatus(err);
+        }
+    }
+
+private:
+    std::atomic_uint16_t mTestIndex;
+    const uint16_t mTestCount = 93;
+
+    uint8_t TestAddArgumentDefaultValue;
+    bool readAttributeBooleanDefaultValue;
+    uint8_t readAttributeBitmap8DefaultValue;
+    uint16_t readAttributeBitmap16DefaultValue;
+    uint32_t readAttributeBitmap32DefaultValue;
+    uint64_t readAttributeBitmap64DefaultValue;
+    uint8_t readAttributeInt8uDefaultValue;
+    uint16_t readAttributeInt16uDefaultValue;
+    uint32_t readAttributeInt32uDefaultValue;
+    uint64_t readAttributeInt64uDefaultValue;
+    int8_t readAttributeInt8sDefaultValue;
+    int16_t readAttributeInt16sDefaultValue;
+    int32_t readAttributeInt32sDefaultValue;
+    int64_t readAttributeInt64sDefaultValue;
+    uint8_t readAttributeEnum8DefaultValue;
+    uint16_t readAttributeEnum16DefaultValue;
+    uint64_t readAttributeEpochUSDefaultValue;
+    uint32_t readAttributeEpochSDefaultValue;
+    chip::VendorId readAttributeVendorIdDefaultValue;
+
+    static void OnFailureCallback_3(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_3(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_3(void * context, bool boolean)
+    {
+        (static_cast<TestSaveAs *>(context))->OnSuccessResponse_3(boolean);
+    }
+
+    static void OnFailureCallback_4(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_4(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_4(void * context) { (static_cast<TestSaveAs *>(context))->OnSuccessResponse_4(); }
+
+    static void OnFailureCallback_5(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_5(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_5(void * context, bool boolean)
+    {
+        (static_cast<TestSaveAs *>(context))->OnSuccessResponse_5(boolean);
+    }
+
+    static void OnFailureCallback_6(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_6(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_6(void * context) { (static_cast<TestSaveAs *>(context))->OnSuccessResponse_6(); }
+
+    static void OnFailureCallback_7(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_7(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_7(void * context, bool boolean)
+    {
+        (static_cast<TestSaveAs *>(context))->OnSuccessResponse_7(boolean);
+    }
+
+    static void OnFailureCallback_8(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_8(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_8(void * context, uint8_t bitmap8)
+    {
+        (static_cast<TestSaveAs *>(context))->OnSuccessResponse_8(bitmap8);
+    }
+
+    static void OnFailureCallback_9(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_9(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_9(void * context) { (static_cast<TestSaveAs *>(context))->OnSuccessResponse_9(); }
+
+    static void OnFailureCallback_10(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_10(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_10(void * context, uint8_t bitmap8)
+    {
+        (static_cast<TestSaveAs *>(context))->OnSuccessResponse_10(bitmap8);
+    }
+
+    static void OnFailureCallback_11(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_11(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_11(void * context) { (static_cast<TestSaveAs *>(context))->OnSuccessResponse_11(); }
+
+    static void OnFailureCallback_12(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_12(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_12(void * context, uint8_t bitmap8)
+    {
+        (static_cast<TestSaveAs *>(context))->OnSuccessResponse_12(bitmap8);
+    }
+
+    static void OnFailureCallback_13(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_13(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_13(void * context, uint16_t bitmap16)
+    {
+        (static_cast<TestSaveAs *>(context))->OnSuccessResponse_13(bitmap16);
+    }
+
+    static void OnFailureCallback_14(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_14(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_14(void * context) { (static_cast<TestSaveAs *>(context))->OnSuccessResponse_14(); }
+
+    static void OnFailureCallback_15(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_15(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_15(void * context, uint16_t bitmap16)
+    {
+        (static_cast<TestSaveAs *>(context))->OnSuccessResponse_15(bitmap16);
+    }
+
+    static void OnFailureCallback_16(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_16(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_16(void * context) { (static_cast<TestSaveAs *>(context))->OnSuccessResponse_16(); }
+
+    static void OnFailureCallback_17(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_17(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_17(void * context, uint16_t bitmap16)
+    {
+        (static_cast<TestSaveAs *>(context))->OnSuccessResponse_17(bitmap16);
+    }
+
+    static void OnFailureCallback_18(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_18(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_18(void * context, uint32_t bitmap32)
+    {
+        (static_cast<TestSaveAs *>(context))->OnSuccessResponse_18(bitmap32);
+    }
+
+    static void OnFailureCallback_19(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_19(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_19(void * context) { (static_cast<TestSaveAs *>(context))->OnSuccessResponse_19(); }
+
+    static void OnFailureCallback_20(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_20(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_20(void * context, uint32_t bitmap32)
+    {
+        (static_cast<TestSaveAs *>(context))->OnSuccessResponse_20(bitmap32);
+    }
+
+    static void OnFailureCallback_21(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_21(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_21(void * context) { (static_cast<TestSaveAs *>(context))->OnSuccessResponse_21(); }
+
+    static void OnFailureCallback_22(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_22(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_22(void * context, uint32_t bitmap32)
+    {
+        (static_cast<TestSaveAs *>(context))->OnSuccessResponse_22(bitmap32);
+    }
+
+    static void OnFailureCallback_23(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_23(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_23(void * context, uint64_t bitmap64)
+    {
+        (static_cast<TestSaveAs *>(context))->OnSuccessResponse_23(bitmap64);
+    }
+
+    static void OnFailureCallback_24(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_24(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_24(void * context) { (static_cast<TestSaveAs *>(context))->OnSuccessResponse_24(); }
+
+    static void OnFailureCallback_25(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_25(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_25(void * context, uint64_t bitmap64)
+    {
+        (static_cast<TestSaveAs *>(context))->OnSuccessResponse_25(bitmap64);
+    }
+
+    static void OnFailureCallback_26(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_26(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_26(void * context) { (static_cast<TestSaveAs *>(context))->OnSuccessResponse_26(); }
+
+    static void OnFailureCallback_27(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_27(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_27(void * context, uint64_t bitmap64)
+    {
+        (static_cast<TestSaveAs *>(context))->OnSuccessResponse_27(bitmap64);
+    }
+
+    static void OnFailureCallback_28(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_28(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_28(void * context, uint8_t int8u)
+    {
+        (static_cast<TestSaveAs *>(context))->OnSuccessResponse_28(int8u);
+    }
+
+    static void OnFailureCallback_29(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_29(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_29(void * context) { (static_cast<TestSaveAs *>(context))->OnSuccessResponse_29(); }
+
+    static void OnFailureCallback_30(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_30(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_30(void * context, uint8_t int8u)
+    {
+        (static_cast<TestSaveAs *>(context))->OnSuccessResponse_30(int8u);
+    }
+
+    static void OnFailureCallback_31(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_31(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_31(void * context) { (static_cast<TestSaveAs *>(context))->OnSuccessResponse_31(); }
+
+    static void OnFailureCallback_32(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_32(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_32(void * context, uint8_t int8u)
+    {
+        (static_cast<TestSaveAs *>(context))->OnSuccessResponse_32(int8u);
+    }
+
+    static void OnFailureCallback_33(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_33(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_33(void * context, uint16_t int16u)
+    {
+        (static_cast<TestSaveAs *>(context))->OnSuccessResponse_33(int16u);
+    }
+
+    static void OnFailureCallback_34(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_34(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_34(void * context) { (static_cast<TestSaveAs *>(context))->OnSuccessResponse_34(); }
+
+    static void OnFailureCallback_35(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_35(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_35(void * context, uint16_t int16u)
+    {
+        (static_cast<TestSaveAs *>(context))->OnSuccessResponse_35(int16u);
+    }
+
+    static void OnFailureCallback_36(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_36(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_36(void * context) { (static_cast<TestSaveAs *>(context))->OnSuccessResponse_36(); }
+
+    static void OnFailureCallback_37(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_37(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_37(void * context, uint16_t int16u)
+    {
+        (static_cast<TestSaveAs *>(context))->OnSuccessResponse_37(int16u);
+    }
+
+    static void OnFailureCallback_38(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_38(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_38(void * context, uint32_t int32u)
+    {
+        (static_cast<TestSaveAs *>(context))->OnSuccessResponse_38(int32u);
+    }
+
+    static void OnFailureCallback_39(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_39(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_39(void * context) { (static_cast<TestSaveAs *>(context))->OnSuccessResponse_39(); }
+
+    static void OnFailureCallback_40(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_40(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_40(void * context, uint32_t int32u)
+    {
+        (static_cast<TestSaveAs *>(context))->OnSuccessResponse_40(int32u);
+    }
+
+    static void OnFailureCallback_41(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_41(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_41(void * context) { (static_cast<TestSaveAs *>(context))->OnSuccessResponse_41(); }
+
+    static void OnFailureCallback_42(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_42(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_42(void * context, uint32_t int32u)
+    {
+        (static_cast<TestSaveAs *>(context))->OnSuccessResponse_42(int32u);
+    }
+
+    static void OnFailureCallback_43(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_43(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_43(void * context, uint64_t int64u)
+    {
+        (static_cast<TestSaveAs *>(context))->OnSuccessResponse_43(int64u);
+    }
+
+    static void OnFailureCallback_44(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_44(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_44(void * context) { (static_cast<TestSaveAs *>(context))->OnSuccessResponse_44(); }
+
+    static void OnFailureCallback_45(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_45(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_45(void * context, uint64_t int64u)
+    {
+        (static_cast<TestSaveAs *>(context))->OnSuccessResponse_45(int64u);
+    }
+
+    static void OnFailureCallback_46(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_46(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_46(void * context) { (static_cast<TestSaveAs *>(context))->OnSuccessResponse_46(); }
+
+    static void OnFailureCallback_47(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_47(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_47(void * context, uint64_t int64u)
+    {
+        (static_cast<TestSaveAs *>(context))->OnSuccessResponse_47(int64u);
+    }
+
+    static void OnFailureCallback_48(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_48(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_48(void * context, int8_t int8s)
+    {
+        (static_cast<TestSaveAs *>(context))->OnSuccessResponse_48(int8s);
+    }
+
+    static void OnFailureCallback_49(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_49(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_49(void * context) { (static_cast<TestSaveAs *>(context))->OnSuccessResponse_49(); }
+
+    static void OnFailureCallback_50(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_50(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_50(void * context, int8_t int8s)
+    {
+        (static_cast<TestSaveAs *>(context))->OnSuccessResponse_50(int8s);
+    }
+
+    static void OnFailureCallback_51(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_51(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_51(void * context) { (static_cast<TestSaveAs *>(context))->OnSuccessResponse_51(); }
+
+    static void OnFailureCallback_52(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_52(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_52(void * context, int8_t int8s)
+    {
+        (static_cast<TestSaveAs *>(context))->OnSuccessResponse_52(int8s);
+    }
+
+    static void OnFailureCallback_53(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_53(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_53(void * context, int16_t int16s)
+    {
+        (static_cast<TestSaveAs *>(context))->OnSuccessResponse_53(int16s);
+    }
+
+    static void OnFailureCallback_54(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_54(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_54(void * context) { (static_cast<TestSaveAs *>(context))->OnSuccessResponse_54(); }
+
+    static void OnFailureCallback_55(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_55(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_55(void * context, int16_t int16s)
+    {
+        (static_cast<TestSaveAs *>(context))->OnSuccessResponse_55(int16s);
+    }
+
+    static void OnFailureCallback_56(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_56(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_56(void * context) { (static_cast<TestSaveAs *>(context))->OnSuccessResponse_56(); }
+
+    static void OnFailureCallback_57(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_57(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_57(void * context, int16_t int16s)
+    {
+        (static_cast<TestSaveAs *>(context))->OnSuccessResponse_57(int16s);
+    }
+
+    static void OnFailureCallback_58(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_58(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_58(void * context, int32_t int32s)
+    {
+        (static_cast<TestSaveAs *>(context))->OnSuccessResponse_58(int32s);
+    }
+
+    static void OnFailureCallback_59(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_59(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_59(void * context) { (static_cast<TestSaveAs *>(context))->OnSuccessResponse_59(); }
+
+    static void OnFailureCallback_60(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_60(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_60(void * context, int32_t int32s)
+    {
+        (static_cast<TestSaveAs *>(context))->OnSuccessResponse_60(int32s);
+    }
+
+    static void OnFailureCallback_61(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_61(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_61(void * context) { (static_cast<TestSaveAs *>(context))->OnSuccessResponse_61(); }
+
+    static void OnFailureCallback_62(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_62(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_62(void * context, int32_t int32s)
+    {
+        (static_cast<TestSaveAs *>(context))->OnSuccessResponse_62(int32s);
+    }
+
+    static void OnFailureCallback_63(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_63(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_63(void * context, int64_t int64s)
+    {
+        (static_cast<TestSaveAs *>(context))->OnSuccessResponse_63(int64s);
+    }
+
+    static void OnFailureCallback_64(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_64(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_64(void * context) { (static_cast<TestSaveAs *>(context))->OnSuccessResponse_64(); }
+
+    static void OnFailureCallback_65(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_65(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_65(void * context, int64_t int64s)
+    {
+        (static_cast<TestSaveAs *>(context))->OnSuccessResponse_65(int64s);
+    }
+
+    static void OnFailureCallback_66(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_66(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_66(void * context) { (static_cast<TestSaveAs *>(context))->OnSuccessResponse_66(); }
+
+    static void OnFailureCallback_67(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_67(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_67(void * context, int64_t int64s)
+    {
+        (static_cast<TestSaveAs *>(context))->OnSuccessResponse_67(int64s);
+    }
+
+    static void OnFailureCallback_68(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_68(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_68(void * context, uint8_t enum8)
+    {
+        (static_cast<TestSaveAs *>(context))->OnSuccessResponse_68(enum8);
+    }
+
+    static void OnFailureCallback_69(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_69(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_69(void * context) { (static_cast<TestSaveAs *>(context))->OnSuccessResponse_69(); }
+
+    static void OnFailureCallback_70(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_70(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_70(void * context, uint8_t enum8)
+    {
+        (static_cast<TestSaveAs *>(context))->OnSuccessResponse_70(enum8);
+    }
+
+    static void OnFailureCallback_71(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_71(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_71(void * context) { (static_cast<TestSaveAs *>(context))->OnSuccessResponse_71(); }
+
+    static void OnFailureCallback_72(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_72(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_72(void * context, uint8_t enum8)
+    {
+        (static_cast<TestSaveAs *>(context))->OnSuccessResponse_72(enum8);
+    }
+
+    static void OnFailureCallback_73(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_73(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_73(void * context, uint16_t enum16)
+    {
+        (static_cast<TestSaveAs *>(context))->OnSuccessResponse_73(enum16);
+    }
+
+    static void OnFailureCallback_74(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_74(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_74(void * context) { (static_cast<TestSaveAs *>(context))->OnSuccessResponse_74(); }
+
+    static void OnFailureCallback_75(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_75(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_75(void * context, uint16_t enum16)
+    {
+        (static_cast<TestSaveAs *>(context))->OnSuccessResponse_75(enum16);
+    }
+
+    static void OnFailureCallback_76(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_76(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_76(void * context) { (static_cast<TestSaveAs *>(context))->OnSuccessResponse_76(); }
+
+    static void OnFailureCallback_77(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_77(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_77(void * context, uint16_t enum16)
+    {
+        (static_cast<TestSaveAs *>(context))->OnSuccessResponse_77(enum16);
+    }
+
+    static void OnFailureCallback_78(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_78(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_78(void * context, uint64_t epochUs)
+    {
+        (static_cast<TestSaveAs *>(context))->OnSuccessResponse_78(epochUs);
+    }
+
+    static void OnFailureCallback_79(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_79(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_79(void * context) { (static_cast<TestSaveAs *>(context))->OnSuccessResponse_79(); }
+
+    static void OnFailureCallback_80(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_80(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_80(void * context, uint64_t epochUs)
+    {
+        (static_cast<TestSaveAs *>(context))->OnSuccessResponse_80(epochUs);
+    }
+
+    static void OnFailureCallback_81(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_81(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_81(void * context) { (static_cast<TestSaveAs *>(context))->OnSuccessResponse_81(); }
+
+    static void OnFailureCallback_82(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_82(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_82(void * context, uint64_t epochUs)
+    {
+        (static_cast<TestSaveAs *>(context))->OnSuccessResponse_82(epochUs);
+    }
+
+    static void OnFailureCallback_83(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_83(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_83(void * context, uint32_t epochS)
+    {
+        (static_cast<TestSaveAs *>(context))->OnSuccessResponse_83(epochS);
+    }
+
+    static void OnFailureCallback_84(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_84(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_84(void * context) { (static_cast<TestSaveAs *>(context))->OnSuccessResponse_84(); }
+
+    static void OnFailureCallback_85(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_85(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_85(void * context, uint32_t epochS)
+    {
+        (static_cast<TestSaveAs *>(context))->OnSuccessResponse_85(epochS);
+    }
+
+    static void OnFailureCallback_86(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_86(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_86(void * context) { (static_cast<TestSaveAs *>(context))->OnSuccessResponse_86(); }
+
+    static void OnFailureCallback_87(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_87(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_87(void * context, uint32_t epochS)
+    {
+        (static_cast<TestSaveAs *>(context))->OnSuccessResponse_87(epochS);
+    }
+
+    static void OnFailureCallback_88(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_88(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_88(void * context, chip::VendorId vendorId)
+    {
+        (static_cast<TestSaveAs *>(context))->OnSuccessResponse_88(vendorId);
+    }
+
+    static void OnFailureCallback_89(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_89(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_89(void * context) { (static_cast<TestSaveAs *>(context))->OnSuccessResponse_89(); }
+
+    static void OnFailureCallback_90(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_90(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_90(void * context, chip::VendorId vendorId)
+    {
+        (static_cast<TestSaveAs *>(context))->OnSuccessResponse_90(vendorId);
+    }
+
+    static void OnFailureCallback_91(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_91(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_91(void * context) { (static_cast<TestSaveAs *>(context))->OnSuccessResponse_91(); }
+
+    static void OnFailureCallback_92(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestSaveAs *>(context))->OnFailureResponse_92(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_92(void * context, chip::VendorId vendorId)
+    {
+        (static_cast<TestSaveAs *>(context))->OnSuccessResponse_92(vendorId);
+    }
+
+    //
+    // Tests methods
+    //
+
+    CHIP_ERROR TestSendTestAddArgumentsCommand_0()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        using RequestType               = chip::app::Clusters::TestCluster::Commands::TestAddArguments::Type;
+
+        RequestType request;
+        request.arg1 = 3;
+        request.arg2 = 17;
+
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
+            (static_cast<TestSaveAs *>(context))->OnSuccessResponse_0(data.returnValue);
+        };
+
+        auto failure = [](void * context, EmberAfStatus status) {
+            (static_cast<TestSaveAs *>(context))->OnFailureResponse_0(status);
+        };
+
+        ReturnErrorOnFailure(chip::Controller::InvokeCommand(mDevice, this, success, failure, endpoint, request));
+        return CHIP_NO_ERROR;
+    }
+
+    void OnFailureResponse_0(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_0(uint8_t returnValue)
+    {
+        VerifyOrReturn(CheckValue<uint8_t>("returnValue", returnValue, 20));
+
+        TestAddArgumentDefaultValue = returnValue;
+        NextTest();
+    }
+
+    CHIP_ERROR TestSendTestAddArgumentsCommand_1()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        using RequestType               = chip::app::Clusters::TestCluster::Commands::TestAddArguments::Type;
+
+        RequestType request;
+        request.arg1 = 3;
+        request.arg2 = 17;
+
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
+            (static_cast<TestSaveAs *>(context))->OnSuccessResponse_1(data.returnValue);
+        };
+
+        auto failure = [](void * context, EmberAfStatus status) {
+            (static_cast<TestSaveAs *>(context))->OnFailureResponse_1(status);
+        };
+
+        ReturnErrorOnFailure(chip::Controller::InvokeCommand(mDevice, this, success, failure, endpoint, request));
+        return CHIP_NO_ERROR;
+    }
+
+    void OnFailureResponse_1(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_1(uint8_t returnValue)
+    {
+        VerifyOrReturn(CheckValue<uint8_t>("returnValue", returnValue, TestAddArgumentDefaultValue));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestSendTestAddArgumentsCommand_2()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        using RequestType               = chip::app::Clusters::TestCluster::Commands::TestAddArguments::Type;
+
+        RequestType request;
+        request.arg1 = 3;
+        request.arg2 = TestAddArgumentDefaultValue;
+
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
+            (static_cast<TestSaveAs *>(context))->OnSuccessResponse_2(data.returnValue);
+        };
+
+        auto failure = [](void * context, EmberAfStatus status) {
+            (static_cast<TestSaveAs *>(context))->OnFailureResponse_2(status);
+        };
+
+        ReturnErrorOnFailure(chip::Controller::InvokeCommand(mDevice, this, success, failure, endpoint, request));
+        return CHIP_NO_ERROR;
+    }
+
+    void OnFailureResponse_2(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_2(uint8_t returnValue)
+    {
+        VerifyOrReturn(CheckConstraintNotValue<uint8_t>("returnValue", returnValue, TestAddArgumentDefaultValue));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestReadAttributeBooleanDefaultValue_3()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Boolean::TypeInfo>(this, OnSuccessCallback_3,
+                                                                                                      OnFailureCallback_3);
+    }
+
+    void OnFailureResponse_3(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_3(bool boolean)
+    {
+        VerifyOrReturn(CheckValue<bool>("boolean", boolean, 0));
+
+        readAttributeBooleanDefaultValue = boolean;
+        NextTest();
+    }
+
+    CHIP_ERROR TestWriteAttributeBooleanNotDefaultValue_4()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        bool booleanArgument;
+        booleanArgument = 1;
+
+        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::Boolean::TypeInfo>(
+            booleanArgument, this, OnSuccessCallback_4, OnFailureCallback_4);
+    }
+
+    void OnFailureResponse_4(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_4() { NextTest(); }
+
+    CHIP_ERROR TestReadAttributeBooleanNotDefaultValue_5()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Boolean::TypeInfo>(this, OnSuccessCallback_5,
+                                                                                                      OnFailureCallback_5);
+    }
+
+    void OnFailureResponse_5(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_5(bool boolean)
+    {
+        VerifyOrReturn(CheckConstraintNotValue<bool>("boolean", boolean, readAttributeBooleanDefaultValue));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestWriteAttributeBooleanDefaultValue_6()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        bool booleanArgument;
+        booleanArgument = readAttributeBooleanDefaultValue;
+
+        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::Boolean::TypeInfo>(
+            booleanArgument, this, OnSuccessCallback_6, OnFailureCallback_6);
+    }
+
+    void OnFailureResponse_6(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_6() { NextTest(); }
+
+    CHIP_ERROR TestReadAttributeBooleanFalse_7()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Boolean::TypeInfo>(this, OnSuccessCallback_7,
+                                                                                                      OnFailureCallback_7);
+    }
+
+    void OnFailureResponse_7(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_7(bool boolean)
+    {
+        VerifyOrReturn(CheckValue<bool>("boolean", boolean, readAttributeBooleanDefaultValue));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestReadAttributeBitmap8DefaultValue_8()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Bitmap8::TypeInfo>(this, OnSuccessCallback_8,
+                                                                                                      OnFailureCallback_8);
+    }
+
+    void OnFailureResponse_8(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_8(uint8_t bitmap8)
+    {
+        VerifyOrReturn(CheckValue<uint8_t>("bitmap8", bitmap8, 0));
+
+        readAttributeBitmap8DefaultValue = bitmap8;
+        NextTest();
+    }
+
+    CHIP_ERROR TestWriteAttributeBitmap8NotDefaultValue_9()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        uint8_t bitmap8Argument;
+        bitmap8Argument = 1;
+
+        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::Bitmap8::TypeInfo>(
+            bitmap8Argument, this, OnSuccessCallback_9, OnFailureCallback_9);
+    }
+
+    void OnFailureResponse_9(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_9() { NextTest(); }
+
+    CHIP_ERROR TestReadAttributeBitmap8NotDefaultValue_10()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Bitmap8::TypeInfo>(this, OnSuccessCallback_10,
+                                                                                                      OnFailureCallback_10);
+    }
+
+    void OnFailureResponse_10(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_10(uint8_t bitmap8)
+    {
+        VerifyOrReturn(CheckConstraintNotValue<uint8_t>("bitmap8", bitmap8, readAttributeBitmap8DefaultValue));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestWriteAttributeBitmap8DefaultValue_11()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        uint8_t bitmap8Argument;
+        bitmap8Argument = readAttributeBitmap8DefaultValue;
+
+        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::Bitmap8::TypeInfo>(
+            bitmap8Argument, this, OnSuccessCallback_11, OnFailureCallback_11);
+    }
+
+    void OnFailureResponse_11(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_11() { NextTest(); }
+
+    CHIP_ERROR TestReadAttributeBitmap8DefaultValue_12()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Bitmap8::TypeInfo>(this, OnSuccessCallback_12,
+                                                                                                      OnFailureCallback_12);
+    }
+
+    void OnFailureResponse_12(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_12(uint8_t bitmap8)
+    {
+        VerifyOrReturn(CheckValue<uint8_t>("bitmap8", bitmap8, readAttributeBitmap8DefaultValue));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestReadAttributeBitmap16DefaultValue_13()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Bitmap16::TypeInfo>(this, OnSuccessCallback_13,
+                                                                                                       OnFailureCallback_13);
+    }
+
+    void OnFailureResponse_13(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_13(uint16_t bitmap16)
+    {
+        VerifyOrReturn(CheckValue<uint16_t>("bitmap16", bitmap16, 0U));
+
+        readAttributeBitmap16DefaultValue = bitmap16;
+        NextTest();
+    }
+
+    CHIP_ERROR TestWriteAttributeBitmap16NotDefaultValue_14()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        uint16_t bitmap16Argument;
+        bitmap16Argument = 1U;
+
+        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::Bitmap16::TypeInfo>(
+            bitmap16Argument, this, OnSuccessCallback_14, OnFailureCallback_14);
+    }
+
+    void OnFailureResponse_14(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_14() { NextTest(); }
+
+    CHIP_ERROR TestReadAttributeBitmap16NotDefaultValue_15()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Bitmap16::TypeInfo>(this, OnSuccessCallback_15,
+                                                                                                       OnFailureCallback_15);
+    }
+
+    void OnFailureResponse_15(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_15(uint16_t bitmap16)
+    {
+        VerifyOrReturn(CheckConstraintNotValue<uint16_t>("bitmap16", bitmap16, readAttributeBitmap16DefaultValue));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestWriteAttributeBitmap16DefaultValue_16()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        uint16_t bitmap16Argument;
+        bitmap16Argument = readAttributeBitmap16DefaultValue;
+
+        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::Bitmap16::TypeInfo>(
+            bitmap16Argument, this, OnSuccessCallback_16, OnFailureCallback_16);
+    }
+
+    void OnFailureResponse_16(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_16() { NextTest(); }
+
+    CHIP_ERROR TestReadAttributeBitmap16DefaultValue_17()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Bitmap16::TypeInfo>(this, OnSuccessCallback_17,
+                                                                                                       OnFailureCallback_17);
+    }
+
+    void OnFailureResponse_17(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_17(uint16_t bitmap16)
+    {
+        VerifyOrReturn(CheckValue<uint16_t>("bitmap16", bitmap16, readAttributeBitmap16DefaultValue));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestReadAttributeBitmap32DefaultValue_18()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Bitmap32::TypeInfo>(this, OnSuccessCallback_18,
+                                                                                                       OnFailureCallback_18);
+    }
+
+    void OnFailureResponse_18(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_18(uint32_t bitmap32)
+    {
+        VerifyOrReturn(CheckValue<uint32_t>("bitmap32", bitmap32, 0UL));
+
+        readAttributeBitmap32DefaultValue = bitmap32;
+        NextTest();
+    }
+
+    CHIP_ERROR TestWriteAttributeBitmap32NotDefaultValue_19()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        uint32_t bitmap32Argument;
+        bitmap32Argument = 1UL;
+
+        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::Bitmap32::TypeInfo>(
+            bitmap32Argument, this, OnSuccessCallback_19, OnFailureCallback_19);
+    }
+
+    void OnFailureResponse_19(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_19() { NextTest(); }
+
+    CHIP_ERROR TestReadAttributeBitmap32NotDefaultValue_20()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Bitmap32::TypeInfo>(this, OnSuccessCallback_20,
+                                                                                                       OnFailureCallback_20);
+    }
+
+    void OnFailureResponse_20(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_20(uint32_t bitmap32)
+    {
+        VerifyOrReturn(CheckConstraintNotValue<uint32_t>("bitmap32", bitmap32, readAttributeBitmap32DefaultValue));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestWriteAttributeBitmap32DefaultValue_21()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        uint32_t bitmap32Argument;
+        bitmap32Argument = readAttributeBitmap32DefaultValue;
+
+        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::Bitmap32::TypeInfo>(
+            bitmap32Argument, this, OnSuccessCallback_21, OnFailureCallback_21);
+    }
+
+    void OnFailureResponse_21(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_21() { NextTest(); }
+
+    CHIP_ERROR TestReadAttributeBitmap32DefaultValue_22()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Bitmap32::TypeInfo>(this, OnSuccessCallback_22,
+                                                                                                       OnFailureCallback_22);
+    }
+
+    void OnFailureResponse_22(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_22(uint32_t bitmap32)
+    {
+        VerifyOrReturn(CheckValue<uint32_t>("bitmap32", bitmap32, readAttributeBitmap32DefaultValue));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestReadAttributeBitmap64DefaultValue_23()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Bitmap64::TypeInfo>(this, OnSuccessCallback_23,
+                                                                                                       OnFailureCallback_23);
+    }
+
+    void OnFailureResponse_23(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_23(uint64_t bitmap64)
+    {
+        VerifyOrReturn(CheckValue<uint64_t>("bitmap64", bitmap64, 0ULL));
+
+        readAttributeBitmap64DefaultValue = bitmap64;
+        NextTest();
+    }
+
+    CHIP_ERROR TestWriteAttributeBitmap64NotDefaultValue_24()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        uint64_t bitmap64Argument;
+        bitmap64Argument = 1ULL;
+
+        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::Bitmap64::TypeInfo>(
+            bitmap64Argument, this, OnSuccessCallback_24, OnFailureCallback_24);
+    }
+
+    void OnFailureResponse_24(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_24() { NextTest(); }
+
+    CHIP_ERROR TestReadAttributeBitmap64DefaultValue_25()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Bitmap64::TypeInfo>(this, OnSuccessCallback_25,
+                                                                                                       OnFailureCallback_25);
+    }
+
+    void OnFailureResponse_25(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_25(uint64_t bitmap64)
+    {
+        VerifyOrReturn(CheckConstraintNotValue<uint64_t>("bitmap64", bitmap64, readAttributeBitmap64DefaultValue));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestWriteAttributeBitmap64DefaultValue_26()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        uint64_t bitmap64Argument;
+        bitmap64Argument = readAttributeBitmap64DefaultValue;
+
+        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::Bitmap64::TypeInfo>(
+            bitmap64Argument, this, OnSuccessCallback_26, OnFailureCallback_26);
+    }
+
+    void OnFailureResponse_26(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_26() { NextTest(); }
+
+    CHIP_ERROR TestReadAttributeBitmap64DefaultValue_27()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Bitmap64::TypeInfo>(this, OnSuccessCallback_27,
+                                                                                                       OnFailureCallback_27);
+    }
+
+    void OnFailureResponse_27(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_27(uint64_t bitmap64)
+    {
+        VerifyOrReturn(CheckValue<uint64_t>("bitmap64", bitmap64, readAttributeBitmap64DefaultValue));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestReadAttributeInt8uDefaultValue_28()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int8u::TypeInfo>(this, OnSuccessCallback_28,
+                                                                                                    OnFailureCallback_28);
+    }
+
+    void OnFailureResponse_28(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_28(uint8_t int8u)
+    {
+        VerifyOrReturn(CheckValue<uint8_t>("int8u", int8u, 0));
+
+        readAttributeInt8uDefaultValue = int8u;
+        NextTest();
+    }
+
+    CHIP_ERROR TestWriteAttributeInt8uNotDefaultValue_29()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        uint8_t int8uArgument;
+        int8uArgument = 1;
+
+        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::Int8u::TypeInfo>(
+            int8uArgument, this, OnSuccessCallback_29, OnFailureCallback_29);
+    }
+
+    void OnFailureResponse_29(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_29() { NextTest(); }
+
+    CHIP_ERROR TestReadAttributeInt8uNotDefaultValue_30()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int8u::TypeInfo>(this, OnSuccessCallback_30,
+                                                                                                    OnFailureCallback_30);
+    }
+
+    void OnFailureResponse_30(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_30(uint8_t int8u)
+    {
+        VerifyOrReturn(CheckConstraintNotValue<uint8_t>("int8u", int8u, readAttributeInt8uDefaultValue));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestWriteAttributeInt8uDefaultValue_31()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        uint8_t int8uArgument;
+        int8uArgument = readAttributeInt8uDefaultValue;
+
+        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::Int8u::TypeInfo>(
+            int8uArgument, this, OnSuccessCallback_31, OnFailureCallback_31);
+    }
+
+    void OnFailureResponse_31(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_31() { NextTest(); }
+
+    CHIP_ERROR TestReadAttributeInt8uDefaultValue_32()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int8u::TypeInfo>(this, OnSuccessCallback_32,
+                                                                                                    OnFailureCallback_32);
+    }
+
+    void OnFailureResponse_32(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_32(uint8_t int8u)
+    {
+        VerifyOrReturn(CheckValue<uint8_t>("int8u", int8u, readAttributeInt8uDefaultValue));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestReadAttributeInt16uDefaultValue_33()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int16u::TypeInfo>(this, OnSuccessCallback_33,
+                                                                                                     OnFailureCallback_33);
+    }
+
+    void OnFailureResponse_33(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_33(uint16_t int16u)
+    {
+        VerifyOrReturn(CheckValue<uint16_t>("int16u", int16u, 0U));
+
+        readAttributeInt16uDefaultValue = int16u;
+        NextTest();
+    }
+
+    CHIP_ERROR TestWriteAttributeInt16uNotDefaultValue_34()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        uint16_t int16uArgument;
+        int16uArgument = 1U;
+
+        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::Int16u::TypeInfo>(
+            int16uArgument, this, OnSuccessCallback_34, OnFailureCallback_34);
+    }
+
+    void OnFailureResponse_34(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_34() { NextTest(); }
+
+    CHIP_ERROR TestReadAttributeInt16uNotDefaultValue_35()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int16u::TypeInfo>(this, OnSuccessCallback_35,
+                                                                                                     OnFailureCallback_35);
+    }
+
+    void OnFailureResponse_35(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_35(uint16_t int16u)
+    {
+        VerifyOrReturn(CheckConstraintNotValue<uint16_t>("int16u", int16u, readAttributeInt16uDefaultValue));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestWriteAttributeInt16uDefaultValue_36()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        uint16_t int16uArgument;
+        int16uArgument = readAttributeInt16uDefaultValue;
+
+        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::Int16u::TypeInfo>(
+            int16uArgument, this, OnSuccessCallback_36, OnFailureCallback_36);
+    }
+
+    void OnFailureResponse_36(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_36() { NextTest(); }
+
+    CHIP_ERROR TestReadAttributeInt16uDefaultValue_37()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int16u::TypeInfo>(this, OnSuccessCallback_37,
+                                                                                                     OnFailureCallback_37);
+    }
+
+    void OnFailureResponse_37(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_37(uint16_t int16u)
+    {
+        VerifyOrReturn(CheckValue<uint16_t>("int16u", int16u, readAttributeInt16uDefaultValue));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestReadAttributeInt32uDefaultValue_38()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int32u::TypeInfo>(this, OnSuccessCallback_38,
+                                                                                                     OnFailureCallback_38);
+    }
+
+    void OnFailureResponse_38(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_38(uint32_t int32u)
+    {
+        VerifyOrReturn(CheckValue<uint32_t>("int32u", int32u, 0UL));
+
+        readAttributeInt32uDefaultValue = int32u;
+        NextTest();
+    }
+
+    CHIP_ERROR TestWriteAttributeInt32uNotDefaultValue_39()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        uint32_t int32uArgument;
+        int32uArgument = 1UL;
+
+        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::Int32u::TypeInfo>(
+            int32uArgument, this, OnSuccessCallback_39, OnFailureCallback_39);
+    }
+
+    void OnFailureResponse_39(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_39() { NextTest(); }
+
+    CHIP_ERROR TestReadAttributeInt32uNotDefaultValue_40()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int32u::TypeInfo>(this, OnSuccessCallback_40,
+                                                                                                     OnFailureCallback_40);
+    }
+
+    void OnFailureResponse_40(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_40(uint32_t int32u)
+    {
+        VerifyOrReturn(CheckConstraintNotValue<uint32_t>("int32u", int32u, readAttributeInt32uDefaultValue));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestWriteAttributeInt32uDefaultValue_41()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        uint32_t int32uArgument;
+        int32uArgument = readAttributeInt32uDefaultValue;
+
+        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::Int32u::TypeInfo>(
+            int32uArgument, this, OnSuccessCallback_41, OnFailureCallback_41);
+    }
+
+    void OnFailureResponse_41(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_41() { NextTest(); }
+
+    CHIP_ERROR TestReadAttributeInt32uDefaultValue_42()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int32u::TypeInfo>(this, OnSuccessCallback_42,
+                                                                                                     OnFailureCallback_42);
+    }
+
+    void OnFailureResponse_42(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_42(uint32_t int32u)
+    {
+        VerifyOrReturn(CheckValue<uint32_t>("int32u", int32u, readAttributeInt32uDefaultValue));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestReadAttributeInt64uDefaultValue_43()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int64u::TypeInfo>(this, OnSuccessCallback_43,
+                                                                                                     OnFailureCallback_43);
+    }
+
+    void OnFailureResponse_43(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_43(uint64_t int64u)
+    {
+        VerifyOrReturn(CheckValue<uint64_t>("int64u", int64u, 0ULL));
+
+        readAttributeInt64uDefaultValue = int64u;
+        NextTest();
+    }
+
+    CHIP_ERROR TestWriteAttributeInt64uNotDefaultValue_44()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        uint64_t int64uArgument;
+        int64uArgument = 1ULL;
+
+        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::Int64u::TypeInfo>(
+            int64uArgument, this, OnSuccessCallback_44, OnFailureCallback_44);
+    }
+
+    void OnFailureResponse_44(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_44() { NextTest(); }
+
+    CHIP_ERROR TestReadAttributeInt64uNotDefaultValue_45()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int64u::TypeInfo>(this, OnSuccessCallback_45,
+                                                                                                     OnFailureCallback_45);
+    }
+
+    void OnFailureResponse_45(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_45(uint64_t int64u)
+    {
+        VerifyOrReturn(CheckConstraintNotValue<uint64_t>("int64u", int64u, readAttributeInt64uDefaultValue));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestWriteAttributeInt64uDefaultValue_46()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        uint64_t int64uArgument;
+        int64uArgument = readAttributeInt64uDefaultValue;
+
+        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::Int64u::TypeInfo>(
+            int64uArgument, this, OnSuccessCallback_46, OnFailureCallback_46);
+    }
+
+    void OnFailureResponse_46(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_46() { NextTest(); }
+
+    CHIP_ERROR TestReadAttributeInt64uDefaultValue_47()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int64u::TypeInfo>(this, OnSuccessCallback_47,
+                                                                                                     OnFailureCallback_47);
+    }
+
+    void OnFailureResponse_47(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_47(uint64_t int64u)
+    {
+        VerifyOrReturn(CheckValue<uint64_t>("int64u", int64u, readAttributeInt64uDefaultValue));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestReadAttributeInt8sDefaultValue_48()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int8s::TypeInfo>(this, OnSuccessCallback_48,
+                                                                                                    OnFailureCallback_48);
+    }
+
+    void OnFailureResponse_48(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_48(int8_t int8s)
+    {
+        VerifyOrReturn(CheckValue<int8_t>("int8s", int8s, 0));
+
+        readAttributeInt8sDefaultValue = int8s;
+        NextTest();
+    }
+
+    CHIP_ERROR TestWriteAttributeInt8sNotDefaultValue_49()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        int8_t int8sArgument;
+        int8sArgument = 1;
+
+        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::Int8s::TypeInfo>(
+            int8sArgument, this, OnSuccessCallback_49, OnFailureCallback_49);
+    }
+
+    void OnFailureResponse_49(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_49() { NextTest(); }
+
+    CHIP_ERROR TestReadAttributeInt8sNotDefaultValue_50()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int8s::TypeInfo>(this, OnSuccessCallback_50,
+                                                                                                    OnFailureCallback_50);
+    }
+
+    void OnFailureResponse_50(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_50(int8_t int8s)
+    {
+        VerifyOrReturn(CheckConstraintNotValue<int8_t>("int8s", int8s, readAttributeInt8sDefaultValue));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestWriteAttributeInt8sDefaultValue_51()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        int8_t int8sArgument;
+        int8sArgument = readAttributeInt8sDefaultValue;
+
+        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::Int8s::TypeInfo>(
+            int8sArgument, this, OnSuccessCallback_51, OnFailureCallback_51);
+    }
+
+    void OnFailureResponse_51(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_51() { NextTest(); }
+
+    CHIP_ERROR TestReadAttributeInt8sDefaultValue_52()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int8s::TypeInfo>(this, OnSuccessCallback_52,
+                                                                                                    OnFailureCallback_52);
+    }
+
+    void OnFailureResponse_52(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_52(int8_t int8s)
+    {
+        VerifyOrReturn(CheckValue<int8_t>("int8s", int8s, readAttributeInt8sDefaultValue));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestReadAttributeInt16sDefaultValue_53()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int16s::TypeInfo>(this, OnSuccessCallback_53,
+                                                                                                     OnFailureCallback_53);
+    }
+
+    void OnFailureResponse_53(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_53(int16_t int16s)
+    {
+        VerifyOrReturn(CheckValue<int16_t>("int16s", int16s, 0));
+
+        readAttributeInt16sDefaultValue = int16s;
+        NextTest();
+    }
+
+    CHIP_ERROR TestWriteAttributeInt16sNotDefaultValue_54()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        int16_t int16sArgument;
+        int16sArgument = 1;
+
+        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::Int16s::TypeInfo>(
+            int16sArgument, this, OnSuccessCallback_54, OnFailureCallback_54);
+    }
+
+    void OnFailureResponse_54(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_54() { NextTest(); }
+
+    CHIP_ERROR TestReadAttributeInt16sNotDefaultValue_55()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int16s::TypeInfo>(this, OnSuccessCallback_55,
+                                                                                                     OnFailureCallback_55);
+    }
+
+    void OnFailureResponse_55(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_55(int16_t int16s)
+    {
+        VerifyOrReturn(CheckConstraintNotValue<int16_t>("int16s", int16s, readAttributeInt16sDefaultValue));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestWriteAttributeInt16sDefaultValue_56()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        int16_t int16sArgument;
+        int16sArgument = readAttributeInt16sDefaultValue;
+
+        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::Int16s::TypeInfo>(
+            int16sArgument, this, OnSuccessCallback_56, OnFailureCallback_56);
+    }
+
+    void OnFailureResponse_56(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_56() { NextTest(); }
+
+    CHIP_ERROR TestReadAttributeInt16sDefaultValue_57()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int16s::TypeInfo>(this, OnSuccessCallback_57,
+                                                                                                     OnFailureCallback_57);
+    }
+
+    void OnFailureResponse_57(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_57(int16_t int16s)
+    {
+        VerifyOrReturn(CheckValue<int16_t>("int16s", int16s, readAttributeInt16sDefaultValue));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestReadAttributeInt32sDefaultValue_58()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int32s::TypeInfo>(this, OnSuccessCallback_58,
+                                                                                                     OnFailureCallback_58);
+    }
+
+    void OnFailureResponse_58(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_58(int32_t int32s)
+    {
+        VerifyOrReturn(CheckValue<int32_t>("int32s", int32s, 0L));
+
+        readAttributeInt32sDefaultValue = int32s;
+        NextTest();
+    }
+
+    CHIP_ERROR TestWriteAttributeInt32sNotDefaultValue_59()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        int32_t int32sArgument;
+        int32sArgument = 1L;
+
+        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::Int32s::TypeInfo>(
+            int32sArgument, this, OnSuccessCallback_59, OnFailureCallback_59);
+    }
+
+    void OnFailureResponse_59(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_59() { NextTest(); }
+
+    CHIP_ERROR TestReadAttributeInt32sNotDefaultValue_60()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int32s::TypeInfo>(this, OnSuccessCallback_60,
+                                                                                                     OnFailureCallback_60);
+    }
+
+    void OnFailureResponse_60(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_60(int32_t int32s)
+    {
+        VerifyOrReturn(CheckConstraintNotValue<int32_t>("int32s", int32s, readAttributeInt32sDefaultValue));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestWriteAttributeInt32sDefaultValue_61()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        int32_t int32sArgument;
+        int32sArgument = readAttributeInt32sDefaultValue;
+
+        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::Int32s::TypeInfo>(
+            int32sArgument, this, OnSuccessCallback_61, OnFailureCallback_61);
+    }
+
+    void OnFailureResponse_61(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_61() { NextTest(); }
+
+    CHIP_ERROR TestReadAttributeInt32sDefaultValue_62()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int32s::TypeInfo>(this, OnSuccessCallback_62,
+                                                                                                     OnFailureCallback_62);
+    }
+
+    void OnFailureResponse_62(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_62(int32_t int32s)
+    {
+        VerifyOrReturn(CheckValue<int32_t>("int32s", int32s, readAttributeInt32sDefaultValue));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestReadAttributeInt64sDefaultValue_63()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int64s::TypeInfo>(this, OnSuccessCallback_63,
+                                                                                                     OnFailureCallback_63);
+    }
+
+    void OnFailureResponse_63(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_63(int64_t int64s)
+    {
+        VerifyOrReturn(CheckValue<int64_t>("int64s", int64s, 0LL));
+
+        readAttributeInt64sDefaultValue = int64s;
+        NextTest();
+    }
+
+    CHIP_ERROR TestWriteAttributeIntsNotDefaultValue_64()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        int64_t int64sArgument;
+        int64sArgument = 1LL;
+
+        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::Int64s::TypeInfo>(
+            int64sArgument, this, OnSuccessCallback_64, OnFailureCallback_64);
+    }
+
+    void OnFailureResponse_64(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_64() { NextTest(); }
+
+    CHIP_ERROR TestReadAttributeInt64sNotDefaultValue_65()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int64s::TypeInfo>(this, OnSuccessCallback_65,
+                                                                                                     OnFailureCallback_65);
+    }
+
+    void OnFailureResponse_65(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_65(int64_t int64s)
+    {
+        VerifyOrReturn(CheckConstraintNotValue<int64_t>("int64s", int64s, readAttributeInt64sDefaultValue));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestWriteAttributeInt64sDefaultValue_66()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        int64_t int64sArgument;
+        int64sArgument = readAttributeInt64sDefaultValue;
+
+        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::Int64s::TypeInfo>(
+            int64sArgument, this, OnSuccessCallback_66, OnFailureCallback_66);
+    }
+
+    void OnFailureResponse_66(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_66() { NextTest(); }
+
+    CHIP_ERROR TestReadAttributeInt64sDefaultValue_67()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Int64s::TypeInfo>(this, OnSuccessCallback_67,
+                                                                                                     OnFailureCallback_67);
+    }
+
+    void OnFailureResponse_67(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_67(int64_t int64s)
+    {
+        VerifyOrReturn(CheckValue<int64_t>("int64s", int64s, readAttributeInt64sDefaultValue));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestReadAttributeEnum8DefaultValue_68()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Enum8::TypeInfo>(this, OnSuccessCallback_68,
+                                                                                                    OnFailureCallback_68);
+    }
+
+    void OnFailureResponse_68(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_68(uint8_t enum8)
+    {
+        VerifyOrReturn(CheckValue<uint8_t>("enum8", enum8, 0));
+
+        readAttributeEnum8DefaultValue = enum8;
+        NextTest();
+    }
+
+    CHIP_ERROR TestWriteAttributeEnum8NotDefaultValue_69()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        uint8_t enum8Argument;
+        enum8Argument = static_cast<uint8_t>(1);
+
+        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::Enum8::TypeInfo>(
+            enum8Argument, this, OnSuccessCallback_69, OnFailureCallback_69);
+    }
+
+    void OnFailureResponse_69(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_69() { NextTest(); }
+
+    CHIP_ERROR TestReadAttributeEnum8NotDefaultValue_70()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Enum8::TypeInfo>(this, OnSuccessCallback_70,
+                                                                                                    OnFailureCallback_70);
+    }
+
+    void OnFailureResponse_70(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_70(uint8_t enum8)
+    {
+        VerifyOrReturn(CheckConstraintNotValue<uint8_t>("enum8", enum8, readAttributeEnum8DefaultValue));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestWriteAttributeEnum8DefaultValue_71()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        uint8_t enum8Argument;
+        enum8Argument = static_cast<uint8_t>(readAttributeEnum8DefaultValue);
+
+        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::Enum8::TypeInfo>(
+            enum8Argument, this, OnSuccessCallback_71, OnFailureCallback_71);
+    }
+
+    void OnFailureResponse_71(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_71() { NextTest(); }
+
+    CHIP_ERROR TestReadAttributeEnum8DefaultValue_72()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Enum8::TypeInfo>(this, OnSuccessCallback_72,
+                                                                                                    OnFailureCallback_72);
+    }
+
+    void OnFailureResponse_72(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_72(uint8_t enum8)
+    {
+        VerifyOrReturn(CheckValue<uint8_t>("enum8", enum8, readAttributeEnum8DefaultValue));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestReadAttributeEnum16DefaultValue_73()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Enum16::TypeInfo>(this, OnSuccessCallback_73,
+                                                                                                     OnFailureCallback_73);
+    }
+
+    void OnFailureResponse_73(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_73(uint16_t enum16)
+    {
+        VerifyOrReturn(CheckValue<uint16_t>("enum16", enum16, 0U));
+
+        readAttributeEnum16DefaultValue = enum16;
+        NextTest();
+    }
+
+    CHIP_ERROR TestWriteAttributeEnum16NotDefaultValue_74()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        uint16_t enum16Argument;
+        enum16Argument = static_cast<uint16_t>(1);
+
+        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::Enum16::TypeInfo>(
+            enum16Argument, this, OnSuccessCallback_74, OnFailureCallback_74);
+    }
+
+    void OnFailureResponse_74(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_74() { NextTest(); }
+
+    CHIP_ERROR TestReadAttributeEnum16NotDefaultValue_75()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Enum16::TypeInfo>(this, OnSuccessCallback_75,
+                                                                                                     OnFailureCallback_75);
+    }
+
+    void OnFailureResponse_75(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_75(uint16_t enum16)
+    {
+        VerifyOrReturn(CheckConstraintNotValue<uint16_t>("enum16", enum16, readAttributeEnum16DefaultValue));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestWriteAttributeEnum16DefaultValue_76()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        uint16_t enum16Argument;
+        enum16Argument = static_cast<uint16_t>(readAttributeEnum16DefaultValue);
+
+        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::Enum16::TypeInfo>(
+            enum16Argument, this, OnSuccessCallback_76, OnFailureCallback_76);
+    }
+
+    void OnFailureResponse_76(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_76() { NextTest(); }
+
+    CHIP_ERROR TestReadAttributeEnum16DefaultValue_77()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::Enum16::TypeInfo>(this, OnSuccessCallback_77,
+                                                                                                     OnFailureCallback_77);
+    }
+
+    void OnFailureResponse_77(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_77(uint16_t enum16)
+    {
+        VerifyOrReturn(CheckValue<uint16_t>("enum16", enum16, readAttributeEnum16DefaultValue));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestReadAttributeEpochUsDefaultValue_78()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::EpochUs::TypeInfo>(this, OnSuccessCallback_78,
+                                                                                                      OnFailureCallback_78);
+    }
+
+    void OnFailureResponse_78(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_78(uint64_t epochUs)
+    {
+        VerifyOrReturn(CheckValue<uint64_t>("epochUs", epochUs, 0ULL));
+
+        readAttributeEpochUSDefaultValue = epochUs;
+        NextTest();
+    }
+
+    CHIP_ERROR TestWriteAttributeEpochUsNotDefaultValue_79()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        uint64_t epochUsArgument;
+        epochUsArgument = 1ULL;
+
+        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::EpochUs::TypeInfo>(
+            epochUsArgument, this, OnSuccessCallback_79, OnFailureCallback_79);
+    }
+
+    void OnFailureResponse_79(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_79() { NextTest(); }
+
+    CHIP_ERROR TestReadAttributeEpochUsNotDefaultValue_80()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::EpochUs::TypeInfo>(this, OnSuccessCallback_80,
+                                                                                                      OnFailureCallback_80);
+    }
+
+    void OnFailureResponse_80(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_80(uint64_t epochUs)
+    {
+        VerifyOrReturn(CheckConstraintNotValue<uint64_t>("epochUs", epochUs, readAttributeEpochUSDefaultValue));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestWriteAttributeEpochUsDefaultValue_81()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        uint64_t epochUsArgument;
+        epochUsArgument = readAttributeEpochUSDefaultValue;
+
+        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::EpochUs::TypeInfo>(
+            epochUsArgument, this, OnSuccessCallback_81, OnFailureCallback_81);
+    }
+
+    void OnFailureResponse_81(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_81() { NextTest(); }
+
+    CHIP_ERROR TestReadAttributeEpochUsDefaultValue_82()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::EpochUs::TypeInfo>(this, OnSuccessCallback_82,
+                                                                                                      OnFailureCallback_82);
+    }
+
+    void OnFailureResponse_82(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_82(uint64_t epochUs)
+    {
+        VerifyOrReturn(CheckValue<uint64_t>("epochUs", epochUs, readAttributeEpochUSDefaultValue));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestReadAttributeEpochSDefaultValue_83()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::EpochS::TypeInfo>(this, OnSuccessCallback_83,
+                                                                                                     OnFailureCallback_83);
+    }
+
+    void OnFailureResponse_83(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_83(uint32_t epochS)
+    {
+        VerifyOrReturn(CheckValue<uint32_t>("epochS", epochS, 0UL));
+
+        readAttributeEpochSDefaultValue = epochS;
+        NextTest();
+    }
+
+    CHIP_ERROR TestWriteAttributeEpochSNotDefaultValue_84()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        uint32_t epochSArgument;
+        epochSArgument = 1UL;
+
+        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::EpochS::TypeInfo>(
+            epochSArgument, this, OnSuccessCallback_84, OnFailureCallback_84);
+    }
+
+    void OnFailureResponse_84(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_84() { NextTest(); }
+
+    CHIP_ERROR TestReadAttributeEpochSNotDefaultValue_85()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::EpochS::TypeInfo>(this, OnSuccessCallback_85,
+                                                                                                     OnFailureCallback_85);
+    }
+
+    void OnFailureResponse_85(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_85(uint32_t epochS)
+    {
+        VerifyOrReturn(CheckConstraintNotValue<uint32_t>("epochS", epochS, readAttributeEpochSDefaultValue));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestWriteAttributeEpochSDefaultValue_86()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        uint32_t epochSArgument;
+        epochSArgument = readAttributeEpochSDefaultValue;
+
+        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::EpochS::TypeInfo>(
+            epochSArgument, this, OnSuccessCallback_86, OnFailureCallback_86);
+    }
+
+    void OnFailureResponse_86(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_86() { NextTest(); }
+
+    CHIP_ERROR TestReadAttributeEpochSDefaultValue_87()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::EpochS::TypeInfo>(this, OnSuccessCallback_87,
+                                                                                                     OnFailureCallback_87);
+    }
+
+    void OnFailureResponse_87(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_87(uint32_t epochS)
+    {
+        VerifyOrReturn(CheckValue<uint32_t>("epochS", epochS, readAttributeEpochSDefaultValue));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestReadAttributeVendorIdDefaultValue_88()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::VendorId::TypeInfo>(this, OnSuccessCallback_88,
+                                                                                                       OnFailureCallback_88);
+    }
+
+    void OnFailureResponse_88(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_88(chip::VendorId vendorId)
+    {
+        VerifyOrReturn(CheckValue<chip::VendorId>("vendorId", vendorId, 0U));
+
+        readAttributeVendorIdDefaultValue = vendorId;
+        NextTest();
+    }
+
+    CHIP_ERROR TestWriteAttributeVendorIdNotDefaultValue_89()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        chip::VendorId vendorIdArgument;
+        vendorIdArgument = static_cast<chip::VendorId>(1);
+
+        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::VendorId::TypeInfo>(
+            vendorIdArgument, this, OnSuccessCallback_89, OnFailureCallback_89);
+    }
+
+    void OnFailureResponse_89(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_89() { NextTest(); }
+
+    CHIP_ERROR TestReadAttributeVendorIdNotDefaultValue_90()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::VendorId::TypeInfo>(this, OnSuccessCallback_90,
+                                                                                                       OnFailureCallback_90);
+    }
+
+    void OnFailureResponse_90(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_90(chip::VendorId vendorId)
+    {
+        VerifyOrReturn(CheckConstraintNotValue<chip::VendorId>("vendorId", vendorId, readAttributeVendorIdDefaultValue));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestWriteAttributeVendorIdDefaultValue_91()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        chip::VendorId vendorIdArgument;
+        vendorIdArgument = static_cast<chip::VendorId>(readAttributeVendorIdDefaultValue);
+
+        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::VendorId::TypeInfo>(
+            vendorIdArgument, this, OnSuccessCallback_91, OnFailureCallback_91);
+    }
+
+    void OnFailureResponse_91(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_91() { NextTest(); }
+
+    CHIP_ERROR TestReadAttributeVendorIdDefaultValue_92()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::VendorId::TypeInfo>(this, OnSuccessCallback_92,
+                                                                                                       OnFailureCallback_92);
+    }
+
+    void OnFailureResponse_92(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_92(chip::VendorId vendorId)
+    {
+        VerifyOrReturn(CheckValue<chip::VendorId>("vendorId", vendorId, readAttributeVendorIdDefaultValue));
+
+        NextTest();
+    }
 };
 
 class TestDescriptorCluster : public TestCommand
@@ -38368,6 +42000,7 @@ private:
         VerifyOrReturn(CheckValue<>("deviceList[0].type", iter.GetValue().type, 0UL));
         VerifyOrReturn(CheckValue<>("deviceList[0].revision", iter.GetValue().revision, 1U));
         VerifyOrReturn(CheckNoMoreListItems<decltype(deviceList)>("deviceList", iter, 1));
+
         NextTest();
     }
 
@@ -38423,6 +42056,7 @@ private:
         VerifyOrReturn(CheckNextListItemDecodes<decltype(serverList)>("serverList", iter, 17));
         VerifyOrReturn(CheckValue<chip::ClusterId>("serverList[17]", iter.GetValue(), 61444UL));
         VerifyOrReturn(CheckNoMoreListItems<decltype(serverList)>("serverList", iter, 18));
+
         NextTest();
     }
 
@@ -38442,6 +42076,7 @@ private:
     {
         auto iter = clientList.begin();
         VerifyOrReturn(CheckNoMoreListItems<decltype(clientList)>("clientList", iter, 0));
+
         NextTest();
     }
 
@@ -38465,6 +42100,7 @@ private:
         VerifyOrReturn(CheckNextListItemDecodes<decltype(partsList)>("partsList", iter, 1));
         VerifyOrReturn(CheckValue<chip::EndpointId>("partsList[1]", iter.GetValue(), 2U));
         VerifyOrReturn(CheckNoMoreListItems<decltype(partsList)>("partsList", iter, 2));
+
         NextTest();
     }
 };
@@ -38581,6 +42217,7 @@ private:
     void OnSuccessResponse_0(chip::CharSpan location)
     {
         VerifyOrReturn(CheckValueAsString("location", location, chip::CharSpan("", 0)));
+
         NextTest();
     }
 
@@ -38616,6 +42253,7 @@ private:
     void OnSuccessResponse_2(chip::CharSpan location)
     {
         VerifyOrReturn(CheckValueAsString("location", location, chip::CharSpan("us", 2)));
+
         NextTest();
     }
 
@@ -38910,6 +42548,7 @@ private:
         VerifyOrReturn(CheckValue<uint8_t>("status", status, 0));
 
         VerifyOrReturn(CheckValue<uint16_t>("groupId", groupId, 1U));
+
         NextTest();
     }
 
@@ -38942,6 +42581,7 @@ private:
         VerifyOrReturn(CheckValue<uint16_t>("groupId", groupId, 1U));
 
         VerifyOrReturn(CheckValueAsString("groupName", groupName, chip::CharSpan("Group #1", 8)));
+
         NextTest();
     }
 
@@ -39036,6 +42676,7 @@ private:
         VerifyOrReturn(CheckValue<uint16_t>("groupId", groupId, 1U));
 
         VerifyOrReturn(CheckValueAsString("groupName", groupName, chip::CharSpan("Group #1", 8)));
+
         NextTest();
     }
 
@@ -39066,6 +42707,7 @@ private:
         VerifyOrReturn(CheckValue<uint8_t>("status", status, 135));
 
         VerifyOrReturn(CheckValue<uint16_t>("groupId", groupId, 0U));
+
         NextTest();
     }
 
@@ -39096,6 +42738,7 @@ private:
         VerifyOrReturn(CheckValue<uint8_t>("status", status, 139));
 
         VerifyOrReturn(CheckValue<uint16_t>("groupId", groupId, 4U));
+
         NextTest();
     }
 
@@ -39128,6 +42771,7 @@ private:
         VerifyOrReturn(CheckValue<uint16_t>("groupId", groupId, 1U));
 
         VerifyOrReturn(CheckValueAsString("groupName", groupName, chip::CharSpan("Group #1", 8)));
+
         NextTest();
     }
 
@@ -39384,6 +43028,7 @@ private:
     {
         VerifyOrReturn(CheckConstraintType("supportedFabrics", "", "uint8"));
         VerifyOrReturn(CheckConstraintMinValue<uint8_t>("supportedFabrics", supportedFabrics, 4));
+
         NextTest();
     }
 
@@ -39403,6 +43048,7 @@ private:
     {
         VerifyOrReturn(CheckConstraintType("commissionedFabrics", "", "uint8"));
         VerifyOrReturn(CheckConstraintMinValue<uint8_t>("commissionedFabrics", commissionedFabrics, 1));
+
         NextTest();
     }
 
@@ -39422,6 +43068,7 @@ private:
     {
         VerifyOrReturn(CheckConstraintType("currentFabricIndex", "", "uint8"));
         VerifyOrReturn(CheckConstraintMinValue<chip::FabricIndex>("currentFabricIndex", currentFabricIndex, 1));
+
         NextTest();
     }
 };
@@ -39583,6 +43230,7 @@ private:
     void OnSuccessResponse_0(uint8_t currentMode)
     {
         VerifyOrReturn(CheckValue<uint8_t>("currentMode", currentMode, 0));
+
         NextTest();
     }
 
@@ -39601,6 +43249,7 @@ private:
     void OnSuccessResponse_1(uint8_t onMode)
     {
         VerifyOrReturn(CheckValue<uint8_t>("onMode", onMode, 0));
+
         NextTest();
     }
 
@@ -39619,6 +43268,7 @@ private:
     void OnSuccessResponse_2(uint8_t startUpMode)
     {
         VerifyOrReturn(CheckValue<uint8_t>("startUpMode", startUpMode, 0));
+
         NextTest();
     }
 
@@ -39637,6 +43287,7 @@ private:
     void OnSuccessResponse_3(chip::CharSpan description)
     {
         VerifyOrReturn(CheckValueAsString("description", description, chip::CharSpan("Coffee", 6)));
+
         NextTest();
     }
 
@@ -39670,6 +43321,7 @@ private:
         VerifyOrReturn(CheckValue<>("supportedModes[2].mode", iter.GetValue().mode, 7));
         VerifyOrReturn(CheckValue<>("supportedModes[2].semanticTag", iter.GetValue().semanticTag, 0UL));
         VerifyOrReturn(CheckNoMoreListItems<decltype(supportedModes)>("supportedModes", iter, 3));
+
         NextTest();
     }
 
@@ -39712,6 +43364,7 @@ private:
     void OnSuccessResponse_6(uint8_t currentMode)
     {
         VerifyOrReturn(CheckValue<uint8_t>("currentMode", currentMode, 4));
+
         NextTest();
     }
 
@@ -39869,6 +43522,7 @@ private:
     void OnSuccessResponse_1(chip::CharSpan location)
     {
         VerifyOrReturn(CheckValueAsString("location", location, chip::CharSpan("us", 2)));
+
         NextTest();
     }
 
@@ -39904,6 +43558,7 @@ private:
     void OnSuccessResponse_3(chip::CharSpan location)
     {
         VerifyOrReturn(CheckValueAsString("location", location, chip::CharSpan("", 0)));
+
         NextTest();
     }
 };
@@ -40015,6 +43670,7 @@ private:
     void OnSuccessResponse_0(uint64_t currentHeapFree)
     {
         VerifyOrReturn(CheckConstraintType("currentHeapFree", "", "uint64"));
+
         NextTest();
     }
 
@@ -40036,6 +43692,7 @@ private:
     void OnSuccessResponse_1(uint64_t currentHeapUsed)
     {
         VerifyOrReturn(CheckConstraintType("currentHeapUsed", "", "uint64"));
+
         NextTest();
     }
 
@@ -40057,6 +43714,7 @@ private:
     void OnSuccessResponse_2(uint64_t currentHeapHighWatermark)
     {
         VerifyOrReturn(CheckConstraintType("currentHeapHighWatermark", "", "uint64"));
+
         NextTest();
     }
 };
@@ -40395,6 +44053,7 @@ private:
         mReceivedReport_4 = true;
 
         VerifyOrReturn(CheckValue<bool>("onOff", onOff, true));
+
         NextTest();
     }
 
@@ -40438,6 +44097,7 @@ private:
         mReceivedReport_6 = true;
 
         VerifyOrReturn(CheckValue<bool>("onOff", onOff, false));
+
         NextTest();
     }
 };
@@ -40551,6 +44211,7 @@ void registerCommandsTests(Commands & commands)
         make_unique<TestConstraints>(),
         make_unique<TestDelayCommands>(),
         make_unique<TestLogCommands>(),
+        make_unique<TestSaveAs>(),
         make_unique<TestDescriptorCluster>(),
         make_unique<TestBasicInformation>(),
         make_unique<TestIdentifyCluster>(),


### PR DESCRIPTION
#### Problem

In various tests, some steps require to store the values of attributes in previous steps to be used in subsequent steps , so need this support in YAML as well.

#### Change overview
 * Add `saveAs` keyword into the YAML syntax
 * Update c++ and objective-c template to generates some code for it

#### Testing
`TestSaveAs.yaml` has been added.

#fixes #10816