### PR TITLE
[Group] Add Group msg yaml test case

### DIFF
--- a/examples/chip-tool/templates/partials/test_cluster.zapt
+++ b/examples/chip-tool/templates/partials/test_cluster.zapt
@@ -138,7 +138,11 @@ class {{filename}}: public TestCommand
 
     CHIP_ERROR {{>testCommand}}()
     {
+        {{#if isGroupCommand}}
+        const chip::GroupId groupId = {{groupId}};
+        {{else}}
         const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : {{endpoint}};
+        {{/if}}
         {{#if isCommand}}
         using RequestType = chip::app::Clusters::{{asUpperCamelCase cluster}}::Commands::{{asUpperCamelCase command}}::Type;
 
@@ -159,7 +163,11 @@ class {{filename}}: public TestCommand
         {{#unless async}}return CHIP_NO_ERROR;{{/unless}}
         {{else}}
         chip::Controller::{{asUpperCamelCase cluster}}ClusterTest cluster;
+        {{#if isGroupCommand}}
+        cluster.Associate(groupId, mDevice);
+        {{else}}
         cluster.Associate(mDevice, endpoint);
+        {{/if}}
 
         {{#chip_tests_item_parameters}}
         {{zapTypeToEncodableClusterObjectType type ns=parent.cluster}} {{asLowerCamelCase name}}Argument;

--- a/examples/chip-tool/templates/partials/test_cluster.zapt
+++ b/examples/chip-tool/templates/partials/test_cluster.zapt
@@ -164,7 +164,7 @@ class {{filename}}: public TestCommand
         {{else}}
         chip::Controller::{{asUpperCamelCase cluster}}ClusterTest cluster;
         {{#if isGroupCommand}}
-        cluster.Associate(groupId, mDevice);
+        cluster.AssociateWithGroup(mDevice, groupId);
         {{else}}
         cluster.Associate(mDevice, endpoint);
         {{/if}}

--- a/examples/chip-tool/templates/tests.js
+++ b/examples/chip-tool/templates/tests.js
@@ -186,6 +186,7 @@ function getTests()
     'TestIdentifyCluster',
     'TestOperationalCredentialsCluster',
     'TestModeSelectCluster',
+    'TestGroupMessaging',
   ];
 
   const SoftwareDiagnostics = [

--- a/src/app/tests/suites/TestGroupMessaging.yaml
+++ b/src/app/tests/suites/TestGroupMessaging.yaml
@@ -1,0 +1,54 @@
+# Copyright (c) 2021 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Basic Group Messaging Tests
+
+config:
+    cluster: "Basic"
+    endpoint: 0
+
+tests:
+    #TODO : Add Group membership command when implemented Issue #11077
+    # - label: "Add device to Group"
+    #   command: "TODO"
+
+    - label: "Group Write Attribute"
+      command: "writeAttribute"
+      attribute: "location"
+      disabled: true
+      groupId: "1234"
+      arguments:
+          value: "us"
+
+    - label: "Read back Attribute"
+      command: "readAttribute"
+      attribute: "location"
+      disabled: true
+      response:
+          value: "us"
+
+    - label: "Restore initial location value"
+      command: "writeAttribute"
+      attribute: "location"
+      groupId: "1234"
+      disabled: true
+      arguments:
+          value: ""
+
+    - label: "Read back Attribute"
+      command: "readAttribute"
+      attribute: "location"
+      disabled: true
+      response:
+          value: ""

--- a/src/app/zap-templates/common/ClusterTestGeneration.js
+++ b/src/app/zap-templates/common/ClusterTestGeneration.js
@@ -33,6 +33,7 @@ const { asUpperCamelCase }              = require(basePath + 'src/app/zap-templa
 
 const kClusterName       = 'cluster';
 const kEndpointName      = 'endpoint';
+const kGroupId           = 'groupId';
 const kCommandName       = 'command';
 const kWaitCommandName   = 'wait';
 const kIndexName         = 'index';
@@ -117,6 +118,10 @@ function setDefaultTypeForCommand(test)
     test.commandName      = 'Write';
     test.isAttribute      = true;
     test.isWriteAttribute = true;
+    if ((kGroupId in test)) {
+      test.isGroupCommand = true;
+      test.groupId        = parseInt(test[kGroupId], 10);
+    }
     break;
 
   case 'subscribeAttribute':

--- a/src/controller/CHIPCluster.cpp
+++ b/src/controller/CHIPCluster.cpp
@@ -42,10 +42,11 @@ CHIP_ERROR ClusterBase::Associate(DeviceProxy * device, EndpointId endpoint)
     return err;
 }
 
-CHIP_ERROR ClusterBase::Associate(GroupId groupId, DeviceProxy * device)
+CHIP_ERROR ClusterBase::AssociateWithGroup(DeviceProxy * device, GroupId groupId)
 {
+    // TODO Update this function to work in all possible conditions Issue #11850
+
     CHIP_ERROR err = CHIP_NO_ERROR;
-    // TODO: Check if the device supports mCluster at the requested endpoint
 
     mDevice = device;
     if (mDevice->GetSecureSession().HasValue())

--- a/src/controller/CHIPCluster.cpp
+++ b/src/controller/CHIPCluster.cpp
@@ -42,6 +42,37 @@ CHIP_ERROR ClusterBase::Associate(DeviceProxy * device, EndpointId endpoint)
     return err;
 }
 
+CHIP_ERROR ClusterBase::Associate(GroupId groupId, DeviceProxy * device)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    // TODO: Check if the device supports mCluster at the requested endpoint
+
+    mDevice = device;
+    if (mDevice->GetSecureSession().HasValue())
+    {
+        // Local copy to preserve original SessionHandle for future Unicast communication.
+        SessionHandle session = mDevice->GetSecureSession().Value();
+        session.SetGroupId(groupId);
+        mSessionHandle.SetValue(session);
+
+        // Sanity check
+        if (!mSessionHandle.Value().IsGroupSession())
+        {
+            err = CHIP_ERROR_INCORRECT_STATE;
+        }
+    }
+    else
+    {
+        // something fishy is going on
+        err = CHIP_ERROR_INCORRECT_STATE;
+    }
+
+    // Set to 0 for now.
+    mEndpoint = 0;
+
+    return err;
+}
+
 void ClusterBase::Dissociate()
 {
     mDevice = nullptr;

--- a/src/controller/CHIPCluster.h
+++ b/src/controller/CHIPCluster.h
@@ -51,7 +51,7 @@ public:
     virtual ~ClusterBase() {}
 
     CHIP_ERROR Associate(DeviceProxy * device, EndpointId endpoint);
-    CHIP_ERROR Associate(GroupId groupId, DeviceProxy * device);
+    CHIP_ERROR AssociateWithGroup(DeviceProxy * device, GroupId groupId);
 
     void Dissociate();
 

--- a/src/controller/CHIPCluster.h
+++ b/src/controller/CHIPCluster.h
@@ -51,6 +51,7 @@ public:
     virtual ~ClusterBase() {}
 
     CHIP_ERROR Associate(DeviceProxy * device, EndpointId endpoint);
+    CHIP_ERROR Associate(GroupId groupId, DeviceProxy * device);
 
     void Dissociate();
 
@@ -110,8 +111,9 @@ public:
             }
         };
 
-        return chip::Controller::WriteAttribute<AttrType>(mDevice->GetSecureSession().Value(), mEndpoint, clusterId, attributeId,
-                                                          requestData, onSuccessCb, onFailureCb);
+        return chip::Controller::WriteAttribute<AttrType>((mSessionHandle.HasValue()) ? mSessionHandle.Value()
+                                                                                      : mDevice->GetSecureSession().Value(),
+                                                          mEndpoint, clusterId, attributeId, requestData, onSuccessCb, onFailureCb);
     }
 
     template <typename AttributeInfo>
@@ -179,6 +181,7 @@ protected:
     const ClusterId mClusterId;
     DeviceProxy * mDevice;
     EndpointId mEndpoint;
+    chip::Optional<SessionHandle> mSessionHandle;
 };
 
 } // namespace Controller

--- a/src/controller/WriteInteraction.h
+++ b/src/controller/WriteInteraction.h
@@ -97,8 +97,18 @@ CHIP_ERROR WriteAttribute(SessionHandle sessionHandle, chip::EndpointId endpoint
     VerifyOrReturnError(callback != nullptr, CHIP_ERROR_NO_MEMORY);
 
     ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle, callback.get()));
-    ReturnErrorOnFailure(
-        handle.EncodeAttributeWritePayload(chip::app::AttributePathParams(endpointId, clusterId, attributeId), requestData));
+    if (sessionHandle.IsGroupSession())
+    {
+        // TODO : Issue #11604
+        return CHIP_ERROR_NOT_IMPLEMENTED;
+        // ReturnErrorOnFailure(
+        // handle.EncodeAttributeWritePayload(chip::app::AttributePathParams(clusterId, attributeId), requestData));
+    }
+    else
+    {
+        ReturnErrorOnFailure(
+            handle.EncodeAttributeWritePayload(chip::app::AttributePathParams(endpointId, clusterId, attributeId), requestData));
+    }
     ReturnErrorOnFailure(handle.SendWriteRequest(sessionHandle));
 
     callback.release();

--- a/src/darwin/Framework/CHIP/templates/tests.js
+++ b/src/darwin/Framework/CHIP/templates/tests.js
@@ -168,6 +168,7 @@ function getTests()
     'TestIdentifyCluster',
     'TestOperationalCredentialsCluster',
     'TestModeSelectCluster',
+    'TestGroupMessaging',
   ];
 
   const SoftwareDiagnostics = [

--- a/src/transport/SessionHandle.h
+++ b/src/transport/SessionHandle.h
@@ -53,6 +53,7 @@ public:
     bool HasFabricIndex() const { return (mFabric != kUndefinedFabricIndex); }
     FabricIndex GetFabricIndex() const { return mFabric; }
     void SetFabricIndex(FabricIndex fabricId) { mFabric = fabricId; }
+    void SetGroupId(GroupId groupId) { mGroupId.SetValue(groupId); }
 
     bool operator==(const SessionHandle & that) const
     {

--- a/zzz_generated/chip-tool/zap-generated/test/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/test/Commands.h
@@ -36107,6 +36107,54 @@ private:
     void OnSuccessResponse_7() { ThrowSuccessResponse(); }
 };
 
+class TestGroupMessaging : public TestCommand
+{
+public:
+    TestGroupMessaging() : TestCommand("TestGroupMessaging"), mTestIndex(0) {}
+
+    /////////// TestCommand Interface /////////
+    void NextTest() override
+    {
+        CHIP_ERROR err = CHIP_NO_ERROR;
+
+        if (0 == mTestIndex)
+        {
+            ChipLogProgress(chipTool, " **** Test Start: TestGroupMessaging\n");
+        }
+
+        if (mTestCount == mTestIndex)
+        {
+            ChipLogProgress(chipTool, " **** Test Complete: TestGroupMessaging\n");
+            SetCommandExitStatus(CHIP_NO_ERROR);
+            return;
+        }
+
+        Wait();
+
+        // Ensure we increment mTestIndex before we start running the relevant
+        // command.  That way if we lose the timeslice after we send the message
+        // but before our function call returns, we won't end up with an
+        // incorrect mTestIndex value observed when we get the response.
+        switch (mTestIndex++)
+        {
+        }
+
+        if (CHIP_NO_ERROR != err)
+        {
+            ChipLogError(chipTool, " ***** Test Failure: %s\n", chip::ErrorStr(err));
+            SetCommandExitStatus(err);
+        }
+    }
+
+private:
+    std::atomic_uint16_t mTestIndex;
+    const uint16_t mTestCount = 0;
+
+    //
+    // Tests methods
+    //
+};
+
 class Test_TC_DIAGSW_1_1 : public TestCommand
 {
 public:
@@ -36658,6 +36706,7 @@ void registerCommandsTests(Commands & commands)
         make_unique<TestIdentifyCluster>(),
         make_unique<TestOperationalCredentialsCluster>(),
         make_unique<TestModeSelectCluster>(),
+        make_unique<TestGroupMessaging>(),
         make_unique<Test_TC_DIAGSW_1_1>(),
         make_unique<TestSubscribe_OnOff>(),
     };


### PR DESCRIPTION
#### Problem
Fix #11389 

Also partial fix of #11078 since the `ClusterBase::Associate` method was changed for group instantiation.

#### Change overview
Add the group communication yaml test case as discussed with @bzbarsky-apple and @vivien-apple

Still needs #3377 , #11597 #11604 before enabling the test case.

#### Testing
Tested with the test case added until we reached the coded failure point.
Then the test case was disabled to prevent CI failure.
