### PR TITLE
Cleanup IM messagedef

### DIFF
--- a/src/app/MessageDef/ArrayParser.cpp
+++ b/src/app/MessageDef/ArrayParser.cpp
@@ -24,7 +24,7 @@ CHIP_ERROR ArrayParser::Init(const TLV::TLVReader & aReader)
 {
     mReader.Init(aReader);
     VerifyOrReturnError(TLV::kTLVType_Array == mReader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnLogErrorOnFailure(mReader.EnterContainer(mOuterContainerType));
+    ReturnErrorOnFailure(mReader.EnterContainer(mOuterContainerType));
     return CHIP_NO_ERROR;
 }
 } // namespace app

--- a/src/app/MessageDef/Builder.cpp
+++ b/src/app/MessageDef/Builder.cpp
@@ -54,25 +54,11 @@ void Builder::ResetError(CHIP_ERROR aErr)
 void Builder::EndOfContainer()
 {
     // skip if error has already been set
-    SuccessOrExit(mError);
-
-    mError = mpWriter->EndContainer(mOuterContainerType);
-    SuccessOrExit(mError);
-
+    ReturnOnFailure(mError);
+    ReturnOnFailure(mError = mpWriter->EndContainer(mOuterContainerType));
     // we've just closed properly
     // mark it so we do not panic when the build object destructor is called
     mOuterContainerType = chip::TLV::kTLVType_NotSpecified;
-
-exit:;
-}
-
-CHIP_ERROR Builder::InitAnonymousStructure(chip::TLV::TLVWriter * const apWriter)
-{
-    mpWriter            = apWriter;
-    mOuterContainerType = chip::TLV::kTLVType_NotSpecified;
-    mError              = mpWriter->StartContainer(chip::TLV::AnonymousTag, chip::TLV::kTLVType_Structure, mOuterContainerType);
-
-    return mError;
 }
 } // namespace app
 } // namespace chip

--- a/src/app/MessageDef/EventFilterIB.cpp
+++ b/src/app/MessageDef/EventFilterIB.cpp
@@ -57,7 +57,7 @@ CHIP_ERROR EventFilterIB::Parser::CheckSchemaValidity() const
 #if CHIP_DETAIL_LOGGING
             {
                 NodeId node;
-                ReturnLogErrorOnFailure(reader.Get(node));
+                ReturnErrorOnFailure(reader.Get(node));
                 PRETTY_PRINT("\tNode = 0x%" PRIx64 ",", node);
             }
 #endif // CHIP_DETAIL_LOGGING
@@ -69,7 +69,7 @@ CHIP_ERROR EventFilterIB::Parser::CheckSchemaValidity() const
 #if CHIP_DETAIL_LOGGING
             {
                 uint64_t eventMin;
-                ReturnLogErrorOnFailure(reader.Get(eventMin));
+                ReturnErrorOnFailure(reader.Get(eventMin));
                 PRETTY_PRINT("\tEventMin = 0x%" PRIx64 ",", eventMin);
             }
 #endif // CHIP_DETAIL_LOGGING

