### PR TITLE
Switch attribute writes on Darwin to support all types.

### DIFF
--- a/src/darwin/Framework/CHIP.xcodeproj/project.pbxproj
+++ b/src/darwin/Framework/CHIP.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		2F79A67726CE6672006377B0 /* im-client-callbacks.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2F79A67626CE6672006377B0 /* im-client-callbacks.cpp */; };
 		2FD775552695557E00FF4B12 /* error-mapping.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2FD775542695557E00FF4B12 /* error-mapping.cpp */; };
 		5129BCFD26A9EE3300122DDF /* CHIPError.h in Headers */ = {isa = PBXBuildFile; fileRef = 5129BCFC26A9EE3300122DDF /* CHIPError.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5145F81027435A5500225B60 /* CHIPListUtils_internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 5145F80F27435A5400225B60 /* CHIPListUtils_internal.h */; };
 		51B22C1E2740CB0A008D5055 /* CHIPStructsObjc.h in Headers */ = {isa = PBXBuildFile; fileRef = 51B22C1D2740CB0A008D5055 /* CHIPStructsObjc.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		51B22C222740CB1D008D5055 /* CHIPCommandPayloadsObjc.h in Headers */ = {isa = PBXBuildFile; fileRef = 51B22C212740CB1D008D5055 /* CHIPCommandPayloadsObjc.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		51B22C262740CB32008D5055 /* CHIPStructsObjc.mm in Sources */ = {isa = PBXBuildFile; fileRef = 51B22C252740CB32008D5055 /* CHIPStructsObjc.mm */; };
@@ -145,6 +146,7 @@
 		2F79A67626CE6672006377B0 /* im-client-callbacks.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "im-client-callbacks.cpp"; path = "../../../app/util/im-client-callbacks.cpp"; sourceTree = "<group>"; };
 		2FD775542695557E00FF4B12 /* error-mapping.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "error-mapping.cpp"; path = "../../../app/util/error-mapping.cpp"; sourceTree = "<group>"; };
 		5129BCFC26A9EE3300122DDF /* CHIPError.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = CHIPError.h; path = CHIP/CHIPError.h; sourceTree = "<group>"; };
+		5145F80F27435A5400225B60 /* CHIPListUtils_internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CHIPListUtils_internal.h; sourceTree = "<group>"; };
 		51B22C1D2740CB0A008D5055 /* CHIPStructsObjc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CHIPStructsObjc.h; path = "zap-generated/CHIPStructsObjc.h"; sourceTree = "<group>"; };
 		51B22C212740CB1D008D5055 /* CHIPCommandPayloadsObjc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CHIPCommandPayloadsObjc.h; path = "zap-generated/CHIPCommandPayloadsObjc.h"; sourceTree = "<group>"; };
 		51B22C252740CB32008D5055 /* CHIPStructsObjc.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = CHIPStructsObjc.mm; path = "zap-generated/CHIPStructsObjc.mm"; sourceTree = "<group>"; };
@@ -273,6 +275,7 @@
 		B202528F2459E34F00F97062 /* CHIP */ = {
 			isa = PBXGroup;
 			children = (
+				5145F80F27435A5400225B60 /* CHIPListUtils_internal.h */,
 				1ED276E326C5832500547A89 /* CHIPCluster.h */,
 				1ED276E126C5812A00547A89 /* CHIPCluster.mm */,
 				2C5EEEF4268A85C400CAE3D3 /* CHIPDeviceConnectionBridge.h */,
@@ -364,6 +367,7 @@
 				B2E0D7B5245B0B5C003C5B48 /* CHIPQRCodeSetupPayloadParser.h in Headers */,
 				1EC4CE6425CC276600D7304F /* CHIPClustersObjc.h in Headers */,
 				2C5EEEF6268A85C400CAE3D3 /* CHIPDeviceConnectionBridge.h in Headers */,
+				5145F81027435A5500225B60 /* CHIPListUtils_internal.h in Headers */,
 				2C8C8FC0253E0C2100797F05 /* CHIPPersistentStorageDelegateBridge.h in Headers */,
 				998F286F26D55EC5001846C6 /* CHIPP256KeypairBridge.h in Headers */,
 				2C222ADF255C811800E446B9 /* CHIPDevice_Internal.h in Headers */,

--- a/src/darwin/Framework/CHIP/CHIPListUtils_internal.h
+++ b/src/darwin/Framework/CHIP/CHIPListUtils_internal.h
@@ -1,0 +1,65 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#ifndef CHIP_LISTUTILS_INTERNAL_H
+#define CHIP_LISTUTILS_INTERNAL_H
+
+#include <set>
+#include <type_traits>
+
+template <typename T>
+struct ListMemberTypeGetter
+{
+};
+template <typename T>
+struct ListMemberTypeGetter<chip::app::DataModel::List<T>>
+{
+    // We use List<const ...> in data model data structures, so consumers can
+    // use const data.  Just grab the type with the const stripped off.
+    using Type = std::remove_const_t<T>;
+};
+
+struct ListHolderBase
+{
+    // Just here so we can delete an instance to trigger the subclass destructor.
+    virtual ~ListHolderBase() {}
+};
+
+template <typename T>
+struct ListHolder : ListHolderBase
+{
+    ListHolder(size_t N) { mList = new T[N]; }
+    ~ListHolder() { delete[] mList; }
+    T * mList;
+};
+
+struct ListFreer
+{
+    ~ListFreer()
+    {
+        for (auto listHolder : mListHolders)
+        {
+            delete listHolder;
+        }
+    }
+
+    void add(ListHolderBase * listHolder) { mListHolders.insert(listHolder); }
+
+    std::set<ListHolderBase *> mListHolders;
+};
+
+#endif /* CHIP_LISTUTILS_INTERNAL_H */

--- a/src/darwin/Framework/CHIP/templates/CHIPCallbackBridge-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/CHIPCallbackBridge-src.zapt
@@ -6,6 +6,7 @@
 #import "CHIPCommandPayloadsObjc.h"
 
 {{#>CHIPCallbackBridge partial-type=""            }}DefaultSuccessCallback{{/CHIPCallbackBridge}}
+{{#>CHIPCallbackBridge partial-type="CommandStatus"}}CommandSuccessCallback{{/CHIPCallbackBridge}}
 {{#>CHIPCallbackBridge partial-type="Octet_String"}}OctetStringAttributeCallback{{/CHIPCallbackBridge}}
 {{#>CHIPCallbackBridge partial-type="Char_String" }}CharStringAttributeCallback{{/CHIPCallbackBridge}}
 {{#>CHIPCallbackBridge partial-type="Boolean"     }}BooleanAttributeCallback{{/CHIPCallbackBridge}}

--- a/src/darwin/Framework/CHIP/templates/CHIPCallbackBridge_internal.zapt
+++ b/src/darwin/Framework/CHIP/templates/CHIPCallbackBridge_internal.zapt
@@ -7,7 +7,9 @@
 #include <app/data-model/DecodableList.h>
 #include <app-common/zap-generated/cluster-objects.h>
 
-typedef void (*CHIPDefaultSuccessCallbackType)(void *, const chip::app::DataModel::NullObjectType &);
+typedef void (*CommandSuccessCallback)(void *, const chip::app::DataModel::NullObjectType &);
+using CHIPCommandSuccessCallbackType = CommandSuccessCallback;
+typedef void (*CHIPDefaultSuccessCallbackType)(void *);
 typedef void (*CHIPDefaultFailureCallbackType)(void *, EmberAfStatus);
 
 {{#chip_client_clusters}}
@@ -17,6 +19,7 @@ typedef void (*CHIP{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase nam
 {{/chip_client_clusters}}
 
 {{#>CHIPCallbackBridge header="1" partial-type=""            }}DefaultSuccessCallback{{/CHIPCallbackBridge}}
+{{#>CHIPCallbackBridge header="1" partial-type="CommandStatus"}}CommandSuccessCallback{{/CHIPCallbackBridge}}
 {{#>CHIPCallbackBridge header="1" partial-type="Octet_String"}}OctetStringAttributeCallback{{/CHIPCallbackBridge}}
 {{#>CHIPCallbackBridge header="1" partial-type="Char_String" }}CharStringAttributeCallback{{/CHIPCallbackBridge}}
 {{#>CHIPCallbackBridge header="1" partial-type="Boolean"     }}BooleanAttributeCallback{{/CHIPCallbackBridge}}

--- a/src/darwin/Framework/CHIP/templates/CHIPClustersObjc-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/CHIPClustersObjc-src.zapt
@@ -10,50 +10,13 @@
 #import "CHIPDevice_Internal.h"
 #import "CHIPStructsObjc.h"
 #import "CHIPCommandPayloadsObjc.h"
+#import "CHIPListUtils_internal.h"
 
-#include <set>
 #include <type_traits>
 
 using chip::Callback::Callback;
 using chip::Callback::Cancelable;
 using namespace chip::app::Clusters;
-
-template<typename T> struct ListMemberTypeGetter {};
-template<typename T> struct ListMemberTypeGetter<chip::app::DataModel::List<T>> {
-  // We use List<const ...> in data model data structures, so consumers can
-  // use const data.  Just grab the type with the const stripped off.
-  using Type = std::remove_const_t<T>;
-};
-
-struct ListHolderBase {
-  // Just here so we can delete an instance to trigger the subclass destructor.
-  virtual ~ListHolderBase() {}
-};
-
-template<typename T>
-struct ListHolder : ListHolderBase {
-  ListHolder(size_t N) {
-    mList = new T[N];
-  }
-  ~ListHolder() {
-    delete [] mList;
-  }
-  T * mList;
-};
-
-struct ListFreer {
-  ~ListFreer() {
-    for (auto listHolder : mListHolders) {
-      delete listHolder;
-    }
-  }
-
-  void add(ListHolderBase * listHolder) {
-    mListHolders.insert(listHolder);
-  }
-
-  std::set<ListHolderBase *> mListHolders;
-};
 
 {{#chip_client_clusters}}
 @implementation CHIP{{asUpperCamelCase name}}
@@ -64,13 +27,13 @@ struct ListFreer {
 }
 
 {{#chip_cluster_commands}}
-{{#*inline "callbackName"}}{{#if hasSpecificResponse}}{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase responseName}}{{else}}DefaultSuccess{{/if}}{{/inline}}
+{{#*inline "callbackName"}}{{#if hasSpecificResponse}}{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase responseName}}{{else}}CommandSuccess{{/if}}{{/inline}}
 - (void){{asLowerCamelCase name}}:(CHIP{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}Payload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler
 {
     ListFreer listFreer;
     {{asUpperCamelCase parent.name}}::Commands::{{asUpperCamelCase name}}::Type request;
     {{#chip_cluster_command_arguments}}
-    {{>encode_value target=(concat "request." (asLowerCamelCase label)) source=(concat "payload." (asUpperCamelCase label)) cluster=parent.parent.name}}
+    {{>encode_value target=(concat "request." (asLowerCamelCase label)) source=(concat "payload." (asUpperCamelCase label)) cluster=parent.parent.name errorCode="return;" depth=0}}
     {{/chip_cluster_command_arguments}}
 
     new CHIP{{>callbackName}}CallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -93,21 +56,16 @@ struct ListFreer {
 
 {{#if isWritableAttribute}}
 {{#*inline "callbackName"}}DefaultSuccess{{/inline}}
-{{#*inline "callbackParams"}},
-  {{#if_chip_enum type}}
-    static_cast<{{chipType}}>(value)
-  {{else if (isOctetString type)}}
-    [self asByteSpan:value]
-  {{else if (isCharString type)}}
-    [self asCharSpan:value]
-  {{else}}
-    value
-  {{/if_chip_enum}}
-{{/inline}}
-- (void)write{{>attribute}}WithValue:({{asObjectiveCBasicType type}})value responseHandler:(ResponseHandler)responseHandler
+- (void)write{{>attribute}}WithValue:({{asObjectiveCType type parent.name}})value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIP{{>callbackName}}CallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.Write{{>attribute}}(success, failure{{>callbackParams}});
+        ListFreer listFreer;
+        using TypeInfo = {{asUpperCamelCase parent.name}}::Attributes::{{asUpperCamelCase name}}::TypeInfo;
+        TypeInfo::Type cppValue;
+        {{>encode_value target="cppValue" source="value" cluster=parent.name errorCode="return CHIP_ERROR_INVALID_ARGUMENT;" depth=0}}
+        auto successFn = Callback<CHIP{{>callbackName}}CallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 

--- a/src/darwin/Framework/CHIP/templates/CHIPClustersObjc.zapt
+++ b/src/darwin/Framework/CHIP/templates/CHIPClustersObjc.zapt
@@ -30,7 +30,7 @@ NS_ASSUME_NONNULL_BEGIN
 {{#*inline "attribute"}}Attribute{{asUpperCamelCase name}}{{/inline}}
 - (void)read{{>attribute}}WithResponseHandler:(ResponseHandler)responseHandler;
 {{#if isWritableAttribute}}
-- (void)write{{>attribute}}WithValue:({{asObjectiveCBasicType type}})value responseHandler:(ResponseHandler)responseHandler;
+- (void)write{{>attribute}}WithValue:({{asObjectiveCType type parent.name}})value responseHandler:(ResponseHandler)responseHandler;
 {{/if}}
 {{#if isReportableAttribute}}
 - (void) subscribe{{>attribute}}WithMinInterval:(uint16_t)minInterval  maxInterval:(uint16_t)maxInterval responseHandler:(ResponseHandler)responseHandler;

--- a/src/darwin/Framework/CHIP/templates/CHIPTestClustersObjc-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/CHIPTestClustersObjc-src.zapt
@@ -6,11 +6,16 @@
 #import "CHIPCluster_internal.h"
 #import "CHIPDevice.h"
 #import "CHIPDevice_Internal.h"
+#import "CHIPListUtils_internal.h"
 
 #import "zap-generated/tests/CHIPClustersTest.h"
 #import "zap-generated/CHIPTestClustersObjc.h"
 
+#include <type_traits>
+
+using chip::Callback::Callback;
 using chip::Callback::Cancelable;
+using namespace chip::app::Clusters;
 
 {{#chip_client_clusters}}
 
@@ -27,28 +32,21 @@ using chip::Callback::Cancelable;
 
 {{#chip_server_cluster_attributes}}
 {{#unless isWritableAttribute}}
-{{#unless isList}}
-{{#unless isStruct}}
 {{#*inline "attribute"}}Attribute{{asUpperCamelCase name}}{{/inline}}
 {{#*inline "callbackName"}}DefaultSuccess{{/inline}}
-{{#*inline "callbackParams"}},
-  {{#if (isOctetString type)}}
-    [self asByteSpan:value]
-  {{else if (isCharString type)}}
-    [self asCharSpan:value]
-  {{else}}
-    value
-  {{/if}}
-{{/inline}}
-- (void)write{{>attribute}}WithValue:({{asObjectiveCBasicType type}})value responseHandler:(ResponseHandler)responseHandler
+- (void)write{{>attribute}}WithValue:({{asObjectiveCType type parent.name}})value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIP{{>callbackName}}CallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.Write{{>attribute}}(success, failure{{>callbackParams}});
+        ListFreer listFreer;
+        using TypeInfo = {{asUpperCamelCase parent.name}}::Attributes::{{asUpperCamelCase name}}::TypeInfo;
+        TypeInfo::Type cppValue;
+        {{>encode_value target="cppValue" source="value" cluster=parent.name errorCode="return CHIP_ERROR_INVALID_ARGUMENT;" depth=0}}
+        auto successFn = Callback<CHIP{{>callbackName}}CallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-{{/unless}}
-{{/unless}}
 {{/unless}}
 {{/chip_server_cluster_attributes}}
 

--- a/src/darwin/Framework/CHIP/templates/CHIPTestClustersObjc.zapt
+++ b/src/darwin/Framework/CHIP/templates/CHIPTestClustersObjc.zapt
@@ -17,11 +17,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 {{#chip_server_cluster_attributes}}
 {{#unless isWritableAttribute}}
-{{#unless isList}}
-{{#unless isStruct}}
-- (void)writeAttribute{{asUpperCamelCase name}}WithValue:({{asObjectiveCBasicType type}})value responseHandler:(ResponseHandler)responseHandler;
-{{/unless}}
-{{/unless}}
+- (void)writeAttribute{{asUpperCamelCase name}}WithValue:({{asObjectiveCType type parent.name}})value responseHandler:(ResponseHandler)responseHandler;
 {{/unless}}
 {{/chip_server_cluster_attributes}}
 

--- a/src/darwin/Framework/CHIP/templates/clusters-tests.zapt
+++ b/src/darwin/Framework/CHIP/templates/clusters-tests.zapt
@@ -197,7 +197,7 @@ CHIPDevice * GetConnectedDevice()
     CHIP{{asUpperCamelCase parent.name}} * cluster = [[CHIP{{asUpperCamelCase parent.name}} alloc] initWithDevice:device endpoint:{{asExpectedEndpointForCluster (asUpperCamelCase parent.name)}} queue:queue];
     XCTAssertNotNil(cluster);
 
-    {{asObjectiveCBasicType type}} value = {{asTestValue}};
+    {{asObjectiveCType type parent.name}} value = {{asTestValue}};
     [cluster writeAttribute{{asUpperCamelCase name}}WithValue:value responseHandler:^(NSError * err, NSDictionary * values) {
         NSLog(@"{{asUpperCamelCase parent.name}} {{asUpperCamelCase name}} Error: %@", err);
         XCTAssertEqual(err.code, 0);

--- a/src/darwin/Framework/CHIP/templates/helper.js
+++ b/src/darwin/Framework/CHIP/templates/helper.js
@@ -56,7 +56,7 @@ function asTestValue()
   } else if (StringHelper.isCharString(this.type)) {
     return '@"Test"';
   } else {
-    return this.min || this.max || 0;
+    return `@(${this.min || this.max || 0})`;
   }
 }
 
@@ -163,6 +163,11 @@ async function arrayElementObjectiveCClass(type, cluster, options)
   return asObjectiveCClass.call(this, type, cluster, options);
 }
 
+function incrementDepth(depth)
+{
+  return depth + 1;
+}
+
 //
 // Module exports
 //
@@ -174,3 +179,4 @@ exports.asTestValue                  = asTestValue;
 exports.asObjectiveCClass            = asObjectiveCClass;
 exports.asObjectiveCType             = asObjectiveCType;
 exports.arrayElementObjectiveCClass  = arrayElementObjectiveCClass;
+exports.incrementDepth               = incrementDepth;

--- a/src/darwin/Framework/CHIP/templates/partials/CHIPCallbackBridge.zapt
+++ b/src/darwin/Framework/CHIP/templates/partials/CHIPCallbackBridge.zapt
@@ -10,6 +10,8 @@ public:
     static void OnSuccessFn(void * context
       {{#if (isStrEqual partial-type "Command")}}
       , const chip::app::Clusters::{{asUpperCamelCase parent.name}}::Commands::{{asUpperCamelCase name}}::DecodableType & data
+      {{else if (isStrEqual partial-type "CommandStatus")}}
+      , const chip::app::DataModel::NullObjectType &
       {{else if (isStrEqual partial-type "List")}}
       , {{zapTypeToDecodableClusterObjectType type ns=parent.name isArgument=true}} list
       {{else if partial-type}}
@@ -22,6 +24,8 @@ public:
 void CHIP{{> @partial-block}}Bridge::OnSuccessFn(void * context
   {{#if (isStrEqual partial-type "Command")}}
   , const chip::app::Clusters::{{asUpperCamelCase parent.name}}::Commands::{{asUpperCamelCase name}}::DecodableType & data
+  {{else if (isStrEqual partial-type "CommandStatus")}}
+  , const chip::app::DataModel::NullObjectType &
   {{else if (isStrEqual partial-type "List")}}
   , {{zapTypeToDecodableClusterObjectType type ns=parent.name isArgument=true}} list
   {{else if partial-type}}
@@ -88,6 +92,8 @@ void CHIP{{> @partial-block}}Bridge::OnSuccessFn(void * context
     DispatchSuccess(context, @{ @"value": [NSData dataWithBytes: value.data() length: value.size()] });
     {{else if (isCharString partial-type)}}
     DispatchSuccess(context, @{ @"value": [[NSString alloc] initWithBytes:value.data() length:value.size() encoding:NSUTF8StringEncoding] });
+    {{else if (isStrEqual partial-type "CommandStatus")}}
+    DispatchSuccess(context, nil);
     {{else if partial-type}}
     DispatchSuccess(context, @{ @"value": [NSNumber numberWith{{asObjectiveCNumberType name partial-type false}}:value] });
     {{else}}

--- a/src/darwin/Framework/CHIP/templates/partials/encode_value.zapt
+++ b/src/darwin/Framework/CHIP/templates/partials/encode_value.zapt
@@ -1,14 +1,14 @@
 {{#if isOptional}}
   if ({{source}} != nil) {
-    auto & definedValue = {{target}}.Emplace();
-    {{>encode_value target="definedValue" source=source cluster=cluster isOptional=false}}
+    auto & definedValue_{{depth}} = {{target}}.Emplace();
+    {{>encode_value target=(concat "definedValue_" depth) source=source cluster=cluster errorCode=errorCode depth=(incrementDepth depth) isOptional=false}}
   }
 {{else if isNullable}}
   if ({{source}} == nil) {
     {{target}}.SetNull();
   } else {
-    auto & nonNullValue = {{target}}.SetNonNull();
-    {{>encode_value target="nonNullValue" source=source cluster=cluster isNullable=false}}
+    auto & nonNullValue_{{depth}} = {{target}}.SetNonNull();
+    {{>encode_value target=(concat "nonNullValue_" depth) source=source cluster=cluster errorCode=errorCode depth=(incrementDepth depth) isNullable=false}}
   }
 {{else if isArray}}
   {{! TODO: This is not great, with its fallible allocation and
@@ -18,44 +18,45 @@
       we are right now it may not (e.g. for a nullable list we're
       inside an "else" block here).  }}
   {
-    using ListType = decltype({{target}});
+    using ListType = std::remove_reference_t<decltype({{target}})>;
     using ListMemberType = ListMemberTypeGetter<ListType>::Type;
     if ({{source}}.count != 0) {
-      auto * listHolder = new ListHolder<ListMemberType>({{source}}.count);
-      if (listHolder == nullptr || listHolder->mList == nullptr) {
-        // Now what?
-        return;
+      auto * listHolder_{{depth}} = new ListHolder<ListMemberType>({{source}}.count);
+      if (listHolder_{{depth}} == nullptr || listHolder_{{depth}}->mList == nullptr) {
+        {{errorCode}}
       }
-      listFreer.add(listHolder);
+      listFreer.add(listHolder_{{depth}});
       for (size_t i = 0; i < {{source}}.count; ++i) {
         if (![{{source}}[i] isKindOfClass:[{{asObjectiveCClass type cluster forceNotList=true}} class]]) {
-          // Wrong kind of value, now what?
-          return;
+          // Wrong kind of value.
+          {{errorCode}}
         }
-        auto element = ({{asObjectiveCClass type cluster forceNotList=true}} *){{source}}[i];
-        {{>encode_value target="listHolder->mList[i]" source="element" cluster=cluster isArray=false}}
+        auto element_{{depth}} = ({{asObjectiveCClass type cluster forceNotList=true}} *){{source}}[i];
+        {{>encode_value target=(concat "listHolder_" depth "->mList[i]") source=(concat "element_" depth) cluster=cluster errorCode=errorCode depth=(incrementDepth depth) isArray=false}}
       }
-      {{target}} = ListType(listHolder->mList, {{source}}.count);
+      {{target}} = ListType(listHolder_{{depth}}->mList, {{source}}.count);
     } else {
       {{target}} = ListType();
     }
   }
-{{else if isStruct}}
-  {{#zcl_struct_items_by_struct_name type}}
-    {{>encode_value target=(concat ../target "." (asLowerCamelCase label)) source=(concat ../source "." (asUpperCamelCase label)) cluster=../cluster}}
-  {{/zcl_struct_items_by_struct_name}}
 {{else if (isOctetString type)}}
   {{target}} = [self asByteSpan:{{source}}];
 {{else if (isCharString type)}}
   {{target}} = [self asCharSpan:{{source}}];
 {{else}}
-  {{#if_chip_enum type}}
-    {{target}} = static_cast<std::remove_reference_t<decltype({{target}})>>({{source}}.{{asObjectiveCNumberType source type true}}Value);
+  {{#if_is_struct type}}
+    {{#zcl_struct_items_by_struct_name type}}
+     {{>encode_value target=(concat ../target "." (asLowerCamelCase label)) source=(concat ../source "." (asUpperCamelCase label)) cluster=../cluster errorCode=../errorCode depth=(incrementDepth ../depth)}}
+    {{/zcl_struct_items_by_struct_name}}
   {{else}}
-    {{#if_is_bitmap type}}
+    {{#if_chip_enum type}}
       {{target}} = static_cast<std::remove_reference_t<decltype({{target}})>>({{source}}.{{asObjectiveCNumberType source type true}}Value);
     {{else}}
-      {{target}} = {{source}}.{{asObjectiveCNumberType source type true}}Value;
-    {{/if_is_bitmap}}
-  {{/if_chip_enum}}
+      {{#if_is_bitmap type}}
+        {{target}} = static_cast<std::remove_reference_t<decltype({{target}})>>({{source}}.{{asObjectiveCNumberType source type true}}Value);
+      {{else}}
+        {{target}} = {{source}}.{{asObjectiveCNumberType source type true}}Value;
+      {{/if_is_bitmap}}
+    {{/if_chip_enum}}
+  {{/if_is_struct}}
 {{/if}}

--- a/src/darwin/Framework/CHIP/templates/partials/test_cluster.zapt
+++ b/src/darwin/Framework/CHIP/templates/partials/test_cluster.zapt
@@ -45,15 +45,8 @@ bool testSendCluster{{parent.filename}}_{{asTestIndex index}}_{{asUpperCamelCase
     [cluster readAttribute{{asUpperCamelCase attribute}}WithResponseHandler:^(NSError * err, NSDictionary * values) {
     {{else if isWriteAttribute}}
     {{#chip_tests_item_parameters}}
-    {{#if (isString type)}}
-    {{#if (isOctetString type)}}
-    NSData * {{asLowerCamelCase name}}Argument = [[NSData alloc] initWithBytes:"{{octetStringEscapedForCLiteral definedValue}}" length:{{definedValue.length}}];
-    {{else}}
-    NSString * {{asLowerCamelCase name}}Argument= @"{{definedValue}}";
-    {{/if}}
-    {{else}}
-    {{asObjectiveCBasicType type}} {{asLowerCamelCase name}}Argument = {{definedValue}}{{asTypeLiteralSuffix type}};
-    {{/if}}
+    id {{asLowerCamelCase name}}Argument;
+    {{>test_value target=(concat (asLowerCamelCase name) "Argument") definedValue=definedValue cluster=parent.cluster}}
     {{/chip_tests_item_parameters}}
     [cluster writeAttribute{{asUpperCamelCase attribute}}WithValue:{{#chip_tests_item_parameters}}{{asLowerCamelCase name}}Argument{{/chip_tests_item_parameters}} responseHandler:^(NSError * err, NSDictionary * values) {
     {{/if}}

--- a/src/darwin/Framework/CHIP/templates/partials/test_value.zapt
+++ b/src/darwin/Framework/CHIP/templates/partials/test_value.zapt
@@ -29,6 +29,6 @@
   {{else if (isOctetString type)}}
     {{target}} = [[NSData alloc] initWithBytes:"{{octetStringEscapedForCLiteral definedValue}}" length:{{definedValue.length}}];
   {{else}}
-    {{target}} = [NSNumber numberWith{{asObjectiveCNumberType definedValue type false}}:{{definedValue}}];
+    {{target}} = [NSNumber numberWith{{asObjectiveCNumberType definedValue type false}}:{{definedValue}}{{asTypeLiteralSuffix type}}];
   {{/if_is_struct}}
 {{/if}}

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPCallbackBridge.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPCallbackBridge.mm
@@ -23,6 +23,11 @@
 
 void CHIPDefaultSuccessCallbackBridge::OnSuccessFn(void * context) { DispatchSuccess(context, nil); };
 
+void CHIPCommandSuccessCallbackBridge::OnSuccessFn(void * context, const chip::app::DataModel::NullObjectType &)
+{
+    DispatchSuccess(context, nil);
+};
+
 void CHIPOctetStringAttributeCallbackBridge::OnSuccessFn(void * context, chip::ByteSpan value)
 {
     DispatchSuccess(context, @ { @"value" : [NSData dataWithBytes:value.data() length:value.size()] });

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPCallbackBridge_internal.h
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPCallbackBridge_internal.h
@@ -23,7 +23,9 @@
 #include <app-common/zap-generated/cluster-objects.h>
 #include <app/data-model/DecodableList.h>
 
-typedef void (*CHIPDefaultSuccessCallbackType)(void *, const chip::app::DataModel::NullObjectType &);
+typedef void (*CommandSuccessCallback)(void *, const chip::app::DataModel::NullObjectType &);
+using CHIPCommandSuccessCallbackType = CommandSuccessCallback;
+typedef void (*CHIPDefaultSuccessCallbackType)(void *);
 typedef void (*CHIPDefaultFailureCallbackType)(void *, EmberAfStatus);
 
 typedef void (*CHIPAccountLoginClusterGetSetupPINResponseCallbackType)(
@@ -187,6 +189,16 @@ public:
         CHIPCallbackBridge<DefaultSuccessCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
 
     static void OnSuccessFn(void * context);
+};
+
+class CHIPCommandSuccessCallbackBridge : public CHIPCallbackBridge<CommandSuccessCallback>
+{
+public:
+    CHIPCommandSuccessCallbackBridge(dispatch_queue_t queue, ResponseHandler handler, CHIPActionBlock action,
+                                     bool keepAlive = false) :
+        CHIPCallbackBridge<CommandSuccessCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
+
+    static void OnSuccessFn(void * context, const chip::app::DataModel::NullObjectType &);
 };
 
 class CHIPOctetStringAttributeCallbackBridge : public CHIPCallbackBridge<OctetStringAttributeCallback>

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPClustersObjc.h
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPClustersObjc.h
@@ -164,10 +164,10 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)readAttributeProductIDWithResponseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeUserLabelWithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeUserLabelWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeUserLabelWithValue:(NSString * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeLocationWithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeLocationWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeLocationWithValue:(NSString * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeHardwareVersionWithResponseHandler:(ResponseHandler)responseHandler;
 
@@ -188,7 +188,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)readAttributeSerialNumberWithResponseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeLocalConfigDisabledWithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeLocalConfigDisabledWithValue:(bool)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeLocalConfigDisabledWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeReachableWithResponseHandler:(ResponseHandler)responseHandler;
 
@@ -203,10 +203,10 @@ NS_ASSUME_NONNULL_BEGIN
 @interface CHIPBinaryInputBasic : CHIPCluster
 
 - (void)readAttributeOutOfServiceWithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeOutOfServiceWithValue:(bool)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeOutOfServiceWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributePresentValueWithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributePresentValueWithValue:(bool)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributePresentValueWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 - (void)subscribeAttributePresentValueWithMinInterval:(uint16_t)minInterval
                                           maxInterval:(uint16_t)maxInterval
                                       responseHandler:(ResponseHandler)responseHandler;
@@ -304,7 +304,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)readAttributeProductNameWithResponseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeUserLabelWithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeUserLabelWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeUserLabelWithValue:(NSString * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeHardwareVersionWithResponseHandler:(ResponseHandler)responseHandler;
 
@@ -408,7 +408,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)readAttributeColorModeWithResponseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeColorControlOptionsWithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeColorControlOptionsWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeColorControlOptionsWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeNumberOfPrimariesWithResponseHandler:(ResponseHandler)responseHandler;
 
@@ -449,37 +449,37 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)readAttributePrimary6IntensityWithResponseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeWhitePointXWithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeWhitePointXWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeWhitePointXWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeWhitePointYWithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeWhitePointYWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeWhitePointYWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeColorPointRXWithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeColorPointRXWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeColorPointRXWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeColorPointRYWithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeColorPointRYWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeColorPointRYWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeColorPointRIntensityWithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeColorPointRIntensityWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeColorPointRIntensityWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeColorPointGXWithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeColorPointGXWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeColorPointGXWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeColorPointGYWithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeColorPointGYWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeColorPointGYWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeColorPointGIntensityWithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeColorPointGIntensityWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeColorPointGIntensityWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeColorPointBXWithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeColorPointBXWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeColorPointBXWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeColorPointBYWithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeColorPointBYWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeColorPointBYWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeColorPointBIntensityWithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeColorPointBIntensityWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeColorPointBIntensityWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeEnhancedCurrentHueWithResponseHandler:(ResponseHandler)responseHandler;
 
@@ -504,7 +504,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)readAttributeCoupleColorTempToLevelMinMiredsWithResponseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeStartUpColorTemperatureMiredsWithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeStartUpColorTemperatureMiredsWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeStartUpColorTemperatureMiredsWithValue:(NSNumber * _Nonnull)value
+                                             responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeClusterRevisionWithResponseHandler:(ResponseHandler)responseHandler;
 
@@ -718,7 +719,7 @@ NS_ASSUME_NONNULL_BEGIN
             responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeBreadcrumbWithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeBreadcrumbWithValue:(uint64_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeBreadcrumbWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeBasicCommissioningInfoListWithResponseHandler:(ResponseHandler)responseHandler;
 
@@ -793,7 +794,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)triggerEffect:(CHIPIdentifyClusterTriggerEffectPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeIdentifyTimeWithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeIdentifyTimeWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeIdentifyTimeWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeIdentifyTypeWithResponseHandler:(ResponseHandler)responseHandler;
 
@@ -875,25 +876,25 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)readAttributeMaxFrequencyWithResponseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeOptionsWithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeOptionsWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeOptionsWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeOnOffTransitionTimeWithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeOnOffTransitionTimeWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeOnOffTransitionTimeWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeOnLevelWithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeOnLevelWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeOnLevelWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeOnTransitionTimeWithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeOnTransitionTimeWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeOnTransitionTimeWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeOffTransitionTimeWithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeOffTransitionTimeWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeOffTransitionTimeWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeDefaultMoveRateWithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeDefaultMoveRateWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeDefaultMoveRateWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeStartUpCurrentLevelWithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeStartUpCurrentLevelWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeStartUpCurrentLevelWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeClusterRevisionWithResponseHandler:(ResponseHandler)responseHandler;
 
@@ -992,7 +993,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)readAttributeSupportedModesWithResponseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeOnModeWithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeOnModeWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeOnModeWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeStartUpModeWithResponseHandler:(ResponseHandler)responseHandler;
 
@@ -1058,7 +1059,7 @@ NS_ASSUME_NONNULL_BEGIN
             responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeDefaultOtaProviderWithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeDefaultOtaProviderWithValue:(NSData *)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeDefaultOtaProviderWithValue:(NSData * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeUpdatePossibleWithResponseHandler:(ResponseHandler)responseHandler;
 
@@ -1109,13 +1110,13 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)readAttributeGlobalSceneControlWithResponseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeOnTimeWithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeOnTimeWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeOnTimeWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeOffWaitTimeWithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeOffWaitTimeWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeOffWaitTimeWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeStartUpOnOffWithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeStartUpOnOffWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeStartUpOnOffWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeFeatureMapWithResponseHandler:(ResponseHandler)responseHandler;
 
@@ -1132,7 +1133,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)readAttributeSwitchTypeWithResponseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeSwitchActionsWithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeSwitchActionsWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeSwitchActionsWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeClusterRevisionWithResponseHandler:(ResponseHandler)responseHandler;
 
@@ -1279,10 +1280,10 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)readAttributeLifetimeEnergyConsumedWithResponseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeOperationModeWithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeOperationModeWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeOperationModeWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeControlModeWithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeControlModeWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeControlModeWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeAlarmMaskWithResponseHandler:(ResponseHandler)responseHandler;
 
@@ -1481,52 +1482,52 @@ NS_ASSUME_NONNULL_BEGIN
            responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeBooleanWithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeBooleanWithValue:(bool)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeBooleanWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeBitmap8WithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeBitmap8WithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeBitmap8WithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeBitmap16WithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeBitmap16WithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeBitmap16WithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeBitmap32WithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeBitmap32WithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeBitmap32WithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeBitmap64WithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeBitmap64WithValue:(uint64_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeBitmap64WithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeInt8uWithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeInt8uWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeInt8uWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeInt16uWithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeInt16uWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeInt16uWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeInt32uWithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeInt32uWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeInt32uWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeInt64uWithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeInt64uWithValue:(uint64_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeInt64uWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeInt8sWithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeInt8sWithValue:(int8_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeInt8sWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeInt16sWithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeInt16sWithValue:(int16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeInt16sWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeInt32sWithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeInt32sWithValue:(int32_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeInt32sWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeInt64sWithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeInt64sWithValue:(int64_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeInt64sWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeEnum8WithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeEnum8WithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeEnum8WithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeEnum16WithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeEnum16WithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeEnum16WithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeOctetStringWithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeOctetStringWithValue:(NSData *)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeOctetStringWithValue:(NSData * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeListInt8uWithResponseHandler:(ResponseHandler)responseHandler;
 
@@ -1535,78 +1536,78 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)readAttributeListStructOctetStringWithResponseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeLongOctetStringWithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeLongOctetStringWithValue:(NSData *)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeLongOctetStringWithValue:(NSData * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeCharStringWithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeCharStringWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeCharStringWithValue:(NSString * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeLongCharStringWithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeLongCharStringWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeLongCharStringWithValue:(NSString * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeEpochUsWithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeEpochUsWithValue:(uint64_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeEpochUsWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeEpochSWithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeEpochSWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeEpochSWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeVendorIdWithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeVendorIdWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeVendorIdWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeListNullablesAndOptionalsStructWithResponseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeUnsupportedWithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeUnsupportedWithValue:(bool)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeUnsupportedWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeNullableBooleanWithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeNullableBooleanWithValue:(bool)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeNullableBooleanWithValue:(NSNumber * _Nullable)value responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeNullableBitmap8WithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeNullableBitmap8WithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeNullableBitmap8WithValue:(NSNumber * _Nullable)value responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeNullableBitmap16WithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeNullableBitmap16WithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeNullableBitmap16WithValue:(NSNumber * _Nullable)value responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeNullableBitmap32WithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeNullableBitmap32WithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeNullableBitmap32WithValue:(NSNumber * _Nullable)value responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeNullableBitmap64WithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeNullableBitmap64WithValue:(uint64_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeNullableBitmap64WithValue:(NSNumber * _Nullable)value responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeNullableInt8uWithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeNullableInt8uWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeNullableInt8uWithValue:(NSNumber * _Nullable)value responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeNullableInt16uWithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeNullableInt16uWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeNullableInt16uWithValue:(NSNumber * _Nullable)value responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeNullableInt32uWithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeNullableInt32uWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeNullableInt32uWithValue:(NSNumber * _Nullable)value responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeNullableInt64uWithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeNullableInt64uWithValue:(uint64_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeNullableInt64uWithValue:(NSNumber * _Nullable)value responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeNullableInt8sWithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeNullableInt8sWithValue:(int8_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeNullableInt8sWithValue:(NSNumber * _Nullable)value responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeNullableInt16sWithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeNullableInt16sWithValue:(int16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeNullableInt16sWithValue:(NSNumber * _Nullable)value responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeNullableInt32sWithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeNullableInt32sWithValue:(int32_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeNullableInt32sWithValue:(NSNumber * _Nullable)value responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeNullableInt64sWithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeNullableInt64sWithValue:(int64_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeNullableInt64sWithValue:(NSNumber * _Nullable)value responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeNullableEnum8WithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeNullableEnum8WithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeNullableEnum8WithValue:(NSNumber * _Nullable)value responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeNullableEnum16WithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeNullableEnum16WithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeNullableEnum16WithValue:(NSNumber * _Nullable)value responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeNullableOctetStringWithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeNullableOctetStringWithValue:(NSData *)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeNullableOctetStringWithValue:(NSData * _Nullable)value responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeNullableCharStringWithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeNullableCharStringWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeNullableCharStringWithValue:(NSString * _Nullable)value responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeClusterRevisionWithResponseHandler:(ResponseHandler)responseHandler;
 
@@ -1644,31 +1645,32 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)readAttributeAbsMaxCoolSetpointLimitWithResponseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeOccupiedCoolingSetpointWithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeOccupiedCoolingSetpointWithValue:(int16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeOccupiedCoolingSetpointWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeOccupiedHeatingSetpointWithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeOccupiedHeatingSetpointWithValue:(int16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeOccupiedHeatingSetpointWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeMinHeatSetpointLimitWithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeMinHeatSetpointLimitWithValue:(int16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeMinHeatSetpointLimitWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeMaxHeatSetpointLimitWithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeMaxHeatSetpointLimitWithValue:(int16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeMaxHeatSetpointLimitWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeMinCoolSetpointLimitWithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeMinCoolSetpointLimitWithValue:(int16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeMinCoolSetpointLimitWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeMaxCoolSetpointLimitWithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeMaxCoolSetpointLimitWithValue:(int16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeMaxCoolSetpointLimitWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeMinSetpointDeadBandWithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeMinSetpointDeadBandWithValue:(int8_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeMinSetpointDeadBandWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeControlSequenceOfOperationWithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeControlSequenceOfOperationWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeControlSequenceOfOperationWithValue:(NSNumber * _Nonnull)value
+                                          responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeSystemModeWithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeSystemModeWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeSystemModeWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeStartOfWeekWithResponseHandler:(ResponseHandler)responseHandler;
 
@@ -1689,13 +1691,14 @@ NS_ASSUME_NONNULL_BEGIN
 @interface CHIPThermostatUserInterfaceConfiguration : CHIPCluster
 
 - (void)readAttributeTemperatureDisplayModeWithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeTemperatureDisplayModeWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeTemperatureDisplayModeWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeKeypadLockoutWithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeKeypadLockoutWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeKeypadLockoutWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeScheduleProgrammingVisibilityWithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeScheduleProgrammingVisibilityWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeScheduleProgrammingVisibilityWithValue:(NSNumber * _Nonnull)value
+                                             responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeClusterRevisionWithResponseHandler:(ResponseHandler)responseHandler;
 
@@ -1971,7 +1974,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)readAttributeInstalledClosedLimitTiltWithResponseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeModeWithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeModeWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeModeWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeSafetyStatusWithResponseHandler:(ResponseHandler)responseHandler;
 - (void)subscribeAttributeSafetyStatusWithMinInterval:(uint16_t)minInterval

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPClustersObjc.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPClustersObjc.mm
@@ -25,46 +25,14 @@
 #import "CHIPCommandPayloadsObjc.h"
 #import "CHIPDevice.h"
 #import "CHIPDevice_Internal.h"
+#import "CHIPListUtils_internal.h"
 #import "CHIPStructsObjc.h"
 
-#include <set>
 #include <type_traits>
 
 using chip::Callback::Callback;
 using chip::Callback::Cancelable;
 using namespace chip::app::Clusters;
-
-template <typename T> struct ListMemberTypeGetter {
-};
-template <typename T> struct ListMemberTypeGetter<chip::app::DataModel::List<T>> {
-    // We use List<const ...> in data model data structures, so consumers can
-    // use const data.  Just grab the type with the const stripped off.
-    using Type = std::remove_const_t<T>;
-};
-
-struct ListHolderBase {
-    // Just here so we can delete an instance to trigger the subclass destructor.
-    virtual ~ListHolderBase() {}
-};
-
-template <typename T> struct ListHolder : ListHolderBase {
-    ListHolder(size_t N) { mList = new T[N]; }
-    ~ListHolder() { delete[] mList; }
-    T * mList;
-};
-
-struct ListFreer {
-    ~ListFreer()
-    {
-        for (auto listHolder : mListHolders) {
-            delete listHolder;
-        }
-    }
-
-    void add(ListHolderBase * listHolder) { mListHolders.insert(listHolder); }
-
-    std::set<ListHolderBase *> mListHolders;
-};
 
 @implementation CHIPAccountLogin
 
@@ -94,8 +62,8 @@ struct ListFreer {
     request.tempAccountIdentifier = [self asCharSpan:payload.TempAccountIdentifier];
     request.setupPIN = [self asCharSpan:payload.SetupPIN];
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -124,8 +92,8 @@ struct ListFreer {
     AdministratorCommissioning::Commands::OpenBasicCommissioningWindow::Type request;
     request.commissioningTimeout = payload.CommissioningTimeout.unsignedShortValue;
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -143,8 +111,8 @@ struct ListFreer {
     request.salt = [self asByteSpan:payload.Salt];
     request.passcodeID = payload.PasscodeID.unsignedShortValue;
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -156,8 +124,8 @@ struct ListFreer {
     ListFreer listFreer;
     AdministratorCommissioning::Commands::RevokeCommissioning::Type request;
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -186,8 +154,8 @@ struct ListFreer {
     ApplicationBasic::Commands::ChangeStatus::Type request;
     request.status = static_cast<std::remove_reference_t<decltype(request.status)>>(payload.Status.unsignedCharValue);
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -320,8 +288,8 @@ struct ListFreer {
     request.index = payload.Index.unsignedCharValue;
     request.name = [self asCharSpan:payload.Name];
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -333,8 +301,8 @@ struct ListFreer {
     AudioOutput::Commands::SelectOutput::Type request;
     request.index = payload.Index.unsignedCharValue;
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -378,8 +346,8 @@ struct ListFreer {
     BarrierControl::Commands::BarrierControlGoToPercent::Type request;
     request.percentOpen = payload.PercentOpen.unsignedCharValue;
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -391,8 +359,8 @@ struct ListFreer {
     ListFreer listFreer;
     BarrierControl::Commands::BarrierControlStop::Type request;
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -447,8 +415,8 @@ struct ListFreer {
     ListFreer listFreer;
     Basic::Commands::MfgSpecificPing::Type request;
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -496,10 +464,16 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeUserLabelWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeUserLabelWithValue:(NSString * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeUserLabel(success, failure, [self asCharSpan:value]);
+        ListFreer listFreer;
+        using TypeInfo = Basic::Attributes::UserLabel::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = [self asCharSpan:value];
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -510,10 +484,16 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeLocationWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeLocationWithValue:(NSString * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeLocation(success, failure, [self asCharSpan:value]);
+        ListFreer listFreer;
+        using TypeInfo = Basic::Attributes::Location::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = [self asCharSpan:value];
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -587,10 +567,16 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeLocalConfigDisabledWithValue:(bool)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeLocalConfigDisabledWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeLocalConfigDisabled(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = Basic::Attributes::LocalConfigDisabled::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.boolValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -624,10 +610,16 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeOutOfServiceWithValue:(bool)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeOutOfServiceWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeOutOfService(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = BinaryInputBasic::Attributes::OutOfService::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.boolValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -638,10 +630,16 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributePresentValueWithValue:(bool)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributePresentValueWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributePresentValue(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = BinaryInputBasic::Attributes::PresentValue::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.boolValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -715,8 +713,8 @@ struct ListFreer {
     request.endpointId = payload.EndpointId.unsignedShortValue;
     request.clusterId = payload.ClusterId.unsignedIntValue;
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -731,8 +729,8 @@ struct ListFreer {
     request.endpointId = payload.EndpointId.unsignedShortValue;
     request.clusterId = payload.ClusterId.unsignedIntValue;
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -803,12 +801,12 @@ struct ListFreer {
     BridgedActions::Commands::DisableAction::Type request;
     request.actionID = payload.ActionID.unsignedShortValue;
     if (payload.InvokeID != nil) {
-        auto & definedValue = request.invokeID.Emplace();
-        definedValue = payload.InvokeID.unsignedIntValue;
+        auto & definedValue_0 = request.invokeID.Emplace();
+        definedValue_0 = payload.InvokeID.unsignedIntValue;
     }
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -821,13 +819,13 @@ struct ListFreer {
     BridgedActions::Commands::DisableActionWithDuration::Type request;
     request.actionID = payload.ActionID.unsignedShortValue;
     if (payload.InvokeID != nil) {
-        auto & definedValue = request.invokeID.Emplace();
-        definedValue = payload.InvokeID.unsignedIntValue;
+        auto & definedValue_0 = request.invokeID.Emplace();
+        definedValue_0 = payload.InvokeID.unsignedIntValue;
     }
     request.duration = payload.Duration.unsignedIntValue;
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -840,12 +838,12 @@ struct ListFreer {
     BridgedActions::Commands::EnableAction::Type request;
     request.actionID = payload.ActionID.unsignedShortValue;
     if (payload.InvokeID != nil) {
-        auto & definedValue = request.invokeID.Emplace();
-        definedValue = payload.InvokeID.unsignedIntValue;
+        auto & definedValue_0 = request.invokeID.Emplace();
+        definedValue_0 = payload.InvokeID.unsignedIntValue;
     }
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -858,13 +856,13 @@ struct ListFreer {
     BridgedActions::Commands::EnableActionWithDuration::Type request;
     request.actionID = payload.ActionID.unsignedShortValue;
     if (payload.InvokeID != nil) {
-        auto & definedValue = request.invokeID.Emplace();
-        definedValue = payload.InvokeID.unsignedIntValue;
+        auto & definedValue_0 = request.invokeID.Emplace();
+        definedValue_0 = payload.InvokeID.unsignedIntValue;
     }
     request.duration = payload.Duration.unsignedIntValue;
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -877,12 +875,12 @@ struct ListFreer {
     BridgedActions::Commands::InstantAction::Type request;
     request.actionID = payload.ActionID.unsignedShortValue;
     if (payload.InvokeID != nil) {
-        auto & definedValue = request.invokeID.Emplace();
-        definedValue = payload.InvokeID.unsignedIntValue;
+        auto & definedValue_0 = request.invokeID.Emplace();
+        definedValue_0 = payload.InvokeID.unsignedIntValue;
     }
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -895,13 +893,13 @@ struct ListFreer {
     BridgedActions::Commands::InstantActionWithTransition::Type request;
     request.actionID = payload.ActionID.unsignedShortValue;
     if (payload.InvokeID != nil) {
-        auto & definedValue = request.invokeID.Emplace();
-        definedValue = payload.InvokeID.unsignedIntValue;
+        auto & definedValue_0 = request.invokeID.Emplace();
+        definedValue_0 = payload.InvokeID.unsignedIntValue;
     }
     request.transitionTime = payload.TransitionTime.unsignedShortValue;
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -913,12 +911,12 @@ struct ListFreer {
     BridgedActions::Commands::PauseAction::Type request;
     request.actionID = payload.ActionID.unsignedShortValue;
     if (payload.InvokeID != nil) {
-        auto & definedValue = request.invokeID.Emplace();
-        definedValue = payload.InvokeID.unsignedIntValue;
+        auto & definedValue_0 = request.invokeID.Emplace();
+        definedValue_0 = payload.InvokeID.unsignedIntValue;
     }
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -931,13 +929,13 @@ struct ListFreer {
     BridgedActions::Commands::PauseActionWithDuration::Type request;
     request.actionID = payload.ActionID.unsignedShortValue;
     if (payload.InvokeID != nil) {
-        auto & definedValue = request.invokeID.Emplace();
-        definedValue = payload.InvokeID.unsignedIntValue;
+        auto & definedValue_0 = request.invokeID.Emplace();
+        definedValue_0 = payload.InvokeID.unsignedIntValue;
     }
     request.duration = payload.Duration.unsignedIntValue;
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -950,12 +948,12 @@ struct ListFreer {
     BridgedActions::Commands::ResumeAction::Type request;
     request.actionID = payload.ActionID.unsignedShortValue;
     if (payload.InvokeID != nil) {
-        auto & definedValue = request.invokeID.Emplace();
-        definedValue = payload.InvokeID.unsignedIntValue;
+        auto & definedValue_0 = request.invokeID.Emplace();
+        definedValue_0 = payload.InvokeID.unsignedIntValue;
     }
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -967,12 +965,12 @@ struct ListFreer {
     BridgedActions::Commands::StartAction::Type request;
     request.actionID = payload.ActionID.unsignedShortValue;
     if (payload.InvokeID != nil) {
-        auto & definedValue = request.invokeID.Emplace();
-        definedValue = payload.InvokeID.unsignedIntValue;
+        auto & definedValue_0 = request.invokeID.Emplace();
+        definedValue_0 = payload.InvokeID.unsignedIntValue;
     }
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -985,13 +983,13 @@ struct ListFreer {
     BridgedActions::Commands::StartActionWithDuration::Type request;
     request.actionID = payload.ActionID.unsignedShortValue;
     if (payload.InvokeID != nil) {
-        auto & definedValue = request.invokeID.Emplace();
-        definedValue = payload.InvokeID.unsignedIntValue;
+        auto & definedValue_0 = request.invokeID.Emplace();
+        definedValue_0 = payload.InvokeID.unsignedIntValue;
     }
     request.duration = payload.Duration.unsignedIntValue;
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -1003,12 +1001,12 @@ struct ListFreer {
     BridgedActions::Commands::StopAction::Type request;
     request.actionID = payload.ActionID.unsignedShortValue;
     if (payload.InvokeID != nil) {
-        auto & definedValue = request.invokeID.Emplace();
-        definedValue = payload.InvokeID.unsignedIntValue;
+        auto & definedValue_0 = request.invokeID.Emplace();
+        definedValue_0 = payload.InvokeID.unsignedIntValue;
     }
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -1081,10 +1079,16 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeUserLabelWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeUserLabelWithValue:(NSString * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeUserLabel(success, failure, [self asCharSpan:value]);
+        ListFreer listFreer;
+        using TypeInfo = BridgedDeviceBasic::Attributes::UserLabel::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = [self asCharSpan:value];
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -1187,8 +1191,8 @@ struct ListFreer {
     request.optionsMask = payload.OptionsMask.unsignedCharValue;
     request.optionsOverride = payload.OptionsOverride.unsignedCharValue;
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -1204,8 +1208,8 @@ struct ListFreer {
     request.optionsMask = payload.OptionsMask.unsignedCharValue;
     request.optionsOverride = payload.OptionsOverride.unsignedCharValue;
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -1222,8 +1226,8 @@ struct ListFreer {
     request.optionsMask = payload.OptionsMask.unsignedCharValue;
     request.optionsOverride = payload.OptionsOverride.unsignedCharValue;
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -1240,8 +1244,8 @@ struct ListFreer {
     request.optionsMask = payload.OptionsMask.unsignedCharValue;
     request.optionsOverride = payload.OptionsOverride.unsignedCharValue;
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -1258,8 +1262,8 @@ struct ListFreer {
     request.optionsMask = payload.OptionsMask.unsignedCharValue;
     request.optionsOverride = payload.OptionsOverride.unsignedCharValue;
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -1274,8 +1278,8 @@ struct ListFreer {
     request.optionsMask = payload.OptionsMask.unsignedCharValue;
     request.optionsOverride = payload.OptionsOverride.unsignedCharValue;
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -1293,8 +1297,8 @@ struct ListFreer {
     request.optionsMask = payload.OptionsMask.unsignedCharValue;
     request.optionsOverride = payload.OptionsOverride.unsignedCharValue;
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -1309,8 +1313,8 @@ struct ListFreer {
     request.optionsMask = payload.OptionsMask.unsignedCharValue;
     request.optionsOverride = payload.OptionsOverride.unsignedCharValue;
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -1326,8 +1330,8 @@ struct ListFreer {
     request.optionsMask = payload.OptionsMask.unsignedCharValue;
     request.optionsOverride = payload.OptionsOverride.unsignedCharValue;
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -1343,8 +1347,8 @@ struct ListFreer {
     request.optionsMask = payload.OptionsMask.unsignedCharValue;
     request.optionsOverride = payload.OptionsOverride.unsignedCharValue;
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -1360,8 +1364,8 @@ struct ListFreer {
     request.optionsMask = payload.OptionsMask.unsignedCharValue;
     request.optionsOverride = payload.OptionsOverride.unsignedCharValue;
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -1377,8 +1381,8 @@ struct ListFreer {
     request.optionsMask = payload.OptionsMask.unsignedCharValue;
     request.optionsOverride = payload.OptionsOverride.unsignedCharValue;
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -1395,8 +1399,8 @@ struct ListFreer {
     request.optionsMask = payload.OptionsMask.unsignedCharValue;
     request.optionsOverride = payload.OptionsOverride.unsignedCharValue;
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -1412,8 +1416,8 @@ struct ListFreer {
     request.optionsMask = payload.OptionsMask.unsignedCharValue;
     request.optionsOverride = payload.OptionsOverride.unsignedCharValue;
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -1429,8 +1433,8 @@ struct ListFreer {
     request.optionsMask = payload.OptionsMask.unsignedCharValue;
     request.optionsOverride = payload.OptionsOverride.unsignedCharValue;
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -1449,8 +1453,8 @@ struct ListFreer {
     request.optionsMask = payload.OptionsMask.unsignedCharValue;
     request.optionsOverride = payload.OptionsOverride.unsignedCharValue;
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -1466,8 +1470,8 @@ struct ListFreer {
     request.optionsMask = payload.OptionsMask.unsignedCharValue;
     request.optionsOverride = payload.OptionsOverride.unsignedCharValue;
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -1484,8 +1488,8 @@ struct ListFreer {
     request.optionsMask = payload.OptionsMask.unsignedCharValue;
     request.optionsOverride = payload.OptionsOverride.unsignedCharValue;
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -1498,8 +1502,8 @@ struct ListFreer {
     request.optionsMask = payload.OptionsMask.unsignedCharValue;
     request.optionsOverride = payload.OptionsOverride.unsignedCharValue;
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -1670,10 +1674,16 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeColorControlOptionsWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeColorControlOptionsWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeColorControlOptions(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ColorControl::Attributes::ColorControlOptions::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedCharValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -1817,10 +1827,16 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeWhitePointXWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeWhitePointXWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeWhitePointX(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ColorControl::Attributes::WhitePointX::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -1831,10 +1847,16 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeWhitePointYWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeWhitePointYWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeWhitePointY(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ColorControl::Attributes::WhitePointY::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -1845,10 +1867,16 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeColorPointRXWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeColorPointRXWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeColorPointRX(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ColorControl::Attributes::ColorPointRX::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -1859,10 +1887,16 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeColorPointRYWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeColorPointRYWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeColorPointRY(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ColorControl::Attributes::ColorPointRY::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -1873,10 +1907,16 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeColorPointRIntensityWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeColorPointRIntensityWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeColorPointRIntensity(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ColorControl::Attributes::ColorPointRIntensity::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedCharValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -1887,10 +1927,16 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeColorPointGXWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeColorPointGXWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeColorPointGX(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ColorControl::Attributes::ColorPointGX::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -1901,10 +1947,16 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeColorPointGYWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeColorPointGYWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeColorPointGY(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ColorControl::Attributes::ColorPointGY::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -1915,10 +1967,16 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeColorPointGIntensityWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeColorPointGIntensityWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeColorPointGIntensity(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ColorControl::Attributes::ColorPointGIntensity::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedCharValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -1929,10 +1987,16 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeColorPointBXWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeColorPointBXWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeColorPointBX(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ColorControl::Attributes::ColorPointBX::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -1943,10 +2007,16 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeColorPointBYWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeColorPointBYWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeColorPointBY(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ColorControl::Attributes::ColorPointBY::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -1957,10 +2027,16 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeColorPointBIntensityWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeColorPointBIntensityWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeColorPointBIntensity(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ColorControl::Attributes::ColorPointBIntensity::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedCharValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -2048,10 +2124,17 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeStartUpColorTemperatureMiredsWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeStartUpColorTemperatureMiredsWithValue:(NSNumber * _Nonnull)value
+                                             responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeStartUpColorTemperatureMireds(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ColorControl::Attributes::StartUpColorTemperatureMireds::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -2718,8 +2801,8 @@ struct ListFreer {
     ListFreer listFreer;
     EthernetNetworkDiagnostics::Commands::ResetCounts::Type request;
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -2930,10 +3013,16 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeBreadcrumbWithValue:(uint64_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeBreadcrumbWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeBreadcrumb(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = GeneralCommissioning::Attributes::Breadcrumb::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedLongLongValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -3068,8 +3157,8 @@ struct ListFreer {
     request.groupId = payload.GroupId.unsignedShortValue;
     request.groupName = [self asCharSpan:payload.GroupName];
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -3082,24 +3171,23 @@ struct ListFreer {
     Groups::Commands::GetGroupMembership::Type request;
     request.groupCount = payload.GroupCount.unsignedCharValue;
     {
-        using ListType = decltype(request.groupList);
+        using ListType = std::remove_reference_t<decltype(request.groupList)>;
         using ListMemberType = ListMemberTypeGetter<ListType>::Type;
         if (payload.GroupList.count != 0) {
-            auto * listHolder = new ListHolder<ListMemberType>(payload.GroupList.count);
-            if (listHolder == nullptr || listHolder->mList == nullptr) {
-                // Now what?
+            auto * listHolder_0 = new ListHolder<ListMemberType>(payload.GroupList.count);
+            if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
                 return;
             }
-            listFreer.add(listHolder);
+            listFreer.add(listHolder_0);
             for (size_t i = 0; i < payload.GroupList.count; ++i) {
                 if (![payload.GroupList[i] isKindOfClass:[NSNumber class]]) {
-                    // Wrong kind of value, now what?
+                    // Wrong kind of value.
                     return;
                 }
-                auto element = (NSNumber *) payload.GroupList[i];
-                listHolder->mList[i] = element.unsignedShortValue;
+                auto element_0 = (NSNumber *) payload.GroupList[i];
+                listHolder_0->mList[i] = element_0.unsignedShortValue;
             }
-            request.groupList = ListType(listHolder->mList, payload.GroupList.count);
+            request.groupList = ListType(listHolder_0->mList, payload.GroupList.count);
         } else {
             request.groupList = ListType();
         }
@@ -3118,8 +3206,8 @@ struct ListFreer {
     ListFreer listFreer;
     Groups::Commands::RemoveAllGroups::Type request;
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -3182,8 +3270,8 @@ struct ListFreer {
     Identify::Commands::Identify::Type request;
     request.identifyTime = payload.IdentifyTime.unsignedShortValue;
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -3211,8 +3299,8 @@ struct ListFreer {
     request.effectVariant
         = static_cast<std::remove_reference_t<decltype(request.effectVariant)>>(payload.EffectVariant.unsignedCharValue);
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -3225,10 +3313,16 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeIdentifyTimeWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeIdentifyTimeWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeIdentifyTime(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = Identify::Attributes::IdentifyTime::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -3364,8 +3458,8 @@ struct ListFreer {
     request.optionMask = payload.OptionMask.unsignedCharValue;
     request.optionOverride = payload.OptionOverride.unsignedCharValue;
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -3380,8 +3474,8 @@ struct ListFreer {
     request.optionMask = payload.OptionMask.unsignedCharValue;
     request.optionOverride = payload.OptionOverride.unsignedCharValue;
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -3395,8 +3489,8 @@ struct ListFreer {
     request.level = payload.Level.unsignedCharValue;
     request.transitionTime = payload.TransitionTime.unsignedShortValue;
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -3410,8 +3504,8 @@ struct ListFreer {
     request.moveMode = static_cast<std::remove_reference_t<decltype(request.moveMode)>>(payload.MoveMode.unsignedCharValue);
     request.rate = payload.Rate.unsignedCharValue;
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -3427,8 +3521,8 @@ struct ListFreer {
     request.optionMask = payload.OptionMask.unsignedCharValue;
     request.optionOverride = payload.OptionOverride.unsignedCharValue;
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -3443,8 +3537,8 @@ struct ListFreer {
     request.stepSize = payload.StepSize.unsignedCharValue;
     request.transitionTime = payload.TransitionTime.unsignedShortValue;
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -3457,8 +3551,8 @@ struct ListFreer {
     request.optionMask = payload.OptionMask.unsignedCharValue;
     request.optionOverride = payload.OptionOverride.unsignedCharValue;
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -3470,8 +3564,8 @@ struct ListFreer {
     ListFreer listFreer;
     LevelControl::Commands::StopWithOnOff::Type request;
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -3552,10 +3646,16 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeOptionsWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeOptionsWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeOptions(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = LevelControl::Attributes::Options::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedCharValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -3566,10 +3666,16 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeOnOffTransitionTimeWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeOnOffTransitionTimeWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeOnOffTransitionTime(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = LevelControl::Attributes::OnOffTransitionTime::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -3580,10 +3686,16 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeOnLevelWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeOnLevelWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeOnLevel(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = LevelControl::Attributes::OnLevel::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedCharValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -3594,10 +3706,16 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeOnTransitionTimeWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeOnTransitionTimeWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeOnTransitionTime(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = LevelControl::Attributes::OnTransitionTime::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -3608,10 +3726,16 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeOffTransitionTimeWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeOffTransitionTimeWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeOffTransitionTime(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = LevelControl::Attributes::OffTransitionTime::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -3622,10 +3746,16 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeDefaultMoveRateWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeDefaultMoveRateWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeDefaultMoveRate(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = LevelControl::Attributes::DefaultMoveRate::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedCharValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -3636,10 +3766,16 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeStartUpCurrentLevelWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeStartUpCurrentLevelWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeStartUpCurrentLevel(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = LevelControl::Attributes::StartUpCurrentLevel::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedCharValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -3664,8 +3800,8 @@ struct ListFreer {
     ListFreer listFreer;
     LowPower::Commands::Sleep::Type request;
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -3693,8 +3829,8 @@ struct ListFreer {
     ListFreer listFreer;
     MediaInput::Commands::HideInputStatus::Type request;
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -3707,8 +3843,8 @@ struct ListFreer {
     request.index = payload.Index.unsignedCharValue;
     request.name = [self asCharSpan:payload.Name];
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -3720,8 +3856,8 @@ struct ListFreer {
     MediaInput::Commands::SelectInput::Type request;
     request.index = payload.Index.unsignedCharValue;
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -3733,8 +3869,8 @@ struct ListFreer {
     ListFreer listFreer;
     MediaInput::Commands::ShowInputStatus::Type request;
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -4000,8 +4136,8 @@ struct ListFreer {
     ModeSelect::Commands::ChangeToMode::Type request;
     request.newMode = payload.NewMode.unsignedCharValue;
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -4048,10 +4184,16 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeOnModeWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeOnModeWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeOnMode(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ModeSelect::Attributes::OnMode::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedCharValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -4272,8 +4414,8 @@ struct ListFreer {
     request.updateToken = [self asByteSpan:payload.UpdateToken];
     request.softwareVersion = payload.SoftwareVersion.unsignedIntValue;
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -4288,44 +4430,43 @@ struct ListFreer {
     request.productId = payload.ProductId.unsignedShortValue;
     request.softwareVersion = payload.SoftwareVersion.unsignedIntValue;
     {
-        using ListType = decltype(request.protocolsSupported);
+        using ListType = std::remove_reference_t<decltype(request.protocolsSupported)>;
         using ListMemberType = ListMemberTypeGetter<ListType>::Type;
         if (payload.ProtocolsSupported.count != 0) {
-            auto * listHolder = new ListHolder<ListMemberType>(payload.ProtocolsSupported.count);
-            if (listHolder == nullptr || listHolder->mList == nullptr) {
-                // Now what?
+            auto * listHolder_0 = new ListHolder<ListMemberType>(payload.ProtocolsSupported.count);
+            if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
                 return;
             }
-            listFreer.add(listHolder);
+            listFreer.add(listHolder_0);
             for (size_t i = 0; i < payload.ProtocolsSupported.count; ++i) {
                 if (![payload.ProtocolsSupported[i] isKindOfClass:[NSNumber class]]) {
-                    // Wrong kind of value, now what?
+                    // Wrong kind of value.
                     return;
                 }
-                auto element = (NSNumber *) payload.ProtocolsSupported[i];
-                listHolder->mList[i]
-                    = static_cast<std::remove_reference_t<decltype(listHolder->mList[i])>>(element.unsignedCharValue);
+                auto element_0 = (NSNumber *) payload.ProtocolsSupported[i];
+                listHolder_0->mList[i]
+                    = static_cast<std::remove_reference_t<decltype(listHolder_0->mList[i])>>(element_0.unsignedCharValue);
             }
-            request.protocolsSupported = ListType(listHolder->mList, payload.ProtocolsSupported.count);
+            request.protocolsSupported = ListType(listHolder_0->mList, payload.ProtocolsSupported.count);
         } else {
             request.protocolsSupported = ListType();
         }
     }
     if (payload.HardwareVersion != nil) {
-        auto & definedValue = request.hardwareVersion.Emplace();
-        definedValue = payload.HardwareVersion.unsignedShortValue;
+        auto & definedValue_0 = request.hardwareVersion.Emplace();
+        definedValue_0 = payload.HardwareVersion.unsignedShortValue;
     }
     if (payload.Location != nil) {
-        auto & definedValue = request.location.Emplace();
-        definedValue = [self asCharSpan:payload.Location];
+        auto & definedValue_0 = request.location.Emplace();
+        definedValue_0 = [self asCharSpan:payload.Location];
     }
     if (payload.RequestorCanConsent != nil) {
-        auto & definedValue = request.requestorCanConsent.Emplace();
-        definedValue = payload.RequestorCanConsent.boolValue;
+        auto & definedValue_0 = request.requestorCanConsent.Emplace();
+        definedValue_0 = payload.RequestorCanConsent.boolValue;
     }
     if (payload.MetadataForProvider != nil) {
-        auto & definedValue = request.metadataForProvider.Emplace();
-        definedValue = [self asByteSpan:payload.MetadataForProvider];
+        auto & definedValue_0 = request.metadataForProvider.Emplace();
+        definedValue_0 = [self asByteSpan:payload.MetadataForProvider];
     }
 
     new CHIPOtaSoftwareUpdateProviderClusterQueryImageResponseCallbackBridge(
@@ -4362,12 +4503,12 @@ struct ListFreer {
     request.announcementReason
         = static_cast<std::remove_reference_t<decltype(request.announcementReason)>>(payload.AnnouncementReason.unsignedCharValue);
     if (payload.MetadataForNode != nil) {
-        auto & definedValue = request.metadataForNode.Emplace();
-        definedValue = [self asByteSpan:payload.MetadataForNode];
+        auto & definedValue_0 = request.metadataForNode.Emplace();
+        definedValue_0 = [self asByteSpan:payload.MetadataForNode];
     }
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -4380,10 +4521,16 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeDefaultOtaProviderWithValue:(NSData *)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeDefaultOtaProviderWithValue:(NSData * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeDefaultOtaProvider(success, failure, [self asByteSpan:value]);
+        ListFreer listFreer;
+        using TypeInfo = OtaSoftwareUpdateRequestor::Attributes::DefaultOtaProvider::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = [self asByteSpan:value];
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -4471,8 +4618,8 @@ struct ListFreer {
     ListFreer listFreer;
     OnOff::Commands::Off::Type request;
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -4486,8 +4633,8 @@ struct ListFreer {
     request.effectVariant
         = static_cast<std::remove_reference_t<decltype(request.effectVariant)>>(payload.EffectVariant.unsignedCharValue);
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -4498,8 +4645,8 @@ struct ListFreer {
     ListFreer listFreer;
     OnOff::Commands::On::Type request;
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -4511,8 +4658,8 @@ struct ListFreer {
     ListFreer listFreer;
     OnOff::Commands::OnWithRecallGlobalScene::Type request;
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -4527,8 +4674,8 @@ struct ListFreer {
     request.onTime = payload.OnTime.unsignedShortValue;
     request.offWaitTime = payload.OffWaitTime.unsignedShortValue;
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -4539,8 +4686,8 @@ struct ListFreer {
     ListFreer listFreer;
     OnOff::Commands::Toggle::Type request;
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -4586,10 +4733,16 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeOnTimeWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeOnTimeWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeOnTime(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = OnOff::Attributes::OnTime::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -4600,10 +4753,16 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeOffWaitTimeWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeOffWaitTimeWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeOffWaitTime(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = OnOff::Attributes::OffWaitTime::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -4614,10 +4773,16 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeStartUpOnOffWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeStartUpOnOffWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeStartUpOnOff(success, failure, static_cast<uint8_t>(value));
+        ListFreer listFreer;
+        using TypeInfo = OnOff::Attributes::StartUpOnOff::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = static_cast<std::remove_reference_t<decltype(cppValue)>>(value.unsignedCharValue);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -4658,10 +4823,16 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeSwitchActionsWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeSwitchActionsWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeSwitchActions(success, failure, static_cast<uint8_t>(value));
+        ListFreer listFreer;
+        using TypeInfo = OnOffSwitchConfiguration::Attributes::SwitchActions::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = static_cast<std::remove_reference_t<decltype(cppValue)>>(value.unsignedCharValue);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -4687,8 +4858,8 @@ struct ListFreer {
     OperationalCredentials::Commands::AddNOC::Type request;
     request.NOCValue = [self asByteSpan:payload.NOCValue];
     if (payload.ICACValue != nil) {
-        auto & definedValue = request.ICACValue.Emplace();
-        definedValue = [self asByteSpan:payload.ICACValue];
+        auto & definedValue_0 = request.ICACValue.Emplace();
+        definedValue_0 = [self asByteSpan:payload.ICACValue];
     }
     request.IPKValue = [self asByteSpan:payload.IPKValue];
     request.caseAdminNode = payload.CaseAdminNode.unsignedLongLongValue;
@@ -4709,8 +4880,8 @@ struct ListFreer {
     OperationalCredentials::Commands::AddTrustedRootCertificate::Type request;
     request.rootCertificate = [self asByteSpan:payload.RootCertificate];
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -4784,8 +4955,8 @@ struct ListFreer {
     OperationalCredentials::Commands::RemoveTrustedRootCertificate::Type request;
     request.trustedRootIdentifier = [self asByteSpan:payload.TrustedRootIdentifier];
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -4813,8 +4984,8 @@ struct ListFreer {
     OperationalCredentials::Commands::UpdateNOC::Type request;
     request.NOCValue = [self asByteSpan:payload.NOCValue];
     if (payload.ICACValue != nil) {
-        auto & definedValue = request.ICACValue.Emplace();
-        definedValue = [self asByteSpan:payload.ICACValue];
+        auto & definedValue_0 = request.ICACValue.Emplace();
+        definedValue_0 = [self asByteSpan:payload.ICACValue];
     }
 
     new CHIPOperationalCredentialsClusterNOCResponseCallbackBridge(
@@ -5199,10 +5370,16 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeOperationModeWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeOperationModeWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeOperationMode(success, failure, static_cast<uint8_t>(value));
+        ListFreer listFreer;
+        using TypeInfo = PumpConfigurationAndControl::Attributes::OperationMode::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = static_cast<std::remove_reference_t<decltype(cppValue)>>(value.unsignedCharValue);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -5213,10 +5390,16 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeControlModeWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeControlModeWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeControlMode(success, failure, static_cast<uint8_t>(value));
+        ListFreer listFreer;
+        using TypeInfo = PumpConfigurationAndControl::Attributes::ControlMode::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = static_cast<std::remove_reference_t<decltype(cppValue)>>(value.unsignedCharValue);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -5341,26 +5524,25 @@ struct ListFreer {
     request.transitionTime = payload.TransitionTime.unsignedShortValue;
     request.sceneName = [self asCharSpan:payload.SceneName];
     {
-        using ListType = decltype(request.extensionFieldSets);
+        using ListType = std::remove_reference_t<decltype(request.extensionFieldSets)>;
         using ListMemberType = ListMemberTypeGetter<ListType>::Type;
         if (payload.ExtensionFieldSets.count != 0) {
-            auto * listHolder = new ListHolder<ListMemberType>(payload.ExtensionFieldSets.count);
-            if (listHolder == nullptr || listHolder->mList == nullptr) {
-                // Now what?
+            auto * listHolder_0 = new ListHolder<ListMemberType>(payload.ExtensionFieldSets.count);
+            if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
                 return;
             }
-            listFreer.add(listHolder);
+            listFreer.add(listHolder_0);
             for (size_t i = 0; i < payload.ExtensionFieldSets.count; ++i) {
                 if (![payload.ExtensionFieldSets[i] isKindOfClass:[CHIPScenesClusterSceneExtensionFieldSet class]]) {
-                    // Wrong kind of value, now what?
+                    // Wrong kind of value.
                     return;
                 }
-                auto element = (CHIPScenesClusterSceneExtensionFieldSet *) payload.ExtensionFieldSets[i];
-                listHolder->mList[i].clusterId = element.ClusterId.unsignedIntValue;
-                listHolder->mList[i].length = element.Length.unsignedCharValue;
-                listHolder->mList[i].value = element.Value.unsignedCharValue;
+                auto element_0 = (CHIPScenesClusterSceneExtensionFieldSet *) payload.ExtensionFieldSets[i];
+                listHolder_0->mList[i].clusterId = element_0.ClusterId.unsignedIntValue;
+                listHolder_0->mList[i].length = element_0.Length.unsignedCharValue;
+                listHolder_0->mList[i].value = element_0.Value.unsignedCharValue;
             }
-            request.extensionFieldSets = ListType(listHolder->mList, payload.ExtensionFieldSets.count);
+            request.extensionFieldSets = ListType(listHolder_0->mList, payload.ExtensionFieldSets.count);
         } else {
             request.extensionFieldSets = ListType();
         }
@@ -5397,8 +5579,8 @@ struct ListFreer {
     request.sceneId = payload.SceneId.unsignedCharValue;
     request.transitionTime = payload.TransitionTime.unsignedShortValue;
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -5520,8 +5702,8 @@ struct ListFreer {
     ListFreer listFreer;
     SoftwareDiagnostics::Commands::ResetWatermarks::Type request;
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -5657,8 +5839,8 @@ struct ListFreer {
     request.majorNumber = payload.MajorNumber.unsignedShortValue;
     request.minorNumber = payload.MinorNumber.unsignedShortValue;
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -5670,8 +5852,8 @@ struct ListFreer {
     TvChannel::Commands::SkipChannel::Type request;
     request.count = payload.Count.unsignedShortValue;
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -5842,8 +6024,8 @@ struct ListFreer {
     ListFreer listFreer;
     TestCluster::Commands::Test::Type request;
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -5887,24 +6069,23 @@ struct ListFreer {
     ListFreer listFreer;
     TestCluster::Commands::TestListInt8UArgumentRequest::Type request;
     {
-        using ListType = decltype(request.arg1);
+        using ListType = std::remove_reference_t<decltype(request.arg1)>;
         using ListMemberType = ListMemberTypeGetter<ListType>::Type;
         if (payload.Arg1.count != 0) {
-            auto * listHolder = new ListHolder<ListMemberType>(payload.Arg1.count);
-            if (listHolder == nullptr || listHolder->mList == nullptr) {
-                // Now what?
+            auto * listHolder_0 = new ListHolder<ListMemberType>(payload.Arg1.count);
+            if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
                 return;
             }
-            listFreer.add(listHolder);
+            listFreer.add(listHolder_0);
             for (size_t i = 0; i < payload.Arg1.count; ++i) {
                 if (![payload.Arg1[i] isKindOfClass:[NSNumber class]]) {
-                    // Wrong kind of value, now what?
+                    // Wrong kind of value.
                     return;
                 }
-                auto element = (NSNumber *) payload.Arg1[i];
-                listHolder->mList[i] = element.unsignedCharValue;
+                auto element_0 = (NSNumber *) payload.Arg1[i];
+                listHolder_0->mList[i] = element_0.unsignedCharValue;
             }
-            request.arg1 = ListType(listHolder->mList, payload.Arg1.count);
+            request.arg1 = ListType(listHolder_0->mList, payload.Arg1.count);
         } else {
             request.arg1 = ListType();
         }
@@ -5924,24 +6105,23 @@ struct ListFreer {
     ListFreer listFreer;
     TestCluster::Commands::TestListInt8UReverseRequest::Type request;
     {
-        using ListType = decltype(request.arg1);
+        using ListType = std::remove_reference_t<decltype(request.arg1)>;
         using ListMemberType = ListMemberTypeGetter<ListType>::Type;
         if (payload.Arg1.count != 0) {
-            auto * listHolder = new ListHolder<ListMemberType>(payload.Arg1.count);
-            if (listHolder == nullptr || listHolder->mList == nullptr) {
-                // Now what?
+            auto * listHolder_0 = new ListHolder<ListMemberType>(payload.Arg1.count);
+            if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
                 return;
             }
-            listFreer.add(listHolder);
+            listFreer.add(listHolder_0);
             for (size_t i = 0; i < payload.Arg1.count; ++i) {
                 if (![payload.Arg1[i] isKindOfClass:[NSNumber class]]) {
-                    // Wrong kind of value, now what?
+                    // Wrong kind of value.
                     return;
                 }
-                auto element = (NSNumber *) payload.Arg1[i];
-                listHolder->mList[i] = element.unsignedCharValue;
+                auto element_0 = (NSNumber *) payload.Arg1[i];
+                listHolder_0->mList[i] = element_0.unsignedCharValue;
             }
-            request.arg1 = ListType(listHolder->mList, payload.Arg1.count);
+            request.arg1 = ListType(listHolder_0->mList, payload.Arg1.count);
         } else {
             request.arg1 = ListType();
         }
@@ -5961,31 +6141,30 @@ struct ListFreer {
     ListFreer listFreer;
     TestCluster::Commands::TestListStructArgumentRequest::Type request;
     {
-        using ListType = decltype(request.arg1);
+        using ListType = std::remove_reference_t<decltype(request.arg1)>;
         using ListMemberType = ListMemberTypeGetter<ListType>::Type;
         if (payload.Arg1.count != 0) {
-            auto * listHolder = new ListHolder<ListMemberType>(payload.Arg1.count);
-            if (listHolder == nullptr || listHolder->mList == nullptr) {
-                // Now what?
+            auto * listHolder_0 = new ListHolder<ListMemberType>(payload.Arg1.count);
+            if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
                 return;
             }
-            listFreer.add(listHolder);
+            listFreer.add(listHolder_0);
             for (size_t i = 0; i < payload.Arg1.count; ++i) {
                 if (![payload.Arg1[i] isKindOfClass:[CHIPTestClusterClusterSimpleStruct class]]) {
-                    // Wrong kind of value, now what?
+                    // Wrong kind of value.
                     return;
                 }
-                auto element = (CHIPTestClusterClusterSimpleStruct *) payload.Arg1[i];
-                listHolder->mList[i].a = element.A.unsignedCharValue;
-                listHolder->mList[i].b = element.B.boolValue;
-                listHolder->mList[i].c
-                    = static_cast<std::remove_reference_t<decltype(listHolder->mList[i].c)>>(element.C.unsignedCharValue);
-                listHolder->mList[i].d = [self asByteSpan:element.D];
-                listHolder->mList[i].e = [self asCharSpan:element.E];
-                listHolder->mList[i].f
-                    = static_cast<std::remove_reference_t<decltype(listHolder->mList[i].f)>>(element.F.unsignedCharValue);
+                auto element_0 = (CHIPTestClusterClusterSimpleStruct *) payload.Arg1[i];
+                listHolder_0->mList[i].a = element_0.A.unsignedCharValue;
+                listHolder_0->mList[i].b = element_0.B.boolValue;
+                listHolder_0->mList[i].c
+                    = static_cast<std::remove_reference_t<decltype(listHolder_0->mList[i].c)>>(element_0.C.unsignedCharValue);
+                listHolder_0->mList[i].d = [self asByteSpan:element_0.D];
+                listHolder_0->mList[i].e = [self asCharSpan:element_0.E];
+                listHolder_0->mList[i].f
+                    = static_cast<std::remove_reference_t<decltype(listHolder_0->mList[i].f)>>(element_0.F.unsignedCharValue);
             }
-            request.arg1 = ListType(listHolder->mList, payload.Arg1.count);
+            request.arg1 = ListType(listHolder_0->mList, payload.Arg1.count);
         } else {
             request.arg1 = ListType();
         }
@@ -6005,8 +6184,8 @@ struct ListFreer {
     ListFreer listFreer;
     TestCluster::Commands::TestNotHandled::Type request;
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -6018,12 +6197,12 @@ struct ListFreer {
     ListFreer listFreer;
     TestCluster::Commands::TestNullableOptionalRequest::Type request;
     if (payload.Arg1 != nil) {
-        auto & definedValue = request.arg1.Emplace();
+        auto & definedValue_0 = request.arg1.Emplace();
         if (payload.Arg1 == nil) {
-            definedValue.SetNull();
+            definedValue_0.SetNull();
         } else {
-            auto & nonNullValue = definedValue.SetNonNull();
-            nonNullValue = payload.Arg1.unsignedCharValue;
+            auto & nonNullValue_1 = definedValue_0.SetNonNull();
+            nonNullValue_1 = payload.Arg1.unsignedCharValue;
         }
     }
 
@@ -6074,8 +6253,8 @@ struct ListFreer {
     ListFreer listFreer;
     TestCluster::Commands::TestUnknownCommand::Type request;
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -6088,10 +6267,16 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeBooleanWithValue:(bool)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeBooleanWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeBoolean(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = TestCluster::Attributes::Boolean::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.boolValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -6102,10 +6287,16 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeBitmap8WithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeBitmap8WithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeBitmap8(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = TestCluster::Attributes::Bitmap8::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedCharValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -6116,10 +6307,16 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeBitmap16WithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeBitmap16WithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeBitmap16(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = TestCluster::Attributes::Bitmap16::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -6130,10 +6327,16 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeBitmap32WithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeBitmap32WithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeBitmap32(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = TestCluster::Attributes::Bitmap32::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedIntValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -6144,10 +6347,16 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeBitmap64WithValue:(uint64_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeBitmap64WithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeBitmap64(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = TestCluster::Attributes::Bitmap64::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedLongLongValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -6158,10 +6367,16 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeInt8uWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeInt8uWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeInt8u(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = TestCluster::Attributes::Int8u::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedCharValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -6172,10 +6387,16 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeInt16uWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeInt16uWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeInt16u(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = TestCluster::Attributes::Int16u::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -6186,10 +6407,16 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeInt32uWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeInt32uWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeInt32u(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = TestCluster::Attributes::Int32u::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedIntValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -6200,10 +6427,16 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeInt64uWithValue:(uint64_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeInt64uWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeInt64u(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = TestCluster::Attributes::Int64u::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedLongLongValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -6214,10 +6447,16 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeInt8sWithValue:(int8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeInt8sWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeInt8s(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = TestCluster::Attributes::Int8s::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.charValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -6228,10 +6467,16 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeInt16sWithValue:(int16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeInt16sWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeInt16s(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = TestCluster::Attributes::Int16s::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.shortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -6242,10 +6487,16 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeInt32sWithValue:(int32_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeInt32sWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeInt32s(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = TestCluster::Attributes::Int32s::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.intValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -6256,10 +6507,16 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeInt64sWithValue:(int64_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeInt64sWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeInt64s(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = TestCluster::Attributes::Int64s::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.longLongValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -6270,10 +6527,16 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeEnum8WithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeEnum8WithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeEnum8(success, failure, static_cast<uint8_t>(value));
+        ListFreer listFreer;
+        using TypeInfo = TestCluster::Attributes::Enum8::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = static_cast<std::remove_reference_t<decltype(cppValue)>>(value.unsignedCharValue);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -6284,10 +6547,16 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeEnum16WithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeEnum16WithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeEnum16(success, failure, static_cast<uint16_t>(value));
+        ListFreer listFreer;
+        using TypeInfo = TestCluster::Attributes::Enum16::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = static_cast<std::remove_reference_t<decltype(cppValue)>>(value.unsignedShortValue);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -6298,10 +6567,16 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeOctetStringWithValue:(NSData *)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeOctetStringWithValue:(NSData * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeOctetString(success, failure, [self asByteSpan:value]);
+        ListFreer listFreer;
+        using TypeInfo = TestCluster::Attributes::OctetString::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = [self asByteSpan:value];
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -6336,10 +6611,16 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeLongOctetStringWithValue:(NSData *)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeLongOctetStringWithValue:(NSData * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeLongOctetString(success, failure, [self asByteSpan:value]);
+        ListFreer listFreer;
+        using TypeInfo = TestCluster::Attributes::LongOctetString::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = [self asByteSpan:value];
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -6350,10 +6631,16 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeCharStringWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeCharStringWithValue:(NSString * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeCharString(success, failure, [self asCharSpan:value]);
+        ListFreer listFreer;
+        using TypeInfo = TestCluster::Attributes::CharString::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = [self asCharSpan:value];
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -6364,10 +6651,16 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeLongCharStringWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeLongCharStringWithValue:(NSString * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeLongCharString(success, failure, [self asCharSpan:value]);
+        ListFreer listFreer;
+        using TypeInfo = TestCluster::Attributes::LongCharString::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = [self asCharSpan:value];
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -6378,10 +6671,16 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeEpochUsWithValue:(uint64_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeEpochUsWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeEpochUs(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = TestCluster::Attributes::EpochUs::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedLongLongValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -6392,10 +6691,16 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeEpochSWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeEpochSWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeEpochS(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = TestCluster::Attributes::EpochS::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedIntValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -6406,10 +6711,16 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeVendorIdWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeVendorIdWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeVendorId(success, failure, static_cast<chip::VendorId>(value));
+        ListFreer listFreer;
+        using TypeInfo = TestCluster::Attributes::VendorId::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = static_cast<std::remove_reference_t<decltype(cppValue)>>(value.unsignedShortValue);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -6428,10 +6739,16 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeUnsupportedWithValue:(bool)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeUnsupportedWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeUnsupported(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = TestCluster::Attributes::Unsupported::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.boolValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -6442,10 +6759,21 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeNullableBooleanWithValue:(bool)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeNullableBooleanWithValue:(NSNumber * _Nullable)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeNullableBoolean(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = TestCluster::Attributes::NullableBoolean::TypeInfo;
+        TypeInfo::Type cppValue;
+        if (value == nil) {
+            cppValue.SetNull();
+        } else {
+            auto & nonNullValue_0 = cppValue.SetNonNull();
+            nonNullValue_0 = value.boolValue;
+        }
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -6456,10 +6784,21 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeNullableBitmap8WithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeNullableBitmap8WithValue:(NSNumber * _Nullable)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeNullableBitmap8(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = TestCluster::Attributes::NullableBitmap8::TypeInfo;
+        TypeInfo::Type cppValue;
+        if (value == nil) {
+            cppValue.SetNull();
+        } else {
+            auto & nonNullValue_0 = cppValue.SetNonNull();
+            nonNullValue_0 = value.unsignedCharValue;
+        }
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -6470,10 +6809,21 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeNullableBitmap16WithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeNullableBitmap16WithValue:(NSNumber * _Nullable)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeNullableBitmap16(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = TestCluster::Attributes::NullableBitmap16::TypeInfo;
+        TypeInfo::Type cppValue;
+        if (value == nil) {
+            cppValue.SetNull();
+        } else {
+            auto & nonNullValue_0 = cppValue.SetNonNull();
+            nonNullValue_0 = value.unsignedShortValue;
+        }
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -6484,10 +6834,21 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeNullableBitmap32WithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeNullableBitmap32WithValue:(NSNumber * _Nullable)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeNullableBitmap32(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = TestCluster::Attributes::NullableBitmap32::TypeInfo;
+        TypeInfo::Type cppValue;
+        if (value == nil) {
+            cppValue.SetNull();
+        } else {
+            auto & nonNullValue_0 = cppValue.SetNonNull();
+            nonNullValue_0 = value.unsignedIntValue;
+        }
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -6498,10 +6859,21 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeNullableBitmap64WithValue:(uint64_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeNullableBitmap64WithValue:(NSNumber * _Nullable)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeNullableBitmap64(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = TestCluster::Attributes::NullableBitmap64::TypeInfo;
+        TypeInfo::Type cppValue;
+        if (value == nil) {
+            cppValue.SetNull();
+        } else {
+            auto & nonNullValue_0 = cppValue.SetNonNull();
+            nonNullValue_0 = value.unsignedLongLongValue;
+        }
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -6512,10 +6884,21 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeNullableInt8uWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeNullableInt8uWithValue:(NSNumber * _Nullable)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeNullableInt8u(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = TestCluster::Attributes::NullableInt8u::TypeInfo;
+        TypeInfo::Type cppValue;
+        if (value == nil) {
+            cppValue.SetNull();
+        } else {
+            auto & nonNullValue_0 = cppValue.SetNonNull();
+            nonNullValue_0 = value.unsignedCharValue;
+        }
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -6526,10 +6909,21 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeNullableInt16uWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeNullableInt16uWithValue:(NSNumber * _Nullable)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeNullableInt16u(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = TestCluster::Attributes::NullableInt16u::TypeInfo;
+        TypeInfo::Type cppValue;
+        if (value == nil) {
+            cppValue.SetNull();
+        } else {
+            auto & nonNullValue_0 = cppValue.SetNonNull();
+            nonNullValue_0 = value.unsignedShortValue;
+        }
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -6540,10 +6934,21 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeNullableInt32uWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeNullableInt32uWithValue:(NSNumber * _Nullable)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeNullableInt32u(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = TestCluster::Attributes::NullableInt32u::TypeInfo;
+        TypeInfo::Type cppValue;
+        if (value == nil) {
+            cppValue.SetNull();
+        } else {
+            auto & nonNullValue_0 = cppValue.SetNonNull();
+            nonNullValue_0 = value.unsignedIntValue;
+        }
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -6554,10 +6959,21 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeNullableInt64uWithValue:(uint64_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeNullableInt64uWithValue:(NSNumber * _Nullable)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeNullableInt64u(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = TestCluster::Attributes::NullableInt64u::TypeInfo;
+        TypeInfo::Type cppValue;
+        if (value == nil) {
+            cppValue.SetNull();
+        } else {
+            auto & nonNullValue_0 = cppValue.SetNonNull();
+            nonNullValue_0 = value.unsignedLongLongValue;
+        }
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -6568,10 +6984,21 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeNullableInt8sWithValue:(int8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeNullableInt8sWithValue:(NSNumber * _Nullable)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeNullableInt8s(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = TestCluster::Attributes::NullableInt8s::TypeInfo;
+        TypeInfo::Type cppValue;
+        if (value == nil) {
+            cppValue.SetNull();
+        } else {
+            auto & nonNullValue_0 = cppValue.SetNonNull();
+            nonNullValue_0 = value.charValue;
+        }
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -6582,10 +7009,21 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeNullableInt16sWithValue:(int16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeNullableInt16sWithValue:(NSNumber * _Nullable)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeNullableInt16s(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = TestCluster::Attributes::NullableInt16s::TypeInfo;
+        TypeInfo::Type cppValue;
+        if (value == nil) {
+            cppValue.SetNull();
+        } else {
+            auto & nonNullValue_0 = cppValue.SetNonNull();
+            nonNullValue_0 = value.shortValue;
+        }
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -6596,10 +7034,21 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeNullableInt32sWithValue:(int32_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeNullableInt32sWithValue:(NSNumber * _Nullable)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeNullableInt32s(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = TestCluster::Attributes::NullableInt32s::TypeInfo;
+        TypeInfo::Type cppValue;
+        if (value == nil) {
+            cppValue.SetNull();
+        } else {
+            auto & nonNullValue_0 = cppValue.SetNonNull();
+            nonNullValue_0 = value.intValue;
+        }
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -6610,10 +7059,21 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeNullableInt64sWithValue:(int64_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeNullableInt64sWithValue:(NSNumber * _Nullable)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeNullableInt64s(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = TestCluster::Attributes::NullableInt64s::TypeInfo;
+        TypeInfo::Type cppValue;
+        if (value == nil) {
+            cppValue.SetNull();
+        } else {
+            auto & nonNullValue_0 = cppValue.SetNonNull();
+            nonNullValue_0 = value.longLongValue;
+        }
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -6624,10 +7084,21 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeNullableEnum8WithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeNullableEnum8WithValue:(NSNumber * _Nullable)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeNullableEnum8(success, failure, static_cast<uint8_t>(value));
+        ListFreer listFreer;
+        using TypeInfo = TestCluster::Attributes::NullableEnum8::TypeInfo;
+        TypeInfo::Type cppValue;
+        if (value == nil) {
+            cppValue.SetNull();
+        } else {
+            auto & nonNullValue_0 = cppValue.SetNonNull();
+            nonNullValue_0 = static_cast<std::remove_reference_t<decltype(nonNullValue_0)>>(value.unsignedCharValue);
+        }
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -6638,10 +7109,21 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeNullableEnum16WithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeNullableEnum16WithValue:(NSNumber * _Nullable)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeNullableEnum16(success, failure, static_cast<uint16_t>(value));
+        ListFreer listFreer;
+        using TypeInfo = TestCluster::Attributes::NullableEnum16::TypeInfo;
+        TypeInfo::Type cppValue;
+        if (value == nil) {
+            cppValue.SetNull();
+        } else {
+            auto & nonNullValue_0 = cppValue.SetNonNull();
+            nonNullValue_0 = static_cast<std::remove_reference_t<decltype(nonNullValue_0)>>(value.unsignedShortValue);
+        }
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -6652,10 +7134,21 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeNullableOctetStringWithValue:(NSData *)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeNullableOctetStringWithValue:(NSData * _Nullable)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeNullableOctetString(success, failure, [self asByteSpan:value]);
+        ListFreer listFreer;
+        using TypeInfo = TestCluster::Attributes::NullableOctetString::TypeInfo;
+        TypeInfo::Type cppValue;
+        if (value == nil) {
+            cppValue.SetNull();
+        } else {
+            auto & nonNullValue_0 = cppValue.SetNonNull();
+            nonNullValue_0 = [self asByteSpan:value];
+        }
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -6666,10 +7159,21 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeNullableCharStringWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeNullableCharStringWithValue:(NSString * _Nullable)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeNullableCharString(success, failure, [self asCharSpan:value]);
+        ListFreer listFreer;
+        using TypeInfo = TestCluster::Attributes::NullableCharString::TypeInfo;
+        TypeInfo::Type cppValue;
+        if (value == nil) {
+            cppValue.SetNull();
+        } else {
+            auto & nonNullValue_0 = cppValue.SetNonNull();
+            nonNullValue_0 = [self asCharSpan:value];
+        }
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -6695,8 +7199,8 @@ struct ListFreer {
     ListFreer listFreer;
     Thermostat::Commands::ClearWeeklySchedule::Type request;
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -6708,8 +7212,8 @@ struct ListFreer {
     ListFreer listFreer;
     Thermostat::Commands::GetRelayStatusLog::Type request;
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -6725,8 +7229,8 @@ struct ListFreer {
     request.modeToReturn
         = static_cast<std::remove_reference_t<decltype(request.modeToReturn)>>(payload.ModeToReturn.unsignedCharValue);
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -6743,31 +7247,30 @@ struct ListFreer {
     request.modeForSequence
         = static_cast<std::remove_reference_t<decltype(request.modeForSequence)>>(payload.ModeForSequence.unsignedCharValue);
     {
-        using ListType = decltype(request.payload);
+        using ListType = std::remove_reference_t<decltype(request.payload)>;
         using ListMemberType = ListMemberTypeGetter<ListType>::Type;
         if (payload.Payload.count != 0) {
-            auto * listHolder = new ListHolder<ListMemberType>(payload.Payload.count);
-            if (listHolder == nullptr || listHolder->mList == nullptr) {
-                // Now what?
+            auto * listHolder_0 = new ListHolder<ListMemberType>(payload.Payload.count);
+            if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
                 return;
             }
-            listFreer.add(listHolder);
+            listFreer.add(listHolder_0);
             for (size_t i = 0; i < payload.Payload.count; ++i) {
                 if (![payload.Payload[i] isKindOfClass:[NSNumber class]]) {
-                    // Wrong kind of value, now what?
+                    // Wrong kind of value.
                     return;
                 }
-                auto element = (NSNumber *) payload.Payload[i];
-                listHolder->mList[i] = element.unsignedCharValue;
+                auto element_0 = (NSNumber *) payload.Payload[i];
+                listHolder_0->mList[i] = element_0.unsignedCharValue;
             }
-            request.payload = ListType(listHolder->mList, payload.Payload.count);
+            request.payload = ListType(listHolder_0->mList, payload.Payload.count);
         } else {
             request.payload = ListType();
         }
     }
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -6781,8 +7284,8 @@ struct ListFreer {
     request.mode = static_cast<std::remove_reference_t<decltype(request.mode)>>(payload.Mode.unsignedCharValue);
     request.amount = payload.Amount.charValue;
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -6849,10 +7352,16 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeOccupiedCoolingSetpointWithValue:(int16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeOccupiedCoolingSetpointWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeOccupiedCoolingSetpoint(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = Thermostat::Attributes::OccupiedCoolingSetpoint::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.shortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -6863,10 +7372,16 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeOccupiedHeatingSetpointWithValue:(int16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeOccupiedHeatingSetpointWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeOccupiedHeatingSetpoint(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = Thermostat::Attributes::OccupiedHeatingSetpoint::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.shortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -6877,10 +7392,16 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeMinHeatSetpointLimitWithValue:(int16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeMinHeatSetpointLimitWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeMinHeatSetpointLimit(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = Thermostat::Attributes::MinHeatSetpointLimit::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.shortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -6891,10 +7412,16 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeMaxHeatSetpointLimitWithValue:(int16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeMaxHeatSetpointLimitWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeMaxHeatSetpointLimit(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = Thermostat::Attributes::MaxHeatSetpointLimit::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.shortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -6905,10 +7432,16 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeMinCoolSetpointLimitWithValue:(int16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeMinCoolSetpointLimitWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeMinCoolSetpointLimit(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = Thermostat::Attributes::MinCoolSetpointLimit::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.shortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -6919,10 +7452,16 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeMaxCoolSetpointLimitWithValue:(int16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeMaxCoolSetpointLimitWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeMaxCoolSetpointLimit(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = Thermostat::Attributes::MaxCoolSetpointLimit::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.shortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -6933,10 +7472,16 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeMinSetpointDeadBandWithValue:(int8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeMinSetpointDeadBandWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeMinSetpointDeadBand(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = Thermostat::Attributes::MinSetpointDeadBand::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.charValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -6947,10 +7492,17 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeControlSequenceOfOperationWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeControlSequenceOfOperationWithValue:(NSNumber * _Nonnull)value
+                                          responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeControlSequenceOfOperation(success, failure, static_cast<uint8_t>(value));
+        ListFreer listFreer;
+        using TypeInfo = Thermostat::Attributes::ControlSequenceOfOperation::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = static_cast<std::remove_reference_t<decltype(cppValue)>>(value.unsignedCharValue);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -6961,10 +7513,16 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeSystemModeWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeSystemModeWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeSystemMode(success, failure, static_cast<uint8_t>(value));
+        ListFreer listFreer;
+        using TypeInfo = Thermostat::Attributes::SystemMode::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = static_cast<std::remove_reference_t<decltype(cppValue)>>(value.unsignedCharValue);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -7019,10 +7577,16 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeTemperatureDisplayModeWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeTemperatureDisplayModeWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeTemperatureDisplayMode(success, failure, static_cast<uint8_t>(value));
+        ListFreer listFreer;
+        using TypeInfo = ThermostatUserInterfaceConfiguration::Attributes::TemperatureDisplayMode::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = static_cast<std::remove_reference_t<decltype(cppValue)>>(value.unsignedCharValue);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -7033,10 +7597,16 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeKeypadLockoutWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeKeypadLockoutWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeKeypadLockout(success, failure, static_cast<uint8_t>(value));
+        ListFreer listFreer;
+        using TypeInfo = ThermostatUserInterfaceConfiguration::Attributes::KeypadLockout::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = static_cast<std::remove_reference_t<decltype(cppValue)>>(value.unsignedCharValue);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -7047,10 +7617,17 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeScheduleProgrammingVisibilityWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeScheduleProgrammingVisibilityWithValue:(NSNumber * _Nonnull)value
+                                             responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeScheduleProgrammingVisibility(success, failure, static_cast<uint8_t>(value));
+        ListFreer listFreer;
+        using TypeInfo = ThermostatUserInterfaceConfiguration::Attributes::ScheduleProgrammingVisibility::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = static_cast<std::remove_reference_t<decltype(cppValue)>>(value.unsignedCharValue);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -7076,8 +7653,8 @@ struct ListFreer {
     ListFreer listFreer;
     ThreadNetworkDiagnostics::Commands::ResetCounts::Type request;
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -7574,8 +8151,8 @@ struct ListFreer {
     ListFreer listFreer;
     WiFiNetworkDiagnostics::Commands::ResetCounts::Type request;
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -7693,8 +8270,8 @@ struct ListFreer {
     ListFreer listFreer;
     WindowCovering::Commands::DownOrClose::Type request;
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -7708,8 +8285,8 @@ struct ListFreer {
     request.liftPercentageValue = payload.LiftPercentageValue.unsignedCharValue;
     request.liftPercent100thsValue = payload.LiftPercent100thsValue.unsignedShortValue;
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -7722,8 +8299,8 @@ struct ListFreer {
     WindowCovering::Commands::GoToLiftValue::Type request;
     request.liftValue = payload.LiftValue.unsignedShortValue;
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -7737,8 +8314,8 @@ struct ListFreer {
     request.tiltPercentageValue = payload.TiltPercentageValue.unsignedCharValue;
     request.tiltPercent100thsValue = payload.TiltPercent100thsValue.unsignedShortValue;
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -7751,8 +8328,8 @@ struct ListFreer {
     WindowCovering::Commands::GoToTiltValue::Type request;
     request.tiltValue = payload.TiltValue.unsignedShortValue;
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -7763,8 +8340,8 @@ struct ListFreer {
     ListFreer listFreer;
     WindowCovering::Commands::StopMotion::Type request;
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -7775,8 +8352,8 @@ struct ListFreer {
     ListFreer listFreer;
     WindowCovering::Commands::UpOrOpen::Type request;
 
-    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
@@ -8034,10 +8611,16 @@ struct ListFreer {
     });
 }
 
-- (void)writeAttributeModeWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeModeWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeMode(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = WindowCovering::Attributes::Mode::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedCharValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPTestClustersObjc.h
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPTestClustersObjc.h
@@ -29,7 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPTestAccountLogin : CHIPAccountLogin
 
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 @end
 
@@ -39,7 +39,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPTestAdministratorCommissioning : CHIPAdministratorCommissioning
 
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 @end
 
@@ -49,14 +49,14 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPTestApplicationBasic : CHIPApplicationBasic
 
-- (void)writeAttributeVendorNameWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeVendorIdWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeApplicationNameWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeProductIdWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeApplicationIdWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeCatalogVendorIdWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeApplicationStatusWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeVendorNameWithValue:(NSString * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeVendorIdWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeApplicationNameWithValue:(NSString * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeProductIdWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeApplicationIdWithValue:(NSString * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeCatalogVendorIdWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeApplicationStatusWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 @end
 
@@ -66,9 +66,10 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPTestApplicationLauncher : CHIPApplicationLauncher
 
-- (void)writeAttributeCatalogVendorIdWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeApplicationIdWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeApplicationLauncherListWithValue:(NSArray * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeCatalogVendorIdWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeApplicationIdWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 @end
 
@@ -78,8 +79,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPTestAudioOutput : CHIPAudioOutput
 
-- (void)writeAttributeCurrentAudioOutputWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeAudioOutputListWithValue:(NSArray * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeCurrentAudioOutputWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 @end
 
@@ -89,11 +91,11 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPTestBarrierControl : CHIPBarrierControl
 
-- (void)writeAttributeBarrierMovingStateWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeBarrierSafetyStatusWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeBarrierCapabilitiesWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeBarrierPositionWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeBarrierMovingStateWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeBarrierSafetyStatusWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeBarrierCapabilitiesWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeBarrierPositionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 @end
 
@@ -103,22 +105,22 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPTestBasic : CHIPBasic
 
-- (void)writeAttributeInteractionModelVersionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeVendorNameWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeVendorIDWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeProductNameWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeProductIDWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeHardwareVersionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeHardwareVersionStringWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeSoftwareVersionWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeSoftwareVersionStringWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeManufacturingDateWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributePartNumberWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeProductURLWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeProductLabelWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeSerialNumberWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeReachableWithValue:(bool)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeInteractionModelVersionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeVendorNameWithValue:(NSString * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeVendorIDWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeProductNameWithValue:(NSString * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeProductIDWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeHardwareVersionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeHardwareVersionStringWithValue:(NSString * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeSoftwareVersionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeSoftwareVersionStringWithValue:(NSString * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeManufacturingDateWithValue:(NSString * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributePartNumberWithValue:(NSString * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeProductURLWithValue:(NSString * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeProductLabelWithValue:(NSString * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeSerialNumberWithValue:(NSString * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeReachableWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 @end
 
@@ -128,8 +130,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPTestBinaryInputBasic : CHIPBinaryInputBasic
 
-- (void)writeAttributeStatusFlagsWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeStatusFlagsWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 @end
 
@@ -139,7 +141,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPTestBinding : CHIPBinding
 
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 @end
 
@@ -149,8 +151,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPTestBooleanState : CHIPBooleanState
 
-- (void)writeAttributeStateValueWithValue:(bool)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeStateValueWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 @end
 
@@ -160,8 +162,10 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPTestBridgedActions : CHIPBridgedActions
 
-- (void)writeAttributeSetupUrlWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeActionListWithValue:(NSArray * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeEndpointListWithValue:(NSArray * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeSetupUrlWithValue:(NSString * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 @end
 
@@ -171,20 +175,20 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPTestBridgedDeviceBasic : CHIPBridgedDeviceBasic
 
-- (void)writeAttributeVendorNameWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeVendorIDWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeProductNameWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeHardwareVersionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeHardwareVersionStringWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeSoftwareVersionWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeSoftwareVersionStringWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeManufacturingDateWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributePartNumberWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeProductURLWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeProductLabelWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeSerialNumberWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeReachableWithValue:(bool)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeVendorNameWithValue:(NSString * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeVendorIDWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeProductNameWithValue:(NSString * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeHardwareVersionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeHardwareVersionStringWithValue:(NSString * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeSoftwareVersionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeSoftwareVersionStringWithValue:(NSString * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeManufacturingDateWithValue:(NSString * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributePartNumberWithValue:(NSString * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeProductURLWithValue:(NSString * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeProductLabelWithValue:(NSString * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeSerialNumberWithValue:(NSString * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeReachableWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 @end
 
@@ -194,46 +198,49 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPTestColorControl : CHIPColorControl
 
-- (void)writeAttributeCurrentHueWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeCurrentSaturationWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeRemainingTimeWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeCurrentXWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeCurrentYWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeDriftCompensationWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeCompensationTextWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeColorTemperatureWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeColorModeWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeNumberOfPrimariesWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributePrimary1XWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributePrimary1YWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributePrimary1IntensityWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributePrimary2XWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributePrimary2YWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributePrimary2IntensityWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributePrimary3XWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributePrimary3YWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributePrimary3IntensityWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributePrimary4XWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributePrimary4YWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributePrimary4IntensityWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributePrimary5XWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributePrimary5YWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributePrimary5IntensityWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributePrimary6XWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributePrimary6YWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributePrimary6IntensityWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeEnhancedCurrentHueWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeEnhancedColorModeWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeColorLoopActiveWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeColorLoopDirectionWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeColorLoopTimeWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeColorLoopStartEnhancedHueWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeColorLoopStoredEnhancedHueWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeColorCapabilitiesWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeColorTempPhysicalMinWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeColorTempPhysicalMaxWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeCoupleColorTempToLevelMinMiredsWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeCurrentHueWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeCurrentSaturationWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeRemainingTimeWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeCurrentXWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeCurrentYWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeDriftCompensationWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeCompensationTextWithValue:(NSString * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeColorTemperatureWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeColorModeWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeNumberOfPrimariesWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributePrimary1XWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributePrimary1YWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributePrimary1IntensityWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributePrimary2XWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributePrimary2YWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributePrimary2IntensityWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributePrimary3XWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributePrimary3YWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributePrimary3IntensityWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributePrimary4XWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributePrimary4YWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributePrimary4IntensityWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributePrimary5XWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributePrimary5YWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributePrimary5IntensityWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributePrimary6XWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributePrimary6YWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributePrimary6IntensityWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeEnhancedCurrentHueWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeEnhancedColorModeWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeColorLoopActiveWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeColorLoopDirectionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeColorLoopTimeWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeColorLoopStartEnhancedHueWithValue:(NSNumber * _Nonnull)value
+                                         responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeColorLoopStoredEnhancedHueWithValue:(NSNumber * _Nonnull)value
+                                          responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeColorCapabilitiesWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeColorTempPhysicalMinWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeColorTempPhysicalMaxWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeCoupleColorTempToLevelMinMiredsWithValue:(NSNumber * _Nonnull)value
+                                               responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 @end
 
@@ -243,7 +250,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPTestContentLauncher : CHIPContentLauncher
 
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeAcceptsHeaderListWithValue:(NSArray * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeSupportedStreamingTypesWithValue:(NSArray * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 @end
 
@@ -253,7 +262,11 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPTestDescriptor : CHIPDescriptor
 
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeDeviceListWithValue:(NSArray * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeServerListWithValue:(NSArray * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeClientListWithValue:(NSArray * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributePartsListWithValue:(NSArray * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 @end
 
@@ -271,10 +284,10 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPTestDoorLock : CHIPDoorLock
 
-- (void)writeAttributeLockStateWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeLockTypeWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeActuatorEnabledWithValue:(bool)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeLockStateWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeLockTypeWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeActuatorEnabledWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 @end
 
@@ -284,18 +297,18 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPTestElectricalMeasurement : CHIPElectricalMeasurement
 
-- (void)writeAttributeMeasurementTypeWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeTotalActivePowerWithValue:(int32_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeRmsVoltageWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeRmsVoltageMinWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeRmsVoltageMaxWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeRmsCurrentWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeRmsCurrentMinWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeRmsCurrentMaxWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeActivePowerWithValue:(int16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeActivePowerMinWithValue:(int16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeActivePowerMaxWithValue:(int16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeMeasurementTypeWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeTotalActivePowerWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeRmsVoltageWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeRmsVoltageMinWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeRmsVoltageMaxWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeRmsCurrentWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeRmsCurrentMinWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeRmsCurrentMaxWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeActivePowerWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeActivePowerMinWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeActivePowerMaxWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 @end
 
@@ -305,16 +318,16 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPTestEthernetNetworkDiagnostics : CHIPEthernetNetworkDiagnostics
 
-- (void)writeAttributePHYRateWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeFullDuplexWithValue:(bool)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributePacketRxCountWithValue:(uint64_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributePacketTxCountWithValue:(uint64_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeTxErrCountWithValue:(uint64_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeCollisionCountWithValue:(uint64_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeOverrunCountWithValue:(uint64_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeCarrierDetectWithValue:(bool)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeTimeSinceResetWithValue:(uint64_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributePHYRateWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeFullDuplexWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributePacketRxCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributePacketTxCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeTxErrCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeCollisionCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeOverrunCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeCarrierDetectWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeTimeSinceResetWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 @end
 
@@ -324,7 +337,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPTestFixedLabel : CHIPFixedLabel
 
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeLabelListWithValue:(NSArray * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 @end
 
@@ -334,11 +348,11 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPTestFlowMeasurement : CHIPFlowMeasurement
 
-- (void)writeAttributeMeasuredValueWithValue:(int16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeMinMeasuredValueWithValue:(int16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeMaxMeasuredValueWithValue:(int16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeToleranceWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeMeasuredValueWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeMinMeasuredValueWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeMaxMeasuredValueWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeToleranceWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 @end
 
@@ -348,7 +362,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPTestGeneralCommissioning : CHIPGeneralCommissioning
 
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeBasicCommissioningInfoListWithValue:(NSArray * _Nonnull)value
+                                          responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 @end
 
@@ -358,11 +374,12 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPTestGeneralDiagnostics : CHIPGeneralDiagnostics
 
-- (void)writeAttributeRebootCountWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeUpTimeWithValue:(uint64_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeTotalOperationalHoursWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeBootReasonsWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeNetworkInterfacesWithValue:(NSArray * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeRebootCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeUpTimeWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeTotalOperationalHoursWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeBootReasonsWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 @end
 
@@ -372,7 +389,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPTestGroupKeyManagement : CHIPGroupKeyManagement
 
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeGroupsWithValue:(NSArray * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeGroupKeysWithValue:(NSArray * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 @end
 
@@ -382,8 +401,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPTestGroups : CHIPGroups
 
-- (void)writeAttributeNameSupportWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeNameSupportWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 @end
 
@@ -393,8 +412,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPTestIdentify : CHIPIdentify
 
-- (void)writeAttributeIdentifyTypeWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeIdentifyTypeWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 @end
 
@@ -404,12 +423,12 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPTestIlluminanceMeasurement : CHIPIlluminanceMeasurement
 
-- (void)writeAttributeMeasuredValueWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeMinMeasuredValueWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeMaxMeasuredValueWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeToleranceWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeLightSensorTypeWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeMeasuredValueWithValue:(NSNumber * _Nullable)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeMinMeasuredValueWithValue:(NSNumber * _Nullable)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeMaxMeasuredValueWithValue:(NSNumber * _Nullable)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeToleranceWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeLightSensorTypeWithValue:(NSNumber * _Nullable)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 @end
 
@@ -419,7 +438,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPTestKeypadInput : CHIPKeypadInput
 
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 @end
 
@@ -429,14 +448,14 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPTestLevelControl : CHIPLevelControl
 
-- (void)writeAttributeCurrentLevelWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeRemainingTimeWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeMinLevelWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeMaxLevelWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeCurrentFrequencyWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeMinFrequencyWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeMaxFrequencyWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeCurrentLevelWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeRemainingTimeWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeMinLevelWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeMaxLevelWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeCurrentFrequencyWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeMinFrequencyWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeMaxFrequencyWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 @end
 
@@ -446,7 +465,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPTestLowPower : CHIPLowPower
 
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 @end
 
@@ -456,8 +475,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPTestMediaInput : CHIPMediaInput
 
-- (void)writeAttributeCurrentMediaInputWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeMediaInputListWithValue:(NSArray * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeCurrentMediaInputWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 @end
 
@@ -467,15 +487,15 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPTestMediaPlayback : CHIPMediaPlayback
 
-- (void)writeAttributePlaybackStateWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeStartTimeWithValue:(uint64_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeDurationWithValue:(uint64_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributePositionUpdatedAtWithValue:(uint64_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributePositionWithValue:(uint64_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributePlaybackSpeedWithValue:(uint64_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeSeekRangeEndWithValue:(uint64_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeSeekRangeStartWithValue:(uint64_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributePlaybackStateWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeStartTimeWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeDurationWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributePositionUpdatedAtWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributePositionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributePlaybackSpeedWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeSeekRangeEndWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeSeekRangeStartWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 @end
 
@@ -485,10 +505,11 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPTestModeSelect : CHIPModeSelect
 
-- (void)writeAttributeCurrentModeWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeStartUpModeWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeDescriptionWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeCurrentModeWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeSupportedModesWithValue:(NSArray * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeStartUpModeWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeDescriptionWithValue:(NSString * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 @end
 
@@ -498,8 +519,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPTestNetworkCommissioning : CHIPNetworkCommissioning
 
-- (void)writeAttributeFeatureMapWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeFeatureMapWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 @end
 
@@ -509,7 +530,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPTestOtaSoftwareUpdateProvider : CHIPOtaSoftwareUpdateProvider
 
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 @end
 
@@ -519,8 +540,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPTestOtaSoftwareUpdateRequestor : CHIPOtaSoftwareUpdateRequestor
 
-- (void)writeAttributeUpdatePossibleWithValue:(bool)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeUpdatePossibleWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 @end
 
@@ -530,10 +551,11 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPTestOccupancySensing : CHIPOccupancySensing
 
-- (void)writeAttributeOccupancyWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeOccupancySensorTypeWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeOccupancySensorTypeBitmapWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeOccupancyWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeOccupancySensorTypeWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeOccupancySensorTypeBitmapWithValue:(NSNumber * _Nonnull)value
+                                         responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 @end
 
@@ -543,10 +565,10 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPTestOnOff : CHIPOnOff
 
-- (void)writeAttributeOnOffWithValue:(bool)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeGlobalSceneControlWithValue:(bool)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeFeatureMapWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeOnOffWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeGlobalSceneControlWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeFeatureMapWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 @end
 
@@ -556,8 +578,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPTestOnOffSwitchConfiguration : CHIPOnOffSwitchConfiguration
 
-- (void)writeAttributeSwitchTypeWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeSwitchTypeWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 @end
 
@@ -567,10 +589,12 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPTestOperationalCredentials : CHIPOperationalCredentials
 
-- (void)writeAttributeSupportedFabricsWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeCommissionedFabricsWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeCurrentFabricIndexWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeFabricsListWithValue:(NSArray * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeSupportedFabricsWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeCommissionedFabricsWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeTrustedRootCertificatesWithValue:(NSArray * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeCurrentFabricIndexWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 @end
 
@@ -580,16 +604,17 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPTestPowerSource : CHIPPowerSource
 
-- (void)writeAttributeStatusWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeOrderWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeDescriptionWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeBatteryVoltageWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeBatteryPercentRemainingWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeBatteryTimeRemainingWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeBatteryChargeLevelWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeBatteryChargeStateWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeFeatureMapWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeStatusWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeOrderWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeDescriptionWithValue:(NSString * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeBatteryVoltageWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeBatteryPercentRemainingWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeBatteryTimeRemainingWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeBatteryChargeLevelWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeActiveBatteryFaultsWithValue:(NSArray * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeBatteryChargeStateWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeFeatureMapWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 @end
 
@@ -599,10 +624,10 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPTestPressureMeasurement : CHIPPressureMeasurement
 
-- (void)writeAttributeMeasuredValueWithValue:(int16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeMinMeasuredValueWithValue:(int16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeMaxMeasuredValueWithValue:(int16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeMeasuredValueWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeMinMeasuredValueWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeMaxMeasuredValueWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 @end
 
@@ -612,28 +637,28 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPTestPumpConfigurationAndControl : CHIPPumpConfigurationAndControl
 
-- (void)writeAttributeMaxPressureWithValue:(int16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeMaxSpeedWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeMaxFlowWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeMinConstPressureWithValue:(int16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeMaxConstPressureWithValue:(int16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeMinCompPressureWithValue:(int16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeMaxCompPressureWithValue:(int16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeMinConstSpeedWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeMaxConstSpeedWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeMinConstFlowWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeMaxConstFlowWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeMinConstTempWithValue:(int16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeMaxConstTempWithValue:(int16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributePumpStatusWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeEffectiveOperationModeWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeEffectiveControlModeWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeCapacityWithValue:(int16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeSpeedWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeLifetimeEnergyConsumedWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeAlarmMaskWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeFeatureMapWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeMaxPressureWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeMaxSpeedWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeMaxFlowWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeMinConstPressureWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeMaxConstPressureWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeMinCompPressureWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeMaxCompPressureWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeMinConstSpeedWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeMaxConstSpeedWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeMinConstFlowWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeMaxConstFlowWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeMinConstTempWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeMaxConstTempWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributePumpStatusWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeEffectiveOperationModeWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeEffectiveControlModeWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeCapacityWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeSpeedWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeLifetimeEnergyConsumedWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeAlarmMaskWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeFeatureMapWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 @end
 
@@ -643,11 +668,11 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPTestRelativeHumidityMeasurement : CHIPRelativeHumidityMeasurement
 
-- (void)writeAttributeMeasuredValueWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeMinMeasuredValueWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeMaxMeasuredValueWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeToleranceWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeMeasuredValueWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeMinMeasuredValueWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeMaxMeasuredValueWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeToleranceWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 @end
 
@@ -657,12 +682,12 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPTestScenes : CHIPScenes
 
-- (void)writeAttributeSceneCountWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeCurrentSceneWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeCurrentGroupWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeSceneValidWithValue:(bool)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeNameSupportWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeSceneCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeCurrentSceneWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeCurrentGroupWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeSceneValidWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeNameSupportWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 @end
 
@@ -672,10 +697,11 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPTestSoftwareDiagnostics : CHIPSoftwareDiagnostics
 
-- (void)writeAttributeCurrentHeapFreeWithValue:(uint64_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeCurrentHeapUsedWithValue:(uint64_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeCurrentHeapHighWatermarkWithValue:(uint64_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeThreadMetricsWithValue:(NSArray * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeCurrentHeapFreeWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeCurrentHeapUsedWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeCurrentHeapHighWatermarkWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 @end
 
@@ -685,11 +711,11 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPTestSwitch : CHIPSwitch
 
-- (void)writeAttributeNumberOfPositionsWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeCurrentPositionWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeMultiPressMaxWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeFeatureMapWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeNumberOfPositionsWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeCurrentPositionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeMultiPressMaxWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeFeatureMapWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 @end
 
@@ -699,9 +725,10 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPTestTvChannel : CHIPTvChannel
 
-- (void)writeAttributeTvChannelLineupWithValue:(NSData *)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeCurrentTvChannelWithValue:(NSData *)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeTvChannelListWithValue:(NSArray * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeTvChannelLineupWithValue:(NSData * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeCurrentTvChannelWithValue:(NSData * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 @end
 
@@ -711,7 +738,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPTestTargetNavigator : CHIPTargetNavigator
 
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeTargetNavigatorListWithValue:(NSArray * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 @end
 
@@ -721,11 +749,11 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPTestTemperatureMeasurement : CHIPTemperatureMeasurement
 
-- (void)writeAttributeMeasuredValueWithValue:(int16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeMinMeasuredValueWithValue:(int16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeMaxMeasuredValueWithValue:(int16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeToleranceWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeMeasuredValueWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeMinMeasuredValueWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeMaxMeasuredValueWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeToleranceWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 @end
 
@@ -735,7 +763,12 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPTestTestCluster : CHIPTestCluster
 
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeListInt8uWithValue:(NSArray * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeListOctetStringWithValue:(NSArray * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeListStructOctetStringWithValue:(NSArray * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeListNullablesAndOptionalsStructWithValue:(NSArray * _Nonnull)value
+                                               responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 @end
 
@@ -745,16 +778,17 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPTestThermostat : CHIPThermostat
 
-- (void)writeAttributeLocalTemperatureWithValue:(int16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeAbsMinHeatSetpointLimitWithValue:(int16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeAbsMaxHeatSetpointLimitWithValue:(int16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeAbsMinCoolSetpointLimitWithValue:(int16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeAbsMaxCoolSetpointLimitWithValue:(int16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeStartOfWeekWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeNumberOfWeeklyTransitionsWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeNumberOfDailyTransitionsWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeFeatureMapWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeLocalTemperatureWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeAbsMinHeatSetpointLimitWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeAbsMaxHeatSetpointLimitWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeAbsMinCoolSetpointLimitWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeAbsMaxCoolSetpointLimitWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeStartOfWeekWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeNumberOfWeeklyTransitionsWithValue:(NSNumber * _Nonnull)value
+                                         responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeNumberOfDailyTransitionsWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeFeatureMapWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 @end
 
@@ -764,7 +798,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPTestThermostatUserInterfaceConfiguration : CHIPThermostatUserInterfaceConfiguration
 
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 @end
 
@@ -774,65 +808,75 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPTestThreadNetworkDiagnostics : CHIPThreadNetworkDiagnostics
 
-- (void)writeAttributeChannelWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeRoutingRoleWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeNetworkNameWithValue:(NSData *)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributePanIdWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeExtendedPanIdWithValue:(uint64_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeMeshLocalPrefixWithValue:(NSData *)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeOverrunCountWithValue:(uint64_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributePartitionIdWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeWeightingWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeDataVersionWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeStableDataVersionWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeLeaderRouterIdWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeDetachedRoleCountWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeChildRoleCountWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeRouterRoleCountWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeLeaderRoleCountWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeAttachAttemptCountWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributePartitionIdChangeCountWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeBetterPartitionAttachAttemptCountWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeParentChangeCountWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeTxTotalCountWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeTxUnicastCountWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeTxBroadcastCountWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeTxAckRequestedCountWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeTxAckedCountWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeTxNoAckRequestedCountWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeTxDataCountWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeTxDataPollCountWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeTxBeaconCountWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeTxBeaconRequestCountWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeTxOtherCountWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeTxRetryCountWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeTxDirectMaxRetryExpiryCountWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeTxIndirectMaxRetryExpiryCountWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeTxErrCcaCountWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeTxErrAbortCountWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeTxErrBusyChannelCountWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeRxTotalCountWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeRxUnicastCountWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeRxBroadcastCountWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeRxDataCountWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeRxDataPollCountWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeRxBeaconCountWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeRxBeaconRequestCountWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeRxOtherCountWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeRxAddressFilteredCountWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeRxDestAddrFilteredCountWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeRxDuplicatedCountWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeRxErrNoFrameCountWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeRxErrUnknownNeighborCountWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeRxErrInvalidSrcAddrCountWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeRxErrSecCountWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeRxErrFcsCountWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeRxErrOtherCountWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeActiveTimestampWithValue:(uint64_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributePendingTimestampWithValue:(uint64_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeDelayWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeChannelMaskWithValue:(NSData *)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeChannelWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeRoutingRoleWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeNetworkNameWithValue:(NSData * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributePanIdWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeExtendedPanIdWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeMeshLocalPrefixWithValue:(NSData * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeOverrunCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeNeighborTableListWithValue:(NSArray * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeRouteTableListWithValue:(NSArray * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributePartitionIdWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeWeightingWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeDataVersionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeStableDataVersionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeLeaderRouterIdWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeDetachedRoleCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeChildRoleCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeRouterRoleCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeLeaderRoleCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeAttachAttemptCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributePartitionIdChangeCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeBetterPartitionAttachAttemptCountWithValue:(NSNumber * _Nonnull)value
+                                                 responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeParentChangeCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeTxTotalCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeTxUnicastCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeTxBroadcastCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeTxAckRequestedCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeTxAckedCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeTxNoAckRequestedCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeTxDataCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeTxDataPollCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeTxBeaconCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeTxBeaconRequestCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeTxOtherCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeTxRetryCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeTxDirectMaxRetryExpiryCountWithValue:(NSNumber * _Nonnull)value
+                                           responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeTxIndirectMaxRetryExpiryCountWithValue:(NSNumber * _Nonnull)value
+                                             responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeTxErrCcaCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeTxErrAbortCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeTxErrBusyChannelCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeRxTotalCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeRxUnicastCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeRxBroadcastCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeRxDataCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeRxDataPollCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeRxBeaconCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeRxBeaconRequestCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeRxOtherCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeRxAddressFilteredCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeRxDestAddrFilteredCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeRxDuplicatedCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeRxErrNoFrameCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeRxErrUnknownNeighborCountWithValue:(NSNumber * _Nonnull)value
+                                         responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeRxErrInvalidSrcAddrCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeRxErrSecCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeRxErrFcsCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeRxErrOtherCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeActiveTimestampWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributePendingTimestampWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeDelayWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeSecurityPolicyWithValue:(NSArray * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeChannelMaskWithValue:(NSData * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeOperationalDatasetComponentsWithValue:(NSArray * _Nonnull)value
+                                            responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeActiveNetworkFaultsListWithValue:(NSArray * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 @end
 
@@ -842,8 +886,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPTestWakeOnLan : CHIPWakeOnLan
 
-- (void)writeAttributeWakeOnLanMacAddressWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeWakeOnLanMacAddressWithValue:(NSString * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 @end
 
@@ -853,20 +897,20 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPTestWiFiNetworkDiagnostics : CHIPWiFiNetworkDiagnostics
 
-- (void)writeAttributeBssidWithValue:(NSData *)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeSecurityTypeWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeWiFiVersionWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeChannelNumberWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeRssiWithValue:(int8_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeBeaconLostCountWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeBeaconRxCountWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributePacketMulticastRxCountWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributePacketMulticastTxCountWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributePacketUnicastRxCountWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributePacketUnicastTxCountWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeCurrentMaxRateWithValue:(uint64_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeOverrunCountWithValue:(uint64_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeBssidWithValue:(NSData * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeSecurityTypeWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeWiFiVersionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeChannelNumberWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeRssiWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeBeaconLostCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeBeaconRxCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributePacketMulticastRxCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributePacketMulticastTxCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributePacketUnicastRxCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributePacketUnicastTxCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeCurrentMaxRateWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeOverrunCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 @end
 
@@ -876,25 +920,31 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPTestWindowCovering : CHIPWindowCovering
 
-- (void)writeAttributeTypeWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeCurrentPositionLiftWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeCurrentPositionTiltWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeConfigStatusWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeCurrentPositionLiftPercentageWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeCurrentPositionTiltPercentageWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeOperationalStatusWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeTargetPositionLiftPercent100thsWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeTargetPositionTiltPercent100thsWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeEndProductTypeWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeCurrentPositionLiftPercent100thsWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeCurrentPositionTiltPercent100thsWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeInstalledOpenLimitLiftWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeInstalledClosedLimitLiftWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeInstalledOpenLimitTiltWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeInstalledClosedLimitTiltWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeSafetyStatusWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeFeatureMapWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeTypeWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeCurrentPositionLiftWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeCurrentPositionTiltWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeConfigStatusWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeCurrentPositionLiftPercentageWithValue:(NSNumber * _Nonnull)value
+                                             responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeCurrentPositionTiltPercentageWithValue:(NSNumber * _Nonnull)value
+                                             responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeOperationalStatusWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeTargetPositionLiftPercent100thsWithValue:(NSNumber * _Nonnull)value
+                                               responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeTargetPositionTiltPercent100thsWithValue:(NSNumber * _Nonnull)value
+                                               responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeEndProductTypeWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeCurrentPositionLiftPercent100thsWithValue:(NSNumber * _Nonnull)value
+                                                responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeCurrentPositionTiltPercent100thsWithValue:(NSNumber * _Nonnull)value
+                                                responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeInstalledOpenLimitLiftWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeInstalledClosedLimitLiftWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeInstalledOpenLimitTiltWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeInstalledClosedLimitTiltWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeSafetyStatusWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeFeatureMapWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
 
 @end
 

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPTestClustersObjc.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPTestClustersObjc.mm
@@ -22,11 +22,16 @@
 #import "CHIPCluster_internal.h"
 #import "CHIPDevice.h"
 #import "CHIPDevice_Internal.h"
+#import "CHIPListUtils_internal.h"
 
 #import "zap-generated/CHIPTestClustersObjc.h"
 #import "zap-generated/tests/CHIPClustersTest.h"
 
+#include <type_traits>
+
+using chip::Callback::Callback;
 using chip::Callback::Cancelable;
+using namespace chip::app::Clusters;
 
 @interface CHIPTestAccountLogin ()
 @property (readonly) chip::Controller::AccountLoginClusterTest cppCluster;
@@ -39,10 +44,16 @@ using chip::Callback::Cancelable;
     return &_cppCluster;
 }
 
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeClusterRevision(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = AccountLogin::Attributes::ClusterRevision::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -59,10 +70,16 @@ using chip::Callback::Cancelable;
     return &_cppCluster;
 }
 
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeClusterRevision(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = AdministratorCommissioning::Attributes::ClusterRevision::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -79,59 +96,107 @@ using chip::Callback::Cancelable;
     return &_cppCluster;
 }
 
-- (void)writeAttributeVendorNameWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeVendorNameWithValue:(NSString * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeVendorName(success, failure, [self asCharSpan:value]);
+        ListFreer listFreer;
+        using TypeInfo = ApplicationBasic::Attributes::VendorName::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = [self asCharSpan:value];
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeVendorIdWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeVendorIdWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeVendorId(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ApplicationBasic::Attributes::VendorId::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeApplicationNameWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeApplicationNameWithValue:(NSString * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeApplicationName(success, failure, [self asCharSpan:value]);
+        ListFreer listFreer;
+        using TypeInfo = ApplicationBasic::Attributes::ApplicationName::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = [self asCharSpan:value];
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeProductIdWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeProductIdWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeProductId(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ApplicationBasic::Attributes::ProductId::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeApplicationIdWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeApplicationIdWithValue:(NSString * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeApplicationId(success, failure, [self asCharSpan:value]);
+        ListFreer listFreer;
+        using TypeInfo = ApplicationBasic::Attributes::ApplicationId::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = [self asCharSpan:value];
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeCatalogVendorIdWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeCatalogVendorIdWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeCatalogVendorId(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ApplicationBasic::Attributes::CatalogVendorId::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeApplicationStatusWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeApplicationStatusWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeApplicationStatus(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ApplicationBasic::Attributes::ApplicationStatus::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = static_cast<std::remove_reference_t<decltype(cppValue)>>(value.unsignedCharValue);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeClusterRevision(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ApplicationBasic::Attributes::ClusterRevision::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -148,24 +213,76 @@ using chip::Callback::Cancelable;
     return &_cppCluster;
 }
 
-- (void)writeAttributeCatalogVendorIdWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeApplicationLauncherListWithValue:(NSArray * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeCatalogVendorId(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ApplicationLauncher::Attributes::ApplicationLauncherList::TypeInfo;
+        TypeInfo::Type cppValue;
+        {
+            using ListType = std::remove_reference_t<decltype(cppValue)>;
+            using ListMemberType = ListMemberTypeGetter<ListType>::Type;
+            if (value.count != 0) {
+                auto * listHolder_0 = new ListHolder<ListMemberType>(value.count);
+                if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
+                    return CHIP_ERROR_INVALID_ARGUMENT;
+                }
+                listFreer.add(listHolder_0);
+                for (size_t i = 0; i < value.count; ++i) {
+                    if (![value[i] isKindOfClass:[NSNumber class]]) {
+                        // Wrong kind of value.
+                        return CHIP_ERROR_INVALID_ARGUMENT;
+                    }
+                    auto element_0 = (NSNumber *) value[i];
+                    listHolder_0->mList[i] = element_0.unsignedShortValue;
+                }
+                cppValue = ListType(listHolder_0->mList, value.count);
+            } else {
+                cppValue = ListType();
+            }
+        }
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeApplicationIdWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeCatalogVendorIdWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeApplicationId(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ApplicationLauncher::Attributes::CatalogVendorId::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedCharValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeApplicationIdWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeClusterRevision(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ApplicationLauncher::Attributes::ApplicationId::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedCharValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
+    });
+}
+
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
+{
+    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        ListFreer listFreer;
+        using TypeInfo = ApplicationLauncher::Attributes::ClusterRevision::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -182,17 +299,67 @@ using chip::Callback::Cancelable;
     return &_cppCluster;
 }
 
-- (void)writeAttributeCurrentAudioOutputWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeAudioOutputListWithValue:(NSArray * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeCurrentAudioOutput(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = AudioOutput::Attributes::AudioOutputList::TypeInfo;
+        TypeInfo::Type cppValue;
+        {
+            using ListType = std::remove_reference_t<decltype(cppValue)>;
+            using ListMemberType = ListMemberTypeGetter<ListType>::Type;
+            if (value.count != 0) {
+                auto * listHolder_0 = new ListHolder<ListMemberType>(value.count);
+                if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
+                    return CHIP_ERROR_INVALID_ARGUMENT;
+                }
+                listFreer.add(listHolder_0);
+                for (size_t i = 0; i < value.count; ++i) {
+                    if (![value[i] isKindOfClass:[CHIPAudioOutputClusterAudioOutputInfo class]]) {
+                        // Wrong kind of value.
+                        return CHIP_ERROR_INVALID_ARGUMENT;
+                    }
+                    auto element_0 = (CHIPAudioOutputClusterAudioOutputInfo *) value[i];
+                    listHolder_0->mList[i].index = element_0.Index.unsignedCharValue;
+                    listHolder_0->mList[i].outputType
+                        = static_cast<std::remove_reference_t<decltype(listHolder_0->mList[i].outputType)>>(
+                            element_0.OutputType.unsignedCharValue);
+                    listHolder_0->mList[i].name = [self asCharSpan:element_0.Name];
+                }
+                cppValue = ListType(listHolder_0->mList, value.count);
+            } else {
+                cppValue = ListType();
+            }
+        }
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeCurrentAudioOutputWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeClusterRevision(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = AudioOutput::Attributes::CurrentAudioOutput::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedCharValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
+    });
+}
+
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
+{
+    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        ListFreer listFreer;
+        using TypeInfo = AudioOutput::Attributes::ClusterRevision::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -209,38 +376,68 @@ using chip::Callback::Cancelable;
     return &_cppCluster;
 }
 
-- (void)writeAttributeBarrierMovingStateWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeBarrierMovingStateWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeBarrierMovingState(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = BarrierControl::Attributes::BarrierMovingState::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = static_cast<std::remove_reference_t<decltype(cppValue)>>(value.unsignedCharValue);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeBarrierSafetyStatusWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeBarrierSafetyStatusWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeBarrierSafetyStatus(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = BarrierControl::Attributes::BarrierSafetyStatus::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeBarrierCapabilitiesWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeBarrierCapabilitiesWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeBarrierCapabilities(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = BarrierControl::Attributes::BarrierCapabilities::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedCharValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeBarrierPositionWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeBarrierPositionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeBarrierPosition(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = BarrierControl::Attributes::BarrierPosition::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedCharValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeClusterRevision(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = BarrierControl::Attributes::ClusterRevision::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -257,115 +454,211 @@ using chip::Callback::Cancelable;
     return &_cppCluster;
 }
 
-- (void)writeAttributeInteractionModelVersionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeInteractionModelVersionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeInteractionModelVersion(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = Basic::Attributes::InteractionModelVersion::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeVendorNameWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeVendorNameWithValue:(NSString * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeVendorName(success, failure, [self asCharSpan:value]);
+        ListFreer listFreer;
+        using TypeInfo = Basic::Attributes::VendorName::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = [self asCharSpan:value];
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeVendorIDWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeVendorIDWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeVendorID(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = Basic::Attributes::VendorID::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeProductNameWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeProductNameWithValue:(NSString * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeProductName(success, failure, [self asCharSpan:value]);
+        ListFreer listFreer;
+        using TypeInfo = Basic::Attributes::ProductName::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = [self asCharSpan:value];
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeProductIDWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeProductIDWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeProductID(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = Basic::Attributes::ProductID::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeHardwareVersionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeHardwareVersionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeHardwareVersion(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = Basic::Attributes::HardwareVersion::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeHardwareVersionStringWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeHardwareVersionStringWithValue:(NSString * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeHardwareVersionString(success, failure, [self asCharSpan:value]);
+        ListFreer listFreer;
+        using TypeInfo = Basic::Attributes::HardwareVersionString::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = [self asCharSpan:value];
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeSoftwareVersionWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeSoftwareVersionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeSoftwareVersion(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = Basic::Attributes::SoftwareVersion::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedIntValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeSoftwareVersionStringWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeSoftwareVersionStringWithValue:(NSString * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeSoftwareVersionString(success, failure, [self asCharSpan:value]);
+        ListFreer listFreer;
+        using TypeInfo = Basic::Attributes::SoftwareVersionString::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = [self asCharSpan:value];
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeManufacturingDateWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeManufacturingDateWithValue:(NSString * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeManufacturingDate(success, failure, [self asCharSpan:value]);
+        ListFreer listFreer;
+        using TypeInfo = Basic::Attributes::ManufacturingDate::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = [self asCharSpan:value];
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributePartNumberWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributePartNumberWithValue:(NSString * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributePartNumber(success, failure, [self asCharSpan:value]);
+        ListFreer listFreer;
+        using TypeInfo = Basic::Attributes::PartNumber::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = [self asCharSpan:value];
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeProductURLWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeProductURLWithValue:(NSString * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeProductURL(success, failure, [self asCharSpan:value]);
+        ListFreer listFreer;
+        using TypeInfo = Basic::Attributes::ProductURL::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = [self asCharSpan:value];
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeProductLabelWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeProductLabelWithValue:(NSString * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeProductLabel(success, failure, [self asCharSpan:value]);
+        ListFreer listFreer;
+        using TypeInfo = Basic::Attributes::ProductLabel::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = [self asCharSpan:value];
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeSerialNumberWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeSerialNumberWithValue:(NSString * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeSerialNumber(success, failure, [self asCharSpan:value]);
+        ListFreer listFreer;
+        using TypeInfo = Basic::Attributes::SerialNumber::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = [self asCharSpan:value];
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeReachableWithValue:(bool)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeReachableWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeReachable(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = Basic::Attributes::Reachable::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.boolValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeClusterRevision(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = Basic::Attributes::ClusterRevision::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -382,17 +675,29 @@ using chip::Callback::Cancelable;
     return &_cppCluster;
 }
 
-- (void)writeAttributeStatusFlagsWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeStatusFlagsWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeStatusFlags(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = BinaryInputBasic::Attributes::StatusFlags::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedCharValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeClusterRevision(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = BinaryInputBasic::Attributes::ClusterRevision::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -409,10 +714,16 @@ using chip::Callback::Cancelable;
     return &_cppCluster;
 }
 
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeClusterRevision(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = Binding::Attributes::ClusterRevision::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -429,17 +740,29 @@ using chip::Callback::Cancelable;
     return &_cppCluster;
 }
 
-- (void)writeAttributeStateValueWithValue:(bool)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeStateValueWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeStateValue(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = BooleanState::Attributes::StateValue::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.boolValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeClusterRevision(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = BooleanState::Attributes::ClusterRevision::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -456,17 +779,108 @@ using chip::Callback::Cancelable;
     return &_cppCluster;
 }
 
-- (void)writeAttributeSetupUrlWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeActionListWithValue:(NSArray * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeSetupUrl(success, failure, [self asCharSpan:value]);
+        ListFreer listFreer;
+        using TypeInfo = BridgedActions::Attributes::ActionList::TypeInfo;
+        TypeInfo::Type cppValue;
+        {
+            using ListType = std::remove_reference_t<decltype(cppValue)>;
+            using ListMemberType = ListMemberTypeGetter<ListType>::Type;
+            if (value.count != 0) {
+                auto * listHolder_0 = new ListHolder<ListMemberType>(value.count);
+                if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
+                    return CHIP_ERROR_INVALID_ARGUMENT;
+                }
+                listFreer.add(listHolder_0);
+                for (size_t i = 0; i < value.count; ++i) {
+                    if (![value[i] isKindOfClass:[CHIPBridgedActionsClusterActionStruct class]]) {
+                        // Wrong kind of value.
+                        return CHIP_ERROR_INVALID_ARGUMENT;
+                    }
+                    auto element_0 = (CHIPBridgedActionsClusterActionStruct *) value[i];
+                    listHolder_0->mList[i].actionID = element_0.ActionID.unsignedShortValue;
+                    listHolder_0->mList[i].name = [self asCharSpan:element_0.Name];
+                    listHolder_0->mList[i].type = static_cast<std::remove_reference_t<decltype(listHolder_0->mList[i].type)>>(
+                        element_0.Type.unsignedCharValue);
+                    listHolder_0->mList[i].endpointListID = element_0.EndpointListID.unsignedShortValue;
+                    listHolder_0->mList[i].supportedCommands = element_0.SupportedCommands.unsignedShortValue;
+                    listHolder_0->mList[i].status = static_cast<std::remove_reference_t<decltype(listHolder_0->mList[i].status)>>(
+                        element_0.Status.unsignedCharValue);
+                }
+                cppValue = ListType(listHolder_0->mList, value.count);
+            } else {
+                cppValue = ListType();
+            }
+        }
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeEndpointListWithValue:(NSArray * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeClusterRevision(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = BridgedActions::Attributes::EndpointList::TypeInfo;
+        TypeInfo::Type cppValue;
+        {
+            using ListType = std::remove_reference_t<decltype(cppValue)>;
+            using ListMemberType = ListMemberTypeGetter<ListType>::Type;
+            if (value.count != 0) {
+                auto * listHolder_0 = new ListHolder<ListMemberType>(value.count);
+                if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
+                    return CHIP_ERROR_INVALID_ARGUMENT;
+                }
+                listFreer.add(listHolder_0);
+                for (size_t i = 0; i < value.count; ++i) {
+                    if (![value[i] isKindOfClass:[CHIPBridgedActionsClusterEndpointListStruct class]]) {
+                        // Wrong kind of value.
+                        return CHIP_ERROR_INVALID_ARGUMENT;
+                    }
+                    auto element_0 = (CHIPBridgedActionsClusterEndpointListStruct *) value[i];
+                    listHolder_0->mList[i].endpointListID = element_0.EndpointListID.unsignedShortValue;
+                    listHolder_0->mList[i].name = [self asCharSpan:element_0.Name];
+                    listHolder_0->mList[i].type = static_cast<std::remove_reference_t<decltype(listHolder_0->mList[i].type)>>(
+                        element_0.Type.unsignedCharValue);
+                    listHolder_0->mList[i].endpoints = [self asByteSpan:element_0.Endpoints];
+                }
+                cppValue = ListType(listHolder_0->mList, value.count);
+            } else {
+                cppValue = ListType();
+            }
+        }
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
+    });
+}
+
+- (void)writeAttributeSetupUrlWithValue:(NSString * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
+{
+    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        ListFreer listFreer;
+        using TypeInfo = BridgedActions::Attributes::SetupUrl::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = [self asCharSpan:value];
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
+    });
+}
+
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
+{
+    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        ListFreer listFreer;
+        using TypeInfo = BridgedActions::Attributes::ClusterRevision::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -483,101 +897,185 @@ using chip::Callback::Cancelable;
     return &_cppCluster;
 }
 
-- (void)writeAttributeVendorNameWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeVendorNameWithValue:(NSString * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeVendorName(success, failure, [self asCharSpan:value]);
+        ListFreer listFreer;
+        using TypeInfo = BridgedDeviceBasic::Attributes::VendorName::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = [self asCharSpan:value];
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeVendorIDWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeVendorIDWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeVendorID(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = BridgedDeviceBasic::Attributes::VendorID::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeProductNameWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeProductNameWithValue:(NSString * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeProductName(success, failure, [self asCharSpan:value]);
+        ListFreer listFreer;
+        using TypeInfo = BridgedDeviceBasic::Attributes::ProductName::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = [self asCharSpan:value];
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeHardwareVersionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeHardwareVersionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeHardwareVersion(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = BridgedDeviceBasic::Attributes::HardwareVersion::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeHardwareVersionStringWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeHardwareVersionStringWithValue:(NSString * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeHardwareVersionString(success, failure, [self asCharSpan:value]);
+        ListFreer listFreer;
+        using TypeInfo = BridgedDeviceBasic::Attributes::HardwareVersionString::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = [self asCharSpan:value];
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeSoftwareVersionWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeSoftwareVersionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeSoftwareVersion(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = BridgedDeviceBasic::Attributes::SoftwareVersion::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedIntValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeSoftwareVersionStringWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeSoftwareVersionStringWithValue:(NSString * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeSoftwareVersionString(success, failure, [self asCharSpan:value]);
+        ListFreer listFreer;
+        using TypeInfo = BridgedDeviceBasic::Attributes::SoftwareVersionString::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = [self asCharSpan:value];
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeManufacturingDateWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeManufacturingDateWithValue:(NSString * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeManufacturingDate(success, failure, [self asCharSpan:value]);
+        ListFreer listFreer;
+        using TypeInfo = BridgedDeviceBasic::Attributes::ManufacturingDate::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = [self asCharSpan:value];
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributePartNumberWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributePartNumberWithValue:(NSString * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributePartNumber(success, failure, [self asCharSpan:value]);
+        ListFreer listFreer;
+        using TypeInfo = BridgedDeviceBasic::Attributes::PartNumber::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = [self asCharSpan:value];
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeProductURLWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeProductURLWithValue:(NSString * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeProductURL(success, failure, [self asCharSpan:value]);
+        ListFreer listFreer;
+        using TypeInfo = BridgedDeviceBasic::Attributes::ProductURL::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = [self asCharSpan:value];
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeProductLabelWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeProductLabelWithValue:(NSString * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeProductLabel(success, failure, [self asCharSpan:value]);
+        ListFreer listFreer;
+        using TypeInfo = BridgedDeviceBasic::Attributes::ProductLabel::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = [self asCharSpan:value];
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeSerialNumberWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeSerialNumberWithValue:(NSString * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeSerialNumber(success, failure, [self asCharSpan:value]);
+        ListFreer listFreer;
+        using TypeInfo = BridgedDeviceBasic::Attributes::SerialNumber::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = [self asCharSpan:value];
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeReachableWithValue:(bool)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeReachableWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeReachable(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = BridgedDeviceBasic::Attributes::Reachable::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.boolValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeClusterRevision(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = BridgedDeviceBasic::Attributes::ClusterRevision::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -594,283 +1092,525 @@ using chip::Callback::Cancelable;
     return &_cppCluster;
 }
 
-- (void)writeAttributeCurrentHueWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeCurrentHueWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeCurrentHue(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ColorControl::Attributes::CurrentHue::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedCharValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeCurrentSaturationWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeCurrentSaturationWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeCurrentSaturation(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ColorControl::Attributes::CurrentSaturation::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedCharValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeRemainingTimeWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeRemainingTimeWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeRemainingTime(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ColorControl::Attributes::RemainingTime::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeCurrentXWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeCurrentXWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeCurrentX(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ColorControl::Attributes::CurrentX::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeCurrentYWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeCurrentYWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeCurrentY(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ColorControl::Attributes::CurrentY::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeDriftCompensationWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeDriftCompensationWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeDriftCompensation(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ColorControl::Attributes::DriftCompensation::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = static_cast<std::remove_reference_t<decltype(cppValue)>>(value.unsignedCharValue);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeCompensationTextWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeCompensationTextWithValue:(NSString * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeCompensationText(success, failure, [self asCharSpan:value]);
+        ListFreer listFreer;
+        using TypeInfo = ColorControl::Attributes::CompensationText::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = [self asCharSpan:value];
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeColorTemperatureWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeColorTemperatureWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeColorTemperature(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ColorControl::Attributes::ColorTemperature::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeColorModeWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeColorModeWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeColorMode(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ColorControl::Attributes::ColorMode::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = static_cast<std::remove_reference_t<decltype(cppValue)>>(value.unsignedCharValue);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeNumberOfPrimariesWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeNumberOfPrimariesWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeNumberOfPrimaries(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ColorControl::Attributes::NumberOfPrimaries::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedCharValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributePrimary1XWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributePrimary1XWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributePrimary1X(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ColorControl::Attributes::Primary1X::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributePrimary1YWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributePrimary1YWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributePrimary1Y(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ColorControl::Attributes::Primary1Y::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributePrimary1IntensityWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributePrimary1IntensityWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributePrimary1Intensity(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ColorControl::Attributes::Primary1Intensity::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedCharValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributePrimary2XWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributePrimary2XWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributePrimary2X(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ColorControl::Attributes::Primary2X::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributePrimary2YWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributePrimary2YWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributePrimary2Y(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ColorControl::Attributes::Primary2Y::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributePrimary2IntensityWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributePrimary2IntensityWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributePrimary2Intensity(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ColorControl::Attributes::Primary2Intensity::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedCharValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributePrimary3XWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributePrimary3XWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributePrimary3X(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ColorControl::Attributes::Primary3X::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributePrimary3YWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributePrimary3YWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributePrimary3Y(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ColorControl::Attributes::Primary3Y::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributePrimary3IntensityWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributePrimary3IntensityWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributePrimary3Intensity(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ColorControl::Attributes::Primary3Intensity::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedCharValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributePrimary4XWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributePrimary4XWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributePrimary4X(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ColorControl::Attributes::Primary4X::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributePrimary4YWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributePrimary4YWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributePrimary4Y(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ColorControl::Attributes::Primary4Y::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributePrimary4IntensityWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributePrimary4IntensityWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributePrimary4Intensity(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ColorControl::Attributes::Primary4Intensity::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedCharValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributePrimary5XWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributePrimary5XWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributePrimary5X(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ColorControl::Attributes::Primary5X::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributePrimary5YWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributePrimary5YWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributePrimary5Y(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ColorControl::Attributes::Primary5Y::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributePrimary5IntensityWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributePrimary5IntensityWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributePrimary5Intensity(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ColorControl::Attributes::Primary5Intensity::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedCharValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributePrimary6XWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributePrimary6XWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributePrimary6X(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ColorControl::Attributes::Primary6X::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributePrimary6YWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributePrimary6YWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributePrimary6Y(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ColorControl::Attributes::Primary6Y::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributePrimary6IntensityWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributePrimary6IntensityWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributePrimary6Intensity(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ColorControl::Attributes::Primary6Intensity::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedCharValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeEnhancedCurrentHueWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeEnhancedCurrentHueWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeEnhancedCurrentHue(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ColorControl::Attributes::EnhancedCurrentHue::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeEnhancedColorModeWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeEnhancedColorModeWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeEnhancedColorMode(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ColorControl::Attributes::EnhancedColorMode::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = static_cast<std::remove_reference_t<decltype(cppValue)>>(value.unsignedCharValue);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeColorLoopActiveWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeColorLoopActiveWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeColorLoopActive(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ColorControl::Attributes::ColorLoopActive::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedCharValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeColorLoopDirectionWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeColorLoopDirectionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeColorLoopDirection(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ColorControl::Attributes::ColorLoopDirection::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedCharValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeColorLoopTimeWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeColorLoopTimeWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeColorLoopTime(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ColorControl::Attributes::ColorLoopTime::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeColorLoopStartEnhancedHueWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeColorLoopStartEnhancedHueWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeColorLoopStartEnhancedHue(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ColorControl::Attributes::ColorLoopStartEnhancedHue::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeColorLoopStoredEnhancedHueWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeColorLoopStoredEnhancedHueWithValue:(NSNumber * _Nonnull)value
+                                          responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeColorLoopStoredEnhancedHue(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ColorControl::Attributes::ColorLoopStoredEnhancedHue::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeColorCapabilitiesWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeColorCapabilitiesWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeColorCapabilities(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ColorControl::Attributes::ColorCapabilities::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeColorTempPhysicalMinWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeColorTempPhysicalMinWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeColorTempPhysicalMin(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ColorControl::Attributes::ColorTempPhysicalMin::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeColorTempPhysicalMaxWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeColorTempPhysicalMaxWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeColorTempPhysicalMax(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ColorControl::Attributes::ColorTempPhysicalMax::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeCoupleColorTempToLevelMinMiredsWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeCoupleColorTempToLevelMinMiredsWithValue:(NSNumber * _Nonnull)value
+                                               responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeCoupleColorTempToLevelMinMireds(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ColorControl::Attributes::CoupleColorTempToLevelMinMireds::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeClusterRevision(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ColorControl::Attributes::ClusterRevision::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -887,10 +1627,85 @@ using chip::Callback::Cancelable;
     return &_cppCluster;
 }
 
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeAcceptsHeaderListWithValue:(NSArray * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeClusterRevision(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ContentLauncher::Attributes::AcceptsHeaderList::TypeInfo;
+        TypeInfo::Type cppValue;
+        {
+            using ListType = std::remove_reference_t<decltype(cppValue)>;
+            using ListMemberType = ListMemberTypeGetter<ListType>::Type;
+            if (value.count != 0) {
+                auto * listHolder_0 = new ListHolder<ListMemberType>(value.count);
+                if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
+                    return CHIP_ERROR_INVALID_ARGUMENT;
+                }
+                listFreer.add(listHolder_0);
+                for (size_t i = 0; i < value.count; ++i) {
+                    if (![value[i] isKindOfClass:[NSData class]]) {
+                        // Wrong kind of value.
+                        return CHIP_ERROR_INVALID_ARGUMENT;
+                    }
+                    auto element_0 = (NSData *) value[i];
+                    listHolder_0->mList[i] = [self asByteSpan:element_0];
+                }
+                cppValue = ListType(listHolder_0->mList, value.count);
+            } else {
+                cppValue = ListType();
+            }
+        }
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
+    });
+}
+
+- (void)writeAttributeSupportedStreamingTypesWithValue:(NSArray * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
+{
+    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        ListFreer listFreer;
+        using TypeInfo = ContentLauncher::Attributes::SupportedStreamingTypes::TypeInfo;
+        TypeInfo::Type cppValue;
+        {
+            using ListType = std::remove_reference_t<decltype(cppValue)>;
+            using ListMemberType = ListMemberTypeGetter<ListType>::Type;
+            if (value.count != 0) {
+                auto * listHolder_0 = new ListHolder<ListMemberType>(value.count);
+                if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
+                    return CHIP_ERROR_INVALID_ARGUMENT;
+                }
+                listFreer.add(listHolder_0);
+                for (size_t i = 0; i < value.count; ++i) {
+                    if (![value[i] isKindOfClass:[NSNumber class]]) {
+                        // Wrong kind of value.
+                        return CHIP_ERROR_INVALID_ARGUMENT;
+                    }
+                    auto element_0 = (NSNumber *) value[i];
+                    listHolder_0->mList[i]
+                        = static_cast<std::remove_reference_t<decltype(listHolder_0->mList[i])>>(element_0.unsignedCharValue);
+                }
+                cppValue = ListType(listHolder_0->mList, value.count);
+            } else {
+                cppValue = ListType();
+            }
+        }
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
+    });
+}
+
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
+{
+    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        ListFreer listFreer;
+        using TypeInfo = ContentLauncher::Attributes::ClusterRevision::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -907,10 +1722,153 @@ using chip::Callback::Cancelable;
     return &_cppCluster;
 }
 
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeDeviceListWithValue:(NSArray * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeClusterRevision(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = Descriptor::Attributes::DeviceList::TypeInfo;
+        TypeInfo::Type cppValue;
+        {
+            using ListType = std::remove_reference_t<decltype(cppValue)>;
+            using ListMemberType = ListMemberTypeGetter<ListType>::Type;
+            if (value.count != 0) {
+                auto * listHolder_0 = new ListHolder<ListMemberType>(value.count);
+                if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
+                    return CHIP_ERROR_INVALID_ARGUMENT;
+                }
+                listFreer.add(listHolder_0);
+                for (size_t i = 0; i < value.count; ++i) {
+                    if (![value[i] isKindOfClass:[CHIPDescriptorClusterDeviceType class]]) {
+                        // Wrong kind of value.
+                        return CHIP_ERROR_INVALID_ARGUMENT;
+                    }
+                    auto element_0 = (CHIPDescriptorClusterDeviceType *) value[i];
+                    listHolder_0->mList[i].type = element_0.Type.unsignedIntValue;
+                    listHolder_0->mList[i].revision = element_0.Revision.unsignedShortValue;
+                }
+                cppValue = ListType(listHolder_0->mList, value.count);
+            } else {
+                cppValue = ListType();
+            }
+        }
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
+    });
+}
+
+- (void)writeAttributeServerListWithValue:(NSArray * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
+{
+    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        ListFreer listFreer;
+        using TypeInfo = Descriptor::Attributes::ServerList::TypeInfo;
+        TypeInfo::Type cppValue;
+        {
+            using ListType = std::remove_reference_t<decltype(cppValue)>;
+            using ListMemberType = ListMemberTypeGetter<ListType>::Type;
+            if (value.count != 0) {
+                auto * listHolder_0 = new ListHolder<ListMemberType>(value.count);
+                if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
+                    return CHIP_ERROR_INVALID_ARGUMENT;
+                }
+                listFreer.add(listHolder_0);
+                for (size_t i = 0; i < value.count; ++i) {
+                    if (![value[i] isKindOfClass:[NSNumber class]]) {
+                        // Wrong kind of value.
+                        return CHIP_ERROR_INVALID_ARGUMENT;
+                    }
+                    auto element_0 = (NSNumber *) value[i];
+                    listHolder_0->mList[i] = element_0.unsignedIntValue;
+                }
+                cppValue = ListType(listHolder_0->mList, value.count);
+            } else {
+                cppValue = ListType();
+            }
+        }
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
+    });
+}
+
+- (void)writeAttributeClientListWithValue:(NSArray * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
+{
+    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        ListFreer listFreer;
+        using TypeInfo = Descriptor::Attributes::ClientList::TypeInfo;
+        TypeInfo::Type cppValue;
+        {
+            using ListType = std::remove_reference_t<decltype(cppValue)>;
+            using ListMemberType = ListMemberTypeGetter<ListType>::Type;
+            if (value.count != 0) {
+                auto * listHolder_0 = new ListHolder<ListMemberType>(value.count);
+                if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
+                    return CHIP_ERROR_INVALID_ARGUMENT;
+                }
+                listFreer.add(listHolder_0);
+                for (size_t i = 0; i < value.count; ++i) {
+                    if (![value[i] isKindOfClass:[NSNumber class]]) {
+                        // Wrong kind of value.
+                        return CHIP_ERROR_INVALID_ARGUMENT;
+                    }
+                    auto element_0 = (NSNumber *) value[i];
+                    listHolder_0->mList[i] = element_0.unsignedIntValue;
+                }
+                cppValue = ListType(listHolder_0->mList, value.count);
+            } else {
+                cppValue = ListType();
+            }
+        }
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
+    });
+}
+
+- (void)writeAttributePartsListWithValue:(NSArray * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
+{
+    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        ListFreer listFreer;
+        using TypeInfo = Descriptor::Attributes::PartsList::TypeInfo;
+        TypeInfo::Type cppValue;
+        {
+            using ListType = std::remove_reference_t<decltype(cppValue)>;
+            using ListMemberType = ListMemberTypeGetter<ListType>::Type;
+            if (value.count != 0) {
+                auto * listHolder_0 = new ListHolder<ListMemberType>(value.count);
+                if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
+                    return CHIP_ERROR_INVALID_ARGUMENT;
+                }
+                listFreer.add(listHolder_0);
+                for (size_t i = 0; i < value.count; ++i) {
+                    if (![value[i] isKindOfClass:[NSNumber class]]) {
+                        // Wrong kind of value.
+                        return CHIP_ERROR_INVALID_ARGUMENT;
+                    }
+                    auto element_0 = (NSNumber *) value[i];
+                    listHolder_0->mList[i] = element_0.unsignedShortValue;
+                }
+                cppValue = ListType(listHolder_0->mList, value.count);
+            } else {
+                cppValue = ListType();
+            }
+        }
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
+    });
+}
+
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
+{
+    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        ListFreer listFreer;
+        using TypeInfo = Descriptor::Attributes::ClusterRevision::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -940,31 +1898,55 @@ using chip::Callback::Cancelable;
     return &_cppCluster;
 }
 
-- (void)writeAttributeLockStateWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeLockStateWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeLockState(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = DoorLock::Attributes::LockState::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = static_cast<std::remove_reference_t<decltype(cppValue)>>(value.unsignedCharValue);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeLockTypeWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeLockTypeWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeLockType(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = DoorLock::Attributes::LockType::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = static_cast<std::remove_reference_t<decltype(cppValue)>>(value.unsignedCharValue);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeActuatorEnabledWithValue:(bool)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeActuatorEnabledWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeActuatorEnabled(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = DoorLock::Attributes::ActuatorEnabled::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.boolValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeClusterRevision(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = DoorLock::Attributes::ClusterRevision::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -981,87 +1963,159 @@ using chip::Callback::Cancelable;
     return &_cppCluster;
 }
 
-- (void)writeAttributeMeasurementTypeWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeMeasurementTypeWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeMeasurementType(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ElectricalMeasurement::Attributes::MeasurementType::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedIntValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeTotalActivePowerWithValue:(int32_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeTotalActivePowerWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeTotalActivePower(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ElectricalMeasurement::Attributes::TotalActivePower::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.intValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeRmsVoltageWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeRmsVoltageWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeRmsVoltage(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ElectricalMeasurement::Attributes::RmsVoltage::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeRmsVoltageMinWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeRmsVoltageMinWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeRmsVoltageMin(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ElectricalMeasurement::Attributes::RmsVoltageMin::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeRmsVoltageMaxWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeRmsVoltageMaxWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeRmsVoltageMax(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ElectricalMeasurement::Attributes::RmsVoltageMax::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeRmsCurrentWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeRmsCurrentWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeRmsCurrent(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ElectricalMeasurement::Attributes::RmsCurrent::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeRmsCurrentMinWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeRmsCurrentMinWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeRmsCurrentMin(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ElectricalMeasurement::Attributes::RmsCurrentMin::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeRmsCurrentMaxWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeRmsCurrentMaxWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeRmsCurrentMax(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ElectricalMeasurement::Attributes::RmsCurrentMax::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeActivePowerWithValue:(int16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeActivePowerWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeActivePower(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ElectricalMeasurement::Attributes::ActivePower::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.shortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeActivePowerMinWithValue:(int16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeActivePowerMinWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeActivePowerMin(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ElectricalMeasurement::Attributes::ActivePowerMin::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.shortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeActivePowerMaxWithValue:(int16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeActivePowerMaxWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeActivePowerMax(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ElectricalMeasurement::Attributes::ActivePowerMax::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.shortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeClusterRevision(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ElectricalMeasurement::Attributes::ClusterRevision::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -1078,73 +2132,133 @@ using chip::Callback::Cancelable;
     return &_cppCluster;
 }
 
-- (void)writeAttributePHYRateWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributePHYRateWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributePHYRate(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = EthernetNetworkDiagnostics::Attributes::PHYRate::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = static_cast<std::remove_reference_t<decltype(cppValue)>>(value.unsignedCharValue);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeFullDuplexWithValue:(bool)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeFullDuplexWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeFullDuplex(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = EthernetNetworkDiagnostics::Attributes::FullDuplex::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.boolValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributePacketRxCountWithValue:(uint64_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributePacketRxCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributePacketRxCount(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = EthernetNetworkDiagnostics::Attributes::PacketRxCount::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedLongLongValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributePacketTxCountWithValue:(uint64_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributePacketTxCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributePacketTxCount(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = EthernetNetworkDiagnostics::Attributes::PacketTxCount::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedLongLongValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeTxErrCountWithValue:(uint64_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeTxErrCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeTxErrCount(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = EthernetNetworkDiagnostics::Attributes::TxErrCount::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedLongLongValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeCollisionCountWithValue:(uint64_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeCollisionCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeCollisionCount(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = EthernetNetworkDiagnostics::Attributes::CollisionCount::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedLongLongValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeOverrunCountWithValue:(uint64_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeOverrunCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeOverrunCount(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = EthernetNetworkDiagnostics::Attributes::OverrunCount::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedLongLongValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeCarrierDetectWithValue:(bool)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeCarrierDetectWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeCarrierDetect(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = EthernetNetworkDiagnostics::Attributes::CarrierDetect::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.boolValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeTimeSinceResetWithValue:(uint64_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeTimeSinceResetWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeTimeSinceReset(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = EthernetNetworkDiagnostics::Attributes::TimeSinceReset::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedLongLongValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeClusterRevision(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = EthernetNetworkDiagnostics::Attributes::ClusterRevision::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -1161,10 +2275,51 @@ using chip::Callback::Cancelable;
     return &_cppCluster;
 }
 
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeLabelListWithValue:(NSArray * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeClusterRevision(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = FixedLabel::Attributes::LabelList::TypeInfo;
+        TypeInfo::Type cppValue;
+        {
+            using ListType = std::remove_reference_t<decltype(cppValue)>;
+            using ListMemberType = ListMemberTypeGetter<ListType>::Type;
+            if (value.count != 0) {
+                auto * listHolder_0 = new ListHolder<ListMemberType>(value.count);
+                if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
+                    return CHIP_ERROR_INVALID_ARGUMENT;
+                }
+                listFreer.add(listHolder_0);
+                for (size_t i = 0; i < value.count; ++i) {
+                    if (![value[i] isKindOfClass:[CHIPFixedLabelClusterLabelStruct class]]) {
+                        // Wrong kind of value.
+                        return CHIP_ERROR_INVALID_ARGUMENT;
+                    }
+                    auto element_0 = (CHIPFixedLabelClusterLabelStruct *) value[i];
+                    listHolder_0->mList[i].label = [self asCharSpan:element_0.Label];
+                    listHolder_0->mList[i].value = [self asCharSpan:element_0.Value];
+                }
+                cppValue = ListType(listHolder_0->mList, value.count);
+            } else {
+                cppValue = ListType();
+            }
+        }
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
+    });
+}
+
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
+{
+    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        ListFreer listFreer;
+        using TypeInfo = FixedLabel::Attributes::ClusterRevision::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -1181,38 +2336,68 @@ using chip::Callback::Cancelable;
     return &_cppCluster;
 }
 
-- (void)writeAttributeMeasuredValueWithValue:(int16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeMeasuredValueWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeMeasuredValue(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = FlowMeasurement::Attributes::MeasuredValue::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.shortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeMinMeasuredValueWithValue:(int16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeMinMeasuredValueWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeMinMeasuredValue(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = FlowMeasurement::Attributes::MinMeasuredValue::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.shortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeMaxMeasuredValueWithValue:(int16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeMaxMeasuredValueWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeMaxMeasuredValue(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = FlowMeasurement::Attributes::MaxMeasuredValue::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.shortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeToleranceWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeToleranceWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeTolerance(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = FlowMeasurement::Attributes::Tolerance::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeClusterRevision(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = FlowMeasurement::Attributes::ClusterRevision::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -1229,10 +2414,50 @@ using chip::Callback::Cancelable;
     return &_cppCluster;
 }
 
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeBasicCommissioningInfoListWithValue:(NSArray * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeClusterRevision(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = GeneralCommissioning::Attributes::BasicCommissioningInfoList::TypeInfo;
+        TypeInfo::Type cppValue;
+        {
+            using ListType = std::remove_reference_t<decltype(cppValue)>;
+            using ListMemberType = ListMemberTypeGetter<ListType>::Type;
+            if (value.count != 0) {
+                auto * listHolder_0 = new ListHolder<ListMemberType>(value.count);
+                if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
+                    return CHIP_ERROR_INVALID_ARGUMENT;
+                }
+                listFreer.add(listHolder_0);
+                for (size_t i = 0; i < value.count; ++i) {
+                    if (![value[i] isKindOfClass:[CHIPGeneralCommissioningClusterBasicCommissioningInfoType class]]) {
+                        // Wrong kind of value.
+                        return CHIP_ERROR_INVALID_ARGUMENT;
+                    }
+                    auto element_0 = (CHIPGeneralCommissioningClusterBasicCommissioningInfoType *) value[i];
+                    listHolder_0->mList[i].failSafeExpiryLengthMs = element_0.FailSafeExpiryLengthMs.unsignedIntValue;
+                }
+                cppValue = ListType(listHolder_0->mList, value.count);
+            } else {
+                cppValue = ListType();
+            }
+        }
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
+    });
+}
+
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
+{
+    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        ListFreer listFreer;
+        using TypeInfo = GeneralCommissioning::Attributes::ClusterRevision::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -1249,38 +2474,108 @@ using chip::Callback::Cancelable;
     return &_cppCluster;
 }
 
-- (void)writeAttributeRebootCountWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeNetworkInterfacesWithValue:(NSArray * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeRebootCount(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = GeneralDiagnostics::Attributes::NetworkInterfaces::TypeInfo;
+        TypeInfo::Type cppValue;
+        {
+            using ListType = std::remove_reference_t<decltype(cppValue)>;
+            using ListMemberType = ListMemberTypeGetter<ListType>::Type;
+            if (value.count != 0) {
+                auto * listHolder_0 = new ListHolder<ListMemberType>(value.count);
+                if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
+                    return CHIP_ERROR_INVALID_ARGUMENT;
+                }
+                listFreer.add(listHolder_0);
+                for (size_t i = 0; i < value.count; ++i) {
+                    if (![value[i] isKindOfClass:[CHIPGeneralDiagnosticsClusterNetworkInterfaceType class]]) {
+                        // Wrong kind of value.
+                        return CHIP_ERROR_INVALID_ARGUMENT;
+                    }
+                    auto element_0 = (CHIPGeneralDiagnosticsClusterNetworkInterfaceType *) value[i];
+                    listHolder_0->mList[i].name = [self asCharSpan:element_0.Name];
+                    listHolder_0->mList[i].fabricConnected = element_0.FabricConnected.boolValue;
+                    listHolder_0->mList[i].offPremiseServicesReachableIPv4 = element_0.OffPremiseServicesReachableIPv4.boolValue;
+                    listHolder_0->mList[i].offPremiseServicesReachableIPv6 = element_0.OffPremiseServicesReachableIPv6.boolValue;
+                    listHolder_0->mList[i].hardwareAddress = [self asByteSpan:element_0.HardwareAddress];
+                    listHolder_0->mList[i].type = static_cast<std::remove_reference_t<decltype(listHolder_0->mList[i].type)>>(
+                        element_0.Type.unsignedCharValue);
+                }
+                cppValue = ListType(listHolder_0->mList, value.count);
+            } else {
+                cppValue = ListType();
+            }
+        }
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeUpTimeWithValue:(uint64_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeRebootCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeUpTime(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = GeneralDiagnostics::Attributes::RebootCount::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeTotalOperationalHoursWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeUpTimeWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeTotalOperationalHours(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = GeneralDiagnostics::Attributes::UpTime::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedLongLongValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeBootReasonsWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeTotalOperationalHoursWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeBootReasons(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = GeneralDiagnostics::Attributes::TotalOperationalHours::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedIntValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeBootReasonsWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeClusterRevision(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = GeneralDiagnostics::Attributes::BootReasons::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = static_cast<std::remove_reference_t<decltype(cppValue)>>(value.unsignedCharValue);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
+    });
+}
+
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
+{
+    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        ListFreer listFreer;
+        using TypeInfo = GeneralDiagnostics::Attributes::ClusterRevision::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -1297,10 +2592,92 @@ using chip::Callback::Cancelable;
     return &_cppCluster;
 }
 
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeGroupsWithValue:(NSArray * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeClusterRevision(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = GroupKeyManagement::Attributes::Groups::TypeInfo;
+        TypeInfo::Type cppValue;
+        {
+            using ListType = std::remove_reference_t<decltype(cppValue)>;
+            using ListMemberType = ListMemberTypeGetter<ListType>::Type;
+            if (value.count != 0) {
+                auto * listHolder_0 = new ListHolder<ListMemberType>(value.count);
+                if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
+                    return CHIP_ERROR_INVALID_ARGUMENT;
+                }
+                listFreer.add(listHolder_0);
+                for (size_t i = 0; i < value.count; ++i) {
+                    if (![value[i] isKindOfClass:[CHIPGroupKeyManagementClusterGroupState class]]) {
+                        // Wrong kind of value.
+                        return CHIP_ERROR_INVALID_ARGUMENT;
+                    }
+                    auto element_0 = (CHIPGroupKeyManagementClusterGroupState *) value[i];
+                    listHolder_0->mList[i].vendorId = element_0.VendorId.unsignedShortValue;
+                    listHolder_0->mList[i].vendorGroupId = element_0.VendorGroupId.unsignedShortValue;
+                    listHolder_0->mList[i].groupKeySetIndex = element_0.GroupKeySetIndex.unsignedShortValue;
+                }
+                cppValue = ListType(listHolder_0->mList, value.count);
+            } else {
+                cppValue = ListType();
+            }
+        }
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
+    });
+}
+
+- (void)writeAttributeGroupKeysWithValue:(NSArray * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
+{
+    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        ListFreer listFreer;
+        using TypeInfo = GroupKeyManagement::Attributes::GroupKeys::TypeInfo;
+        TypeInfo::Type cppValue;
+        {
+            using ListType = std::remove_reference_t<decltype(cppValue)>;
+            using ListMemberType = ListMemberTypeGetter<ListType>::Type;
+            if (value.count != 0) {
+                auto * listHolder_0 = new ListHolder<ListMemberType>(value.count);
+                if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
+                    return CHIP_ERROR_INVALID_ARGUMENT;
+                }
+                listFreer.add(listHolder_0);
+                for (size_t i = 0; i < value.count; ++i) {
+                    if (![value[i] isKindOfClass:[CHIPGroupKeyManagementClusterGroupKey class]]) {
+                        // Wrong kind of value.
+                        return CHIP_ERROR_INVALID_ARGUMENT;
+                    }
+                    auto element_0 = (CHIPGroupKeyManagementClusterGroupKey *) value[i];
+                    listHolder_0->mList[i].vendorId = element_0.VendorId.unsignedShortValue;
+                    listHolder_0->mList[i].groupKeyIndex = element_0.GroupKeyIndex.unsignedShortValue;
+                    listHolder_0->mList[i].groupKeyRoot = [self asByteSpan:element_0.GroupKeyRoot];
+                    listHolder_0->mList[i].groupKeyEpochStartTime = element_0.GroupKeyEpochStartTime.unsignedLongLongValue;
+                    listHolder_0->mList[i].groupKeySecurityPolicy
+                        = static_cast<std::remove_reference_t<decltype(listHolder_0->mList[i].groupKeySecurityPolicy)>>(
+                            element_0.GroupKeySecurityPolicy.unsignedCharValue);
+                }
+                cppValue = ListType(listHolder_0->mList, value.count);
+            } else {
+                cppValue = ListType();
+            }
+        }
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
+    });
+}
+
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
+{
+    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        ListFreer listFreer;
+        using TypeInfo = GroupKeyManagement::Attributes::ClusterRevision::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -1317,17 +2694,29 @@ using chip::Callback::Cancelable;
     return &_cppCluster;
 }
 
-- (void)writeAttributeNameSupportWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeNameSupportWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeNameSupport(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = Groups::Attributes::NameSupport::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedCharValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeClusterRevision(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = Groups::Attributes::ClusterRevision::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -1344,17 +2733,29 @@ using chip::Callback::Cancelable;
     return &_cppCluster;
 }
 
-- (void)writeAttributeIdentifyTypeWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeIdentifyTypeWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeIdentifyType(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = Identify::Attributes::IdentifyType::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = static_cast<std::remove_reference_t<decltype(cppValue)>>(value.unsignedCharValue);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeClusterRevision(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = Identify::Attributes::ClusterRevision::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -1371,45 +2772,101 @@ using chip::Callback::Cancelable;
     return &_cppCluster;
 }
 
-- (void)writeAttributeMeasuredValueWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeMeasuredValueWithValue:(NSNumber * _Nullable)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeMeasuredValue(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = IlluminanceMeasurement::Attributes::MeasuredValue::TypeInfo;
+        TypeInfo::Type cppValue;
+        if (value == nil) {
+            cppValue.SetNull();
+        } else {
+            auto & nonNullValue_0 = cppValue.SetNonNull();
+            nonNullValue_0 = value.unsignedShortValue;
+        }
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeMinMeasuredValueWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeMinMeasuredValueWithValue:(NSNumber * _Nullable)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeMinMeasuredValue(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = IlluminanceMeasurement::Attributes::MinMeasuredValue::TypeInfo;
+        TypeInfo::Type cppValue;
+        if (value == nil) {
+            cppValue.SetNull();
+        } else {
+            auto & nonNullValue_0 = cppValue.SetNonNull();
+            nonNullValue_0 = value.unsignedShortValue;
+        }
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeMaxMeasuredValueWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeMaxMeasuredValueWithValue:(NSNumber * _Nullable)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeMaxMeasuredValue(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = IlluminanceMeasurement::Attributes::MaxMeasuredValue::TypeInfo;
+        TypeInfo::Type cppValue;
+        if (value == nil) {
+            cppValue.SetNull();
+        } else {
+            auto & nonNullValue_0 = cppValue.SetNonNull();
+            nonNullValue_0 = value.unsignedShortValue;
+        }
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeToleranceWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeToleranceWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeTolerance(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = IlluminanceMeasurement::Attributes::Tolerance::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeLightSensorTypeWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeLightSensorTypeWithValue:(NSNumber * _Nullable)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeLightSensorType(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = IlluminanceMeasurement::Attributes::LightSensorType::TypeInfo;
+        TypeInfo::Type cppValue;
+        if (value == nil) {
+            cppValue.SetNull();
+        } else {
+            auto & nonNullValue_0 = cppValue.SetNonNull();
+            nonNullValue_0 = static_cast<std::remove_reference_t<decltype(nonNullValue_0)>>(value.unsignedCharValue);
+        }
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeClusterRevision(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = IlluminanceMeasurement::Attributes::ClusterRevision::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -1426,10 +2883,16 @@ using chip::Callback::Cancelable;
     return &_cppCluster;
 }
 
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeClusterRevision(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = KeypadInput::Attributes::ClusterRevision::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -1446,59 +2909,107 @@ using chip::Callback::Cancelable;
     return &_cppCluster;
 }
 
-- (void)writeAttributeCurrentLevelWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeCurrentLevelWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeCurrentLevel(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = LevelControl::Attributes::CurrentLevel::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedCharValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeRemainingTimeWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeRemainingTimeWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeRemainingTime(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = LevelControl::Attributes::RemainingTime::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeMinLevelWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeMinLevelWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeMinLevel(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = LevelControl::Attributes::MinLevel::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedCharValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeMaxLevelWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeMaxLevelWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeMaxLevel(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = LevelControl::Attributes::MaxLevel::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedCharValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeCurrentFrequencyWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeCurrentFrequencyWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeCurrentFrequency(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = LevelControl::Attributes::CurrentFrequency::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeMinFrequencyWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeMinFrequencyWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeMinFrequency(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = LevelControl::Attributes::MinFrequency::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeMaxFrequencyWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeMaxFrequencyWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeMaxFrequency(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = LevelControl::Attributes::MaxFrequency::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeClusterRevision(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = LevelControl::Attributes::ClusterRevision::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -1515,10 +3026,16 @@ using chip::Callback::Cancelable;
     return &_cppCluster;
 }
 
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeClusterRevision(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = LowPower::Attributes::ClusterRevision::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -1535,17 +3052,68 @@ using chip::Callback::Cancelable;
     return &_cppCluster;
 }
 
-- (void)writeAttributeCurrentMediaInputWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeMediaInputListWithValue:(NSArray * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeCurrentMediaInput(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = MediaInput::Attributes::MediaInputList::TypeInfo;
+        TypeInfo::Type cppValue;
+        {
+            using ListType = std::remove_reference_t<decltype(cppValue)>;
+            using ListMemberType = ListMemberTypeGetter<ListType>::Type;
+            if (value.count != 0) {
+                auto * listHolder_0 = new ListHolder<ListMemberType>(value.count);
+                if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
+                    return CHIP_ERROR_INVALID_ARGUMENT;
+                }
+                listFreer.add(listHolder_0);
+                for (size_t i = 0; i < value.count; ++i) {
+                    if (![value[i] isKindOfClass:[CHIPMediaInputClusterMediaInputInfo class]]) {
+                        // Wrong kind of value.
+                        return CHIP_ERROR_INVALID_ARGUMENT;
+                    }
+                    auto element_0 = (CHIPMediaInputClusterMediaInputInfo *) value[i];
+                    listHolder_0->mList[i].index = element_0.Index.unsignedCharValue;
+                    listHolder_0->mList[i].inputType
+                        = static_cast<std::remove_reference_t<decltype(listHolder_0->mList[i].inputType)>>(
+                            element_0.InputType.unsignedCharValue);
+                    listHolder_0->mList[i].name = [self asCharSpan:element_0.Name];
+                    listHolder_0->mList[i].description = [self asCharSpan:element_0.Description];
+                }
+                cppValue = ListType(listHolder_0->mList, value.count);
+            } else {
+                cppValue = ListType();
+            }
+        }
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeCurrentMediaInputWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeClusterRevision(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = MediaInput::Attributes::CurrentMediaInput::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedCharValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
+    });
+}
+
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
+{
+    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        ListFreer listFreer;
+        using TypeInfo = MediaInput::Attributes::ClusterRevision::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -1562,66 +3130,120 @@ using chip::Callback::Cancelable;
     return &_cppCluster;
 }
 
-- (void)writeAttributePlaybackStateWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributePlaybackStateWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributePlaybackState(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = MediaPlayback::Attributes::PlaybackState::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = static_cast<std::remove_reference_t<decltype(cppValue)>>(value.unsignedCharValue);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeStartTimeWithValue:(uint64_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeStartTimeWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeStartTime(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = MediaPlayback::Attributes::StartTime::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedLongLongValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeDurationWithValue:(uint64_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeDurationWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeDuration(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = MediaPlayback::Attributes::Duration::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedLongLongValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributePositionUpdatedAtWithValue:(uint64_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributePositionUpdatedAtWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributePositionUpdatedAt(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = MediaPlayback::Attributes::PositionUpdatedAt::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedLongLongValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributePositionWithValue:(uint64_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributePositionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributePosition(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = MediaPlayback::Attributes::Position::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedLongLongValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributePlaybackSpeedWithValue:(uint64_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributePlaybackSpeedWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributePlaybackSpeed(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = MediaPlayback::Attributes::PlaybackSpeed::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedLongLongValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeSeekRangeEndWithValue:(uint64_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeSeekRangeEndWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeSeekRangeEnd(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = MediaPlayback::Attributes::SeekRangeEnd::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedLongLongValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeSeekRangeStartWithValue:(uint64_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeSeekRangeStartWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeSeekRangeStart(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = MediaPlayback::Attributes::SeekRangeStart::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedLongLongValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeClusterRevision(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = MediaPlayback::Attributes::ClusterRevision::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -1638,31 +3260,91 @@ using chip::Callback::Cancelable;
     return &_cppCluster;
 }
 
-- (void)writeAttributeCurrentModeWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeCurrentModeWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeCurrentMode(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ModeSelect::Attributes::CurrentMode::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedCharValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeStartUpModeWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeSupportedModesWithValue:(NSArray * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeStartUpMode(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ModeSelect::Attributes::SupportedModes::TypeInfo;
+        TypeInfo::Type cppValue;
+        {
+            using ListType = std::remove_reference_t<decltype(cppValue)>;
+            using ListMemberType = ListMemberTypeGetter<ListType>::Type;
+            if (value.count != 0) {
+                auto * listHolder_0 = new ListHolder<ListMemberType>(value.count);
+                if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
+                    return CHIP_ERROR_INVALID_ARGUMENT;
+                }
+                listFreer.add(listHolder_0);
+                for (size_t i = 0; i < value.count; ++i) {
+                    if (![value[i] isKindOfClass:[CHIPModeSelectClusterModeOptionStruct class]]) {
+                        // Wrong kind of value.
+                        return CHIP_ERROR_INVALID_ARGUMENT;
+                    }
+                    auto element_0 = (CHIPModeSelectClusterModeOptionStruct *) value[i];
+                    listHolder_0->mList[i].label = [self asCharSpan:element_0.Label];
+                    listHolder_0->mList[i].mode = element_0.Mode.unsignedCharValue;
+                    listHolder_0->mList[i].semanticTag = element_0.SemanticTag.unsignedIntValue;
+                }
+                cppValue = ListType(listHolder_0->mList, value.count);
+            } else {
+                cppValue = ListType();
+            }
+        }
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeDescriptionWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeStartUpModeWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeDescription(success, failure, [self asCharSpan:value]);
+        ListFreer listFreer;
+        using TypeInfo = ModeSelect::Attributes::StartUpMode::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedCharValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeDescriptionWithValue:(NSString * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeClusterRevision(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ModeSelect::Attributes::Description::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = [self asCharSpan:value];
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
+    });
+}
+
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
+{
+    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        ListFreer listFreer;
+        using TypeInfo = ModeSelect::Attributes::ClusterRevision::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -1679,17 +3361,29 @@ using chip::Callback::Cancelable;
     return &_cppCluster;
 }
 
-- (void)writeAttributeFeatureMapWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeFeatureMapWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeFeatureMap(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = NetworkCommissioning::Attributes::FeatureMap::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedIntValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeClusterRevision(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = NetworkCommissioning::Attributes::ClusterRevision::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -1706,10 +3400,16 @@ using chip::Callback::Cancelable;
     return &_cppCluster;
 }
 
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeClusterRevision(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = OtaSoftwareUpdateProvider::Attributes::ClusterRevision::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -1726,17 +3426,29 @@ using chip::Callback::Cancelable;
     return &_cppCluster;
 }
 
-- (void)writeAttributeUpdatePossibleWithValue:(bool)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeUpdatePossibleWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeUpdatePossible(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = OtaSoftwareUpdateRequestor::Attributes::UpdatePossible::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.boolValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeClusterRevision(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = OtaSoftwareUpdateRequestor::Attributes::ClusterRevision::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -1753,31 +3465,55 @@ using chip::Callback::Cancelable;
     return &_cppCluster;
 }
 
-- (void)writeAttributeOccupancyWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeOccupancyWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeOccupancy(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = OccupancySensing::Attributes::Occupancy::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedCharValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeOccupancySensorTypeWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeOccupancySensorTypeWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeOccupancySensorType(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = OccupancySensing::Attributes::OccupancySensorType::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = static_cast<std::remove_reference_t<decltype(cppValue)>>(value.unsignedCharValue);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeOccupancySensorTypeBitmapWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeOccupancySensorTypeBitmapWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeOccupancySensorTypeBitmap(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = OccupancySensing::Attributes::OccupancySensorTypeBitmap::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedCharValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeClusterRevision(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = OccupancySensing::Attributes::ClusterRevision::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -1794,31 +3530,55 @@ using chip::Callback::Cancelable;
     return &_cppCluster;
 }
 
-- (void)writeAttributeOnOffWithValue:(bool)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeOnOffWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeOnOff(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = OnOff::Attributes::OnOff::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.boolValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeGlobalSceneControlWithValue:(bool)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeGlobalSceneControlWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeGlobalSceneControl(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = OnOff::Attributes::GlobalSceneControl::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.boolValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeFeatureMapWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeFeatureMapWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeFeatureMap(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = OnOff::Attributes::FeatureMap::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedIntValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeClusterRevision(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = OnOff::Attributes::ClusterRevision::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -1835,17 +3595,29 @@ using chip::Callback::Cancelable;
     return &_cppCluster;
 }
 
-- (void)writeAttributeSwitchTypeWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeSwitchTypeWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeSwitchType(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = OnOffSwitchConfiguration::Attributes::SwitchType::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = static_cast<std::remove_reference_t<decltype(cppValue)>>(value.unsignedCharValue);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeClusterRevision(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = OnOffSwitchConfiguration::Attributes::ClusterRevision::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -1862,31 +3634,128 @@ using chip::Callback::Cancelable;
     return &_cppCluster;
 }
 
-- (void)writeAttributeSupportedFabricsWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeFabricsListWithValue:(NSArray * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeSupportedFabrics(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = OperationalCredentials::Attributes::FabricsList::TypeInfo;
+        TypeInfo::Type cppValue;
+        {
+            using ListType = std::remove_reference_t<decltype(cppValue)>;
+            using ListMemberType = ListMemberTypeGetter<ListType>::Type;
+            if (value.count != 0) {
+                auto * listHolder_0 = new ListHolder<ListMemberType>(value.count);
+                if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
+                    return CHIP_ERROR_INVALID_ARGUMENT;
+                }
+                listFreer.add(listHolder_0);
+                for (size_t i = 0; i < value.count; ++i) {
+                    if (![value[i] isKindOfClass:[CHIPOperationalCredentialsClusterFabricDescriptor class]]) {
+                        // Wrong kind of value.
+                        return CHIP_ERROR_INVALID_ARGUMENT;
+                    }
+                    auto element_0 = (CHIPOperationalCredentialsClusterFabricDescriptor *) value[i];
+                    listHolder_0->mList[i].fabricIndex = element_0.FabricIndex.unsignedCharValue;
+                    listHolder_0->mList[i].rootPublicKey = [self asByteSpan:element_0.RootPublicKey];
+                    listHolder_0->mList[i].vendorId = element_0.VendorId.unsignedShortValue;
+                    listHolder_0->mList[i].fabricId = element_0.FabricId.unsignedLongLongValue;
+                    listHolder_0->mList[i].nodeId = element_0.NodeId.unsignedLongLongValue;
+                    listHolder_0->mList[i].label = [self asCharSpan:element_0.Label];
+                }
+                cppValue = ListType(listHolder_0->mList, value.count);
+            } else {
+                cppValue = ListType();
+            }
+        }
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeCommissionedFabricsWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeSupportedFabricsWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeCommissionedFabrics(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = OperationalCredentials::Attributes::SupportedFabrics::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedCharValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeCurrentFabricIndexWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeCommissionedFabricsWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeCurrentFabricIndex(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = OperationalCredentials::Attributes::CommissionedFabrics::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedCharValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeTrustedRootCertificatesWithValue:(NSArray * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeClusterRevision(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = OperationalCredentials::Attributes::TrustedRootCertificates::TypeInfo;
+        TypeInfo::Type cppValue;
+        {
+            using ListType = std::remove_reference_t<decltype(cppValue)>;
+            using ListMemberType = ListMemberTypeGetter<ListType>::Type;
+            if (value.count != 0) {
+                auto * listHolder_0 = new ListHolder<ListMemberType>(value.count);
+                if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
+                    return CHIP_ERROR_INVALID_ARGUMENT;
+                }
+                listFreer.add(listHolder_0);
+                for (size_t i = 0; i < value.count; ++i) {
+                    if (![value[i] isKindOfClass:[NSData class]]) {
+                        // Wrong kind of value.
+                        return CHIP_ERROR_INVALID_ARGUMENT;
+                    }
+                    auto element_0 = (NSData *) value[i];
+                    listHolder_0->mList[i] = [self asByteSpan:element_0];
+                }
+                cppValue = ListType(listHolder_0->mList, value.count);
+            } else {
+                cppValue = ListType();
+            }
+        }
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
+    });
+}
+
+- (void)writeAttributeCurrentFabricIndexWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
+{
+    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        ListFreer listFreer;
+        using TypeInfo = OperationalCredentials::Attributes::CurrentFabricIndex::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedCharValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
+    });
+}
+
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
+{
+    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        ListFreer listFreer;
+        using TypeInfo = OperationalCredentials::Attributes::ClusterRevision::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -1903,73 +3772,167 @@ using chip::Callback::Cancelable;
     return &_cppCluster;
 }
 
-- (void)writeAttributeStatusWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeStatusWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeStatus(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = PowerSource::Attributes::Status::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = static_cast<std::remove_reference_t<decltype(cppValue)>>(value.unsignedCharValue);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeOrderWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeOrderWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeOrder(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = PowerSource::Attributes::Order::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedCharValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeDescriptionWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeDescriptionWithValue:(NSString * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeDescription(success, failure, [self asCharSpan:value]);
+        ListFreer listFreer;
+        using TypeInfo = PowerSource::Attributes::Description::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = [self asCharSpan:value];
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeBatteryVoltageWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeBatteryVoltageWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeBatteryVoltage(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = PowerSource::Attributes::BatteryVoltage::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedIntValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeBatteryPercentRemainingWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeBatteryPercentRemainingWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeBatteryPercentRemaining(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = PowerSource::Attributes::BatteryPercentRemaining::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedCharValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeBatteryTimeRemainingWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeBatteryTimeRemainingWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeBatteryTimeRemaining(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = PowerSource::Attributes::BatteryTimeRemaining::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedIntValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeBatteryChargeLevelWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeBatteryChargeLevelWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeBatteryChargeLevel(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = PowerSource::Attributes::BatteryChargeLevel::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = static_cast<std::remove_reference_t<decltype(cppValue)>>(value.unsignedCharValue);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeBatteryChargeStateWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeActiveBatteryFaultsWithValue:(NSArray * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeBatteryChargeState(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = PowerSource::Attributes::ActiveBatteryFaults::TypeInfo;
+        TypeInfo::Type cppValue;
+        {
+            using ListType = std::remove_reference_t<decltype(cppValue)>;
+            using ListMemberType = ListMemberTypeGetter<ListType>::Type;
+            if (value.count != 0) {
+                auto * listHolder_0 = new ListHolder<ListMemberType>(value.count);
+                if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
+                    return CHIP_ERROR_INVALID_ARGUMENT;
+                }
+                listFreer.add(listHolder_0);
+                for (size_t i = 0; i < value.count; ++i) {
+                    if (![value[i] isKindOfClass:[NSNumber class]]) {
+                        // Wrong kind of value.
+                        return CHIP_ERROR_INVALID_ARGUMENT;
+                    }
+                    auto element_0 = (NSNumber *) value[i];
+                    listHolder_0->mList[i] = element_0.unsignedCharValue;
+                }
+                cppValue = ListType(listHolder_0->mList, value.count);
+            } else {
+                cppValue = ListType();
+            }
+        }
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeFeatureMapWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeBatteryChargeStateWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeFeatureMap(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = PowerSource::Attributes::BatteryChargeState::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = static_cast<std::remove_reference_t<decltype(cppValue)>>(value.unsignedCharValue);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeFeatureMapWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeClusterRevision(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = PowerSource::Attributes::FeatureMap::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedIntValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
+    });
+}
+
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
+{
+    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        ListFreer listFreer;
+        using TypeInfo = PowerSource::Attributes::ClusterRevision::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -1986,31 +3949,55 @@ using chip::Callback::Cancelable;
     return &_cppCluster;
 }
 
-- (void)writeAttributeMeasuredValueWithValue:(int16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeMeasuredValueWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeMeasuredValue(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = PressureMeasurement::Attributes::MeasuredValue::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.shortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeMinMeasuredValueWithValue:(int16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeMinMeasuredValueWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeMinMeasuredValue(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = PressureMeasurement::Attributes::MinMeasuredValue::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.shortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeMaxMeasuredValueWithValue:(int16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeMaxMeasuredValueWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeMaxMeasuredValue(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = PressureMeasurement::Attributes::MaxMeasuredValue::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.shortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeClusterRevision(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = PressureMeasurement::Attributes::ClusterRevision::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -2027,157 +4014,289 @@ using chip::Callback::Cancelable;
     return &_cppCluster;
 }
 
-- (void)writeAttributeMaxPressureWithValue:(int16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeMaxPressureWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeMaxPressure(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = PumpConfigurationAndControl::Attributes::MaxPressure::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.shortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeMaxSpeedWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeMaxSpeedWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeMaxSpeed(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = PumpConfigurationAndControl::Attributes::MaxSpeed::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeMaxFlowWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeMaxFlowWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeMaxFlow(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = PumpConfigurationAndControl::Attributes::MaxFlow::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeMinConstPressureWithValue:(int16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeMinConstPressureWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeMinConstPressure(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = PumpConfigurationAndControl::Attributes::MinConstPressure::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.shortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeMaxConstPressureWithValue:(int16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeMaxConstPressureWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeMaxConstPressure(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = PumpConfigurationAndControl::Attributes::MaxConstPressure::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.shortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeMinCompPressureWithValue:(int16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeMinCompPressureWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeMinCompPressure(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = PumpConfigurationAndControl::Attributes::MinCompPressure::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.shortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeMaxCompPressureWithValue:(int16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeMaxCompPressureWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeMaxCompPressure(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = PumpConfigurationAndControl::Attributes::MaxCompPressure::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.shortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeMinConstSpeedWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeMinConstSpeedWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeMinConstSpeed(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = PumpConfigurationAndControl::Attributes::MinConstSpeed::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeMaxConstSpeedWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeMaxConstSpeedWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeMaxConstSpeed(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = PumpConfigurationAndControl::Attributes::MaxConstSpeed::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeMinConstFlowWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeMinConstFlowWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeMinConstFlow(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = PumpConfigurationAndControl::Attributes::MinConstFlow::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeMaxConstFlowWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeMaxConstFlowWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeMaxConstFlow(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = PumpConfigurationAndControl::Attributes::MaxConstFlow::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeMinConstTempWithValue:(int16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeMinConstTempWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeMinConstTemp(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = PumpConfigurationAndControl::Attributes::MinConstTemp::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.shortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeMaxConstTempWithValue:(int16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeMaxConstTempWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeMaxConstTemp(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = PumpConfigurationAndControl::Attributes::MaxConstTemp::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.shortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributePumpStatusWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributePumpStatusWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributePumpStatus(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = PumpConfigurationAndControl::Attributes::PumpStatus::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeEffectiveOperationModeWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeEffectiveOperationModeWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeEffectiveOperationMode(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = PumpConfigurationAndControl::Attributes::EffectiveOperationMode::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = static_cast<std::remove_reference_t<decltype(cppValue)>>(value.unsignedCharValue);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeEffectiveControlModeWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeEffectiveControlModeWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeEffectiveControlMode(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = PumpConfigurationAndControl::Attributes::EffectiveControlMode::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = static_cast<std::remove_reference_t<decltype(cppValue)>>(value.unsignedCharValue);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeCapacityWithValue:(int16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeCapacityWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeCapacity(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = PumpConfigurationAndControl::Attributes::Capacity::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.shortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeSpeedWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeSpeedWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeSpeed(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = PumpConfigurationAndControl::Attributes::Speed::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeLifetimeEnergyConsumedWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeLifetimeEnergyConsumedWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeLifetimeEnergyConsumed(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = PumpConfigurationAndControl::Attributes::LifetimeEnergyConsumed::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedIntValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeAlarmMaskWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeAlarmMaskWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeAlarmMask(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = PumpConfigurationAndControl::Attributes::AlarmMask::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeFeatureMapWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeFeatureMapWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeFeatureMap(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = PumpConfigurationAndControl::Attributes::FeatureMap::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedIntValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeClusterRevision(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = PumpConfigurationAndControl::Attributes::ClusterRevision::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -2194,38 +4313,68 @@ using chip::Callback::Cancelable;
     return &_cppCluster;
 }
 
-- (void)writeAttributeMeasuredValueWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeMeasuredValueWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeMeasuredValue(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = RelativeHumidityMeasurement::Attributes::MeasuredValue::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeMinMeasuredValueWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeMinMeasuredValueWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeMinMeasuredValue(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = RelativeHumidityMeasurement::Attributes::MinMeasuredValue::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeMaxMeasuredValueWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeMaxMeasuredValueWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeMaxMeasuredValue(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = RelativeHumidityMeasurement::Attributes::MaxMeasuredValue::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeToleranceWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeToleranceWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeTolerance(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = RelativeHumidityMeasurement::Attributes::Tolerance::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeClusterRevision(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = RelativeHumidityMeasurement::Attributes::ClusterRevision::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -2242,45 +4391,81 @@ using chip::Callback::Cancelable;
     return &_cppCluster;
 }
 
-- (void)writeAttributeSceneCountWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeSceneCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeSceneCount(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = Scenes::Attributes::SceneCount::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedCharValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeCurrentSceneWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeCurrentSceneWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeCurrentScene(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = Scenes::Attributes::CurrentScene::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedCharValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeCurrentGroupWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeCurrentGroupWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeCurrentGroup(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = Scenes::Attributes::CurrentGroup::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeSceneValidWithValue:(bool)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeSceneValidWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeSceneValid(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = Scenes::Attributes::SceneValid::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.boolValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeNameSupportWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeNameSupportWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeNameSupport(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = Scenes::Attributes::NameSupport::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedCharValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeClusterRevision(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = Scenes::Attributes::ClusterRevision::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -2297,31 +4482,93 @@ using chip::Callback::Cancelable;
     return &_cppCluster;
 }
 
-- (void)writeAttributeCurrentHeapFreeWithValue:(uint64_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeThreadMetricsWithValue:(NSArray * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeCurrentHeapFree(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = SoftwareDiagnostics::Attributes::ThreadMetrics::TypeInfo;
+        TypeInfo::Type cppValue;
+        {
+            using ListType = std::remove_reference_t<decltype(cppValue)>;
+            using ListMemberType = ListMemberTypeGetter<ListType>::Type;
+            if (value.count != 0) {
+                auto * listHolder_0 = new ListHolder<ListMemberType>(value.count);
+                if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
+                    return CHIP_ERROR_INVALID_ARGUMENT;
+                }
+                listFreer.add(listHolder_0);
+                for (size_t i = 0; i < value.count; ++i) {
+                    if (![value[i] isKindOfClass:[CHIPSoftwareDiagnosticsClusterThreadMetrics class]]) {
+                        // Wrong kind of value.
+                        return CHIP_ERROR_INVALID_ARGUMENT;
+                    }
+                    auto element_0 = (CHIPSoftwareDiagnosticsClusterThreadMetrics *) value[i];
+                    listHolder_0->mList[i].id = element_0.Id.unsignedLongLongValue;
+                    listHolder_0->mList[i].name = [self asCharSpan:element_0.Name];
+                    listHolder_0->mList[i].stackFreeCurrent = element_0.StackFreeCurrent.unsignedIntValue;
+                    listHolder_0->mList[i].stackFreeMinimum = element_0.StackFreeMinimum.unsignedIntValue;
+                    listHolder_0->mList[i].stackSize = element_0.StackSize.unsignedIntValue;
+                }
+                cppValue = ListType(listHolder_0->mList, value.count);
+            } else {
+                cppValue = ListType();
+            }
+        }
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeCurrentHeapUsedWithValue:(uint64_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeCurrentHeapFreeWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeCurrentHeapUsed(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = SoftwareDiagnostics::Attributes::CurrentHeapFree::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedLongLongValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeCurrentHeapHighWatermarkWithValue:(uint64_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeCurrentHeapUsedWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeCurrentHeapHighWatermark(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = SoftwareDiagnostics::Attributes::CurrentHeapUsed::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedLongLongValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeCurrentHeapHighWatermarkWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeClusterRevision(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = SoftwareDiagnostics::Attributes::CurrentHeapHighWatermark::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedLongLongValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
+    });
+}
+
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
+{
+    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        ListFreer listFreer;
+        using TypeInfo = SoftwareDiagnostics::Attributes::ClusterRevision::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -2338,38 +4585,68 @@ using chip::Callback::Cancelable;
     return &_cppCluster;
 }
 
-- (void)writeAttributeNumberOfPositionsWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeNumberOfPositionsWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeNumberOfPositions(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = Switch::Attributes::NumberOfPositions::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedCharValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeCurrentPositionWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeCurrentPositionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeCurrentPosition(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = Switch::Attributes::CurrentPosition::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedCharValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeMultiPressMaxWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeMultiPressMaxWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeMultiPressMax(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = Switch::Attributes::MultiPressMax::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedCharValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeFeatureMapWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeFeatureMapWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeFeatureMap(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = Switch::Attributes::FeatureMap::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedIntValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeClusterRevision(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = Switch::Attributes::ClusterRevision::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -2386,24 +4663,80 @@ using chip::Callback::Cancelable;
     return &_cppCluster;
 }
 
-- (void)writeAttributeTvChannelLineupWithValue:(NSData *)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeTvChannelListWithValue:(NSArray * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeTvChannelLineup(success, failure, [self asByteSpan:value]);
+        ListFreer listFreer;
+        using TypeInfo = TvChannel::Attributes::TvChannelList::TypeInfo;
+        TypeInfo::Type cppValue;
+        {
+            using ListType = std::remove_reference_t<decltype(cppValue)>;
+            using ListMemberType = ListMemberTypeGetter<ListType>::Type;
+            if (value.count != 0) {
+                auto * listHolder_0 = new ListHolder<ListMemberType>(value.count);
+                if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
+                    return CHIP_ERROR_INVALID_ARGUMENT;
+                }
+                listFreer.add(listHolder_0);
+                for (size_t i = 0; i < value.count; ++i) {
+                    if (![value[i] isKindOfClass:[CHIPTvChannelClusterTvChannelInfo class]]) {
+                        // Wrong kind of value.
+                        return CHIP_ERROR_INVALID_ARGUMENT;
+                    }
+                    auto element_0 = (CHIPTvChannelClusterTvChannelInfo *) value[i];
+                    listHolder_0->mList[i].majorNumber = element_0.MajorNumber.unsignedShortValue;
+                    listHolder_0->mList[i].minorNumber = element_0.MinorNumber.unsignedShortValue;
+                    listHolder_0->mList[i].name = [self asCharSpan:element_0.Name];
+                    listHolder_0->mList[i].callSign = [self asCharSpan:element_0.CallSign];
+                    listHolder_0->mList[i].affiliateCallSign = [self asCharSpan:element_0.AffiliateCallSign];
+                }
+                cppValue = ListType(listHolder_0->mList, value.count);
+            } else {
+                cppValue = ListType();
+            }
+        }
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeCurrentTvChannelWithValue:(NSData *)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeTvChannelLineupWithValue:(NSData * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeCurrentTvChannel(success, failure, [self asByteSpan:value]);
+        ListFreer listFreer;
+        using TypeInfo = TvChannel::Attributes::TvChannelLineup::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = [self asByteSpan:value];
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeCurrentTvChannelWithValue:(NSData * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeClusterRevision(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = TvChannel::Attributes::CurrentTvChannel::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = [self asByteSpan:value];
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
+    });
+}
+
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
+{
+    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        ListFreer listFreer;
+        using TypeInfo = TvChannel::Attributes::ClusterRevision::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -2420,10 +4753,51 @@ using chip::Callback::Cancelable;
     return &_cppCluster;
 }
 
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeTargetNavigatorListWithValue:(NSArray * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeClusterRevision(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = TargetNavigator::Attributes::TargetNavigatorList::TypeInfo;
+        TypeInfo::Type cppValue;
+        {
+            using ListType = std::remove_reference_t<decltype(cppValue)>;
+            using ListMemberType = ListMemberTypeGetter<ListType>::Type;
+            if (value.count != 0) {
+                auto * listHolder_0 = new ListHolder<ListMemberType>(value.count);
+                if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
+                    return CHIP_ERROR_INVALID_ARGUMENT;
+                }
+                listFreer.add(listHolder_0);
+                for (size_t i = 0; i < value.count; ++i) {
+                    if (![value[i] isKindOfClass:[CHIPTargetNavigatorClusterNavigateTargetTargetInfo class]]) {
+                        // Wrong kind of value.
+                        return CHIP_ERROR_INVALID_ARGUMENT;
+                    }
+                    auto element_0 = (CHIPTargetNavigatorClusterNavigateTargetTargetInfo *) value[i];
+                    listHolder_0->mList[i].identifier = element_0.Identifier.unsignedCharValue;
+                    listHolder_0->mList[i].name = [self asCharSpan:element_0.Name];
+                }
+                cppValue = ListType(listHolder_0->mList, value.count);
+            } else {
+                cppValue = ListType();
+            }
+        }
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
+    });
+}
+
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
+{
+    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        ListFreer listFreer;
+        using TypeInfo = TargetNavigator::Attributes::ClusterRevision::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -2440,38 +4814,68 @@ using chip::Callback::Cancelable;
     return &_cppCluster;
 }
 
-- (void)writeAttributeMeasuredValueWithValue:(int16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeMeasuredValueWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeMeasuredValue(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = TemperatureMeasurement::Attributes::MeasuredValue::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.shortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeMinMeasuredValueWithValue:(int16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeMinMeasuredValueWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeMinMeasuredValue(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = TemperatureMeasurement::Attributes::MinMeasuredValue::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.shortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeMaxMeasuredValueWithValue:(int16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeMaxMeasuredValueWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeMaxMeasuredValue(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = TemperatureMeasurement::Attributes::MaxMeasuredValue::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.shortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeToleranceWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeToleranceWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeTolerance(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = TemperatureMeasurement::Attributes::Tolerance::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeClusterRevision(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = TemperatureMeasurement::Attributes::ClusterRevision::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -2488,10 +4892,317 @@ using chip::Callback::Cancelable;
     return &_cppCluster;
 }
 
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeListInt8uWithValue:(NSArray * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeClusterRevision(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = TestCluster::Attributes::ListInt8u::TypeInfo;
+        TypeInfo::Type cppValue;
+        {
+            using ListType = std::remove_reference_t<decltype(cppValue)>;
+            using ListMemberType = ListMemberTypeGetter<ListType>::Type;
+            if (value.count != 0) {
+                auto * listHolder_0 = new ListHolder<ListMemberType>(value.count);
+                if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
+                    return CHIP_ERROR_INVALID_ARGUMENT;
+                }
+                listFreer.add(listHolder_0);
+                for (size_t i = 0; i < value.count; ++i) {
+                    if (![value[i] isKindOfClass:[NSNumber class]]) {
+                        // Wrong kind of value.
+                        return CHIP_ERROR_INVALID_ARGUMENT;
+                    }
+                    auto element_0 = (NSNumber *) value[i];
+                    listHolder_0->mList[i] = element_0.unsignedCharValue;
+                }
+                cppValue = ListType(listHolder_0->mList, value.count);
+            } else {
+                cppValue = ListType();
+            }
+        }
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
+    });
+}
+
+- (void)writeAttributeListOctetStringWithValue:(NSArray * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
+{
+    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        ListFreer listFreer;
+        using TypeInfo = TestCluster::Attributes::ListOctetString::TypeInfo;
+        TypeInfo::Type cppValue;
+        {
+            using ListType = std::remove_reference_t<decltype(cppValue)>;
+            using ListMemberType = ListMemberTypeGetter<ListType>::Type;
+            if (value.count != 0) {
+                auto * listHolder_0 = new ListHolder<ListMemberType>(value.count);
+                if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
+                    return CHIP_ERROR_INVALID_ARGUMENT;
+                }
+                listFreer.add(listHolder_0);
+                for (size_t i = 0; i < value.count; ++i) {
+                    if (![value[i] isKindOfClass:[NSData class]]) {
+                        // Wrong kind of value.
+                        return CHIP_ERROR_INVALID_ARGUMENT;
+                    }
+                    auto element_0 = (NSData *) value[i];
+                    listHolder_0->mList[i] = [self asByteSpan:element_0];
+                }
+                cppValue = ListType(listHolder_0->mList, value.count);
+            } else {
+                cppValue = ListType();
+            }
+        }
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
+    });
+}
+
+- (void)writeAttributeListStructOctetStringWithValue:(NSArray * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
+{
+    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        ListFreer listFreer;
+        using TypeInfo = TestCluster::Attributes::ListStructOctetString::TypeInfo;
+        TypeInfo::Type cppValue;
+        {
+            using ListType = std::remove_reference_t<decltype(cppValue)>;
+            using ListMemberType = ListMemberTypeGetter<ListType>::Type;
+            if (value.count != 0) {
+                auto * listHolder_0 = new ListHolder<ListMemberType>(value.count);
+                if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
+                    return CHIP_ERROR_INVALID_ARGUMENT;
+                }
+                listFreer.add(listHolder_0);
+                for (size_t i = 0; i < value.count; ++i) {
+                    if (![value[i] isKindOfClass:[CHIPTestClusterClusterTestListStructOctet class]]) {
+                        // Wrong kind of value.
+                        return CHIP_ERROR_INVALID_ARGUMENT;
+                    }
+                    auto element_0 = (CHIPTestClusterClusterTestListStructOctet *) value[i];
+                    listHolder_0->mList[i].fabricIndex = element_0.FabricIndex.unsignedLongLongValue;
+                    listHolder_0->mList[i].operationalCert = [self asByteSpan:element_0.OperationalCert];
+                }
+                cppValue = ListType(listHolder_0->mList, value.count);
+            } else {
+                cppValue = ListType();
+            }
+        }
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
+    });
+}
+
+- (void)writeAttributeListNullablesAndOptionalsStructWithValue:(NSArray * _Nonnull)value
+                                               responseHandler:(ResponseHandler)responseHandler
+{
+    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        ListFreer listFreer;
+        using TypeInfo = TestCluster::Attributes::ListNullablesAndOptionalsStruct::TypeInfo;
+        TypeInfo::Type cppValue;
+        {
+            using ListType = std::remove_reference_t<decltype(cppValue)>;
+            using ListMemberType = ListMemberTypeGetter<ListType>::Type;
+            if (value.count != 0) {
+                auto * listHolder_0 = new ListHolder<ListMemberType>(value.count);
+                if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
+                    return CHIP_ERROR_INVALID_ARGUMENT;
+                }
+                listFreer.add(listHolder_0);
+                for (size_t i = 0; i < value.count; ++i) {
+                    if (![value[i] isKindOfClass:[CHIPTestClusterClusterNullablesAndOptionalsStruct class]]) {
+                        // Wrong kind of value.
+                        return CHIP_ERROR_INVALID_ARGUMENT;
+                    }
+                    auto element_0 = (CHIPTestClusterClusterNullablesAndOptionalsStruct *) value[i];
+                    if (element_0.NullableInt == nil) {
+                        listHolder_0->mList[i].nullableInt.SetNull();
+                    } else {
+                        auto & nonNullValue_2 = listHolder_0->mList[i].nullableInt.SetNonNull();
+                        nonNullValue_2 = element_0.NullableInt.unsignedShortValue;
+                    }
+                    if (element_0.OptionalInt != nil) {
+                        auto & definedValue_2 = listHolder_0->mList[i].optionalInt.Emplace();
+                        definedValue_2 = element_0.OptionalInt.unsignedShortValue;
+                    }
+                    if (element_0.NullableOptionalInt != nil) {
+                        auto & definedValue_2 = listHolder_0->mList[i].nullableOptionalInt.Emplace();
+                        if (element_0.NullableOptionalInt == nil) {
+                            definedValue_2.SetNull();
+                        } else {
+                            auto & nonNullValue_3 = definedValue_2.SetNonNull();
+                            nonNullValue_3 = element_0.NullableOptionalInt.unsignedShortValue;
+                        }
+                    }
+                    if (element_0.NullableString == nil) {
+                        listHolder_0->mList[i].nullableString.SetNull();
+                    } else {
+                        auto & nonNullValue_2 = listHolder_0->mList[i].nullableString.SetNonNull();
+                        nonNullValue_2 = [self asCharSpan:element_0.NullableString];
+                    }
+                    if (element_0.OptionalString != nil) {
+                        auto & definedValue_2 = listHolder_0->mList[i].optionalString.Emplace();
+                        definedValue_2 = [self asCharSpan:element_0.OptionalString];
+                    }
+                    if (element_0.NullableOptionalString != nil) {
+                        auto & definedValue_2 = listHolder_0->mList[i].nullableOptionalString.Emplace();
+                        if (element_0.NullableOptionalString == nil) {
+                            definedValue_2.SetNull();
+                        } else {
+                            auto & nonNullValue_3 = definedValue_2.SetNonNull();
+                            nonNullValue_3 = [self asCharSpan:element_0.NullableOptionalString];
+                        }
+                    }
+                    if (element_0.NullableStruct == nil) {
+                        listHolder_0->mList[i].nullableStruct.SetNull();
+                    } else {
+                        auto & nonNullValue_2 = listHolder_0->mList[i].nullableStruct.SetNonNull();
+                        nonNullValue_2.a = element_0.NullableStruct.A.unsignedCharValue;
+                        nonNullValue_2.b = element_0.NullableStruct.B.boolValue;
+                        nonNullValue_2.c = static_cast<std::remove_reference_t<decltype(nonNullValue_2.c)>>(
+                            element_0.NullableStruct.C.unsignedCharValue);
+                        nonNullValue_2.d = [self asByteSpan:element_0.NullableStruct.D];
+                        nonNullValue_2.e = [self asCharSpan:element_0.NullableStruct.E];
+                        nonNullValue_2.f = static_cast<std::remove_reference_t<decltype(nonNullValue_2.f)>>(
+                            element_0.NullableStruct.F.unsignedCharValue);
+                    }
+                    if (element_0.OptionalStruct != nil) {
+                        auto & definedValue_2 = listHolder_0->mList[i].optionalStruct.Emplace();
+                        definedValue_2.a = element_0.OptionalStruct.A.unsignedCharValue;
+                        definedValue_2.b = element_0.OptionalStruct.B.boolValue;
+                        definedValue_2.c = static_cast<std::remove_reference_t<decltype(definedValue_2.c)>>(
+                            element_0.OptionalStruct.C.unsignedCharValue);
+                        definedValue_2.d = [self asByteSpan:element_0.OptionalStruct.D];
+                        definedValue_2.e = [self asCharSpan:element_0.OptionalStruct.E];
+                        definedValue_2.f = static_cast<std::remove_reference_t<decltype(definedValue_2.f)>>(
+                            element_0.OptionalStruct.F.unsignedCharValue);
+                    }
+                    if (element_0.NullableOptionalStruct != nil) {
+                        auto & definedValue_2 = listHolder_0->mList[i].nullableOptionalStruct.Emplace();
+                        if (element_0.NullableOptionalStruct == nil) {
+                            definedValue_2.SetNull();
+                        } else {
+                            auto & nonNullValue_3 = definedValue_2.SetNonNull();
+                            nonNullValue_3.a = element_0.NullableOptionalStruct.A.unsignedCharValue;
+                            nonNullValue_3.b = element_0.NullableOptionalStruct.B.boolValue;
+                            nonNullValue_3.c = static_cast<std::remove_reference_t<decltype(nonNullValue_3.c)>>(
+                                element_0.NullableOptionalStruct.C.unsignedCharValue);
+                            nonNullValue_3.d = [self asByteSpan:element_0.NullableOptionalStruct.D];
+                            nonNullValue_3.e = [self asCharSpan:element_0.NullableOptionalStruct.E];
+                            nonNullValue_3.f = static_cast<std::remove_reference_t<decltype(nonNullValue_3.f)>>(
+                                element_0.NullableOptionalStruct.F.unsignedCharValue);
+                        }
+                    }
+                    if (element_0.NullableList == nil) {
+                        listHolder_0->mList[i].nullableList.SetNull();
+                    } else {
+                        auto & nonNullValue_2 = listHolder_0->mList[i].nullableList.SetNonNull();
+                        {
+                            using ListType = std::remove_reference_t<decltype(nonNullValue_2)>;
+                            using ListMemberType = ListMemberTypeGetter<ListType>::Type;
+                            if (element_0.NullableList.count != 0) {
+                                auto * listHolder_3 = new ListHolder<ListMemberType>(element_0.NullableList.count);
+                                if (listHolder_3 == nullptr || listHolder_3->mList == nullptr) {
+                                    return CHIP_ERROR_INVALID_ARGUMENT;
+                                }
+                                listFreer.add(listHolder_3);
+                                for (size_t i = 0; i < element_0.NullableList.count; ++i) {
+                                    if (![element_0.NullableList[i] isKindOfClass:[NSNumber class]]) {
+                                        // Wrong kind of value.
+                                        return CHIP_ERROR_INVALID_ARGUMENT;
+                                    }
+                                    auto element_3 = (NSNumber *) element_0.NullableList[i];
+                                    listHolder_3->mList[i] = static_cast<std::remove_reference_t<decltype(listHolder_3->mList[i])>>(
+                                        element_3.unsignedCharValue);
+                                }
+                                nonNullValue_2 = ListType(listHolder_3->mList, element_0.NullableList.count);
+                            } else {
+                                nonNullValue_2 = ListType();
+                            }
+                        }
+                    }
+                    if (element_0.OptionalList != nil) {
+                        auto & definedValue_2 = listHolder_0->mList[i].optionalList.Emplace();
+                        {
+                            using ListType = std::remove_reference_t<decltype(definedValue_2)>;
+                            using ListMemberType = ListMemberTypeGetter<ListType>::Type;
+                            if (element_0.OptionalList.count != 0) {
+                                auto * listHolder_3 = new ListHolder<ListMemberType>(element_0.OptionalList.count);
+                                if (listHolder_3 == nullptr || listHolder_3->mList == nullptr) {
+                                    return CHIP_ERROR_INVALID_ARGUMENT;
+                                }
+                                listFreer.add(listHolder_3);
+                                for (size_t i = 0; i < element_0.OptionalList.count; ++i) {
+                                    if (![element_0.OptionalList[i] isKindOfClass:[NSNumber class]]) {
+                                        // Wrong kind of value.
+                                        return CHIP_ERROR_INVALID_ARGUMENT;
+                                    }
+                                    auto element_3 = (NSNumber *) element_0.OptionalList[i];
+                                    listHolder_3->mList[i] = static_cast<std::remove_reference_t<decltype(listHolder_3->mList[i])>>(
+                                        element_3.unsignedCharValue);
+                                }
+                                definedValue_2 = ListType(listHolder_3->mList, element_0.OptionalList.count);
+                            } else {
+                                definedValue_2 = ListType();
+                            }
+                        }
+                    }
+                    if (element_0.NullableOptionalList != nil) {
+                        auto & definedValue_2 = listHolder_0->mList[i].nullableOptionalList.Emplace();
+                        if (element_0.NullableOptionalList == nil) {
+                            definedValue_2.SetNull();
+                        } else {
+                            auto & nonNullValue_3 = definedValue_2.SetNonNull();
+                            {
+                                using ListType = std::remove_reference_t<decltype(nonNullValue_3)>;
+                                using ListMemberType = ListMemberTypeGetter<ListType>::Type;
+                                if (element_0.NullableOptionalList.count != 0) {
+                                    auto * listHolder_4 = new ListHolder<ListMemberType>(element_0.NullableOptionalList.count);
+                                    if (listHolder_4 == nullptr || listHolder_4->mList == nullptr) {
+                                        return CHIP_ERROR_INVALID_ARGUMENT;
+                                    }
+                                    listFreer.add(listHolder_4);
+                                    for (size_t i = 0; i < element_0.NullableOptionalList.count; ++i) {
+                                        if (![element_0.NullableOptionalList[i] isKindOfClass:[NSNumber class]]) {
+                                            // Wrong kind of value.
+                                            return CHIP_ERROR_INVALID_ARGUMENT;
+                                        }
+                                        auto element_4 = (NSNumber *) element_0.NullableOptionalList[i];
+                                        listHolder_4->mList[i]
+                                            = static_cast<std::remove_reference_t<decltype(listHolder_4->mList[i])>>(
+                                                element_4.unsignedCharValue);
+                                    }
+                                    nonNullValue_3 = ListType(listHolder_4->mList, element_0.NullableOptionalList.count);
+                                } else {
+                                    nonNullValue_3 = ListType();
+                                }
+                            }
+                        }
+                    }
+                }
+                cppValue = ListType(listHolder_0->mList, value.count);
+            } else {
+                cppValue = ListType();
+            }
+        }
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
+    });
+}
+
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
+{
+    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        ListFreer listFreer;
+        using TypeInfo = TestCluster::Attributes::ClusterRevision::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -2508,73 +5219,133 @@ using chip::Callback::Cancelable;
     return &_cppCluster;
 }
 
-- (void)writeAttributeLocalTemperatureWithValue:(int16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeLocalTemperatureWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeLocalTemperature(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = Thermostat::Attributes::LocalTemperature::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.shortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeAbsMinHeatSetpointLimitWithValue:(int16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeAbsMinHeatSetpointLimitWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeAbsMinHeatSetpointLimit(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = Thermostat::Attributes::AbsMinHeatSetpointLimit::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.shortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeAbsMaxHeatSetpointLimitWithValue:(int16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeAbsMaxHeatSetpointLimitWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeAbsMaxHeatSetpointLimit(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = Thermostat::Attributes::AbsMaxHeatSetpointLimit::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.shortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeAbsMinCoolSetpointLimitWithValue:(int16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeAbsMinCoolSetpointLimitWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeAbsMinCoolSetpointLimit(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = Thermostat::Attributes::AbsMinCoolSetpointLimit::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.shortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeAbsMaxCoolSetpointLimitWithValue:(int16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeAbsMaxCoolSetpointLimitWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeAbsMaxCoolSetpointLimit(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = Thermostat::Attributes::AbsMaxCoolSetpointLimit::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.shortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeStartOfWeekWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeStartOfWeekWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeStartOfWeek(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = Thermostat::Attributes::StartOfWeek::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = static_cast<std::remove_reference_t<decltype(cppValue)>>(value.unsignedCharValue);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeNumberOfWeeklyTransitionsWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeNumberOfWeeklyTransitionsWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeNumberOfWeeklyTransitions(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = Thermostat::Attributes::NumberOfWeeklyTransitions::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedCharValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeNumberOfDailyTransitionsWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeNumberOfDailyTransitionsWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeNumberOfDailyTransitions(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = Thermostat::Attributes::NumberOfDailyTransitions::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedCharValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeFeatureMapWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeFeatureMapWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeFeatureMap(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = Thermostat::Attributes::FeatureMap::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedIntValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeClusterRevision(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = Thermostat::Attributes::ClusterRevision::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -2591,10 +5362,16 @@ using chip::Callback::Cancelable;
     return &_cppCluster;
 }
 
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeClusterRevision(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ThermostatUserInterfaceConfiguration::Attributes::ClusterRevision::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -2611,416 +5388,979 @@ using chip::Callback::Cancelable;
     return &_cppCluster;
 }
 
-- (void)writeAttributeChannelWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeChannelWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeChannel(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ThreadNetworkDiagnostics::Attributes::Channel::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedCharValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeRoutingRoleWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeRoutingRoleWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeRoutingRole(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ThreadNetworkDiagnostics::Attributes::RoutingRole::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = static_cast<std::remove_reference_t<decltype(cppValue)>>(value.unsignedCharValue);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeNetworkNameWithValue:(NSData *)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeNetworkNameWithValue:(NSData * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeNetworkName(success, failure, [self asByteSpan:value]);
+        ListFreer listFreer;
+        using TypeInfo = ThreadNetworkDiagnostics::Attributes::NetworkName::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = [self asByteSpan:value];
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributePanIdWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributePanIdWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributePanId(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ThreadNetworkDiagnostics::Attributes::PanId::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeExtendedPanIdWithValue:(uint64_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeExtendedPanIdWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeExtendedPanId(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ThreadNetworkDiagnostics::Attributes::ExtendedPanId::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedLongLongValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeMeshLocalPrefixWithValue:(NSData *)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeMeshLocalPrefixWithValue:(NSData * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeMeshLocalPrefix(success, failure, [self asByteSpan:value]);
+        ListFreer listFreer;
+        using TypeInfo = ThreadNetworkDiagnostics::Attributes::MeshLocalPrefix::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = [self asByteSpan:value];
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeOverrunCountWithValue:(uint64_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeOverrunCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeOverrunCount(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ThreadNetworkDiagnostics::Attributes::OverrunCount::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedLongLongValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributePartitionIdWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeNeighborTableListWithValue:(NSArray * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributePartitionId(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ThreadNetworkDiagnostics::Attributes::NeighborTableList::TypeInfo;
+        TypeInfo::Type cppValue;
+        {
+            using ListType = std::remove_reference_t<decltype(cppValue)>;
+            using ListMemberType = ListMemberTypeGetter<ListType>::Type;
+            if (value.count != 0) {
+                auto * listHolder_0 = new ListHolder<ListMemberType>(value.count);
+                if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
+                    return CHIP_ERROR_INVALID_ARGUMENT;
+                }
+                listFreer.add(listHolder_0);
+                for (size_t i = 0; i < value.count; ++i) {
+                    if (![value[i] isKindOfClass:[CHIPThreadNetworkDiagnosticsClusterNeighborTable class]]) {
+                        // Wrong kind of value.
+                        return CHIP_ERROR_INVALID_ARGUMENT;
+                    }
+                    auto element_0 = (CHIPThreadNetworkDiagnosticsClusterNeighborTable *) value[i];
+                    listHolder_0->mList[i].extAddress = element_0.ExtAddress.unsignedLongLongValue;
+                    listHolder_0->mList[i].age = element_0.Age.unsignedIntValue;
+                    listHolder_0->mList[i].rloc16 = element_0.Rloc16.unsignedShortValue;
+                    listHolder_0->mList[i].linkFrameCounter = element_0.LinkFrameCounter.unsignedIntValue;
+                    listHolder_0->mList[i].mleFrameCounter = element_0.MleFrameCounter.unsignedIntValue;
+                    listHolder_0->mList[i].lqi = element_0.Lqi.unsignedCharValue;
+                    listHolder_0->mList[i].averageRssi = element_0.AverageRssi.charValue;
+                    listHolder_0->mList[i].lastRssi = element_0.LastRssi.charValue;
+                    listHolder_0->mList[i].frameErrorRate = element_0.FrameErrorRate.unsignedCharValue;
+                    listHolder_0->mList[i].messageErrorRate = element_0.MessageErrorRate.unsignedCharValue;
+                    listHolder_0->mList[i].rxOnWhenIdle = element_0.RxOnWhenIdle.boolValue;
+                    listHolder_0->mList[i].fullThreadDevice = element_0.FullThreadDevice.boolValue;
+                    listHolder_0->mList[i].fullNetworkData = element_0.FullNetworkData.boolValue;
+                    listHolder_0->mList[i].isChild = element_0.IsChild.boolValue;
+                }
+                cppValue = ListType(listHolder_0->mList, value.count);
+            } else {
+                cppValue = ListType();
+            }
+        }
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeWeightingWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeRouteTableListWithValue:(NSArray * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeWeighting(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ThreadNetworkDiagnostics::Attributes::RouteTableList::TypeInfo;
+        TypeInfo::Type cppValue;
+        {
+            using ListType = std::remove_reference_t<decltype(cppValue)>;
+            using ListMemberType = ListMemberTypeGetter<ListType>::Type;
+            if (value.count != 0) {
+                auto * listHolder_0 = new ListHolder<ListMemberType>(value.count);
+                if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
+                    return CHIP_ERROR_INVALID_ARGUMENT;
+                }
+                listFreer.add(listHolder_0);
+                for (size_t i = 0; i < value.count; ++i) {
+                    if (![value[i] isKindOfClass:[CHIPThreadNetworkDiagnosticsClusterRouteTable class]]) {
+                        // Wrong kind of value.
+                        return CHIP_ERROR_INVALID_ARGUMENT;
+                    }
+                    auto element_0 = (CHIPThreadNetworkDiagnosticsClusterRouteTable *) value[i];
+                    listHolder_0->mList[i].extAddress = element_0.ExtAddress.unsignedLongLongValue;
+                    listHolder_0->mList[i].rloc16 = element_0.Rloc16.unsignedShortValue;
+                    listHolder_0->mList[i].routerId = element_0.RouterId.unsignedCharValue;
+                    listHolder_0->mList[i].nextHop = element_0.NextHop.unsignedCharValue;
+                    listHolder_0->mList[i].pathCost = element_0.PathCost.unsignedCharValue;
+                    listHolder_0->mList[i].LQIIn = element_0.LQIIn.unsignedCharValue;
+                    listHolder_0->mList[i].LQIOut = element_0.LQIOut.unsignedCharValue;
+                    listHolder_0->mList[i].age = element_0.Age.unsignedCharValue;
+                    listHolder_0->mList[i].allocated = element_0.Allocated.boolValue;
+                    listHolder_0->mList[i].linkEstablished = element_0.LinkEstablished.boolValue;
+                }
+                cppValue = ListType(listHolder_0->mList, value.count);
+            } else {
+                cppValue = ListType();
+            }
+        }
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeDataVersionWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributePartitionIdWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeDataVersion(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ThreadNetworkDiagnostics::Attributes::PartitionId::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedIntValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeStableDataVersionWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeWeightingWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeStableDataVersion(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ThreadNetworkDiagnostics::Attributes::Weighting::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedCharValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeLeaderRouterIdWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeDataVersionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeLeaderRouterId(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ThreadNetworkDiagnostics::Attributes::DataVersion::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedCharValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeDetachedRoleCountWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeStableDataVersionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeDetachedRoleCount(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ThreadNetworkDiagnostics::Attributes::StableDataVersion::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedCharValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeChildRoleCountWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeLeaderRouterIdWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeChildRoleCount(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ThreadNetworkDiagnostics::Attributes::LeaderRouterId::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedCharValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeRouterRoleCountWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeDetachedRoleCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeRouterRoleCount(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ThreadNetworkDiagnostics::Attributes::DetachedRoleCount::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeLeaderRoleCountWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeChildRoleCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeLeaderRoleCount(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ThreadNetworkDiagnostics::Attributes::ChildRoleCount::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeAttachAttemptCountWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeRouterRoleCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeAttachAttemptCount(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ThreadNetworkDiagnostics::Attributes::RouterRoleCount::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributePartitionIdChangeCountWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeLeaderRoleCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributePartitionIdChangeCount(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ThreadNetworkDiagnostics::Attributes::LeaderRoleCount::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeBetterPartitionAttachAttemptCountWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeAttachAttemptCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeBetterPartitionAttachAttemptCount(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ThreadNetworkDiagnostics::Attributes::AttachAttemptCount::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeParentChangeCountWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributePartitionIdChangeCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeParentChangeCount(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ThreadNetworkDiagnostics::Attributes::PartitionIdChangeCount::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeTxTotalCountWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeBetterPartitionAttachAttemptCountWithValue:(NSNumber * _Nonnull)value
+                                                 responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeTxTotalCount(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ThreadNetworkDiagnostics::Attributes::BetterPartitionAttachAttemptCount::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeTxUnicastCountWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeParentChangeCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeTxUnicastCount(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ThreadNetworkDiagnostics::Attributes::ParentChangeCount::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeTxBroadcastCountWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeTxTotalCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeTxBroadcastCount(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ThreadNetworkDiagnostics::Attributes::TxTotalCount::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedIntValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeTxAckRequestedCountWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeTxUnicastCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeTxAckRequestedCount(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ThreadNetworkDiagnostics::Attributes::TxUnicastCount::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedIntValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeTxAckedCountWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeTxBroadcastCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeTxAckedCount(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ThreadNetworkDiagnostics::Attributes::TxBroadcastCount::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedIntValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeTxNoAckRequestedCountWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeTxAckRequestedCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeTxNoAckRequestedCount(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ThreadNetworkDiagnostics::Attributes::TxAckRequestedCount::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedIntValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeTxDataCountWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeTxAckedCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeTxDataCount(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ThreadNetworkDiagnostics::Attributes::TxAckedCount::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedIntValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeTxDataPollCountWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeTxNoAckRequestedCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeTxDataPollCount(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ThreadNetworkDiagnostics::Attributes::TxNoAckRequestedCount::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedIntValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeTxBeaconCountWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeTxDataCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeTxBeaconCount(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ThreadNetworkDiagnostics::Attributes::TxDataCount::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedIntValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeTxBeaconRequestCountWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeTxDataPollCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeTxBeaconRequestCount(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ThreadNetworkDiagnostics::Attributes::TxDataPollCount::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedIntValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeTxOtherCountWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeTxBeaconCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeTxOtherCount(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ThreadNetworkDiagnostics::Attributes::TxBeaconCount::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedIntValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeTxRetryCountWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeTxBeaconRequestCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeTxRetryCount(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ThreadNetworkDiagnostics::Attributes::TxBeaconRequestCount::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedIntValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeTxDirectMaxRetryExpiryCountWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeTxOtherCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeTxDirectMaxRetryExpiryCount(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ThreadNetworkDiagnostics::Attributes::TxOtherCount::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedIntValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeTxIndirectMaxRetryExpiryCountWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeTxRetryCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeTxIndirectMaxRetryExpiryCount(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ThreadNetworkDiagnostics::Attributes::TxRetryCount::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedIntValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeTxErrCcaCountWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeTxDirectMaxRetryExpiryCountWithValue:(NSNumber * _Nonnull)value
+                                           responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeTxErrCcaCount(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ThreadNetworkDiagnostics::Attributes::TxDirectMaxRetryExpiryCount::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedIntValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeTxErrAbortCountWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeTxIndirectMaxRetryExpiryCountWithValue:(NSNumber * _Nonnull)value
+                                             responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeTxErrAbortCount(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ThreadNetworkDiagnostics::Attributes::TxIndirectMaxRetryExpiryCount::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedIntValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeTxErrBusyChannelCountWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeTxErrCcaCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeTxErrBusyChannelCount(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ThreadNetworkDiagnostics::Attributes::TxErrCcaCount::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedIntValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeRxTotalCountWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeTxErrAbortCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeRxTotalCount(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ThreadNetworkDiagnostics::Attributes::TxErrAbortCount::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedIntValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeRxUnicastCountWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeTxErrBusyChannelCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeRxUnicastCount(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ThreadNetworkDiagnostics::Attributes::TxErrBusyChannelCount::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedIntValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeRxBroadcastCountWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeRxTotalCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeRxBroadcastCount(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ThreadNetworkDiagnostics::Attributes::RxTotalCount::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedIntValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeRxDataCountWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeRxUnicastCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeRxDataCount(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ThreadNetworkDiagnostics::Attributes::RxUnicastCount::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedIntValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeRxDataPollCountWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeRxBroadcastCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeRxDataPollCount(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ThreadNetworkDiagnostics::Attributes::RxBroadcastCount::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedIntValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeRxBeaconCountWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeRxDataCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeRxBeaconCount(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ThreadNetworkDiagnostics::Attributes::RxDataCount::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedIntValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeRxBeaconRequestCountWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeRxDataPollCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeRxBeaconRequestCount(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ThreadNetworkDiagnostics::Attributes::RxDataPollCount::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedIntValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeRxOtherCountWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeRxBeaconCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeRxOtherCount(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ThreadNetworkDiagnostics::Attributes::RxBeaconCount::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedIntValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeRxAddressFilteredCountWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeRxBeaconRequestCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeRxAddressFilteredCount(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ThreadNetworkDiagnostics::Attributes::RxBeaconRequestCount::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedIntValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeRxDestAddrFilteredCountWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeRxOtherCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeRxDestAddrFilteredCount(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ThreadNetworkDiagnostics::Attributes::RxOtherCount::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedIntValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeRxDuplicatedCountWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeRxAddressFilteredCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeRxDuplicatedCount(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ThreadNetworkDiagnostics::Attributes::RxAddressFilteredCount::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedIntValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeRxErrNoFrameCountWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeRxDestAddrFilteredCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeRxErrNoFrameCount(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ThreadNetworkDiagnostics::Attributes::RxDestAddrFilteredCount::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedIntValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeRxErrUnknownNeighborCountWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeRxDuplicatedCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeRxErrUnknownNeighborCount(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ThreadNetworkDiagnostics::Attributes::RxDuplicatedCount::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedIntValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeRxErrInvalidSrcAddrCountWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeRxErrNoFrameCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeRxErrInvalidSrcAddrCount(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ThreadNetworkDiagnostics::Attributes::RxErrNoFrameCount::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedIntValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeRxErrSecCountWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeRxErrUnknownNeighborCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeRxErrSecCount(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ThreadNetworkDiagnostics::Attributes::RxErrUnknownNeighborCount::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedIntValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeRxErrFcsCountWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeRxErrInvalidSrcAddrCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeRxErrFcsCount(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ThreadNetworkDiagnostics::Attributes::RxErrInvalidSrcAddrCount::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedIntValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeRxErrOtherCountWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeRxErrSecCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeRxErrOtherCount(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ThreadNetworkDiagnostics::Attributes::RxErrSecCount::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedIntValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeActiveTimestampWithValue:(uint64_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeRxErrFcsCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeActiveTimestamp(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ThreadNetworkDiagnostics::Attributes::RxErrFcsCount::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedIntValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributePendingTimestampWithValue:(uint64_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeRxErrOtherCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributePendingTimestamp(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ThreadNetworkDiagnostics::Attributes::RxErrOtherCount::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedIntValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeDelayWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeActiveTimestampWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeDelay(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ThreadNetworkDiagnostics::Attributes::ActiveTimestamp::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedLongLongValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeChannelMaskWithValue:(NSData *)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributePendingTimestampWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeChannelMask(success, failure, [self asByteSpan:value]);
+        ListFreer listFreer;
+        using TypeInfo = ThreadNetworkDiagnostics::Attributes::PendingTimestamp::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedLongLongValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeDelayWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeClusterRevision(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = ThreadNetworkDiagnostics::Attributes::Delay::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedIntValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
+    });
+}
+
+- (void)writeAttributeSecurityPolicyWithValue:(NSArray * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
+{
+    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        ListFreer listFreer;
+        using TypeInfo = ThreadNetworkDiagnostics::Attributes::SecurityPolicy::TypeInfo;
+        TypeInfo::Type cppValue;
+        {
+            using ListType = std::remove_reference_t<decltype(cppValue)>;
+            using ListMemberType = ListMemberTypeGetter<ListType>::Type;
+            if (value.count != 0) {
+                auto * listHolder_0 = new ListHolder<ListMemberType>(value.count);
+                if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
+                    return CHIP_ERROR_INVALID_ARGUMENT;
+                }
+                listFreer.add(listHolder_0);
+                for (size_t i = 0; i < value.count; ++i) {
+                    if (![value[i] isKindOfClass:[CHIPThreadNetworkDiagnosticsClusterSecurityPolicy class]]) {
+                        // Wrong kind of value.
+                        return CHIP_ERROR_INVALID_ARGUMENT;
+                    }
+                    auto element_0 = (CHIPThreadNetworkDiagnosticsClusterSecurityPolicy *) value[i];
+                    listHolder_0->mList[i].rotationTime = element_0.RotationTime.unsignedShortValue;
+                    listHolder_0->mList[i].flags = element_0.Flags.unsignedShortValue;
+                }
+                cppValue = ListType(listHolder_0->mList, value.count);
+            } else {
+                cppValue = ListType();
+            }
+        }
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
+    });
+}
+
+- (void)writeAttributeChannelMaskWithValue:(NSData * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
+{
+    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        ListFreer listFreer;
+        using TypeInfo = ThreadNetworkDiagnostics::Attributes::ChannelMask::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = [self asByteSpan:value];
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
+    });
+}
+
+- (void)writeAttributeOperationalDatasetComponentsWithValue:(NSArray * _Nonnull)value
+                                            responseHandler:(ResponseHandler)responseHandler
+{
+    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        ListFreer listFreer;
+        using TypeInfo = ThreadNetworkDiagnostics::Attributes::OperationalDatasetComponents::TypeInfo;
+        TypeInfo::Type cppValue;
+        {
+            using ListType = std::remove_reference_t<decltype(cppValue)>;
+            using ListMemberType = ListMemberTypeGetter<ListType>::Type;
+            if (value.count != 0) {
+                auto * listHolder_0 = new ListHolder<ListMemberType>(value.count);
+                if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
+                    return CHIP_ERROR_INVALID_ARGUMENT;
+                }
+                listFreer.add(listHolder_0);
+                for (size_t i = 0; i < value.count; ++i) {
+                    if (![value[i] isKindOfClass:[CHIPThreadNetworkDiagnosticsClusterOperationalDatasetComponents class]]) {
+                        // Wrong kind of value.
+                        return CHIP_ERROR_INVALID_ARGUMENT;
+                    }
+                    auto element_0 = (CHIPThreadNetworkDiagnosticsClusterOperationalDatasetComponents *) value[i];
+                    listHolder_0->mList[i].activeTimestampPresent = element_0.ActiveTimestampPresent.boolValue;
+                    listHolder_0->mList[i].pendingTimestampPresent = element_0.PendingTimestampPresent.boolValue;
+                    listHolder_0->mList[i].masterKeyPresent = element_0.MasterKeyPresent.boolValue;
+                    listHolder_0->mList[i].networkNamePresent = element_0.NetworkNamePresent.boolValue;
+                    listHolder_0->mList[i].extendedPanIdPresent = element_0.ExtendedPanIdPresent.boolValue;
+                    listHolder_0->mList[i].meshLocalPrefixPresent = element_0.MeshLocalPrefixPresent.boolValue;
+                    listHolder_0->mList[i].delayPresent = element_0.DelayPresent.boolValue;
+                    listHolder_0->mList[i].panIdPresent = element_0.PanIdPresent.boolValue;
+                    listHolder_0->mList[i].channelPresent = element_0.ChannelPresent.boolValue;
+                    listHolder_0->mList[i].pskcPresent = element_0.PskcPresent.boolValue;
+                    listHolder_0->mList[i].securityPolicyPresent = element_0.SecurityPolicyPresent.boolValue;
+                    listHolder_0->mList[i].channelMaskPresent = element_0.ChannelMaskPresent.boolValue;
+                }
+                cppValue = ListType(listHolder_0->mList, value.count);
+            } else {
+                cppValue = ListType();
+            }
+        }
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
+    });
+}
+
+- (void)writeAttributeActiveNetworkFaultsListWithValue:(NSArray * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
+{
+    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        ListFreer listFreer;
+        using TypeInfo = ThreadNetworkDiagnostics::Attributes::ActiveNetworkFaultsList::TypeInfo;
+        TypeInfo::Type cppValue;
+        {
+            using ListType = std::remove_reference_t<decltype(cppValue)>;
+            using ListMemberType = ListMemberTypeGetter<ListType>::Type;
+            if (value.count != 0) {
+                auto * listHolder_0 = new ListHolder<ListMemberType>(value.count);
+                if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
+                    return CHIP_ERROR_INVALID_ARGUMENT;
+                }
+                listFreer.add(listHolder_0);
+                for (size_t i = 0; i < value.count; ++i) {
+                    if (![value[i] isKindOfClass:[NSNumber class]]) {
+                        // Wrong kind of value.
+                        return CHIP_ERROR_INVALID_ARGUMENT;
+                    }
+                    auto element_0 = (NSNumber *) value[i];
+                    listHolder_0->mList[i]
+                        = static_cast<std::remove_reference_t<decltype(listHolder_0->mList[i])>>(element_0.unsignedCharValue);
+                }
+                cppValue = ListType(listHolder_0->mList, value.count);
+            } else {
+                cppValue = ListType();
+            }
+        }
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
+    });
+}
+
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
+{
+    new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        ListFreer listFreer;
+        using TypeInfo = ThreadNetworkDiagnostics::Attributes::ClusterRevision::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -3037,17 +6377,29 @@ using chip::Callback::Cancelable;
     return &_cppCluster;
 }
 
-- (void)writeAttributeWakeOnLanMacAddressWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeWakeOnLanMacAddressWithValue:(NSString * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeWakeOnLanMacAddress(success, failure, [self asCharSpan:value]);
+        ListFreer listFreer;
+        using TypeInfo = WakeOnLan::Attributes::WakeOnLanMacAddress::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = [self asCharSpan:value];
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeClusterRevision(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = WakeOnLan::Attributes::ClusterRevision::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -3064,101 +6416,185 @@ using chip::Callback::Cancelable;
     return &_cppCluster;
 }
 
-- (void)writeAttributeBssidWithValue:(NSData *)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeBssidWithValue:(NSData * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeBssid(success, failure, [self asByteSpan:value]);
+        ListFreer listFreer;
+        using TypeInfo = WiFiNetworkDiagnostics::Attributes::Bssid::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = [self asByteSpan:value];
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeSecurityTypeWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeSecurityTypeWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeSecurityType(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = WiFiNetworkDiagnostics::Attributes::SecurityType::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = static_cast<std::remove_reference_t<decltype(cppValue)>>(value.unsignedCharValue);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeWiFiVersionWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeWiFiVersionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeWiFiVersion(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = WiFiNetworkDiagnostics::Attributes::WiFiVersion::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = static_cast<std::remove_reference_t<decltype(cppValue)>>(value.unsignedCharValue);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeChannelNumberWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeChannelNumberWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeChannelNumber(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = WiFiNetworkDiagnostics::Attributes::ChannelNumber::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeRssiWithValue:(int8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeRssiWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeRssi(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = WiFiNetworkDiagnostics::Attributes::Rssi::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.charValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeBeaconLostCountWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeBeaconLostCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeBeaconLostCount(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = WiFiNetworkDiagnostics::Attributes::BeaconLostCount::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedIntValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeBeaconRxCountWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeBeaconRxCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeBeaconRxCount(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = WiFiNetworkDiagnostics::Attributes::BeaconRxCount::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedIntValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributePacketMulticastRxCountWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributePacketMulticastRxCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributePacketMulticastRxCount(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = WiFiNetworkDiagnostics::Attributes::PacketMulticastRxCount::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedIntValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributePacketMulticastTxCountWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributePacketMulticastTxCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributePacketMulticastTxCount(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = WiFiNetworkDiagnostics::Attributes::PacketMulticastTxCount::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedIntValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributePacketUnicastRxCountWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributePacketUnicastRxCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributePacketUnicastRxCount(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = WiFiNetworkDiagnostics::Attributes::PacketUnicastRxCount::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedIntValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributePacketUnicastTxCountWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributePacketUnicastTxCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributePacketUnicastTxCount(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = WiFiNetworkDiagnostics::Attributes::PacketUnicastTxCount::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedIntValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeCurrentMaxRateWithValue:(uint64_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeCurrentMaxRateWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeCurrentMaxRate(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = WiFiNetworkDiagnostics::Attributes::CurrentMaxRate::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedLongLongValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeOverrunCountWithValue:(uint64_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeOverrunCountWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeOverrunCount(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = WiFiNetworkDiagnostics::Attributes::OverrunCount::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedLongLongValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeClusterRevision(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = WiFiNetworkDiagnostics::Attributes::ClusterRevision::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
@@ -3175,136 +6611,256 @@ using chip::Callback::Cancelable;
     return &_cppCluster;
 }
 
-- (void)writeAttributeTypeWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeTypeWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeType(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = WindowCovering::Attributes::Type::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = static_cast<std::remove_reference_t<decltype(cppValue)>>(value.unsignedCharValue);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeCurrentPositionLiftWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeCurrentPositionLiftWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeCurrentPositionLift(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = WindowCovering::Attributes::CurrentPositionLift::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeCurrentPositionTiltWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeCurrentPositionTiltWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeCurrentPositionTilt(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = WindowCovering::Attributes::CurrentPositionTilt::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeConfigStatusWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeConfigStatusWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeConfigStatus(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = WindowCovering::Attributes::ConfigStatus::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedCharValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeCurrentPositionLiftPercentageWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeCurrentPositionLiftPercentageWithValue:(NSNumber * _Nonnull)value
+                                             responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeCurrentPositionLiftPercentage(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = WindowCovering::Attributes::CurrentPositionLiftPercentage::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedCharValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeCurrentPositionTiltPercentageWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeCurrentPositionTiltPercentageWithValue:(NSNumber * _Nonnull)value
+                                             responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeCurrentPositionTiltPercentage(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = WindowCovering::Attributes::CurrentPositionTiltPercentage::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedCharValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeOperationalStatusWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeOperationalStatusWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeOperationalStatus(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = WindowCovering::Attributes::OperationalStatus::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedCharValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeTargetPositionLiftPercent100thsWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeTargetPositionLiftPercent100thsWithValue:(NSNumber * _Nonnull)value
+                                               responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeTargetPositionLiftPercent100ths(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = WindowCovering::Attributes::TargetPositionLiftPercent100ths::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeTargetPositionTiltPercent100thsWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeTargetPositionTiltPercent100thsWithValue:(NSNumber * _Nonnull)value
+                                               responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeTargetPositionTiltPercent100ths(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = WindowCovering::Attributes::TargetPositionTiltPercent100ths::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeEndProductTypeWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeEndProductTypeWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeEndProductType(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = WindowCovering::Attributes::EndProductType::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = static_cast<std::remove_reference_t<decltype(cppValue)>>(value.unsignedCharValue);
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeCurrentPositionLiftPercent100thsWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeCurrentPositionLiftPercent100thsWithValue:(NSNumber * _Nonnull)value
+                                                responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeCurrentPositionLiftPercent100ths(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = WindowCovering::Attributes::CurrentPositionLiftPercent100ths::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeCurrentPositionTiltPercent100thsWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeCurrentPositionTiltPercent100thsWithValue:(NSNumber * _Nonnull)value
+                                                responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeCurrentPositionTiltPercent100ths(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = WindowCovering::Attributes::CurrentPositionTiltPercent100ths::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeInstalledOpenLimitLiftWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeInstalledOpenLimitLiftWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeInstalledOpenLimitLift(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = WindowCovering::Attributes::InstalledOpenLimitLift::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeInstalledClosedLimitLiftWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeInstalledClosedLimitLiftWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeInstalledClosedLimitLift(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = WindowCovering::Attributes::InstalledClosedLimitLift::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeInstalledOpenLimitTiltWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeInstalledOpenLimitTiltWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeInstalledOpenLimitTilt(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = WindowCovering::Attributes::InstalledOpenLimitTilt::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeInstalledClosedLimitTiltWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeInstalledClosedLimitTiltWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeInstalledClosedLimitTilt(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = WindowCovering::Attributes::InstalledClosedLimitTilt::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeSafetyStatusWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeSafetyStatusWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeSafetyStatus(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = WindowCovering::Attributes::SafetyStatus::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeFeatureMapWithValue:(uint32_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeFeatureMapWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeFeatureMap(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = WindowCovering::Attributes::FeatureMap::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedIntValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)writeAttributeClusterRevisionWithValue:(uint16_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeClusterRevisionWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler
 {
     new CHIPDefaultSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
-        return self.cppCluster.WriteAttributeClusterRevision(success, failure, value);
+        ListFreer listFreer;
+        using TypeInfo = WindowCovering::Attributes::ClusterRevision::TypeInfo;
+        TypeInfo::Type cppValue;
+        cppValue = value.unsignedShortValue;
+        auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
+        auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+        return self.cppCluster.WriteAttribute<TypeInfo>(cppValue, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 

--- a/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
+++ b/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
@@ -214,7 +214,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestBinaryInputBasic * cluster = [[CHIPTestBinaryInputBasic alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint16_t clusterRevisionArgument = 1U;
+    id clusterRevisionArgument;
+    clusterRevisionArgument = [NSNumber numberWithUnsignedShort:1U];
     [cluster
         writeAttributeClusterRevisionWithValue:clusterRevisionArgument
                                responseHandler:^(NSError * err, NSDictionary * values) {
@@ -305,7 +306,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestBinaryInputBasic * cluster = [[CHIPTestBinaryInputBasic alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    bool outOfServiceArgument = 0;
+    id outOfServiceArgument;
+    outOfServiceArgument = [NSNumber numberWithBool:0];
     [cluster
         writeAttributeOutOfServiceWithValue:outOfServiceArgument
                             responseHandler:^(NSError * err, NSDictionary * values) {
@@ -373,7 +375,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestBinaryInputBasic * cluster = [[CHIPTestBinaryInputBasic alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    bool presentValueArgument = 0;
+    id presentValueArgument;
+    presentValueArgument = [NSNumber numberWithBool:0];
     [cluster
         writeAttributePresentValueWithValue:presentValueArgument
                             responseHandler:^(NSError * err, NSDictionary * values) {
@@ -467,7 +470,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestBinaryInputBasic * cluster = [[CHIPTestBinaryInputBasic alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint8_t statusFlagsArgument = 0;
+    id statusFlagsArgument;
+    statusFlagsArgument = [NSNumber numberWithUnsignedChar:0];
     [cluster
         writeAttributeStatusFlagsWithValue:statusFlagsArgument
                            responseHandler:^(NSError * err, NSDictionary * values) {
@@ -732,7 +736,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestBooleanState * cluster = [[CHIPTestBooleanState alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint16_t clusterRevisionArgument = 1U;
+    id clusterRevisionArgument;
+    clusterRevisionArgument = [NSNumber numberWithUnsignedShort:1U];
     [cluster
         writeAttributeClusterRevisionWithValue:clusterRevisionArgument
                                responseHandler:^(NSError * err, NSDictionary * values) {
@@ -823,7 +828,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestBooleanState * cluster = [[CHIPTestBooleanState alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    bool stateValueArgument = 1;
+    id stateValueArgument;
+    stateValueArgument = [NSNumber numberWithBool:1];
     [cluster writeAttributeStateValueWithValue:stateValueArgument
                                responseHandler:^(NSError * err, NSDictionary * values) {
                                    NSLog(@"Write the default value to mandatory non-global attribute: StateValue Error: %@", err);
@@ -870,7 +876,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint16_t clusterRevisionArgument = 4U;
+    id clusterRevisionArgument;
+    clusterRevisionArgument = [NSNumber numberWithUnsignedShort:4U];
     [cluster
         writeAttributeClusterRevisionWithValue:clusterRevisionArgument
                                responseHandler:^(NSError * err, NSDictionary * values) {
@@ -938,7 +945,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint8_t currentHueArgument = 0;
+    id currentHueArgument;
+    currentHueArgument = [NSNumber numberWithUnsignedChar:0];
     [cluster writeAttributeCurrentHueWithValue:currentHueArgument
                                responseHandler:^(NSError * err, NSDictionary * values) {
                                    NSLog(@"Write the default value to mandatory attribute: CurrentHue Error: %@", err);
@@ -1028,7 +1036,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint8_t currentSaturationArgument = 0;
+    id currentSaturationArgument;
+    currentSaturationArgument = [NSNumber numberWithUnsignedChar:0];
     [cluster
         writeAttributeCurrentSaturationWithValue:currentSaturationArgument
                                  responseHandler:^(NSError * err, NSDictionary * values) {
@@ -1118,7 +1127,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint16_t currentXArgument = 24939U;
+    id currentXArgument;
+    currentXArgument = [NSNumber numberWithUnsignedShort:24939U];
     [cluster writeAttributeCurrentXWithValue:currentXArgument
                              responseHandler:^(NSError * err, NSDictionary * values) {
                                  NSLog(@"Write the default value to mandatory attribute: CurrentX Error: %@", err);
@@ -1208,7 +1218,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint16_t currentYArgument = 24701U;
+    id currentYArgument;
+    currentYArgument = [NSNumber numberWithUnsignedShort:24701U];
     [cluster writeAttributeCurrentYWithValue:currentYArgument
                              responseHandler:^(NSError * err, NSDictionary * values) {
                                  NSLog(@"Write the default values to mandatory attribute: CurrentY Error: %@", err);
@@ -1338,7 +1349,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint8_t colorControlOptionsArgument = 0;
+    id colorControlOptionsArgument;
+    colorControlOptionsArgument = [NSNumber numberWithUnsignedChar:0];
     [cluster writeAttributeColorControlOptionsWithValue:colorControlOptionsArgument
                                         responseHandler:^(NSError * err, NSDictionary * values) {
                                             NSLog(@"Write the default values to mandatory attribute: Options Error: %@", err);
@@ -1427,7 +1439,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint16_t enhancedCurrentHueArgument = 0U;
+    id enhancedCurrentHueArgument;
+    enhancedCurrentHueArgument = [NSNumber numberWithUnsignedShort:0U];
     [cluster
         writeAttributeEnhancedCurrentHueWithValue:enhancedCurrentHueArgument
                                   responseHandler:^(NSError * err, NSDictionary * values) {
@@ -1535,7 +1548,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint8_t colorLoopActiveArgument = 0;
+    id colorLoopActiveArgument;
+    colorLoopActiveArgument = [NSNumber numberWithUnsignedChar:0];
     [cluster writeAttributeColorLoopActiveWithValue:colorLoopActiveArgument
                                     responseHandler:^(NSError * err, NSDictionary * values) {
                                         NSLog(@"Write the default values to mandatory attribute: ColorLoopActive Error: %@", err);
@@ -1623,7 +1637,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint8_t colorLoopDirectionArgument = 0;
+    id colorLoopDirectionArgument;
+    colorLoopDirectionArgument = [NSNumber numberWithUnsignedChar:0];
     [cluster
         writeAttributeColorLoopDirectionWithValue:colorLoopDirectionArgument
                                   responseHandler:^(NSError * err, NSDictionary * values) {
@@ -1712,7 +1727,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint16_t colorLoopTimeArgument = 25U;
+    id colorLoopTimeArgument;
+    colorLoopTimeArgument = [NSNumber numberWithUnsignedShort:25U];
     [cluster writeAttributeColorLoopTimeWithValue:colorLoopTimeArgument
                                   responseHandler:^(NSError * err, NSDictionary * values) {
                                       NSLog(@"Write the default values to mandatory attribute: ColorLoopTime Error: %@", err);
@@ -1801,7 +1817,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint16_t colorLoopStartEnhancedHueArgument = 8960U;
+    id colorLoopStartEnhancedHueArgument;
+    colorLoopStartEnhancedHueArgument = [NSNumber numberWithUnsignedShort:8960U];
     [cluster writeAttributeColorLoopStartEnhancedHueWithValue:colorLoopStartEnhancedHueArgument
                                               responseHandler:^(NSError * err, NSDictionary * values) {
                                                   NSLog(@"Write the default values to mandatory attribute: "
@@ -1893,7 +1910,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint16_t colorLoopStoredEnhancedHueArgument = 0U;
+    id colorLoopStoredEnhancedHueArgument;
+    colorLoopStoredEnhancedHueArgument = [NSNumber numberWithUnsignedShort:0U];
     [cluster writeAttributeColorLoopStoredEnhancedHueWithValue:colorLoopStoredEnhancedHueArgument
                                                responseHandler:^(NSError * err, NSDictionary * values) {
                                                    NSLog(@"Write the default values to mandatory attribute: "
@@ -1986,7 +2004,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint16_t colorCapabilitiesArgument = 0U;
+    id colorCapabilitiesArgument;
+    colorCapabilitiesArgument = [NSNumber numberWithUnsignedShort:0U];
     [cluster
         writeAttributeColorCapabilitiesWithValue:colorCapabilitiesArgument
                                  responseHandler:^(NSError * err, NSDictionary * values) {
@@ -2078,7 +2097,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint16_t colorTempPhysicalMinArgument = 0U;
+    id colorTempPhysicalMinArgument;
+    colorTempPhysicalMinArgument = [NSNumber numberWithUnsignedShort:0U];
     [cluster writeAttributeColorTempPhysicalMinWithValue:colorTempPhysicalMinArgument
                                          responseHandler:^(NSError * err, NSDictionary * values) {
                                              NSLog(@"Write the default values to mandatory  attribute: ColorTempPhysicalMinMireds "
@@ -2172,7 +2192,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint16_t colorTempPhysicalMaxArgument = 65279U;
+    id colorTempPhysicalMaxArgument;
+    colorTempPhysicalMaxArgument = [NSNumber numberWithUnsignedShort:65279U];
     [cluster writeAttributeColorTempPhysicalMaxWithValue:colorTempPhysicalMaxArgument
                                          responseHandler:^(NSError * err, NSDictionary * values) {
                                              NSLog(@"Write the default values to mandatory attribute: ColorTempPhysicalMaxMireds "
@@ -2240,7 +2261,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint16_t coupleColorTempToLevelMinMiredsArgument = 0U;
+    id coupleColorTempToLevelMinMiredsArgument;
+    coupleColorTempToLevelMinMiredsArgument = [NSNumber numberWithUnsignedShort:0U];
     [cluster writeAttributeCoupleColorTempToLevelMinMiredsWithValue:coupleColorTempToLevelMinMiredsArgument
                                                     responseHandler:^(NSError * err, NSDictionary * values) {
                                                         NSLog(@"Write the default values to optional attribute: "
@@ -2310,7 +2332,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint16_t startUpColorTemperatureMiredsArgument = 0U;
+    id startUpColorTemperatureMiredsArgument;
+    startUpColorTemperatureMiredsArgument = [NSNumber numberWithUnsignedShort:0U];
     [cluster writeAttributeStartUpColorTemperatureMiredsWithValue:startUpColorTemperatureMiredsArgument
                                                   responseHandler:^(NSError * err, NSDictionary * values) {
                                                       NSLog(@"Write the default values to optional attribute: "
@@ -2404,7 +2427,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint16_t remainingTimeArgument = 0U;
+    id remainingTimeArgument;
+    remainingTimeArgument = [NSNumber numberWithUnsignedShort:0U];
     [cluster writeAttributeRemainingTimeWithValue:remainingTimeArgument
                                   responseHandler:^(NSError * err, NSDictionary * values) {
                                       NSLog(@"Write the default values to optional attribute: RemainingTime Error: %@", err);
@@ -2470,7 +2494,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint8_t driftCompensationArgument = 0;
+    id driftCompensationArgument;
+    driftCompensationArgument = [NSNumber numberWithUnsignedChar:0];
     [cluster
         writeAttributeDriftCompensationWithValue:driftCompensationArgument
                                  responseHandler:^(NSError * err, NSDictionary * values) {
@@ -2557,7 +2582,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint8_t numberOfPrimariesArgument = 0;
+    id numberOfPrimariesArgument;
+    numberOfPrimariesArgument = [NSNumber numberWithUnsignedChar:0];
     [cluster writeAttributeNumberOfPrimariesWithValue:numberOfPrimariesArgument
                                       responseHandler:^(NSError * err, NSDictionary * values) {
                                           NSLog(@"Write the default mandatory attribute: NumberOfPrimaries Error: %@", err);
@@ -2622,7 +2648,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint16_t primary1XArgument = 0U;
+    id primary1XArgument;
+    primary1XArgument = [NSNumber numberWithUnsignedShort:0U];
     [cluster writeAttributePrimary1XWithValue:primary1XArgument
                               responseHandler:^(NSError * err, NSDictionary * values) {
                                   NSLog(@"Write the default mandatory attribute: Primary1X Error: %@", err);
@@ -2687,7 +2714,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint16_t primary1YArgument = 0U;
+    id primary1YArgument;
+    primary1YArgument = [NSNumber numberWithUnsignedShort:0U];
     [cluster writeAttributePrimary1YWithValue:primary1YArgument
                               responseHandler:^(NSError * err, NSDictionary * values) {
                                   NSLog(@"Write the default mandatory attribute: Primary1Y Error: %@", err);
@@ -2771,7 +2799,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint16_t primary2XArgument = 0U;
+    id primary2XArgument;
+    primary2XArgument = [NSNumber numberWithUnsignedShort:0U];
     [cluster writeAttributePrimary2XWithValue:primary2XArgument
                               responseHandler:^(NSError * err, NSDictionary * values) {
                                   NSLog(@"Write the default mandatory attribute: Primary2X Error: %@", err);
@@ -2836,7 +2865,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint16_t primary2YArgument = 0U;
+    id primary2YArgument;
+    primary2YArgument = [NSNumber numberWithUnsignedShort:0U];
     [cluster writeAttributePrimary2YWithValue:primary2YArgument
                               responseHandler:^(NSError * err, NSDictionary * values) {
                                   NSLog(@"Write the default mandatory attribute: Primary2Y Error: %@", err);
@@ -2920,7 +2950,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint16_t primary3XArgument = 0U;
+    id primary3XArgument;
+    primary3XArgument = [NSNumber numberWithUnsignedShort:0U];
     [cluster writeAttributePrimary3XWithValue:primary3XArgument
                               responseHandler:^(NSError * err, NSDictionary * values) {
                                   NSLog(@"Write the default mandatory attribute: Primary3X Error: %@", err);
@@ -2985,7 +3016,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint16_t primary3YArgument = 0U;
+    id primary3YArgument;
+    primary3YArgument = [NSNumber numberWithUnsignedShort:0U];
     [cluster writeAttributePrimary3YWithValue:primary3YArgument
                               responseHandler:^(NSError * err, NSDictionary * values) {
                                   NSLog(@"Write the default mandatory attribute: Primary3Y Error: %@", err);
@@ -3069,7 +3101,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint16_t primary4XArgument = 0U;
+    id primary4XArgument;
+    primary4XArgument = [NSNumber numberWithUnsignedShort:0U];
     [cluster writeAttributePrimary4XWithValue:primary4XArgument
                               responseHandler:^(NSError * err, NSDictionary * values) {
                                   NSLog(@"Write the default mandatory attribute: Primary4X Error: %@", err);
@@ -3134,7 +3167,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint16_t primary4YArgument = 0U;
+    id primary4YArgument;
+    primary4YArgument = [NSNumber numberWithUnsignedShort:0U];
     [cluster writeAttributePrimary4YWithValue:primary4YArgument
                               responseHandler:^(NSError * err, NSDictionary * values) {
                                   NSLog(@"Write the default mandatory attribute: Primary4Y Error: %@", err);
@@ -3218,7 +3252,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint16_t primary5XArgument = 0U;
+    id primary5XArgument;
+    primary5XArgument = [NSNumber numberWithUnsignedShort:0U];
     [cluster writeAttributePrimary5XWithValue:primary5XArgument
                               responseHandler:^(NSError * err, NSDictionary * values) {
                                   NSLog(@"Write the default mandatory attribute: Primary5X Error: %@", err);
@@ -3283,7 +3318,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint16_t primary5YArgument = 0U;
+    id primary5YArgument;
+    primary5YArgument = [NSNumber numberWithUnsignedShort:0U];
     [cluster writeAttributePrimary5YWithValue:primary5YArgument
                               responseHandler:^(NSError * err, NSDictionary * values) {
                                   NSLog(@"Write the default mandatory attribute: Primary5Y Error: %@", err);
@@ -3367,7 +3403,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint16_t primary6XArgument = 0U;
+    id primary6XArgument;
+    primary6XArgument = [NSNumber numberWithUnsignedShort:0U];
     [cluster writeAttributePrimary6XWithValue:primary6XArgument
                               responseHandler:^(NSError * err, NSDictionary * values) {
                                   NSLog(@"Write the default mandatory attribute: Primary6X Error: %@", err);
@@ -3432,7 +3469,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint16_t primary6YArgument = 0U;
+    id primary6YArgument;
+    primary6YArgument = [NSNumber numberWithUnsignedShort:0U];
     [cluster writeAttributePrimary6YWithValue:primary6YArgument
                               responseHandler:^(NSError * err, NSDictionary * values) {
                                   NSLog(@"Write the default mandatory attribute: Primary6Y Error: %@", err);
@@ -3516,7 +3554,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint16_t whitePointXArgument = 0U;
+    id whitePointXArgument;
+    whitePointXArgument = [NSNumber numberWithUnsignedShort:0U];
     [cluster writeAttributeWhitePointXWithValue:whitePointXArgument
                                 responseHandler:^(NSError * err, NSDictionary * values) {
                                     NSLog(@"Write the default optional attribute: WhitePointX Error: %@", err);
@@ -3582,7 +3621,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint16_t whitePointYArgument = 0U;
+    id whitePointYArgument;
+    whitePointYArgument = [NSNumber numberWithUnsignedShort:0U];
     [cluster writeAttributeWhitePointYWithValue:whitePointYArgument
                                 responseHandler:^(NSError * err, NSDictionary * values) {
                                     NSLog(@"Write the default optional attribute: WhitePointY Error: %@", err);
@@ -3648,7 +3688,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint16_t colorPointRXArgument = 0U;
+    id colorPointRXArgument;
+    colorPointRXArgument = [NSNumber numberWithUnsignedShort:0U];
     [cluster writeAttributeColorPointRXWithValue:colorPointRXArgument
                                  responseHandler:^(NSError * err, NSDictionary * values) {
                                      NSLog(@"Write the default optional attribute: ColorPointRX Error: %@", err);
@@ -3714,7 +3755,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint16_t colorPointRYArgument = 0U;
+    id colorPointRYArgument;
+    colorPointRYArgument = [NSNumber numberWithUnsignedShort:0U];
     [cluster writeAttributeColorPointRYWithValue:colorPointRYArgument
                                  responseHandler:^(NSError * err, NSDictionary * values) {
                                      NSLog(@"Write the default optional attribute: ColorPointRY Error: %@", err);
@@ -3799,7 +3841,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint16_t colorPointGXArgument = 0U;
+    id colorPointGXArgument;
+    colorPointGXArgument = [NSNumber numberWithUnsignedShort:0U];
     [cluster writeAttributeColorPointGXWithValue:colorPointGXArgument
                                  responseHandler:^(NSError * err, NSDictionary * values) {
                                      NSLog(@"Write the default optional attribute: ColorPointGX Error: %@", err);
@@ -3865,7 +3908,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint16_t colorPointGYArgument = 0U;
+    id colorPointGYArgument;
+    colorPointGYArgument = [NSNumber numberWithUnsignedShort:0U];
     [cluster writeAttributeColorPointGYWithValue:colorPointGYArgument
                                  responseHandler:^(NSError * err, NSDictionary * values) {
                                      NSLog(@"Write the default optional attribute: ColorPointGY Error: %@", err);
@@ -3950,7 +3994,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint16_t colorPointBXArgument = 0U;
+    id colorPointBXArgument;
+    colorPointBXArgument = [NSNumber numberWithUnsignedShort:0U];
     [cluster writeAttributeColorPointBXWithValue:colorPointBXArgument
                                  responseHandler:^(NSError * err, NSDictionary * values) {
                                      NSLog(@"Write the default optional attribute: ColorPointBX Error: %@", err);
@@ -4016,7 +4061,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint16_t colorPointBYArgument = 0U;
+    id colorPointBYArgument;
+    colorPointBYArgument = [NSNumber numberWithUnsignedShort:0U];
     [cluster writeAttributeColorPointBYWithValue:colorPointBYArgument
                                  responseHandler:^(NSError * err, NSDictionary * values) {
                                      NSLog(@"Write the default optional attribute: ColorPointBY Error: %@", err);
@@ -4129,7 +4175,7 @@ CHIPDevice * GetConnectedDevice()
     __auto_type * payload = [[CHIPColorControlClusterMoveToHuePayload alloc] init];
     payload.Hue = [NSNumber numberWithUnsignedChar:150];
     payload.Direction = [NSNumber numberWithUnsignedChar:0];
-    payload.TransitionTime = [NSNumber numberWithUnsignedShort:100];
+    payload.TransitionTime = [NSNumber numberWithUnsignedShort:100U];
     payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
     payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster moveToHue:payload
@@ -4155,7 +4201,7 @@ CHIPDevice * GetConnectedDevice()
     __auto_type * payload = [[CHIPColorControlClusterMoveToHuePayload alloc] init];
     payload.Hue = [NSNumber numberWithUnsignedChar:200];
     payload.Direction = [NSNumber numberWithUnsignedChar:1];
-    payload.TransitionTime = [NSNumber numberWithUnsignedShort:100];
+    payload.TransitionTime = [NSNumber numberWithUnsignedShort:100U];
     payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
     payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster moveToHue:payload
@@ -4181,7 +4227,7 @@ CHIPDevice * GetConnectedDevice()
     __auto_type * payload = [[CHIPColorControlClusterMoveToHuePayload alloc] init];
     payload.Hue = [NSNumber numberWithUnsignedChar:250];
     payload.Direction = [NSNumber numberWithUnsignedChar:2];
-    payload.TransitionTime = [NSNumber numberWithUnsignedShort:100];
+    payload.TransitionTime = [NSNumber numberWithUnsignedShort:100U];
     payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
     payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster moveToHue:payload
@@ -4207,7 +4253,7 @@ CHIPDevice * GetConnectedDevice()
     __auto_type * payload = [[CHIPColorControlClusterMoveToHuePayload alloc] init];
     payload.Hue = [NSNumber numberWithUnsignedChar:225];
     payload.Direction = [NSNumber numberWithUnsignedChar:3];
-    payload.TransitionTime = [NSNumber numberWithUnsignedShort:100];
+    payload.TransitionTime = [NSNumber numberWithUnsignedShort:100U];
     payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
     payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster moveToHue:payload
@@ -4657,7 +4703,7 @@ CHIPDevice * GetConnectedDevice()
 
     __auto_type * payload = [[CHIPColorControlClusterMoveToSaturationPayload alloc] init];
     payload.Saturation = [NSNumber numberWithUnsignedChar:90];
-    payload.TransitionTime = [NSNumber numberWithUnsignedShort:10];
+    payload.TransitionTime = [NSNumber numberWithUnsignedShort:10U];
     payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
     payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster moveToSaturation:payload
@@ -5058,7 +5104,7 @@ CHIPDevice * GetConnectedDevice()
     __auto_type * payload = [[CHIPColorControlClusterMoveToHueAndSaturationPayload alloc] init];
     payload.Hue = [NSNumber numberWithUnsignedChar:40];
     payload.Saturation = [NSNumber numberWithUnsignedChar:160];
-    payload.TransitionTime = [NSNumber numberWithUnsignedShort:10];
+    payload.TransitionTime = [NSNumber numberWithUnsignedShort:10U];
     payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
     payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster moveToHueAndSaturation:payload
@@ -5173,9 +5219,9 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPColorControlClusterMoveToColorPayload alloc] init];
-    payload.ColorX = [NSNumber numberWithUnsignedShort:200];
-    payload.ColorY = [NSNumber numberWithUnsignedShort:300];
-    payload.TransitionTime = [NSNumber numberWithUnsignedShort:20];
+    payload.ColorX = [NSNumber numberWithUnsignedShort:200U];
+    payload.ColorY = [NSNumber numberWithUnsignedShort:300U];
+    payload.TransitionTime = [NSNumber numberWithUnsignedShort:20U];
     payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
     payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster moveToColor:payload
@@ -5431,7 +5477,7 @@ CHIPDevice * GetConnectedDevice()
     __auto_type * payload = [[CHIPColorControlClusterStepColorPayload alloc] init];
     payload.StepX = [NSNumber numberWithShort:15];
     payload.StepY = [NSNumber numberWithShort:20];
-    payload.TransitionTime = [NSNumber numberWithUnsignedShort:50];
+    payload.TransitionTime = [NSNumber numberWithUnsignedShort:50U];
     payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
     payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster stepColor:payload
@@ -5546,8 +5592,8 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPColorControlClusterMoveToColorTemperaturePayload alloc] init];
-    payload.ColorTemperature = [NSNumber numberWithUnsignedShort:100];
-    payload.TransitionTime = [NSNumber numberWithUnsignedShort:10];
+    payload.ColorTemperature = [NSNumber numberWithUnsignedShort:100U];
+    payload.TransitionTime = [NSNumber numberWithUnsignedShort:10U];
     payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
     payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster moveToColorTemperature:payload
@@ -5663,9 +5709,9 @@ CHIPDevice * GetConnectedDevice()
 
     __auto_type * payload = [[CHIPColorControlClusterMoveColorTemperaturePayload alloc] init];
     payload.MoveMode = [NSNumber numberWithUnsignedChar:1];
-    payload.Rate = [NSNumber numberWithUnsignedShort:10];
-    payload.ColorTemperatureMinimum = [NSNumber numberWithUnsignedShort:1];
-    payload.ColorTemperatureMaximum = [NSNumber numberWithUnsignedShort:255];
+    payload.Rate = [NSNumber numberWithUnsignedShort:10U];
+    payload.ColorTemperatureMinimum = [NSNumber numberWithUnsignedShort:1U];
+    payload.ColorTemperatureMaximum = [NSNumber numberWithUnsignedShort:255U];
     payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
     payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster moveColorTemperature:payload
@@ -5690,9 +5736,9 @@ CHIPDevice * GetConnectedDevice()
 
     __auto_type * payload = [[CHIPColorControlClusterMoveColorTemperaturePayload alloc] init];
     payload.MoveMode = [NSNumber numberWithUnsignedChar:0];
-    payload.Rate = [NSNumber numberWithUnsignedShort:10];
-    payload.ColorTemperatureMinimum = [NSNumber numberWithUnsignedShort:1];
-    payload.ColorTemperatureMaximum = [NSNumber numberWithUnsignedShort:255];
+    payload.Rate = [NSNumber numberWithUnsignedShort:10U];
+    payload.ColorTemperatureMinimum = [NSNumber numberWithUnsignedShort:1U];
+    payload.ColorTemperatureMaximum = [NSNumber numberWithUnsignedShort:255U];
     payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
     payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster moveColorTemperature:payload
@@ -5717,9 +5763,9 @@ CHIPDevice * GetConnectedDevice()
 
     __auto_type * payload = [[CHIPColorControlClusterMoveColorTemperaturePayload alloc] init];
     payload.MoveMode = [NSNumber numberWithUnsignedChar:3];
-    payload.Rate = [NSNumber numberWithUnsignedShort:20];
-    payload.ColorTemperatureMinimum = [NSNumber numberWithUnsignedShort:1];
-    payload.ColorTemperatureMaximum = [NSNumber numberWithUnsignedShort:255];
+    payload.Rate = [NSNumber numberWithUnsignedShort:20U];
+    payload.ColorTemperatureMinimum = [NSNumber numberWithUnsignedShort:1U];
+    payload.ColorTemperatureMaximum = [NSNumber numberWithUnsignedShort:255U];
     payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
     payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster moveColorTemperature:payload
@@ -5835,10 +5881,10 @@ CHIPDevice * GetConnectedDevice()
 
     __auto_type * payload = [[CHIPColorControlClusterStepColorTemperaturePayload alloc] init];
     payload.StepMode = [NSNumber numberWithUnsignedChar:1];
-    payload.StepSize = [NSNumber numberWithUnsignedShort:5];
-    payload.TransitionTime = [NSNumber numberWithUnsignedShort:50];
-    payload.ColorTemperatureMinimum = [NSNumber numberWithUnsignedShort:5];
-    payload.ColorTemperatureMaximum = [NSNumber numberWithUnsignedShort:100];
+    payload.StepSize = [NSNumber numberWithUnsignedShort:5U];
+    payload.TransitionTime = [NSNumber numberWithUnsignedShort:50U];
+    payload.ColorTemperatureMinimum = [NSNumber numberWithUnsignedShort:5U];
+    payload.ColorTemperatureMaximum = [NSNumber numberWithUnsignedShort:100U];
     payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
     payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster stepColorTemperature:payload
@@ -5863,10 +5909,10 @@ CHIPDevice * GetConnectedDevice()
 
     __auto_type * payload = [[CHIPColorControlClusterStepColorTemperaturePayload alloc] init];
     payload.StepMode = [NSNumber numberWithUnsignedChar:3];
-    payload.StepSize = [NSNumber numberWithUnsignedShort:5];
-    payload.TransitionTime = [NSNumber numberWithUnsignedShort:50];
-    payload.ColorTemperatureMinimum = [NSNumber numberWithUnsignedShort:5];
-    payload.ColorTemperatureMaximum = [NSNumber numberWithUnsignedShort:100];
+    payload.StepSize = [NSNumber numberWithUnsignedShort:5U];
+    payload.TransitionTime = [NSNumber numberWithUnsignedShort:50U];
+    payload.ColorTemperatureMinimum = [NSNumber numberWithUnsignedShort:5U];
+    payload.ColorTemperatureMaximum = [NSNumber numberWithUnsignedShort:100U];
     payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
     payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster stepColorTemperature:payload
@@ -5981,9 +6027,9 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPColorControlClusterEnhancedMoveToHuePayload alloc] init];
-    payload.EnhancedHue = [NSNumber numberWithUnsignedShort:1025];
+    payload.EnhancedHue = [NSNumber numberWithUnsignedShort:1025U];
     payload.Direction = [NSNumber numberWithUnsignedChar:0];
-    payload.TransitionTime = [NSNumber numberWithUnsignedShort:1];
+    payload.TransitionTime = [NSNumber numberWithUnsignedShort:1U];
     payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
     payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster enhancedMoveToHue:payload
@@ -6124,7 +6170,7 @@ CHIPDevice * GetConnectedDevice()
 
     __auto_type * payload = [[CHIPColorControlClusterEnhancedMoveHuePayload alloc] init];
     payload.MoveMode = [NSNumber numberWithUnsignedChar:3];
-    payload.Rate = [NSNumber numberWithUnsignedShort:5];
+    payload.Rate = [NSNumber numberWithUnsignedShort:5U];
     payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
     payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster enhancedMoveHue:payload
@@ -6149,7 +6195,7 @@ CHIPDevice * GetConnectedDevice()
 
     __auto_type * payload = [[CHIPColorControlClusterEnhancedMoveHuePayload alloc] init];
     payload.MoveMode = [NSNumber numberWithUnsignedChar:0];
-    payload.Rate = [NSNumber numberWithUnsignedShort:0];
+    payload.Rate = [NSNumber numberWithUnsignedShort:0U];
     payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
     payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster enhancedMoveHue:payload
@@ -6174,7 +6220,7 @@ CHIPDevice * GetConnectedDevice()
 
     __auto_type * payload = [[CHIPColorControlClusterEnhancedMoveHuePayload alloc] init];
     payload.MoveMode = [NSNumber numberWithUnsignedChar:1];
-    payload.Rate = [NSNumber numberWithUnsignedShort:50];
+    payload.Rate = [NSNumber numberWithUnsignedShort:50U];
     payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
     payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster enhancedMoveHue:payload
@@ -6199,7 +6245,7 @@ CHIPDevice * GetConnectedDevice()
 
     __auto_type * payload = [[CHIPColorControlClusterEnhancedMoveHuePayload alloc] init];
     payload.MoveMode = [NSNumber numberWithUnsignedChar:0];
-    payload.Rate = [NSNumber numberWithUnsignedShort:0];
+    payload.Rate = [NSNumber numberWithUnsignedShort:0U];
     payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
     payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster enhancedMoveHue:payload
@@ -6315,8 +6361,8 @@ CHIPDevice * GetConnectedDevice()
 
     __auto_type * payload = [[CHIPColorControlClusterEnhancedStepHuePayload alloc] init];
     payload.StepMode = [NSNumber numberWithUnsignedChar:0];
-    payload.StepSize = [NSNumber numberWithUnsignedShort:50];
-    payload.TransitionTime = [NSNumber numberWithUnsignedShort:1];
+    payload.StepSize = [NSNumber numberWithUnsignedShort:50U];
+    payload.TransitionTime = [NSNumber numberWithUnsignedShort:1U];
     payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
     payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster enhancedStepHue:payload
@@ -6341,8 +6387,8 @@ CHIPDevice * GetConnectedDevice()
 
     __auto_type * payload = [[CHIPColorControlClusterEnhancedStepHuePayload alloc] init];
     payload.StepMode = [NSNumber numberWithUnsignedChar:1];
-    payload.StepSize = [NSNumber numberWithUnsignedShort:75];
-    payload.TransitionTime = [NSNumber numberWithUnsignedShort:1];
+    payload.StepSize = [NSNumber numberWithUnsignedShort:75U];
+    payload.TransitionTime = [NSNumber numberWithUnsignedShort:1U];
     payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
     payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster enhancedStepHue:payload
@@ -6457,9 +6503,9 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPColorControlClusterEnhancedMoveToHueAndSaturationPayload alloc] init];
-    payload.EnhancedHue = [NSNumber numberWithUnsignedShort:1200];
+    payload.EnhancedHue = [NSNumber numberWithUnsignedShort:1200U];
     payload.Saturation = [NSNumber numberWithUnsignedChar:90];
-    payload.TransitionTime = [NSNumber numberWithUnsignedShort:10];
+    payload.TransitionTime = [NSNumber numberWithUnsignedShort:10U];
     payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
     payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster enhancedMoveToHueAndSaturation:payload
@@ -6577,8 +6623,8 @@ CHIPDevice * GetConnectedDevice()
     payload.UpdateFlags = [NSNumber numberWithUnsignedChar:14];
     payload.Action = [NSNumber numberWithUnsignedChar:0];
     payload.Direction = [NSNumber numberWithUnsignedChar:1];
-    payload.Time = [NSNumber numberWithUnsignedShort:100];
-    payload.StartHue = [NSNumber numberWithUnsignedShort:500];
+    payload.Time = [NSNumber numberWithUnsignedShort:100U];
+    payload.StartHue = [NSNumber numberWithUnsignedShort:500U];
     payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
     payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster colorLoopSet:payload
@@ -6701,8 +6747,8 @@ CHIPDevice * GetConnectedDevice()
     payload.UpdateFlags = [NSNumber numberWithUnsignedChar:1];
     payload.Action = [NSNumber numberWithUnsignedChar:1];
     payload.Direction = [NSNumber numberWithUnsignedChar:0];
-    payload.Time = [NSNumber numberWithUnsignedShort:0];
-    payload.StartHue = [NSNumber numberWithUnsignedShort:0];
+    payload.Time = [NSNumber numberWithUnsignedShort:0U];
+    payload.StartHue = [NSNumber numberWithUnsignedShort:0U];
     payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
     payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster colorLoopSet:payload
@@ -6754,8 +6800,8 @@ CHIPDevice * GetConnectedDevice()
     payload.UpdateFlags = [NSNumber numberWithUnsignedChar:6];
     payload.Action = [NSNumber numberWithUnsignedChar:0];
     payload.Direction = [NSNumber numberWithUnsignedChar:0];
-    payload.Time = [NSNumber numberWithUnsignedShort:3500];
-    payload.StartHue = [NSNumber numberWithUnsignedShort:0];
+    payload.Time = [NSNumber numberWithUnsignedShort:3500U];
+    payload.StartHue = [NSNumber numberWithUnsignedShort:0U];
     payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
     payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster colorLoopSet:payload
@@ -6830,8 +6876,8 @@ CHIPDevice * GetConnectedDevice()
     payload.UpdateFlags = [NSNumber numberWithUnsignedChar:2];
     payload.Action = [NSNumber numberWithUnsignedChar:0];
     payload.Direction = [NSNumber numberWithUnsignedChar:1];
-    payload.Time = [NSNumber numberWithUnsignedShort:0];
-    payload.StartHue = [NSNumber numberWithUnsignedShort:0];
+    payload.Time = [NSNumber numberWithUnsignedShort:0U];
+    payload.StartHue = [NSNumber numberWithUnsignedShort:0U];
     payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
     payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster colorLoopSet:payload
@@ -6973,8 +7019,8 @@ CHIPDevice * GetConnectedDevice()
     payload.UpdateFlags = [NSNumber numberWithUnsignedChar:1];
     payload.Action = [NSNumber numberWithUnsignedChar:0];
     payload.Direction = [NSNumber numberWithUnsignedChar:0];
-    payload.Time = [NSNumber numberWithUnsignedShort:0];
-    payload.StartHue = [NSNumber numberWithUnsignedShort:0];
+    payload.Time = [NSNumber numberWithUnsignedShort:0U];
+    payload.StartHue = [NSNumber numberWithUnsignedShort:0U];
     payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
     payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster colorLoopSet:payload
@@ -7025,8 +7071,8 @@ CHIPDevice * GetConnectedDevice()
     payload.UpdateFlags = [NSNumber numberWithUnsignedChar:2];
     payload.Action = [NSNumber numberWithUnsignedChar:0];
     payload.Direction = [NSNumber numberWithUnsignedChar:0];
-    payload.Time = [NSNumber numberWithUnsignedShort:0];
-    payload.StartHue = [NSNumber numberWithUnsignedShort:0];
+    payload.Time = [NSNumber numberWithUnsignedShort:0U];
+    payload.StartHue = [NSNumber numberWithUnsignedShort:0U];
     payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
     payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster colorLoopSet:payload
@@ -7077,8 +7123,8 @@ CHIPDevice * GetConnectedDevice()
     payload.UpdateFlags = [NSNumber numberWithUnsignedChar:4];
     payload.Action = [NSNumber numberWithUnsignedChar:0];
     payload.Direction = [NSNumber numberWithUnsignedChar:0];
-    payload.Time = [NSNumber numberWithUnsignedShort:30];
-    payload.StartHue = [NSNumber numberWithUnsignedShort:0];
+    payload.Time = [NSNumber numberWithUnsignedShort:30U];
+    payload.StartHue = [NSNumber numberWithUnsignedShort:0U];
     payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
     payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster colorLoopSet:payload
@@ -7129,8 +7175,8 @@ CHIPDevice * GetConnectedDevice()
     payload.UpdateFlags = [NSNumber numberWithUnsignedChar:8];
     payload.Action = [NSNumber numberWithUnsignedChar:0];
     payload.Direction = [NSNumber numberWithUnsignedChar:0];
-    payload.Time = [NSNumber numberWithUnsignedShort:0];
-    payload.StartHue = [NSNumber numberWithUnsignedShort:160];
+    payload.Time = [NSNumber numberWithUnsignedShort:0U];
+    payload.StartHue = [NSNumber numberWithUnsignedShort:160U];
     payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
     payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster colorLoopSet:payload
@@ -7181,8 +7227,8 @@ CHIPDevice * GetConnectedDevice()
     payload.UpdateFlags = [NSNumber numberWithUnsignedChar:1];
     payload.Action = [NSNumber numberWithUnsignedChar:1];
     payload.Direction = [NSNumber numberWithUnsignedChar:0];
-    payload.Time = [NSNumber numberWithUnsignedShort:0];
-    payload.StartHue = [NSNumber numberWithUnsignedShort:0];
+    payload.Time = [NSNumber numberWithUnsignedShort:0U];
+    payload.StartHue = [NSNumber numberWithUnsignedShort:0U];
     payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
     payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster colorLoopSet:payload
@@ -7233,8 +7279,8 @@ CHIPDevice * GetConnectedDevice()
     payload.UpdateFlags = [NSNumber numberWithUnsignedChar:1];
     payload.Action = [NSNumber numberWithUnsignedChar:0];
     payload.Direction = [NSNumber numberWithUnsignedChar:0];
-    payload.Time = [NSNumber numberWithUnsignedShort:0];
-    payload.StartHue = [NSNumber numberWithUnsignedShort:0];
+    payload.Time = [NSNumber numberWithUnsignedShort:0U];
+    payload.StartHue = [NSNumber numberWithUnsignedShort:0U];
     payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
     payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster colorLoopSet:payload
@@ -7285,8 +7331,8 @@ CHIPDevice * GetConnectedDevice()
     payload.UpdateFlags = [NSNumber numberWithUnsignedChar:2];
     payload.Action = [NSNumber numberWithUnsignedChar:0];
     payload.Direction = [NSNumber numberWithUnsignedChar:1];
-    payload.Time = [NSNumber numberWithUnsignedShort:0];
-    payload.StartHue = [NSNumber numberWithUnsignedShort:0];
+    payload.Time = [NSNumber numberWithUnsignedShort:0U];
+    payload.StartHue = [NSNumber numberWithUnsignedShort:0U];
     payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
     payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster colorLoopSet:payload
@@ -7337,8 +7383,8 @@ CHIPDevice * GetConnectedDevice()
     payload.UpdateFlags = [NSNumber numberWithUnsignedChar:1];
     payload.Action = [NSNumber numberWithUnsignedChar:1];
     payload.Direction = [NSNumber numberWithUnsignedChar:0];
-    payload.Time = [NSNumber numberWithUnsignedShort:0];
-    payload.StartHue = [NSNumber numberWithUnsignedShort:0];
+    payload.Time = [NSNumber numberWithUnsignedShort:0U];
+    payload.StartHue = [NSNumber numberWithUnsignedShort:0U];
     payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
     payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster colorLoopSet:payload
@@ -7389,8 +7435,8 @@ CHIPDevice * GetConnectedDevice()
     payload.UpdateFlags = [NSNumber numberWithUnsignedChar:1];
     payload.Action = [NSNumber numberWithUnsignedChar:0];
     payload.Direction = [NSNumber numberWithUnsignedChar:0];
-    payload.Time = [NSNumber numberWithUnsignedShort:0];
-    payload.StartHue = [NSNumber numberWithUnsignedShort:0];
+    payload.Time = [NSNumber numberWithUnsignedShort:0U];
+    payload.StartHue = [NSNumber numberWithUnsignedShort:0U];
     payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
     payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster colorLoopSet:payload
@@ -7438,9 +7484,9 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPColorControlClusterEnhancedMoveToHuePayload alloc] init];
-    payload.EnhancedHue = [NSNumber numberWithUnsignedShort:40960];
+    payload.EnhancedHue = [NSNumber numberWithUnsignedShort:40960U];
     payload.Direction = [NSNumber numberWithUnsignedChar:0];
-    payload.TransitionTime = [NSNumber numberWithUnsignedShort:0];
+    payload.TransitionTime = [NSNumber numberWithUnsignedShort:0U];
     payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
     payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster enhancedMoveToHue:payload
@@ -7499,8 +7545,8 @@ CHIPDevice * GetConnectedDevice()
     payload.UpdateFlags = [NSNumber numberWithUnsignedChar:2];
     payload.Action = [NSNumber numberWithUnsignedChar:0];
     payload.Direction = [NSNumber numberWithUnsignedChar:0];
-    payload.Time = [NSNumber numberWithUnsignedShort:0];
-    payload.StartHue = [NSNumber numberWithUnsignedShort:0];
+    payload.Time = [NSNumber numberWithUnsignedShort:0U];
+    payload.StartHue = [NSNumber numberWithUnsignedShort:0U];
     payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
     payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster colorLoopSet:payload
@@ -7551,8 +7597,8 @@ CHIPDevice * GetConnectedDevice()
     payload.UpdateFlags = [NSNumber numberWithUnsignedChar:1];
     payload.Action = [NSNumber numberWithUnsignedChar:2];
     payload.Direction = [NSNumber numberWithUnsignedChar:0];
-    payload.Time = [NSNumber numberWithUnsignedShort:0];
-    payload.StartHue = [NSNumber numberWithUnsignedShort:0];
+    payload.Time = [NSNumber numberWithUnsignedShort:0U];
+    payload.StartHue = [NSNumber numberWithUnsignedShort:0U];
     payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
     payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster colorLoopSet:payload
@@ -7603,8 +7649,8 @@ CHIPDevice * GetConnectedDevice()
     payload.UpdateFlags = [NSNumber numberWithUnsignedChar:1];
     payload.Action = [NSNumber numberWithUnsignedChar:0];
     payload.Direction = [NSNumber numberWithUnsignedChar:0];
-    payload.Time = [NSNumber numberWithUnsignedShort:0];
-    payload.StartHue = [NSNumber numberWithUnsignedShort:0];
+    payload.Time = [NSNumber numberWithUnsignedShort:0U];
+    payload.StartHue = [NSNumber numberWithUnsignedShort:0U];
     payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
     payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster colorLoopSet:payload
@@ -7655,8 +7701,8 @@ CHIPDevice * GetConnectedDevice()
     payload.UpdateFlags = [NSNumber numberWithUnsignedChar:2];
     payload.Action = [NSNumber numberWithUnsignedChar:0];
     payload.Direction = [NSNumber numberWithUnsignedChar:1];
-    payload.Time = [NSNumber numberWithUnsignedShort:0];
-    payload.StartHue = [NSNumber numberWithUnsignedShort:0];
+    payload.Time = [NSNumber numberWithUnsignedShort:0U];
+    payload.StartHue = [NSNumber numberWithUnsignedShort:0U];
     payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
     payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster colorLoopSet:payload
@@ -7707,8 +7753,8 @@ CHIPDevice * GetConnectedDevice()
     payload.UpdateFlags = [NSNumber numberWithUnsignedChar:1];
     payload.Action = [NSNumber numberWithUnsignedChar:2];
     payload.Direction = [NSNumber numberWithUnsignedChar:0];
-    payload.Time = [NSNumber numberWithUnsignedShort:0];
-    payload.StartHue = [NSNumber numberWithUnsignedShort:0];
+    payload.Time = [NSNumber numberWithUnsignedShort:0U];
+    payload.StartHue = [NSNumber numberWithUnsignedShort:0U];
     payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
     payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster colorLoopSet:payload
@@ -7759,8 +7805,8 @@ CHIPDevice * GetConnectedDevice()
     payload.UpdateFlags = [NSNumber numberWithUnsignedChar:1];
     payload.Action = [NSNumber numberWithUnsignedChar:0];
     payload.Direction = [NSNumber numberWithUnsignedChar:0];
-    payload.Time = [NSNumber numberWithUnsignedShort:0];
-    payload.StartHue = [NSNumber numberWithUnsignedShort:0];
+    payload.Time = [NSNumber numberWithUnsignedShort:0U];
+    payload.StartHue = [NSNumber numberWithUnsignedShort:0U];
     payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
     payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster colorLoopSet:payload
@@ -7879,8 +7925,8 @@ CHIPDevice * GetConnectedDevice()
     payload.UpdateFlags = [NSNumber numberWithUnsignedChar:15];
     payload.Action = [NSNumber numberWithUnsignedChar:0];
     payload.Direction = [NSNumber numberWithUnsignedChar:0];
-    payload.Time = [NSNumber numberWithUnsignedShort:30];
-    payload.StartHue = [NSNumber numberWithUnsignedShort:160];
+    payload.Time = [NSNumber numberWithUnsignedShort:30U];
+    payload.StartHue = [NSNumber numberWithUnsignedShort:160U];
     payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
     payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster colorLoopSet:payload
@@ -8003,8 +8049,8 @@ CHIPDevice * GetConnectedDevice()
     payload.UpdateFlags = [NSNumber numberWithUnsignedChar:1];
     payload.Action = [NSNumber numberWithUnsignedChar:1];
     payload.Direction = [NSNumber numberWithUnsignedChar:0];
-    payload.Time = [NSNumber numberWithUnsignedShort:0];
-    payload.StartHue = [NSNumber numberWithUnsignedShort:0];
+    payload.Time = [NSNumber numberWithUnsignedShort:0U];
+    payload.StartHue = [NSNumber numberWithUnsignedShort:0U];
     payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
     payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster colorLoopSet:payload
@@ -8055,8 +8101,8 @@ CHIPDevice * GetConnectedDevice()
     payload.UpdateFlags = [NSNumber numberWithUnsignedChar:2];
     payload.Action = [NSNumber numberWithUnsignedChar:0];
     payload.Direction = [NSNumber numberWithUnsignedChar:1];
-    payload.Time = [NSNumber numberWithUnsignedShort:0];
-    payload.StartHue = [NSNumber numberWithUnsignedShort:0];
+    payload.Time = [NSNumber numberWithUnsignedShort:0U];
+    payload.StartHue = [NSNumber numberWithUnsignedShort:0U];
     payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
     payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster colorLoopSet:payload
@@ -8107,8 +8153,8 @@ CHIPDevice * GetConnectedDevice()
     payload.UpdateFlags = [NSNumber numberWithUnsignedChar:1];
     payload.Action = [NSNumber numberWithUnsignedChar:0];
     payload.Direction = [NSNumber numberWithUnsignedChar:0];
-    payload.Time = [NSNumber numberWithUnsignedShort:0];
-    payload.StartHue = [NSNumber numberWithUnsignedShort:0];
+    payload.Time = [NSNumber numberWithUnsignedShort:0U];
+    payload.StartHue = [NSNumber numberWithUnsignedShort:0U];
     payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
     payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster colorLoopSet:payload
@@ -8227,8 +8273,8 @@ CHIPDevice * GetConnectedDevice()
     payload.UpdateFlags = [NSNumber numberWithUnsignedChar:15];
     payload.Action = [NSNumber numberWithUnsignedChar:0];
     payload.Direction = [NSNumber numberWithUnsignedChar:0];
-    payload.Time = [NSNumber numberWithUnsignedShort:30];
-    payload.StartHue = [NSNumber numberWithUnsignedShort:160];
+    payload.Time = [NSNumber numberWithUnsignedShort:30U];
+    payload.StartHue = [NSNumber numberWithUnsignedShort:160U];
     payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
     payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster colorLoopSet:payload
@@ -8351,8 +8397,8 @@ CHIPDevice * GetConnectedDevice()
     payload.UpdateFlags = [NSNumber numberWithUnsignedChar:1];
     payload.Action = [NSNumber numberWithUnsignedChar:1];
     payload.Direction = [NSNumber numberWithUnsignedChar:0];
-    payload.Time = [NSNumber numberWithUnsignedShort:0];
-    payload.StartHue = [NSNumber numberWithUnsignedShort:0];
+    payload.Time = [NSNumber numberWithUnsignedShort:0U];
+    payload.StartHue = [NSNumber numberWithUnsignedShort:0U];
     payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
     payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster colorLoopSet:payload
@@ -8403,8 +8449,8 @@ CHIPDevice * GetConnectedDevice()
     payload.UpdateFlags = [NSNumber numberWithUnsignedChar:4];
     payload.Action = [NSNumber numberWithUnsignedChar:0];
     payload.Direction = [NSNumber numberWithUnsignedChar:0];
-    payload.Time = [NSNumber numberWithUnsignedShort:60];
-    payload.StartHue = [NSNumber numberWithUnsignedShort:0];
+    payload.Time = [NSNumber numberWithUnsignedShort:60U];
+    payload.StartHue = [NSNumber numberWithUnsignedShort:0U];
     payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
     payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster colorLoopSet:payload
@@ -8455,8 +8501,8 @@ CHIPDevice * GetConnectedDevice()
     payload.UpdateFlags = [NSNumber numberWithUnsignedChar:1];
     payload.Action = [NSNumber numberWithUnsignedChar:0];
     payload.Direction = [NSNumber numberWithUnsignedChar:0];
-    payload.Time = [NSNumber numberWithUnsignedShort:0];
-    payload.StartHue = [NSNumber numberWithUnsignedShort:0];
+    payload.Time = [NSNumber numberWithUnsignedShort:0U];
+    payload.StartHue = [NSNumber numberWithUnsignedShort:0U];
     payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
     payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster colorLoopSet:payload
@@ -8953,7 +8999,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestElectricalMeasurement * cluster = [[CHIPTestElectricalMeasurement alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint16_t clusterRevisionArgument = 1U;
+    id clusterRevisionArgument;
+    clusterRevisionArgument = [NSNumber numberWithUnsignedShort:1U];
     [cluster
         writeAttributeClusterRevisionWithValue:clusterRevisionArgument
                                responseHandler:^(NSError * err, NSDictionary * values) {
@@ -9000,7 +9047,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestFlowMeasurement * cluster = [[CHIPTestFlowMeasurement alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint16_t clusterRevisionArgument = 2U;
+    id clusterRevisionArgument;
+    clusterRevisionArgument = [NSNumber numberWithUnsignedShort:2U];
     [cluster
         writeAttributeClusterRevisionWithValue:clusterRevisionArgument
                                responseHandler:^(NSError * err, NSDictionary * values) {
@@ -9080,7 +9128,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestFlowMeasurement * cluster = [[CHIPTestFlowMeasurement alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    int16_t minMeasuredValueArgument = 0;
+    id minMeasuredValueArgument;
+    minMeasuredValueArgument = [NSNumber numberWithShort:0];
     [cluster writeAttributeMinMeasuredValueWithValue:minMeasuredValueArgument
                                      responseHandler:^(NSError * err, NSDictionary * values) {
                                          NSLog(@"write the default value to optional attribute: MinMeasuredValue Error: %@", err);
@@ -9101,7 +9150,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestFlowMeasurement * cluster = [[CHIPTestFlowMeasurement alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    int16_t maxMeasuredValueArgument = 0;
+    id maxMeasuredValueArgument;
+    maxMeasuredValueArgument = [NSNumber numberWithShort:0];
     [cluster writeAttributeMaxMeasuredValueWithValue:maxMeasuredValueArgument
                                      responseHandler:^(NSError * err, NSDictionary * values) {
                                          NSLog(@"write the default value to optional attribute: MaxMeasuredValue Error: %@", err);
@@ -9247,7 +9297,8 @@ CHIPDevice * GetConnectedDevice()
                                                                                                 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint16_t clusterRevisionArgument = 1U;
+    id clusterRevisionArgument;
+    clusterRevisionArgument = [NSNumber numberWithUnsignedShort:1U];
     [cluster
         writeAttributeClusterRevisionWithValue:clusterRevisionArgument
                                responseHandler:^(NSError * err, NSDictionary * values) {
@@ -9296,7 +9347,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestLevelControl * cluster = [[CHIPTestLevelControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint16_t clusterRevisionArgument = 4U;
+    id clusterRevisionArgument;
+    clusterRevisionArgument = [NSNumber numberWithUnsignedShort:4U];
     [cluster
         writeAttributeClusterRevisionWithValue:clusterRevisionArgument
                                responseHandler:^(NSError * err, NSDictionary * values) {
@@ -9344,7 +9396,7 @@ CHIPDevice * GetConnectedDevice()
 
     __auto_type * payload = [[CHIPLevelControlClusterMoveToLevelPayload alloc] init];
     payload.Level = [NSNumber numberWithUnsignedChar:64];
-    payload.TransitionTime = [NSNumber numberWithUnsignedShort:0];
+    payload.TransitionTime = [NSNumber numberWithUnsignedShort:0U];
     payload.OptionMask = [NSNumber numberWithUnsignedChar:1];
     payload.OptionOverride = [NSNumber numberWithUnsignedChar:1];
     [cluster moveToLevel:payload
@@ -9401,7 +9453,7 @@ CHIPDevice * GetConnectedDevice()
 
     __auto_type * payload = [[CHIPLevelControlClusterMoveToLevelPayload alloc] init];
     payload.Level = [NSNumber numberWithUnsignedChar:128];
-    payload.TransitionTime = [NSNumber numberWithUnsignedShort:1];
+    payload.TransitionTime = [NSNumber numberWithUnsignedShort:1U];
     payload.OptionMask = [NSNumber numberWithUnsignedChar:1];
     payload.OptionOverride = [NSNumber numberWithUnsignedChar:1];
     [cluster moveToLevel:payload
@@ -9482,7 +9534,7 @@ CHIPDevice * GetConnectedDevice()
 
     __auto_type * payload = [[CHIPLevelControlClusterMoveToLevelPayload alloc] init];
     payload.Level = [NSNumber numberWithUnsignedChar:254];
-    payload.TransitionTime = [NSNumber numberWithUnsignedShort:65535];
+    payload.TransitionTime = [NSNumber numberWithUnsignedShort:65535U];
     payload.OptionMask = [NSNumber numberWithUnsignedChar:1];
     payload.OptionOverride = [NSNumber numberWithUnsignedChar:1];
     [cluster moveToLevel:payload
@@ -9539,7 +9591,7 @@ CHIPDevice * GetConnectedDevice()
 
     __auto_type * payload = [[CHIPLevelControlClusterMoveToLevelPayload alloc] init];
     payload.Level = [NSNumber numberWithUnsignedChar:0];
-    payload.TransitionTime = [NSNumber numberWithUnsignedShort:0];
+    payload.TransitionTime = [NSNumber numberWithUnsignedShort:0U];
     payload.OptionMask = [NSNumber numberWithUnsignedChar:1];
     payload.OptionOverride = [NSNumber numberWithUnsignedChar:1];
     [cluster moveToLevel:payload
@@ -9757,7 +9809,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestLevelControl * cluster = [[CHIPTestLevelControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint8_t defaultMoveRateArgument = 20;
+    id defaultMoveRateArgument;
+    defaultMoveRateArgument = [NSNumber numberWithUnsignedChar:20];
     [cluster writeAttributeDefaultMoveRateWithValue:defaultMoveRateArgument
                                     responseHandler:^(NSError * err, NSDictionary * values) {
                                         NSLog(@"Write default move rate attribute from DUT Error: %@", err);
@@ -9881,7 +9934,7 @@ CHIPDevice * GetConnectedDevice()
     __auto_type * payload = [[CHIPLevelControlClusterStepPayload alloc] init];
     payload.StepMode = [NSNumber numberWithUnsignedChar:0];
     payload.StepSize = [NSNumber numberWithUnsignedChar:128];
-    payload.TransitionTime = [NSNumber numberWithUnsignedShort:20];
+    payload.TransitionTime = [NSNumber numberWithUnsignedShort:20U];
     payload.OptionMask = [NSNumber numberWithUnsignedChar:0];
     payload.OptionOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster step:payload
@@ -9939,7 +9992,7 @@ CHIPDevice * GetConnectedDevice()
     __auto_type * payload = [[CHIPLevelControlClusterStepPayload alloc] init];
     payload.StepMode = [NSNumber numberWithUnsignedChar:1];
     payload.StepSize = [NSNumber numberWithUnsignedChar:64];
-    payload.TransitionTime = [NSNumber numberWithUnsignedShort:20];
+    payload.TransitionTime = [NSNumber numberWithUnsignedShort:20U];
     payload.OptionMask = [NSNumber numberWithUnsignedChar:0];
     payload.OptionOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster step:payload
@@ -9997,7 +10050,7 @@ CHIPDevice * GetConnectedDevice()
     __auto_type * payload = [[CHIPLevelControlClusterStepPayload alloc] init];
     payload.StepMode = [NSNumber numberWithUnsignedChar:0];
     payload.StepSize = [NSNumber numberWithUnsignedChar:64];
-    payload.TransitionTime = [NSNumber numberWithUnsignedShort:20];
+    payload.TransitionTime = [NSNumber numberWithUnsignedShort:20U];
     payload.OptionMask = [NSNumber numberWithUnsignedChar:0];
     payload.OptionOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster step:payload
@@ -10098,7 +10151,7 @@ CHIPDevice * GetConnectedDevice()
     __auto_type * payload = [[CHIPLevelControlClusterStepPayload alloc] init];
     payload.StepMode = [NSNumber numberWithUnsignedChar:0];
     payload.StepSize = [NSNumber numberWithUnsignedChar:128];
-    payload.TransitionTime = [NSNumber numberWithUnsignedShort:20];
+    payload.TransitionTime = [NSNumber numberWithUnsignedShort:20U];
     payload.OptionMask = [NSNumber numberWithUnsignedChar:0];
     payload.OptionOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster step:payload
@@ -10210,7 +10263,8 @@ CHIPDevice * GetConnectedDevice()
                                                                                                           queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint16_t clusterRevisionArgument = 1U;
+    id clusterRevisionArgument;
+    clusterRevisionArgument = [NSNumber numberWithUnsignedShort:1U];
     [cluster
         writeAttributeClusterRevisionWithValue:clusterRevisionArgument
                                responseHandler:^(NSError * err, NSDictionary * values) {
@@ -10279,7 +10333,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestOccupancySensing * cluster = [[CHIPTestOccupancySensing alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint16_t clusterRevisionArgument = 2U;
+    id clusterRevisionArgument;
+    clusterRevisionArgument = [NSNumber numberWithUnsignedShort:2U];
     [cluster
         writeAttributeClusterRevisionWithValue:clusterRevisionArgument
                                responseHandler:^(NSError * err, NSDictionary * values) {
@@ -10323,7 +10378,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestOccupancySensing * cluster = [[CHIPTestOccupancySensing alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint8_t occupancyArgument = 0;
+    id occupancyArgument;
+    occupancyArgument = [NSNumber numberWithUnsignedChar:0];
     [cluster writeAttributeOccupancyWithValue:occupancyArgument
                               responseHandler:^(NSError * err, NSDictionary * values) {
                                   NSLog(@"Writes the respective default value to mandatory attribute: Occupancy Error: %@", err);
@@ -10390,7 +10446,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestOccupancySensing * cluster = [[CHIPTestOccupancySensing alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint8_t occupancySensorTypeArgument = 0;
+    id occupancySensorTypeArgument;
+    occupancySensorTypeArgument = [NSNumber numberWithUnsignedChar:0];
     [cluster writeAttributeOccupancySensorTypeWithValue:occupancySensorTypeArgument
                                         responseHandler:^(NSError * err, NSDictionary * values) {
                                             NSLog(@"Writes the respective default value to mandatory attribute: "
@@ -10460,7 +10517,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestOccupancySensing * cluster = [[CHIPTestOccupancySensing alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint8_t occupancySensorTypeBitmapArgument = 1;
+    id occupancySensorTypeBitmapArgument;
+    occupancySensorTypeBitmapArgument = [NSNumber numberWithUnsignedChar:1];
     [cluster writeAttributeOccupancySensorTypeBitmapWithValue:occupancySensorTypeBitmapArgument
                                               responseHandler:^(NSError * err, NSDictionary * values) {
                                                   NSLog(@"Writes the respective default value to mandatory attribute: "
@@ -10572,7 +10630,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint16_t clusterRevisionArgument = 3U;
+    id clusterRevisionArgument;
+    clusterRevisionArgument = [NSNumber numberWithUnsignedShort:3U];
     [cluster
         writeAttributeClusterRevisionWithValue:clusterRevisionArgument
                                responseHandler:^(NSError * err, NSDictionary * values) {
@@ -10642,7 +10701,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint32_t featureMapArgument = 0UL;
+    id featureMapArgument;
+    featureMapArgument = [NSNumber numberWithUnsignedInt:0UL];
     [cluster writeAttributeFeatureMapWithValue:featureMapArgument
                                responseHandler:^(NSError * err, NSDictionary * values) {
                                    NSLog(@"write the default values to optional global attribute: FeatureMap Error: %@", err);
@@ -10831,7 +10891,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint16_t onTimeArgument = 0U;
+    id onTimeArgument;
+    onTimeArgument = [NSNumber numberWithUnsignedShort:0U];
     [cluster writeAttributeOnTimeWithValue:onTimeArgument
                            responseHandler:^(NSError * err, NSDictionary * values) {
                                NSLog(@"write the default value to LT attribute: OnTime Error: %@", err);
@@ -10852,7 +10913,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint16_t offWaitTimeArgument = 0U;
+    id offWaitTimeArgument;
+    offWaitTimeArgument = [NSNumber numberWithUnsignedShort:0U];
     [cluster writeAttributeOffWaitTimeWithValue:offWaitTimeArgument
                                 responseHandler:^(NSError * err, NSDictionary * values) {
                                     NSLog(@"write the default value to LT attribute: OffWaitTime Error: %@", err);
@@ -10873,7 +10935,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint8_t startUpOnOffArgument = 0;
+    id startUpOnOffArgument;
+    startUpOnOffArgument = [NSNumber numberWithUnsignedChar:0];
     [cluster writeAttributeStartUpOnOffWithValue:startUpOnOffArgument
                                  responseHandler:^(NSError * err, NSDictionary * values) {
                                      NSLog(@"write the default value to LT attribute: StartUpOnOff Error: %@", err);
@@ -12356,7 +12419,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestPressureMeasurement * cluster = [[CHIPTestPressureMeasurement alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint16_t clusterRevisionArgument = 2U;
+    id clusterRevisionArgument;
+    clusterRevisionArgument = [NSNumber numberWithUnsignedShort:2U];
     [cluster
         writeAttributeClusterRevisionWithValue:clusterRevisionArgument
                                responseHandler:^(NSError * err, NSDictionary * values) {
@@ -12422,7 +12486,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestPressureMeasurement * cluster = [[CHIPTestPressureMeasurement alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    int16_t measuredValueArgument = 0;
+    id measuredValueArgument;
+    measuredValueArgument = [NSNumber numberWithShort:0];
     [cluster writeAttributeMeasuredValueWithValue:measuredValueArgument
                                   responseHandler:^(NSError * err, NSDictionary * values) {
                                       NSLog(@"Write the default values to mandatory attribute: MeasuredValue Error: %@", err);
@@ -12487,7 +12552,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestPressureMeasurement * cluster = [[CHIPTestPressureMeasurement alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    int16_t minMeasuredValueArgument = 0;
+    id minMeasuredValueArgument;
+    minMeasuredValueArgument = [NSNumber numberWithShort:0];
     [cluster writeAttributeMinMeasuredValueWithValue:minMeasuredValueArgument
                                      responseHandler:^(NSError * err, NSDictionary * values) {
                                          NSLog(@"Write the default values to mandatory attribute: MinMeasuredValue Error: %@", err);
@@ -12552,7 +12618,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestPressureMeasurement * cluster = [[CHIPTestPressureMeasurement alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    int16_t maxMeasuredValueArgument = 0;
+    id maxMeasuredValueArgument;
+    maxMeasuredValueArgument = [NSNumber numberWithShort:0];
     [cluster writeAttributeMaxMeasuredValueWithValue:maxMeasuredValueArgument
                                      responseHandler:^(NSError * err, NSDictionary * values) {
                                          NSLog(@"Write the default values to mandatory attribute: MaxMeasuredValue Error: %@", err);
@@ -12600,7 +12667,8 @@ CHIPDevice * GetConnectedDevice()
                                                                                                           queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint16_t clusterRevisionArgument = 3U;
+    id clusterRevisionArgument;
+    clusterRevisionArgument = [NSNumber numberWithUnsignedShort:3U];
     [cluster
         writeAttributeClusterRevisionWithValue:clusterRevisionArgument
                                responseHandler:^(NSError * err, NSDictionary * values) {
@@ -12794,7 +12862,8 @@ CHIPDevice * GetConnectedDevice()
                                                                                                           queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint8_t operationModeArgument = 1;
+    id operationModeArgument;
+    operationModeArgument = [NSNumber numberWithUnsignedChar:1];
     [cluster writeAttributeOperationModeWithValue:operationModeArgument
                                   responseHandler:^(NSError * err, NSDictionary * values) {
                                       NSLog(@"Write 1 to the OperationMode attribute to DUT: OperationMode Error: %@", err);
@@ -12818,7 +12887,8 @@ CHIPDevice * GetConnectedDevice()
                                                                                                           queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint8_t operationModeArgument = 2;
+    id operationModeArgument;
+    operationModeArgument = [NSNumber numberWithUnsignedChar:2];
     [cluster writeAttributeOperationModeWithValue:operationModeArgument
                                   responseHandler:^(NSError * err, NSDictionary * values) {
                                       NSLog(@"Write 2 to the OperationMode attribute to DUT: OperationMode Error: %@", err);
@@ -12842,7 +12912,8 @@ CHIPDevice * GetConnectedDevice()
                                                                                                           queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint8_t operationModeArgument = 3;
+    id operationModeArgument;
+    operationModeArgument = [NSNumber numberWithUnsignedChar:3];
     [cluster writeAttributeOperationModeWithValue:operationModeArgument
                                   responseHandler:^(NSError * err, NSDictionary * values) {
                                       NSLog(@"Write 3 to the OperationMode attribute to DUT: OperationMode Error: %@", err);
@@ -12866,7 +12937,8 @@ CHIPDevice * GetConnectedDevice()
                                                                                                           queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint8_t operationModeArgument = 0;
+    id operationModeArgument;
+    operationModeArgument = [NSNumber numberWithUnsignedChar:0];
     [cluster writeAttributeOperationModeWithValue:operationModeArgument
                                   responseHandler:^(NSError * err, NSDictionary * values) {
                                       NSLog(@"Write 0 to the OperationMode attribute to DUT Error: %@", err);
@@ -12917,7 +12989,8 @@ CHIPDevice * GetConnectedDevice()
                                                                                                           queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint16_t clusterRevisionArgument = 1U;
+    id clusterRevisionArgument;
+    clusterRevisionArgument = [NSNumber numberWithUnsignedShort:1U];
     [cluster
         writeAttributeClusterRevisionWithValue:clusterRevisionArgument
                                responseHandler:^(NSError * err, NSDictionary * values) {
@@ -13056,7 +13129,8 @@ CHIPDevice * GetConnectedDevice()
                                                                                                 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint16_t clusterRevisionArgument = 3U;
+    id clusterRevisionArgument;
+    clusterRevisionArgument = [NSNumber numberWithUnsignedShort:3U];
     [cluster
         writeAttributeClusterRevisionWithValue:clusterRevisionArgument
                                responseHandler:^(NSError * err, NSDictionary * values) {
@@ -13170,7 +13244,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestThermostat * cluster = [[CHIPTestThermostat alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint16_t clusterRevisionArgument = 5U;
+    id clusterRevisionArgument;
+    clusterRevisionArgument = [NSNumber numberWithUnsignedShort:5U];
     [cluster
         writeAttributeClusterRevisionWithValue:clusterRevisionArgument
                                responseHandler:^(NSError * err, NSDictionary * values) {
@@ -13261,7 +13336,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestThermostat * cluster = [[CHIPTestThermostat alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    int16_t absMinHeatSetpointLimitArgument = 700;
+    id absMinHeatSetpointLimitArgument;
+    absMinHeatSetpointLimitArgument = [NSNumber numberWithShort:700];
     [cluster writeAttributeAbsMinHeatSetpointLimitWithValue:absMinHeatSetpointLimitArgument
                                             responseHandler:^(NSError * err, NSDictionary * values) {
                                                 NSLog(@"Writes the respective default value to mandatory attributes to DUT: "
@@ -13357,7 +13433,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestThermostat * cluster = [[CHIPTestThermostat alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    int16_t absMaxHeatSetpointLimitArgument = 3000;
+    id absMaxHeatSetpointLimitArgument;
+    absMaxHeatSetpointLimitArgument = [NSNumber numberWithShort:3000];
     [cluster writeAttributeAbsMaxHeatSetpointLimitWithValue:absMaxHeatSetpointLimitArgument
                                             responseHandler:^(NSError * err, NSDictionary * values) {
                                                 NSLog(@"Writes the respective default value to mandatory attributes to DUT: "
@@ -13453,7 +13530,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestThermostat * cluster = [[CHIPTestThermostat alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    int16_t absMinCoolSetpointLimitArgument = 1600;
+    id absMinCoolSetpointLimitArgument;
+    absMinCoolSetpointLimitArgument = [NSNumber numberWithShort:1600];
     [cluster writeAttributeAbsMinCoolSetpointLimitWithValue:absMinCoolSetpointLimitArgument
                                             responseHandler:^(NSError * err, NSDictionary * values) {
                                                 NSLog(@"Writes the respective default value to mandatory attributes to DUT: "
@@ -13549,7 +13627,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestThermostat * cluster = [[CHIPTestThermostat alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    int16_t absMaxCoolSetpointLimitArgument = 3200;
+    id absMaxCoolSetpointLimitArgument;
+    absMaxCoolSetpointLimitArgument = [NSNumber numberWithShort:3200];
     [cluster writeAttributeAbsMaxCoolSetpointLimitWithValue:absMaxCoolSetpointLimitArgument
                                             responseHandler:^(NSError * err, NSDictionary * values) {
                                                 NSLog(@"Writes the respective default value to mandatory attributes to DUT: "
@@ -13645,7 +13724,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestThermostat * cluster = [[CHIPTestThermostat alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    int16_t occupiedCoolingSetpointArgument = 2600;
+    id occupiedCoolingSetpointArgument;
+    occupiedCoolingSetpointArgument = [NSNumber numberWithShort:2600];
     [cluster writeAttributeOccupiedCoolingSetpointWithValue:occupiedCoolingSetpointArgument
                                             responseHandler:^(NSError * err, NSDictionary * values) {
                                                 NSLog(@"Writes the respective default value to mandatory attributes to DUT: "
@@ -13742,7 +13822,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestThermostat * cluster = [[CHIPTestThermostat alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    int16_t occupiedHeatingSetpointArgument = 2000;
+    id occupiedHeatingSetpointArgument;
+    occupiedHeatingSetpointArgument = [NSNumber numberWithShort:2000];
     [cluster writeAttributeOccupiedHeatingSetpointWithValue:occupiedHeatingSetpointArgument
                                             responseHandler:^(NSError * err, NSDictionary * values) {
                                                 NSLog(@"Writes the respective default value to mandatory attributes to DUT: "
@@ -13839,7 +13920,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestThermostat * cluster = [[CHIPTestThermostat alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    int16_t minHeatSetpointLimitArgument = 700;
+    id minHeatSetpointLimitArgument;
+    minHeatSetpointLimitArgument = [NSNumber numberWithShort:700];
     [cluster writeAttributeMinHeatSetpointLimitWithValue:minHeatSetpointLimitArgument
                                          responseHandler:^(NSError * err, NSDictionary * values) {
                                              NSLog(@"Writes the respective default value to mandatory attributes to DUT: "
@@ -13936,7 +14018,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestThermostat * cluster = [[CHIPTestThermostat alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    int16_t maxHeatSetpointLimitArgument = 3000;
+    id maxHeatSetpointLimitArgument;
+    maxHeatSetpointLimitArgument = [NSNumber numberWithShort:3000];
     [cluster writeAttributeMaxHeatSetpointLimitWithValue:maxHeatSetpointLimitArgument
                                          responseHandler:^(NSError * err, NSDictionary * values) {
                                              NSLog(@"Writes the respective default value to mandatory attributes to DUT: "
@@ -14033,7 +14116,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestThermostat * cluster = [[CHIPTestThermostat alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    int16_t minCoolSetpointLimitArgument = 1600;
+    id minCoolSetpointLimitArgument;
+    minCoolSetpointLimitArgument = [NSNumber numberWithShort:1600];
     [cluster writeAttributeMinCoolSetpointLimitWithValue:minCoolSetpointLimitArgument
                                          responseHandler:^(NSError * err, NSDictionary * values) {
                                              NSLog(@"Writes the respective default value to mandatory attributes to DUT: "
@@ -14130,7 +14214,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestThermostat * cluster = [[CHIPTestThermostat alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    int16_t maxCoolSetpointLimitArgument = 3200;
+    id maxCoolSetpointLimitArgument;
+    maxCoolSetpointLimitArgument = [NSNumber numberWithShort:3200];
     [cluster writeAttributeMaxCoolSetpointLimitWithValue:maxCoolSetpointLimitArgument
                                          responseHandler:^(NSError * err, NSDictionary * values) {
                                              NSLog(@"Writes the respective default value to mandatory attributes to DUT: "
@@ -14227,7 +14312,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestThermostat * cluster = [[CHIPTestThermostat alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint8_t controlSequenceOfOperationArgument = 4;
+    id controlSequenceOfOperationArgument;
+    controlSequenceOfOperationArgument = [NSNumber numberWithUnsignedChar:4];
     [cluster writeAttributeControlSequenceOfOperationWithValue:controlSequenceOfOperationArgument
                                                responseHandler:^(NSError * err, NSDictionary * values) {
                                                    NSLog(@"Writes the respective default value to mandatory attributes to DUT: "
@@ -14322,7 +14408,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestThermostat * cluster = [[CHIPTestThermostat alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint8_t systemModeArgument = 1;
+    id systemModeArgument;
+    systemModeArgument = [NSNumber numberWithUnsignedChar:1];
     [cluster
         writeAttributeSystemModeWithValue:systemModeArgument
                           responseHandler:^(NSError * err, NSDictionary * values) {
@@ -14416,7 +14503,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestThermostat * cluster = [[CHIPTestThermostat alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    int8_t minSetpointDeadBandArgument = 25;
+    id minSetpointDeadBandArgument;
+    minSetpointDeadBandArgument = [NSNumber numberWithChar:25];
     [cluster writeAttributeMinSetpointDeadBandWithValue:minSetpointDeadBandArgument
                                         responseHandler:^(NSError * err, NSDictionary * values) {
                                             NSLog(@"Writes the respective default value to optional attributes to DUT: "
@@ -14487,7 +14575,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestThermostat * cluster = [[CHIPTestThermostat alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint8_t startOfWeekArgument = 0;
+    id startOfWeekArgument;
+    startOfWeekArgument = [NSNumber numberWithUnsignedChar:0];
     [cluster
         writeAttributeStartOfWeekWithValue:startOfWeekArgument
                            responseHandler:^(NSError * err, NSDictionary * values) {
@@ -14554,7 +14643,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestThermostat * cluster = [[CHIPTestThermostat alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint8_t numberOfWeeklyTransitionsArgument = 0;
+    id numberOfWeeklyTransitionsArgument;
+    numberOfWeeklyTransitionsArgument = [NSNumber numberWithUnsignedChar:0];
     [cluster writeAttributeNumberOfWeeklyTransitionsWithValue:numberOfWeeklyTransitionsArgument
                                               responseHandler:^(NSError * err, NSDictionary * values) {
                                                   NSLog(@"Writes the respective default value to optional attributes to DUT: "
@@ -14597,7 +14687,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestThermostat * cluster = [[CHIPTestThermostat alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint8_t numberOfDailyTransitionsArgument = 0;
+    id numberOfDailyTransitionsArgument;
+    numberOfDailyTransitionsArgument = [NSNumber numberWithUnsignedChar:0];
     [cluster writeAttributeNumberOfDailyTransitionsWithValue:numberOfDailyTransitionsArgument
                                              responseHandler:^(NSError * err, NSDictionary * values) {
                                                  NSLog(@"Writes the respective default value to optional attributes to DUT: "
@@ -14622,7 +14713,8 @@ CHIPDevice * GetConnectedDevice()
         [[CHIPTestThermostatUserInterfaceConfiguration alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint16_t clusterRevisionArgument = 2U;
+    id clusterRevisionArgument;
+    clusterRevisionArgument = [NSNumber numberWithUnsignedShort:2U];
     [cluster
         writeAttributeClusterRevisionWithValue:clusterRevisionArgument
                                responseHandler:^(NSError * err, NSDictionary * values) {
@@ -14690,7 +14782,8 @@ CHIPDevice * GetConnectedDevice()
         [[CHIPTestThermostatUserInterfaceConfiguration alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint8_t temperatureDisplayModeArgument = 0;
+    id temperatureDisplayModeArgument;
+    temperatureDisplayModeArgument = [NSNumber numberWithUnsignedChar:0];
     [cluster writeAttributeTemperatureDisplayModeWithValue:temperatureDisplayModeArgument
                                            responseHandler:^(NSError * err, NSDictionary * values) {
                                                NSLog(@"write to the mandatory attribute: TemperatureDisplayMode Error: %@", err);
@@ -14802,7 +14895,8 @@ CHIPDevice * GetConnectedDevice()
         [[CHIPTestThermostatUserInterfaceConfiguration alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint8_t keypadLockoutArgument = 0;
+    id keypadLockoutArgument;
+    keypadLockoutArgument = [NSNumber numberWithUnsignedChar:0];
     [cluster writeAttributeKeypadLockoutWithValue:keypadLockoutArgument
                                   responseHandler:^(NSError * err, NSDictionary * values) {
                                       NSLog(@"write to the mandatory attribute: KeypadLockout Error: %@", err);
@@ -14917,7 +15011,8 @@ CHIPDevice * GetConnectedDevice()
         [[CHIPTestThermostatUserInterfaceConfiguration alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint8_t scheduleProgrammingVisibilityArgument = 0;
+    id scheduleProgrammingVisibilityArgument;
+    scheduleProgrammingVisibilityArgument = [NSNumber numberWithUnsignedChar:0];
     [cluster
         writeAttributeScheduleProgrammingVisibilityWithValue:scheduleProgrammingVisibilityArgument
                                              responseHandler:^(NSError * err, NSDictionary * values) {
@@ -14990,7 +15085,8 @@ CHIPDevice * GetConnectedDevice()
         [[CHIPTestThermostatUserInterfaceConfiguration alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint8_t temperatureDisplayModeArgument = 0;
+    id temperatureDisplayModeArgument;
+    temperatureDisplayModeArgument = [NSNumber numberWithUnsignedChar:0];
     [cluster
         writeAttributeTemperatureDisplayModeWithValue:temperatureDisplayModeArgument
                                       responseHandler:^(NSError * err, NSDictionary * values) {
@@ -15014,7 +15110,8 @@ CHIPDevice * GetConnectedDevice()
         [[CHIPTestThermostatUserInterfaceConfiguration alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint8_t temperatureDisplayModeArgument = 1;
+    id temperatureDisplayModeArgument;
+    temperatureDisplayModeArgument = [NSNumber numberWithUnsignedChar:1];
     [cluster
         writeAttributeTemperatureDisplayModeWithValue:temperatureDisplayModeArgument
                                       responseHandler:^(NSError * err, NSDictionary * values) {
@@ -15037,7 +15134,8 @@ CHIPDevice * GetConnectedDevice()
         [[CHIPTestThermostatUserInterfaceConfiguration alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint8_t keypadLockoutArgument = 0;
+    id keypadLockoutArgument;
+    keypadLockoutArgument = [NSNumber numberWithUnsignedChar:0];
     [cluster writeAttributeKeypadLockoutWithValue:keypadLockoutArgument
                                   responseHandler:^(NSError * err, NSDictionary * values) {
                                       NSLog(@"Writes a value of 0 to KeypadLockout attribute of DUT Error: %@", err);
@@ -15059,7 +15157,8 @@ CHIPDevice * GetConnectedDevice()
         [[CHIPTestThermostatUserInterfaceConfiguration alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint8_t keypadLockoutArgument = 1;
+    id keypadLockoutArgument;
+    keypadLockoutArgument = [NSNumber numberWithUnsignedChar:1];
     [cluster writeAttributeKeypadLockoutWithValue:keypadLockoutArgument
                                   responseHandler:^(NSError * err, NSDictionary * values) {
                                       NSLog(@"Writes a value of 1 to KeypadLockout attribute of DUT Error: %@", err);
@@ -15081,7 +15180,8 @@ CHIPDevice * GetConnectedDevice()
         [[CHIPTestThermostatUserInterfaceConfiguration alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint8_t keypadLockoutArgument = 2;
+    id keypadLockoutArgument;
+    keypadLockoutArgument = [NSNumber numberWithUnsignedChar:2];
     [cluster writeAttributeKeypadLockoutWithValue:keypadLockoutArgument
                                   responseHandler:^(NSError * err, NSDictionary * values) {
                                       NSLog(@"Writes a value of 2 to KeypadLockout attribute of DUT Error: %@", err);
@@ -15103,7 +15203,8 @@ CHIPDevice * GetConnectedDevice()
         [[CHIPTestThermostatUserInterfaceConfiguration alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint8_t keypadLockoutArgument = 3;
+    id keypadLockoutArgument;
+    keypadLockoutArgument = [NSNumber numberWithUnsignedChar:3];
     [cluster writeAttributeKeypadLockoutWithValue:keypadLockoutArgument
                                   responseHandler:^(NSError * err, NSDictionary * values) {
                                       NSLog(@"Writes a value of 3 to KeypadLockout attribute of DUT Error: %@", err);
@@ -15125,7 +15226,8 @@ CHIPDevice * GetConnectedDevice()
         [[CHIPTestThermostatUserInterfaceConfiguration alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint8_t keypadLockoutArgument = 4;
+    id keypadLockoutArgument;
+    keypadLockoutArgument = [NSNumber numberWithUnsignedChar:4];
     [cluster writeAttributeKeypadLockoutWithValue:keypadLockoutArgument
                                   responseHandler:^(NSError * err, NSDictionary * values) {
                                       NSLog(@"Writes a value of 4 to KeypadLockout attribute of DUT Error: %@", err);
@@ -15147,7 +15249,8 @@ CHIPDevice * GetConnectedDevice()
         [[CHIPTestThermostatUserInterfaceConfiguration alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint8_t keypadLockoutArgument = 5;
+    id keypadLockoutArgument;
+    keypadLockoutArgument = [NSNumber numberWithUnsignedChar:5];
     [cluster writeAttributeKeypadLockoutWithValue:keypadLockoutArgument
                                   responseHandler:^(NSError * err, NSDictionary * values) {
                                       NSLog(@"Writes a value of 5 to KeypadLockout attribute of DUT Error: %@", err);
@@ -15170,7 +15273,8 @@ CHIPDevice * GetConnectedDevice()
         [[CHIPTestThermostatUserInterfaceConfiguration alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint8_t scheduleProgrammingVisibilityArgument = 0;
+    id scheduleProgrammingVisibilityArgument;
+    scheduleProgrammingVisibilityArgument = [NSNumber numberWithUnsignedChar:0];
     [cluster writeAttributeScheduleProgrammingVisibilityWithValue:scheduleProgrammingVisibilityArgument
                                                   responseHandler:^(NSError * err, NSDictionary * values) {
                                                       NSLog(@"Writes a value of 0 to ScheduleProgrammingVisibility attribute of "
@@ -15195,7 +15299,8 @@ CHIPDevice * GetConnectedDevice()
         [[CHIPTestThermostatUserInterfaceConfiguration alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint8_t scheduleProgrammingVisibilityArgument = 1;
+    id scheduleProgrammingVisibilityArgument;
+    scheduleProgrammingVisibilityArgument = [NSNumber numberWithUnsignedChar:1];
     [cluster writeAttributeScheduleProgrammingVisibilityWithValue:scheduleProgrammingVisibilityArgument
                                                   responseHandler:^(NSError * err, NSDictionary * values) {
                                                       NSLog(@"Writes a value of 1 to ScheduleProgrammingVisibility attribute of "
@@ -15248,7 +15353,8 @@ CHIPDevice * GetConnectedDevice()
                                                                                                     queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint16_t clusterRevisionArgument = 1U;
+    id clusterRevisionArgument;
+    clusterRevisionArgument = [NSNumber numberWithUnsignedShort:1U];
     [cluster
         writeAttributeClusterRevisionWithValue:clusterRevisionArgument
                                responseHandler:^(NSError * err, NSDictionary * values) {
@@ -15321,7 +15427,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestWindowCovering * cluster = [[CHIPTestWindowCovering alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint16_t clusterRevisionArgument = 5U;
+    id clusterRevisionArgument;
+    clusterRevisionArgument = [NSNumber numberWithUnsignedShort:5U];
     [cluster
         writeAttributeClusterRevisionWithValue:clusterRevisionArgument
                                responseHandler:^(NSError * err, NSDictionary * values) {
@@ -15632,7 +15739,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestWindowCovering * cluster = [[CHIPTestWindowCovering alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint8_t modeArgument = 7;
+    id modeArgument;
+    modeArgument = [NSNumber numberWithUnsignedChar:7];
     [cluster writeAttributeModeWithValue:modeArgument
                          responseHandler:^(NSError * err, NSDictionary * values) {
                              NSLog(@"write a value into the RW mandatory attribute:: Mode Error: %@", err);
@@ -16066,7 +16174,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    bool booleanArgument = 1;
+    id booleanArgument;
+    booleanArgument = [NSNumber numberWithBool:1];
     [cluster writeAttributeBooleanWithValue:booleanArgument
                             responseHandler:^(NSError * err, NSDictionary * values) {
                                 NSLog(@"Write attribute BOOLEAN True Error: %@", err);
@@ -16111,7 +16220,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    bool booleanArgument = 0;
+    id booleanArgument;
+    booleanArgument = [NSNumber numberWithBool:0];
     [cluster writeAttributeBooleanWithValue:booleanArgument
                             responseHandler:^(NSError * err, NSDictionary * values) {
                                 NSLog(@"Write attribute BOOLEAN False Error: %@", err);
@@ -16180,7 +16290,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint8_t bitmap8Argument = 255;
+    id bitmap8Argument;
+    bitmap8Argument = [NSNumber numberWithUnsignedChar:255];
     [cluster writeAttributeBitmap8WithValue:bitmap8Argument
                             responseHandler:^(NSError * err, NSDictionary * values) {
                                 NSLog(@"Write attribute BITMAP8 Max Value Error: %@", err);
@@ -16225,7 +16336,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint8_t bitmap8Argument = 0;
+    id bitmap8Argument;
+    bitmap8Argument = [NSNumber numberWithUnsignedChar:0];
     [cluster writeAttributeBitmap8WithValue:bitmap8Argument
                             responseHandler:^(NSError * err, NSDictionary * values) {
                                 NSLog(@"Write attribute BITMAP8 Min Value Error: %@", err);
@@ -16294,7 +16406,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint16_t bitmap16Argument = 65535U;
+    id bitmap16Argument;
+    bitmap16Argument = [NSNumber numberWithUnsignedShort:65535U];
     [cluster writeAttributeBitmap16WithValue:bitmap16Argument
                              responseHandler:^(NSError * err, NSDictionary * values) {
                                  NSLog(@"Write attribute BITMAP16 Max Value Error: %@", err);
@@ -16339,7 +16452,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint16_t bitmap16Argument = 0U;
+    id bitmap16Argument;
+    bitmap16Argument = [NSNumber numberWithUnsignedShort:0U];
     [cluster writeAttributeBitmap16WithValue:bitmap16Argument
                              responseHandler:^(NSError * err, NSDictionary * values) {
                                  NSLog(@"Write attribute BITMAP16 Min Value Error: %@", err);
@@ -16408,7 +16522,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint32_t bitmap32Argument = 4294967295UL;
+    id bitmap32Argument;
+    bitmap32Argument = [NSNumber numberWithUnsignedInt:4294967295UL];
     [cluster writeAttributeBitmap32WithValue:bitmap32Argument
                              responseHandler:^(NSError * err, NSDictionary * values) {
                                  NSLog(@"Write attribute BITMAP32 Max Value Error: %@", err);
@@ -16453,7 +16568,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint32_t bitmap32Argument = 0UL;
+    id bitmap32Argument;
+    bitmap32Argument = [NSNumber numberWithUnsignedInt:0UL];
     [cluster writeAttributeBitmap32WithValue:bitmap32Argument
                              responseHandler:^(NSError * err, NSDictionary * values) {
                                  NSLog(@"Write attribute BITMAP32 Min Value Error: %@", err);
@@ -16522,7 +16638,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint64_t bitmap64Argument = 18446744073709551615ULL;
+    id bitmap64Argument;
+    bitmap64Argument = [NSNumber numberWithUnsignedLongLong:18446744073709551615ULL];
     [cluster writeAttributeBitmap64WithValue:bitmap64Argument
                              responseHandler:^(NSError * err, NSDictionary * values) {
                                  NSLog(@"Write attribute BITMAP64 Max Value Error: %@", err);
@@ -16567,7 +16684,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint64_t bitmap64Argument = 0ULL;
+    id bitmap64Argument;
+    bitmap64Argument = [NSNumber numberWithUnsignedLongLong:0ULL];
     [cluster writeAttributeBitmap64WithValue:bitmap64Argument
                              responseHandler:^(NSError * err, NSDictionary * values) {
                                  NSLog(@"Write attribute BITMAP64 Min Value Error: %@", err);
@@ -16636,7 +16754,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint8_t int8uArgument = 255;
+    id int8uArgument;
+    int8uArgument = [NSNumber numberWithUnsignedChar:255];
     [cluster writeAttributeInt8uWithValue:int8uArgument
                           responseHandler:^(NSError * err, NSDictionary * values) {
                               NSLog(@"Write attribute INT8U Max Value Error: %@", err);
@@ -16681,7 +16800,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint8_t int8uArgument = 0;
+    id int8uArgument;
+    int8uArgument = [NSNumber numberWithUnsignedChar:0];
     [cluster writeAttributeInt8uWithValue:int8uArgument
                           responseHandler:^(NSError * err, NSDictionary * values) {
                               NSLog(@"Write attribute INT8U Min Value Error: %@", err);
@@ -16750,7 +16870,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint16_t int16uArgument = 65535U;
+    id int16uArgument;
+    int16uArgument = [NSNumber numberWithUnsignedShort:65535U];
     [cluster writeAttributeInt16uWithValue:int16uArgument
                            responseHandler:^(NSError * err, NSDictionary * values) {
                                NSLog(@"Write attribute INT16U Max Value Error: %@", err);
@@ -16795,7 +16916,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint16_t int16uArgument = 0U;
+    id int16uArgument;
+    int16uArgument = [NSNumber numberWithUnsignedShort:0U];
     [cluster writeAttributeInt16uWithValue:int16uArgument
                            responseHandler:^(NSError * err, NSDictionary * values) {
                                NSLog(@"Write attribute INT16U Min Value Error: %@", err);
@@ -16864,7 +16986,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint32_t int32uArgument = 4294967295UL;
+    id int32uArgument;
+    int32uArgument = [NSNumber numberWithUnsignedInt:4294967295UL];
     [cluster writeAttributeInt32uWithValue:int32uArgument
                            responseHandler:^(NSError * err, NSDictionary * values) {
                                NSLog(@"Write attribute INT32U Max Value Error: %@", err);
@@ -16909,7 +17032,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint32_t int32uArgument = 0UL;
+    id int32uArgument;
+    int32uArgument = [NSNumber numberWithUnsignedInt:0UL];
     [cluster writeAttributeInt32uWithValue:int32uArgument
                            responseHandler:^(NSError * err, NSDictionary * values) {
                                NSLog(@"Write attribute INT32U Min Value Error: %@", err);
@@ -16978,7 +17102,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint64_t int64uArgument = 18446744073709551615ULL;
+    id int64uArgument;
+    int64uArgument = [NSNumber numberWithUnsignedLongLong:18446744073709551615ULL];
     [cluster writeAttributeInt64uWithValue:int64uArgument
                            responseHandler:^(NSError * err, NSDictionary * values) {
                                NSLog(@"Write attribute INT64U Max Value Error: %@", err);
@@ -17023,7 +17148,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint64_t int64uArgument = 0ULL;
+    id int64uArgument;
+    int64uArgument = [NSNumber numberWithUnsignedLongLong:0ULL];
     [cluster writeAttributeInt64uWithValue:int64uArgument
                            responseHandler:^(NSError * err, NSDictionary * values) {
                                NSLog(@"Write attribute INT64U Min Value Error: %@", err);
@@ -17092,7 +17218,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    int8_t int8sArgument = 127;
+    id int8sArgument;
+    int8sArgument = [NSNumber numberWithChar:127];
     [cluster writeAttributeInt8sWithValue:int8sArgument
                           responseHandler:^(NSError * err, NSDictionary * values) {
                               NSLog(@"Write attribute INT8S Max Value Error: %@", err);
@@ -17137,7 +17264,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    int8_t int8sArgument = -128;
+    id int8sArgument;
+    int8sArgument = [NSNumber numberWithChar:-128];
     [cluster writeAttributeInt8sWithValue:int8sArgument
                           responseHandler:^(NSError * err, NSDictionary * values) {
                               NSLog(@"Write attribute INT8S Min Value Error: %@", err);
@@ -17182,7 +17310,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    int8_t int8sArgument = 0;
+    id int8sArgument;
+    int8sArgument = [NSNumber numberWithChar:0];
     [cluster writeAttributeInt8sWithValue:int8sArgument
                           responseHandler:^(NSError * err, NSDictionary * values) {
                               NSLog(@"Write attribute INT8S Default Value Error: %@", err);
@@ -17251,7 +17380,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    int16_t int16sArgument = 32767;
+    id int16sArgument;
+    int16sArgument = [NSNumber numberWithShort:32767];
     [cluster writeAttributeInt16sWithValue:int16sArgument
                            responseHandler:^(NSError * err, NSDictionary * values) {
                                NSLog(@"Write attribute INT16S Max Value Error: %@", err);
@@ -17296,7 +17426,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    int16_t int16sArgument = -32768;
+    id int16sArgument;
+    int16sArgument = [NSNumber numberWithShort:-32768];
     [cluster writeAttributeInt16sWithValue:int16sArgument
                            responseHandler:^(NSError * err, NSDictionary * values) {
                                NSLog(@"Write attribute INT16S Min Value Error: %@", err);
@@ -17341,7 +17472,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    int16_t int16sArgument = 0;
+    id int16sArgument;
+    int16sArgument = [NSNumber numberWithShort:0];
     [cluster writeAttributeInt16sWithValue:int16sArgument
                            responseHandler:^(NSError * err, NSDictionary * values) {
                                NSLog(@"Write attribute INT16S Default Value Error: %@", err);
@@ -17410,7 +17542,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    int32_t int32sArgument = 2147483647L;
+    id int32sArgument;
+    int32sArgument = [NSNumber numberWithInt:2147483647L];
     [cluster writeAttributeInt32sWithValue:int32sArgument
                            responseHandler:^(NSError * err, NSDictionary * values) {
                                NSLog(@"Write attribute INT32S Max Value Error: %@", err);
@@ -17455,7 +17588,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    int32_t int32sArgument = -2147483648L;
+    id int32sArgument;
+    int32sArgument = [NSNumber numberWithInt:-2147483648L];
     [cluster writeAttributeInt32sWithValue:int32sArgument
                            responseHandler:^(NSError * err, NSDictionary * values) {
                                NSLog(@"Write attribute INT32S Min Value Error: %@", err);
@@ -17500,7 +17634,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    int32_t int32sArgument = 0L;
+    id int32sArgument;
+    int32sArgument = [NSNumber numberWithInt:0L];
     [cluster writeAttributeInt32sWithValue:int32sArgument
                            responseHandler:^(NSError * err, NSDictionary * values) {
                                NSLog(@"Write attribute INT32S Default Value Error: %@", err);
@@ -17569,7 +17704,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    int64_t int64sArgument = 9223372036854775807LL;
+    id int64sArgument;
+    int64sArgument = [NSNumber numberWithLongLong:9223372036854775807LL];
     [cluster writeAttributeInt64sWithValue:int64sArgument
                            responseHandler:^(NSError * err, NSDictionary * values) {
                                NSLog(@"Write attribute INT64S Max Value Error: %@", err);
@@ -17614,7 +17750,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    int64_t int64sArgument = -9223372036854775807LL;
+    id int64sArgument;
+    int64sArgument = [NSNumber numberWithLongLong:-9223372036854775807LL];
     [cluster writeAttributeInt64sWithValue:int64sArgument
                            responseHandler:^(NSError * err, NSDictionary * values) {
                                NSLog(@"Write attribute INT64S Min Value Error: %@", err);
@@ -17659,7 +17796,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    int64_t int64sArgument = 0LL;
+    id int64sArgument;
+    int64sArgument = [NSNumber numberWithLongLong:0LL];
     [cluster writeAttributeInt64sWithValue:int64sArgument
                            responseHandler:^(NSError * err, NSDictionary * values) {
                                NSLog(@"Write attribute INT64S Default Value Error: %@", err);
@@ -17728,7 +17866,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint8_t enum8Argument = 255;
+    id enum8Argument;
+    enum8Argument = [NSNumber numberWithUnsignedChar:255];
     [cluster writeAttributeEnum8WithValue:enum8Argument
                           responseHandler:^(NSError * err, NSDictionary * values) {
                               NSLog(@"Write attribute ENUM8 Max Value Error: %@", err);
@@ -17773,7 +17912,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint8_t enum8Argument = 0;
+    id enum8Argument;
+    enum8Argument = [NSNumber numberWithUnsignedChar:0];
     [cluster writeAttributeEnum8WithValue:enum8Argument
                           responseHandler:^(NSError * err, NSDictionary * values) {
                               NSLog(@"Write attribute ENUM8 Min Value Error: %@", err);
@@ -17842,7 +17982,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint16_t enum16Argument = 65535U;
+    id enum16Argument;
+    enum16Argument = [NSNumber numberWithUnsignedShort:65535U];
     [cluster writeAttributeEnum16WithValue:enum16Argument
                            responseHandler:^(NSError * err, NSDictionary * values) {
                                NSLog(@"Write attribute ENUM16 Max Value Error: %@", err);
@@ -17887,7 +18028,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint16_t enum16Argument = 0U;
+    id enum16Argument;
+    enum16Argument = [NSNumber numberWithUnsignedShort:0U];
     [cluster writeAttributeEnum16WithValue:enum16Argument
                            responseHandler:^(NSError * err, NSDictionary * values) {
                                NSLog(@"Write attribute ENUM16 Min Value Error: %@", err);
@@ -17956,7 +18098,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    NSData * octetStringArgument = [[NSData alloc] initWithBytes:"Tes\x00ti\x00ng" length:9];
+    id octetStringArgument;
+    octetStringArgument = [[NSData alloc] initWithBytes:"Tes\x00ti\x00ng" length:9];
     [cluster writeAttributeOctetStringWithValue:octetStringArgument
                                 responseHandler:^(NSError * err, NSDictionary * values) {
                                     NSLog(@"Write attribute OCTET_STRING with embedded null Error: %@", err);
@@ -18001,7 +18144,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    NSData * octetStringArgument = [[NSData alloc] initWithBytes:"TestValue" length:9];
+    id octetStringArgument;
+    octetStringArgument = [[NSData alloc] initWithBytes:"TestValue" length:9];
     [cluster writeAttributeOctetStringWithValue:octetStringArgument
                                 responseHandler:^(NSError * err, NSDictionary * values) {
                                     NSLog(@"Write attribute OCTET_STRING Error: %@", err);
@@ -18046,7 +18190,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    NSData * octetStringArgument = [[NSData alloc] initWithBytes:"TestValueLongerThan10" length:21];
+    id octetStringArgument;
+    octetStringArgument = [[NSData alloc] initWithBytes:"TestValueLongerThan10" length:21];
     [cluster writeAttributeOctetStringWithValue:octetStringArgument
                                 responseHandler:^(NSError * err, NSDictionary * values) {
                                     NSLog(@"Write attribute OCTET_STRING Error: %@", err);
@@ -18090,7 +18235,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    NSData * octetStringArgument = [[NSData alloc] initWithBytes:"" length:0];
+    id octetStringArgument;
+    octetStringArgument = [[NSData alloc] initWithBytes:"" length:0];
     [cluster writeAttributeOctetStringWithValue:octetStringArgument
                                 responseHandler:^(NSError * err, NSDictionary * values) {
                                     NSLog(@"Write attribute OCTET_STRING Error: %@", err);
@@ -18135,7 +18281,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    NSData * longOctetStringArgument = [[NSData alloc]
+    id longOctetStringArgument;
+    longOctetStringArgument = [[NSData alloc]
         initWithBytes:"111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111"
                       "111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111"
                       "111111111111111111111111111111111111111111111111111111111111111111111111111111111111"
@@ -18190,7 +18337,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    NSData * longOctetStringArgument = [[NSData alloc] initWithBytes:"" length:0];
+    id longOctetStringArgument;
+    longOctetStringArgument = [[NSData alloc] initWithBytes:"" length:0];
     [cluster writeAttributeLongOctetStringWithValue:longOctetStringArgument
                                     responseHandler:^(NSError * err, NSDictionary * values) {
                                         NSLog(@"Write attribute LONG_OCTET_STRING Error: %@", err);
@@ -18235,7 +18383,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    NSString * charStringArgument = @"☉T☉";
+    id charStringArgument;
+    charStringArgument = @"☉T☉";
     [cluster writeAttributeCharStringWithValue:charStringArgument
                                responseHandler:^(NSError * err, NSDictionary * values) {
                                    NSLog(@"Write attribute CHAR_STRING Error: %@", err);
@@ -18256,7 +18405,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    NSString * charStringArgument = @"☉TestValueLongerThan10☉";
+    id charStringArgument;
+    charStringArgument = @"☉TestValueLongerThan10☉";
     [cluster writeAttributeCharStringWithValue:charStringArgument
                                responseHandler:^(NSError * err, NSDictionary * values) {
                                    NSLog(@"Write attribute CHAR_STRING - Value too long Error: %@", err);
@@ -18276,7 +18426,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    NSString * charStringArgument = @"";
+    id charStringArgument;
+    charStringArgument = @"";
     [cluster writeAttributeCharStringWithValue:charStringArgument
                                responseHandler:^(NSError * err, NSDictionary * values) {
                                    NSLog(@"Write attribute CHAR_STRING - Empty Error: %@", err);
@@ -18321,7 +18472,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    NSString * longCharStringArgument
+    id longCharStringArgument;
+    longCharStringArgument
         = @"☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉"
           @"☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉"
           @"☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉";
@@ -18373,7 +18525,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    NSString * longCharStringArgument = @"";
+    id longCharStringArgument;
+    longCharStringArgument = @"";
     [cluster writeAttributeLongCharStringWithValue:longCharStringArgument
                                    responseHandler:^(NSError * err, NSDictionary * values) {
                                        NSLog(@"Write attribute LONG_CHAR_STRING Error: %@", err);
@@ -18418,7 +18571,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint64_t epochUsArgument = 18446744073709551615ULL;
+    id epochUsArgument;
+    epochUsArgument = [NSNumber numberWithUnsignedLongLong:18446744073709551615ULL];
     [cluster writeAttributeEpochUsWithValue:epochUsArgument
                             responseHandler:^(NSError * err, NSDictionary * values) {
                                 NSLog(@"Write attribute EPOCH_US Max Value Error: %@", err);
@@ -18463,7 +18617,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint64_t epochUsArgument = 0ULL;
+    id epochUsArgument;
+    epochUsArgument = [NSNumber numberWithUnsignedLongLong:0ULL];
     [cluster writeAttributeEpochUsWithValue:epochUsArgument
                             responseHandler:^(NSError * err, NSDictionary * values) {
                                 NSLog(@"Write attribute EPOCH_US Min Value Error: %@", err);
@@ -18532,7 +18687,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint32_t epochSArgument = 4294967295UL;
+    id epochSArgument;
+    epochSArgument = [NSNumber numberWithUnsignedInt:4294967295UL];
     [cluster writeAttributeEpochSWithValue:epochSArgument
                            responseHandler:^(NSError * err, NSDictionary * values) {
                                NSLog(@"Write attribute EPOCH_S Max Value Error: %@", err);
@@ -18577,7 +18733,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint32_t epochSArgument = 0UL;
+    id epochSArgument;
+    epochSArgument = [NSNumber numberWithUnsignedInt:0UL];
     [cluster writeAttributeEpochSWithValue:epochSArgument
                            responseHandler:^(NSError * err, NSDictionary * values) {
                                NSLog(@"Write attribute EPOCH_S Min Value Error: %@", err);
@@ -18651,7 +18808,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    bool unsupportedArgument = 0;
+    id unsupportedArgument;
+    unsupportedArgument = [NSNumber numberWithBool:0];
     [cluster writeAttributeUnsupportedWithValue:unsupportedArgument
                                 responseHandler:^(NSError * err, NSDictionary * values) {
                                     NSLog(@"Writeattribute UNSUPPORTED Error: %@", err);
@@ -18721,7 +18879,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint16_t vendorIdArgument = 17U;
+    id vendorIdArgument;
+    vendorIdArgument = [NSNumber numberWithUnsignedShort:17U];
     [cluster writeAttributeVendorIdWithValue:vendorIdArgument
                              responseHandler:^(NSError * err, NSDictionary * values) {
                                  NSLog(@"Write attribute vendor_id Error: %@", err);
@@ -18766,7 +18925,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint16_t vendorIdArgument = 0U;
+    id vendorIdArgument;
+    vendorIdArgument = [NSNumber numberWithUnsignedShort:0U];
     [cluster writeAttributeVendorIdWithValue:vendorIdArgument
                              responseHandler:^(NSError * err, NSDictionary * values) {
                                  NSLog(@"Restore attribute vendor_id Error: %@", err);
@@ -18788,7 +18948,7 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPTestClusterClusterTestEnumsRequestPayload alloc] init];
-    payload.Arg1 = [NSNumber numberWithUnsignedShort:20003];
+    payload.Arg1 = [NSNumber numberWithUnsignedShort:20003U];
     payload.Arg2 = [NSNumber numberWithUnsignedChar:101];
     [cluster testEnumsRequest:payload
               responseHandler:^(NSError * err, NSDictionary * values) {
@@ -19212,7 +19372,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint32_t int32uArgument = 5UL;
+    id int32uArgument;
+    int32uArgument = [NSNumber numberWithUnsignedInt:5UL];
     [cluster writeAttributeInt32uWithValue:int32uArgument
                            responseHandler:^(NSError * err, NSDictionary * values) {
                                NSLog(@"Write attribute INT32U Value Error: %@", err);
@@ -19457,7 +19618,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestBasic * cluster = [[CHIPTestBasic alloc] initWithDevice:device endpoint:0 queue:queue];
     XCTAssertNotNil(cluster);
 
-    NSString * locationArgument = @"us";
+    id locationArgument;
+    locationArgument = @"us";
     [cluster writeAttributeLocationWithValue:locationArgument
                              responseHandler:^(NSError * err, NSDictionary * values) {
                                  NSLog(@"Write location Error: %@", err);
@@ -19502,7 +19664,8 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestBasic * cluster = [[CHIPTestBasic alloc] initWithDevice:device endpoint:0 queue:queue];
     XCTAssertNotNil(cluster);
 
-    NSString * locationArgument = @"";
+    id locationArgument;
+    locationArgument = @"";
     [cluster writeAttributeLocationWithValue:locationArgument
                              responseHandler:^(NSError * err, NSDictionary * values) {
                                  NSLog(@"Restore initial location value Error: %@", err);
@@ -19525,7 +19688,7 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPIdentifyClusterIdentifyPayload alloc] init];
-    payload.IdentifyTime = [NSNumber numberWithUnsignedShort:0];
+    payload.IdentifyTime = [NSNumber numberWithUnsignedShort:0U];
     [cluster identify:payload
         responseHandler:^(NSError * err, NSDictionary * values) {
             NSLog(@"Send Identify command and expect success response Error: %@", err);
@@ -20521,7 +20684,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
     CHIPBinaryInputBasic * cluster = [[CHIPBinaryInputBasic alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    bool value = 0x00;
+    NSNumber * _Nonnull value = @(0x00);
     [cluster writeAttributeOutOfServiceWithValue:value
                                  responseHandler:^(NSError * err, NSDictionary * values) {
                                      NSLog(@"BinaryInputBasic OutOfService Error: %@", err);
@@ -20559,7 +20722,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
     CHIPBinaryInputBasic * cluster = [[CHIPBinaryInputBasic alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    bool value = 0;
+    NSNumber * _Nonnull value = @(0);
     [cluster writeAttributePresentValueWithValue:value
                                  responseHandler:^(NSError * err, NSDictionary * values) {
                                      NSLog(@"BinaryInputBasic PresentValue Error: %@", err);
@@ -20821,7 +20984,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
     CHIPBridgedDeviceBasic * cluster = [[CHIPBridgedDeviceBasic alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    NSString * value = @"Test";
+    NSString * _Nonnull value = @"Test";
     [cluster writeAttributeUserLabelWithValue:value
                               responseHandler:^(NSError * err, NSDictionary * values) {
                                   NSLog(@"BridgedDeviceBasic UserLabel Error: %@", err);
@@ -21235,7 +21398,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
     CHIPColorControl * cluster = [[CHIPColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint8_t value = 0x00;
+    NSNumber * _Nonnull value = @(0x00);
     [cluster writeAttributeColorControlOptionsWithValue:value
                                         responseHandler:^(NSError * err, NSDictionary * values) {
                                             NSLog(@"ColorControl ColorControlOptions Error: %@", err);
@@ -21621,7 +21784,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
     CHIPColorControl * cluster = [[CHIPColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint16_t value = 0x0000;
+    NSNumber * _Nonnull value = @(0x0000);
     [cluster writeAttributeWhitePointXWithValue:value
                                 responseHandler:^(NSError * err, NSDictionary * values) {
                                     NSLog(@"ColorControl WhitePointX Error: %@", err);
@@ -21658,7 +21821,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
     CHIPColorControl * cluster = [[CHIPColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint16_t value = 0x0000;
+    NSNumber * _Nonnull value = @(0x0000);
     [cluster writeAttributeWhitePointYWithValue:value
                                 responseHandler:^(NSError * err, NSDictionary * values) {
                                     NSLog(@"ColorControl WhitePointY Error: %@", err);
@@ -21695,7 +21858,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
     CHIPColorControl * cluster = [[CHIPColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint16_t value = 0x0000;
+    NSNumber * _Nonnull value = @(0x0000);
     [cluster writeAttributeColorPointRXWithValue:value
                                  responseHandler:^(NSError * err, NSDictionary * values) {
                                      NSLog(@"ColorControl ColorPointRX Error: %@", err);
@@ -21732,7 +21895,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
     CHIPColorControl * cluster = [[CHIPColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint16_t value = 0x0000;
+    NSNumber * _Nonnull value = @(0x0000);
     [cluster writeAttributeColorPointRYWithValue:value
                                  responseHandler:^(NSError * err, NSDictionary * values) {
                                      NSLog(@"ColorControl ColorPointRY Error: %@", err);
@@ -21770,7 +21933,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
     CHIPColorControl * cluster = [[CHIPColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint8_t value = 0x00;
+    NSNumber * _Nonnull value = @(0x00);
     [cluster writeAttributeColorPointRIntensityWithValue:value
                                          responseHandler:^(NSError * err, NSDictionary * values) {
                                              NSLog(@"ColorControl ColorPointRIntensity Error: %@", err);
@@ -21807,7 +21970,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
     CHIPColorControl * cluster = [[CHIPColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint16_t value = 0x0000;
+    NSNumber * _Nonnull value = @(0x0000);
     [cluster writeAttributeColorPointGXWithValue:value
                                  responseHandler:^(NSError * err, NSDictionary * values) {
                                      NSLog(@"ColorControl ColorPointGX Error: %@", err);
@@ -21844,7 +22007,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
     CHIPColorControl * cluster = [[CHIPColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint16_t value = 0x0000;
+    NSNumber * _Nonnull value = @(0x0000);
     [cluster writeAttributeColorPointGYWithValue:value
                                  responseHandler:^(NSError * err, NSDictionary * values) {
                                      NSLog(@"ColorControl ColorPointGY Error: %@", err);
@@ -21882,7 +22045,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
     CHIPColorControl * cluster = [[CHIPColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint8_t value = 0x00;
+    NSNumber * _Nonnull value = @(0x00);
     [cluster writeAttributeColorPointGIntensityWithValue:value
                                          responseHandler:^(NSError * err, NSDictionary * values) {
                                              NSLog(@"ColorControl ColorPointGIntensity Error: %@", err);
@@ -21919,7 +22082,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
     CHIPColorControl * cluster = [[CHIPColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint16_t value = 0x0000;
+    NSNumber * _Nonnull value = @(0x0000);
     [cluster writeAttributeColorPointBXWithValue:value
                                  responseHandler:^(NSError * err, NSDictionary * values) {
                                      NSLog(@"ColorControl ColorPointBX Error: %@", err);
@@ -21956,7 +22119,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
     CHIPColorControl * cluster = [[CHIPColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint16_t value = 0x0000;
+    NSNumber * _Nonnull value = @(0x0000);
     [cluster writeAttributeColorPointBYWithValue:value
                                  responseHandler:^(NSError * err, NSDictionary * values) {
                                      NSLog(@"ColorControl ColorPointBY Error: %@", err);
@@ -21994,7 +22157,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
     CHIPColorControl * cluster = [[CHIPColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint8_t value = 0x00;
+    NSNumber * _Nonnull value = @(0x00);
     [cluster writeAttributeColorPointBIntensityWithValue:value
                                          responseHandler:^(NSError * err, NSDictionary * values) {
                                              NSLog(@"ColorControl ColorPointBIntensity Error: %@", err);
@@ -22242,7 +22405,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
     CHIPColorControl * cluster = [[CHIPColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint16_t value = 0x0000;
+    NSNumber * _Nonnull value = @(0x0000);
     [cluster writeAttributeStartUpColorTemperatureMiredsWithValue:value
                                                   responseHandler:^(NSError * err, NSDictionary * values) {
                                                       NSLog(@"ColorControl StartUpColorTemperatureMireds Error: %@", err);
@@ -23088,7 +23251,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
     CHIPGeneralCommissioning * cluster = [[CHIPGeneralCommissioning alloc] initWithDevice:device endpoint:0 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint64_t value = 0x0000000000000000;
+    NSNumber * _Nonnull value = @(0x0000000000000000);
     [cluster writeAttributeBreadcrumbWithValue:value
                                responseHandler:^(NSError * err, NSDictionary * values) {
                                    NSLog(@"GeneralCommissioning Breadcrumb Error: %@", err);
@@ -23368,7 +23531,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
     CHIPIdentify * cluster = [[CHIPIdentify alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint16_t value = 0x00;
+    NSNumber * _Nonnull value = @(0x00);
     [cluster writeAttributeIdentifyTimeWithValue:value
                                  responseHandler:^(NSError * err, NSDictionary * values) {
                                      NSLog(@"Identify IdentifyTime Error: %@", err);
@@ -23588,7 +23751,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
     CHIPLevelControl * cluster = [[CHIPLevelControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint8_t value = 0x00;
+    NSNumber * _Nonnull value = @(0x00);
     [cluster writeAttributeOptionsWithValue:value
                             responseHandler:^(NSError * err, NSDictionary * values) {
                                 NSLog(@"LevelControl Options Error: %@", err);
@@ -23626,7 +23789,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
     CHIPLevelControl * cluster = [[CHIPLevelControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint16_t value = 0x0000;
+    NSNumber * _Nonnull value = @(0x0000);
     [cluster writeAttributeOnOffTransitionTimeWithValue:value
                                         responseHandler:^(NSError * err, NSDictionary * values) {
                                             NSLog(@"LevelControl OnOffTransitionTime Error: %@", err);
@@ -23663,7 +23826,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
     CHIPLevelControl * cluster = [[CHIPLevelControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint8_t value = 0x00;
+    NSNumber * _Nonnull value = @(0x00);
     [cluster writeAttributeOnLevelWithValue:value
                             responseHandler:^(NSError * err, NSDictionary * values) {
                                 NSLog(@"LevelControl OnLevel Error: %@", err);
@@ -23701,7 +23864,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
     CHIPLevelControl * cluster = [[CHIPLevelControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint16_t value = 0x0000;
+    NSNumber * _Nonnull value = @(0x0000);
     [cluster writeAttributeOnTransitionTimeWithValue:value
                                      responseHandler:^(NSError * err, NSDictionary * values) {
                                          NSLog(@"LevelControl OnTransitionTime Error: %@", err);
@@ -23739,7 +23902,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
     CHIPLevelControl * cluster = [[CHIPLevelControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint16_t value = 0x0000;
+    NSNumber * _Nonnull value = @(0x0000);
     [cluster writeAttributeOffTransitionTimeWithValue:value
                                       responseHandler:^(NSError * err, NSDictionary * values) {
                                           NSLog(@"LevelControl OffTransitionTime Error: %@", err);
@@ -23777,7 +23940,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
     CHIPLevelControl * cluster = [[CHIPLevelControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint8_t value = 0x00;
+    NSNumber * _Nonnull value = @(0x00);
     [cluster writeAttributeDefaultMoveRateWithValue:value
                                     responseHandler:^(NSError * err, NSDictionary * values) {
                                         NSLog(@"LevelControl DefaultMoveRate Error: %@", err);
@@ -23815,7 +23978,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
     CHIPLevelControl * cluster = [[CHIPLevelControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint8_t value = 0x01;
+    NSNumber * _Nonnull value = @(0x01);
     [cluster writeAttributeStartUpCurrentLevelWithValue:value
                                         responseHandler:^(NSError * err, NSDictionary * values) {
                                             NSLog(@"LevelControl StartUpCurrentLevel Error: %@", err);
@@ -24149,7 +24312,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
     CHIPModeSelect * cluster = [[CHIPModeSelect alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint8_t value = 0;
+    NSNumber * _Nonnull value = @(0);
     [cluster writeAttributeOnModeWithValue:value
                            responseHandler:^(NSError * err, NSDictionary * values) {
                                NSLog(@"ModeSelect OnMode Error: %@", err);
@@ -24304,7 +24467,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
                                                                                                 queue:queue];
     XCTAssertNotNil(cluster);
 
-    NSData * value = [@"Test" dataUsingEncoding:NSUTF8StringEncoding];
+    NSData * _Nonnull value = [@"Test" dataUsingEncoding:NSUTF8StringEncoding];
     [cluster writeAttributeDefaultOtaProviderWithValue:value
                                        responseHandler:^(NSError * err, NSDictionary * values) {
                                            NSLog(@"OtaSoftwareUpdateRequestor DefaultOtaProvider Error: %@", err);
@@ -24495,7 +24658,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
     CHIPOnOff * cluster = [[CHIPOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint16_t value = 0;
+    NSNumber * _Nonnull value = @(0);
     [cluster writeAttributeOnTimeWithValue:value
                            responseHandler:^(NSError * err, NSDictionary * values) {
                                NSLog(@"OnOff OnTime Error: %@", err);
@@ -24532,7 +24695,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
     CHIPOnOff * cluster = [[CHIPOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint16_t value = 0;
+    NSNumber * _Nonnull value = @(0);
     [cluster writeAttributeOffWaitTimeWithValue:value
                                 responseHandler:^(NSError * err, NSDictionary * values) {
                                     NSLog(@"OnOff OffWaitTime Error: %@", err);
@@ -24569,7 +24732,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
     CHIPOnOff * cluster = [[CHIPOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint8_t value = 0;
+    NSNumber * _Nonnull value = @(0);
     [cluster writeAttributeStartUpOnOffWithValue:value
                                  responseHandler:^(NSError * err, NSDictionary * values) {
                                      NSLog(@"OnOff StartUpOnOff Error: %@", err);
@@ -24663,7 +24826,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
     CHIPOnOffSwitchConfiguration * cluster = [[CHIPOnOffSwitchConfiguration alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint8_t value = 0x00;
+    NSNumber * _Nonnull value = @(0x00);
     [cluster writeAttributeSwitchActionsWithValue:value
                                   responseHandler:^(NSError * err, NSDictionary * values) {
                                       NSLog(@"OnOffSwitchConfiguration SwitchActions Error: %@", err);
@@ -25519,7 +25682,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
                                                                                                   queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint8_t value = 0x00;
+    NSNumber * _Nonnull value = @(0x00);
     [cluster writeAttributeOperationModeWithValue:value
                                   responseHandler:^(NSError * err, NSDictionary * values) {
                                       NSLog(@"PumpConfigurationAndControl OperationMode Error: %@", err);
@@ -25562,7 +25725,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
                                                                                                   queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint8_t value = 0x00;
+    NSNumber * _Nonnull value = @(0x00);
     [cluster writeAttributeControlModeWithValue:value
                                 responseHandler:^(NSError * err, NSDictionary * values) {
                                     NSLog(@"PumpConfigurationAndControl ControlMode Error: %@", err);
@@ -26272,7 +26435,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
                                                                                                                     queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint8_t value = 0x00;
+    NSNumber * _Nonnull value = @(0x00);
     [cluster writeAttributeTemperatureDisplayModeWithValue:value
                                            responseHandler:^(NSError * err, NSDictionary * values) {
                                                NSLog(@"ThermostatUserInterfaceConfiguration TemperatureDisplayMode Error: %@", err);
@@ -26315,7 +26478,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
                                                                                                                     queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint8_t value = 0x00;
+    NSNumber * _Nonnull value = @(0x00);
     [cluster writeAttributeKeypadLockoutWithValue:value
                                   responseHandler:^(NSError * err, NSDictionary * values) {
                                       NSLog(@"ThermostatUserInterfaceConfiguration KeypadLockout Error: %@", err);
@@ -26359,7 +26522,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
                                                                                                                     queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint8_t value = 0x00;
+    NSNumber * _Nonnull value = @(0x00);
     [cluster writeAttributeScheduleProgrammingVisibilityWithValue:value
                                                   responseHandler:^(NSError * err, NSDictionary * values) {
                                                       NSLog(@"ThermostatUserInterfaceConfiguration ScheduleProgrammingVisibility "
@@ -28241,7 +28404,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
     CHIPWindowCovering * cluster = [[CHIPWindowCovering alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint8_t value = 0x00;
+    NSNumber * _Nonnull value = @(0x00);
     [cluster writeAttributeModeWithValue:value
                          responseHandler:^(NSError * err, NSDictionary * values) {
                              NSLog(@"WindowCovering Mode Error: %@", err);


### PR DESCRIPTION
#### Problem
Can't do writes of list-typed attributes, nullable attributes using the current Darwin APIs.

#### Change overview
Fix the APIs to allow all Matter types.

#### Testing
Code inspection and some manual testing.  The YAML tests for this need me to fix reads as well, which will be a separate PR.