### PR TITLE
Fix missing param when compiling simulator

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -66,10 +66,6 @@ jobs:
                   path: |
                    .environment/gn_out/.ninja_log
                    .environment/pigweed-venv/*.log
-            - name: Build simulated device
-              timeout-minutes: 5
-              run: |
-                  scripts/examples/gn_build_test_example.sh app1
             - name: Build all clusters app
               timeout-minutes: 5
               run: |
@@ -171,10 +167,6 @@ jobs:
                   # The idea is to not upload our objdir unless builds have
                   # actually succeeded, because that just wastes space.
                   rsync -a out/debug/standalone/ objdir-clone || true
-            - name: Build simulated device
-              timeout-minutes: 5
-              run: |
-                  scripts/examples/gn_build_test_example.sh app1
             - name: Run Test Suites
               timeout-minutes: 35
               run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -66,6 +66,10 @@ jobs:
                   path: |
                    .environment/gn_out/.ninja_log
                    .environment/pigweed-venv/*.log
+            - name: Build simulated device
+              timeout-minutes: 5
+              run: |
+                  scripts/examples/gn_build_test_example.sh app1
             - name: Build all clusters app
               timeout-minutes: 5
               run: |
@@ -167,6 +171,10 @@ jobs:
                   # The idea is to not upload our objdir unless builds have
                   # actually succeeded, because that just wastes space.
                   rsync -a out/debug/standalone/ objdir-clone || true
+            - name: Build simulated device
+              timeout-minutes: 5
+              run: |
+                  scripts/examples/gn_build_test_example.sh app1
             - name: Run Test Suites
               timeout-minutes: 35
               run: |

--- a/examples/placeholder/linux/include/TestCommand.h
+++ b/examples/placeholder/linux/include/TestCommand.h
@@ -127,4 +127,5 @@ public:
 protected:
     chip::app::ConcreteCommandPath mCommandPath;
     chip::app::ConcreteAttributePath mAttributePath;
+    chip::Optional<chip::EndpointId> mEndpointId;
 };


### PR DESCRIPTION
#### Problem
Issue #11761 was filed. Compiling fails on the simulator app.


#### Change overview
Add missing argument. 
Add GitHub workflow.

#### Testing
Compiled without change verified issue, compiled with the change and verified that issue was resolved. 