--- a/src/app/MessageDef/InvokeRequestMessage.cpp
+++ b/src/app/MessageDef/InvokeRequestMessage.cpp
@@ -25,14 +25,6 @@
 
 namespace chip {
 namespace app {
-CHIP_ERROR InvokeRequestMessage::Parser::Init(const TLV::TLVReader & aReader)
-{
-    mReader.Init(aReader);
-    VerifyOrReturnError(TLV::kTLVType_Structure == mReader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(mReader.EnterContainer(mOuterContainerType));
-    return CHIP_NO_ERROR;
-}
-
 #if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
 CHIP_ERROR InvokeRequestMessage::Parser::CheckSchemaValidity() const
 {

--- a/src/app/MessageDef/InvokeRequestMessage.h
+++ b/src/app/MessageDef/InvokeRequestMessage.h
@@ -41,15 +41,6 @@ enum class Tag : uint8_t
 class Parser : public StructParser
 {
 public:
-    /**
-     *  @brief Initialize the parser object with TLVReader
-     *
-     *  @param [in] aReader A pointer to a TLVReader, which should point to the beginning of this request
-     *
-     *  @return #CHIP_NO_ERROR on success
-     */
-    CHIP_ERROR Init(const TLV::TLVReader & aReader);
-
 #if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
     /**
      *  @brief Roughly verify the message is correctly formed

--- a/src/app/MessageDef/ListParser.cpp
+++ b/src/app/MessageDef/ListParser.cpp
@@ -24,7 +24,7 @@ CHIP_ERROR ListParser::Init(const TLV::TLVReader & aReader)
 {
     mReader.Init(aReader);
     VerifyOrReturnError(TLV::kTLVType_List == mReader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnLogErrorOnFailure(mReader.EnterContainer(mOuterContainerType));
+    ReturnErrorOnFailure(mReader.EnterContainer(mOuterContainerType));
     return CHIP_NO_ERROR;
 }
 } // namespace app

--- a/src/app/MessageDef/ReadRequestMessage.cpp
+++ b/src/app/MessageDef/ReadRequestMessage.cpp
@@ -33,22 +33,6 @@ using namespace chip::TLV;
 
 namespace chip {
 namespace app {
-CHIP_ERROR ReadRequestMessage::Parser::Init(const chip::TLV::TLVReader & aReader)
-{
-    CHIP_ERROR err = CHIP_NO_ERROR;
-
-    // make a copy of the reader here
-    mReader.Init(aReader);
-
-    VerifyOrExit(chip::TLV::kTLVType_Structure == mReader.GetType(), err = CHIP_ERROR_WRONG_TLV_TYPE);
-
-    err = mReader.EnterContainer(mOuterContainerType);
-
-exit:
-
-    return err;
-}
-
 #if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
 CHIP_ERROR ReadRequestMessage::Parser::CheckSchemaValidity() const
 {
@@ -222,11 +206,6 @@ exit:
 CHIP_ERROR ReadRequestMessage::Parser::GetEventNumber(uint64_t * const apEventNumber) const
 {
     return GetUnsignedInteger(kCsTag_EventNumber, apEventNumber);
-}
-
-CHIP_ERROR ReadRequestMessage::Builder::Init(chip::TLV::TLVWriter * const apWriter)
-{
-    return InitAnonymousStructure(apWriter);
 }
 
 AttributePathIBs::Builder & ReadRequestMessage::Builder::CreateAttributePathListBuilder()

--- a/src/app/MessageDef/ReadRequestMessage.h
+++ b/src/app/MessageDef/ReadRequestMessage.h
@@ -48,17 +48,9 @@ enum
     kCsTag_EventNumber              = 3,
 };
 
-class Parser : public chip::app::Parser
+class Parser : public StructParser
 {
 public:
-    /**
-     *  @brief Initialize the parser object with TLVReader
-     *
-     *  @param [in] aReader A pointer to a TLVReader, which should point to the beginning of this request
-     *
-     *  @return #CHIP_NO_ERROR on success
-     */
-    CHIP_ERROR Init(const chip::TLV::TLVReader & aReader);
 #if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
     /**
      *  @brief Roughly verify the message is correctly formed
@@ -117,18 +109,9 @@ public:
     CHIP_ERROR GetEventNumber(uint64_t * const apEventNumber) const;
 };
 
-class Builder : public chip::app::Builder
+class Builder : public StructBuilder
 {
 public:
-    /**
-     *  @brief Initialize a ReadRequestMessage::Builder for writing into a TLV stream
-     *
-     *  @param [in] apWriter    A pointer to TLVWriter
-     *
-     *  @return #CHIP_NO_ERROR on success
-     */
-    CHIP_ERROR Init(chip::TLV::TLVWriter * const apWriter);
-
     /**
      *  @brief Initialize a AttributePathIBs::Builder for writing into the TLV stream
      *

--- a/src/app/MessageDef/StatusIB.cpp
+++ b/src/app/MessageDef/StatusIB.cpp
@@ -36,15 +36,6 @@ using namespace chip::TLV;
 
 namespace chip {
 namespace app {
-CHIP_ERROR StatusIB::Parser::Init(const TLV::TLVReader & aReader)
-{
-    // make a copy of the reader here
-    mReader.Init(aReader);
-    VerifyOrReturnError(TLV::kTLVType_Structure == mReader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(mReader.EnterContainer(mOuterContainerType));
-    return CHIP_NO_ERROR;
-}
-
 CHIP_ERROR StatusIB::Parser::DecodeStatusIB(StatusIB & aStatusIB) const
 {
     TLV::TLVReader reader;

--- a/src/app/MessageDef/StatusIB.h
+++ b/src/app/MessageDef/StatusIB.h
@@ -55,15 +55,6 @@ struct StatusIB
     class Parser : public StructParser
     {
     public:
-        /**
-         *  @brief Initialize the parser object with TLVReader
-         *
-         *  @param [in] aReader A pointer to a TLVReader, which should point to the beginning of this StatusIB
-         *
-         *  @return #CHIP_NO_ERROR on success
-         */
-        CHIP_ERROR Init(const TLV::TLVReader & aReader);
-
 #if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
         /**
          *  @brief Roughly verify the message is correctly formed

--- a/src/app/MessageDef/StatusResponseMessage.cpp
+++ b/src/app/MessageDef/StatusResponseMessage.cpp
@@ -19,15 +19,6 @@
 
 namespace chip {
 namespace app {
-CHIP_ERROR StatusResponseMessage::Parser::Init(const TLV::TLVReader & aReader)
-{
-    // make a copy of the reader here
-    mReader.Init(aReader);
-    VerifyOrReturnLogError(TLV::kTLVType_Structure == mReader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnLogErrorOnFailure(mReader.EnterContainer(mOuterContainerType));
-    return CHIP_NO_ERROR;
-}
-
 #if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
 CHIP_ERROR StatusResponseMessage::Parser::CheckSchemaValidity() const
 {
@@ -42,23 +33,23 @@ CHIP_ERROR StatusResponseMessage::Parser::CheckSchemaValidity() const
 
     while (CHIP_NO_ERROR == (err = reader.Next()))
     {
-        VerifyOrReturnLogError(TLV::IsContextTag(reader.GetTag()), CHIP_ERROR_INVALID_TLV_TAG);
+        VerifyOrReturnError(TLV::IsContextTag(reader.GetTag()), CHIP_ERROR_INVALID_TLV_TAG);
         switch (TLV::TagNumFromTag(reader.GetTag()))
         {
         case kCsTag_Status:
-            VerifyOrReturnLogError(!statusTagPresence, CHIP_ERROR_INVALID_TLV_TAG);
+            VerifyOrReturnError(!statusTagPresence, CHIP_ERROR_INVALID_TLV_TAG);
             statusTagPresence = true;
-            VerifyOrReturnLogError(TLV::kTLVType_UnsignedInteger == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
+            VerifyOrReturnError(TLV::kTLVType_UnsignedInteger == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
 #if CHIP_DETAIL_LOGGING
             {
                 uint16_t status;
-                ReturnLogErrorOnFailure(reader.Get(status));
+                ReturnErrorOnFailure(reader.Get(status));
                 PRETTY_PRINT("\tStatus = 0x%" PRIx16 ",", status);
             }
 #endif // CHIP_DETAIL_LOGGING
             break;
         default:
-            ReturnLogErrorOnFailure(CHIP_ERROR_INVALID_TLV_TAG);
+            ReturnErrorOnFailure(CHIP_ERROR_INVALID_TLV_TAG);
         }
     }
     PRETTY_PRINT("}");
@@ -68,7 +59,7 @@ CHIP_ERROR StatusResponseMessage::Parser::CheckSchemaValidity() const
     {
         err = CHIP_NO_ERROR;
     }
-    ReturnLogErrorOnFailure(err);
+    ReturnErrorOnFailure(err);
     return reader.ExitContainer(mOuterContainerType);
 }
 #endif // CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
@@ -79,11 +70,6 @@ CHIP_ERROR StatusResponseMessage::Parser::GetStatus(Protocols::InteractionModel:
     CHIP_ERROR err  = GetUnsignedInteger(kCsTag_Status, &status);
     aStatus         = static_cast<Protocols::InteractionModel::Status>(status);
     return err;
-}
-
-CHIP_ERROR StatusResponseMessage::Builder::Init(TLV::TLVWriter * const apWriter)
-{
-    return InitAnonymousStructure(apWriter);
 }
 
 StatusResponseMessage::Builder & StatusResponseMessage::Builder::Status(const Protocols::InteractionModel::Status aStatus)

--- a/src/app/MessageDef/StatusResponseMessage.h
+++ b/src/app/MessageDef/StatusResponseMessage.h
@@ -16,8 +16,8 @@
  */
 
 #pragma once
-#include "Builder.h"
-#include "Parser.h"
+#include "StructBuilder.h"
+#include "StructParser.h"
 #include <app/AppBuildConfig.h>
 #include <app/util/basic-types.h>
 #include <lib/core/CHIPCore.h>
@@ -34,13 +34,9 @@ enum
     kCsTag_Status = 0,
 };
 
-class Parser : public app::Parser
+class Parser : public StructParser
 {
 public:
-    /**
-     *  @param [in] aReader A pointer to a TLVReader, which should point to the beginning of this response
-     */
-    CHIP_ERROR Init(const TLV::TLVReader & aReader);
 #if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
     /**
      *  @brief Roughly verify the message is correctly formed
@@ -67,10 +63,9 @@ public:
     CHIP_ERROR GetStatus(Protocols::InteractionModel::Status & aStatus) const;
 };
 
-class Builder : public app::Builder
+class Builder : public StructBuilder
 {
 public:
-    CHIP_ERROR Init(TLV::TLVWriter * const apWriter);
     StatusResponseMessage::Builder & Status(const Protocols::InteractionModel::Status aStatus);
 };
 } // namespace StatusResponseMessage

--- a/src/app/MessageDef/StructParser.cpp
+++ b/src/app/MessageDef/StructParser.cpp
@@ -22,7 +22,7 @@ CHIP_ERROR StructParser::Init(const TLV::TLVReader & aReader)
 {
     mReader.Init(aReader);
     VerifyOrReturnError(TLV::kTLVType_Structure == mReader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnLogErrorOnFailure(mReader.EnterContainer(mOuterContainerType));
+    ReturnErrorOnFailure(mReader.EnterContainer(mOuterContainerType));
     return CHIP_NO_ERROR;
 }
 } // namespace app

--- a/src/app/MessageDef/SubscribeRequestMessage.cpp
+++ b/src/app/MessageDef/SubscribeRequestMessage.cpp
@@ -19,16 +19,6 @@
 
 namespace chip {
 namespace app {
-CHIP_ERROR SubscribeRequestMessage::Parser::Init(const chip::TLV::TLVReader & aReader)
-{
-    // make a copy of the reader here
-    mReader.Init(aReader);
-
-    VerifyOrReturnLogError(chip::TLV::kTLVType_Structure == mReader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnLogErrorOnFailure(mReader.EnterContainer(mOuterContainerType));
-    return CHIP_NO_ERROR;
-}
-
 #if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
 CHIP_ERROR SubscribeRequestMessage::Parser::CheckSchemaValidity() const
 {
@@ -46,106 +36,106 @@ CHIP_ERROR SubscribeRequestMessage::Parser::CheckSchemaValidity() const
 
     while (CHIP_NO_ERROR == (err = reader.Next()))
     {
-        VerifyOrReturnLogError(chip::TLV::IsContextTag(reader.GetTag()), CHIP_ERROR_INVALID_TLV_TAG);
+        VerifyOrReturnError(chip::TLV::IsContextTag(reader.GetTag()), CHIP_ERROR_INVALID_TLV_TAG);
         switch (chip::TLV::TagNumFromTag(reader.GetTag()))
         {
         case kCsTag_AttributePathList:
-            VerifyOrReturnLogError(!(TagPresenceMask & (1 << kCsTag_AttributePathList)), CHIP_ERROR_INVALID_TLV_TAG);
+            VerifyOrReturnError(!(TagPresenceMask & (1 << kCsTag_AttributePathList)), CHIP_ERROR_INVALID_TLV_TAG);
             TagPresenceMask |= (1 << kCsTag_AttributePathList);
-            VerifyOrReturnLogError(chip::TLV::kTLVType_Array == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
+            VerifyOrReturnError(chip::TLV::kTLVType_Array == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
 
             AttributePathIBs.Init(reader);
 
             PRETTY_PRINT_INCDEPTH();
-            ReturnLogErrorOnFailure(AttributePathIBs.CheckSchemaValidity());
+            ReturnErrorOnFailure(AttributePathIBs.CheckSchemaValidity());
             PRETTY_PRINT_DECDEPTH();
             break;
         case kCsTag_EventPaths:
-            VerifyOrReturnLogError(!(TagPresenceMask & (1 << kCsTag_EventPaths)), CHIP_ERROR_INVALID_TLV_TAG);
+            VerifyOrReturnError(!(TagPresenceMask & (1 << kCsTag_EventPaths)), CHIP_ERROR_INVALID_TLV_TAG);
             TagPresenceMask |= (1 << kCsTag_EventPaths);
-            VerifyOrReturnLogError(chip::TLV::kTLVType_Array == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
+            VerifyOrReturnError(chip::TLV::kTLVType_Array == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
 
             eventPathList.Init(reader);
 
             PRETTY_PRINT_INCDEPTH();
 
-            ReturnLogErrorOnFailure(eventPathList.CheckSchemaValidity());
+            ReturnErrorOnFailure(eventPathList.CheckSchemaValidity());
 
             PRETTY_PRINT_DECDEPTH();
             break;
         case kCsTag_AttributeDataVersionList:
-            VerifyOrReturnLogError(!(TagPresenceMask & (1 << kCsTag_AttributeDataVersionList)), CHIP_ERROR_INVALID_TLV_TAG);
+            VerifyOrReturnError(!(TagPresenceMask & (1 << kCsTag_AttributeDataVersionList)), CHIP_ERROR_INVALID_TLV_TAG);
             TagPresenceMask |= (1 << kCsTag_AttributeDataVersionList);
-            VerifyOrReturnLogError(chip::TLV::kTLVType_Array == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
+            VerifyOrReturnError(chip::TLV::kTLVType_Array == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
 
             attributeDataVersionList.Init(reader);
 
             PRETTY_PRINT_INCDEPTH();
-            ReturnLogErrorOnFailure(attributeDataVersionList.CheckSchemaValidity());
+            ReturnErrorOnFailure(attributeDataVersionList.CheckSchemaValidity());
             PRETTY_PRINT_DECDEPTH();
             break;
         case kCsTag_EventNumber:
-            VerifyOrReturnLogError(!(TagPresenceMask & (1 << kCsTag_EventNumber)), CHIP_ERROR_INVALID_TLV_TAG);
+            VerifyOrReturnError(!(TagPresenceMask & (1 << kCsTag_EventNumber)), CHIP_ERROR_INVALID_TLV_TAG);
             TagPresenceMask |= (1 << kCsTag_EventNumber);
-            VerifyOrReturnLogError(chip::TLV::kTLVType_UnsignedInteger == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
+            VerifyOrReturnError(chip::TLV::kTLVType_UnsignedInteger == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
 #if CHIP_DETAIL_LOGGING
             {
                 uint64_t eventNumber;
-                ReturnLogErrorOnFailure(reader.Get(eventNumber));
+                ReturnErrorOnFailure(reader.Get(eventNumber));
                 PRETTY_PRINT("\tEventNumber = 0x%" PRIx64 ",", eventNumber);
             }
 #endif // CHIP_DETAIL_LOGGING
             break;
         case kCsTag_MinIntervalSeconds:
-            VerifyOrReturnLogError(!(TagPresenceMask & (1 << kCsTag_MinIntervalSeconds)), CHIP_ERROR_INVALID_TLV_TAG);
+            VerifyOrReturnError(!(TagPresenceMask & (1 << kCsTag_MinIntervalSeconds)), CHIP_ERROR_INVALID_TLV_TAG);
             TagPresenceMask |= (1 << kCsTag_MinIntervalSeconds);
-            VerifyOrReturnLogError(chip::TLV::kTLVType_UnsignedInteger == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
+            VerifyOrReturnError(chip::TLV::kTLVType_UnsignedInteger == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
 #if CHIP_DETAIL_LOGGING
             {
                 uint16_t minIntervalSeconds;
-                ReturnLogErrorOnFailure(reader.Get(minIntervalSeconds));
+                ReturnErrorOnFailure(reader.Get(minIntervalSeconds));
                 PRETTY_PRINT("\tMinIntervalSeconds = 0x%" PRIx16 ",", minIntervalSeconds);
             }
 #endif // CHIP_DETAIL_LOGGING
             break;
         case kCsTag_MaxIntervalSeconds:
-            VerifyOrReturnLogError(!(TagPresenceMask & (1 << kCsTag_MaxIntervalSeconds)), CHIP_ERROR_INVALID_TLV_TAG);
+            VerifyOrReturnError(!(TagPresenceMask & (1 << kCsTag_MaxIntervalSeconds)), CHIP_ERROR_INVALID_TLV_TAG);
             TagPresenceMask |= (1 << kCsTag_MaxIntervalSeconds);
-            VerifyOrReturnLogError(chip::TLV::kTLVType_UnsignedInteger == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
+            VerifyOrReturnError(chip::TLV::kTLVType_UnsignedInteger == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
 #if CHIP_DETAIL_LOGGING
             {
                 uint16_t maxIntervalSeconds;
-                ReturnLogErrorOnFailure(reader.Get(maxIntervalSeconds));
+                ReturnErrorOnFailure(reader.Get(maxIntervalSeconds));
                 PRETTY_PRINT("\tkMaxInterval = 0x%" PRIx16 ",", maxIntervalSeconds);
             }
 #endif // CHIP_DETAIL_LOGGING
             break;
         case kCsTag_KeepSubscriptions:
-            VerifyOrReturnLogError(!(TagPresenceMask & (1 << kCsTag_KeepSubscriptions)), CHIP_ERROR_INVALID_TLV_TAG);
+            VerifyOrReturnError(!(TagPresenceMask & (1 << kCsTag_KeepSubscriptions)), CHIP_ERROR_INVALID_TLV_TAG);
             TagPresenceMask |= (1 << kCsTag_KeepSubscriptions);
-            VerifyOrReturnLogError(chip::TLV::kTLVType_Boolean == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
+            VerifyOrReturnError(chip::TLV::kTLVType_Boolean == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
 #if CHIP_DETAIL_LOGGING
             {
                 bool keepSubscriptions;
-                ReturnLogErrorOnFailure(reader.Get(keepSubscriptions));
+                ReturnErrorOnFailure(reader.Get(keepSubscriptions));
                 PRETTY_PRINT("\tKeepSubscriptions = %s, ", keepSubscriptions ? "true" : "false");
             }
 #endif // CHIP_DETAIL_LOGGING
             break;
         case kCsTag_IsProxy:
-            VerifyOrReturnLogError(!(TagPresenceMask & (1 << kCsTag_IsProxy)), CHIP_ERROR_INVALID_TLV_TAG);
+            VerifyOrReturnError(!(TagPresenceMask & (1 << kCsTag_IsProxy)), CHIP_ERROR_INVALID_TLV_TAG);
             TagPresenceMask |= (1 << kCsTag_IsProxy);
-            VerifyOrReturnLogError(chip::TLV::kTLVType_Boolean == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
+            VerifyOrReturnError(chip::TLV::kTLVType_Boolean == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
 #if CHIP_DETAIL_LOGGING
             {
                 bool isProxy;
-                ReturnLogErrorOnFailure(reader.Get(isProxy));
+                ReturnErrorOnFailure(reader.Get(isProxy));
                 PRETTY_PRINT("\tIsProxy = %s, ", isProxy ? "true" : "false");
             }
 #endif // CHIP_DETAIL_LOGGING
             break;
         default:
-            ReturnLogErrorOnFailure(CHIP_ERROR_INVALID_TLV_TAG);
+            ReturnErrorOnFailure(CHIP_ERROR_INVALID_TLV_TAG);
         }
     }
 
@@ -160,7 +150,7 @@ CHIP_ERROR SubscribeRequestMessage::Parser::CheckSchemaValidity() const
             err = CHIP_NO_ERROR;
         }
     }
-    ReturnLogErrorOnFailure(err);
+    ReturnErrorOnFailure(err);
     return reader.ExitContainer(mOuterContainerType);
 }
 #endif // CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
@@ -168,16 +158,16 @@ CHIP_ERROR SubscribeRequestMessage::Parser::CheckSchemaValidity() const
 CHIP_ERROR SubscribeRequestMessage::Parser::GetPathList(AttributePathIBs::Parser * const apAttributePathList) const
 {
     TLV::TLVReader reader;
-    ReturnLogErrorOnFailure(mReader.FindElementWithTag(chip::TLV::ContextTag(kCsTag_AttributePathList), reader));
-    VerifyOrReturnLogError(chip::TLV::kTLVType_Array == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
+    ReturnErrorOnFailure(mReader.FindElementWithTag(chip::TLV::ContextTag(kCsTag_AttributePathList), reader));
+    VerifyOrReturnError(chip::TLV::kTLVType_Array == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
     return apAttributePathList->Init(reader);
 }
 
 CHIP_ERROR SubscribeRequestMessage::Parser::GetEventPaths(EventPaths::Parser * const apEventPaths) const
 {
     TLV::TLVReader reader;
-    ReturnLogErrorOnFailure(mReader.FindElementWithTag(chip::TLV::ContextTag(kCsTag_EventPaths), reader));
-    VerifyOrReturnLogError(chip::TLV::kTLVType_Array == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
+    ReturnErrorOnFailure(mReader.FindElementWithTag(chip::TLV::ContextTag(kCsTag_EventPaths), reader));
+    VerifyOrReturnError(chip::TLV::kTLVType_Array == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
     return apEventPaths->Init(reader);
 }
 
@@ -186,8 +176,8 @@ SubscribeRequestMessage::Parser::GetAttributeDataVersionList(
     AttributeDataVersionList::Parser * const apAttributeDataVersionList) const
 {
     TLV::TLVReader reader;
-    ReturnLogErrorOnFailure(mReader.FindElementWithTag(chip::TLV::ContextTag(kCsTag_AttributeDataVersionList), reader));
-    VerifyOrReturnLogError(TLV::kTLVType_Array == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
+    ReturnErrorOnFailure(mReader.FindElementWithTag(chip::TLV::ContextTag(kCsTag_AttributeDataVersionList), reader));
+    VerifyOrReturnError(TLV::kTLVType_Array == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
     return apAttributeDataVersionList->Init(reader);
 }
 
@@ -214,11 +204,6 @@ CHIP_ERROR SubscribeRequestMessage::Parser::GetKeepSubscriptions(bool * const ap
 CHIP_ERROR SubscribeRequestMessage::Parser::GetIsProxy(bool * const apIsProxy) const
 {
     return GetSimpleValue(kCsTag_IsProxy, chip::TLV::kTLVType_Boolean, apIsProxy);
-}
-
-CHIP_ERROR SubscribeRequestMessage::Builder::Init(chip::TLV::TLVWriter * const apWriter)
-{
-    return InitAnonymousStructure(apWriter);
 }
 
 AttributePathIBs::Builder & SubscribeRequestMessage::Builder::CreateAttributePathListBuilder()

--- a/src/app/MessageDef/SubscribeRequestMessage.h
+++ b/src/app/MessageDef/SubscribeRequestMessage.h
@@ -19,9 +19,9 @@
 
 #include "AttributeDataVersionList.h"
 #include "AttributePathIBs.h"
-#include "Builder.h"
 #include "EventPaths.h"
-#include "Parser.h"
+#include "StructBuilder.h"
+#include "StructParser.h"
 #include <app/AppBuildConfig.h>
 #include <app/util/basic-types.h>
 #include <lib/core/CHIPCore.h>
@@ -44,13 +44,9 @@ enum
     kCsTag_IsProxy                  = 7,
 };
 
-class Parser : public chip::app::Parser
+class Parser : public StructParser
 {
 public:
-    /**
-     *  @param [in] aReader A pointer to a TLVReader, which should point to the beginning of this request
-     */
-    CHIP_ERROR Init(const chip::TLV::TLVReader & aReader);
 #if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
     /**
      *  @brief Roughly verify the message is correctly formed
@@ -128,11 +124,9 @@ public:
     CHIP_ERROR GetIsProxy(bool * const apIsProxy) const;
 };
 
-class Builder : public chip::app::Builder
+class Builder : public StructBuilder
 {
 public:
-    CHIP_ERROR Init(chip::TLV::TLVWriter * const apWriter);
-
     AttributePathIBs::Builder & CreateAttributePathListBuilder();
 
     /**

--- a/src/app/MessageDef/SubscribeResponseMessage.cpp
+++ b/src/app/MessageDef/SubscribeResponseMessage.cpp
@@ -19,17 +19,6 @@
 
 namespace chip {
 namespace app {
-CHIP_ERROR SubscribeResponseMessage::Parser::Init(const chip::TLV::TLVReader & aReader)
-{
-    // make a copy of the reader here
-    mReader.Init(aReader);
-
-    VerifyOrReturnLogError(chip::TLV::kTLVType_Structure == mReader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-
-    ReturnLogErrorOnFailure(mReader.EnterContainer(mOuterContainerType));
-    return CHIP_NO_ERROR;
-}
-
 #if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
 CHIP_ERROR SubscribeResponseMessage::Parser::CheckSchemaValidity() const
 {
@@ -44,47 +33,47 @@ CHIP_ERROR SubscribeResponseMessage::Parser::CheckSchemaValidity() const
 
     while (CHIP_NO_ERROR == (err = reader.Next()))
     {
-        VerifyOrReturnLogError(chip::TLV::IsContextTag(reader.GetTag()), CHIP_ERROR_INVALID_TLV_TAG);
+        VerifyOrReturnError(chip::TLV::IsContextTag(reader.GetTag()), CHIP_ERROR_INVALID_TLV_TAG);
         switch (chip::TLV::TagNumFromTag(reader.GetTag()))
         {
         case kCsTag_SubscriptionId:
-            VerifyOrReturnLogError(!(TagPresenceMask & (1 << kCsTag_SubscriptionId)), CHIP_ERROR_INVALID_TLV_TAG);
+            VerifyOrReturnError(!(TagPresenceMask & (1 << kCsTag_SubscriptionId)), CHIP_ERROR_INVALID_TLV_TAG);
             TagPresenceMask |= (1 << kCsTag_SubscriptionId);
-            VerifyOrReturnLogError(TLV::kTLVType_UnsignedInteger == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
+            VerifyOrReturnError(TLV::kTLVType_UnsignedInteger == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
 #if CHIP_DETAIL_LOGGING
             {
                 uint64_t subscriptionId;
-                ReturnLogErrorOnFailure(reader.Get(subscriptionId));
+                ReturnErrorOnFailure(reader.Get(subscriptionId));
                 PRETTY_PRINT("\tSubscriptionId = 0x%" PRIx64 ",", subscriptionId);
             }
 #endif // CHIP_DETAIL_LOGGING
             break;
         case kCsTag_MinIntervalFloorSeconds:
-            VerifyOrReturnLogError(!(TagPresenceMask & (1 << kCsTag_MinIntervalFloorSeconds)), CHIP_ERROR_INVALID_TLV_TAG);
+            VerifyOrReturnError(!(TagPresenceMask & (1 << kCsTag_MinIntervalFloorSeconds)), CHIP_ERROR_INVALID_TLV_TAG);
             TagPresenceMask |= (1 << kCsTag_MinIntervalFloorSeconds);
-            VerifyOrReturnLogError(chip::TLV::kTLVType_UnsignedInteger == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
+            VerifyOrReturnError(chip::TLV::kTLVType_UnsignedInteger == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
 #if CHIP_DETAIL_LOGGING
             {
                 uint16_t minIntervalFloorSeconds;
-                ReturnLogErrorOnFailure(reader.Get(minIntervalFloorSeconds));
+                ReturnErrorOnFailure(reader.Get(minIntervalFloorSeconds));
                 PRETTY_PRINT("\tMinIntervalFloorSeconds = 0x%" PRIx16 ",", minIntervalFloorSeconds);
             }
 #endif // CHIP_DETAIL_LOGGING
             break;
         case kCsTag_MaxIntervalCeilingSeconds:
-            VerifyOrReturnLogError(!(TagPresenceMask & (1 << kCsTag_MaxIntervalCeilingSeconds)), CHIP_ERROR_INVALID_TLV_TAG);
+            VerifyOrReturnError(!(TagPresenceMask & (1 << kCsTag_MaxIntervalCeilingSeconds)), CHIP_ERROR_INVALID_TLV_TAG);
             TagPresenceMask |= (1 << kCsTag_MaxIntervalCeilingSeconds);
-            VerifyOrReturnLogError(chip::TLV::kTLVType_UnsignedInteger == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
+            VerifyOrReturnError(chip::TLV::kTLVType_UnsignedInteger == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
 #if CHIP_DETAIL_LOGGING
             {
                 uint16_t maxIntervalCeilingSeconds;
-                ReturnLogErrorOnFailure(reader.Get(maxIntervalCeilingSeconds));
+                ReturnErrorOnFailure(reader.Get(maxIntervalCeilingSeconds));
                 PRETTY_PRINT("\tMaxIntervalCeilingSeconds = 0x%" PRIx16 ",", maxIntervalCeilingSeconds);
             }
 #endif // CHIP_DETAIL_LOGGING
             break;
         default:
-            ReturnLogErrorOnFailure(CHIP_ERROR_INVALID_TLV_TAG);
+            ReturnErrorOnFailure(CHIP_ERROR_INVALID_TLV_TAG);
         }
     }
     PRETTY_PRINT("}");
@@ -100,7 +89,7 @@ CHIP_ERROR SubscribeResponseMessage::Parser::CheckSchemaValidity() const
             err = CHIP_NO_ERROR;
         }
     }
-    ReturnLogErrorOnFailure(err);
+    ReturnErrorOnFailure(err);
     return reader.ExitContainer(mOuterContainerType);
 }
 #endif // CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
@@ -118,11 +107,6 @@ CHIP_ERROR SubscribeResponseMessage::Parser::GetMinIntervalFloorSeconds(uint16_t
 CHIP_ERROR SubscribeResponseMessage::Parser::GetMaxIntervalCeilingSeconds(uint16_t * const apMaxIntervalCeilingSeconds) const
 {
     return GetUnsignedInteger(kCsTag_MaxIntervalCeilingSeconds, apMaxIntervalCeilingSeconds);
-}
-
-CHIP_ERROR SubscribeResponseMessage::Builder::Init(chip::TLV::TLVWriter * const apWriter)
-{
-    return InitAnonymousStructure(apWriter);
 }
 
 SubscribeResponseMessage::Builder & SubscribeResponseMessage::Builder::SubscriptionId(const uint64_t aSubscribeId)

--- a/src/app/MessageDef/SubscribeResponseMessage.h
+++ b/src/app/MessageDef/SubscribeResponseMessage.h
@@ -16,9 +16,9 @@
  */
 
 #pragma once
-#include "Builder.h"
 #include "EventPaths.h"
-#include "Parser.h"
+#include "StructBuilder.h"
+#include "StructParser.h"
 #include <app/AppBuildConfig.h>
 #include <app/util/basic-types.h>
 #include <lib/core/CHIPCore.h>
@@ -36,13 +36,9 @@ enum
     kCsTag_MaxIntervalCeilingSeconds = 2,
 };
 
-class Parser : public chip::app::Parser
+class Parser : public StructParser
 {
 public:
-    /**
-     *  @param [in] aReader A pointer to a TLVReader, which should point to the beginning of this response
-     */
-    CHIP_ERROR Init(const chip::TLV::TLVReader & aReader);
 #if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
     /**
      *  @brief Roughly verify the message is correctly formed
@@ -83,11 +79,9 @@ public:
     CHIP_ERROR GetMaxIntervalCeilingSeconds(uint16_t * const apMaxIntervalCeilingSeconds) const;
 };
 
-class Builder : public chip::app::Builder
+class Builder : public StructBuilder
 {
 public:
-    CHIP_ERROR Init(chip::TLV::TLVWriter * const apWriter);
-
     /**
      *  @brief final subscription Id for the subscription back to the client.s.
      */

--- a/src/app/MessageDef/TimedRequestMessage.cpp
+++ b/src/app/MessageDef/TimedRequestMessage.cpp
@@ -19,15 +19,6 @@
 
 namespace chip {
 namespace app {
-CHIP_ERROR TimedRequestMessage::Parser::Init(const chip::TLV::TLVReader & aReader)
-{
-    // make a copy of the reader here
-    mReader.Init(aReader);
-    VerifyOrReturnError(TLV::kTLVType_Structure == mReader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    ReturnErrorOnFailure(mReader.EnterContainer(mOuterContainerType));
-    return CHIP_NO_ERROR;
-}
-
 #if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
 CHIP_ERROR TimedRequestMessage::Parser::CheckSchemaValidity() const
 {
@@ -73,7 +64,7 @@ CHIP_ERROR TimedRequestMessage::Parser::CheckSchemaValidity() const
             err = CHIP_NO_ERROR;
         }
     }
-    ReturnLogErrorOnFailure(err);
+    ReturnErrorOnFailure(err);
     return reader.ExitContainer(mOuterContainerType);
 }
 #endif // CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
@@ -81,11 +72,6 @@ CHIP_ERROR TimedRequestMessage::Parser::CheckSchemaValidity() const
 CHIP_ERROR TimedRequestMessage::Parser::GetTimeoutMs(uint16_t * const apTimeoutMs) const
 {
     return GetUnsignedInteger(to_underlying(Tag::kTimeoutMs), apTimeoutMs);
-}
-
-CHIP_ERROR TimedRequestMessage::Builder::Init(TLV::TLVWriter * const apWriter)
-{
-    return InitAnonymousStructure(apWriter);
 }
 
 TimedRequestMessage::Builder & TimedRequestMessage::Builder::TimeoutMs(const uint16_t aTimeoutMs)

--- a/src/app/MessageDef/TimedRequestMessage.h
+++ b/src/app/MessageDef/TimedRequestMessage.h
@@ -16,8 +16,8 @@
  */
 
 #pragma once
-#include "Builder.h"
-#include "Parser.h"
+#include "StructBuilder.h"
+#include "StructParser.h"
 #include <app/AppBuildConfig.h>
 #include <app/util/basic-types.h>
 #include <lib/core/CHIPCore.h>
@@ -33,13 +33,9 @@ enum class Tag : uint8_t
     kTimeoutMs = 0,
 };
 
-class Parser : public chip::app::Parser
+class Parser : public StructParser
 {
 public:
-    /**
-     *  @param [in] aReader A pointer to a TLVReader, which should point to the beginning of this request
-     */
-    CHIP_ERROR Init(const TLV::TLVReader & aReader);
 #if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
     /**
      *  @brief Roughly verify the message is correctly formed
@@ -66,11 +62,9 @@ public:
     CHIP_ERROR GetTimeoutMs(uint16_t * const apTimeoutMs) const;
 };
 
-class Builder : public chip::app::Builder
+class Builder : public StructBuilder
 {
 public:
-    CHIP_ERROR Init(TLV::TLVWriter * const apWriter);
-
     /**
      *  @brief Timeout value, sent by a client to a server, if there is a preceding successful Timed Request action,
      *  the following action SHALL be received before the end of the Timeout interval.

--- a/src/app/MessageDef/WriteRequestMessage.cpp
+++ b/src/app/MessageDef/WriteRequestMessage.cpp
@@ -33,21 +33,6 @@ using namespace chip::TLV;
 
 namespace chip {
 namespace app {
-CHIP_ERROR WriteRequestMessage::Parser::Init(const chip::TLV::TLVReader & aReader)
-{
-    CHIP_ERROR err = CHIP_NO_ERROR;
-
-    mReader.Init(aReader);
-
-    VerifyOrExit(chip::TLV::kTLVType_Structure == mReader.GetType(), err = CHIP_ERROR_WRONG_TLV_TYPE);
-
-    err = mReader.EnterContainer(mOuterContainerType);
-
-exit:
-
-    return err;
-}
-
 #if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
 CHIP_ERROR WriteRequestMessage::Parser::CheckSchemaValidity() const
 {
@@ -188,11 +173,6 @@ exit:
 CHIP_ERROR WriteRequestMessage::Parser::GetMoreChunkedMessages(bool * const apMoreChunkedMessages) const
 {
     return GetSimpleValue(kCsTag_MoreChunkedMessages, chip::TLV::kTLVType_Boolean, apMoreChunkedMessages);
-}
-
-CHIP_ERROR WriteRequestMessage::Builder::Init(chip::TLV::TLVWriter * const apWriter)
-{
-    return InitAnonymousStructure(apWriter);
 }
 
 WriteRequestMessage::Builder & WriteRequestMessage::Builder::SuppressResponse(const bool aSuppressResponse)

--- a/src/app/MessageDef/WriteRequestMessage.h
+++ b/src/app/MessageDef/WriteRequestMessage.h
@@ -24,8 +24,8 @@
 
 #include "AttributeDataIBs.h"
 #include "AttributeDataVersionList.h"
-#include "Builder.h"
-#include "Parser.h"
+#include "StructBuilder.h"
+#include "StructParser.h"
 #include <app/util/basic-types.h>
 #include <lib/core/CHIPCore.h>
 #include <lib/core/CHIPTLV.h>
@@ -43,18 +43,9 @@ enum
     kCsTag_MoreChunkedMessages      = 3,
 };
 
-class Parser : public chip::app::Parser
+class Parser : public StructParser
 {
 public:
-    /**
-     *  @brief Initialize the parser object with TLVReader
-     *
-     *  @param [in] aReader A pointer to a TLVReader, which should point to the beginning of this request
-     *
-     *  @return #CHIP_NO_ERROR on success
-     */
-    CHIP_ERROR Init(const chip::TLV::TLVReader & aReader);
-
     /**
      *  @brief Roughly verify the message is correctly formed
      *   1) all mandatory tags are present
@@ -109,18 +100,9 @@ public:
     CHIP_ERROR GetMoreChunkedMessages(bool * const apMoreChunkedMessages) const;
 };
 
-class Builder : public chip::app::Builder
+class Builder : public StructBuilder
 {
 public:
-    /**
-     *  @brief Initialize a WriteRequestMessage::Builder for writing into a TLV stream
-     *
-     *  @param [in] apWriter    A pointer to TLVWriter
-     *
-     *  @return #CHIP_NO_ERROR on success
-     */
-    CHIP_ERROR Init(chip::TLV::TLVWriter * const apWriter);
-
     /**
      *  @brief This can be used to optionally signal to the server that no responses are to be sent back.
      *  @param [in] aSuppressResponse true if client need to signal suppress response


### PR DESCRIPTION
#### Problem
Replace buidler/parser base with  structBuilder/Parser for the rest of IM struct type message.
Replace ReturnLogErroronFailure and VerifyLogErrorOnFailure without log since CHIP_ERROR has recorded the initial error location.

#### Change overview
See above

#### Testing
Presubmit test validates it, no logic change