### PR TITLE
Quick Fix CharString to be String type.

### DIFF
--- a/examples/chip-tool/commands/common/Command.cpp
+++ b/examples/chip-tool/commands/common/Command.cpp
@@ -389,7 +389,7 @@ size_t Command::AddArgument(const char * name, const char * value, bool optional
 size_t Command::AddArgument(const char * name, char ** value, bool optional)
 {
     Argument arg;
-    arg.type     = ArgumentType::CharString;
+    arg.type     = ArgumentType::String;
     arg.name     = name;
     arg.value    = reinterpret_cast<void *>(value);
     arg.optional = optional;


### PR DESCRIPTION
#### Problem
When running chip-tool commands that have char * as a param, there is a crash reported as follows:
munmap_chunk(): invalid pointer. #11798 

#### Change overview
Changed the char * param in arguments from CharString to String type. 

#### Testing
Tested without change and reproduced issue. 
