### PR TITLE
Allow build-examples to build darwin-x64-rpc-console

### DIFF
--- a/.github/workflows/cirque.yaml
+++ b/.github/workflows/cirque.yaml
@@ -104,7 +104,8 @@ jobs:
                     chip_build_tests=false \
                     enable_host_gcc_build=true \
                     enable_host_gcc_mbedtls_build=false \
-                    enable_host_clang_build = false
+                    enable_host_clang_build = false \
+                    enable_fake_tests = false
             - name: Run Tests
               timeout-minutes: 25
               run: |

--- a/.github/workflows/cirque.yaml
+++ b/.github/workflows/cirque.yaml
@@ -104,8 +104,8 @@ jobs:
                     chip_build_tests=false \
                     enable_host_gcc_build=true \
                     enable_host_gcc_mbedtls_build=false \
-                    enable_host_clang_build = false \
-                    enable_fake_tests = false
+                    enable_host_clang_build=false \
+                    enable_fake_tests=false
             - name: Run Tests
               timeout-minutes: 25
               run: |

--- a/build/toolchain/host/BUILD.gn
+++ b/build/toolchain/host/BUILD.gn
@@ -33,12 +33,14 @@ gcc_toolchain("${host_os}_${host_cpu}_clang") {
   }
 }
 
-gcc_toolchain("fake_${host_cpu}_gcc") {
-  toolchain_args = {
-    current_os = host_os
-    current_os = host_os
-    current_cpu = host_cpu
-    is_clang = false
-    chip_fake_platform = true
+if (defined(chip_fake_plaform)) {
+  gcc_toolchain("fake_${host_cpu}_gcc") {
+    toolchain_args = {
+      current_os = host_os
+      current_os = host_os
+      current_cpu = host_cpu
+      is_clang = false
+      chip_fake_platform = true
+    }
   }
 }


### PR DESCRIPTION
#### Problem
build-examples.py fails to build rpc-console on darwin since fake_platform is not declared as an argument

#### Change overview
make the fake platform available only if the corresponding device.gni declare has been included.

#### Testing
ran `./scripts/build/build_examples.py --target-glob '*rpc-console'  build` on darwin
