### PR TITLE
Added steps to validate CASE Authentication Tags (CAT)

### DIFF
--- a/src/access/SubjectDescriptor.h
+++ b/src/access/SubjectDescriptor.h
@@ -32,6 +32,12 @@ union SubjectId
 {
     PasscodeId passcode;
     NodeId node;
+    uint32_t cat_raw;
+    struct
+    {
+        uint16_t version;
+        uint16_t id;
+    } cat;
     GroupId group;
 };
 

--- a/src/access/tests/TestAccessControl.cpp
+++ b/src/access/tests/TestAccessControl.cpp
@@ -66,7 +66,7 @@ constexpr SubjectId Node(NodeId node)
 
 constexpr SubjectId CAT(uint16_t catId, uint16_t catVersion)
 {
-    return { .node = kTestSubjectCAT | (catId << 16) | catVersion };
+    return { .node = kTestSubjectCAT | (static_cast<uint64_t>(catId) << 16) | catVersion };
 }
 
 constexpr SubjectId Group(GroupId group)
@@ -280,7 +280,7 @@ public:
             else if ((p->node & kTestSubjectCATMask) == kTestSubjectCAT)
             {
                 if (((p->node & ~kTestSubjectCATMask) >> 16) == subject.cat.id &&
-                    (p->node & ~kTestSubjectMask) <= subject.cat.version)
+                    (p->node & ~kTestSubjectCATVersionMask) <= subject.cat.version)
                 {
                     return true;
                 }


### PR DESCRIPTION
**Problem**
* ACL currently does not validate CASE Authentication Tags (CAT) Access Control Requests (Issue [#10243](https://github.com/project-chip/connectedhomeip/issues/10243)).

**Change overview**
* Added step to validate CASE Authentication Tags.
* Added new test cases for checking valid/non-valid CAT access requests.

Testing
* Added Matter Unit Tests