### PR TITLE
Make the Objective-C APIs play slightly better with platform conventions

### DIFF
--- a/src/darwin/Framework/CHIP/templates/CHIPClustersObjc-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/CHIPClustersObjc-src.zapt
@@ -33,7 +33,7 @@ using namespace chip::app::Clusters;
     ListFreer listFreer;
     {{asUpperCamelCase parent.name}}::Commands::{{asUpperCamelCase name}}::Type request;
     {{#chip_cluster_command_arguments}}
-    {{>encode_value target=(concat "request." (asLowerCamelCase label)) source=(concat "payload." (asUpperCamelCase label)) cluster=parent.parent.name errorCode="return;" depth=0}}
+    {{>encode_value target=(concat "request." (asLowerCamelCase label)) source=(concat "payload." (asStructPropertyName label)) cluster=parent.parent.name errorCode="return;" depth=0}}
     {{/chip_cluster_command_arguments}}
 
     new CHIP{{>callbackName}}CallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {

--- a/src/darwin/Framework/CHIP/templates/CHIPCommandPayloadsObjc.zapt
+++ b/src/darwin/Framework/CHIP/templates/CHIPCommandPayloadsObjc.zapt
@@ -9,8 +9,10 @@
 {{#zcl_clusters}}
 {{#zcl_commands}}
 @interface CHIP{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}Payload : NSObject
+{{! Override the getter name because some of our properties start with things
+    like "new" or "init" }}
 {{#zcl_command_arguments}}
-@property (strong) {{asObjectiveCType type parent.parent.name}} {{asUpperCamelCase label}};
+@property (strong, nonatomic{{#unless (isStrEqual (asGetterName label) (asStructPropertyName label))}}, getter={{asGetterName label}}{{/unless}}) {{asObjectiveCType type parent.parent.name}} {{asStructPropertyName label}};
 {{/zcl_command_arguments}}
 @end
 

--- a/src/darwin/Framework/CHIP/templates/CHIPStructsObjc.zapt
+++ b/src/darwin/Framework/CHIP/templates/CHIPStructsObjc.zapt
@@ -8,8 +8,10 @@
 {{#zcl_clusters}}
 {{#zcl_structs}}
 @interface CHIP{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}} : NSObject
+{{! Override the getter name because some of our properties start with things
+    like "new" or "init" }}
 {{#zcl_struct_items}}
-@property (strong) {{asObjectiveCType type parent.parent.name}} {{asUpperCamelCase label}};
+@property (strong, nonatomic{{#unless (isStrEqual (asGetterName label) (asStructPropertyName label))}}, getter={{asGetterName label}}{{/unless}}) {{asObjectiveCType type parent.parent.name}} {{asStructPropertyName label}};
 {{/zcl_struct_items}}
 @end
 

--- a/src/darwin/Framework/CHIP/templates/helper.js
+++ b/src/darwin/Framework/CHIP/templates/helper.js
@@ -23,6 +23,7 @@ const zclHelper    = require(zapPath + 'generator/helper-zcl.js')
 
 const ChipTypesHelper = require('../../../../../src/app/zap-templates/common/ChipTypesHelper.js');
 const StringHelper    = require('../../../../../src/app/zap-templates/common/StringHelper.js');
+const appHelper       = require('../../../../../src/app/zap-templates/templates/app/helper.js');
 
 // Ideally those clusters clusters endpoints should be retrieved from the
 // descriptor cluster.
@@ -115,12 +116,6 @@ function asTestIndex(index)
   return index.toString().padStart(6, 0);
 }
 
-function asUpperCamelCase(label)
-{
-  let str = string.toCamelCase(label, false);
-  return str.replace(/[\.:]/g, '');
-}
-
 async function asObjectiveCClass(type, cluster, options)
 {
   let pkgId    = await templateUtil.ensureZclPackageId(this);
@@ -139,7 +134,7 @@ async function asObjectiveCClass(type, cluster, options)
   }
 
   if (isStruct) {
-    return `CHIP${asUpperCamelCase(cluster)}Cluster${asUpperCamelCase(type)}`;
+    return `CHIP${appHelper.asUpperCamelCase(cluster)}Cluster${appHelper.asUpperCamelCase(type)}`;
   }
 
   return 'NSNumber';
@@ -168,6 +163,31 @@ function incrementDepth(depth)
   return depth + 1;
 }
 
+function asStructPropertyName(prop)
+{
+  prop = appHelper.asLowerCamelCase(prop);
+
+  // If prop is now "description", we need to rename it, because that's
+  // reserved.
+  if (prop == "description") {
+    return "descriptionString";
+  }
+
+  // If prop starts with a sequence of capital letters (which can happen for
+  // output of asLowerCamelCase if the original string started that way,
+  // lowercase all but the last one.
+  return prop.replace(/^([A-Z]+)([A-Z])/, (match, p1, p2) => { return p1.toLowerCase() + p2 });
+}
+
+function asGetterName(prop)
+{
+  let propName = asStructPropertyName(prop);
+  if (propName.match(/^new[A-Z]/) || propName == "count") {
+    return "get" + appHelper.asUpperCamelCase(prop);
+  }
+  return propName;
+}
+
 //
 // Module exports
 //
@@ -180,3 +200,5 @@ exports.asObjectiveCClass            = asObjectiveCClass;
 exports.asObjectiveCType             = asObjectiveCType;
 exports.arrayElementObjectiveCClass  = arrayElementObjectiveCClass;
 exports.incrementDepth               = incrementDepth;
+exports.asStructPropertyName         = asStructPropertyName;
+exports.asGetterName                 = asGetterName;

--- a/src/darwin/Framework/CHIP/templates/partials/CHIPCallbackBridge.zapt
+++ b/src/darwin/Framework/CHIP/templates/partials/CHIPCallbackBridge.zapt
@@ -40,7 +40,7 @@ void CHIP{{> @partial-block}}Bridge::OnSuccessFn(void * context
     {
       id value;
       {{>decode_value target="value" source=(concat "data." (asLowerCamelCase label)) cluster=parent.parent.name errorCode="OnFailureFn(context, EMBER_ZCL_STATUS_INVALID_VALUE); return;"}}
-      response[@"{{asUpperCamelCase label}}"] = value;
+      response[@"{{asStructPropertyName label}}"] = value;
     }
     {{/chip_cluster_response_arguments}}
     DispatchSuccess(context, response);
@@ -60,16 +60,16 @@ void CHIP{{> @partial-block}}Bridge::OnSuccessFn(void * context
           {{! TODO: Add support for nullable types, probably by having a templated ToObjectiveCType function }}
           {{else if isArray}}
           {{! TODO: Add support for list members of structs in list attributes }}
-          @"{{asUpperCamelCase name}}": [[NSMutableArray alloc] init],
+          @"{{asStructPropertyName name}}": [[NSMutableArray alloc] init],
           {{else if (isOctetString type)}}
-          @"{{asUpperCamelCase name}}" : [NSData dataWithBytes:entry.{{asLowerCamelCase name}}.data() length:entry.{{asLowerCamelCase name}}.size()],
+          @"{{asStructPropertyName name}}" : [NSData dataWithBytes:entry.{{asLowerCamelCase name}}.data() length:entry.{{asLowerCamelCase name}}.size()],
           {{else if (isCharString type)}}
-          @"{{asUpperCamelCase name}}" : [[NSString alloc] initWithBytes:entry.{{asLowerCamelCase name}}.data() length:entry.{{asLowerCamelCase name}}.size() encoding:NSUTF8StringEncoding],
+          @"{{asStructPropertyName name}}" : [[NSString alloc] initWithBytes:entry.{{asLowerCamelCase name}}.data() length:entry.{{asLowerCamelCase name}}.size() encoding:NSUTF8StringEncoding],
           {{else if isStruct}}
           {{! TODO: Add support for struct members of structs in list attributes }}
-          @"{{asUpperCamelCase name}}": @{}
+          @"{{asStructPropertyName name}}": @{}
           {{else}}
-          @"{{asUpperCamelCase name}}" : [NSNumber numberWith{{asObjectiveCNumberType label type false}}:entry.{{asLowerCamelCase name}}],
+          @"{{asStructPropertyName name}}" : [NSNumber numberWith{{asObjectiveCNumberType label type false}}:entry.{{asLowerCamelCase name}}],
           {{/if}}
           {{/chip_attribute_list_entryTypes}}
         }];

--- a/src/darwin/Framework/CHIP/templates/partials/check_test_value.zapt
+++ b/src/darwin/Framework/CHIP/templates/partials/check_test_value.zapt
@@ -24,9 +24,9 @@
       {{#if (expectedValueHasProp ../expected (asLowerCamelCase label))}}
         {{! TODO: This is a hack because right now some of our return values (attribute reads) are using NSDictionary for structs while others (commands) are using generated object types.  Just support both for now. }}
         if ([{{../actual}} isKindOfClass:[NSDictionary class]]) {
-          {{>check_test_value actual=(concat ../actual '[@"' (asUpperCamelCase label) '"]') expected=(lookup ../expected (asLowerCamelCase label)) cluster=../cluster}}
+          {{>check_test_value actual=(concat ../actual '[@"' (asStructPropertyName label) '"]') expected=(lookup ../expected (asLowerCamelCase label)) cluster=../cluster}}
         } else {
-          {{>check_test_value actual=(concat "[" ../actual (asUpperCamelCase label) "]") expected=(lookup ../expected (asLowerCamelCase label)) cluster=../cluster}}
+          {{>check_test_value actual=(concat "((CHIP" (asUpperCamelCase ../cluster) "Cluster" (asUpperCamelCase ../type) " *)" ../actual ")." (asStructPropertyName label)) expected=(lookup ../expected (asLowerCamelCase label)) cluster=../cluster}}
         }
       {{/if}}
     {{/zcl_struct_items_by_struct_name}}

--- a/src/darwin/Framework/CHIP/templates/partials/decode_value.zapt
+++ b/src/darwin/Framework/CHIP/templates/partials/decode_value.zapt
@@ -28,7 +28,7 @@
 {{else}}
   {{#if_is_struct type}}
     {{#zcl_struct_items_by_struct_name type}}
-      {{>decode_value target=(concat ../target "." (asUpperCamelCase label)) source=(concat ../source "." (asLowerCamelCase label)) cluster=../cluster}}
+      {{>decode_value target=(concat ../target "." (asStructPropertyName label)) source=(concat ../source "." (asLowerCamelCase label)) cluster=../cluster}}
     {{/zcl_struct_items_by_struct_name}}
   {{else if (isOctetString type)}}
     {{target}} = [NSData dataWithBytes:{{source}}.data() length:{{source}}.size()];

--- a/src/darwin/Framework/CHIP/templates/partials/encode_value.zapt
+++ b/src/darwin/Framework/CHIP/templates/partials/encode_value.zapt
@@ -46,7 +46,7 @@
 {{else}}
   {{#if_is_struct type}}
     {{#zcl_struct_items_by_struct_name type}}
-     {{>encode_value target=(concat ../target "." (asLowerCamelCase label)) source=(concat ../source "." (asUpperCamelCase label)) cluster=../cluster errorCode=../errorCode depth=(incrementDepth ../depth)}}
+     {{>encode_value target=(concat ../target "." (asLowerCamelCase label)) source=(concat ../source "." (asStructPropertyName label)) cluster=../cluster errorCode=../errorCode depth=(incrementDepth ../depth)}}
     {{/zcl_struct_items_by_struct_name}}
   {{else}}
     {{#if_chip_enum type}}

--- a/src/darwin/Framework/CHIP/templates/partials/test_cluster.zapt
+++ b/src/darwin/Framework/CHIP/templates/partials/test_cluster.zapt
@@ -21,7 +21,7 @@ bool testSendCluster{{parent.filename}}_{{asTestIndex index}}_{{asUpperCamelCase
     {{#if isCommand}}
     __auto_type * payload = [[CHIP{{asUpperCamelCase cluster}}Cluster{{asUpperCamelCase command}}Payload alloc] init];
     {{#chip_tests_item_parameters}}
-      {{>test_value target=(concat "payload." (asUpperCamelCase label)) definedValue=definedValue cluster=parent.cluster}}
+      {{>test_value target=(concat "payload." (asStructPropertyName label)) definedValue=definedValue cluster=parent.cluster}}
     {{/chip_tests_item_parameters}}
     [cluster {{asLowerCamelCase command}}:payload responseHandler:^(NSError * err, NSDictionary * values) {
     {{else if isSubscribeAttribute}}
@@ -68,7 +68,7 @@ bool testSendCluster{{parent.filename}}_{{asTestIndex index}}_{{asUpperCamelCase
         {{#chip_tests_item_response_parameters}}
         {{#if hasExpectedValue}}
         {
-          id actualValue = values[@"{{#if parent.isAttribute}}value{{else}}{{asUpperCamelCase name}}{{/if}}"];
+          id actualValue = values[@"{{#if parent.isAttribute}}value{{else}}{{asStructPropertyName name}}{{/if}}"];
           {{>check_test_value actual="actualValue" expected=expectedValue cluster=../cluster}}
         }
         {{/if}}

--- a/src/darwin/Framework/CHIP/templates/partials/test_value.zapt
+++ b/src/darwin/Framework/CHIP/templates/partials/test_value.zapt
@@ -21,7 +21,7 @@
     {{#zcl_struct_items_by_struct_name type}}
       {{! target may be some place where we lost type information (e.g. an id),
           so add explicit cast when trying to assign to our properties. }}
-      {{>test_value target=(concat "((CHIP" (asUpperCamelCase ../cluster) "Cluster" (asUpperCamelCase ../type) " *)" ../target ")." (asUpperCamelCase label)) definedValue=(lookup ../definedValue name) cluster=../cluster}}
+      {{>test_value target=(concat "((CHIP" (asUpperCamelCase ../cluster) "Cluster" (asUpperCamelCase ../type) " *)" ../target ")." (asStructPropertyName label)) definedValue=(lookup ../definedValue name) cluster=../cluster}}
     {{/zcl_struct_items_by_struct_name}}
 
   {{else if (isCharString type)}}

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPCallbackBridge.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPCallbackBridge.mm
@@ -111,9 +111,9 @@ void CHIPAudioOutputAudioOutputListListAttributeCallbackBridge::OnSuccessFn(void
         auto & entry = iter.GetValue();
         (void) entry; // All our types below might be unsupported
         [array addObject:@ {
-            @"Index" : [NSNumber numberWithUnsignedChar:entry.index],
-            @"OutputType" : [NSNumber numberWithUnsignedChar:entry.outputType],
-            @"Name" : [[NSString alloc] initWithBytes:entry.name.data() length:entry.name.size() encoding:NSUTF8StringEncoding],
+            @"index" : [NSNumber numberWithUnsignedChar:entry.index],
+            @"outputType" : [NSNumber numberWithUnsignedChar:entry.outputType],
+            @"name" : [[NSString alloc] initWithBytes:entry.name.data() length:entry.name.size() encoding:NSUTF8StringEncoding],
         }];
     }
     if (iter.GetStatus() != CHIP_NO_ERROR) {
@@ -133,12 +133,12 @@ void CHIPBridgedActionsActionListListAttributeCallbackBridge::OnSuccessFn(void *
         auto & entry = iter.GetValue();
         (void) entry; // All our types below might be unsupported
         [array addObject:@ {
-            @"ActionID" : [NSNumber numberWithUnsignedShort:entry.actionID],
-            @"Name" : [[NSString alloc] initWithBytes:entry.name.data() length:entry.name.size() encoding:NSUTF8StringEncoding],
-            @"Type" : [NSNumber numberWithUnsignedChar:entry.type],
-            @"EndpointListID" : [NSNumber numberWithUnsignedShort:entry.endpointListID],
-            @"SupportedCommands" : [NSNumber numberWithUnsignedShort:entry.supportedCommands],
-            @"Status" : [NSNumber numberWithUnsignedChar:entry.status],
+            @"actionID" : [NSNumber numberWithUnsignedShort:entry.actionID],
+            @"name" : [[NSString alloc] initWithBytes:entry.name.data() length:entry.name.size() encoding:NSUTF8StringEncoding],
+            @"type" : [NSNumber numberWithUnsignedChar:entry.type],
+            @"endpointListID" : [NSNumber numberWithUnsignedShort:entry.endpointListID],
+            @"supportedCommands" : [NSNumber numberWithUnsignedShort:entry.supportedCommands],
+            @"status" : [NSNumber numberWithUnsignedChar:entry.status],
         }];
     }
     if (iter.GetStatus() != CHIP_NO_ERROR) {
@@ -159,10 +159,10 @@ void CHIPBridgedActionsEndpointListListAttributeCallbackBridge::OnSuccessFn(void
         auto & entry = iter.GetValue();
         (void) entry; // All our types below might be unsupported
         [array addObject:@ {
-            @"EndpointListID" : [NSNumber numberWithUnsignedShort:entry.endpointListID],
-            @"Name" : [[NSString alloc] initWithBytes:entry.name.data() length:entry.name.size() encoding:NSUTF8StringEncoding],
-            @"Type" : [NSNumber numberWithUnsignedChar:entry.type],
-            @"Endpoints" : [NSData dataWithBytes:entry.endpoints.data() length:entry.endpoints.size()],
+            @"endpointListID" : [NSNumber numberWithUnsignedShort:entry.endpointListID],
+            @"name" : [[NSString alloc] initWithBytes:entry.name.data() length:entry.name.size() encoding:NSUTF8StringEncoding],
+            @"type" : [NSNumber numberWithUnsignedChar:entry.type],
+            @"endpoints" : [NSData dataWithBytes:entry.endpoints.data() length:entry.endpoints.size()],
         }];
     }
     if (iter.GetStatus() != CHIP_NO_ERROR) {
@@ -218,8 +218,8 @@ void CHIPDescriptorDeviceListListAttributeCallbackBridge::OnSuccessFn(void * con
         auto & entry = iter.GetValue();
         (void) entry; // All our types below might be unsupported
         [array addObject:@ {
-            @"Type" : [NSNumber numberWithUnsignedInt:entry.type],
-            @"Revision" : [NSNumber numberWithUnsignedShort:entry.revision],
+            @"type" : [NSNumber numberWithUnsignedInt:entry.type],
+            @"revision" : [NSNumber numberWithUnsignedShort:entry.revision],
         }];
     }
     if (iter.GetStatus() != CHIP_NO_ERROR) {
@@ -293,8 +293,8 @@ void CHIPFixedLabelLabelListListAttributeCallbackBridge::OnSuccessFn(void * cont
         auto & entry = iter.GetValue();
         (void) entry; // All our types below might be unsupported
         [array addObject:@ {
-            @"Label" : [[NSString alloc] initWithBytes:entry.label.data() length:entry.label.size() encoding:NSUTF8StringEncoding],
-            @"Value" : [[NSString alloc] initWithBytes:entry.value.data() length:entry.value.size() encoding:NSUTF8StringEncoding],
+            @"label" : [[NSString alloc] initWithBytes:entry.label.data() length:entry.label.size() encoding:NSUTF8StringEncoding],
+            @"value" : [[NSString alloc] initWithBytes:entry.value.data() length:entry.value.size() encoding:NSUTF8StringEncoding],
         }];
     }
     if (iter.GetStatus() != CHIP_NO_ERROR) {
@@ -315,7 +315,7 @@ void CHIPGeneralCommissioningBasicCommissioningInfoListListAttributeCallbackBrid
         auto & entry = iter.GetValue();
         (void) entry; // All our types below might be unsupported
         [array addObject:@ {
-            @"FailSafeExpiryLengthMs" : [NSNumber numberWithUnsignedInt:entry.failSafeExpiryLengthMs],
+            @"failSafeExpiryLengthMs" : [NSNumber numberWithUnsignedInt:entry.failSafeExpiryLengthMs],
         }];
     }
     if (iter.GetStatus() != CHIP_NO_ERROR) {
@@ -336,12 +336,12 @@ void CHIPGeneralDiagnosticsNetworkInterfacesListAttributeCallbackBridge::OnSucce
         auto & entry = iter.GetValue();
         (void) entry; // All our types below might be unsupported
         [array addObject:@ {
-            @"Name" : [[NSString alloc] initWithBytes:entry.name.data() length:entry.name.size() encoding:NSUTF8StringEncoding],
-            @"FabricConnected" : [NSNumber numberWithBool:entry.fabricConnected],
-            @"OffPremiseServicesReachableIPv4" : [NSNumber numberWithBool:entry.offPremiseServicesReachableIPv4],
-            @"OffPremiseServicesReachableIPv6" : [NSNumber numberWithBool:entry.offPremiseServicesReachableIPv6],
-            @"HardwareAddress" : [NSData dataWithBytes:entry.hardwareAddress.data() length:entry.hardwareAddress.size()],
-            @"Type" : [NSNumber numberWithUnsignedChar:entry.type],
+            @"name" : [[NSString alloc] initWithBytes:entry.name.data() length:entry.name.size() encoding:NSUTF8StringEncoding],
+            @"fabricConnected" : [NSNumber numberWithBool:entry.fabricConnected],
+            @"offPremiseServicesReachableIPv4" : [NSNumber numberWithBool:entry.offPremiseServicesReachableIPv4],
+            @"offPremiseServicesReachableIPv6" : [NSNumber numberWithBool:entry.offPremiseServicesReachableIPv6],
+            @"hardwareAddress" : [NSData dataWithBytes:entry.hardwareAddress.data() length:entry.hardwareAddress.size()],
+            @"type" : [NSNumber numberWithUnsignedChar:entry.type],
         }];
     }
     if (iter.GetStatus() != CHIP_NO_ERROR) {
@@ -361,9 +361,9 @@ void CHIPGroupKeyManagementGroupsListAttributeCallbackBridge::OnSuccessFn(void *
         auto & entry = iter.GetValue();
         (void) entry; // All our types below might be unsupported
         [array addObject:@ {
-            @"VendorId" : [NSNumber numberWithUnsignedShort:entry.vendorId],
-            @"VendorGroupId" : [NSNumber numberWithUnsignedShort:entry.vendorGroupId],
-            @"GroupKeySetIndex" : [NSNumber numberWithUnsignedShort:entry.groupKeySetIndex],
+            @"vendorId" : [NSNumber numberWithUnsignedShort:entry.vendorId],
+            @"vendorGroupId" : [NSNumber numberWithUnsignedShort:entry.vendorGroupId],
+            @"groupKeySetIndex" : [NSNumber numberWithUnsignedShort:entry.groupKeySetIndex],
         }];
     }
     if (iter.GetStatus() != CHIP_NO_ERROR) {
@@ -383,11 +383,11 @@ void CHIPGroupKeyManagementGroupKeysListAttributeCallbackBridge::OnSuccessFn(voi
         auto & entry = iter.GetValue();
         (void) entry; // All our types below might be unsupported
         [array addObject:@ {
-            @"VendorId" : [NSNumber numberWithUnsignedShort:entry.vendorId],
-            @"GroupKeyIndex" : [NSNumber numberWithUnsignedShort:entry.groupKeyIndex],
-            @"GroupKeyRoot" : [NSData dataWithBytes:entry.groupKeyRoot.data() length:entry.groupKeyRoot.size()],
-            @"GroupKeyEpochStartTime" : [NSNumber numberWithUnsignedLongLong:entry.groupKeyEpochStartTime],
-            @"GroupKeySecurityPolicy" : [NSNumber numberWithUnsignedChar:entry.groupKeySecurityPolicy],
+            @"vendorId" : [NSNumber numberWithUnsignedShort:entry.vendorId],
+            @"groupKeyIndex" : [NSNumber numberWithUnsignedShort:entry.groupKeyIndex],
+            @"groupKeyRoot" : [NSData dataWithBytes:entry.groupKeyRoot.data() length:entry.groupKeyRoot.size()],
+            @"groupKeyEpochStartTime" : [NSNumber numberWithUnsignedLongLong:entry.groupKeyEpochStartTime],
+            @"groupKeySecurityPolicy" : [NSNumber numberWithUnsignedChar:entry.groupKeySecurityPolicy],
         }];
     }
     if (iter.GetStatus() != CHIP_NO_ERROR) {
@@ -407,12 +407,12 @@ void CHIPMediaInputMediaInputListListAttributeCallbackBridge::OnSuccessFn(void *
         auto & entry = iter.GetValue();
         (void) entry; // All our types below might be unsupported
         [array addObject:@ {
-            @"Index" : [NSNumber numberWithUnsignedChar:entry.index],
-            @"InputType" : [NSNumber numberWithUnsignedChar:entry.inputType],
-            @"Name" : [[NSString alloc] initWithBytes:entry.name.data() length:entry.name.size() encoding:NSUTF8StringEncoding],
-            @"Description" : [[NSString alloc] initWithBytes:entry.description.data()
-                                                      length:entry.description.size()
-                                                    encoding:NSUTF8StringEncoding],
+            @"index" : [NSNumber numberWithUnsignedChar:entry.index],
+            @"inputType" : [NSNumber numberWithUnsignedChar:entry.inputType],
+            @"name" : [[NSString alloc] initWithBytes:entry.name.data() length:entry.name.size() encoding:NSUTF8StringEncoding],
+            @"descriptionString" : [[NSString alloc] initWithBytes:entry.description.data()
+                                                            length:entry.description.size()
+                                                          encoding:NSUTF8StringEncoding],
         }];
     }
     if (iter.GetStatus() != CHIP_NO_ERROR) {
@@ -432,9 +432,9 @@ void CHIPModeSelectSupportedModesListAttributeCallbackBridge::OnSuccessFn(void *
         auto & entry = iter.GetValue();
         (void) entry; // All our types below might be unsupported
         [array addObject:@ {
-            @"Label" : [[NSString alloc] initWithBytes:entry.label.data() length:entry.label.size() encoding:NSUTF8StringEncoding],
-            @"Mode" : [NSNumber numberWithUnsignedChar:entry.mode],
-            @"SemanticTag" : [NSNumber numberWithUnsignedInt:entry.semanticTag],
+            @"label" : [[NSString alloc] initWithBytes:entry.label.data() length:entry.label.size() encoding:NSUTF8StringEncoding],
+            @"mode" : [NSNumber numberWithUnsignedChar:entry.mode],
+            @"semanticTag" : [NSNumber numberWithUnsignedInt:entry.semanticTag],
         }];
     }
     if (iter.GetStatus() != CHIP_NO_ERROR) {
@@ -455,12 +455,12 @@ void CHIPOperationalCredentialsFabricsListListAttributeCallbackBridge::OnSuccess
         auto & entry = iter.GetValue();
         (void) entry; // All our types below might be unsupported
         [array addObject:@ {
-            @"FabricIndex" : [NSNumber numberWithUnsignedChar:entry.fabricIndex],
-            @"RootPublicKey" : [NSData dataWithBytes:entry.rootPublicKey.data() length:entry.rootPublicKey.size()],
-            @"VendorId" : [NSNumber numberWithUnsignedShort:entry.vendorId],
-            @"FabricId" : [NSNumber numberWithUnsignedLongLong:entry.fabricId],
-            @"NodeId" : [NSNumber numberWithUnsignedLongLong:entry.nodeId],
-            @"Label" : [[NSString alloc] initWithBytes:entry.label.data() length:entry.label.size() encoding:NSUTF8StringEncoding],
+            @"fabricIndex" : [NSNumber numberWithUnsignedChar:entry.fabricIndex],
+            @"rootPublicKey" : [NSData dataWithBytes:entry.rootPublicKey.data() length:entry.rootPublicKey.size()],
+            @"vendorId" : [NSNumber numberWithUnsignedShort:entry.vendorId],
+            @"fabricId" : [NSNumber numberWithUnsignedLongLong:entry.fabricId],
+            @"nodeId" : [NSNumber numberWithUnsignedLongLong:entry.nodeId],
+            @"label" : [[NSString alloc] initWithBytes:entry.label.data() length:entry.label.size() encoding:NSUTF8StringEncoding],
         }];
     }
     if (iter.GetStatus() != CHIP_NO_ERROR) {
@@ -517,11 +517,11 @@ void CHIPSoftwareDiagnosticsThreadMetricsListAttributeCallbackBridge::OnSuccessF
         auto & entry = iter.GetValue();
         (void) entry; // All our types below might be unsupported
         [array addObject:@ {
-            @"Id" : [NSNumber numberWithUnsignedLongLong:entry.id],
-            @"Name" : [[NSString alloc] initWithBytes:entry.name.data() length:entry.name.size() encoding:NSUTF8StringEncoding],
-            @"StackFreeCurrent" : [NSNumber numberWithUnsignedInt:entry.stackFreeCurrent],
-            @"StackFreeMinimum" : [NSNumber numberWithUnsignedInt:entry.stackFreeMinimum],
-            @"StackSize" : [NSNumber numberWithUnsignedInt:entry.stackSize],
+            @"id" : [NSNumber numberWithUnsignedLongLong:entry.id],
+            @"name" : [[NSString alloc] initWithBytes:entry.name.data() length:entry.name.size() encoding:NSUTF8StringEncoding],
+            @"stackFreeCurrent" : [NSNumber numberWithUnsignedInt:entry.stackFreeCurrent],
+            @"stackFreeMinimum" : [NSNumber numberWithUnsignedInt:entry.stackFreeMinimum],
+            @"stackSize" : [NSNumber numberWithUnsignedInt:entry.stackSize],
         }];
     }
     if (iter.GetStatus() != CHIP_NO_ERROR) {
@@ -541,13 +541,13 @@ void CHIPTvChannelTvChannelListListAttributeCallbackBridge::OnSuccessFn(void * c
         auto & entry = iter.GetValue();
         (void) entry; // All our types below might be unsupported
         [array addObject:@ {
-            @"MajorNumber" : [NSNumber numberWithUnsignedShort:entry.majorNumber],
-            @"MinorNumber" : [NSNumber numberWithUnsignedShort:entry.minorNumber],
-            @"Name" : [[NSString alloc] initWithBytes:entry.name.data() length:entry.name.size() encoding:NSUTF8StringEncoding],
-            @"CallSign" : [[NSString alloc] initWithBytes:entry.callSign.data()
+            @"majorNumber" : [NSNumber numberWithUnsignedShort:entry.majorNumber],
+            @"minorNumber" : [NSNumber numberWithUnsignedShort:entry.minorNumber],
+            @"name" : [[NSString alloc] initWithBytes:entry.name.data() length:entry.name.size() encoding:NSUTF8StringEncoding],
+            @"callSign" : [[NSString alloc] initWithBytes:entry.callSign.data()
                                                    length:entry.callSign.size()
                                                  encoding:NSUTF8StringEncoding],
-            @"AffiliateCallSign" : [[NSString alloc] initWithBytes:entry.affiliateCallSign.data()
+            @"affiliateCallSign" : [[NSString alloc] initWithBytes:entry.affiliateCallSign.data()
                                                             length:entry.affiliateCallSign.size()
                                                           encoding:NSUTF8StringEncoding],
         }];
@@ -570,8 +570,8 @@ void CHIPTargetNavigatorTargetNavigatorListListAttributeCallbackBridge::OnSucces
         auto & entry = iter.GetValue();
         (void) entry; // All our types below might be unsupported
         [array addObject:@ {
-            @"Identifier" : [NSNumber numberWithUnsignedChar:entry.identifier],
-            @"Name" : [[NSString alloc] initWithBytes:entry.name.data() length:entry.name.size() encoding:NSUTF8StringEncoding],
+            @"identifier" : [NSNumber numberWithUnsignedChar:entry.identifier],
+            @"name" : [[NSString alloc] initWithBytes:entry.name.data() length:entry.name.size() encoding:NSUTF8StringEncoding],
         }];
     }
     if (iter.GetStatus() != CHIP_NO_ERROR) {
@@ -627,8 +627,8 @@ void CHIPTestClusterListStructOctetStringListAttributeCallbackBridge::OnSuccessF
         auto & entry = iter.GetValue();
         (void) entry; // All our types below might be unsupported
         [array addObject:@ {
-            @"FabricIndex" : [NSNumber numberWithUnsignedLongLong:entry.fabricIndex],
-            @"OperationalCert" : [NSData dataWithBytes:entry.operationalCert.data() length:entry.operationalCert.size()],
+            @"fabricIndex" : [NSNumber numberWithUnsignedLongLong:entry.fabricIndex],
+            @"operationalCert" : [NSData dataWithBytes:entry.operationalCert.data() length:entry.operationalCert.size()],
         }];
     }
     if (iter.GetStatus() != CHIP_NO_ERROR) {
@@ -668,20 +668,20 @@ void CHIPThreadNetworkDiagnosticsNeighborTableListListAttributeCallbackBridge::O
         auto & entry = iter.GetValue();
         (void) entry; // All our types below might be unsupported
         [array addObject:@ {
-            @"ExtAddress" : [NSNumber numberWithUnsignedLongLong:entry.extAddress],
-            @"Age" : [NSNumber numberWithUnsignedInt:entry.age],
-            @"Rloc16" : [NSNumber numberWithUnsignedShort:entry.rloc16],
-            @"LinkFrameCounter" : [NSNumber numberWithUnsignedInt:entry.linkFrameCounter],
-            @"MleFrameCounter" : [NSNumber numberWithUnsignedInt:entry.mleFrameCounter],
-            @"Lqi" : [NSNumber numberWithUnsignedChar:entry.lqi],
-            @"AverageRssi" : [NSNumber numberWithChar:entry.averageRssi],
-            @"LastRssi" : [NSNumber numberWithChar:entry.lastRssi],
-            @"FrameErrorRate" : [NSNumber numberWithUnsignedChar:entry.frameErrorRate],
-            @"MessageErrorRate" : [NSNumber numberWithUnsignedChar:entry.messageErrorRate],
-            @"RxOnWhenIdle" : [NSNumber numberWithBool:entry.rxOnWhenIdle],
-            @"FullThreadDevice" : [NSNumber numberWithBool:entry.fullThreadDevice],
-            @"FullNetworkData" : [NSNumber numberWithBool:entry.fullNetworkData],
-            @"IsChild" : [NSNumber numberWithBool:entry.isChild],
+            @"extAddress" : [NSNumber numberWithUnsignedLongLong:entry.extAddress],
+            @"age" : [NSNumber numberWithUnsignedInt:entry.age],
+            @"rloc16" : [NSNumber numberWithUnsignedShort:entry.rloc16],
+            @"linkFrameCounter" : [NSNumber numberWithUnsignedInt:entry.linkFrameCounter],
+            @"mleFrameCounter" : [NSNumber numberWithUnsignedInt:entry.mleFrameCounter],
+            @"lqi" : [NSNumber numberWithUnsignedChar:entry.lqi],
+            @"averageRssi" : [NSNumber numberWithChar:entry.averageRssi],
+            @"lastRssi" : [NSNumber numberWithChar:entry.lastRssi],
+            @"frameErrorRate" : [NSNumber numberWithUnsignedChar:entry.frameErrorRate],
+            @"messageErrorRate" : [NSNumber numberWithUnsignedChar:entry.messageErrorRate],
+            @"rxOnWhenIdle" : [NSNumber numberWithBool:entry.rxOnWhenIdle],
+            @"fullThreadDevice" : [NSNumber numberWithBool:entry.fullThreadDevice],
+            @"fullNetworkData" : [NSNumber numberWithBool:entry.fullNetworkData],
+            @"isChild" : [NSNumber numberWithBool:entry.isChild],
         }];
     }
     if (iter.GetStatus() != CHIP_NO_ERROR) {
@@ -702,16 +702,16 @@ void CHIPThreadNetworkDiagnosticsRouteTableListListAttributeCallbackBridge::OnSu
         auto & entry = iter.GetValue();
         (void) entry; // All our types below might be unsupported
         [array addObject:@ {
-            @"ExtAddress" : [NSNumber numberWithUnsignedLongLong:entry.extAddress],
-            @"Rloc16" : [NSNumber numberWithUnsignedShort:entry.rloc16],
-            @"RouterId" : [NSNumber numberWithUnsignedChar:entry.routerId],
-            @"NextHop" : [NSNumber numberWithUnsignedChar:entry.nextHop],
-            @"PathCost" : [NSNumber numberWithUnsignedChar:entry.pathCost],
-            @"LQIIn" : [NSNumber numberWithUnsignedChar:entry.LQIIn],
-            @"LQIOut" : [NSNumber numberWithUnsignedChar:entry.LQIOut],
-            @"Age" : [NSNumber numberWithUnsignedChar:entry.age],
-            @"Allocated" : [NSNumber numberWithBool:entry.allocated],
-            @"LinkEstablished" : [NSNumber numberWithBool:entry.linkEstablished],
+            @"extAddress" : [NSNumber numberWithUnsignedLongLong:entry.extAddress],
+            @"rloc16" : [NSNumber numberWithUnsignedShort:entry.rloc16],
+            @"routerId" : [NSNumber numberWithUnsignedChar:entry.routerId],
+            @"nextHop" : [NSNumber numberWithUnsignedChar:entry.nextHop],
+            @"pathCost" : [NSNumber numberWithUnsignedChar:entry.pathCost],
+            @"lqiIn" : [NSNumber numberWithUnsignedChar:entry.LQIIn],
+            @"lqiOut" : [NSNumber numberWithUnsignedChar:entry.LQIOut],
+            @"age" : [NSNumber numberWithUnsignedChar:entry.age],
+            @"allocated" : [NSNumber numberWithBool:entry.allocated],
+            @"linkEstablished" : [NSNumber numberWithBool:entry.linkEstablished],
         }];
     }
     if (iter.GetStatus() != CHIP_NO_ERROR) {
@@ -732,8 +732,8 @@ void CHIPThreadNetworkDiagnosticsSecurityPolicyListAttributeCallbackBridge::OnSu
         auto & entry = iter.GetValue();
         (void) entry; // All our types below might be unsupported
         [array addObject:@ {
-            @"RotationTime" : [NSNumber numberWithUnsignedShort:entry.rotationTime],
-            @"Flags" : [NSNumber numberWithUnsignedShort:entry.flags],
+            @"rotationTime" : [NSNumber numberWithUnsignedShort:entry.rotationTime],
+            @"flags" : [NSNumber numberWithUnsignedShort:entry.flags],
         }];
     }
     if (iter.GetStatus() != CHIP_NO_ERROR) {
@@ -754,18 +754,18 @@ void CHIPThreadNetworkDiagnosticsOperationalDatasetComponentsListAttributeCallba
         auto & entry = iter.GetValue();
         (void) entry; // All our types below might be unsupported
         [array addObject:@ {
-            @"ActiveTimestampPresent" : [NSNumber numberWithBool:entry.activeTimestampPresent],
-            @"PendingTimestampPresent" : [NSNumber numberWithBool:entry.pendingTimestampPresent],
-            @"MasterKeyPresent" : [NSNumber numberWithBool:entry.masterKeyPresent],
-            @"NetworkNamePresent" : [NSNumber numberWithBool:entry.networkNamePresent],
-            @"ExtendedPanIdPresent" : [NSNumber numberWithBool:entry.extendedPanIdPresent],
-            @"MeshLocalPrefixPresent" : [NSNumber numberWithBool:entry.meshLocalPrefixPresent],
-            @"DelayPresent" : [NSNumber numberWithBool:entry.delayPresent],
-            @"PanIdPresent" : [NSNumber numberWithBool:entry.panIdPresent],
-            @"ChannelPresent" : [NSNumber numberWithBool:entry.channelPresent],
-            @"PskcPresent" : [NSNumber numberWithBool:entry.pskcPresent],
-            @"SecurityPolicyPresent" : [NSNumber numberWithBool:entry.securityPolicyPresent],
-            @"ChannelMaskPresent" : [NSNumber numberWithBool:entry.channelMaskPresent],
+            @"activeTimestampPresent" : [NSNumber numberWithBool:entry.activeTimestampPresent],
+            @"pendingTimestampPresent" : [NSNumber numberWithBool:entry.pendingTimestampPresent],
+            @"masterKeyPresent" : [NSNumber numberWithBool:entry.masterKeyPresent],
+            @"networkNamePresent" : [NSNumber numberWithBool:entry.networkNamePresent],
+            @"extendedPanIdPresent" : [NSNumber numberWithBool:entry.extendedPanIdPresent],
+            @"meshLocalPrefixPresent" : [NSNumber numberWithBool:entry.meshLocalPrefixPresent],
+            @"delayPresent" : [NSNumber numberWithBool:entry.delayPresent],
+            @"panIdPresent" : [NSNumber numberWithBool:entry.panIdPresent],
+            @"channelPresent" : [NSNumber numberWithBool:entry.channelPresent],
+            @"pskcPresent" : [NSNumber numberWithBool:entry.pskcPresent],
+            @"securityPolicyPresent" : [NSNumber numberWithBool:entry.securityPolicyPresent],
+            @"channelMaskPresent" : [NSNumber numberWithBool:entry.channelMaskPresent],
         }];
     }
     if (iter.GetStatus() != CHIP_NO_ERROR) {
@@ -801,7 +801,7 @@ void CHIPAccountLoginClusterGetSetupPINResponseCallbackBridge::OnSuccessFn(
     {
         id value;
         value = [[NSString alloc] initWithBytes:data.setupPIN.data() length:data.setupPIN.size() encoding:NSUTF8StringEncoding];
-        response[@"SetupPIN"] = value;
+        response[@"setupPIN"] = value;
     }
     DispatchSuccess(context, response);
 };
@@ -813,12 +813,12 @@ void CHIPApplicationLauncherClusterLaunchAppResponseCallbackBridge::OnSuccessFn(
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.status];
-        response[@"Status"] = value;
+        response[@"status"] = value;
     }
     {
         id value;
         value = [[NSString alloc] initWithBytes:data.data.data() length:data.data.size() encoding:NSUTF8StringEncoding];
-        response[@"Data"] = value;
+        response[@"data"] = value;
     }
     DispatchSuccess(context, response);
 };
@@ -830,12 +830,12 @@ void CHIPContentLauncherClusterLaunchContentResponseCallbackBridge::OnSuccessFn(
     {
         id value;
         value = [[NSString alloc] initWithBytes:data.data.data() length:data.data.size() encoding:NSUTF8StringEncoding];
-        response[@"Data"] = value;
+        response[@"data"] = value;
     }
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.contentLaunchStatus];
-        response[@"ContentLaunchStatus"] = value;
+        response[@"contentLaunchStatus"] = value;
     }
     DispatchSuccess(context, response);
 };
@@ -847,12 +847,12 @@ void CHIPContentLauncherClusterLaunchURLResponseCallbackBridge::OnSuccessFn(
     {
         id value;
         value = [[NSString alloc] initWithBytes:data.data.data() length:data.data.size() encoding:NSUTF8StringEncoding];
-        response[@"Data"] = value;
+        response[@"data"] = value;
     }
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.contentLaunchStatus];
-        response[@"ContentLaunchStatus"] = value;
+        response[@"contentLaunchStatus"] = value;
     }
     DispatchSuccess(context, response);
 };
@@ -864,22 +864,22 @@ void CHIPDiagnosticLogsClusterRetrieveLogsResponseCallbackBridge::OnSuccessFn(
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.status];
-        response[@"Status"] = value;
+        response[@"status"] = value;
     }
     {
         id value;
         value = [NSData dataWithBytes:data.content.data() length:data.content.size()];
-        response[@"Content"] = value;
+        response[@"content"] = value;
     }
     {
         id value;
         value = [NSNumber numberWithUnsignedInt:data.timeStamp];
-        response[@"TimeStamp"] = value;
+        response[@"timeStamp"] = value;
     }
     {
         id value;
         value = [NSNumber numberWithUnsignedInt:data.timeSinceBoot];
-        response[@"TimeSinceBoot"] = value;
+        response[@"timeSinceBoot"] = value;
     }
     DispatchSuccess(context, response);
 };
@@ -891,7 +891,7 @@ void CHIPDoorLockClusterClearAllPinsResponseCallbackBridge::OnSuccessFn(
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.status];
-        response[@"Status"] = value;
+        response[@"status"] = value;
     }
     DispatchSuccess(context, response);
 };
@@ -903,7 +903,7 @@ void CHIPDoorLockClusterClearAllRfidsResponseCallbackBridge::OnSuccessFn(
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.status];
-        response[@"Status"] = value;
+        response[@"status"] = value;
     }
     DispatchSuccess(context, response);
 };
@@ -915,7 +915,7 @@ void CHIPDoorLockClusterClearHolidayScheduleResponseCallbackBridge::OnSuccessFn(
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.status];
-        response[@"Status"] = value;
+        response[@"status"] = value;
     }
     DispatchSuccess(context, response);
 };
@@ -927,7 +927,7 @@ void CHIPDoorLockClusterClearPinResponseCallbackBridge::OnSuccessFn(
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.status];
-        response[@"Status"] = value;
+        response[@"status"] = value;
     }
     DispatchSuccess(context, response);
 };
@@ -939,7 +939,7 @@ void CHIPDoorLockClusterClearRfidResponseCallbackBridge::OnSuccessFn(
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.status];
-        response[@"Status"] = value;
+        response[@"status"] = value;
     }
     DispatchSuccess(context, response);
 };
@@ -951,7 +951,7 @@ void CHIPDoorLockClusterClearWeekdayScheduleResponseCallbackBridge::OnSuccessFn(
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.status];
-        response[@"Status"] = value;
+        response[@"status"] = value;
     }
     DispatchSuccess(context, response);
 };
@@ -963,7 +963,7 @@ void CHIPDoorLockClusterClearYeardayScheduleResponseCallbackBridge::OnSuccessFn(
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.status];
-        response[@"Status"] = value;
+        response[@"status"] = value;
     }
     DispatchSuccess(context, response);
 };
@@ -975,27 +975,27 @@ void CHIPDoorLockClusterGetHolidayScheduleResponseCallbackBridge::OnSuccessFn(
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.scheduleId];
-        response[@"ScheduleId"] = value;
+        response[@"scheduleId"] = value;
     }
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.status];
-        response[@"Status"] = value;
+        response[@"status"] = value;
     }
     {
         id value;
         value = [NSNumber numberWithUnsignedInt:data.localStartTime];
-        response[@"LocalStartTime"] = value;
+        response[@"localStartTime"] = value;
     }
     {
         id value;
         value = [NSNumber numberWithUnsignedInt:data.localEndTime];
-        response[@"LocalEndTime"] = value;
+        response[@"localEndTime"] = value;
     }
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.operatingModeDuringHoliday];
-        response[@"OperatingModeDuringHoliday"] = value;
+        response[@"operatingModeDuringHoliday"] = value;
     }
     DispatchSuccess(context, response);
 };
@@ -1007,37 +1007,37 @@ void CHIPDoorLockClusterGetLogRecordResponseCallbackBridge::OnSuccessFn(
     {
         id value;
         value = [NSNumber numberWithUnsignedShort:data.logEntryId];
-        response[@"LogEntryId"] = value;
+        response[@"logEntryId"] = value;
     }
     {
         id value;
         value = [NSNumber numberWithUnsignedInt:data.timestamp];
-        response[@"Timestamp"] = value;
+        response[@"timestamp"] = value;
     }
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.eventType];
-        response[@"EventType"] = value;
+        response[@"eventType"] = value;
     }
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.source];
-        response[@"Source"] = value;
+        response[@"source"] = value;
     }
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.eventIdOrAlarmCode];
-        response[@"EventIdOrAlarmCode"] = value;
+        response[@"eventIdOrAlarmCode"] = value;
     }
     {
         id value;
         value = [NSNumber numberWithUnsignedShort:data.userId];
-        response[@"UserId"] = value;
+        response[@"userId"] = value;
     }
     {
         id value;
         value = [NSData dataWithBytes:data.pin.data() length:data.pin.size()];
-        response[@"Pin"] = value;
+        response[@"pin"] = value;
     }
     DispatchSuccess(context, response);
 };
@@ -1049,22 +1049,22 @@ void CHIPDoorLockClusterGetPinResponseCallbackBridge::OnSuccessFn(
     {
         id value;
         value = [NSNumber numberWithUnsignedShort:data.userId];
-        response[@"UserId"] = value;
+        response[@"userId"] = value;
     }
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.userStatus];
-        response[@"UserStatus"] = value;
+        response[@"userStatus"] = value;
     }
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.userType];
-        response[@"UserType"] = value;
+        response[@"userType"] = value;
     }
     {
         id value;
         value = [NSData dataWithBytes:data.pin.data() length:data.pin.size()];
-        response[@"Pin"] = value;
+        response[@"pin"] = value;
     }
     DispatchSuccess(context, response);
 };
@@ -1076,22 +1076,22 @@ void CHIPDoorLockClusterGetRfidResponseCallbackBridge::OnSuccessFn(
     {
         id value;
         value = [NSNumber numberWithUnsignedShort:data.userId];
-        response[@"UserId"] = value;
+        response[@"userId"] = value;
     }
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.userStatus];
-        response[@"UserStatus"] = value;
+        response[@"userStatus"] = value;
     }
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.userType];
-        response[@"UserType"] = value;
+        response[@"userType"] = value;
     }
     {
         id value;
         value = [NSData dataWithBytes:data.rfid.data() length:data.rfid.size()];
-        response[@"Rfid"] = value;
+        response[@"rfid"] = value;
     }
     DispatchSuccess(context, response);
 };
@@ -1103,12 +1103,12 @@ void CHIPDoorLockClusterGetUserTypeResponseCallbackBridge::OnSuccessFn(
     {
         id value;
         value = [NSNumber numberWithUnsignedShort:data.userId];
-        response[@"UserId"] = value;
+        response[@"userId"] = value;
     }
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.userType];
-        response[@"UserType"] = value;
+        response[@"userType"] = value;
     }
     DispatchSuccess(context, response);
 };
@@ -1120,42 +1120,42 @@ void CHIPDoorLockClusterGetWeekdayScheduleResponseCallbackBridge::OnSuccessFn(
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.scheduleId];
-        response[@"ScheduleId"] = value;
+        response[@"scheduleId"] = value;
     }
     {
         id value;
         value = [NSNumber numberWithUnsignedShort:data.userId];
-        response[@"UserId"] = value;
+        response[@"userId"] = value;
     }
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.status];
-        response[@"Status"] = value;
+        response[@"status"] = value;
     }
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.daysMask];
-        response[@"DaysMask"] = value;
+        response[@"daysMask"] = value;
     }
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.startHour];
-        response[@"StartHour"] = value;
+        response[@"startHour"] = value;
     }
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.startMinute];
-        response[@"StartMinute"] = value;
+        response[@"startMinute"] = value;
     }
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.endHour];
-        response[@"EndHour"] = value;
+        response[@"endHour"] = value;
     }
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.endMinute];
-        response[@"EndMinute"] = value;
+        response[@"endMinute"] = value;
     }
     DispatchSuccess(context, response);
 };
@@ -1167,27 +1167,27 @@ void CHIPDoorLockClusterGetYeardayScheduleResponseCallbackBridge::OnSuccessFn(
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.scheduleId];
-        response[@"ScheduleId"] = value;
+        response[@"scheduleId"] = value;
     }
     {
         id value;
         value = [NSNumber numberWithUnsignedShort:data.userId];
-        response[@"UserId"] = value;
+        response[@"userId"] = value;
     }
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.status];
-        response[@"Status"] = value;
+        response[@"status"] = value;
     }
     {
         id value;
         value = [NSNumber numberWithUnsignedInt:data.localStartTime];
-        response[@"LocalStartTime"] = value;
+        response[@"localStartTime"] = value;
     }
     {
         id value;
         value = [NSNumber numberWithUnsignedInt:data.localEndTime];
-        response[@"LocalEndTime"] = value;
+        response[@"localEndTime"] = value;
     }
     DispatchSuccess(context, response);
 };
@@ -1199,7 +1199,7 @@ void CHIPDoorLockClusterLockDoorResponseCallbackBridge::OnSuccessFn(
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.status];
-        response[@"Status"] = value;
+        response[@"status"] = value;
     }
     DispatchSuccess(context, response);
 };
@@ -1211,7 +1211,7 @@ void CHIPDoorLockClusterSetHolidayScheduleResponseCallbackBridge::OnSuccessFn(
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.status];
-        response[@"Status"] = value;
+        response[@"status"] = value;
     }
     DispatchSuccess(context, response);
 };
@@ -1223,7 +1223,7 @@ void CHIPDoorLockClusterSetPinResponseCallbackBridge::OnSuccessFn(
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.status];
-        response[@"Status"] = value;
+        response[@"status"] = value;
     }
     DispatchSuccess(context, response);
 };
@@ -1235,7 +1235,7 @@ void CHIPDoorLockClusterSetRfidResponseCallbackBridge::OnSuccessFn(
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.status];
-        response[@"Status"] = value;
+        response[@"status"] = value;
     }
     DispatchSuccess(context, response);
 };
@@ -1247,7 +1247,7 @@ void CHIPDoorLockClusterSetUserTypeResponseCallbackBridge::OnSuccessFn(
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.status];
-        response[@"Status"] = value;
+        response[@"status"] = value;
     }
     DispatchSuccess(context, response);
 };
@@ -1259,7 +1259,7 @@ void CHIPDoorLockClusterSetWeekdayScheduleResponseCallbackBridge::OnSuccessFn(
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.status];
-        response[@"Status"] = value;
+        response[@"status"] = value;
     }
     DispatchSuccess(context, response);
 };
@@ -1271,7 +1271,7 @@ void CHIPDoorLockClusterSetYeardayScheduleResponseCallbackBridge::OnSuccessFn(
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.status];
-        response[@"Status"] = value;
+        response[@"status"] = value;
     }
     DispatchSuccess(context, response);
 };
@@ -1283,7 +1283,7 @@ void CHIPDoorLockClusterUnlockDoorResponseCallbackBridge::OnSuccessFn(
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.status];
-        response[@"Status"] = value;
+        response[@"status"] = value;
     }
     DispatchSuccess(context, response);
 };
@@ -1295,7 +1295,7 @@ void CHIPDoorLockClusterUnlockWithTimeoutResponseCallbackBridge::OnSuccessFn(
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.status];
-        response[@"Status"] = value;
+        response[@"status"] = value;
     }
     DispatchSuccess(context, response);
 };
@@ -1307,12 +1307,12 @@ void CHIPGeneralCommissioningClusterArmFailSafeResponseCallbackBridge::OnSuccess
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.errorCode];
-        response[@"ErrorCode"] = value;
+        response[@"errorCode"] = value;
     }
     {
         id value;
         value = [[NSString alloc] initWithBytes:data.debugText.data() length:data.debugText.size() encoding:NSUTF8StringEncoding];
-        response[@"DebugText"] = value;
+        response[@"debugText"] = value;
     }
     DispatchSuccess(context, response);
 };
@@ -1324,12 +1324,12 @@ void CHIPGeneralCommissioningClusterCommissioningCompleteResponseCallbackBridge:
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.errorCode];
-        response[@"ErrorCode"] = value;
+        response[@"errorCode"] = value;
     }
     {
         id value;
         value = [[NSString alloc] initWithBytes:data.debugText.data() length:data.debugText.size() encoding:NSUTF8StringEncoding];
-        response[@"DebugText"] = value;
+        response[@"debugText"] = value;
     }
     DispatchSuccess(context, response);
 };
@@ -1341,12 +1341,12 @@ void CHIPGeneralCommissioningClusterSetRegulatoryConfigResponseCallbackBridge::O
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.errorCode];
-        response[@"ErrorCode"] = value;
+        response[@"errorCode"] = value;
     }
     {
         id value;
         value = [[NSString alloc] initWithBytes:data.debugText.data() length:data.debugText.size() encoding:NSUTF8StringEncoding];
-        response[@"DebugText"] = value;
+        response[@"debugText"] = value;
     }
     DispatchSuccess(context, response);
 };
@@ -1358,12 +1358,12 @@ void CHIPGroupsClusterAddGroupResponseCallbackBridge::OnSuccessFn(
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.status];
-        response[@"Status"] = value;
+        response[@"status"] = value;
     }
     {
         id value;
         value = [NSNumber numberWithUnsignedShort:data.groupId];
-        response[@"GroupId"] = value;
+        response[@"groupId"] = value;
     }
     DispatchSuccess(context, response);
 };
@@ -1375,12 +1375,12 @@ void CHIPGroupsClusterGetGroupMembershipResponseCallbackBridge::OnSuccessFn(
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.capacity];
-        response[@"Capacity"] = value;
+        response[@"capacity"] = value;
     }
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.groupCount];
-        response[@"GroupCount"] = value;
+        response[@"groupCount"] = value;
     }
     {
         id value;
@@ -1396,7 +1396,7 @@ void CHIPGroupsClusterGetGroupMembershipResponseCallbackBridge::OnSuccessFn(
             OnFailureFn(context, EMBER_ZCL_STATUS_INVALID_VALUE);
             return;
         }
-        response[@"GroupList"] = value;
+        response[@"groupList"] = value;
     }
     DispatchSuccess(context, response);
 };
@@ -1408,12 +1408,12 @@ void CHIPGroupsClusterRemoveGroupResponseCallbackBridge::OnSuccessFn(
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.status];
-        response[@"Status"] = value;
+        response[@"status"] = value;
     }
     {
         id value;
         value = [NSNumber numberWithUnsignedShort:data.groupId];
-        response[@"GroupId"] = value;
+        response[@"groupId"] = value;
     }
     DispatchSuccess(context, response);
 };
@@ -1425,17 +1425,17 @@ void CHIPGroupsClusterViewGroupResponseCallbackBridge::OnSuccessFn(
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.status];
-        response[@"Status"] = value;
+        response[@"status"] = value;
     }
     {
         id value;
         value = [NSNumber numberWithUnsignedShort:data.groupId];
-        response[@"GroupId"] = value;
+        response[@"groupId"] = value;
     }
     {
         id value;
         value = [[NSString alloc] initWithBytes:data.groupName.data() length:data.groupName.size() encoding:NSUTF8StringEncoding];
-        response[@"GroupName"] = value;
+        response[@"groupName"] = value;
     }
     DispatchSuccess(context, response);
 };
@@ -1447,7 +1447,7 @@ void CHIPIdentifyClusterIdentifyQueryResponseCallbackBridge::OnSuccessFn(
     {
         id value;
         value = [NSNumber numberWithUnsignedShort:data.timeout];
-        response[@"Timeout"] = value;
+        response[@"timeout"] = value;
     }
     DispatchSuccess(context, response);
 };
@@ -1459,7 +1459,7 @@ void CHIPKeypadInputClusterSendKeyResponseCallbackBridge::OnSuccessFn(
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.status];
-        response[@"Status"] = value;
+        response[@"status"] = value;
     }
     DispatchSuccess(context, response);
 };
@@ -1471,7 +1471,7 @@ void CHIPMediaPlaybackClusterMediaFastForwardResponseCallbackBridge::OnSuccessFn
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.mediaPlaybackStatus];
-        response[@"MediaPlaybackStatus"] = value;
+        response[@"mediaPlaybackStatus"] = value;
     }
     DispatchSuccess(context, response);
 };
@@ -1483,7 +1483,7 @@ void CHIPMediaPlaybackClusterMediaNextResponseCallbackBridge::OnSuccessFn(
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.mediaPlaybackStatus];
-        response[@"MediaPlaybackStatus"] = value;
+        response[@"mediaPlaybackStatus"] = value;
     }
     DispatchSuccess(context, response);
 };
@@ -1495,7 +1495,7 @@ void CHIPMediaPlaybackClusterMediaPauseResponseCallbackBridge::OnSuccessFn(
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.mediaPlaybackStatus];
-        response[@"MediaPlaybackStatus"] = value;
+        response[@"mediaPlaybackStatus"] = value;
     }
     DispatchSuccess(context, response);
 };
@@ -1507,7 +1507,7 @@ void CHIPMediaPlaybackClusterMediaPlayResponseCallbackBridge::OnSuccessFn(
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.mediaPlaybackStatus];
-        response[@"MediaPlaybackStatus"] = value;
+        response[@"mediaPlaybackStatus"] = value;
     }
     DispatchSuccess(context, response);
 };
@@ -1519,7 +1519,7 @@ void CHIPMediaPlaybackClusterMediaPreviousResponseCallbackBridge::OnSuccessFn(
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.mediaPlaybackStatus];
-        response[@"MediaPlaybackStatus"] = value;
+        response[@"mediaPlaybackStatus"] = value;
     }
     DispatchSuccess(context, response);
 };
@@ -1531,7 +1531,7 @@ void CHIPMediaPlaybackClusterMediaRewindResponseCallbackBridge::OnSuccessFn(
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.mediaPlaybackStatus];
-        response[@"MediaPlaybackStatus"] = value;
+        response[@"mediaPlaybackStatus"] = value;
     }
     DispatchSuccess(context, response);
 };
@@ -1543,7 +1543,7 @@ void CHIPMediaPlaybackClusterMediaSeekResponseCallbackBridge::OnSuccessFn(
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.mediaPlaybackStatus];
-        response[@"MediaPlaybackStatus"] = value;
+        response[@"mediaPlaybackStatus"] = value;
     }
     DispatchSuccess(context, response);
 };
@@ -1555,7 +1555,7 @@ void CHIPMediaPlaybackClusterMediaSkipBackwardResponseCallbackBridge::OnSuccessF
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.mediaPlaybackStatus];
-        response[@"MediaPlaybackStatus"] = value;
+        response[@"mediaPlaybackStatus"] = value;
     }
     DispatchSuccess(context, response);
 };
@@ -1567,7 +1567,7 @@ void CHIPMediaPlaybackClusterMediaSkipForwardResponseCallbackBridge::OnSuccessFn
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.mediaPlaybackStatus];
-        response[@"MediaPlaybackStatus"] = value;
+        response[@"mediaPlaybackStatus"] = value;
     }
     DispatchSuccess(context, response);
 };
@@ -1579,7 +1579,7 @@ void CHIPMediaPlaybackClusterMediaStartOverResponseCallbackBridge::OnSuccessFn(
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.mediaPlaybackStatus];
-        response[@"MediaPlaybackStatus"] = value;
+        response[@"mediaPlaybackStatus"] = value;
     }
     DispatchSuccess(context, response);
 };
@@ -1591,7 +1591,7 @@ void CHIPMediaPlaybackClusterMediaStopResponseCallbackBridge::OnSuccessFn(
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.mediaPlaybackStatus];
-        response[@"MediaPlaybackStatus"] = value;
+        response[@"mediaPlaybackStatus"] = value;
     }
     DispatchSuccess(context, response);
 };
@@ -1603,12 +1603,12 @@ void CHIPNetworkCommissioningClusterAddThreadNetworkResponseCallbackBridge::OnSu
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.errorCode];
-        response[@"ErrorCode"] = value;
+        response[@"errorCode"] = value;
     }
     {
         id value;
         value = [[NSString alloc] initWithBytes:data.debugText.data() length:data.debugText.size() encoding:NSUTF8StringEncoding];
-        response[@"DebugText"] = value;
+        response[@"debugText"] = value;
     }
     DispatchSuccess(context, response);
 };
@@ -1620,12 +1620,12 @@ void CHIPNetworkCommissioningClusterAddWiFiNetworkResponseCallbackBridge::OnSucc
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.errorCode];
-        response[@"ErrorCode"] = value;
+        response[@"errorCode"] = value;
     }
     {
         id value;
         value = [[NSString alloc] initWithBytes:data.debugText.data() length:data.debugText.size() encoding:NSUTF8StringEncoding];
-        response[@"DebugText"] = value;
+        response[@"debugText"] = value;
     }
     DispatchSuccess(context, response);
 };
@@ -1637,12 +1637,12 @@ void CHIPNetworkCommissioningClusterDisableNetworkResponseCallbackBridge::OnSucc
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.errorCode];
-        response[@"ErrorCode"] = value;
+        response[@"errorCode"] = value;
     }
     {
         id value;
         value = [[NSString alloc] initWithBytes:data.debugText.data() length:data.debugText.size() encoding:NSUTF8StringEncoding];
-        response[@"DebugText"] = value;
+        response[@"debugText"] = value;
     }
     DispatchSuccess(context, response);
 };
@@ -1654,12 +1654,12 @@ void CHIPNetworkCommissioningClusterEnableNetworkResponseCallbackBridge::OnSucce
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.errorCode];
-        response[@"ErrorCode"] = value;
+        response[@"errorCode"] = value;
     }
     {
         id value;
         value = [[NSString alloc] initWithBytes:data.debugText.data() length:data.debugText.size() encoding:NSUTF8StringEncoding];
-        response[@"DebugText"] = value;
+        response[@"debugText"] = value;
     }
     DispatchSuccess(context, response);
 };
@@ -1671,12 +1671,12 @@ void CHIPNetworkCommissioningClusterRemoveNetworkResponseCallbackBridge::OnSucce
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.errorCode];
-        response[@"ErrorCode"] = value;
+        response[@"errorCode"] = value;
     }
     {
         id value;
         value = [[NSString alloc] initWithBytes:data.debugText.data() length:data.debugText.size() encoding:NSUTF8StringEncoding];
-        response[@"DebugText"] = value;
+        response[@"debugText"] = value;
     }
     DispatchSuccess(context, response);
 };
@@ -1688,12 +1688,12 @@ void CHIPNetworkCommissioningClusterScanNetworksResponseCallbackBridge::OnSucces
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.errorCode];
-        response[@"ErrorCode"] = value;
+        response[@"errorCode"] = value;
     }
     {
         id value;
         value = [[NSString alloc] initWithBytes:data.debugText.data() length:data.debugText.size() encoding:NSUTF8StringEncoding];
-        response[@"DebugText"] = value;
+        response[@"debugText"] = value;
     }
     {
         id value;
@@ -1702,18 +1702,18 @@ void CHIPNetworkCommissioningClusterScanNetworksResponseCallbackBridge::OnSucces
         while (iter.Next()) {
             auto & entry = iter.GetValue();
             auto * newElement = [[CHIPNetworkCommissioningClusterWiFiInterfaceScanResult alloc] init];
-            newElement.Security = [NSNumber numberWithUnsignedChar:entry.security];
-            newElement.Ssid = [NSData dataWithBytes:entry.ssid.data() length:entry.ssid.size()];
-            newElement.Bssid = [NSData dataWithBytes:entry.bssid.data() length:entry.bssid.size()];
-            newElement.Channel = [NSNumber numberWithUnsignedChar:entry.channel];
-            newElement.FrequencyBand = [NSNumber numberWithUnsignedInt:entry.frequencyBand];
+            newElement.security = [NSNumber numberWithUnsignedChar:entry.security];
+            newElement.ssid = [NSData dataWithBytes:entry.ssid.data() length:entry.ssid.size()];
+            newElement.bssid = [NSData dataWithBytes:entry.bssid.data() length:entry.bssid.size()];
+            newElement.channel = [NSNumber numberWithUnsignedChar:entry.channel];
+            newElement.frequencyBand = [NSNumber numberWithUnsignedInt:entry.frequencyBand];
             [value addObject:newElement];
         }
         if (iter.GetStatus() != CHIP_NO_ERROR) {
             OnFailureFn(context, EMBER_ZCL_STATUS_INVALID_VALUE);
             return;
         }
-        response[@"WifiScanResults"] = value;
+        response[@"wifiScanResults"] = value;
     }
     {
         id value;
@@ -1722,7 +1722,7 @@ void CHIPNetworkCommissioningClusterScanNetworksResponseCallbackBridge::OnSucces
         while (iter.Next()) {
             auto & entry = iter.GetValue();
             auto * newElement = [[CHIPNetworkCommissioningClusterThreadInterfaceScanResult alloc] init];
-            newElement.DiscoveryResponse = [NSData dataWithBytes:entry.discoveryResponse.data()
+            newElement.discoveryResponse = [NSData dataWithBytes:entry.discoveryResponse.data()
                                                           length:entry.discoveryResponse.size()];
             [value addObject:newElement];
         }
@@ -1730,7 +1730,7 @@ void CHIPNetworkCommissioningClusterScanNetworksResponseCallbackBridge::OnSucces
             OnFailureFn(context, EMBER_ZCL_STATUS_INVALID_VALUE);
             return;
         }
-        response[@"ThreadScanResults"] = value;
+        response[@"threadScanResults"] = value;
     }
     DispatchSuccess(context, response);
 };
@@ -1742,12 +1742,12 @@ void CHIPNetworkCommissioningClusterUpdateThreadNetworkResponseCallbackBridge::O
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.errorCode];
-        response[@"ErrorCode"] = value;
+        response[@"errorCode"] = value;
     }
     {
         id value;
         value = [[NSString alloc] initWithBytes:data.debugText.data() length:data.debugText.size() encoding:NSUTF8StringEncoding];
-        response[@"DebugText"] = value;
+        response[@"debugText"] = value;
     }
     DispatchSuccess(context, response);
 };
@@ -1759,12 +1759,12 @@ void CHIPNetworkCommissioningClusterUpdateWiFiNetworkResponseCallbackBridge::OnS
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.errorCode];
-        response[@"ErrorCode"] = value;
+        response[@"errorCode"] = value;
     }
     {
         id value;
         value = [[NSString alloc] initWithBytes:data.debugText.data() length:data.debugText.size() encoding:NSUTF8StringEncoding];
-        response[@"DebugText"] = value;
+        response[@"debugText"] = value;
     }
     DispatchSuccess(context, response);
 };
@@ -1776,12 +1776,12 @@ void CHIPOtaSoftwareUpdateProviderClusterApplyUpdateResponseCallbackBridge::OnSu
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.action];
-        response[@"Action"] = value;
+        response[@"action"] = value;
     }
     {
         id value;
         value = [NSNumber numberWithUnsignedInt:data.delayedActionTime];
-        response[@"DelayedActionTime"] = value;
+        response[@"delayedActionTime"] = value;
     }
     DispatchSuccess(context, response);
 };
@@ -1793,7 +1793,7 @@ void CHIPOtaSoftwareUpdateProviderClusterQueryImageResponseCallbackBridge::OnSuc
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.status];
-        response[@"Status"] = value;
+        response[@"status"] = value;
     }
     {
         id value;
@@ -1802,7 +1802,7 @@ void CHIPOtaSoftwareUpdateProviderClusterQueryImageResponseCallbackBridge::OnSuc
         } else {
             value = [NSNull null];
         }
-        response[@"DelayedActionTime"] = value;
+        response[@"delayedActionTime"] = value;
     }
     {
         id value;
@@ -1813,7 +1813,7 @@ void CHIPOtaSoftwareUpdateProviderClusterQueryImageResponseCallbackBridge::OnSuc
         } else {
             value = [NSNull null];
         }
-        response[@"ImageURI"] = value;
+        response[@"imageURI"] = value;
     }
     {
         id value;
@@ -1822,7 +1822,7 @@ void CHIPOtaSoftwareUpdateProviderClusterQueryImageResponseCallbackBridge::OnSuc
         } else {
             value = [NSNull null];
         }
-        response[@"SoftwareVersion"] = value;
+        response[@"softwareVersion"] = value;
     }
     {
         id value;
@@ -1833,7 +1833,7 @@ void CHIPOtaSoftwareUpdateProviderClusterQueryImageResponseCallbackBridge::OnSuc
         } else {
             value = [NSNull null];
         }
-        response[@"SoftwareVersionString"] = value;
+        response[@"softwareVersionString"] = value;
     }
     {
         id value;
@@ -1842,7 +1842,7 @@ void CHIPOtaSoftwareUpdateProviderClusterQueryImageResponseCallbackBridge::OnSuc
         } else {
             value = [NSNull null];
         }
-        response[@"UpdateToken"] = value;
+        response[@"updateToken"] = value;
     }
     {
         id value;
@@ -1851,7 +1851,7 @@ void CHIPOtaSoftwareUpdateProviderClusterQueryImageResponseCallbackBridge::OnSuc
         } else {
             value = [NSNull null];
         }
-        response[@"UserConsentNeeded"] = value;
+        response[@"userConsentNeeded"] = value;
     }
     {
         id value;
@@ -1860,7 +1860,7 @@ void CHIPOtaSoftwareUpdateProviderClusterQueryImageResponseCallbackBridge::OnSuc
         } else {
             value = [NSNull null];
         }
-        response[@"MetadataForRequestor"] = value;
+        response[@"metadataForRequestor"] = value;
     }
     DispatchSuccess(context, response);
 };
@@ -1872,12 +1872,12 @@ void CHIPOperationalCredentialsClusterAttestationResponseCallbackBridge::OnSucce
     {
         id value;
         value = [NSData dataWithBytes:data.attestationElements.data() length:data.attestationElements.size()];
-        response[@"AttestationElements"] = value;
+        response[@"attestationElements"] = value;
     }
     {
         id value;
         value = [NSData dataWithBytes:data.signature.data() length:data.signature.size()];
-        response[@"Signature"] = value;
+        response[@"signature"] = value;
     }
     DispatchSuccess(context, response);
 };
@@ -1889,7 +1889,7 @@ void CHIPOperationalCredentialsClusterCertificateChainResponseCallbackBridge::On
     {
         id value;
         value = [NSData dataWithBytes:data.certificate.data() length:data.certificate.size()];
-        response[@"Certificate"] = value;
+        response[@"certificate"] = value;
     }
     DispatchSuccess(context, response);
 };
@@ -1901,17 +1901,17 @@ void CHIPOperationalCredentialsClusterNOCResponseCallbackBridge::OnSuccessFn(
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.statusCode];
-        response[@"StatusCode"] = value;
+        response[@"statusCode"] = value;
     }
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.fabricIndex];
-        response[@"FabricIndex"] = value;
+        response[@"fabricIndex"] = value;
     }
     {
         id value;
         value = [[NSString alloc] initWithBytes:data.debugText.data() length:data.debugText.size() encoding:NSUTF8StringEncoding];
-        response[@"DebugText"] = value;
+        response[@"debugText"] = value;
     }
     DispatchSuccess(context, response);
 };
@@ -1923,12 +1923,12 @@ void CHIPOperationalCredentialsClusterOpCSRResponseCallbackBridge::OnSuccessFn(
     {
         id value;
         value = [NSData dataWithBytes:data.NOCSRElements.data() length:data.NOCSRElements.size()];
-        response[@"NOCSRElements"] = value;
+        response[@"nocsrElements"] = value;
     }
     {
         id value;
         value = [NSData dataWithBytes:data.attestationSignature.data() length:data.attestationSignature.size()];
-        response[@"AttestationSignature"] = value;
+        response[@"attestationSignature"] = value;
     }
     DispatchSuccess(context, response);
 };
@@ -1940,17 +1940,17 @@ void CHIPScenesClusterAddSceneResponseCallbackBridge::OnSuccessFn(
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.status];
-        response[@"Status"] = value;
+        response[@"status"] = value;
     }
     {
         id value;
         value = [NSNumber numberWithUnsignedShort:data.groupId];
-        response[@"GroupId"] = value;
+        response[@"groupId"] = value;
     }
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.sceneId];
-        response[@"SceneId"] = value;
+        response[@"sceneId"] = value;
     }
     DispatchSuccess(context, response);
 };
@@ -1962,22 +1962,22 @@ void CHIPScenesClusterGetSceneMembershipResponseCallbackBridge::OnSuccessFn(
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.status];
-        response[@"Status"] = value;
+        response[@"status"] = value;
     }
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.capacity];
-        response[@"Capacity"] = value;
+        response[@"capacity"] = value;
     }
     {
         id value;
         value = [NSNumber numberWithUnsignedShort:data.groupId];
-        response[@"GroupId"] = value;
+        response[@"groupId"] = value;
     }
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.sceneCount];
-        response[@"SceneCount"] = value;
+        response[@"sceneCount"] = value;
     }
     {
         id value;
@@ -1993,7 +1993,7 @@ void CHIPScenesClusterGetSceneMembershipResponseCallbackBridge::OnSuccessFn(
             OnFailureFn(context, EMBER_ZCL_STATUS_INVALID_VALUE);
             return;
         }
-        response[@"SceneList"] = value;
+        response[@"sceneList"] = value;
     }
     DispatchSuccess(context, response);
 };
@@ -2005,12 +2005,12 @@ void CHIPScenesClusterRemoveAllScenesResponseCallbackBridge::OnSuccessFn(
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.status];
-        response[@"Status"] = value;
+        response[@"status"] = value;
     }
     {
         id value;
         value = [NSNumber numberWithUnsignedShort:data.groupId];
-        response[@"GroupId"] = value;
+        response[@"groupId"] = value;
     }
     DispatchSuccess(context, response);
 };
@@ -2022,17 +2022,17 @@ void CHIPScenesClusterRemoveSceneResponseCallbackBridge::OnSuccessFn(
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.status];
-        response[@"Status"] = value;
+        response[@"status"] = value;
     }
     {
         id value;
         value = [NSNumber numberWithUnsignedShort:data.groupId];
-        response[@"GroupId"] = value;
+        response[@"groupId"] = value;
     }
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.sceneId];
-        response[@"SceneId"] = value;
+        response[@"sceneId"] = value;
     }
     DispatchSuccess(context, response);
 };
@@ -2044,17 +2044,17 @@ void CHIPScenesClusterStoreSceneResponseCallbackBridge::OnSuccessFn(
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.status];
-        response[@"Status"] = value;
+        response[@"status"] = value;
     }
     {
         id value;
         value = [NSNumber numberWithUnsignedShort:data.groupId];
-        response[@"GroupId"] = value;
+        response[@"groupId"] = value;
     }
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.sceneId];
-        response[@"SceneId"] = value;
+        response[@"sceneId"] = value;
     }
     DispatchSuccess(context, response);
 };
@@ -2066,27 +2066,27 @@ void CHIPScenesClusterViewSceneResponseCallbackBridge::OnSuccessFn(
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.status];
-        response[@"Status"] = value;
+        response[@"status"] = value;
     }
     {
         id value;
         value = [NSNumber numberWithUnsignedShort:data.groupId];
-        response[@"GroupId"] = value;
+        response[@"groupId"] = value;
     }
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.sceneId];
-        response[@"SceneId"] = value;
+        response[@"sceneId"] = value;
     }
     {
         id value;
         value = [NSNumber numberWithUnsignedShort:data.transitionTime];
-        response[@"TransitionTime"] = value;
+        response[@"transitionTime"] = value;
     }
     {
         id value;
         value = [[NSString alloc] initWithBytes:data.sceneName.data() length:data.sceneName.size() encoding:NSUTF8StringEncoding];
-        response[@"SceneName"] = value;
+        response[@"sceneName"] = value;
     }
     {
         id value;
@@ -2095,16 +2095,16 @@ void CHIPScenesClusterViewSceneResponseCallbackBridge::OnSuccessFn(
         while (iter.Next()) {
             auto & entry = iter.GetValue();
             auto * newElement = [[CHIPScenesClusterSceneExtensionFieldSet alloc] init];
-            newElement.ClusterId = [NSNumber numberWithUnsignedInt:entry.clusterId];
-            newElement.Length = [NSNumber numberWithUnsignedChar:entry.length];
-            newElement.Value = [NSNumber numberWithUnsignedChar:entry.value];
+            newElement.clusterId = [NSNumber numberWithUnsignedInt:entry.clusterId];
+            newElement.length = [NSNumber numberWithUnsignedChar:entry.length];
+            newElement.value = [NSNumber numberWithUnsignedChar:entry.value];
             [value addObject:newElement];
         }
         if (iter.GetStatus() != CHIP_NO_ERROR) {
             OnFailureFn(context, EMBER_ZCL_STATUS_INVALID_VALUE);
             return;
         }
-        response[@"ExtensionFieldSets"] = value;
+        response[@"extensionFieldSets"] = value;
     }
     DispatchSuccess(context, response);
 };
@@ -2120,15 +2120,15 @@ void CHIPTvChannelClusterChangeChannelResponseCallbackBridge::OnSuccessFn(
         while (iter.Next()) {
             auto & entry = iter.GetValue();
             auto * newElement = [[CHIPTvChannelClusterTvChannelInfo alloc] init];
-            newElement.MajorNumber = [NSNumber numberWithUnsignedShort:entry.majorNumber];
-            newElement.MinorNumber = [NSNumber numberWithUnsignedShort:entry.minorNumber];
-            newElement.Name = [[NSString alloc] initWithBytes:entry.name.data()
+            newElement.majorNumber = [NSNumber numberWithUnsignedShort:entry.majorNumber];
+            newElement.minorNumber = [NSNumber numberWithUnsignedShort:entry.minorNumber];
+            newElement.name = [[NSString alloc] initWithBytes:entry.name.data()
                                                        length:entry.name.size()
                                                      encoding:NSUTF8StringEncoding];
-            newElement.CallSign = [[NSString alloc] initWithBytes:entry.callSign.data()
+            newElement.callSign = [[NSString alloc] initWithBytes:entry.callSign.data()
                                                            length:entry.callSign.size()
                                                          encoding:NSUTF8StringEncoding];
-            newElement.AffiliateCallSign = [[NSString alloc] initWithBytes:entry.affiliateCallSign.data()
+            newElement.affiliateCallSign = [[NSString alloc] initWithBytes:entry.affiliateCallSign.data()
                                                                     length:entry.affiliateCallSign.size()
                                                                   encoding:NSUTF8StringEncoding];
             [value addObject:newElement];
@@ -2137,12 +2137,12 @@ void CHIPTvChannelClusterChangeChannelResponseCallbackBridge::OnSuccessFn(
             OnFailureFn(context, EMBER_ZCL_STATUS_INVALID_VALUE);
             return;
         }
-        response[@"ChannelMatch"] = value;
+        response[@"channelMatch"] = value;
     }
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.errorType];
-        response[@"ErrorType"] = value;
+        response[@"errorType"] = value;
     }
     DispatchSuccess(context, response);
 };
@@ -2154,12 +2154,12 @@ void CHIPTargetNavigatorClusterNavigateTargetResponseCallbackBridge::OnSuccessFn
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.status];
-        response[@"Status"] = value;
+        response[@"status"] = value;
     }
     {
         id value;
         value = [[NSString alloc] initWithBytes:data.data.data() length:data.data.size() encoding:NSUTF8StringEncoding];
-        response[@"Data"] = value;
+        response[@"data"] = value;
     }
     DispatchSuccess(context, response);
 };
@@ -2171,7 +2171,7 @@ void CHIPTestClusterClusterBooleanResponseCallbackBridge::OnSuccessFn(
     {
         id value;
         value = [NSNumber numberWithBool:data.value];
-        response[@"Value"] = value;
+        response[@"value"] = value;
     }
     DispatchSuccess(context, response);
 };
@@ -2183,7 +2183,7 @@ void CHIPTestClusterClusterTestAddArgumentsResponseCallbackBridge::OnSuccessFn(
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.returnValue];
-        response[@"ReturnValue"] = value;
+        response[@"returnValue"] = value;
     }
     DispatchSuccess(context, response);
 };
@@ -2195,12 +2195,12 @@ void CHIPTestClusterClusterTestEnumsResponseCallbackBridge::OnSuccessFn(
     {
         id value;
         value = [NSNumber numberWithUnsignedShort:data.arg1];
-        response[@"Arg1"] = value;
+        response[@"arg1"] = value;
     }
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.arg2];
-        response[@"Arg2"] = value;
+        response[@"arg2"] = value;
     }
     DispatchSuccess(context, response);
 };
@@ -2223,7 +2223,7 @@ void CHIPTestClusterClusterTestListInt8UReverseResponseCallbackBridge::OnSuccess
             OnFailureFn(context, EMBER_ZCL_STATUS_INVALID_VALUE);
             return;
         }
-        response[@"Arg1"] = value;
+        response[@"arg1"] = value;
     }
     DispatchSuccess(context, response);
 };
@@ -2235,7 +2235,7 @@ void CHIPTestClusterClusterTestNullableOptionalResponseCallbackBridge::OnSuccess
     {
         id value;
         value = [NSNumber numberWithBool:data.wasPresent];
-        response[@"WasPresent"] = value;
+        response[@"wasPresent"] = value;
     }
     {
         id value;
@@ -2244,7 +2244,7 @@ void CHIPTestClusterClusterTestNullableOptionalResponseCallbackBridge::OnSuccess
         } else {
             value = [NSNull null];
         }
-        response[@"WasNull"] = value;
+        response[@"wasNull"] = value;
     }
     {
         id value;
@@ -2253,7 +2253,7 @@ void CHIPTestClusterClusterTestNullableOptionalResponseCallbackBridge::OnSuccess
         } else {
             value = [NSNull null];
         }
-        response[@"Value"] = value;
+        response[@"value"] = value;
     }
     {
         id value;
@@ -2266,7 +2266,7 @@ void CHIPTestClusterClusterTestNullableOptionalResponseCallbackBridge::OnSuccess
         } else {
             value = [NSNull null];
         }
-        response[@"OriginalValue"] = value;
+        response[@"originalValue"] = value;
     }
     DispatchSuccess(context, response);
 };
@@ -2278,7 +2278,7 @@ void CHIPTestClusterClusterTestSpecificResponseCallbackBridge::OnSuccessFn(
     {
         id value;
         value = [NSNumber numberWithUnsignedChar:data.returnValue];
-        response[@"ReturnValue"] = value;
+        response[@"returnValue"] = value;
     }
     DispatchSuccess(context, response);
 };

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPClustersObjc.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPClustersObjc.mm
@@ -45,7 +45,7 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     AccountLogin::Commands::GetSetupPIN::Type request;
-    request.tempAccountIdentifier = [self asCharSpan:payload.TempAccountIdentifier];
+    request.tempAccountIdentifier = [self asCharSpan:payload.tempAccountIdentifier];
 
     new CHIPAccountLoginClusterGetSetupPINResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -59,8 +59,8 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     AccountLogin::Commands::Login::Type request;
-    request.tempAccountIdentifier = [self asCharSpan:payload.TempAccountIdentifier];
-    request.setupPIN = [self asCharSpan:payload.SetupPIN];
+    request.tempAccountIdentifier = [self asCharSpan:payload.tempAccountIdentifier];
+    request.setupPIN = [self asCharSpan:payload.setupPIN];
 
     new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
@@ -90,7 +90,7 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     AdministratorCommissioning::Commands::OpenBasicCommissioningWindow::Type request;
-    request.commissioningTimeout = payload.CommissioningTimeout.unsignedShortValue;
+    request.commissioningTimeout = payload.commissioningTimeout.unsignedShortValue;
 
     new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
@@ -104,12 +104,12 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     AdministratorCommissioning::Commands::OpenCommissioningWindow::Type request;
-    request.commissioningTimeout = payload.CommissioningTimeout.unsignedShortValue;
-    request.PAKEVerifier = [self asByteSpan:payload.PAKEVerifier];
-    request.discriminator = payload.Discriminator.unsignedShortValue;
-    request.iterations = payload.Iterations.unsignedIntValue;
-    request.salt = [self asByteSpan:payload.Salt];
-    request.passcodeID = payload.PasscodeID.unsignedShortValue;
+    request.commissioningTimeout = payload.commissioningTimeout.unsignedShortValue;
+    request.PAKEVerifier = [self asByteSpan:payload.pakeVerifier];
+    request.discriminator = payload.discriminator.unsignedShortValue;
+    request.iterations = payload.iterations.unsignedIntValue;
+    request.salt = [self asByteSpan:payload.salt];
+    request.passcodeID = payload.passcodeID.unsignedShortValue;
 
     new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
@@ -152,7 +152,7 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     ApplicationBasic::Commands::ChangeStatus::Type request;
-    request.status = static_cast<std::remove_reference_t<decltype(request.status)>>(payload.Status.unsignedCharValue);
+    request.status = static_cast<std::remove_reference_t<decltype(request.status)>>(payload.status.unsignedCharValue);
 
     new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
@@ -231,9 +231,9 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     ApplicationLauncher::Commands::LaunchApp::Type request;
-    request.data = [self asCharSpan:payload.Data];
-    request.catalogVendorId = payload.CatalogVendorId.unsignedShortValue;
-    request.applicationId = [self asCharSpan:payload.ApplicationId];
+    request.data = [self asCharSpan:payload.data];
+    request.catalogVendorId = payload.catalogVendorId.unsignedShortValue;
+    request.applicationId = [self asCharSpan:payload.applicationId];
 
     new CHIPApplicationLauncherClusterLaunchAppResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -285,8 +285,8 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     AudioOutput::Commands::RenameOutput::Type request;
-    request.index = payload.Index.unsignedCharValue;
-    request.name = [self asCharSpan:payload.Name];
+    request.index = payload.index.unsignedCharValue;
+    request.name = [self asCharSpan:payload.name];
 
     new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
@@ -299,7 +299,7 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     AudioOutput::Commands::SelectOutput::Type request;
-    request.index = payload.Index.unsignedCharValue;
+    request.index = payload.index.unsignedCharValue;
 
     new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
@@ -344,7 +344,7 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     BarrierControl::Commands::BarrierControlGoToPercent::Type request;
-    request.percentOpen = payload.PercentOpen.unsignedCharValue;
+    request.percentOpen = payload.percentOpen.unsignedCharValue;
 
     new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
@@ -708,10 +708,10 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     Binding::Commands::Bind::Type request;
-    request.nodeId = payload.NodeId.unsignedLongLongValue;
-    request.groupId = payload.GroupId.unsignedShortValue;
-    request.endpointId = payload.EndpointId.unsignedShortValue;
-    request.clusterId = payload.ClusterId.unsignedIntValue;
+    request.nodeId = payload.nodeId.unsignedLongLongValue;
+    request.groupId = payload.groupId.unsignedShortValue;
+    request.endpointId = payload.endpointId.unsignedShortValue;
+    request.clusterId = payload.clusterId.unsignedIntValue;
 
     new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
@@ -724,10 +724,10 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     Binding::Commands::Unbind::Type request;
-    request.nodeId = payload.NodeId.unsignedLongLongValue;
-    request.groupId = payload.GroupId.unsignedShortValue;
-    request.endpointId = payload.EndpointId.unsignedShortValue;
-    request.clusterId = payload.ClusterId.unsignedIntValue;
+    request.nodeId = payload.nodeId.unsignedLongLongValue;
+    request.groupId = payload.groupId.unsignedShortValue;
+    request.endpointId = payload.endpointId.unsignedShortValue;
+    request.clusterId = payload.clusterId.unsignedIntValue;
 
     new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
@@ -799,10 +799,10 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     BridgedActions::Commands::DisableAction::Type request;
-    request.actionID = payload.ActionID.unsignedShortValue;
-    if (payload.InvokeID != nil) {
+    request.actionID = payload.actionID.unsignedShortValue;
+    if (payload.invokeID != nil) {
         auto & definedValue_0 = request.invokeID.Emplace();
-        definedValue_0 = payload.InvokeID.unsignedIntValue;
+        definedValue_0 = payload.invokeID.unsignedIntValue;
     }
 
     new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -817,12 +817,12 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     BridgedActions::Commands::DisableActionWithDuration::Type request;
-    request.actionID = payload.ActionID.unsignedShortValue;
-    if (payload.InvokeID != nil) {
+    request.actionID = payload.actionID.unsignedShortValue;
+    if (payload.invokeID != nil) {
         auto & definedValue_0 = request.invokeID.Emplace();
-        definedValue_0 = payload.InvokeID.unsignedIntValue;
+        definedValue_0 = payload.invokeID.unsignedIntValue;
     }
-    request.duration = payload.Duration.unsignedIntValue;
+    request.duration = payload.duration.unsignedIntValue;
 
     new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
@@ -836,10 +836,10 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     BridgedActions::Commands::EnableAction::Type request;
-    request.actionID = payload.ActionID.unsignedShortValue;
-    if (payload.InvokeID != nil) {
+    request.actionID = payload.actionID.unsignedShortValue;
+    if (payload.invokeID != nil) {
         auto & definedValue_0 = request.invokeID.Emplace();
-        definedValue_0 = payload.InvokeID.unsignedIntValue;
+        definedValue_0 = payload.invokeID.unsignedIntValue;
     }
 
     new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -854,12 +854,12 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     BridgedActions::Commands::EnableActionWithDuration::Type request;
-    request.actionID = payload.ActionID.unsignedShortValue;
-    if (payload.InvokeID != nil) {
+    request.actionID = payload.actionID.unsignedShortValue;
+    if (payload.invokeID != nil) {
         auto & definedValue_0 = request.invokeID.Emplace();
-        definedValue_0 = payload.InvokeID.unsignedIntValue;
+        definedValue_0 = payload.invokeID.unsignedIntValue;
     }
-    request.duration = payload.Duration.unsignedIntValue;
+    request.duration = payload.duration.unsignedIntValue;
 
     new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
@@ -873,10 +873,10 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     BridgedActions::Commands::InstantAction::Type request;
-    request.actionID = payload.ActionID.unsignedShortValue;
-    if (payload.InvokeID != nil) {
+    request.actionID = payload.actionID.unsignedShortValue;
+    if (payload.invokeID != nil) {
         auto & definedValue_0 = request.invokeID.Emplace();
-        definedValue_0 = payload.InvokeID.unsignedIntValue;
+        definedValue_0 = payload.invokeID.unsignedIntValue;
     }
 
     new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -891,12 +891,12 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     BridgedActions::Commands::InstantActionWithTransition::Type request;
-    request.actionID = payload.ActionID.unsignedShortValue;
-    if (payload.InvokeID != nil) {
+    request.actionID = payload.actionID.unsignedShortValue;
+    if (payload.invokeID != nil) {
         auto & definedValue_0 = request.invokeID.Emplace();
-        definedValue_0 = payload.InvokeID.unsignedIntValue;
+        definedValue_0 = payload.invokeID.unsignedIntValue;
     }
-    request.transitionTime = payload.TransitionTime.unsignedShortValue;
+    request.transitionTime = payload.transitionTime.unsignedShortValue;
 
     new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
@@ -909,10 +909,10 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     BridgedActions::Commands::PauseAction::Type request;
-    request.actionID = payload.ActionID.unsignedShortValue;
-    if (payload.InvokeID != nil) {
+    request.actionID = payload.actionID.unsignedShortValue;
+    if (payload.invokeID != nil) {
         auto & definedValue_0 = request.invokeID.Emplace();
-        definedValue_0 = payload.InvokeID.unsignedIntValue;
+        definedValue_0 = payload.invokeID.unsignedIntValue;
     }
 
     new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -927,12 +927,12 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     BridgedActions::Commands::PauseActionWithDuration::Type request;
-    request.actionID = payload.ActionID.unsignedShortValue;
-    if (payload.InvokeID != nil) {
+    request.actionID = payload.actionID.unsignedShortValue;
+    if (payload.invokeID != nil) {
         auto & definedValue_0 = request.invokeID.Emplace();
-        definedValue_0 = payload.InvokeID.unsignedIntValue;
+        definedValue_0 = payload.invokeID.unsignedIntValue;
     }
-    request.duration = payload.Duration.unsignedIntValue;
+    request.duration = payload.duration.unsignedIntValue;
 
     new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
@@ -946,10 +946,10 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     BridgedActions::Commands::ResumeAction::Type request;
-    request.actionID = payload.ActionID.unsignedShortValue;
-    if (payload.InvokeID != nil) {
+    request.actionID = payload.actionID.unsignedShortValue;
+    if (payload.invokeID != nil) {
         auto & definedValue_0 = request.invokeID.Emplace();
-        definedValue_0 = payload.InvokeID.unsignedIntValue;
+        definedValue_0 = payload.invokeID.unsignedIntValue;
     }
 
     new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -963,10 +963,10 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     BridgedActions::Commands::StartAction::Type request;
-    request.actionID = payload.ActionID.unsignedShortValue;
-    if (payload.InvokeID != nil) {
+    request.actionID = payload.actionID.unsignedShortValue;
+    if (payload.invokeID != nil) {
         auto & definedValue_0 = request.invokeID.Emplace();
-        definedValue_0 = payload.InvokeID.unsignedIntValue;
+        definedValue_0 = payload.invokeID.unsignedIntValue;
     }
 
     new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -981,12 +981,12 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     BridgedActions::Commands::StartActionWithDuration::Type request;
-    request.actionID = payload.ActionID.unsignedShortValue;
-    if (payload.InvokeID != nil) {
+    request.actionID = payload.actionID.unsignedShortValue;
+    if (payload.invokeID != nil) {
         auto & definedValue_0 = request.invokeID.Emplace();
-        definedValue_0 = payload.InvokeID.unsignedIntValue;
+        definedValue_0 = payload.invokeID.unsignedIntValue;
     }
-    request.duration = payload.Duration.unsignedIntValue;
+    request.duration = payload.duration.unsignedIntValue;
 
     new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
@@ -999,10 +999,10 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     BridgedActions::Commands::StopAction::Type request;
-    request.actionID = payload.ActionID.unsignedShortValue;
-    if (payload.InvokeID != nil) {
+    request.actionID = payload.actionID.unsignedShortValue;
+    if (payload.invokeID != nil) {
         auto & definedValue_0 = request.invokeID.Emplace();
-        definedValue_0 = payload.InvokeID.unsignedIntValue;
+        definedValue_0 = payload.invokeID.unsignedIntValue;
     }
 
     new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -1183,13 +1183,13 @@ using namespace chip::app::Clusters;
     ListFreer listFreer;
     ColorControl::Commands::ColorLoopSet::Type request;
     request.updateFlags
-        = static_cast<std::remove_reference_t<decltype(request.updateFlags)>>(payload.UpdateFlags.unsignedCharValue);
-    request.action = static_cast<std::remove_reference_t<decltype(request.action)>>(payload.Action.unsignedCharValue);
-    request.direction = static_cast<std::remove_reference_t<decltype(request.direction)>>(payload.Direction.unsignedCharValue);
-    request.time = payload.Time.unsignedShortValue;
-    request.startHue = payload.StartHue.unsignedShortValue;
-    request.optionsMask = payload.OptionsMask.unsignedCharValue;
-    request.optionsOverride = payload.OptionsOverride.unsignedCharValue;
+        = static_cast<std::remove_reference_t<decltype(request.updateFlags)>>(payload.updateFlags.unsignedCharValue);
+    request.action = static_cast<std::remove_reference_t<decltype(request.action)>>(payload.action.unsignedCharValue);
+    request.direction = static_cast<std::remove_reference_t<decltype(request.direction)>>(payload.direction.unsignedCharValue);
+    request.time = payload.time.unsignedShortValue;
+    request.startHue = payload.startHue.unsignedShortValue;
+    request.optionsMask = payload.optionsMask.unsignedCharValue;
+    request.optionsOverride = payload.optionsOverride.unsignedCharValue;
 
     new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
@@ -1203,10 +1203,10 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     ColorControl::Commands::EnhancedMoveHue::Type request;
-    request.moveMode = static_cast<std::remove_reference_t<decltype(request.moveMode)>>(payload.MoveMode.unsignedCharValue);
-    request.rate = payload.Rate.unsignedShortValue;
-    request.optionsMask = payload.OptionsMask.unsignedCharValue;
-    request.optionsOverride = payload.OptionsOverride.unsignedCharValue;
+    request.moveMode = static_cast<std::remove_reference_t<decltype(request.moveMode)>>(payload.moveMode.unsignedCharValue);
+    request.rate = payload.rate.unsignedShortValue;
+    request.optionsMask = payload.optionsMask.unsignedCharValue;
+    request.optionsOverride = payload.optionsOverride.unsignedCharValue;
 
     new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
@@ -1220,11 +1220,11 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     ColorControl::Commands::EnhancedMoveToHue::Type request;
-    request.enhancedHue = payload.EnhancedHue.unsignedShortValue;
-    request.direction = static_cast<std::remove_reference_t<decltype(request.direction)>>(payload.Direction.unsignedCharValue);
-    request.transitionTime = payload.TransitionTime.unsignedShortValue;
-    request.optionsMask = payload.OptionsMask.unsignedCharValue;
-    request.optionsOverride = payload.OptionsOverride.unsignedCharValue;
+    request.enhancedHue = payload.enhancedHue.unsignedShortValue;
+    request.direction = static_cast<std::remove_reference_t<decltype(request.direction)>>(payload.direction.unsignedCharValue);
+    request.transitionTime = payload.transitionTime.unsignedShortValue;
+    request.optionsMask = payload.optionsMask.unsignedCharValue;
+    request.optionsOverride = payload.optionsOverride.unsignedCharValue;
 
     new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
@@ -1238,11 +1238,11 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     ColorControl::Commands::EnhancedMoveToHueAndSaturation::Type request;
-    request.enhancedHue = payload.EnhancedHue.unsignedShortValue;
-    request.saturation = payload.Saturation.unsignedCharValue;
-    request.transitionTime = payload.TransitionTime.unsignedShortValue;
-    request.optionsMask = payload.OptionsMask.unsignedCharValue;
-    request.optionsOverride = payload.OptionsOverride.unsignedCharValue;
+    request.enhancedHue = payload.enhancedHue.unsignedShortValue;
+    request.saturation = payload.saturation.unsignedCharValue;
+    request.transitionTime = payload.transitionTime.unsignedShortValue;
+    request.optionsMask = payload.optionsMask.unsignedCharValue;
+    request.optionsOverride = payload.optionsOverride.unsignedCharValue;
 
     new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
@@ -1256,11 +1256,11 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     ColorControl::Commands::EnhancedStepHue::Type request;
-    request.stepMode = static_cast<std::remove_reference_t<decltype(request.stepMode)>>(payload.StepMode.unsignedCharValue);
-    request.stepSize = payload.StepSize.unsignedShortValue;
-    request.transitionTime = payload.TransitionTime.unsignedShortValue;
-    request.optionsMask = payload.OptionsMask.unsignedCharValue;
-    request.optionsOverride = payload.OptionsOverride.unsignedCharValue;
+    request.stepMode = static_cast<std::remove_reference_t<decltype(request.stepMode)>>(payload.stepMode.unsignedCharValue);
+    request.stepSize = payload.stepSize.unsignedShortValue;
+    request.transitionTime = payload.transitionTime.unsignedShortValue;
+    request.optionsMask = payload.optionsMask.unsignedCharValue;
+    request.optionsOverride = payload.optionsOverride.unsignedCharValue;
 
     new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
@@ -1273,10 +1273,10 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     ColorControl::Commands::MoveColor::Type request;
-    request.rateX = payload.RateX.shortValue;
-    request.rateY = payload.RateY.shortValue;
-    request.optionsMask = payload.OptionsMask.unsignedCharValue;
-    request.optionsOverride = payload.OptionsOverride.unsignedCharValue;
+    request.rateX = payload.rateX.shortValue;
+    request.rateY = payload.rateY.shortValue;
+    request.optionsMask = payload.optionsMask.unsignedCharValue;
+    request.optionsOverride = payload.optionsOverride.unsignedCharValue;
 
     new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
@@ -1290,12 +1290,12 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     ColorControl::Commands::MoveColorTemperature::Type request;
-    request.moveMode = static_cast<std::remove_reference_t<decltype(request.moveMode)>>(payload.MoveMode.unsignedCharValue);
-    request.rate = payload.Rate.unsignedShortValue;
-    request.colorTemperatureMinimum = payload.ColorTemperatureMinimum.unsignedShortValue;
-    request.colorTemperatureMaximum = payload.ColorTemperatureMaximum.unsignedShortValue;
-    request.optionsMask = payload.OptionsMask.unsignedCharValue;
-    request.optionsOverride = payload.OptionsOverride.unsignedCharValue;
+    request.moveMode = static_cast<std::remove_reference_t<decltype(request.moveMode)>>(payload.moveMode.unsignedCharValue);
+    request.rate = payload.rate.unsignedShortValue;
+    request.colorTemperatureMinimum = payload.colorTemperatureMinimum.unsignedShortValue;
+    request.colorTemperatureMaximum = payload.colorTemperatureMaximum.unsignedShortValue;
+    request.optionsMask = payload.optionsMask.unsignedCharValue;
+    request.optionsOverride = payload.optionsOverride.unsignedCharValue;
 
     new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
@@ -1308,10 +1308,10 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     ColorControl::Commands::MoveHue::Type request;
-    request.moveMode = static_cast<std::remove_reference_t<decltype(request.moveMode)>>(payload.MoveMode.unsignedCharValue);
-    request.rate = payload.Rate.unsignedCharValue;
-    request.optionsMask = payload.OptionsMask.unsignedCharValue;
-    request.optionsOverride = payload.OptionsOverride.unsignedCharValue;
+    request.moveMode = static_cast<std::remove_reference_t<decltype(request.moveMode)>>(payload.moveMode.unsignedCharValue);
+    request.rate = payload.rate.unsignedCharValue;
+    request.optionsMask = payload.optionsMask.unsignedCharValue;
+    request.optionsOverride = payload.optionsOverride.unsignedCharValue;
 
     new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
@@ -1325,10 +1325,10 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     ColorControl::Commands::MoveSaturation::Type request;
-    request.moveMode = static_cast<std::remove_reference_t<decltype(request.moveMode)>>(payload.MoveMode.unsignedCharValue);
-    request.rate = payload.Rate.unsignedCharValue;
-    request.optionsMask = payload.OptionsMask.unsignedCharValue;
-    request.optionsOverride = payload.OptionsOverride.unsignedCharValue;
+    request.moveMode = static_cast<std::remove_reference_t<decltype(request.moveMode)>>(payload.moveMode.unsignedCharValue);
+    request.rate = payload.rate.unsignedCharValue;
+    request.optionsMask = payload.optionsMask.unsignedCharValue;
+    request.optionsOverride = payload.optionsOverride.unsignedCharValue;
 
     new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
@@ -1341,11 +1341,11 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     ColorControl::Commands::MoveToColor::Type request;
-    request.colorX = payload.ColorX.unsignedShortValue;
-    request.colorY = payload.ColorY.unsignedShortValue;
-    request.transitionTime = payload.TransitionTime.unsignedShortValue;
-    request.optionsMask = payload.OptionsMask.unsignedCharValue;
-    request.optionsOverride = payload.OptionsOverride.unsignedCharValue;
+    request.colorX = payload.colorX.unsignedShortValue;
+    request.colorY = payload.colorY.unsignedShortValue;
+    request.transitionTime = payload.transitionTime.unsignedShortValue;
+    request.optionsMask = payload.optionsMask.unsignedCharValue;
+    request.optionsOverride = payload.optionsOverride.unsignedCharValue;
 
     new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
@@ -1359,10 +1359,10 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     ColorControl::Commands::MoveToColorTemperature::Type request;
-    request.colorTemperature = payload.ColorTemperature.unsignedShortValue;
-    request.transitionTime = payload.TransitionTime.unsignedShortValue;
-    request.optionsMask = payload.OptionsMask.unsignedCharValue;
-    request.optionsOverride = payload.OptionsOverride.unsignedCharValue;
+    request.colorTemperature = payload.colorTemperature.unsignedShortValue;
+    request.transitionTime = payload.transitionTime.unsignedShortValue;
+    request.optionsMask = payload.optionsMask.unsignedCharValue;
+    request.optionsOverride = payload.optionsOverride.unsignedCharValue;
 
     new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
@@ -1375,11 +1375,11 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     ColorControl::Commands::MoveToHue::Type request;
-    request.hue = payload.Hue.unsignedCharValue;
-    request.direction = static_cast<std::remove_reference_t<decltype(request.direction)>>(payload.Direction.unsignedCharValue);
-    request.transitionTime = payload.TransitionTime.unsignedShortValue;
-    request.optionsMask = payload.OptionsMask.unsignedCharValue;
-    request.optionsOverride = payload.OptionsOverride.unsignedCharValue;
+    request.hue = payload.hue.unsignedCharValue;
+    request.direction = static_cast<std::remove_reference_t<decltype(request.direction)>>(payload.direction.unsignedCharValue);
+    request.transitionTime = payload.transitionTime.unsignedShortValue;
+    request.optionsMask = payload.optionsMask.unsignedCharValue;
+    request.optionsOverride = payload.optionsOverride.unsignedCharValue;
 
     new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
@@ -1393,11 +1393,11 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     ColorControl::Commands::MoveToHueAndSaturation::Type request;
-    request.hue = payload.Hue.unsignedCharValue;
-    request.saturation = payload.Saturation.unsignedCharValue;
-    request.transitionTime = payload.TransitionTime.unsignedShortValue;
-    request.optionsMask = payload.OptionsMask.unsignedCharValue;
-    request.optionsOverride = payload.OptionsOverride.unsignedCharValue;
+    request.hue = payload.hue.unsignedCharValue;
+    request.saturation = payload.saturation.unsignedCharValue;
+    request.transitionTime = payload.transitionTime.unsignedShortValue;
+    request.optionsMask = payload.optionsMask.unsignedCharValue;
+    request.optionsOverride = payload.optionsOverride.unsignedCharValue;
 
     new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
@@ -1411,10 +1411,10 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     ColorControl::Commands::MoveToSaturation::Type request;
-    request.saturation = payload.Saturation.unsignedCharValue;
-    request.transitionTime = payload.TransitionTime.unsignedShortValue;
-    request.optionsMask = payload.OptionsMask.unsignedCharValue;
-    request.optionsOverride = payload.OptionsOverride.unsignedCharValue;
+    request.saturation = payload.saturation.unsignedCharValue;
+    request.transitionTime = payload.transitionTime.unsignedShortValue;
+    request.optionsMask = payload.optionsMask.unsignedCharValue;
+    request.optionsOverride = payload.optionsOverride.unsignedCharValue;
 
     new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
@@ -1427,11 +1427,11 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     ColorControl::Commands::StepColor::Type request;
-    request.stepX = payload.StepX.shortValue;
-    request.stepY = payload.StepY.shortValue;
-    request.transitionTime = payload.TransitionTime.unsignedShortValue;
-    request.optionsMask = payload.OptionsMask.unsignedCharValue;
-    request.optionsOverride = payload.OptionsOverride.unsignedCharValue;
+    request.stepX = payload.stepX.shortValue;
+    request.stepY = payload.stepY.shortValue;
+    request.transitionTime = payload.transitionTime.unsignedShortValue;
+    request.optionsMask = payload.optionsMask.unsignedCharValue;
+    request.optionsOverride = payload.optionsOverride.unsignedCharValue;
 
     new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
@@ -1445,13 +1445,13 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     ColorControl::Commands::StepColorTemperature::Type request;
-    request.stepMode = static_cast<std::remove_reference_t<decltype(request.stepMode)>>(payload.StepMode.unsignedCharValue);
-    request.stepSize = payload.StepSize.unsignedShortValue;
-    request.transitionTime = payload.TransitionTime.unsignedShortValue;
-    request.colorTemperatureMinimum = payload.ColorTemperatureMinimum.unsignedShortValue;
-    request.colorTemperatureMaximum = payload.ColorTemperatureMaximum.unsignedShortValue;
-    request.optionsMask = payload.OptionsMask.unsignedCharValue;
-    request.optionsOverride = payload.OptionsOverride.unsignedCharValue;
+    request.stepMode = static_cast<std::remove_reference_t<decltype(request.stepMode)>>(payload.stepMode.unsignedCharValue);
+    request.stepSize = payload.stepSize.unsignedShortValue;
+    request.transitionTime = payload.transitionTime.unsignedShortValue;
+    request.colorTemperatureMinimum = payload.colorTemperatureMinimum.unsignedShortValue;
+    request.colorTemperatureMaximum = payload.colorTemperatureMaximum.unsignedShortValue;
+    request.optionsMask = payload.optionsMask.unsignedCharValue;
+    request.optionsOverride = payload.optionsOverride.unsignedCharValue;
 
     new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
@@ -1464,11 +1464,11 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     ColorControl::Commands::StepHue::Type request;
-    request.stepMode = static_cast<std::remove_reference_t<decltype(request.stepMode)>>(payload.StepMode.unsignedCharValue);
-    request.stepSize = payload.StepSize.unsignedCharValue;
-    request.transitionTime = payload.TransitionTime.unsignedCharValue;
-    request.optionsMask = payload.OptionsMask.unsignedCharValue;
-    request.optionsOverride = payload.OptionsOverride.unsignedCharValue;
+    request.stepMode = static_cast<std::remove_reference_t<decltype(request.stepMode)>>(payload.stepMode.unsignedCharValue);
+    request.stepSize = payload.stepSize.unsignedCharValue;
+    request.transitionTime = payload.transitionTime.unsignedCharValue;
+    request.optionsMask = payload.optionsMask.unsignedCharValue;
+    request.optionsOverride = payload.optionsOverride.unsignedCharValue;
 
     new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
@@ -1482,11 +1482,11 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     ColorControl::Commands::StepSaturation::Type request;
-    request.stepMode = static_cast<std::remove_reference_t<decltype(request.stepMode)>>(payload.StepMode.unsignedCharValue);
-    request.stepSize = payload.StepSize.unsignedCharValue;
-    request.transitionTime = payload.TransitionTime.unsignedCharValue;
-    request.optionsMask = payload.OptionsMask.unsignedCharValue;
-    request.optionsOverride = payload.OptionsOverride.unsignedCharValue;
+    request.stepMode = static_cast<std::remove_reference_t<decltype(request.stepMode)>>(payload.stepMode.unsignedCharValue);
+    request.stepSize = payload.stepSize.unsignedCharValue;
+    request.transitionTime = payload.transitionTime.unsignedCharValue;
+    request.optionsMask = payload.optionsMask.unsignedCharValue;
+    request.optionsOverride = payload.optionsOverride.unsignedCharValue;
 
     new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
@@ -1499,8 +1499,8 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     ColorControl::Commands::StopMoveStep::Type request;
-    request.optionsMask = payload.OptionsMask.unsignedCharValue;
-    request.optionsOverride = payload.OptionsOverride.unsignedCharValue;
+    request.optionsMask = payload.optionsMask.unsignedCharValue;
+    request.optionsOverride = payload.optionsOverride.unsignedCharValue;
 
     new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
@@ -2159,8 +2159,8 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     ContentLauncher::Commands::LaunchContent::Type request;
-    request.autoPlay = payload.AutoPlay.boolValue;
-    request.data = [self asCharSpan:payload.Data];
+    request.autoPlay = payload.autoPlay.boolValue;
+    request.data = [self asCharSpan:payload.data];
 
     new CHIPContentLauncherClusterLaunchContentResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -2174,8 +2174,8 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     ContentLauncher::Commands::LaunchURL::Type request;
-    request.contentURL = [self asCharSpan:payload.ContentURL];
-    request.displayString = [self asCharSpan:payload.DisplayString];
+    request.contentURL = [self asCharSpan:payload.contentURL];
+    request.displayString = [self asCharSpan:payload.displayString];
 
     new CHIPContentLauncherClusterLaunchURLResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -2270,10 +2270,10 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     DiagnosticLogs::Commands::RetrieveLogsRequest::Type request;
-    request.intent = static_cast<std::remove_reference_t<decltype(request.intent)>>(payload.Intent.unsignedCharValue);
+    request.intent = static_cast<std::remove_reference_t<decltype(request.intent)>>(payload.intent.unsignedCharValue);
     request.requestedProtocol
-        = static_cast<std::remove_reference_t<decltype(request.requestedProtocol)>>(payload.RequestedProtocol.unsignedCharValue);
-    request.transferFileDesignator = [self asByteSpan:payload.TransferFileDesignator];
+        = static_cast<std::remove_reference_t<decltype(request.requestedProtocol)>>(payload.requestedProtocol.unsignedCharValue);
+    request.transferFileDesignator = [self asByteSpan:payload.transferFileDesignator];
 
     new CHIPDiagnosticLogsClusterRetrieveLogsResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -2323,7 +2323,7 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     DoorLock::Commands::ClearHolidaySchedule::Type request;
-    request.scheduleId = payload.ScheduleId.unsignedCharValue;
+    request.scheduleId = payload.scheduleId.unsignedCharValue;
 
     new CHIPDoorLockClusterClearHolidayScheduleResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -2337,7 +2337,7 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     DoorLock::Commands::ClearPin::Type request;
-    request.userId = payload.UserId.unsignedShortValue;
+    request.userId = payload.userId.unsignedShortValue;
 
     new CHIPDoorLockClusterClearPinResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -2351,7 +2351,7 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     DoorLock::Commands::ClearRfid::Type request;
-    request.userId = payload.UserId.unsignedShortValue;
+    request.userId = payload.userId.unsignedShortValue;
 
     new CHIPDoorLockClusterClearRfidResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -2366,8 +2366,8 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     DoorLock::Commands::ClearWeekdaySchedule::Type request;
-    request.scheduleId = payload.ScheduleId.unsignedCharValue;
-    request.userId = payload.UserId.unsignedShortValue;
+    request.scheduleId = payload.scheduleId.unsignedCharValue;
+    request.userId = payload.userId.unsignedShortValue;
 
     new CHIPDoorLockClusterClearWeekdayScheduleResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -2382,8 +2382,8 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     DoorLock::Commands::ClearYeardaySchedule::Type request;
-    request.scheduleId = payload.ScheduleId.unsignedCharValue;
-    request.userId = payload.UserId.unsignedShortValue;
+    request.scheduleId = payload.scheduleId.unsignedCharValue;
+    request.userId = payload.userId.unsignedShortValue;
 
     new CHIPDoorLockClusterClearYeardayScheduleResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -2398,7 +2398,7 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     DoorLock::Commands::GetHolidaySchedule::Type request;
-    request.scheduleId = payload.ScheduleId.unsignedCharValue;
+    request.scheduleId = payload.scheduleId.unsignedCharValue;
 
     new CHIPDoorLockClusterGetHolidayScheduleResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -2412,7 +2412,7 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     DoorLock::Commands::GetLogRecord::Type request;
-    request.logIndex = payload.LogIndex.unsignedShortValue;
+    request.logIndex = payload.logIndex.unsignedShortValue;
 
     new CHIPDoorLockClusterGetLogRecordResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -2426,7 +2426,7 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     DoorLock::Commands::GetPin::Type request;
-    request.userId = payload.UserId.unsignedShortValue;
+    request.userId = payload.userId.unsignedShortValue;
 
     new CHIPDoorLockClusterGetPinResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -2440,7 +2440,7 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     DoorLock::Commands::GetRfid::Type request;
-    request.userId = payload.UserId.unsignedShortValue;
+    request.userId = payload.userId.unsignedShortValue;
 
     new CHIPDoorLockClusterGetRfidResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -2454,7 +2454,7 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     DoorLock::Commands::GetUserType::Type request;
-    request.userId = payload.UserId.unsignedShortValue;
+    request.userId = payload.userId.unsignedShortValue;
 
     new CHIPDoorLockClusterGetUserTypeResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -2469,8 +2469,8 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     DoorLock::Commands::GetWeekdaySchedule::Type request;
-    request.scheduleId = payload.ScheduleId.unsignedCharValue;
-    request.userId = payload.UserId.unsignedShortValue;
+    request.scheduleId = payload.scheduleId.unsignedCharValue;
+    request.userId = payload.userId.unsignedShortValue;
 
     new CHIPDoorLockClusterGetWeekdayScheduleResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -2485,8 +2485,8 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     DoorLock::Commands::GetYeardaySchedule::Type request;
-    request.scheduleId = payload.ScheduleId.unsignedCharValue;
-    request.userId = payload.UserId.unsignedShortValue;
+    request.scheduleId = payload.scheduleId.unsignedCharValue;
+    request.userId = payload.userId.unsignedShortValue;
 
     new CHIPDoorLockClusterGetYeardayScheduleResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -2500,7 +2500,7 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     DoorLock::Commands::LockDoor::Type request;
-    request.pin = [self asByteSpan:payload.Pin];
+    request.pin = [self asByteSpan:payload.pin];
 
     new CHIPDoorLockClusterLockDoorResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -2515,10 +2515,10 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     DoorLock::Commands::SetHolidaySchedule::Type request;
-    request.scheduleId = payload.ScheduleId.unsignedCharValue;
-    request.localStartTime = payload.LocalStartTime.unsignedIntValue;
-    request.localEndTime = payload.LocalEndTime.unsignedIntValue;
-    request.operatingModeDuringHoliday = payload.OperatingModeDuringHoliday.unsignedCharValue;
+    request.scheduleId = payload.scheduleId.unsignedCharValue;
+    request.localStartTime = payload.localStartTime.unsignedIntValue;
+    request.localEndTime = payload.localEndTime.unsignedIntValue;
+    request.operatingModeDuringHoliday = payload.operatingModeDuringHoliday.unsignedCharValue;
 
     new CHIPDoorLockClusterSetHolidayScheduleResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -2532,10 +2532,10 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     DoorLock::Commands::SetPin::Type request;
-    request.userId = payload.UserId.unsignedShortValue;
-    request.userStatus = static_cast<std::remove_reference_t<decltype(request.userStatus)>>(payload.UserStatus.unsignedCharValue);
-    request.userType = static_cast<std::remove_reference_t<decltype(request.userType)>>(payload.UserType.unsignedCharValue);
-    request.pin = [self asByteSpan:payload.Pin];
+    request.userId = payload.userId.unsignedShortValue;
+    request.userStatus = static_cast<std::remove_reference_t<decltype(request.userStatus)>>(payload.userStatus.unsignedCharValue);
+    request.userType = static_cast<std::remove_reference_t<decltype(request.userType)>>(payload.userType.unsignedCharValue);
+    request.pin = [self asByteSpan:payload.pin];
 
     new CHIPDoorLockClusterSetPinResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -2549,10 +2549,10 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     DoorLock::Commands::SetRfid::Type request;
-    request.userId = payload.UserId.unsignedShortValue;
-    request.userStatus = static_cast<std::remove_reference_t<decltype(request.userStatus)>>(payload.UserStatus.unsignedCharValue);
-    request.userType = static_cast<std::remove_reference_t<decltype(request.userType)>>(payload.UserType.unsignedCharValue);
-    request.id = [self asByteSpan:payload.Id];
+    request.userId = payload.userId.unsignedShortValue;
+    request.userStatus = static_cast<std::remove_reference_t<decltype(request.userStatus)>>(payload.userStatus.unsignedCharValue);
+    request.userType = static_cast<std::remove_reference_t<decltype(request.userType)>>(payload.userType.unsignedCharValue);
+    request.id = [self asByteSpan:payload.id];
 
     new CHIPDoorLockClusterSetRfidResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -2566,8 +2566,8 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     DoorLock::Commands::SetUserType::Type request;
-    request.userId = payload.UserId.unsignedShortValue;
-    request.userType = static_cast<std::remove_reference_t<decltype(request.userType)>>(payload.UserType.unsignedCharValue);
+    request.userId = payload.userId.unsignedShortValue;
+    request.userType = static_cast<std::remove_reference_t<decltype(request.userType)>>(payload.userType.unsignedCharValue);
 
     new CHIPDoorLockClusterSetUserTypeResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -2582,13 +2582,13 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     DoorLock::Commands::SetWeekdaySchedule::Type request;
-    request.scheduleId = payload.ScheduleId.unsignedCharValue;
-    request.userId = payload.UserId.unsignedShortValue;
-    request.daysMask = static_cast<std::remove_reference_t<decltype(request.daysMask)>>(payload.DaysMask.unsignedCharValue);
-    request.startHour = payload.StartHour.unsignedCharValue;
-    request.startMinute = payload.StartMinute.unsignedCharValue;
-    request.endHour = payload.EndHour.unsignedCharValue;
-    request.endMinute = payload.EndMinute.unsignedCharValue;
+    request.scheduleId = payload.scheduleId.unsignedCharValue;
+    request.userId = payload.userId.unsignedShortValue;
+    request.daysMask = static_cast<std::remove_reference_t<decltype(request.daysMask)>>(payload.daysMask.unsignedCharValue);
+    request.startHour = payload.startHour.unsignedCharValue;
+    request.startMinute = payload.startMinute.unsignedCharValue;
+    request.endHour = payload.endHour.unsignedCharValue;
+    request.endMinute = payload.endMinute.unsignedCharValue;
 
     new CHIPDoorLockClusterSetWeekdayScheduleResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -2603,10 +2603,10 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     DoorLock::Commands::SetYeardaySchedule::Type request;
-    request.scheduleId = payload.ScheduleId.unsignedCharValue;
-    request.userId = payload.UserId.unsignedShortValue;
-    request.localStartTime = payload.LocalStartTime.unsignedIntValue;
-    request.localEndTime = payload.LocalEndTime.unsignedIntValue;
+    request.scheduleId = payload.scheduleId.unsignedCharValue;
+    request.userId = payload.userId.unsignedShortValue;
+    request.localStartTime = payload.localStartTime.unsignedIntValue;
+    request.localEndTime = payload.localEndTime.unsignedIntValue;
 
     new CHIPDoorLockClusterSetYeardayScheduleResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -2620,7 +2620,7 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     DoorLock::Commands::UnlockDoor::Type request;
-    request.pin = [self asByteSpan:payload.Pin];
+    request.pin = [self asByteSpan:payload.pin];
 
     new CHIPDoorLockClusterUnlockDoorResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -2635,8 +2635,8 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     DoorLock::Commands::UnlockWithTimeout::Type request;
-    request.timeoutInSeconds = payload.TimeoutInSeconds.unsignedShortValue;
-    request.pin = [self asByteSpan:payload.Pin];
+    request.timeoutInSeconds = payload.timeoutInSeconds.unsignedShortValue;
+    request.pin = [self asByteSpan:payload.pin];
 
     new CHIPDoorLockClusterUnlockWithTimeoutResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -2960,9 +2960,9 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     GeneralCommissioning::Commands::ArmFailSafe::Type request;
-    request.expiryLengthSeconds = payload.ExpiryLengthSeconds.unsignedShortValue;
-    request.breadcrumb = payload.Breadcrumb.unsignedLongLongValue;
-    request.timeoutMs = payload.TimeoutMs.unsignedIntValue;
+    request.expiryLengthSeconds = payload.expiryLengthSeconds.unsignedShortValue;
+    request.breadcrumb = payload.breadcrumb.unsignedLongLongValue;
+    request.timeoutMs = payload.timeoutMs.unsignedIntValue;
 
     new CHIPGeneralCommissioningClusterArmFailSafeResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -2992,10 +2992,10 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     GeneralCommissioning::Commands::SetRegulatoryConfig::Type request;
-    request.location = static_cast<std::remove_reference_t<decltype(request.location)>>(payload.Location.unsignedCharValue);
-    request.countryCode = [self asCharSpan:payload.CountryCode];
-    request.breadcrumb = payload.Breadcrumb.unsignedLongLongValue;
-    request.timeoutMs = payload.TimeoutMs.unsignedIntValue;
+    request.location = static_cast<std::remove_reference_t<decltype(request.location)>>(payload.location.unsignedCharValue);
+    request.countryCode = [self asCharSpan:payload.countryCode];
+    request.breadcrumb = payload.breadcrumb.unsignedLongLongValue;
+    request.timeoutMs = payload.timeoutMs.unsignedIntValue;
 
     new CHIPGeneralCommissioningClusterSetRegulatoryConfigResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -3138,8 +3138,8 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     Groups::Commands::AddGroup::Type request;
-    request.groupId = payload.GroupId.unsignedShortValue;
-    request.groupName = [self asCharSpan:payload.GroupName];
+    request.groupId = payload.groupId.unsignedShortValue;
+    request.groupName = [self asCharSpan:payload.groupName];
 
     new CHIPGroupsClusterAddGroupResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -3154,8 +3154,8 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     Groups::Commands::AddGroupIfIdentifying::Type request;
-    request.groupId = payload.GroupId.unsignedShortValue;
-    request.groupName = [self asCharSpan:payload.GroupName];
+    request.groupId = payload.groupId.unsignedShortValue;
+    request.groupName = [self asCharSpan:payload.groupName];
 
     new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
@@ -3169,25 +3169,25 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     Groups::Commands::GetGroupMembership::Type request;
-    request.groupCount = payload.GroupCount.unsignedCharValue;
+    request.groupCount = payload.groupCount.unsignedCharValue;
     {
         using ListType = std::remove_reference_t<decltype(request.groupList)>;
         using ListMemberType = ListMemberTypeGetter<ListType>::Type;
-        if (payload.GroupList.count != 0) {
-            auto * listHolder_0 = new ListHolder<ListMemberType>(payload.GroupList.count);
+        if (payload.groupList.count != 0) {
+            auto * listHolder_0 = new ListHolder<ListMemberType>(payload.groupList.count);
             if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
                 return;
             }
             listFreer.add(listHolder_0);
-            for (size_t i = 0; i < payload.GroupList.count; ++i) {
-                if (![payload.GroupList[i] isKindOfClass:[NSNumber class]]) {
+            for (size_t i = 0; i < payload.groupList.count; ++i) {
+                if (![payload.groupList[i] isKindOfClass:[NSNumber class]]) {
                     // Wrong kind of value.
                     return;
                 }
-                auto element_0 = (NSNumber *) payload.GroupList[i];
+                auto element_0 = (NSNumber *) payload.groupList[i];
                 listHolder_0->mList[i] = element_0.unsignedShortValue;
             }
-            request.groupList = ListType(listHolder_0->mList, payload.GroupList.count);
+            request.groupList = ListType(listHolder_0->mList, payload.groupList.count);
         } else {
             request.groupList = ListType();
         }
@@ -3217,7 +3217,7 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     Groups::Commands::RemoveGroup::Type request;
-    request.groupId = payload.GroupId.unsignedShortValue;
+    request.groupId = payload.groupId.unsignedShortValue;
 
     new CHIPGroupsClusterRemoveGroupResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -3231,7 +3231,7 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     Groups::Commands::ViewGroup::Type request;
-    request.groupId = payload.GroupId.unsignedShortValue;
+    request.groupId = payload.groupId.unsignedShortValue;
 
     new CHIPGroupsClusterViewGroupResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -3268,7 +3268,7 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     Identify::Commands::Identify::Type request;
-    request.identifyTime = payload.IdentifyTime.unsignedShortValue;
+    request.identifyTime = payload.identifyTime.unsignedShortValue;
 
     new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
@@ -3295,9 +3295,9 @@ using namespace chip::app::Clusters;
     ListFreer listFreer;
     Identify::Commands::TriggerEffect::Type request;
     request.effectIdentifier
-        = static_cast<std::remove_reference_t<decltype(request.effectIdentifier)>>(payload.EffectIdentifier.unsignedCharValue);
+        = static_cast<std::remove_reference_t<decltype(request.effectIdentifier)>>(payload.effectIdentifier.unsignedCharValue);
     request.effectVariant
-        = static_cast<std::remove_reference_t<decltype(request.effectVariant)>>(payload.EffectVariant.unsignedCharValue);
+        = static_cast<std::remove_reference_t<decltype(request.effectVariant)>>(payload.effectVariant.unsignedCharValue);
 
     new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
@@ -3423,7 +3423,7 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     KeypadInput::Commands::SendKey::Type request;
-    request.keyCode = static_cast<std::remove_reference_t<decltype(request.keyCode)>>(payload.KeyCode.unsignedCharValue);
+    request.keyCode = static_cast<std::remove_reference_t<decltype(request.keyCode)>>(payload.keyCode.unsignedCharValue);
 
     new CHIPKeypadInputClusterSendKeyResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -3453,10 +3453,10 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     LevelControl::Commands::Move::Type request;
-    request.moveMode = static_cast<std::remove_reference_t<decltype(request.moveMode)>>(payload.MoveMode.unsignedCharValue);
-    request.rate = payload.Rate.unsignedCharValue;
-    request.optionMask = payload.OptionMask.unsignedCharValue;
-    request.optionOverride = payload.OptionOverride.unsignedCharValue;
+    request.moveMode = static_cast<std::remove_reference_t<decltype(request.moveMode)>>(payload.moveMode.unsignedCharValue);
+    request.rate = payload.rate.unsignedCharValue;
+    request.optionMask = payload.optionMask.unsignedCharValue;
+    request.optionOverride = payload.optionOverride.unsignedCharValue;
 
     new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
@@ -3469,10 +3469,10 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     LevelControl::Commands::MoveToLevel::Type request;
-    request.level = payload.Level.unsignedCharValue;
-    request.transitionTime = payload.TransitionTime.unsignedShortValue;
-    request.optionMask = payload.OptionMask.unsignedCharValue;
-    request.optionOverride = payload.OptionOverride.unsignedCharValue;
+    request.level = payload.level.unsignedCharValue;
+    request.transitionTime = payload.transitionTime.unsignedShortValue;
+    request.optionMask = payload.optionMask.unsignedCharValue;
+    request.optionOverride = payload.optionOverride.unsignedCharValue;
 
     new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
@@ -3486,8 +3486,8 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     LevelControl::Commands::MoveToLevelWithOnOff::Type request;
-    request.level = payload.Level.unsignedCharValue;
-    request.transitionTime = payload.TransitionTime.unsignedShortValue;
+    request.level = payload.level.unsignedCharValue;
+    request.transitionTime = payload.transitionTime.unsignedShortValue;
 
     new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
@@ -3501,8 +3501,8 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     LevelControl::Commands::MoveWithOnOff::Type request;
-    request.moveMode = static_cast<std::remove_reference_t<decltype(request.moveMode)>>(payload.MoveMode.unsignedCharValue);
-    request.rate = payload.Rate.unsignedCharValue;
+    request.moveMode = static_cast<std::remove_reference_t<decltype(request.moveMode)>>(payload.moveMode.unsignedCharValue);
+    request.rate = payload.rate.unsignedCharValue;
 
     new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
@@ -3515,11 +3515,11 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     LevelControl::Commands::Step::Type request;
-    request.stepMode = static_cast<std::remove_reference_t<decltype(request.stepMode)>>(payload.StepMode.unsignedCharValue);
-    request.stepSize = payload.StepSize.unsignedCharValue;
-    request.transitionTime = payload.TransitionTime.unsignedShortValue;
-    request.optionMask = payload.OptionMask.unsignedCharValue;
-    request.optionOverride = payload.OptionOverride.unsignedCharValue;
+    request.stepMode = static_cast<std::remove_reference_t<decltype(request.stepMode)>>(payload.stepMode.unsignedCharValue);
+    request.stepSize = payload.stepSize.unsignedCharValue;
+    request.transitionTime = payload.transitionTime.unsignedShortValue;
+    request.optionMask = payload.optionMask.unsignedCharValue;
+    request.optionOverride = payload.optionOverride.unsignedCharValue;
 
     new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
@@ -3533,9 +3533,9 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     LevelControl::Commands::StepWithOnOff::Type request;
-    request.stepMode = static_cast<std::remove_reference_t<decltype(request.stepMode)>>(payload.StepMode.unsignedCharValue);
-    request.stepSize = payload.StepSize.unsignedCharValue;
-    request.transitionTime = payload.TransitionTime.unsignedShortValue;
+    request.stepMode = static_cast<std::remove_reference_t<decltype(request.stepMode)>>(payload.stepMode.unsignedCharValue);
+    request.stepSize = payload.stepSize.unsignedCharValue;
+    request.transitionTime = payload.transitionTime.unsignedShortValue;
 
     new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
@@ -3548,8 +3548,8 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     LevelControl::Commands::Stop::Type request;
-    request.optionMask = payload.OptionMask.unsignedCharValue;
-    request.optionOverride = payload.OptionOverride.unsignedCharValue;
+    request.optionMask = payload.optionMask.unsignedCharValue;
+    request.optionOverride = payload.optionOverride.unsignedCharValue;
 
     new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
@@ -3840,8 +3840,8 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     MediaInput::Commands::RenameInput::Type request;
-    request.index = payload.Index.unsignedCharValue;
-    request.name = [self asCharSpan:payload.Name];
+    request.index = payload.index.unsignedCharValue;
+    request.name = [self asCharSpan:payload.name];
 
     new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
@@ -3854,7 +3854,7 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     MediaInput::Commands::SelectInput::Type request;
-    request.index = payload.Index.unsignedCharValue;
+    request.index = payload.index.unsignedCharValue;
 
     new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
@@ -3991,7 +3991,7 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     MediaPlayback::Commands::MediaSeek::Type request;
-    request.position = payload.Position.unsignedLongLongValue;
+    request.position = payload.position.unsignedLongLongValue;
 
     new CHIPMediaPlaybackClusterMediaSeekResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -4006,7 +4006,7 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     MediaPlayback::Commands::MediaSkipBackward::Type request;
-    request.deltaPositionMilliseconds = payload.DeltaPositionMilliseconds.unsignedLongLongValue;
+    request.deltaPositionMilliseconds = payload.deltaPositionMilliseconds.unsignedLongLongValue;
 
     new CHIPMediaPlaybackClusterMediaSkipBackwardResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -4021,7 +4021,7 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     MediaPlayback::Commands::MediaSkipForward::Type request;
-    request.deltaPositionMilliseconds = payload.DeltaPositionMilliseconds.unsignedLongLongValue;
+    request.deltaPositionMilliseconds = payload.deltaPositionMilliseconds.unsignedLongLongValue;
 
     new CHIPMediaPlaybackClusterMediaSkipForwardResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -4134,7 +4134,7 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     ModeSelect::Commands::ChangeToMode::Type request;
-    request.newMode = payload.NewMode.unsignedCharValue;
+    request.newMode = payload.newMode.unsignedCharValue;
 
     new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
@@ -4232,9 +4232,9 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     NetworkCommissioning::Commands::AddThreadNetwork::Type request;
-    request.operationalDataset = [self asByteSpan:payload.OperationalDataset];
-    request.breadcrumb = payload.Breadcrumb.unsignedLongLongValue;
-    request.timeoutMs = payload.TimeoutMs.unsignedIntValue;
+    request.operationalDataset = [self asByteSpan:payload.operationalDataset];
+    request.breadcrumb = payload.breadcrumb.unsignedLongLongValue;
+    request.timeoutMs = payload.timeoutMs.unsignedIntValue;
 
     new CHIPNetworkCommissioningClusterAddThreadNetworkResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -4249,10 +4249,10 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     NetworkCommissioning::Commands::AddWiFiNetwork::Type request;
-    request.ssid = [self asByteSpan:payload.Ssid];
-    request.credentials = [self asByteSpan:payload.Credentials];
-    request.breadcrumb = payload.Breadcrumb.unsignedLongLongValue;
-    request.timeoutMs = payload.TimeoutMs.unsignedIntValue;
+    request.ssid = [self asByteSpan:payload.ssid];
+    request.credentials = [self asByteSpan:payload.credentials];
+    request.breadcrumb = payload.breadcrumb.unsignedLongLongValue;
+    request.timeoutMs = payload.timeoutMs.unsignedIntValue;
 
     new CHIPNetworkCommissioningClusterAddWiFiNetworkResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -4267,9 +4267,9 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     NetworkCommissioning::Commands::DisableNetwork::Type request;
-    request.networkID = [self asByteSpan:payload.NetworkID];
-    request.breadcrumb = payload.Breadcrumb.unsignedLongLongValue;
-    request.timeoutMs = payload.TimeoutMs.unsignedIntValue;
+    request.networkID = [self asByteSpan:payload.networkID];
+    request.breadcrumb = payload.breadcrumb.unsignedLongLongValue;
+    request.timeoutMs = payload.timeoutMs.unsignedIntValue;
 
     new CHIPNetworkCommissioningClusterDisableNetworkResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -4284,9 +4284,9 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     NetworkCommissioning::Commands::EnableNetwork::Type request;
-    request.networkID = [self asByteSpan:payload.NetworkID];
-    request.breadcrumb = payload.Breadcrumb.unsignedLongLongValue;
-    request.timeoutMs = payload.TimeoutMs.unsignedIntValue;
+    request.networkID = [self asByteSpan:payload.networkID];
+    request.breadcrumb = payload.breadcrumb.unsignedLongLongValue;
+    request.timeoutMs = payload.timeoutMs.unsignedIntValue;
 
     new CHIPNetworkCommissioningClusterEnableNetworkResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -4301,9 +4301,9 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     NetworkCommissioning::Commands::RemoveNetwork::Type request;
-    request.networkID = [self asByteSpan:payload.NetworkID];
-    request.breadcrumb = payload.Breadcrumb.unsignedLongLongValue;
-    request.timeoutMs = payload.TimeoutMs.unsignedIntValue;
+    request.networkID = [self asByteSpan:payload.networkID];
+    request.breadcrumb = payload.breadcrumb.unsignedLongLongValue;
+    request.timeoutMs = payload.timeoutMs.unsignedIntValue;
 
     new CHIPNetworkCommissioningClusterRemoveNetworkResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -4318,9 +4318,9 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     NetworkCommissioning::Commands::ScanNetworks::Type request;
-    request.ssid = [self asByteSpan:payload.Ssid];
-    request.breadcrumb = payload.Breadcrumb.unsignedLongLongValue;
-    request.timeoutMs = payload.TimeoutMs.unsignedIntValue;
+    request.ssid = [self asByteSpan:payload.ssid];
+    request.breadcrumb = payload.breadcrumb.unsignedLongLongValue;
+    request.timeoutMs = payload.timeoutMs.unsignedIntValue;
 
     new CHIPNetworkCommissioningClusterScanNetworksResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -4335,9 +4335,9 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     NetworkCommissioning::Commands::UpdateThreadNetwork::Type request;
-    request.operationalDataset = [self asByteSpan:payload.OperationalDataset];
-    request.breadcrumb = payload.Breadcrumb.unsignedLongLongValue;
-    request.timeoutMs = payload.TimeoutMs.unsignedIntValue;
+    request.operationalDataset = [self asByteSpan:payload.operationalDataset];
+    request.breadcrumb = payload.breadcrumb.unsignedLongLongValue;
+    request.timeoutMs = payload.timeoutMs.unsignedIntValue;
 
     new CHIPNetworkCommissioningClusterUpdateThreadNetworkResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -4353,10 +4353,10 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     NetworkCommissioning::Commands::UpdateWiFiNetwork::Type request;
-    request.ssid = [self asByteSpan:payload.Ssid];
-    request.credentials = [self asByteSpan:payload.Credentials];
-    request.breadcrumb = payload.Breadcrumb.unsignedLongLongValue;
-    request.timeoutMs = payload.TimeoutMs.unsignedIntValue;
+    request.ssid = [self asByteSpan:payload.ssid];
+    request.credentials = [self asByteSpan:payload.credentials];
+    request.breadcrumb = payload.breadcrumb.unsignedLongLongValue;
+    request.timeoutMs = payload.timeoutMs.unsignedIntValue;
 
     new CHIPNetworkCommissioningClusterUpdateWiFiNetworkResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -4395,8 +4395,8 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     OtaSoftwareUpdateProvider::Commands::ApplyUpdateRequest::Type request;
-    request.updateToken = [self asByteSpan:payload.UpdateToken];
-    request.newVersion = payload.NewVersion.unsignedIntValue;
+    request.updateToken = [self asByteSpan:payload.updateToken];
+    request.newVersion = payload.newVersion.unsignedIntValue;
 
     new CHIPOtaSoftwareUpdateProviderClusterApplyUpdateResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -4411,8 +4411,8 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     OtaSoftwareUpdateProvider::Commands::NotifyUpdateApplied::Type request;
-    request.updateToken = [self asByteSpan:payload.UpdateToken];
-    request.softwareVersion = payload.SoftwareVersion.unsignedIntValue;
+    request.updateToken = [self asByteSpan:payload.updateToken];
+    request.softwareVersion = payload.softwareVersion.unsignedIntValue;
 
     new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
@@ -4426,47 +4426,47 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     OtaSoftwareUpdateProvider::Commands::QueryImage::Type request;
-    request.vendorId = static_cast<std::remove_reference_t<decltype(request.vendorId)>>(payload.VendorId.unsignedShortValue);
-    request.productId = payload.ProductId.unsignedShortValue;
-    request.softwareVersion = payload.SoftwareVersion.unsignedIntValue;
+    request.vendorId = static_cast<std::remove_reference_t<decltype(request.vendorId)>>(payload.vendorId.unsignedShortValue);
+    request.productId = payload.productId.unsignedShortValue;
+    request.softwareVersion = payload.softwareVersion.unsignedIntValue;
     {
         using ListType = std::remove_reference_t<decltype(request.protocolsSupported)>;
         using ListMemberType = ListMemberTypeGetter<ListType>::Type;
-        if (payload.ProtocolsSupported.count != 0) {
-            auto * listHolder_0 = new ListHolder<ListMemberType>(payload.ProtocolsSupported.count);
+        if (payload.protocolsSupported.count != 0) {
+            auto * listHolder_0 = new ListHolder<ListMemberType>(payload.protocolsSupported.count);
             if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
                 return;
             }
             listFreer.add(listHolder_0);
-            for (size_t i = 0; i < payload.ProtocolsSupported.count; ++i) {
-                if (![payload.ProtocolsSupported[i] isKindOfClass:[NSNumber class]]) {
+            for (size_t i = 0; i < payload.protocolsSupported.count; ++i) {
+                if (![payload.protocolsSupported[i] isKindOfClass:[NSNumber class]]) {
                     // Wrong kind of value.
                     return;
                 }
-                auto element_0 = (NSNumber *) payload.ProtocolsSupported[i];
+                auto element_0 = (NSNumber *) payload.protocolsSupported[i];
                 listHolder_0->mList[i]
                     = static_cast<std::remove_reference_t<decltype(listHolder_0->mList[i])>>(element_0.unsignedCharValue);
             }
-            request.protocolsSupported = ListType(listHolder_0->mList, payload.ProtocolsSupported.count);
+            request.protocolsSupported = ListType(listHolder_0->mList, payload.protocolsSupported.count);
         } else {
             request.protocolsSupported = ListType();
         }
     }
-    if (payload.HardwareVersion != nil) {
+    if (payload.hardwareVersion != nil) {
         auto & definedValue_0 = request.hardwareVersion.Emplace();
-        definedValue_0 = payload.HardwareVersion.unsignedShortValue;
+        definedValue_0 = payload.hardwareVersion.unsignedShortValue;
     }
-    if (payload.Location != nil) {
+    if (payload.location != nil) {
         auto & definedValue_0 = request.location.Emplace();
-        definedValue_0 = [self asCharSpan:payload.Location];
+        definedValue_0 = [self asCharSpan:payload.location];
     }
-    if (payload.RequestorCanConsent != nil) {
+    if (payload.requestorCanConsent != nil) {
         auto & definedValue_0 = request.requestorCanConsent.Emplace();
-        definedValue_0 = payload.RequestorCanConsent.boolValue;
+        definedValue_0 = payload.requestorCanConsent.boolValue;
     }
-    if (payload.MetadataForProvider != nil) {
+    if (payload.metadataForProvider != nil) {
         auto & definedValue_0 = request.metadataForProvider.Emplace();
-        definedValue_0 = [self asByteSpan:payload.MetadataForProvider];
+        definedValue_0 = [self asByteSpan:payload.metadataForProvider];
     }
 
     new CHIPOtaSoftwareUpdateProviderClusterQueryImageResponseCallbackBridge(
@@ -4498,13 +4498,13 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     OtaSoftwareUpdateRequestor::Commands::AnnounceOtaProvider::Type request;
-    request.providerLocation = payload.ProviderLocation.unsignedLongLongValue;
-    request.vendorId = static_cast<std::remove_reference_t<decltype(request.vendorId)>>(payload.VendorId.unsignedShortValue);
+    request.providerLocation = payload.providerLocation.unsignedLongLongValue;
+    request.vendorId = static_cast<std::remove_reference_t<decltype(request.vendorId)>>(payload.vendorId.unsignedShortValue);
     request.announcementReason
-        = static_cast<std::remove_reference_t<decltype(request.announcementReason)>>(payload.AnnouncementReason.unsignedCharValue);
-    if (payload.MetadataForNode != nil) {
+        = static_cast<std::remove_reference_t<decltype(request.announcementReason)>>(payload.announcementReason.unsignedCharValue);
+    if (payload.metadataForNode != nil) {
         auto & definedValue_0 = request.metadataForNode.Emplace();
-        definedValue_0 = [self asByteSpan:payload.MetadataForNode];
+        definedValue_0 = [self asByteSpan:payload.metadataForNode];
     }
 
     new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -4629,9 +4629,9 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     OnOff::Commands::OffWithEffect::Type request;
-    request.effectId = static_cast<std::remove_reference_t<decltype(request.effectId)>>(payload.EffectId.unsignedCharValue);
+    request.effectId = static_cast<std::remove_reference_t<decltype(request.effectId)>>(payload.effectId.unsignedCharValue);
     request.effectVariant
-        = static_cast<std::remove_reference_t<decltype(request.effectVariant)>>(payload.EffectVariant.unsignedCharValue);
+        = static_cast<std::remove_reference_t<decltype(request.effectVariant)>>(payload.effectVariant.unsignedCharValue);
 
     new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
@@ -4670,9 +4670,9 @@ using namespace chip::app::Clusters;
     ListFreer listFreer;
     OnOff::Commands::OnWithTimedOff::Type request;
     request.onOffControl
-        = static_cast<std::remove_reference_t<decltype(request.onOffControl)>>(payload.OnOffControl.unsignedCharValue);
-    request.onTime = payload.OnTime.unsignedShortValue;
-    request.offWaitTime = payload.OffWaitTime.unsignedShortValue;
+        = static_cast<std::remove_reference_t<decltype(request.onOffControl)>>(payload.onOffControl.unsignedCharValue);
+    request.onTime = payload.onTime.unsignedShortValue;
+    request.offWaitTime = payload.offWaitTime.unsignedShortValue;
 
     new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
@@ -4856,14 +4856,14 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     OperationalCredentials::Commands::AddNOC::Type request;
-    request.NOCValue = [self asByteSpan:payload.NOCValue];
-    if (payload.ICACValue != nil) {
+    request.NOCValue = [self asByteSpan:payload.nocValue];
+    if (payload.icacValue != nil) {
         auto & definedValue_0 = request.ICACValue.Emplace();
-        definedValue_0 = [self asByteSpan:payload.ICACValue];
+        definedValue_0 = [self asByteSpan:payload.icacValue];
     }
-    request.IPKValue = [self asByteSpan:payload.IPKValue];
-    request.caseAdminNode = payload.CaseAdminNode.unsignedLongLongValue;
-    request.adminVendorId = payload.AdminVendorId.unsignedShortValue;
+    request.IPKValue = [self asByteSpan:payload.ipkValue];
+    request.caseAdminNode = payload.caseAdminNode.unsignedLongLongValue;
+    request.adminVendorId = payload.adminVendorId.unsignedShortValue;
 
     new CHIPOperationalCredentialsClusterNOCResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -4878,7 +4878,7 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     OperationalCredentials::Commands::AddTrustedRootCertificate::Type request;
-    request.rootCertificate = [self asByteSpan:payload.RootCertificate];
+    request.rootCertificate = [self asByteSpan:payload.rootCertificate];
 
     new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
@@ -4892,7 +4892,7 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     OperationalCredentials::Commands::AttestationRequest::Type request;
-    request.attestationNonce = [self asByteSpan:payload.AttestationNonce];
+    request.attestationNonce = [self asByteSpan:payload.attestationNonce];
 
     new CHIPOperationalCredentialsClusterAttestationResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -4907,7 +4907,7 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     OperationalCredentials::Commands::CertificateChainRequest::Type request;
-    request.certificateType = payload.CertificateType.unsignedCharValue;
+    request.certificateType = payload.certificateType.unsignedCharValue;
 
     new CHIPOperationalCredentialsClusterCertificateChainResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -4923,7 +4923,7 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     OperationalCredentials::Commands::OpCSRRequest::Type request;
-    request.CSRNonce = [self asByteSpan:payload.CSRNonce];
+    request.CSRNonce = [self asByteSpan:payload.csrNonce];
 
     new CHIPOperationalCredentialsClusterOpCSRResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -4938,7 +4938,7 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     OperationalCredentials::Commands::RemoveFabric::Type request;
-    request.fabricIndex = payload.FabricIndex.unsignedCharValue;
+    request.fabricIndex = payload.fabricIndex.unsignedCharValue;
 
     new CHIPOperationalCredentialsClusterNOCResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -4953,7 +4953,7 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     OperationalCredentials::Commands::RemoveTrustedRootCertificate::Type request;
-    request.trustedRootIdentifier = [self asByteSpan:payload.TrustedRootIdentifier];
+    request.trustedRootIdentifier = [self asByteSpan:payload.trustedRootIdentifier];
 
     new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
@@ -4967,7 +4967,7 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     OperationalCredentials::Commands::UpdateFabricLabel::Type request;
-    request.label = [self asCharSpan:payload.Label];
+    request.label = [self asCharSpan:payload.label];
 
     new CHIPOperationalCredentialsClusterNOCResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -4982,10 +4982,10 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     OperationalCredentials::Commands::UpdateNOC::Type request;
-    request.NOCValue = [self asByteSpan:payload.NOCValue];
-    if (payload.ICACValue != nil) {
+    request.NOCValue = [self asByteSpan:payload.nocValue];
+    if (payload.icacValue != nil) {
         auto & definedValue_0 = request.ICACValue.Emplace();
-        definedValue_0 = [self asByteSpan:payload.ICACValue];
+        definedValue_0 = [self asByteSpan:payload.icacValue];
     }
 
     new CHIPOperationalCredentialsClusterNOCResponseCallbackBridge(
@@ -5519,30 +5519,30 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     Scenes::Commands::AddScene::Type request;
-    request.groupId = payload.GroupId.unsignedShortValue;
-    request.sceneId = payload.SceneId.unsignedCharValue;
-    request.transitionTime = payload.TransitionTime.unsignedShortValue;
-    request.sceneName = [self asCharSpan:payload.SceneName];
+    request.groupId = payload.groupId.unsignedShortValue;
+    request.sceneId = payload.sceneId.unsignedCharValue;
+    request.transitionTime = payload.transitionTime.unsignedShortValue;
+    request.sceneName = [self asCharSpan:payload.sceneName];
     {
         using ListType = std::remove_reference_t<decltype(request.extensionFieldSets)>;
         using ListMemberType = ListMemberTypeGetter<ListType>::Type;
-        if (payload.ExtensionFieldSets.count != 0) {
-            auto * listHolder_0 = new ListHolder<ListMemberType>(payload.ExtensionFieldSets.count);
+        if (payload.extensionFieldSets.count != 0) {
+            auto * listHolder_0 = new ListHolder<ListMemberType>(payload.extensionFieldSets.count);
             if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
                 return;
             }
             listFreer.add(listHolder_0);
-            for (size_t i = 0; i < payload.ExtensionFieldSets.count; ++i) {
-                if (![payload.ExtensionFieldSets[i] isKindOfClass:[CHIPScenesClusterSceneExtensionFieldSet class]]) {
+            for (size_t i = 0; i < payload.extensionFieldSets.count; ++i) {
+                if (![payload.extensionFieldSets[i] isKindOfClass:[CHIPScenesClusterSceneExtensionFieldSet class]]) {
                     // Wrong kind of value.
                     return;
                 }
-                auto element_0 = (CHIPScenesClusterSceneExtensionFieldSet *) payload.ExtensionFieldSets[i];
-                listHolder_0->mList[i].clusterId = element_0.ClusterId.unsignedIntValue;
-                listHolder_0->mList[i].length = element_0.Length.unsignedCharValue;
-                listHolder_0->mList[i].value = element_0.Value.unsignedCharValue;
+                auto element_0 = (CHIPScenesClusterSceneExtensionFieldSet *) payload.extensionFieldSets[i];
+                listHolder_0->mList[i].clusterId = element_0.clusterId.unsignedIntValue;
+                listHolder_0->mList[i].length = element_0.length.unsignedCharValue;
+                listHolder_0->mList[i].value = element_0.value.unsignedCharValue;
             }
-            request.extensionFieldSets = ListType(listHolder_0->mList, payload.ExtensionFieldSets.count);
+            request.extensionFieldSets = ListType(listHolder_0->mList, payload.extensionFieldSets.count);
         } else {
             request.extensionFieldSets = ListType();
         }
@@ -5561,7 +5561,7 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     Scenes::Commands::GetSceneMembership::Type request;
-    request.groupId = payload.GroupId.unsignedShortValue;
+    request.groupId = payload.groupId.unsignedShortValue;
 
     new CHIPScenesClusterGetSceneMembershipResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -5575,9 +5575,9 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     Scenes::Commands::RecallScene::Type request;
-    request.groupId = payload.GroupId.unsignedShortValue;
-    request.sceneId = payload.SceneId.unsignedCharValue;
-    request.transitionTime = payload.TransitionTime.unsignedShortValue;
+    request.groupId = payload.groupId.unsignedShortValue;
+    request.sceneId = payload.sceneId.unsignedCharValue;
+    request.transitionTime = payload.transitionTime.unsignedShortValue;
 
     new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
@@ -5590,7 +5590,7 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     Scenes::Commands::RemoveAllScenes::Type request;
-    request.groupId = payload.GroupId.unsignedShortValue;
+    request.groupId = payload.groupId.unsignedShortValue;
 
     new CHIPScenesClusterRemoveAllScenesResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -5604,8 +5604,8 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     Scenes::Commands::RemoveScene::Type request;
-    request.groupId = payload.GroupId.unsignedShortValue;
-    request.sceneId = payload.SceneId.unsignedCharValue;
+    request.groupId = payload.groupId.unsignedShortValue;
+    request.sceneId = payload.sceneId.unsignedCharValue;
 
     new CHIPScenesClusterRemoveSceneResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -5619,8 +5619,8 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     Scenes::Commands::StoreScene::Type request;
-    request.groupId = payload.GroupId.unsignedShortValue;
-    request.sceneId = payload.SceneId.unsignedCharValue;
+    request.groupId = payload.groupId.unsignedShortValue;
+    request.sceneId = payload.sceneId.unsignedCharValue;
 
     new CHIPScenesClusterStoreSceneResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -5634,8 +5634,8 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     Scenes::Commands::ViewScene::Type request;
-    request.groupId = payload.GroupId.unsignedShortValue;
-    request.sceneId = payload.SceneId.unsignedCharValue;
+    request.groupId = payload.groupId.unsignedShortValue;
+    request.sceneId = payload.sceneId.unsignedCharValue;
 
     new CHIPScenesClusterViewSceneResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -5821,7 +5821,7 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     TvChannel::Commands::ChangeChannel::Type request;
-    request.match = [self asCharSpan:payload.Match];
+    request.match = [self asCharSpan:payload.match];
 
     new CHIPTvChannelClusterChangeChannelResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -5836,8 +5836,8 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     TvChannel::Commands::ChangeChannelByNumber::Type request;
-    request.majorNumber = payload.MajorNumber.unsignedShortValue;
-    request.minorNumber = payload.MinorNumber.unsignedShortValue;
+    request.majorNumber = payload.majorNumber.unsignedShortValue;
+    request.minorNumber = payload.minorNumber.unsignedShortValue;
 
     new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
@@ -5850,7 +5850,7 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     TvChannel::Commands::SkipChannel::Type request;
-    request.count = payload.Count.unsignedShortValue;
+    request.count = payload.count.unsignedShortValue;
 
     new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
@@ -5902,8 +5902,8 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     TargetNavigator::Commands::NavigateTarget::Type request;
-    request.target = payload.Target.unsignedCharValue;
-    request.data = [self asCharSpan:payload.Data];
+    request.target = payload.target.unsignedCharValue;
+    request.data = [self asCharSpan:payload.data];
 
     new CHIPTargetNavigatorClusterNavigateTargetResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -6036,8 +6036,8 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     TestCluster::Commands::TestAddArguments::Type request;
-    request.arg1 = payload.Arg1.unsignedCharValue;
-    request.arg2 = payload.Arg2.unsignedCharValue;
+    request.arg1 = payload.arg1.unsignedCharValue;
+    request.arg2 = payload.arg2.unsignedCharValue;
 
     new CHIPTestClusterClusterTestAddArgumentsResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -6052,8 +6052,8 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     TestCluster::Commands::TestEnumsRequest::Type request;
-    request.arg1 = static_cast<std::remove_reference_t<decltype(request.arg1)>>(payload.Arg1.unsignedShortValue);
-    request.arg2 = static_cast<std::remove_reference_t<decltype(request.arg2)>>(payload.Arg2.unsignedCharValue);
+    request.arg1 = static_cast<std::remove_reference_t<decltype(request.arg1)>>(payload.arg1.unsignedShortValue);
+    request.arg2 = static_cast<std::remove_reference_t<decltype(request.arg2)>>(payload.arg2.unsignedCharValue);
 
     new CHIPTestClusterClusterTestEnumsResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -6071,21 +6071,21 @@ using namespace chip::app::Clusters;
     {
         using ListType = std::remove_reference_t<decltype(request.arg1)>;
         using ListMemberType = ListMemberTypeGetter<ListType>::Type;
-        if (payload.Arg1.count != 0) {
-            auto * listHolder_0 = new ListHolder<ListMemberType>(payload.Arg1.count);
+        if (payload.arg1.count != 0) {
+            auto * listHolder_0 = new ListHolder<ListMemberType>(payload.arg1.count);
             if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
                 return;
             }
             listFreer.add(listHolder_0);
-            for (size_t i = 0; i < payload.Arg1.count; ++i) {
-                if (![payload.Arg1[i] isKindOfClass:[NSNumber class]]) {
+            for (size_t i = 0; i < payload.arg1.count; ++i) {
+                if (![payload.arg1[i] isKindOfClass:[NSNumber class]]) {
                     // Wrong kind of value.
                     return;
                 }
-                auto element_0 = (NSNumber *) payload.Arg1[i];
+                auto element_0 = (NSNumber *) payload.arg1[i];
                 listHolder_0->mList[i] = element_0.unsignedCharValue;
             }
-            request.arg1 = ListType(listHolder_0->mList, payload.Arg1.count);
+            request.arg1 = ListType(listHolder_0->mList, payload.arg1.count);
         } else {
             request.arg1 = ListType();
         }
@@ -6107,21 +6107,21 @@ using namespace chip::app::Clusters;
     {
         using ListType = std::remove_reference_t<decltype(request.arg1)>;
         using ListMemberType = ListMemberTypeGetter<ListType>::Type;
-        if (payload.Arg1.count != 0) {
-            auto * listHolder_0 = new ListHolder<ListMemberType>(payload.Arg1.count);
+        if (payload.arg1.count != 0) {
+            auto * listHolder_0 = new ListHolder<ListMemberType>(payload.arg1.count);
             if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
                 return;
             }
             listFreer.add(listHolder_0);
-            for (size_t i = 0; i < payload.Arg1.count; ++i) {
-                if (![payload.Arg1[i] isKindOfClass:[NSNumber class]]) {
+            for (size_t i = 0; i < payload.arg1.count; ++i) {
+                if (![payload.arg1[i] isKindOfClass:[NSNumber class]]) {
                     // Wrong kind of value.
                     return;
                 }
-                auto element_0 = (NSNumber *) payload.Arg1[i];
+                auto element_0 = (NSNumber *) payload.arg1[i];
                 listHolder_0->mList[i] = element_0.unsignedCharValue;
             }
-            request.arg1 = ListType(listHolder_0->mList, payload.Arg1.count);
+            request.arg1 = ListType(listHolder_0->mList, payload.arg1.count);
         } else {
             request.arg1 = ListType();
         }
@@ -6143,28 +6143,28 @@ using namespace chip::app::Clusters;
     {
         using ListType = std::remove_reference_t<decltype(request.arg1)>;
         using ListMemberType = ListMemberTypeGetter<ListType>::Type;
-        if (payload.Arg1.count != 0) {
-            auto * listHolder_0 = new ListHolder<ListMemberType>(payload.Arg1.count);
+        if (payload.arg1.count != 0) {
+            auto * listHolder_0 = new ListHolder<ListMemberType>(payload.arg1.count);
             if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
                 return;
             }
             listFreer.add(listHolder_0);
-            for (size_t i = 0; i < payload.Arg1.count; ++i) {
-                if (![payload.Arg1[i] isKindOfClass:[CHIPTestClusterClusterSimpleStruct class]]) {
+            for (size_t i = 0; i < payload.arg1.count; ++i) {
+                if (![payload.arg1[i] isKindOfClass:[CHIPTestClusterClusterSimpleStruct class]]) {
                     // Wrong kind of value.
                     return;
                 }
-                auto element_0 = (CHIPTestClusterClusterSimpleStruct *) payload.Arg1[i];
-                listHolder_0->mList[i].a = element_0.A.unsignedCharValue;
-                listHolder_0->mList[i].b = element_0.B.boolValue;
+                auto element_0 = (CHIPTestClusterClusterSimpleStruct *) payload.arg1[i];
+                listHolder_0->mList[i].a = element_0.a.unsignedCharValue;
+                listHolder_0->mList[i].b = element_0.b.boolValue;
                 listHolder_0->mList[i].c
-                    = static_cast<std::remove_reference_t<decltype(listHolder_0->mList[i].c)>>(element_0.C.unsignedCharValue);
-                listHolder_0->mList[i].d = [self asByteSpan:element_0.D];
-                listHolder_0->mList[i].e = [self asCharSpan:element_0.E];
+                    = static_cast<std::remove_reference_t<decltype(listHolder_0->mList[i].c)>>(element_0.c.unsignedCharValue);
+                listHolder_0->mList[i].d = [self asByteSpan:element_0.d];
+                listHolder_0->mList[i].e = [self asCharSpan:element_0.e];
                 listHolder_0->mList[i].f
-                    = static_cast<std::remove_reference_t<decltype(listHolder_0->mList[i].f)>>(element_0.F.unsignedCharValue);
+                    = static_cast<std::remove_reference_t<decltype(listHolder_0->mList[i].f)>>(element_0.f.unsignedCharValue);
             }
-            request.arg1 = ListType(listHolder_0->mList, payload.Arg1.count);
+            request.arg1 = ListType(listHolder_0->mList, payload.arg1.count);
         } else {
             request.arg1 = ListType();
         }
@@ -6196,13 +6196,13 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     TestCluster::Commands::TestNullableOptionalRequest::Type request;
-    if (payload.Arg1 != nil) {
+    if (payload.arg1 != nil) {
         auto & definedValue_0 = request.arg1.Emplace();
-        if (payload.Arg1 == nil) {
+        if (payload.arg1 == nil) {
             definedValue_0.SetNull();
         } else {
             auto & nonNullValue_1 = definedValue_0.SetNonNull();
-            nonNullValue_1 = payload.Arg1.unsignedCharValue;
+            nonNullValue_1 = payload.arg1.unsignedCharValue;
         }
     }
 
@@ -6232,12 +6232,12 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     TestCluster::Commands::TestStructArgumentRequest::Type request;
-    request.arg1.a = payload.Arg1.A.unsignedCharValue;
-    request.arg1.b = payload.Arg1.B.boolValue;
-    request.arg1.c = static_cast<std::remove_reference_t<decltype(request.arg1.c)>>(payload.Arg1.C.unsignedCharValue);
-    request.arg1.d = [self asByteSpan:payload.Arg1.D];
-    request.arg1.e = [self asCharSpan:payload.Arg1.E];
-    request.arg1.f = static_cast<std::remove_reference_t<decltype(request.arg1.f)>>(payload.Arg1.F.unsignedCharValue);
+    request.arg1.a = payload.arg1.a.unsignedCharValue;
+    request.arg1.b = payload.arg1.b.boolValue;
+    request.arg1.c = static_cast<std::remove_reference_t<decltype(request.arg1.c)>>(payload.arg1.c.unsignedCharValue);
+    request.arg1.d = [self asByteSpan:payload.arg1.d];
+    request.arg1.e = [self asCharSpan:payload.arg1.e];
+    request.arg1.f = static_cast<std::remove_reference_t<decltype(request.arg1.f)>>(payload.arg1.f.unsignedCharValue);
 
     new CHIPTestClusterClusterBooleanResponseCallbackBridge(
         self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
@@ -7225,9 +7225,9 @@ using namespace chip::app::Clusters;
     ListFreer listFreer;
     Thermostat::Commands::GetWeeklySchedule::Type request;
     request.daysToReturn
-        = static_cast<std::remove_reference_t<decltype(request.daysToReturn)>>(payload.DaysToReturn.unsignedCharValue);
+        = static_cast<std::remove_reference_t<decltype(request.daysToReturn)>>(payload.daysToReturn.unsignedCharValue);
     request.modeToReturn
-        = static_cast<std::remove_reference_t<decltype(request.modeToReturn)>>(payload.ModeToReturn.unsignedCharValue);
+        = static_cast<std::remove_reference_t<decltype(request.modeToReturn)>>(payload.modeToReturn.unsignedCharValue);
 
     new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
@@ -7241,29 +7241,29 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     Thermostat::Commands::SetWeeklySchedule::Type request;
-    request.numberOfTransitionsForSequence = payload.NumberOfTransitionsForSequence.unsignedCharValue;
+    request.numberOfTransitionsForSequence = payload.numberOfTransitionsForSequence.unsignedCharValue;
     request.dayOfWeekForSequence = static_cast<std::remove_reference_t<decltype(request.dayOfWeekForSequence)>>(
-        payload.DayOfWeekForSequence.unsignedCharValue);
+        payload.dayOfWeekForSequence.unsignedCharValue);
     request.modeForSequence
-        = static_cast<std::remove_reference_t<decltype(request.modeForSequence)>>(payload.ModeForSequence.unsignedCharValue);
+        = static_cast<std::remove_reference_t<decltype(request.modeForSequence)>>(payload.modeForSequence.unsignedCharValue);
     {
         using ListType = std::remove_reference_t<decltype(request.payload)>;
         using ListMemberType = ListMemberTypeGetter<ListType>::Type;
-        if (payload.Payload.count != 0) {
-            auto * listHolder_0 = new ListHolder<ListMemberType>(payload.Payload.count);
+        if (payload.payload.count != 0) {
+            auto * listHolder_0 = new ListHolder<ListMemberType>(payload.payload.count);
             if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
                 return;
             }
             listFreer.add(listHolder_0);
-            for (size_t i = 0; i < payload.Payload.count; ++i) {
-                if (![payload.Payload[i] isKindOfClass:[NSNumber class]]) {
+            for (size_t i = 0; i < payload.payload.count; ++i) {
+                if (![payload.payload[i] isKindOfClass:[NSNumber class]]) {
                     // Wrong kind of value.
                     return;
                 }
-                auto element_0 = (NSNumber *) payload.Payload[i];
+                auto element_0 = (NSNumber *) payload.payload[i];
                 listHolder_0->mList[i] = element_0.unsignedCharValue;
             }
-            request.payload = ListType(listHolder_0->mList, payload.Payload.count);
+            request.payload = ListType(listHolder_0->mList, payload.payload.count);
         } else {
             request.payload = ListType();
         }
@@ -7281,8 +7281,8 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     Thermostat::Commands::SetpointRaiseLower::Type request;
-    request.mode = static_cast<std::remove_reference_t<decltype(request.mode)>>(payload.Mode.unsignedCharValue);
-    request.amount = payload.Amount.charValue;
+    request.mode = static_cast<std::remove_reference_t<decltype(request.mode)>>(payload.mode.unsignedCharValue);
+    request.amount = payload.amount.charValue;
 
     new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
@@ -8282,8 +8282,8 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     WindowCovering::Commands::GoToLiftPercentage::Type request;
-    request.liftPercentageValue = payload.LiftPercentageValue.unsignedCharValue;
-    request.liftPercent100thsValue = payload.LiftPercent100thsValue.unsignedShortValue;
+    request.liftPercentageValue = payload.liftPercentageValue.unsignedCharValue;
+    request.liftPercent100thsValue = payload.liftPercent100thsValue.unsignedShortValue;
 
     new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
@@ -8297,7 +8297,7 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     WindowCovering::Commands::GoToLiftValue::Type request;
-    request.liftValue = payload.LiftValue.unsignedShortValue;
+    request.liftValue = payload.liftValue.unsignedShortValue;
 
     new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
@@ -8311,8 +8311,8 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     WindowCovering::Commands::GoToTiltPercentage::Type request;
-    request.tiltPercentageValue = payload.TiltPercentageValue.unsignedCharValue;
-    request.tiltPercent100thsValue = payload.TiltPercent100thsValue.unsignedShortValue;
+    request.tiltPercentageValue = payload.tiltPercentageValue.unsignedCharValue;
+    request.tiltPercent100thsValue = payload.tiltPercent100thsValue.unsignedShortValue;
 
     new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
@@ -8326,7 +8326,7 @@ using namespace chip::app::Clusters;
 {
     ListFreer listFreer;
     WindowCovering::Commands::GoToTiltValue::Type request;
-    request.tiltValue = payload.TiltValue.unsignedShortValue;
+    request.tiltValue = payload.tiltValue.unsignedShortValue;
 
     new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPCommandPayloadsObjc.h
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPCommandPayloadsObjc.h
@@ -24,186 +24,186 @@
 #import <Foundation/Foundation.h>
 
 @interface CHIPIdentifyClusterIdentifyPayload : NSObject
-@property (strong) NSNumber * _Nonnull IdentifyTime;
+@property (strong, nonatomic) NSNumber * _Nonnull identifyTime;
 @end
 
 @interface CHIPIdentifyClusterIdentifyQueryResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull Timeout;
+@property (strong, nonatomic) NSNumber * _Nonnull timeout;
 @end
 
 @interface CHIPIdentifyClusterIdentifyQueryPayload : NSObject
 @end
 
 @interface CHIPIdentifyClusterTriggerEffectPayload : NSObject
-@property (strong) NSNumber * _Nonnull EffectIdentifier;
-@property (strong) NSNumber * _Nonnull EffectVariant;
+@property (strong, nonatomic) NSNumber * _Nonnull effectIdentifier;
+@property (strong, nonatomic) NSNumber * _Nonnull effectVariant;
 @end
 
 @interface CHIPGroupsClusterAddGroupPayload : NSObject
-@property (strong) NSNumber * _Nonnull GroupId;
-@property (strong) NSString * _Nonnull GroupName;
+@property (strong, nonatomic) NSNumber * _Nonnull groupId;
+@property (strong, nonatomic) NSString * _Nonnull groupName;
 @end
 
 @interface CHIPGroupsClusterAddGroupResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull Status;
-@property (strong) NSNumber * _Nonnull GroupId;
+@property (strong, nonatomic) NSNumber * _Nonnull status;
+@property (strong, nonatomic) NSNumber * _Nonnull groupId;
 @end
 
 @interface CHIPGroupsClusterViewGroupPayload : NSObject
-@property (strong) NSNumber * _Nonnull GroupId;
+@property (strong, nonatomic) NSNumber * _Nonnull groupId;
 @end
 
 @interface CHIPGroupsClusterViewGroupResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull Status;
-@property (strong) NSNumber * _Nonnull GroupId;
-@property (strong) NSString * _Nonnull GroupName;
+@property (strong, nonatomic) NSNumber * _Nonnull status;
+@property (strong, nonatomic) NSNumber * _Nonnull groupId;
+@property (strong, nonatomic) NSString * _Nonnull groupName;
 @end
 
 @interface CHIPGroupsClusterGetGroupMembershipPayload : NSObject
-@property (strong) NSNumber * _Nonnull GroupCount;
-@property (strong) NSArray * _Nonnull GroupList;
+@property (strong, nonatomic) NSNumber * _Nonnull groupCount;
+@property (strong, nonatomic) NSArray * _Nonnull groupList;
 @end
 
 @interface CHIPGroupsClusterGetGroupMembershipResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull Capacity;
-@property (strong) NSNumber * _Nonnull GroupCount;
-@property (strong) NSArray * _Nonnull GroupList;
+@property (strong, nonatomic) NSNumber * _Nonnull capacity;
+@property (strong, nonatomic) NSNumber * _Nonnull groupCount;
+@property (strong, nonatomic) NSArray * _Nonnull groupList;
 @end
 
 @interface CHIPGroupsClusterRemoveGroupPayload : NSObject
-@property (strong) NSNumber * _Nonnull GroupId;
+@property (strong, nonatomic) NSNumber * _Nonnull groupId;
 @end
 
 @interface CHIPGroupsClusterRemoveGroupResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull Status;
-@property (strong) NSNumber * _Nonnull GroupId;
+@property (strong, nonatomic) NSNumber * _Nonnull status;
+@property (strong, nonatomic) NSNumber * _Nonnull groupId;
 @end
 
 @interface CHIPGroupsClusterRemoveAllGroupsPayload : NSObject
 @end
 
 @interface CHIPGroupsClusterAddGroupIfIdentifyingPayload : NSObject
-@property (strong) NSNumber * _Nonnull GroupId;
-@property (strong) NSString * _Nonnull GroupName;
+@property (strong, nonatomic) NSNumber * _Nonnull groupId;
+@property (strong, nonatomic) NSString * _Nonnull groupName;
 @end
 
 @interface CHIPScenesClusterAddScenePayload : NSObject
-@property (strong) NSNumber * _Nonnull GroupId;
-@property (strong) NSNumber * _Nonnull SceneId;
-@property (strong) NSNumber * _Nonnull TransitionTime;
-@property (strong) NSString * _Nonnull SceneName;
-@property (strong) NSArray * _Nonnull ExtensionFieldSets;
+@property (strong, nonatomic) NSNumber * _Nonnull groupId;
+@property (strong, nonatomic) NSNumber * _Nonnull sceneId;
+@property (strong, nonatomic) NSNumber * _Nonnull transitionTime;
+@property (strong, nonatomic) NSString * _Nonnull sceneName;
+@property (strong, nonatomic) NSArray * _Nonnull extensionFieldSets;
 @end
 
 @interface CHIPScenesClusterAddSceneResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull Status;
-@property (strong) NSNumber * _Nonnull GroupId;
-@property (strong) NSNumber * _Nonnull SceneId;
+@property (strong, nonatomic) NSNumber * _Nonnull status;
+@property (strong, nonatomic) NSNumber * _Nonnull groupId;
+@property (strong, nonatomic) NSNumber * _Nonnull sceneId;
 @end
 
 @interface CHIPScenesClusterViewScenePayload : NSObject
-@property (strong) NSNumber * _Nonnull GroupId;
-@property (strong) NSNumber * _Nonnull SceneId;
+@property (strong, nonatomic) NSNumber * _Nonnull groupId;
+@property (strong, nonatomic) NSNumber * _Nonnull sceneId;
 @end
 
 @interface CHIPScenesClusterViewSceneResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull Status;
-@property (strong) NSNumber * _Nonnull GroupId;
-@property (strong) NSNumber * _Nonnull SceneId;
-@property (strong) NSNumber * _Nonnull TransitionTime;
-@property (strong) NSString * _Nonnull SceneName;
-@property (strong) NSArray * _Nonnull ExtensionFieldSets;
+@property (strong, nonatomic) NSNumber * _Nonnull status;
+@property (strong, nonatomic) NSNumber * _Nonnull groupId;
+@property (strong, nonatomic) NSNumber * _Nonnull sceneId;
+@property (strong, nonatomic) NSNumber * _Nonnull transitionTime;
+@property (strong, nonatomic) NSString * _Nonnull sceneName;
+@property (strong, nonatomic) NSArray * _Nonnull extensionFieldSets;
 @end
 
 @interface CHIPScenesClusterRemoveScenePayload : NSObject
-@property (strong) NSNumber * _Nonnull GroupId;
-@property (strong) NSNumber * _Nonnull SceneId;
+@property (strong, nonatomic) NSNumber * _Nonnull groupId;
+@property (strong, nonatomic) NSNumber * _Nonnull sceneId;
 @end
 
 @interface CHIPScenesClusterRemoveSceneResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull Status;
-@property (strong) NSNumber * _Nonnull GroupId;
-@property (strong) NSNumber * _Nonnull SceneId;
+@property (strong, nonatomic) NSNumber * _Nonnull status;
+@property (strong, nonatomic) NSNumber * _Nonnull groupId;
+@property (strong, nonatomic) NSNumber * _Nonnull sceneId;
 @end
 
 @interface CHIPScenesClusterRemoveAllScenesPayload : NSObject
-@property (strong) NSNumber * _Nonnull GroupId;
+@property (strong, nonatomic) NSNumber * _Nonnull groupId;
 @end
 
 @interface CHIPScenesClusterRemoveAllScenesResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull Status;
-@property (strong) NSNumber * _Nonnull GroupId;
+@property (strong, nonatomic) NSNumber * _Nonnull status;
+@property (strong, nonatomic) NSNumber * _Nonnull groupId;
 @end
 
 @interface CHIPScenesClusterStoreScenePayload : NSObject
-@property (strong) NSNumber * _Nonnull GroupId;
-@property (strong) NSNumber * _Nonnull SceneId;
+@property (strong, nonatomic) NSNumber * _Nonnull groupId;
+@property (strong, nonatomic) NSNumber * _Nonnull sceneId;
 @end
 
 @interface CHIPScenesClusterStoreSceneResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull Status;
-@property (strong) NSNumber * _Nonnull GroupId;
-@property (strong) NSNumber * _Nonnull SceneId;
+@property (strong, nonatomic) NSNumber * _Nonnull status;
+@property (strong, nonatomic) NSNumber * _Nonnull groupId;
+@property (strong, nonatomic) NSNumber * _Nonnull sceneId;
 @end
 
 @interface CHIPScenesClusterRecallScenePayload : NSObject
-@property (strong) NSNumber * _Nonnull GroupId;
-@property (strong) NSNumber * _Nonnull SceneId;
-@property (strong) NSNumber * _Nonnull TransitionTime;
+@property (strong, nonatomic) NSNumber * _Nonnull groupId;
+@property (strong, nonatomic) NSNumber * _Nonnull sceneId;
+@property (strong, nonatomic) NSNumber * _Nonnull transitionTime;
 @end
 
 @interface CHIPScenesClusterGetSceneMembershipPayload : NSObject
-@property (strong) NSNumber * _Nonnull GroupId;
+@property (strong, nonatomic) NSNumber * _Nonnull groupId;
 @end
 
 @interface CHIPScenesClusterGetSceneMembershipResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull Status;
-@property (strong) NSNumber * _Nonnull Capacity;
-@property (strong) NSNumber * _Nonnull GroupId;
-@property (strong) NSNumber * _Nonnull SceneCount;
-@property (strong) NSArray * _Nonnull SceneList;
+@property (strong, nonatomic) NSNumber * _Nonnull status;
+@property (strong, nonatomic) NSNumber * _Nonnull capacity;
+@property (strong, nonatomic) NSNumber * _Nonnull groupId;
+@property (strong, nonatomic) NSNumber * _Nonnull sceneCount;
+@property (strong, nonatomic) NSArray * _Nonnull sceneList;
 @end
 
 @interface CHIPScenesClusterEnhancedAddScenePayload : NSObject
-@property (strong) NSNumber * _Nonnull GroupId;
-@property (strong) NSNumber * _Nonnull SceneId;
-@property (strong) NSNumber * _Nonnull TransitionTime;
-@property (strong) NSString * _Nonnull SceneName;
-@property (strong) NSArray * _Nonnull ExtensionFieldSets;
+@property (strong, nonatomic) NSNumber * _Nonnull groupId;
+@property (strong, nonatomic) NSNumber * _Nonnull sceneId;
+@property (strong, nonatomic) NSNumber * _Nonnull transitionTime;
+@property (strong, nonatomic) NSString * _Nonnull sceneName;
+@property (strong, nonatomic) NSArray * _Nonnull extensionFieldSets;
 @end
 
 @interface CHIPScenesClusterEnhancedAddSceneResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull Status;
-@property (strong) NSNumber * _Nonnull GroupId;
-@property (strong) NSNumber * _Nonnull SceneId;
+@property (strong, nonatomic) NSNumber * _Nonnull status;
+@property (strong, nonatomic) NSNumber * _Nonnull groupId;
+@property (strong, nonatomic) NSNumber * _Nonnull sceneId;
 @end
 
 @interface CHIPScenesClusterEnhancedViewScenePayload : NSObject
-@property (strong) NSNumber * _Nonnull GroupId;
-@property (strong) NSNumber * _Nonnull SceneId;
+@property (strong, nonatomic) NSNumber * _Nonnull groupId;
+@property (strong, nonatomic) NSNumber * _Nonnull sceneId;
 @end
 
 @interface CHIPScenesClusterEnhancedViewSceneResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull Status;
-@property (strong) NSNumber * _Nonnull GroupId;
-@property (strong) NSNumber * _Nonnull SceneId;
-@property (strong) NSNumber * _Nonnull TransitionTime;
-@property (strong) NSString * _Nonnull SceneName;
-@property (strong) NSArray * _Nonnull ExtensionFieldSets;
+@property (strong, nonatomic) NSNumber * _Nonnull status;
+@property (strong, nonatomic) NSNumber * _Nonnull groupId;
+@property (strong, nonatomic) NSNumber * _Nonnull sceneId;
+@property (strong, nonatomic) NSNumber * _Nonnull transitionTime;
+@property (strong, nonatomic) NSString * _Nonnull sceneName;
+@property (strong, nonatomic) NSArray * _Nonnull extensionFieldSets;
 @end
 
 @interface CHIPScenesClusterCopyScenePayload : NSObject
-@property (strong) NSNumber * _Nonnull Mode;
-@property (strong) NSNumber * _Nonnull GroupIdFrom;
-@property (strong) NSNumber * _Nonnull SceneIdFrom;
-@property (strong) NSNumber * _Nonnull GroupIdTo;
-@property (strong) NSNumber * _Nonnull SceneIdTo;
+@property (strong, nonatomic) NSNumber * _Nonnull mode;
+@property (strong, nonatomic) NSNumber * _Nonnull groupIdFrom;
+@property (strong, nonatomic) NSNumber * _Nonnull sceneIdFrom;
+@property (strong, nonatomic) NSNumber * _Nonnull groupIdTo;
+@property (strong, nonatomic) NSNumber * _Nonnull sceneIdTo;
 @end
 
 @interface CHIPScenesClusterCopySceneResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull Status;
-@property (strong) NSNumber * _Nonnull GroupIdFrom;
-@property (strong) NSNumber * _Nonnull SceneIdFrom;
+@property (strong, nonatomic) NSNumber * _Nonnull status;
+@property (strong, nonatomic) NSNumber * _Nonnull groupIdFrom;
+@property (strong, nonatomic) NSNumber * _Nonnull sceneIdFrom;
 @end
 
 @interface CHIPOnOffClusterOffPayload : NSObject
@@ -231,83 +231,83 @@
 @end
 
 @interface CHIPOnOffClusterOffWithEffectPayload : NSObject
-@property (strong) NSNumber * _Nonnull EffectId;
-@property (strong) NSNumber * _Nonnull EffectVariant;
+@property (strong, nonatomic) NSNumber * _Nonnull effectId;
+@property (strong, nonatomic) NSNumber * _Nonnull effectVariant;
 @end
 
 @interface CHIPOnOffClusterOnWithRecallGlobalScenePayload : NSObject
 @end
 
 @interface CHIPOnOffClusterOnWithTimedOffPayload : NSObject
-@property (strong) NSNumber * _Nonnull OnOffControl;
-@property (strong) NSNumber * _Nonnull OnTime;
-@property (strong) NSNumber * _Nonnull OffWaitTime;
+@property (strong, nonatomic) NSNumber * _Nonnull onOffControl;
+@property (strong, nonatomic) NSNumber * _Nonnull onTime;
+@property (strong, nonatomic) NSNumber * _Nonnull offWaitTime;
 @end
 
 @interface CHIPLevelControlClusterMoveToLevelPayload : NSObject
-@property (strong) NSNumber * _Nonnull Level;
-@property (strong) NSNumber * _Nonnull TransitionTime;
-@property (strong) NSNumber * _Nonnull OptionMask;
-@property (strong) NSNumber * _Nonnull OptionOverride;
+@property (strong, nonatomic) NSNumber * _Nonnull level;
+@property (strong, nonatomic) NSNumber * _Nonnull transitionTime;
+@property (strong, nonatomic) NSNumber * _Nonnull optionMask;
+@property (strong, nonatomic) NSNumber * _Nonnull optionOverride;
 @end
 
 @interface CHIPLevelControlClusterMovePayload : NSObject
-@property (strong) NSNumber * _Nonnull MoveMode;
-@property (strong) NSNumber * _Nonnull Rate;
-@property (strong) NSNumber * _Nonnull OptionMask;
-@property (strong) NSNumber * _Nonnull OptionOverride;
+@property (strong, nonatomic) NSNumber * _Nonnull moveMode;
+@property (strong, nonatomic) NSNumber * _Nonnull rate;
+@property (strong, nonatomic) NSNumber * _Nonnull optionMask;
+@property (strong, nonatomic) NSNumber * _Nonnull optionOverride;
 @end
 
 @interface CHIPLevelControlClusterStepPayload : NSObject
-@property (strong) NSNumber * _Nonnull StepMode;
-@property (strong) NSNumber * _Nonnull StepSize;
-@property (strong) NSNumber * _Nonnull TransitionTime;
-@property (strong) NSNumber * _Nonnull OptionMask;
-@property (strong) NSNumber * _Nonnull OptionOverride;
+@property (strong, nonatomic) NSNumber * _Nonnull stepMode;
+@property (strong, nonatomic) NSNumber * _Nonnull stepSize;
+@property (strong, nonatomic) NSNumber * _Nonnull transitionTime;
+@property (strong, nonatomic) NSNumber * _Nonnull optionMask;
+@property (strong, nonatomic) NSNumber * _Nonnull optionOverride;
 @end
 
 @interface CHIPLevelControlClusterStopPayload : NSObject
-@property (strong) NSNumber * _Nonnull OptionMask;
-@property (strong) NSNumber * _Nonnull OptionOverride;
+@property (strong, nonatomic) NSNumber * _Nonnull optionMask;
+@property (strong, nonatomic) NSNumber * _Nonnull optionOverride;
 @end
 
 @interface CHIPLevelControlClusterMoveToLevelWithOnOffPayload : NSObject
-@property (strong) NSNumber * _Nonnull Level;
-@property (strong) NSNumber * _Nonnull TransitionTime;
+@property (strong, nonatomic) NSNumber * _Nonnull level;
+@property (strong, nonatomic) NSNumber * _Nonnull transitionTime;
 @end
 
 @interface CHIPLevelControlClusterMoveWithOnOffPayload : NSObject
-@property (strong) NSNumber * _Nonnull MoveMode;
-@property (strong) NSNumber * _Nonnull Rate;
+@property (strong, nonatomic) NSNumber * _Nonnull moveMode;
+@property (strong, nonatomic) NSNumber * _Nonnull rate;
 @end
 
 @interface CHIPLevelControlClusterStepWithOnOffPayload : NSObject
-@property (strong) NSNumber * _Nonnull StepMode;
-@property (strong) NSNumber * _Nonnull StepSize;
-@property (strong) NSNumber * _Nonnull TransitionTime;
+@property (strong, nonatomic) NSNumber * _Nonnull stepMode;
+@property (strong, nonatomic) NSNumber * _Nonnull stepSize;
+@property (strong, nonatomic) NSNumber * _Nonnull transitionTime;
 @end
 
 @interface CHIPLevelControlClusterStopWithOnOffPayload : NSObject
 @end
 
 @interface CHIPAlarmsClusterResetAlarmPayload : NSObject
-@property (strong) NSNumber * _Nonnull AlarmCode;
-@property (strong) NSNumber * _Nonnull ClusterId;
+@property (strong, nonatomic) NSNumber * _Nonnull alarmCode;
+@property (strong, nonatomic) NSNumber * _Nonnull clusterId;
 @end
 
 @interface CHIPAlarmsClusterAlarmPayload : NSObject
-@property (strong) NSNumber * _Nonnull AlarmCode;
-@property (strong) NSNumber * _Nonnull ClusterId;
+@property (strong, nonatomic) NSNumber * _Nonnull alarmCode;
+@property (strong, nonatomic) NSNumber * _Nonnull clusterId;
 @end
 
 @interface CHIPAlarmsClusterResetAllAlarmsPayload : NSObject
 @end
 
 @interface CHIPAlarmsClusterGetAlarmResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull Status;
-@property (strong) NSNumber * _Nonnull AlarmCode;
-@property (strong) NSNumber * _Nonnull ClusterId;
-@property (strong) NSNumber * _Nonnull TimeStamp;
+@property (strong, nonatomic) NSNumber * _Nonnull status;
+@property (strong, nonatomic) NSNumber * _Nonnull alarmCode;
+@property (strong, nonatomic) NSNumber * _Nonnull clusterId;
+@property (strong, nonatomic) NSNumber * _Nonnull timeStamp;
 @end
 
 @interface CHIPAlarmsClusterGetAlarmPayload : NSObject
@@ -317,140 +317,140 @@
 @end
 
 @interface CHIPPowerProfileClusterPowerProfileRequestPayload : NSObject
-@property (strong) NSNumber * _Nonnull PowerProfileId;
+@property (strong, nonatomic) NSNumber * _Nonnull powerProfileId;
 @end
 
 @interface CHIPPowerProfileClusterPowerProfileNotificationPayload : NSObject
-@property (strong) NSNumber * _Nonnull TotalProfileNum;
-@property (strong) NSNumber * _Nonnull PowerProfileId;
-@property (strong) NSNumber * _Nonnull NumOfTransferredPhases;
-@property (strong) NSArray * _Nonnull TransferredPhases;
+@property (strong, nonatomic) NSNumber * _Nonnull totalProfileNum;
+@property (strong, nonatomic) NSNumber * _Nonnull powerProfileId;
+@property (strong, nonatomic) NSNumber * _Nonnull numOfTransferredPhases;
+@property (strong, nonatomic) NSArray * _Nonnull transferredPhases;
 @end
 
 @interface CHIPPowerProfileClusterPowerProfileStateRequestPayload : NSObject
 @end
 
 @interface CHIPPowerProfileClusterPowerProfileResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull TotalProfileNum;
-@property (strong) NSNumber * _Nonnull PowerProfileId;
-@property (strong) NSNumber * _Nonnull NumOfTransferredPhases;
-@property (strong) NSArray * _Nonnull TransferredPhases;
+@property (strong, nonatomic) NSNumber * _Nonnull totalProfileNum;
+@property (strong, nonatomic) NSNumber * _Nonnull powerProfileId;
+@property (strong, nonatomic) NSNumber * _Nonnull numOfTransferredPhases;
+@property (strong, nonatomic) NSArray * _Nonnull transferredPhases;
 @end
 
 @interface CHIPPowerProfileClusterGetPowerProfilePriceResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull PowerProfileId;
-@property (strong) NSNumber * _Nonnull Currency;
-@property (strong) NSNumber * _Nonnull Price;
-@property (strong) NSNumber * _Nonnull PriceTrailingDigit;
+@property (strong, nonatomic) NSNumber * _Nonnull powerProfileId;
+@property (strong, nonatomic) NSNumber * _Nonnull currency;
+@property (strong, nonatomic) NSNumber * _Nonnull price;
+@property (strong, nonatomic) NSNumber * _Nonnull priceTrailingDigit;
 @end
 
 @interface CHIPPowerProfileClusterPowerProfileStateResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull PowerProfileCount;
-@property (strong) NSArray * _Nonnull PowerProfileRecords;
+@property (strong, nonatomic) NSNumber * _Nonnull powerProfileCount;
+@property (strong, nonatomic) NSArray * _Nonnull powerProfileRecords;
 @end
 
 @interface CHIPPowerProfileClusterGetOverallSchedulePriceResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull Currency;
-@property (strong) NSNumber * _Nonnull Price;
-@property (strong) NSNumber * _Nonnull PriceTrailingDigit;
+@property (strong, nonatomic) NSNumber * _Nonnull currency;
+@property (strong, nonatomic) NSNumber * _Nonnull price;
+@property (strong, nonatomic) NSNumber * _Nonnull priceTrailingDigit;
 @end
 
 @interface CHIPPowerProfileClusterGetPowerProfilePricePayload : NSObject
-@property (strong) NSNumber * _Nonnull PowerProfileId;
+@property (strong, nonatomic) NSNumber * _Nonnull powerProfileId;
 @end
 
 @interface CHIPPowerProfileClusterEnergyPhasesScheduleNotificationPayload : NSObject
-@property (strong) NSNumber * _Nonnull PowerProfileId;
-@property (strong) NSNumber * _Nonnull NumOfScheduledPhases;
-@property (strong) NSArray * _Nonnull ScheduledPhases;
+@property (strong, nonatomic) NSNumber * _Nonnull powerProfileId;
+@property (strong, nonatomic) NSNumber * _Nonnull numOfScheduledPhases;
+@property (strong, nonatomic) NSArray * _Nonnull scheduledPhases;
 @end
 
 @interface CHIPPowerProfileClusterPowerProfilesStateNotificationPayload : NSObject
-@property (strong) NSNumber * _Nonnull PowerProfileCount;
-@property (strong) NSArray * _Nonnull PowerProfileRecords;
+@property (strong, nonatomic) NSNumber * _Nonnull powerProfileCount;
+@property (strong, nonatomic) NSArray * _Nonnull powerProfileRecords;
 @end
 
 @interface CHIPPowerProfileClusterEnergyPhasesScheduleResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull PowerProfileId;
-@property (strong) NSNumber * _Nonnull NumOfScheduledPhases;
-@property (strong) NSArray * _Nonnull ScheduledPhases;
+@property (strong, nonatomic) NSNumber * _Nonnull powerProfileId;
+@property (strong, nonatomic) NSNumber * _Nonnull numOfScheduledPhases;
+@property (strong, nonatomic) NSArray * _Nonnull scheduledPhases;
 @end
 
 @interface CHIPPowerProfileClusterGetOverallSchedulePricePayload : NSObject
 @end
 
 @interface CHIPPowerProfileClusterPowerProfileScheduleConstraintsRequestPayload : NSObject
-@property (strong) NSNumber * _Nonnull PowerProfileId;
+@property (strong, nonatomic) NSNumber * _Nonnull powerProfileId;
 @end
 
 @interface CHIPPowerProfileClusterEnergyPhasesScheduleRequestPayload : NSObject
-@property (strong) NSNumber * _Nonnull PowerProfileId;
+@property (strong, nonatomic) NSNumber * _Nonnull powerProfileId;
 @end
 
 @interface CHIPPowerProfileClusterEnergyPhasesScheduleStateRequestPayload : NSObject
-@property (strong) NSNumber * _Nonnull PowerProfileId;
+@property (strong, nonatomic) NSNumber * _Nonnull powerProfileId;
 @end
 
 @interface CHIPPowerProfileClusterEnergyPhasesScheduleStateResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull PowerProfileId;
-@property (strong) NSNumber * _Nonnull NumOfScheduledPhases;
-@property (strong) NSArray * _Nonnull ScheduledPhases;
+@property (strong, nonatomic) NSNumber * _Nonnull powerProfileId;
+@property (strong, nonatomic) NSNumber * _Nonnull numOfScheduledPhases;
+@property (strong, nonatomic) NSArray * _Nonnull scheduledPhases;
 @end
 
 @interface CHIPPowerProfileClusterGetPowerProfilePriceExtendedResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull PowerProfileId;
-@property (strong) NSNumber * _Nonnull Currency;
-@property (strong) NSNumber * _Nonnull Price;
-@property (strong) NSNumber * _Nonnull PriceTrailingDigit;
+@property (strong, nonatomic) NSNumber * _Nonnull powerProfileId;
+@property (strong, nonatomic) NSNumber * _Nonnull currency;
+@property (strong, nonatomic) NSNumber * _Nonnull price;
+@property (strong, nonatomic) NSNumber * _Nonnull priceTrailingDigit;
 @end
 
 @interface CHIPPowerProfileClusterEnergyPhasesScheduleStateNotificationPayload : NSObject
-@property (strong) NSNumber * _Nonnull PowerProfileId;
-@property (strong) NSNumber * _Nonnull NumOfScheduledPhases;
-@property (strong) NSArray * _Nonnull ScheduledPhases;
+@property (strong, nonatomic) NSNumber * _Nonnull powerProfileId;
+@property (strong, nonatomic) NSNumber * _Nonnull numOfScheduledPhases;
+@property (strong, nonatomic) NSArray * _Nonnull scheduledPhases;
 @end
 
 @interface CHIPPowerProfileClusterPowerProfileScheduleConstraintsNotificationPayload : NSObject
-@property (strong) NSNumber * _Nonnull PowerProfileId;
-@property (strong) NSNumber * _Nonnull StartAfter;
-@property (strong) NSNumber * _Nonnull StopBefore;
+@property (strong, nonatomic) NSNumber * _Nonnull powerProfileId;
+@property (strong, nonatomic) NSNumber * _Nonnull startAfter;
+@property (strong, nonatomic) NSNumber * _Nonnull stopBefore;
 @end
 
 @interface CHIPPowerProfileClusterPowerProfileScheduleConstraintsResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull PowerProfileId;
-@property (strong) NSNumber * _Nonnull StartAfter;
-@property (strong) NSNumber * _Nonnull StopBefore;
+@property (strong, nonatomic) NSNumber * _Nonnull powerProfileId;
+@property (strong, nonatomic) NSNumber * _Nonnull startAfter;
+@property (strong, nonatomic) NSNumber * _Nonnull stopBefore;
 @end
 
 @interface CHIPPowerProfileClusterGetPowerProfilePriceExtendedPayload : NSObject
-@property (strong) NSNumber * _Nonnull Options;
-@property (strong) NSNumber * _Nonnull PowerProfileId;
-@property (strong) NSNumber * _Nonnull PowerProfileStartTime;
+@property (strong, nonatomic) NSNumber * _Nonnull options;
+@property (strong, nonatomic) NSNumber * _Nonnull powerProfileId;
+@property (strong, nonatomic) NSNumber * _Nonnull powerProfileStartTime;
 @end
 
 @interface CHIPApplianceControlClusterExecutionOfACommandPayload : NSObject
-@property (strong) NSNumber * _Nonnull CommandId;
+@property (strong, nonatomic) NSNumber * _Nonnull commandId;
 @end
 
 @interface CHIPApplianceControlClusterSignalStateResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull ApplianceStatus;
-@property (strong) NSNumber * _Nonnull RemoteEnableFlagsAndDeviceStatus2;
-@property (strong) NSNumber * _Nonnull ApplianceStatus2;
+@property (strong, nonatomic) NSNumber * _Nonnull applianceStatus;
+@property (strong, nonatomic) NSNumber * _Nonnull remoteEnableFlagsAndDeviceStatus2;
+@property (strong, nonatomic) NSNumber * _Nonnull applianceStatus2;
 @end
 
 @interface CHIPApplianceControlClusterSignalStatePayload : NSObject
 @end
 
 @interface CHIPApplianceControlClusterSignalStateNotificationPayload : NSObject
-@property (strong) NSNumber * _Nonnull ApplianceStatus;
-@property (strong) NSNumber * _Nonnull RemoteEnableFlagsAndDeviceStatus2;
-@property (strong) NSNumber * _Nonnull ApplianceStatus2;
+@property (strong, nonatomic) NSNumber * _Nonnull applianceStatus;
+@property (strong, nonatomic) NSNumber * _Nonnull remoteEnableFlagsAndDeviceStatus2;
+@property (strong, nonatomic) NSNumber * _Nonnull applianceStatus2;
 @end
 
 @interface CHIPApplianceControlClusterWriteFunctionsPayload : NSObject
-@property (strong) NSNumber * _Nonnull FunctionId;
-@property (strong) NSNumber * _Nonnull FunctionDataType;
-@property (strong) NSArray * _Nonnull FunctionData;
+@property (strong, nonatomic) NSNumber * _Nonnull functionId;
+@property (strong, nonatomic) NSNumber * _Nonnull functionDataType;
+@property (strong, nonatomic) NSArray * _Nonnull functionData;
 @end
 
 @interface CHIPApplianceControlClusterOverloadPauseResumePayload : NSObject
@@ -460,91 +460,91 @@
 @end
 
 @interface CHIPApplianceControlClusterOverloadWarningPayload : NSObject
-@property (strong) NSNumber * _Nonnull WarningEvent;
+@property (strong, nonatomic) NSNumber * _Nonnull warningEvent;
 @end
 
 @interface CHIPPollControlClusterCheckInPayload : NSObject
 @end
 
 @interface CHIPPollControlClusterCheckInResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull StartFastPolling;
-@property (strong) NSNumber * _Nonnull FastPollTimeout;
+@property (strong, nonatomic) NSNumber * _Nonnull startFastPolling;
+@property (strong, nonatomic) NSNumber * _Nonnull fastPollTimeout;
 @end
 
 @interface CHIPPollControlClusterFastPollStopPayload : NSObject
 @end
 
 @interface CHIPPollControlClusterSetLongPollIntervalPayload : NSObject
-@property (strong) NSNumber * _Nonnull NewLongPollInterval;
+@property (strong, nonatomic, getter=getNewLongPollInterval) NSNumber * _Nonnull newLongPollInterval;
 @end
 
 @interface CHIPPollControlClusterSetShortPollIntervalPayload : NSObject
-@property (strong) NSNumber * _Nonnull NewShortPollInterval;
+@property (strong, nonatomic, getter=getNewShortPollInterval) NSNumber * _Nonnull newShortPollInterval;
 @end
 
 @interface CHIPBridgedActionsClusterInstantActionPayload : NSObject
-@property (strong) NSNumber * _Nonnull ActionID;
-@property (strong) NSNumber * _Nullable InvokeID;
+@property (strong, nonatomic) NSNumber * _Nonnull actionID;
+@property (strong, nonatomic) NSNumber * _Nullable invokeID;
 @end
 
 @interface CHIPBridgedActionsClusterInstantActionWithTransitionPayload : NSObject
-@property (strong) NSNumber * _Nonnull ActionID;
-@property (strong) NSNumber * _Nullable InvokeID;
-@property (strong) NSNumber * _Nonnull TransitionTime;
+@property (strong, nonatomic) NSNumber * _Nonnull actionID;
+@property (strong, nonatomic) NSNumber * _Nullable invokeID;
+@property (strong, nonatomic) NSNumber * _Nonnull transitionTime;
 @end
 
 @interface CHIPBridgedActionsClusterStartActionPayload : NSObject
-@property (strong) NSNumber * _Nonnull ActionID;
-@property (strong) NSNumber * _Nullable InvokeID;
+@property (strong, nonatomic) NSNumber * _Nonnull actionID;
+@property (strong, nonatomic) NSNumber * _Nullable invokeID;
 @end
 
 @interface CHIPBridgedActionsClusterStartActionWithDurationPayload : NSObject
-@property (strong) NSNumber * _Nonnull ActionID;
-@property (strong) NSNumber * _Nullable InvokeID;
-@property (strong) NSNumber * _Nonnull Duration;
+@property (strong, nonatomic) NSNumber * _Nonnull actionID;
+@property (strong, nonatomic) NSNumber * _Nullable invokeID;
+@property (strong, nonatomic) NSNumber * _Nonnull duration;
 @end
 
 @interface CHIPBridgedActionsClusterStopActionPayload : NSObject
-@property (strong) NSNumber * _Nonnull ActionID;
-@property (strong) NSNumber * _Nullable InvokeID;
+@property (strong, nonatomic) NSNumber * _Nonnull actionID;
+@property (strong, nonatomic) NSNumber * _Nullable invokeID;
 @end
 
 @interface CHIPBridgedActionsClusterPauseActionPayload : NSObject
-@property (strong) NSNumber * _Nonnull ActionID;
-@property (strong) NSNumber * _Nullable InvokeID;
+@property (strong, nonatomic) NSNumber * _Nonnull actionID;
+@property (strong, nonatomic) NSNumber * _Nullable invokeID;
 @end
 
 @interface CHIPBridgedActionsClusterPauseActionWithDurationPayload : NSObject
-@property (strong) NSNumber * _Nonnull ActionID;
-@property (strong) NSNumber * _Nullable InvokeID;
-@property (strong) NSNumber * _Nonnull Duration;
+@property (strong, nonatomic) NSNumber * _Nonnull actionID;
+@property (strong, nonatomic) NSNumber * _Nullable invokeID;
+@property (strong, nonatomic) NSNumber * _Nonnull duration;
 @end
 
 @interface CHIPBridgedActionsClusterResumeActionPayload : NSObject
-@property (strong) NSNumber * _Nonnull ActionID;
-@property (strong) NSNumber * _Nullable InvokeID;
+@property (strong, nonatomic) NSNumber * _Nonnull actionID;
+@property (strong, nonatomic) NSNumber * _Nullable invokeID;
 @end
 
 @interface CHIPBridgedActionsClusterEnableActionPayload : NSObject
-@property (strong) NSNumber * _Nonnull ActionID;
-@property (strong) NSNumber * _Nullable InvokeID;
+@property (strong, nonatomic) NSNumber * _Nonnull actionID;
+@property (strong, nonatomic) NSNumber * _Nullable invokeID;
 @end
 
 @interface CHIPBridgedActionsClusterEnableActionWithDurationPayload : NSObject
-@property (strong) NSNumber * _Nonnull ActionID;
-@property (strong) NSNumber * _Nullable InvokeID;
-@property (strong) NSNumber * _Nonnull Duration;
+@property (strong, nonatomic) NSNumber * _Nonnull actionID;
+@property (strong, nonatomic) NSNumber * _Nullable invokeID;
+@property (strong, nonatomic) NSNumber * _Nonnull duration;
 @end
 
 @interface CHIPBridgedActionsClusterDisableActionPayload : NSObject
-@property (strong) NSNumber * _Nonnull ActionID;
-@property (strong) NSNumber * _Nullable InvokeID;
+@property (strong, nonatomic) NSNumber * _Nonnull actionID;
+@property (strong, nonatomic) NSNumber * _Nullable invokeID;
 @end
 
 @interface CHIPBridgedActionsClusterDisableActionWithDurationPayload : NSObject
-@property (strong) NSNumber * _Nonnull ActionID;
-@property (strong) NSNumber * _Nullable InvokeID;
-@property (strong) NSNumber * _Nonnull Duration;
+@property (strong, nonatomic) NSNumber * _Nonnull actionID;
+@property (strong, nonatomic) NSNumber * _Nullable invokeID;
+@property (strong, nonatomic) NSNumber * _Nonnull duration;
 @end
 
 @interface CHIPBasicClusterStartUpPayload : NSObject
@@ -560,183 +560,183 @@
 @end
 
 @interface CHIPOtaSoftwareUpdateProviderClusterQueryImagePayload : NSObject
-@property (strong) NSNumber * _Nonnull VendorId;
-@property (strong) NSNumber * _Nonnull ProductId;
-@property (strong) NSNumber * _Nonnull SoftwareVersion;
-@property (strong) NSArray * _Nonnull ProtocolsSupported;
-@property (strong) NSNumber * _Nullable HardwareVersion;
-@property (strong) NSString * _Nullable Location;
-@property (strong) NSNumber * _Nullable RequestorCanConsent;
-@property (strong) NSData * _Nullable MetadataForProvider;
+@property (strong, nonatomic) NSNumber * _Nonnull vendorId;
+@property (strong, nonatomic) NSNumber * _Nonnull productId;
+@property (strong, nonatomic) NSNumber * _Nonnull softwareVersion;
+@property (strong, nonatomic) NSArray * _Nonnull protocolsSupported;
+@property (strong, nonatomic) NSNumber * _Nullable hardwareVersion;
+@property (strong, nonatomic) NSString * _Nullable location;
+@property (strong, nonatomic) NSNumber * _Nullable requestorCanConsent;
+@property (strong, nonatomic) NSData * _Nullable metadataForProvider;
 @end
 
 @interface CHIPOtaSoftwareUpdateProviderClusterApplyUpdateRequestPayload : NSObject
-@property (strong) NSData * _Nonnull UpdateToken;
-@property (strong) NSNumber * _Nonnull NewVersion;
+@property (strong, nonatomic) NSData * _Nonnull updateToken;
+@property (strong, nonatomic, getter=getNewVersion) NSNumber * _Nonnull newVersion;
 @end
 
 @interface CHIPOtaSoftwareUpdateProviderClusterNotifyUpdateAppliedPayload : NSObject
-@property (strong) NSData * _Nonnull UpdateToken;
-@property (strong) NSNumber * _Nonnull SoftwareVersion;
+@property (strong, nonatomic) NSData * _Nonnull updateToken;
+@property (strong, nonatomic) NSNumber * _Nonnull softwareVersion;
 @end
 
 @interface CHIPOtaSoftwareUpdateProviderClusterQueryImageResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull Status;
-@property (strong) NSNumber * _Nullable DelayedActionTime;
-@property (strong) NSString * _Nullable ImageURI;
-@property (strong) NSNumber * _Nullable SoftwareVersion;
-@property (strong) NSString * _Nullable SoftwareVersionString;
-@property (strong) NSData * _Nullable UpdateToken;
-@property (strong) NSNumber * _Nullable UserConsentNeeded;
-@property (strong) NSData * _Nullable MetadataForRequestor;
+@property (strong, nonatomic) NSNumber * _Nonnull status;
+@property (strong, nonatomic) NSNumber * _Nullable delayedActionTime;
+@property (strong, nonatomic) NSString * _Nullable imageURI;
+@property (strong, nonatomic) NSNumber * _Nullable softwareVersion;
+@property (strong, nonatomic) NSString * _Nullable softwareVersionString;
+@property (strong, nonatomic) NSData * _Nullable updateToken;
+@property (strong, nonatomic) NSNumber * _Nullable userConsentNeeded;
+@property (strong, nonatomic) NSData * _Nullable metadataForRequestor;
 @end
 
 @interface CHIPOtaSoftwareUpdateProviderClusterApplyUpdateResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull Action;
-@property (strong) NSNumber * _Nonnull DelayedActionTime;
+@property (strong, nonatomic) NSNumber * _Nonnull action;
+@property (strong, nonatomic) NSNumber * _Nonnull delayedActionTime;
 @end
 
 @interface CHIPOtaSoftwareUpdateRequestorClusterAnnounceOtaProviderPayload : NSObject
-@property (strong) NSNumber * _Nonnull ProviderLocation;
-@property (strong) NSNumber * _Nonnull VendorId;
-@property (strong) NSNumber * _Nonnull AnnouncementReason;
-@property (strong) NSData * _Nullable MetadataForNode;
+@property (strong, nonatomic) NSNumber * _Nonnull providerLocation;
+@property (strong, nonatomic) NSNumber * _Nonnull vendorId;
+@property (strong, nonatomic) NSNumber * _Nonnull announcementReason;
+@property (strong, nonatomic) NSData * _Nullable metadataForNode;
 @end
 
 @interface CHIPGeneralCommissioningClusterArmFailSafePayload : NSObject
-@property (strong) NSNumber * _Nonnull ExpiryLengthSeconds;
-@property (strong) NSNumber * _Nonnull Breadcrumb;
-@property (strong) NSNumber * _Nonnull TimeoutMs;
+@property (strong, nonatomic) NSNumber * _Nonnull expiryLengthSeconds;
+@property (strong, nonatomic) NSNumber * _Nonnull breadcrumb;
+@property (strong, nonatomic) NSNumber * _Nonnull timeoutMs;
 @end
 
 @interface CHIPGeneralCommissioningClusterArmFailSafeResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull ErrorCode;
-@property (strong) NSString * _Nonnull DebugText;
+@property (strong, nonatomic) NSNumber * _Nonnull errorCode;
+@property (strong, nonatomic) NSString * _Nonnull debugText;
 @end
 
 @interface CHIPGeneralCommissioningClusterSetRegulatoryConfigPayload : NSObject
-@property (strong) NSNumber * _Nonnull Location;
-@property (strong) NSString * _Nonnull CountryCode;
-@property (strong) NSNumber * _Nonnull Breadcrumb;
-@property (strong) NSNumber * _Nonnull TimeoutMs;
+@property (strong, nonatomic) NSNumber * _Nonnull location;
+@property (strong, nonatomic) NSString * _Nonnull countryCode;
+@property (strong, nonatomic) NSNumber * _Nonnull breadcrumb;
+@property (strong, nonatomic) NSNumber * _Nonnull timeoutMs;
 @end
 
 @interface CHIPGeneralCommissioningClusterSetRegulatoryConfigResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull ErrorCode;
-@property (strong) NSString * _Nonnull DebugText;
+@property (strong, nonatomic) NSNumber * _Nonnull errorCode;
+@property (strong, nonatomic) NSString * _Nonnull debugText;
 @end
 
 @interface CHIPGeneralCommissioningClusterCommissioningCompletePayload : NSObject
 @end
 
 @interface CHIPGeneralCommissioningClusterCommissioningCompleteResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull ErrorCode;
-@property (strong) NSString * _Nonnull DebugText;
+@property (strong, nonatomic) NSNumber * _Nonnull errorCode;
+@property (strong, nonatomic) NSString * _Nonnull debugText;
 @end
 
 @interface CHIPNetworkCommissioningClusterScanNetworksPayload : NSObject
-@property (strong) NSData * _Nonnull Ssid;
-@property (strong) NSNumber * _Nonnull Breadcrumb;
-@property (strong) NSNumber * _Nonnull TimeoutMs;
+@property (strong, nonatomic) NSData * _Nonnull ssid;
+@property (strong, nonatomic) NSNumber * _Nonnull breadcrumb;
+@property (strong, nonatomic) NSNumber * _Nonnull timeoutMs;
 @end
 
 @interface CHIPNetworkCommissioningClusterScanNetworksResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull ErrorCode;
-@property (strong) NSString * _Nonnull DebugText;
-@property (strong) NSArray * _Nonnull WifiScanResults;
-@property (strong) NSArray * _Nonnull ThreadScanResults;
+@property (strong, nonatomic) NSNumber * _Nonnull errorCode;
+@property (strong, nonatomic) NSString * _Nonnull debugText;
+@property (strong, nonatomic) NSArray * _Nonnull wifiScanResults;
+@property (strong, nonatomic) NSArray * _Nonnull threadScanResults;
 @end
 
 @interface CHIPNetworkCommissioningClusterAddWiFiNetworkPayload : NSObject
-@property (strong) NSData * _Nonnull Ssid;
-@property (strong) NSData * _Nonnull Credentials;
-@property (strong) NSNumber * _Nonnull Breadcrumb;
-@property (strong) NSNumber * _Nonnull TimeoutMs;
+@property (strong, nonatomic) NSData * _Nonnull ssid;
+@property (strong, nonatomic) NSData * _Nonnull credentials;
+@property (strong, nonatomic) NSNumber * _Nonnull breadcrumb;
+@property (strong, nonatomic) NSNumber * _Nonnull timeoutMs;
 @end
 
 @interface CHIPNetworkCommissioningClusterAddWiFiNetworkResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull ErrorCode;
-@property (strong) NSString * _Nonnull DebugText;
+@property (strong, nonatomic) NSNumber * _Nonnull errorCode;
+@property (strong, nonatomic) NSString * _Nonnull debugText;
 @end
 
 @interface CHIPNetworkCommissioningClusterUpdateWiFiNetworkPayload : NSObject
-@property (strong) NSData * _Nonnull Ssid;
-@property (strong) NSData * _Nonnull Credentials;
-@property (strong) NSNumber * _Nonnull Breadcrumb;
-@property (strong) NSNumber * _Nonnull TimeoutMs;
+@property (strong, nonatomic) NSData * _Nonnull ssid;
+@property (strong, nonatomic) NSData * _Nonnull credentials;
+@property (strong, nonatomic) NSNumber * _Nonnull breadcrumb;
+@property (strong, nonatomic) NSNumber * _Nonnull timeoutMs;
 @end
 
 @interface CHIPNetworkCommissioningClusterUpdateWiFiNetworkResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull ErrorCode;
-@property (strong) NSString * _Nonnull DebugText;
+@property (strong, nonatomic) NSNumber * _Nonnull errorCode;
+@property (strong, nonatomic) NSString * _Nonnull debugText;
 @end
 
 @interface CHIPNetworkCommissioningClusterAddThreadNetworkPayload : NSObject
-@property (strong) NSData * _Nonnull OperationalDataset;
-@property (strong) NSNumber * _Nonnull Breadcrumb;
-@property (strong) NSNumber * _Nonnull TimeoutMs;
+@property (strong, nonatomic) NSData * _Nonnull operationalDataset;
+@property (strong, nonatomic) NSNumber * _Nonnull breadcrumb;
+@property (strong, nonatomic) NSNumber * _Nonnull timeoutMs;
 @end
 
 @interface CHIPNetworkCommissioningClusterAddThreadNetworkResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull ErrorCode;
-@property (strong) NSString * _Nonnull DebugText;
+@property (strong, nonatomic) NSNumber * _Nonnull errorCode;
+@property (strong, nonatomic) NSString * _Nonnull debugText;
 @end
 
 @interface CHIPNetworkCommissioningClusterUpdateThreadNetworkPayload : NSObject
-@property (strong) NSData * _Nonnull OperationalDataset;
-@property (strong) NSNumber * _Nonnull Breadcrumb;
-@property (strong) NSNumber * _Nonnull TimeoutMs;
+@property (strong, nonatomic) NSData * _Nonnull operationalDataset;
+@property (strong, nonatomic) NSNumber * _Nonnull breadcrumb;
+@property (strong, nonatomic) NSNumber * _Nonnull timeoutMs;
 @end
 
 @interface CHIPNetworkCommissioningClusterUpdateThreadNetworkResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull ErrorCode;
-@property (strong) NSString * _Nonnull DebugText;
+@property (strong, nonatomic) NSNumber * _Nonnull errorCode;
+@property (strong, nonatomic) NSString * _Nonnull debugText;
 @end
 
 @interface CHIPNetworkCommissioningClusterRemoveNetworkPayload : NSObject
-@property (strong) NSData * _Nonnull NetworkID;
-@property (strong) NSNumber * _Nonnull Breadcrumb;
-@property (strong) NSNumber * _Nonnull TimeoutMs;
+@property (strong, nonatomic) NSData * _Nonnull networkID;
+@property (strong, nonatomic) NSNumber * _Nonnull breadcrumb;
+@property (strong, nonatomic) NSNumber * _Nonnull timeoutMs;
 @end
 
 @interface CHIPNetworkCommissioningClusterRemoveNetworkResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull ErrorCode;
-@property (strong) NSString * _Nonnull DebugText;
+@property (strong, nonatomic) NSNumber * _Nonnull errorCode;
+@property (strong, nonatomic) NSString * _Nonnull debugText;
 @end
 
 @interface CHIPNetworkCommissioningClusterEnableNetworkPayload : NSObject
-@property (strong) NSData * _Nonnull NetworkID;
-@property (strong) NSNumber * _Nonnull Breadcrumb;
-@property (strong) NSNumber * _Nonnull TimeoutMs;
+@property (strong, nonatomic) NSData * _Nonnull networkID;
+@property (strong, nonatomic) NSNumber * _Nonnull breadcrumb;
+@property (strong, nonatomic) NSNumber * _Nonnull timeoutMs;
 @end
 
 @interface CHIPNetworkCommissioningClusterEnableNetworkResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull ErrorCode;
-@property (strong) NSString * _Nonnull DebugText;
+@property (strong, nonatomic) NSNumber * _Nonnull errorCode;
+@property (strong, nonatomic) NSString * _Nonnull debugText;
 @end
 
 @interface CHIPNetworkCommissioningClusterDisableNetworkPayload : NSObject
-@property (strong) NSData * _Nonnull NetworkID;
-@property (strong) NSNumber * _Nonnull Breadcrumb;
-@property (strong) NSNumber * _Nonnull TimeoutMs;
+@property (strong, nonatomic) NSData * _Nonnull networkID;
+@property (strong, nonatomic) NSNumber * _Nonnull breadcrumb;
+@property (strong, nonatomic) NSNumber * _Nonnull timeoutMs;
 @end
 
 @interface CHIPNetworkCommissioningClusterDisableNetworkResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull ErrorCode;
-@property (strong) NSString * _Nonnull DebugText;
+@property (strong, nonatomic) NSNumber * _Nonnull errorCode;
+@property (strong, nonatomic) NSString * _Nonnull debugText;
 @end
 
 @interface CHIPDiagnosticLogsClusterRetrieveLogsRequestPayload : NSObject
-@property (strong) NSNumber * _Nonnull Intent;
-@property (strong) NSNumber * _Nonnull RequestedProtocol;
-@property (strong) NSData * _Nonnull TransferFileDesignator;
+@property (strong, nonatomic) NSNumber * _Nonnull intent;
+@property (strong, nonatomic) NSNumber * _Nonnull requestedProtocol;
+@property (strong, nonatomic) NSData * _Nonnull transferFileDesignator;
 @end
 
 @interface CHIPDiagnosticLogsClusterRetrieveLogsResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull Status;
-@property (strong) NSData * _Nonnull Content;
-@property (strong) NSNumber * _Nonnull TimeStamp;
-@property (strong) NSNumber * _Nonnull TimeSinceBoot;
+@property (strong, nonatomic) NSNumber * _Nonnull status;
+@property (strong, nonatomic) NSData * _Nonnull content;
+@property (strong, nonatomic) NSNumber * _Nonnull timeStamp;
+@property (strong, nonatomic) NSNumber * _Nonnull timeSinceBoot;
 @end
 
 @interface CHIPSoftwareDiagnosticsClusterResetWatermarksPayload : NSObject
@@ -764,364 +764,364 @@
 @end
 
 @interface CHIPAdministratorCommissioningClusterOpenCommissioningWindowPayload : NSObject
-@property (strong) NSNumber * _Nonnull CommissioningTimeout;
-@property (strong) NSData * _Nonnull PAKEVerifier;
-@property (strong) NSNumber * _Nonnull Discriminator;
-@property (strong) NSNumber * _Nonnull Iterations;
-@property (strong) NSData * _Nonnull Salt;
-@property (strong) NSNumber * _Nonnull PasscodeID;
+@property (strong, nonatomic) NSNumber * _Nonnull commissioningTimeout;
+@property (strong, nonatomic) NSData * _Nonnull pakeVerifier;
+@property (strong, nonatomic) NSNumber * _Nonnull discriminator;
+@property (strong, nonatomic) NSNumber * _Nonnull iterations;
+@property (strong, nonatomic) NSData * _Nonnull salt;
+@property (strong, nonatomic) NSNumber * _Nonnull passcodeID;
 @end
 
 @interface CHIPAdministratorCommissioningClusterOpenBasicCommissioningWindowPayload : NSObject
-@property (strong) NSNumber * _Nonnull CommissioningTimeout;
+@property (strong, nonatomic) NSNumber * _Nonnull commissioningTimeout;
 @end
 
 @interface CHIPAdministratorCommissioningClusterRevokeCommissioningPayload : NSObject
 @end
 
 @interface CHIPOperationalCredentialsClusterAttestationRequestPayload : NSObject
-@property (strong) NSData * _Nonnull AttestationNonce;
+@property (strong, nonatomic) NSData * _Nonnull attestationNonce;
 @end
 
 @interface CHIPOperationalCredentialsClusterAttestationResponsePayload : NSObject
-@property (strong) NSData * _Nonnull AttestationElements;
-@property (strong) NSData * _Nonnull Signature;
+@property (strong, nonatomic) NSData * _Nonnull attestationElements;
+@property (strong, nonatomic) NSData * _Nonnull signature;
 @end
 
 @interface CHIPOperationalCredentialsClusterCertificateChainRequestPayload : NSObject
-@property (strong) NSNumber * _Nonnull CertificateType;
+@property (strong, nonatomic) NSNumber * _Nonnull certificateType;
 @end
 
 @interface CHIPOperationalCredentialsClusterCertificateChainResponsePayload : NSObject
-@property (strong) NSData * _Nonnull Certificate;
+@property (strong, nonatomic) NSData * _Nonnull certificate;
 @end
 
 @interface CHIPOperationalCredentialsClusterOpCSRRequestPayload : NSObject
-@property (strong) NSData * _Nonnull CSRNonce;
+@property (strong, nonatomic) NSData * _Nonnull csrNonce;
 @end
 
 @interface CHIPOperationalCredentialsClusterOpCSRResponsePayload : NSObject
-@property (strong) NSData * _Nonnull NOCSRElements;
-@property (strong) NSData * _Nonnull AttestationSignature;
+@property (strong, nonatomic) NSData * _Nonnull nocsrElements;
+@property (strong, nonatomic) NSData * _Nonnull attestationSignature;
 @end
 
 @interface CHIPOperationalCredentialsClusterAddNOCPayload : NSObject
-@property (strong) NSData * _Nonnull NOCValue;
-@property (strong) NSData * _Nullable ICACValue;
-@property (strong) NSData * _Nonnull IPKValue;
-@property (strong) NSNumber * _Nonnull CaseAdminNode;
-@property (strong) NSNumber * _Nonnull AdminVendorId;
+@property (strong, nonatomic) NSData * _Nonnull nocValue;
+@property (strong, nonatomic) NSData * _Nullable icacValue;
+@property (strong, nonatomic) NSData * _Nonnull ipkValue;
+@property (strong, nonatomic) NSNumber * _Nonnull caseAdminNode;
+@property (strong, nonatomic) NSNumber * _Nonnull adminVendorId;
 @end
 
 @interface CHIPOperationalCredentialsClusterUpdateNOCPayload : NSObject
-@property (strong) NSData * _Nonnull NOCValue;
-@property (strong) NSData * _Nullable ICACValue;
+@property (strong, nonatomic) NSData * _Nonnull nocValue;
+@property (strong, nonatomic) NSData * _Nullable icacValue;
 @end
 
 @interface CHIPOperationalCredentialsClusterNOCResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull StatusCode;
-@property (strong) NSNumber * _Nonnull FabricIndex;
-@property (strong) NSString * _Nonnull DebugText;
+@property (strong, nonatomic) NSNumber * _Nonnull statusCode;
+@property (strong, nonatomic) NSNumber * _Nonnull fabricIndex;
+@property (strong, nonatomic) NSString * _Nonnull debugText;
 @end
 
 @interface CHIPOperationalCredentialsClusterUpdateFabricLabelPayload : NSObject
-@property (strong) NSString * _Nonnull Label;
+@property (strong, nonatomic) NSString * _Nonnull label;
 @end
 
 @interface CHIPOperationalCredentialsClusterRemoveFabricPayload : NSObject
-@property (strong) NSNumber * _Nonnull FabricIndex;
+@property (strong, nonatomic) NSNumber * _Nonnull fabricIndex;
 @end
 
 @interface CHIPOperationalCredentialsClusterAddTrustedRootCertificatePayload : NSObject
-@property (strong) NSData * _Nonnull RootCertificate;
+@property (strong, nonatomic) NSData * _Nonnull rootCertificate;
 @end
 
 @interface CHIPOperationalCredentialsClusterRemoveTrustedRootCertificatePayload : NSObject
-@property (strong) NSData * _Nonnull TrustedRootIdentifier;
+@property (strong, nonatomic) NSData * _Nonnull trustedRootIdentifier;
 @end
 
 @interface CHIPModeSelectClusterChangeToModePayload : NSObject
-@property (strong) NSNumber * _Nonnull NewMode;
+@property (strong, nonatomic, getter=getNewMode) NSNumber * _Nonnull newMode;
 @end
 
 @interface CHIPDoorLockClusterLockDoorPayload : NSObject
-@property (strong) NSData * _Nonnull Pin;
+@property (strong, nonatomic) NSData * _Nonnull pin;
 @end
 
 @interface CHIPDoorLockClusterLockDoorResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull Status;
+@property (strong, nonatomic) NSNumber * _Nonnull status;
 @end
 
 @interface CHIPDoorLockClusterUnlockDoorPayload : NSObject
-@property (strong) NSData * _Nonnull Pin;
+@property (strong, nonatomic) NSData * _Nonnull pin;
 @end
 
 @interface CHIPDoorLockClusterUnlockDoorResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull Status;
+@property (strong, nonatomic) NSNumber * _Nonnull status;
 @end
 
 @interface CHIPDoorLockClusterTogglePayload : NSObject
-@property (strong) NSString * _Nonnull Pin;
+@property (strong, nonatomic) NSString * _Nonnull pin;
 @end
 
 @interface CHIPDoorLockClusterToggleResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull Status;
+@property (strong, nonatomic) NSNumber * _Nonnull status;
 @end
 
 @interface CHIPDoorLockClusterUnlockWithTimeoutPayload : NSObject
-@property (strong) NSNumber * _Nonnull TimeoutInSeconds;
-@property (strong) NSData * _Nonnull Pin;
+@property (strong, nonatomic) NSNumber * _Nonnull timeoutInSeconds;
+@property (strong, nonatomic) NSData * _Nonnull pin;
 @end
 
 @interface CHIPDoorLockClusterUnlockWithTimeoutResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull Status;
+@property (strong, nonatomic) NSNumber * _Nonnull status;
 @end
 
 @interface CHIPDoorLockClusterGetLogRecordPayload : NSObject
-@property (strong) NSNumber * _Nonnull LogIndex;
+@property (strong, nonatomic) NSNumber * _Nonnull logIndex;
 @end
 
 @interface CHIPDoorLockClusterGetLogRecordResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull LogEntryId;
-@property (strong) NSNumber * _Nonnull Timestamp;
-@property (strong) NSNumber * _Nonnull EventType;
-@property (strong) NSNumber * _Nonnull Source;
-@property (strong) NSNumber * _Nonnull EventIdOrAlarmCode;
-@property (strong) NSNumber * _Nonnull UserId;
-@property (strong) NSData * _Nonnull Pin;
+@property (strong, nonatomic) NSNumber * _Nonnull logEntryId;
+@property (strong, nonatomic) NSNumber * _Nonnull timestamp;
+@property (strong, nonatomic) NSNumber * _Nonnull eventType;
+@property (strong, nonatomic) NSNumber * _Nonnull source;
+@property (strong, nonatomic) NSNumber * _Nonnull eventIdOrAlarmCode;
+@property (strong, nonatomic) NSNumber * _Nonnull userId;
+@property (strong, nonatomic) NSData * _Nonnull pin;
 @end
 
 @interface CHIPDoorLockClusterSetPinPayload : NSObject
-@property (strong) NSNumber * _Nonnull UserId;
-@property (strong) NSNumber * _Nonnull UserStatus;
-@property (strong) NSNumber * _Nonnull UserType;
-@property (strong) NSData * _Nonnull Pin;
+@property (strong, nonatomic) NSNumber * _Nonnull userId;
+@property (strong, nonatomic) NSNumber * _Nonnull userStatus;
+@property (strong, nonatomic) NSNumber * _Nonnull userType;
+@property (strong, nonatomic) NSData * _Nonnull pin;
 @end
 
 @interface CHIPDoorLockClusterSetPinResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull Status;
+@property (strong, nonatomic) NSNumber * _Nonnull status;
 @end
 
 @interface CHIPDoorLockClusterGetPinPayload : NSObject
-@property (strong) NSNumber * _Nonnull UserId;
+@property (strong, nonatomic) NSNumber * _Nonnull userId;
 @end
 
 @interface CHIPDoorLockClusterGetPinResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull UserId;
-@property (strong) NSNumber * _Nonnull UserStatus;
-@property (strong) NSNumber * _Nonnull UserType;
-@property (strong) NSData * _Nonnull Pin;
+@property (strong, nonatomic) NSNumber * _Nonnull userId;
+@property (strong, nonatomic) NSNumber * _Nonnull userStatus;
+@property (strong, nonatomic) NSNumber * _Nonnull userType;
+@property (strong, nonatomic) NSData * _Nonnull pin;
 @end
 
 @interface CHIPDoorLockClusterClearPinPayload : NSObject
-@property (strong) NSNumber * _Nonnull UserId;
+@property (strong, nonatomic) NSNumber * _Nonnull userId;
 @end
 
 @interface CHIPDoorLockClusterClearPinResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull Status;
+@property (strong, nonatomic) NSNumber * _Nonnull status;
 @end
 
 @interface CHIPDoorLockClusterClearAllPinsPayload : NSObject
 @end
 
 @interface CHIPDoorLockClusterClearAllPinsResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull Status;
+@property (strong, nonatomic) NSNumber * _Nonnull status;
 @end
 
 @interface CHIPDoorLockClusterSetUserStatusPayload : NSObject
-@property (strong) NSNumber * _Nonnull UserId;
-@property (strong) NSNumber * _Nonnull UserStatus;
+@property (strong, nonatomic) NSNumber * _Nonnull userId;
+@property (strong, nonatomic) NSNumber * _Nonnull userStatus;
 @end
 
 @interface CHIPDoorLockClusterSetUserStatusResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull Status;
+@property (strong, nonatomic) NSNumber * _Nonnull status;
 @end
 
 @interface CHIPDoorLockClusterGetUserStatusPayload : NSObject
-@property (strong) NSNumber * _Nonnull UserId;
+@property (strong, nonatomic) NSNumber * _Nonnull userId;
 @end
 
 @interface CHIPDoorLockClusterGetUserStatusResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull UserId;
-@property (strong) NSNumber * _Nonnull Status;
+@property (strong, nonatomic) NSNumber * _Nonnull userId;
+@property (strong, nonatomic) NSNumber * _Nonnull status;
 @end
 
 @interface CHIPDoorLockClusterSetWeekdaySchedulePayload : NSObject
-@property (strong) NSNumber * _Nonnull ScheduleId;
-@property (strong) NSNumber * _Nonnull UserId;
-@property (strong) NSNumber * _Nonnull DaysMask;
-@property (strong) NSNumber * _Nonnull StartHour;
-@property (strong) NSNumber * _Nonnull StartMinute;
-@property (strong) NSNumber * _Nonnull EndHour;
-@property (strong) NSNumber * _Nonnull EndMinute;
+@property (strong, nonatomic) NSNumber * _Nonnull scheduleId;
+@property (strong, nonatomic) NSNumber * _Nonnull userId;
+@property (strong, nonatomic) NSNumber * _Nonnull daysMask;
+@property (strong, nonatomic) NSNumber * _Nonnull startHour;
+@property (strong, nonatomic) NSNumber * _Nonnull startMinute;
+@property (strong, nonatomic) NSNumber * _Nonnull endHour;
+@property (strong, nonatomic) NSNumber * _Nonnull endMinute;
 @end
 
 @interface CHIPDoorLockClusterSetWeekdayScheduleResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull Status;
+@property (strong, nonatomic) NSNumber * _Nonnull status;
 @end
 
 @interface CHIPDoorLockClusterGetWeekdaySchedulePayload : NSObject
-@property (strong) NSNumber * _Nonnull ScheduleId;
-@property (strong) NSNumber * _Nonnull UserId;
+@property (strong, nonatomic) NSNumber * _Nonnull scheduleId;
+@property (strong, nonatomic) NSNumber * _Nonnull userId;
 @end
 
 @interface CHIPDoorLockClusterGetWeekdayScheduleResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull ScheduleId;
-@property (strong) NSNumber * _Nonnull UserId;
-@property (strong) NSNumber * _Nonnull Status;
-@property (strong) NSNumber * _Nonnull DaysMask;
-@property (strong) NSNumber * _Nonnull StartHour;
-@property (strong) NSNumber * _Nonnull StartMinute;
-@property (strong) NSNumber * _Nonnull EndHour;
-@property (strong) NSNumber * _Nonnull EndMinute;
+@property (strong, nonatomic) NSNumber * _Nonnull scheduleId;
+@property (strong, nonatomic) NSNumber * _Nonnull userId;
+@property (strong, nonatomic) NSNumber * _Nonnull status;
+@property (strong, nonatomic) NSNumber * _Nonnull daysMask;
+@property (strong, nonatomic) NSNumber * _Nonnull startHour;
+@property (strong, nonatomic) NSNumber * _Nonnull startMinute;
+@property (strong, nonatomic) NSNumber * _Nonnull endHour;
+@property (strong, nonatomic) NSNumber * _Nonnull endMinute;
 @end
 
 @interface CHIPDoorLockClusterClearWeekdaySchedulePayload : NSObject
-@property (strong) NSNumber * _Nonnull ScheduleId;
-@property (strong) NSNumber * _Nonnull UserId;
+@property (strong, nonatomic) NSNumber * _Nonnull scheduleId;
+@property (strong, nonatomic) NSNumber * _Nonnull userId;
 @end
 
 @interface CHIPDoorLockClusterClearWeekdayScheduleResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull Status;
+@property (strong, nonatomic) NSNumber * _Nonnull status;
 @end
 
 @interface CHIPDoorLockClusterSetYeardaySchedulePayload : NSObject
-@property (strong) NSNumber * _Nonnull ScheduleId;
-@property (strong) NSNumber * _Nonnull UserId;
-@property (strong) NSNumber * _Nonnull LocalStartTime;
-@property (strong) NSNumber * _Nonnull LocalEndTime;
+@property (strong, nonatomic) NSNumber * _Nonnull scheduleId;
+@property (strong, nonatomic) NSNumber * _Nonnull userId;
+@property (strong, nonatomic) NSNumber * _Nonnull localStartTime;
+@property (strong, nonatomic) NSNumber * _Nonnull localEndTime;
 @end
 
 @interface CHIPDoorLockClusterSetYeardayScheduleResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull Status;
+@property (strong, nonatomic) NSNumber * _Nonnull status;
 @end
 
 @interface CHIPDoorLockClusterGetYeardaySchedulePayload : NSObject
-@property (strong) NSNumber * _Nonnull ScheduleId;
-@property (strong) NSNumber * _Nonnull UserId;
+@property (strong, nonatomic) NSNumber * _Nonnull scheduleId;
+@property (strong, nonatomic) NSNumber * _Nonnull userId;
 @end
 
 @interface CHIPDoorLockClusterGetYeardayScheduleResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull ScheduleId;
-@property (strong) NSNumber * _Nonnull UserId;
-@property (strong) NSNumber * _Nonnull Status;
-@property (strong) NSNumber * _Nonnull LocalStartTime;
-@property (strong) NSNumber * _Nonnull LocalEndTime;
+@property (strong, nonatomic) NSNumber * _Nonnull scheduleId;
+@property (strong, nonatomic) NSNumber * _Nonnull userId;
+@property (strong, nonatomic) NSNumber * _Nonnull status;
+@property (strong, nonatomic) NSNumber * _Nonnull localStartTime;
+@property (strong, nonatomic) NSNumber * _Nonnull localEndTime;
 @end
 
 @interface CHIPDoorLockClusterClearYeardaySchedulePayload : NSObject
-@property (strong) NSNumber * _Nonnull ScheduleId;
-@property (strong) NSNumber * _Nonnull UserId;
+@property (strong, nonatomic) NSNumber * _Nonnull scheduleId;
+@property (strong, nonatomic) NSNumber * _Nonnull userId;
 @end
 
 @interface CHIPDoorLockClusterClearYeardayScheduleResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull Status;
+@property (strong, nonatomic) NSNumber * _Nonnull status;
 @end
 
 @interface CHIPDoorLockClusterSetHolidaySchedulePayload : NSObject
-@property (strong) NSNumber * _Nonnull ScheduleId;
-@property (strong) NSNumber * _Nonnull LocalStartTime;
-@property (strong) NSNumber * _Nonnull LocalEndTime;
-@property (strong) NSNumber * _Nonnull OperatingModeDuringHoliday;
+@property (strong, nonatomic) NSNumber * _Nonnull scheduleId;
+@property (strong, nonatomic) NSNumber * _Nonnull localStartTime;
+@property (strong, nonatomic) NSNumber * _Nonnull localEndTime;
+@property (strong, nonatomic) NSNumber * _Nonnull operatingModeDuringHoliday;
 @end
 
 @interface CHIPDoorLockClusterSetHolidayScheduleResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull Status;
+@property (strong, nonatomic) NSNumber * _Nonnull status;
 @end
 
 @interface CHIPDoorLockClusterGetHolidaySchedulePayload : NSObject
-@property (strong) NSNumber * _Nonnull ScheduleId;
+@property (strong, nonatomic) NSNumber * _Nonnull scheduleId;
 @end
 
 @interface CHIPDoorLockClusterGetHolidayScheduleResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull ScheduleId;
-@property (strong) NSNumber * _Nonnull Status;
-@property (strong) NSNumber * _Nonnull LocalStartTime;
-@property (strong) NSNumber * _Nonnull LocalEndTime;
-@property (strong) NSNumber * _Nonnull OperatingModeDuringHoliday;
+@property (strong, nonatomic) NSNumber * _Nonnull scheduleId;
+@property (strong, nonatomic) NSNumber * _Nonnull status;
+@property (strong, nonatomic) NSNumber * _Nonnull localStartTime;
+@property (strong, nonatomic) NSNumber * _Nonnull localEndTime;
+@property (strong, nonatomic) NSNumber * _Nonnull operatingModeDuringHoliday;
 @end
 
 @interface CHIPDoorLockClusterClearHolidaySchedulePayload : NSObject
-@property (strong) NSNumber * _Nonnull ScheduleId;
+@property (strong, nonatomic) NSNumber * _Nonnull scheduleId;
 @end
 
 @interface CHIPDoorLockClusterClearHolidayScheduleResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull Status;
+@property (strong, nonatomic) NSNumber * _Nonnull status;
 @end
 
 @interface CHIPDoorLockClusterSetUserTypePayload : NSObject
-@property (strong) NSNumber * _Nonnull UserId;
-@property (strong) NSNumber * _Nonnull UserType;
+@property (strong, nonatomic) NSNumber * _Nonnull userId;
+@property (strong, nonatomic) NSNumber * _Nonnull userType;
 @end
 
 @interface CHIPDoorLockClusterSetUserTypeResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull Status;
+@property (strong, nonatomic) NSNumber * _Nonnull status;
 @end
 
 @interface CHIPDoorLockClusterGetUserTypePayload : NSObject
-@property (strong) NSNumber * _Nonnull UserId;
+@property (strong, nonatomic) NSNumber * _Nonnull userId;
 @end
 
 @interface CHIPDoorLockClusterGetUserTypeResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull UserId;
-@property (strong) NSNumber * _Nonnull UserType;
+@property (strong, nonatomic) NSNumber * _Nonnull userId;
+@property (strong, nonatomic) NSNumber * _Nonnull userType;
 @end
 
 @interface CHIPDoorLockClusterSetRfidPayload : NSObject
-@property (strong) NSNumber * _Nonnull UserId;
-@property (strong) NSNumber * _Nonnull UserStatus;
-@property (strong) NSNumber * _Nonnull UserType;
-@property (strong) NSData * _Nonnull Id;
+@property (strong, nonatomic) NSNumber * _Nonnull userId;
+@property (strong, nonatomic) NSNumber * _Nonnull userStatus;
+@property (strong, nonatomic) NSNumber * _Nonnull userType;
+@property (strong, nonatomic) NSData * _Nonnull id;
 @end
 
 @interface CHIPDoorLockClusterSetRfidResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull Status;
+@property (strong, nonatomic) NSNumber * _Nonnull status;
 @end
 
 @interface CHIPDoorLockClusterGetRfidPayload : NSObject
-@property (strong) NSNumber * _Nonnull UserId;
+@property (strong, nonatomic) NSNumber * _Nonnull userId;
 @end
 
 @interface CHIPDoorLockClusterGetRfidResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull UserId;
-@property (strong) NSNumber * _Nonnull UserStatus;
-@property (strong) NSNumber * _Nonnull UserType;
-@property (strong) NSData * _Nonnull Rfid;
+@property (strong, nonatomic) NSNumber * _Nonnull userId;
+@property (strong, nonatomic) NSNumber * _Nonnull userStatus;
+@property (strong, nonatomic) NSNumber * _Nonnull userType;
+@property (strong, nonatomic) NSData * _Nonnull rfid;
 @end
 
 @interface CHIPDoorLockClusterClearRfidPayload : NSObject
-@property (strong) NSNumber * _Nonnull UserId;
+@property (strong, nonatomic) NSNumber * _Nonnull userId;
 @end
 
 @interface CHIPDoorLockClusterClearRfidResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull Status;
+@property (strong, nonatomic) NSNumber * _Nonnull status;
 @end
 
 @interface CHIPDoorLockClusterClearAllRfidsPayload : NSObject
 @end
 
 @interface CHIPDoorLockClusterClearAllRfidsResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull Status;
+@property (strong, nonatomic) NSNumber * _Nonnull status;
 @end
 
 @interface CHIPDoorLockClusterOperationEventNotificationPayload : NSObject
-@property (strong) NSNumber * _Nonnull Source;
-@property (strong) NSNumber * _Nonnull EventCode;
-@property (strong) NSNumber * _Nonnull UserId;
-@property (strong) NSData * _Nonnull Pin;
-@property (strong) NSNumber * _Nonnull TimeStamp;
-@property (strong) NSString * _Nonnull Data;
+@property (strong, nonatomic) NSNumber * _Nonnull source;
+@property (strong, nonatomic) NSNumber * _Nonnull eventCode;
+@property (strong, nonatomic) NSNumber * _Nonnull userId;
+@property (strong, nonatomic) NSData * _Nonnull pin;
+@property (strong, nonatomic) NSNumber * _Nonnull timeStamp;
+@property (strong, nonatomic) NSString * _Nonnull data;
 @end
 
 @interface CHIPDoorLockClusterProgrammingEventNotificationPayload : NSObject
-@property (strong) NSNumber * _Nonnull Source;
-@property (strong) NSNumber * _Nonnull EventCode;
-@property (strong) NSNumber * _Nonnull UserId;
-@property (strong) NSData * _Nonnull Pin;
-@property (strong) NSNumber * _Nonnull UserType;
-@property (strong) NSNumber * _Nonnull UserStatus;
-@property (strong) NSNumber * _Nonnull TimeStamp;
-@property (strong) NSString * _Nonnull Data;
+@property (strong, nonatomic) NSNumber * _Nonnull source;
+@property (strong, nonatomic) NSNumber * _Nonnull eventCode;
+@property (strong, nonatomic) NSNumber * _Nonnull userId;
+@property (strong, nonatomic) NSData * _Nonnull pin;
+@property (strong, nonatomic) NSNumber * _Nonnull userType;
+@property (strong, nonatomic) NSNumber * _Nonnull userStatus;
+@property (strong, nonatomic) NSNumber * _Nonnull timeStamp;
+@property (strong, nonatomic) NSString * _Nonnull data;
 @end
 
 @interface CHIPWindowCoveringClusterUpOrOpenPayload : NSObject
@@ -1134,61 +1134,61 @@
 @end
 
 @interface CHIPWindowCoveringClusterGoToLiftValuePayload : NSObject
-@property (strong) NSNumber * _Nonnull LiftValue;
+@property (strong, nonatomic) NSNumber * _Nonnull liftValue;
 @end
 
 @interface CHIPWindowCoveringClusterGoToLiftPercentagePayload : NSObject
-@property (strong) NSNumber * _Nonnull LiftPercentageValue;
-@property (strong) NSNumber * _Nonnull LiftPercent100thsValue;
+@property (strong, nonatomic) NSNumber * _Nonnull liftPercentageValue;
+@property (strong, nonatomic) NSNumber * _Nonnull liftPercent100thsValue;
 @end
 
 @interface CHIPWindowCoveringClusterGoToTiltValuePayload : NSObject
-@property (strong) NSNumber * _Nonnull TiltValue;
+@property (strong, nonatomic) NSNumber * _Nonnull tiltValue;
 @end
 
 @interface CHIPWindowCoveringClusterGoToTiltPercentagePayload : NSObject
-@property (strong) NSNumber * _Nonnull TiltPercentageValue;
-@property (strong) NSNumber * _Nonnull TiltPercent100thsValue;
+@property (strong, nonatomic) NSNumber * _Nonnull tiltPercentageValue;
+@property (strong, nonatomic) NSNumber * _Nonnull tiltPercent100thsValue;
 @end
 
 @interface CHIPBarrierControlClusterBarrierControlGoToPercentPayload : NSObject
-@property (strong) NSNumber * _Nonnull PercentOpen;
+@property (strong, nonatomic) NSNumber * _Nonnull percentOpen;
 @end
 
 @interface CHIPBarrierControlClusterBarrierControlStopPayload : NSObject
 @end
 
 @interface CHIPThermostatClusterSetpointRaiseLowerPayload : NSObject
-@property (strong) NSNumber * _Nonnull Mode;
-@property (strong) NSNumber * _Nonnull Amount;
+@property (strong, nonatomic) NSNumber * _Nonnull mode;
+@property (strong, nonatomic) NSNumber * _Nonnull amount;
 @end
 
 @interface CHIPThermostatClusterCurrentWeeklySchedulePayload : NSObject
-@property (strong) NSNumber * _Nonnull NumberOfTransitionsForSequence;
-@property (strong) NSNumber * _Nonnull DayOfWeekForSequence;
-@property (strong) NSNumber * _Nonnull ModeForSequence;
-@property (strong) NSArray * _Nonnull Payload;
+@property (strong, nonatomic) NSNumber * _Nonnull numberOfTransitionsForSequence;
+@property (strong, nonatomic) NSNumber * _Nonnull dayOfWeekForSequence;
+@property (strong, nonatomic) NSNumber * _Nonnull modeForSequence;
+@property (strong, nonatomic) NSArray * _Nonnull payload;
 @end
 
 @interface CHIPThermostatClusterSetWeeklySchedulePayload : NSObject
-@property (strong) NSNumber * _Nonnull NumberOfTransitionsForSequence;
-@property (strong) NSNumber * _Nonnull DayOfWeekForSequence;
-@property (strong) NSNumber * _Nonnull ModeForSequence;
-@property (strong) NSArray * _Nonnull Payload;
+@property (strong, nonatomic) NSNumber * _Nonnull numberOfTransitionsForSequence;
+@property (strong, nonatomic) NSNumber * _Nonnull dayOfWeekForSequence;
+@property (strong, nonatomic) NSNumber * _Nonnull modeForSequence;
+@property (strong, nonatomic) NSArray * _Nonnull payload;
 @end
 
 @interface CHIPThermostatClusterRelayStatusLogPayload : NSObject
-@property (strong) NSNumber * _Nonnull TimeOfDay;
-@property (strong) NSNumber * _Nonnull RelayStatus;
-@property (strong) NSNumber * _Nonnull LocalTemperature;
-@property (strong) NSNumber * _Nonnull HumidityInPercentage;
-@property (strong) NSNumber * _Nonnull Setpoint;
-@property (strong) NSNumber * _Nonnull UnreadEntries;
+@property (strong, nonatomic) NSNumber * _Nonnull timeOfDay;
+@property (strong, nonatomic) NSNumber * _Nonnull relayStatus;
+@property (strong, nonatomic) NSNumber * _Nonnull localTemperature;
+@property (strong, nonatomic) NSNumber * _Nonnull humidityInPercentage;
+@property (strong, nonatomic) NSNumber * _Nonnull setpoint;
+@property (strong, nonatomic) NSNumber * _Nonnull unreadEntries;
 @end
 
 @interface CHIPThermostatClusterGetWeeklySchedulePayload : NSObject
-@property (strong) NSNumber * _Nonnull DaysToReturn;
-@property (strong) NSNumber * _Nonnull ModeToReturn;
+@property (strong, nonatomic) NSNumber * _Nonnull daysToReturn;
+@property (strong, nonatomic) NSNumber * _Nonnull modeToReturn;
 @end
 
 @interface CHIPThermostatClusterClearWeeklySchedulePayload : NSObject
@@ -1198,176 +1198,176 @@
 @end
 
 @interface CHIPColorControlClusterMoveToHuePayload : NSObject
-@property (strong) NSNumber * _Nonnull Hue;
-@property (strong) NSNumber * _Nonnull Direction;
-@property (strong) NSNumber * _Nonnull TransitionTime;
-@property (strong) NSNumber * _Nonnull OptionsMask;
-@property (strong) NSNumber * _Nonnull OptionsOverride;
+@property (strong, nonatomic) NSNumber * _Nonnull hue;
+@property (strong, nonatomic) NSNumber * _Nonnull direction;
+@property (strong, nonatomic) NSNumber * _Nonnull transitionTime;
+@property (strong, nonatomic) NSNumber * _Nonnull optionsMask;
+@property (strong, nonatomic) NSNumber * _Nonnull optionsOverride;
 @end
 
 @interface CHIPColorControlClusterMoveHuePayload : NSObject
-@property (strong) NSNumber * _Nonnull MoveMode;
-@property (strong) NSNumber * _Nonnull Rate;
-@property (strong) NSNumber * _Nonnull OptionsMask;
-@property (strong) NSNumber * _Nonnull OptionsOverride;
+@property (strong, nonatomic) NSNumber * _Nonnull moveMode;
+@property (strong, nonatomic) NSNumber * _Nonnull rate;
+@property (strong, nonatomic) NSNumber * _Nonnull optionsMask;
+@property (strong, nonatomic) NSNumber * _Nonnull optionsOverride;
 @end
 
 @interface CHIPColorControlClusterStepHuePayload : NSObject
-@property (strong) NSNumber * _Nonnull StepMode;
-@property (strong) NSNumber * _Nonnull StepSize;
-@property (strong) NSNumber * _Nonnull TransitionTime;
-@property (strong) NSNumber * _Nonnull OptionsMask;
-@property (strong) NSNumber * _Nonnull OptionsOverride;
+@property (strong, nonatomic) NSNumber * _Nonnull stepMode;
+@property (strong, nonatomic) NSNumber * _Nonnull stepSize;
+@property (strong, nonatomic) NSNumber * _Nonnull transitionTime;
+@property (strong, nonatomic) NSNumber * _Nonnull optionsMask;
+@property (strong, nonatomic) NSNumber * _Nonnull optionsOverride;
 @end
 
 @interface CHIPColorControlClusterMoveToSaturationPayload : NSObject
-@property (strong) NSNumber * _Nonnull Saturation;
-@property (strong) NSNumber * _Nonnull TransitionTime;
-@property (strong) NSNumber * _Nonnull OptionsMask;
-@property (strong) NSNumber * _Nonnull OptionsOverride;
+@property (strong, nonatomic) NSNumber * _Nonnull saturation;
+@property (strong, nonatomic) NSNumber * _Nonnull transitionTime;
+@property (strong, nonatomic) NSNumber * _Nonnull optionsMask;
+@property (strong, nonatomic) NSNumber * _Nonnull optionsOverride;
 @end
 
 @interface CHIPColorControlClusterMoveSaturationPayload : NSObject
-@property (strong) NSNumber * _Nonnull MoveMode;
-@property (strong) NSNumber * _Nonnull Rate;
-@property (strong) NSNumber * _Nonnull OptionsMask;
-@property (strong) NSNumber * _Nonnull OptionsOverride;
+@property (strong, nonatomic) NSNumber * _Nonnull moveMode;
+@property (strong, nonatomic) NSNumber * _Nonnull rate;
+@property (strong, nonatomic) NSNumber * _Nonnull optionsMask;
+@property (strong, nonatomic) NSNumber * _Nonnull optionsOverride;
 @end
 
 @interface CHIPColorControlClusterStepSaturationPayload : NSObject
-@property (strong) NSNumber * _Nonnull StepMode;
-@property (strong) NSNumber * _Nonnull StepSize;
-@property (strong) NSNumber * _Nonnull TransitionTime;
-@property (strong) NSNumber * _Nonnull OptionsMask;
-@property (strong) NSNumber * _Nonnull OptionsOverride;
+@property (strong, nonatomic) NSNumber * _Nonnull stepMode;
+@property (strong, nonatomic) NSNumber * _Nonnull stepSize;
+@property (strong, nonatomic) NSNumber * _Nonnull transitionTime;
+@property (strong, nonatomic) NSNumber * _Nonnull optionsMask;
+@property (strong, nonatomic) NSNumber * _Nonnull optionsOverride;
 @end
 
 @interface CHIPColorControlClusterMoveToHueAndSaturationPayload : NSObject
-@property (strong) NSNumber * _Nonnull Hue;
-@property (strong) NSNumber * _Nonnull Saturation;
-@property (strong) NSNumber * _Nonnull TransitionTime;
-@property (strong) NSNumber * _Nonnull OptionsMask;
-@property (strong) NSNumber * _Nonnull OptionsOverride;
+@property (strong, nonatomic) NSNumber * _Nonnull hue;
+@property (strong, nonatomic) NSNumber * _Nonnull saturation;
+@property (strong, nonatomic) NSNumber * _Nonnull transitionTime;
+@property (strong, nonatomic) NSNumber * _Nonnull optionsMask;
+@property (strong, nonatomic) NSNumber * _Nonnull optionsOverride;
 @end
 
 @interface CHIPColorControlClusterMoveToColorPayload : NSObject
-@property (strong) NSNumber * _Nonnull ColorX;
-@property (strong) NSNumber * _Nonnull ColorY;
-@property (strong) NSNumber * _Nonnull TransitionTime;
-@property (strong) NSNumber * _Nonnull OptionsMask;
-@property (strong) NSNumber * _Nonnull OptionsOverride;
+@property (strong, nonatomic) NSNumber * _Nonnull colorX;
+@property (strong, nonatomic) NSNumber * _Nonnull colorY;
+@property (strong, nonatomic) NSNumber * _Nonnull transitionTime;
+@property (strong, nonatomic) NSNumber * _Nonnull optionsMask;
+@property (strong, nonatomic) NSNumber * _Nonnull optionsOverride;
 @end
 
 @interface CHIPColorControlClusterMoveColorPayload : NSObject
-@property (strong) NSNumber * _Nonnull RateX;
-@property (strong) NSNumber * _Nonnull RateY;
-@property (strong) NSNumber * _Nonnull OptionsMask;
-@property (strong) NSNumber * _Nonnull OptionsOverride;
+@property (strong, nonatomic) NSNumber * _Nonnull rateX;
+@property (strong, nonatomic) NSNumber * _Nonnull rateY;
+@property (strong, nonatomic) NSNumber * _Nonnull optionsMask;
+@property (strong, nonatomic) NSNumber * _Nonnull optionsOverride;
 @end
 
 @interface CHIPColorControlClusterStepColorPayload : NSObject
-@property (strong) NSNumber * _Nonnull StepX;
-@property (strong) NSNumber * _Nonnull StepY;
-@property (strong) NSNumber * _Nonnull TransitionTime;
-@property (strong) NSNumber * _Nonnull OptionsMask;
-@property (strong) NSNumber * _Nonnull OptionsOverride;
+@property (strong, nonatomic) NSNumber * _Nonnull stepX;
+@property (strong, nonatomic) NSNumber * _Nonnull stepY;
+@property (strong, nonatomic) NSNumber * _Nonnull transitionTime;
+@property (strong, nonatomic) NSNumber * _Nonnull optionsMask;
+@property (strong, nonatomic) NSNumber * _Nonnull optionsOverride;
 @end
 
 @interface CHIPColorControlClusterMoveToColorTemperaturePayload : NSObject
-@property (strong) NSNumber * _Nonnull ColorTemperature;
-@property (strong) NSNumber * _Nonnull TransitionTime;
-@property (strong) NSNumber * _Nonnull OptionsMask;
-@property (strong) NSNumber * _Nonnull OptionsOverride;
+@property (strong, nonatomic) NSNumber * _Nonnull colorTemperature;
+@property (strong, nonatomic) NSNumber * _Nonnull transitionTime;
+@property (strong, nonatomic) NSNumber * _Nonnull optionsMask;
+@property (strong, nonatomic) NSNumber * _Nonnull optionsOverride;
 @end
 
 @interface CHIPColorControlClusterEnhancedMoveToHuePayload : NSObject
-@property (strong) NSNumber * _Nonnull EnhancedHue;
-@property (strong) NSNumber * _Nonnull Direction;
-@property (strong) NSNumber * _Nonnull TransitionTime;
-@property (strong) NSNumber * _Nonnull OptionsMask;
-@property (strong) NSNumber * _Nonnull OptionsOverride;
+@property (strong, nonatomic) NSNumber * _Nonnull enhancedHue;
+@property (strong, nonatomic) NSNumber * _Nonnull direction;
+@property (strong, nonatomic) NSNumber * _Nonnull transitionTime;
+@property (strong, nonatomic) NSNumber * _Nonnull optionsMask;
+@property (strong, nonatomic) NSNumber * _Nonnull optionsOverride;
 @end
 
 @interface CHIPColorControlClusterEnhancedMoveHuePayload : NSObject
-@property (strong) NSNumber * _Nonnull MoveMode;
-@property (strong) NSNumber * _Nonnull Rate;
-@property (strong) NSNumber * _Nonnull OptionsMask;
-@property (strong) NSNumber * _Nonnull OptionsOverride;
+@property (strong, nonatomic) NSNumber * _Nonnull moveMode;
+@property (strong, nonatomic) NSNumber * _Nonnull rate;
+@property (strong, nonatomic) NSNumber * _Nonnull optionsMask;
+@property (strong, nonatomic) NSNumber * _Nonnull optionsOverride;
 @end
 
 @interface CHIPColorControlClusterEnhancedStepHuePayload : NSObject
-@property (strong) NSNumber * _Nonnull StepMode;
-@property (strong) NSNumber * _Nonnull StepSize;
-@property (strong) NSNumber * _Nonnull TransitionTime;
-@property (strong) NSNumber * _Nonnull OptionsMask;
-@property (strong) NSNumber * _Nonnull OptionsOverride;
+@property (strong, nonatomic) NSNumber * _Nonnull stepMode;
+@property (strong, nonatomic) NSNumber * _Nonnull stepSize;
+@property (strong, nonatomic) NSNumber * _Nonnull transitionTime;
+@property (strong, nonatomic) NSNumber * _Nonnull optionsMask;
+@property (strong, nonatomic) NSNumber * _Nonnull optionsOverride;
 @end
 
 @interface CHIPColorControlClusterEnhancedMoveToHueAndSaturationPayload : NSObject
-@property (strong) NSNumber * _Nonnull EnhancedHue;
-@property (strong) NSNumber * _Nonnull Saturation;
-@property (strong) NSNumber * _Nonnull TransitionTime;
-@property (strong) NSNumber * _Nonnull OptionsMask;
-@property (strong) NSNumber * _Nonnull OptionsOverride;
+@property (strong, nonatomic) NSNumber * _Nonnull enhancedHue;
+@property (strong, nonatomic) NSNumber * _Nonnull saturation;
+@property (strong, nonatomic) NSNumber * _Nonnull transitionTime;
+@property (strong, nonatomic) NSNumber * _Nonnull optionsMask;
+@property (strong, nonatomic) NSNumber * _Nonnull optionsOverride;
 @end
 
 @interface CHIPColorControlClusterColorLoopSetPayload : NSObject
-@property (strong) NSNumber * _Nonnull UpdateFlags;
-@property (strong) NSNumber * _Nonnull Action;
-@property (strong) NSNumber * _Nonnull Direction;
-@property (strong) NSNumber * _Nonnull Time;
-@property (strong) NSNumber * _Nonnull StartHue;
-@property (strong) NSNumber * _Nonnull OptionsMask;
-@property (strong) NSNumber * _Nonnull OptionsOverride;
+@property (strong, nonatomic) NSNumber * _Nonnull updateFlags;
+@property (strong, nonatomic) NSNumber * _Nonnull action;
+@property (strong, nonatomic) NSNumber * _Nonnull direction;
+@property (strong, nonatomic) NSNumber * _Nonnull time;
+@property (strong, nonatomic) NSNumber * _Nonnull startHue;
+@property (strong, nonatomic) NSNumber * _Nonnull optionsMask;
+@property (strong, nonatomic) NSNumber * _Nonnull optionsOverride;
 @end
 
 @interface CHIPColorControlClusterStopMoveStepPayload : NSObject
-@property (strong) NSNumber * _Nonnull OptionsMask;
-@property (strong) NSNumber * _Nonnull OptionsOverride;
+@property (strong, nonatomic) NSNumber * _Nonnull optionsMask;
+@property (strong, nonatomic) NSNumber * _Nonnull optionsOverride;
 @end
 
 @interface CHIPColorControlClusterMoveColorTemperaturePayload : NSObject
-@property (strong) NSNumber * _Nonnull MoveMode;
-@property (strong) NSNumber * _Nonnull Rate;
-@property (strong) NSNumber * _Nonnull ColorTemperatureMinimum;
-@property (strong) NSNumber * _Nonnull ColorTemperatureMaximum;
-@property (strong) NSNumber * _Nonnull OptionsMask;
-@property (strong) NSNumber * _Nonnull OptionsOverride;
+@property (strong, nonatomic) NSNumber * _Nonnull moveMode;
+@property (strong, nonatomic) NSNumber * _Nonnull rate;
+@property (strong, nonatomic) NSNumber * _Nonnull colorTemperatureMinimum;
+@property (strong, nonatomic) NSNumber * _Nonnull colorTemperatureMaximum;
+@property (strong, nonatomic) NSNumber * _Nonnull optionsMask;
+@property (strong, nonatomic) NSNumber * _Nonnull optionsOverride;
 @end
 
 @interface CHIPColorControlClusterStepColorTemperaturePayload : NSObject
-@property (strong) NSNumber * _Nonnull StepMode;
-@property (strong) NSNumber * _Nonnull StepSize;
-@property (strong) NSNumber * _Nonnull TransitionTime;
-@property (strong) NSNumber * _Nonnull ColorTemperatureMinimum;
-@property (strong) NSNumber * _Nonnull ColorTemperatureMaximum;
-@property (strong) NSNumber * _Nonnull OptionsMask;
-@property (strong) NSNumber * _Nonnull OptionsOverride;
+@property (strong, nonatomic) NSNumber * _Nonnull stepMode;
+@property (strong, nonatomic) NSNumber * _Nonnull stepSize;
+@property (strong, nonatomic) NSNumber * _Nonnull transitionTime;
+@property (strong, nonatomic) NSNumber * _Nonnull colorTemperatureMinimum;
+@property (strong, nonatomic) NSNumber * _Nonnull colorTemperatureMaximum;
+@property (strong, nonatomic) NSNumber * _Nonnull optionsMask;
+@property (strong, nonatomic) NSNumber * _Nonnull optionsOverride;
 @end
 
 @interface CHIPIasZoneClusterZoneEnrollResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull EnrollResponseCode;
-@property (strong) NSNumber * _Nonnull ZoneId;
+@property (strong, nonatomic) NSNumber * _Nonnull enrollResponseCode;
+@property (strong, nonatomic) NSNumber * _Nonnull zoneId;
 @end
 
 @interface CHIPIasZoneClusterZoneStatusChangeNotificationPayload : NSObject
-@property (strong) NSNumber * _Nonnull ZoneStatus;
-@property (strong) NSNumber * _Nonnull ExtendedStatus;
-@property (strong) NSNumber * _Nonnull ZoneId;
-@property (strong) NSNumber * _Nonnull Delay;
+@property (strong, nonatomic) NSNumber * _Nonnull zoneStatus;
+@property (strong, nonatomic) NSNumber * _Nonnull extendedStatus;
+@property (strong, nonatomic) NSNumber * _Nonnull zoneId;
+@property (strong, nonatomic) NSNumber * _Nonnull delay;
 @end
 
 @interface CHIPIasZoneClusterInitiateNormalOperationModePayload : NSObject
 @end
 
 @interface CHIPIasZoneClusterZoneEnrollRequestPayload : NSObject
-@property (strong) NSNumber * _Nonnull ZoneType;
-@property (strong) NSNumber * _Nonnull ManufacturerCode;
+@property (strong, nonatomic) NSNumber * _Nonnull zoneType;
+@property (strong, nonatomic) NSNumber * _Nonnull manufacturerCode;
 @end
 
 @interface CHIPIasZoneClusterInitiateTestModePayload : NSObject
-@property (strong) NSNumber * _Nonnull TestModeDuration;
-@property (strong) NSNumber * _Nonnull CurrentZoneSensitivityLevel;
+@property (strong, nonatomic) NSNumber * _Nonnull testModeDuration;
+@property (strong, nonatomic) NSNumber * _Nonnull currentZoneSensitivityLevel;
 @end
 
 @interface CHIPIasZoneClusterInitiateNormalOperationModeResponsePayload : NSObject
@@ -1377,234 +1377,234 @@
 @end
 
 @interface CHIPIasAceClusterArmPayload : NSObject
-@property (strong) NSNumber * _Nonnull ArmMode;
-@property (strong) NSString * _Nonnull ArmDisarmCode;
-@property (strong) NSNumber * _Nonnull ZoneId;
+@property (strong, nonatomic) NSNumber * _Nonnull armMode;
+@property (strong, nonatomic) NSString * _Nonnull armDisarmCode;
+@property (strong, nonatomic) NSNumber * _Nonnull zoneId;
 @end
 
 @interface CHIPIasAceClusterArmResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull ArmNotification;
+@property (strong, nonatomic) NSNumber * _Nonnull armNotification;
 @end
 
 @interface CHIPIasAceClusterBypassPayload : NSObject
-@property (strong) NSNumber * _Nonnull NumberOfZones;
-@property (strong) NSArray * _Nonnull ZoneIds;
-@property (strong) NSString * _Nonnull ArmDisarmCode;
+@property (strong, nonatomic) NSNumber * _Nonnull numberOfZones;
+@property (strong, nonatomic) NSArray * _Nonnull zoneIds;
+@property (strong, nonatomic) NSString * _Nonnull armDisarmCode;
 @end
 
 @interface CHIPIasAceClusterGetZoneIdMapResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull Section0;
-@property (strong) NSNumber * _Nonnull Section1;
-@property (strong) NSNumber * _Nonnull Section2;
-@property (strong) NSNumber * _Nonnull Section3;
-@property (strong) NSNumber * _Nonnull Section4;
-@property (strong) NSNumber * _Nonnull Section5;
-@property (strong) NSNumber * _Nonnull Section6;
-@property (strong) NSNumber * _Nonnull Section7;
-@property (strong) NSNumber * _Nonnull Section8;
-@property (strong) NSNumber * _Nonnull Section9;
-@property (strong) NSNumber * _Nonnull Section10;
-@property (strong) NSNumber * _Nonnull Section11;
-@property (strong) NSNumber * _Nonnull Section12;
-@property (strong) NSNumber * _Nonnull Section13;
-@property (strong) NSNumber * _Nonnull Section14;
-@property (strong) NSNumber * _Nonnull Section15;
+@property (strong, nonatomic) NSNumber * _Nonnull section0;
+@property (strong, nonatomic) NSNumber * _Nonnull section1;
+@property (strong, nonatomic) NSNumber * _Nonnull section2;
+@property (strong, nonatomic) NSNumber * _Nonnull section3;
+@property (strong, nonatomic) NSNumber * _Nonnull section4;
+@property (strong, nonatomic) NSNumber * _Nonnull section5;
+@property (strong, nonatomic) NSNumber * _Nonnull section6;
+@property (strong, nonatomic) NSNumber * _Nonnull section7;
+@property (strong, nonatomic) NSNumber * _Nonnull section8;
+@property (strong, nonatomic) NSNumber * _Nonnull section9;
+@property (strong, nonatomic) NSNumber * _Nonnull section10;
+@property (strong, nonatomic) NSNumber * _Nonnull section11;
+@property (strong, nonatomic) NSNumber * _Nonnull section12;
+@property (strong, nonatomic) NSNumber * _Nonnull section13;
+@property (strong, nonatomic) NSNumber * _Nonnull section14;
+@property (strong, nonatomic) NSNumber * _Nonnull section15;
 @end
 
 @interface CHIPIasAceClusterEmergencyPayload : NSObject
 @end
 
 @interface CHIPIasAceClusterGetZoneInformationResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull ZoneId;
-@property (strong) NSNumber * _Nonnull ZoneType;
-@property (strong) NSNumber * _Nonnull IeeeAddress;
-@property (strong) NSString * _Nonnull ZoneLabel;
+@property (strong, nonatomic) NSNumber * _Nonnull zoneId;
+@property (strong, nonatomic) NSNumber * _Nonnull zoneType;
+@property (strong, nonatomic) NSNumber * _Nonnull ieeeAddress;
+@property (strong, nonatomic) NSString * _Nonnull zoneLabel;
 @end
 
 @interface CHIPIasAceClusterFirePayload : NSObject
 @end
 
 @interface CHIPIasAceClusterZoneStatusChangedPayload : NSObject
-@property (strong) NSNumber * _Nonnull ZoneId;
-@property (strong) NSNumber * _Nonnull ZoneStatus;
-@property (strong) NSNumber * _Nonnull AudibleNotification;
-@property (strong) NSString * _Nonnull ZoneLabel;
+@property (strong, nonatomic) NSNumber * _Nonnull zoneId;
+@property (strong, nonatomic) NSNumber * _Nonnull zoneStatus;
+@property (strong, nonatomic) NSNumber * _Nonnull audibleNotification;
+@property (strong, nonatomic) NSString * _Nonnull zoneLabel;
 @end
 
 @interface CHIPIasAceClusterPanicPayload : NSObject
 @end
 
 @interface CHIPIasAceClusterPanelStatusChangedPayload : NSObject
-@property (strong) NSNumber * _Nonnull PanelStatus;
-@property (strong) NSNumber * _Nonnull SecondsRemaining;
-@property (strong) NSNumber * _Nonnull AudibleNotification;
-@property (strong) NSNumber * _Nonnull AlarmStatus;
+@property (strong, nonatomic) NSNumber * _Nonnull panelStatus;
+@property (strong, nonatomic) NSNumber * _Nonnull secondsRemaining;
+@property (strong, nonatomic) NSNumber * _Nonnull audibleNotification;
+@property (strong, nonatomic) NSNumber * _Nonnull alarmStatus;
 @end
 
 @interface CHIPIasAceClusterGetZoneIdMapPayload : NSObject
 @end
 
 @interface CHIPIasAceClusterGetPanelStatusResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull PanelStatus;
-@property (strong) NSNumber * _Nonnull SecondsRemaining;
-@property (strong) NSNumber * _Nonnull AudibleNotification;
-@property (strong) NSNumber * _Nonnull AlarmStatus;
+@property (strong, nonatomic) NSNumber * _Nonnull panelStatus;
+@property (strong, nonatomic) NSNumber * _Nonnull secondsRemaining;
+@property (strong, nonatomic) NSNumber * _Nonnull audibleNotification;
+@property (strong, nonatomic) NSNumber * _Nonnull alarmStatus;
 @end
 
 @interface CHIPIasAceClusterGetZoneInformationPayload : NSObject
-@property (strong) NSNumber * _Nonnull ZoneId;
+@property (strong, nonatomic) NSNumber * _Nonnull zoneId;
 @end
 
 @interface CHIPIasAceClusterSetBypassedZoneListPayload : NSObject
-@property (strong) NSNumber * _Nonnull NumberOfZones;
-@property (strong) NSArray * _Nonnull ZoneIds;
+@property (strong, nonatomic) NSNumber * _Nonnull numberOfZones;
+@property (strong, nonatomic) NSArray * _Nonnull zoneIds;
 @end
 
 @interface CHIPIasAceClusterGetPanelStatusPayload : NSObject
 @end
 
 @interface CHIPIasAceClusterBypassResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull NumberOfZones;
-@property (strong) NSArray * _Nonnull BypassResult;
+@property (strong, nonatomic) NSNumber * _Nonnull numberOfZones;
+@property (strong, nonatomic) NSArray * _Nonnull bypassResult;
 @end
 
 @interface CHIPIasAceClusterGetBypassedZoneListPayload : NSObject
 @end
 
 @interface CHIPIasAceClusterGetZoneStatusResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull ZoneStatusComplete;
-@property (strong) NSNumber * _Nonnull NumberOfZones;
-@property (strong) NSArray * _Nonnull ZoneStatusResult;
+@property (strong, nonatomic) NSNumber * _Nonnull zoneStatusComplete;
+@property (strong, nonatomic) NSNumber * _Nonnull numberOfZones;
+@property (strong, nonatomic) NSArray * _Nonnull zoneStatusResult;
 @end
 
 @interface CHIPIasAceClusterGetZoneStatusPayload : NSObject
-@property (strong) NSNumber * _Nonnull StartingZoneId;
-@property (strong) NSNumber * _Nonnull MaxNumberOfZoneIds;
-@property (strong) NSNumber * _Nonnull ZoneStatusMaskFlag;
-@property (strong) NSNumber * _Nonnull ZoneStatusMask;
+@property (strong, nonatomic) NSNumber * _Nonnull startingZoneId;
+@property (strong, nonatomic) NSNumber * _Nonnull maxNumberOfZoneIds;
+@property (strong, nonatomic) NSNumber * _Nonnull zoneStatusMaskFlag;
+@property (strong, nonatomic) NSNumber * _Nonnull zoneStatusMask;
 @end
 
 @interface CHIPIasWdClusterStartWarningPayload : NSObject
-@property (strong) NSNumber * _Nonnull WarningInfo;
-@property (strong) NSNumber * _Nonnull WarningDuration;
-@property (strong) NSNumber * _Nonnull StrobeDutyCycle;
-@property (strong) NSNumber * _Nonnull StrobeLevel;
+@property (strong, nonatomic) NSNumber * _Nonnull warningInfo;
+@property (strong, nonatomic) NSNumber * _Nonnull warningDuration;
+@property (strong, nonatomic) NSNumber * _Nonnull strobeDutyCycle;
+@property (strong, nonatomic) NSNumber * _Nonnull strobeLevel;
 @end
 
 @interface CHIPIasWdClusterSquawkPayload : NSObject
-@property (strong) NSNumber * _Nonnull SquawkInfo;
+@property (strong, nonatomic) NSNumber * _Nonnull squawkInfo;
 @end
 
 @interface CHIPTvChannelClusterChangeChannelPayload : NSObject
-@property (strong) NSString * _Nonnull Match;
+@property (strong, nonatomic) NSString * _Nonnull match;
 @end
 
 @interface CHIPTvChannelClusterChangeChannelResponsePayload : NSObject
-@property (strong) NSArray * _Nonnull ChannelMatch;
-@property (strong) NSNumber * _Nonnull ErrorType;
+@property (strong, nonatomic) NSArray * _Nonnull channelMatch;
+@property (strong, nonatomic) NSNumber * _Nonnull errorType;
 @end
 
 @interface CHIPTvChannelClusterChangeChannelByNumberPayload : NSObject
-@property (strong) NSNumber * _Nonnull MajorNumber;
-@property (strong) NSNumber * _Nonnull MinorNumber;
+@property (strong, nonatomic) NSNumber * _Nonnull majorNumber;
+@property (strong, nonatomic) NSNumber * _Nonnull minorNumber;
 @end
 
 @interface CHIPTvChannelClusterSkipChannelPayload : NSObject
-@property (strong) NSNumber * _Nonnull Count;
+@property (strong, nonatomic, getter=getCount) NSNumber * _Nonnull count;
 @end
 
 @interface CHIPTargetNavigatorClusterNavigateTargetPayload : NSObject
-@property (strong) NSNumber * _Nonnull Target;
-@property (strong) NSString * _Nonnull Data;
+@property (strong, nonatomic) NSNumber * _Nonnull target;
+@property (strong, nonatomic) NSString * _Nonnull data;
 @end
 
 @interface CHIPTargetNavigatorClusterNavigateTargetResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull Status;
-@property (strong) NSString * _Nonnull Data;
+@property (strong, nonatomic) NSNumber * _Nonnull status;
+@property (strong, nonatomic) NSString * _Nonnull data;
 @end
 
 @interface CHIPMediaPlaybackClusterMediaPlayPayload : NSObject
 @end
 
 @interface CHIPMediaPlaybackClusterMediaPlayResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull MediaPlaybackStatus;
+@property (strong, nonatomic) NSNumber * _Nonnull mediaPlaybackStatus;
 @end
 
 @interface CHIPMediaPlaybackClusterMediaPausePayload : NSObject
 @end
 
 @interface CHIPMediaPlaybackClusterMediaPauseResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull MediaPlaybackStatus;
+@property (strong, nonatomic) NSNumber * _Nonnull mediaPlaybackStatus;
 @end
 
 @interface CHIPMediaPlaybackClusterMediaStopPayload : NSObject
 @end
 
 @interface CHIPMediaPlaybackClusterMediaStopResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull MediaPlaybackStatus;
+@property (strong, nonatomic) NSNumber * _Nonnull mediaPlaybackStatus;
 @end
 
 @interface CHIPMediaPlaybackClusterMediaStartOverPayload : NSObject
 @end
 
 @interface CHIPMediaPlaybackClusterMediaStartOverResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull MediaPlaybackStatus;
+@property (strong, nonatomic) NSNumber * _Nonnull mediaPlaybackStatus;
 @end
 
 @interface CHIPMediaPlaybackClusterMediaPreviousPayload : NSObject
 @end
 
 @interface CHIPMediaPlaybackClusterMediaPreviousResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull MediaPlaybackStatus;
+@property (strong, nonatomic) NSNumber * _Nonnull mediaPlaybackStatus;
 @end
 
 @interface CHIPMediaPlaybackClusterMediaNextPayload : NSObject
 @end
 
 @interface CHIPMediaPlaybackClusterMediaNextResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull MediaPlaybackStatus;
+@property (strong, nonatomic) NSNumber * _Nonnull mediaPlaybackStatus;
 @end
 
 @interface CHIPMediaPlaybackClusterMediaRewindPayload : NSObject
 @end
 
 @interface CHIPMediaPlaybackClusterMediaRewindResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull MediaPlaybackStatus;
+@property (strong, nonatomic) NSNumber * _Nonnull mediaPlaybackStatus;
 @end
 
 @interface CHIPMediaPlaybackClusterMediaFastForwardPayload : NSObject
 @end
 
 @interface CHIPMediaPlaybackClusterMediaFastForwardResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull MediaPlaybackStatus;
+@property (strong, nonatomic) NSNumber * _Nonnull mediaPlaybackStatus;
 @end
 
 @interface CHIPMediaPlaybackClusterMediaSkipForwardPayload : NSObject
-@property (strong) NSNumber * _Nonnull DeltaPositionMilliseconds;
+@property (strong, nonatomic) NSNumber * _Nonnull deltaPositionMilliseconds;
 @end
 
 @interface CHIPMediaPlaybackClusterMediaSkipForwardResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull MediaPlaybackStatus;
+@property (strong, nonatomic) NSNumber * _Nonnull mediaPlaybackStatus;
 @end
 
 @interface CHIPMediaPlaybackClusterMediaSkipBackwardPayload : NSObject
-@property (strong) NSNumber * _Nonnull DeltaPositionMilliseconds;
+@property (strong, nonatomic) NSNumber * _Nonnull deltaPositionMilliseconds;
 @end
 
 @interface CHIPMediaPlaybackClusterMediaSkipBackwardResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull MediaPlaybackStatus;
+@property (strong, nonatomic) NSNumber * _Nonnull mediaPlaybackStatus;
 @end
 
 @interface CHIPMediaPlaybackClusterMediaSeekPayload : NSObject
-@property (strong) NSNumber * _Nonnull Position;
+@property (strong, nonatomic) NSNumber * _Nonnull position;
 @end
 
 @interface CHIPMediaPlaybackClusterMediaSeekResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull MediaPlaybackStatus;
+@property (strong, nonatomic) NSNumber * _Nonnull mediaPlaybackStatus;
 @end
 
 @interface CHIPMediaInputClusterSelectInputPayload : NSObject
-@property (strong) NSNumber * _Nonnull Index;
+@property (strong, nonatomic) NSNumber * _Nonnull index;
 @end
 
 @interface CHIPMediaInputClusterShowInputStatusPayload : NSObject
@@ -1614,367 +1614,367 @@
 @end
 
 @interface CHIPMediaInputClusterRenameInputPayload : NSObject
-@property (strong) NSNumber * _Nonnull Index;
-@property (strong) NSString * _Nonnull Name;
+@property (strong, nonatomic) NSNumber * _Nonnull index;
+@property (strong, nonatomic) NSString * _Nonnull name;
 @end
 
 @interface CHIPLowPowerClusterSleepPayload : NSObject
 @end
 
 @interface CHIPKeypadInputClusterSendKeyPayload : NSObject
-@property (strong) NSNumber * _Nonnull KeyCode;
+@property (strong, nonatomic) NSNumber * _Nonnull keyCode;
 @end
 
 @interface CHIPKeypadInputClusterSendKeyResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull Status;
+@property (strong, nonatomic) NSNumber * _Nonnull status;
 @end
 
 @interface CHIPContentLauncherClusterLaunchContentPayload : NSObject
-@property (strong) NSNumber * _Nonnull AutoPlay;
-@property (strong) NSString * _Nonnull Data;
+@property (strong, nonatomic) NSNumber * _Nonnull autoPlay;
+@property (strong, nonatomic) NSString * _Nonnull data;
 @end
 
 @interface CHIPContentLauncherClusterLaunchContentResponsePayload : NSObject
-@property (strong) NSString * _Nonnull Data;
-@property (strong) NSNumber * _Nonnull ContentLaunchStatus;
+@property (strong, nonatomic) NSString * _Nonnull data;
+@property (strong, nonatomic) NSNumber * _Nonnull contentLaunchStatus;
 @end
 
 @interface CHIPContentLauncherClusterLaunchURLPayload : NSObject
-@property (strong) NSString * _Nonnull ContentURL;
-@property (strong) NSString * _Nonnull DisplayString;
+@property (strong, nonatomic) NSString * _Nonnull contentURL;
+@property (strong, nonatomic) NSString * _Nonnull displayString;
 @end
 
 @interface CHIPContentLauncherClusterLaunchURLResponsePayload : NSObject
-@property (strong) NSString * _Nonnull Data;
-@property (strong) NSNumber * _Nonnull ContentLaunchStatus;
+@property (strong, nonatomic) NSString * _Nonnull data;
+@property (strong, nonatomic) NSNumber * _Nonnull contentLaunchStatus;
 @end
 
 @interface CHIPAudioOutputClusterSelectOutputPayload : NSObject
-@property (strong) NSNumber * _Nonnull Index;
+@property (strong, nonatomic) NSNumber * _Nonnull index;
 @end
 
 @interface CHIPAudioOutputClusterRenameOutputPayload : NSObject
-@property (strong) NSNumber * _Nonnull Index;
-@property (strong) NSString * _Nonnull Name;
+@property (strong, nonatomic) NSNumber * _Nonnull index;
+@property (strong, nonatomic) NSString * _Nonnull name;
 @end
 
 @interface CHIPApplicationLauncherClusterLaunchAppPayload : NSObject
-@property (strong) NSString * _Nonnull Data;
-@property (strong) NSNumber * _Nonnull CatalogVendorId;
-@property (strong) NSString * _Nonnull ApplicationId;
+@property (strong, nonatomic) NSString * _Nonnull data;
+@property (strong, nonatomic) NSNumber * _Nonnull catalogVendorId;
+@property (strong, nonatomic) NSString * _Nonnull applicationId;
 @end
 
 @interface CHIPApplicationLauncherClusterLaunchAppResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull Status;
-@property (strong) NSString * _Nonnull Data;
+@property (strong, nonatomic) NSNumber * _Nonnull status;
+@property (strong, nonatomic) NSString * _Nonnull data;
 @end
 
 @interface CHIPApplicationBasicClusterChangeStatusPayload : NSObject
-@property (strong) NSNumber * _Nonnull Status;
+@property (strong, nonatomic) NSNumber * _Nonnull status;
 @end
 
 @interface CHIPAccountLoginClusterGetSetupPINPayload : NSObject
-@property (strong) NSString * _Nonnull TempAccountIdentifier;
+@property (strong, nonatomic) NSString * _Nonnull tempAccountIdentifier;
 @end
 
 @interface CHIPAccountLoginClusterGetSetupPINResponsePayload : NSObject
-@property (strong) NSString * _Nonnull SetupPIN;
+@property (strong, nonatomic) NSString * _Nonnull setupPIN;
 @end
 
 @interface CHIPAccountLoginClusterLoginPayload : NSObject
-@property (strong) NSString * _Nonnull TempAccountIdentifier;
-@property (strong) NSString * _Nonnull SetupPIN;
+@property (strong, nonatomic) NSString * _Nonnull tempAccountIdentifier;
+@property (strong, nonatomic) NSString * _Nonnull setupPIN;
 @end
 
 @interface CHIPTestClusterClusterTestPayload : NSObject
 @end
 
 @interface CHIPTestClusterClusterTestSpecificResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull ReturnValue;
+@property (strong, nonatomic) NSNumber * _Nonnull returnValue;
 @end
 
 @interface CHIPTestClusterClusterTestNotHandledPayload : NSObject
 @end
 
 @interface CHIPTestClusterClusterTestAddArgumentsResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull ReturnValue;
+@property (strong, nonatomic) NSNumber * _Nonnull returnValue;
 @end
 
 @interface CHIPTestClusterClusterTestSpecificPayload : NSObject
 @end
 
 @interface CHIPTestClusterClusterTestSimpleArgumentResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull ReturnValue;
+@property (strong, nonatomic) NSNumber * _Nonnull returnValue;
 @end
 
 @interface CHIPTestClusterClusterTestUnknownCommandPayload : NSObject
 @end
 
 @interface CHIPTestClusterClusterTestStructArrayArgumentResponsePayload : NSObject
-@property (strong) NSArray * _Nonnull Arg1;
-@property (strong) NSArray * _Nonnull Arg2;
-@property (strong) NSArray * _Nonnull Arg3;
-@property (strong) NSArray * _Nonnull Arg4;
-@property (strong) NSNumber * _Nonnull Arg5;
-@property (strong) NSNumber * _Nonnull Arg6;
+@property (strong, nonatomic) NSArray * _Nonnull arg1;
+@property (strong, nonatomic) NSArray * _Nonnull arg2;
+@property (strong, nonatomic) NSArray * _Nonnull arg3;
+@property (strong, nonatomic) NSArray * _Nonnull arg4;
+@property (strong, nonatomic) NSNumber * _Nonnull arg5;
+@property (strong, nonatomic) NSNumber * _Nonnull arg6;
 @end
 
 @interface CHIPTestClusterClusterTestAddArgumentsPayload : NSObject
-@property (strong) NSNumber * _Nonnull Arg1;
-@property (strong) NSNumber * _Nonnull Arg2;
+@property (strong, nonatomic) NSNumber * _Nonnull arg1;
+@property (strong, nonatomic) NSNumber * _Nonnull arg2;
 @end
 
 @interface CHIPTestClusterClusterTestListInt8UReverseResponsePayload : NSObject
-@property (strong) NSArray * _Nonnull Arg1;
+@property (strong, nonatomic) NSArray * _Nonnull arg1;
 @end
 
 @interface CHIPTestClusterClusterTestSimpleArgumentRequestPayload : NSObject
-@property (strong) NSNumber * _Nonnull Arg1;
+@property (strong, nonatomic) NSNumber * _Nonnull arg1;
 @end
 
 @interface CHIPTestClusterClusterTestEnumsResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull Arg1;
-@property (strong) NSNumber * _Nonnull Arg2;
+@property (strong, nonatomic) NSNumber * _Nonnull arg1;
+@property (strong, nonatomic) NSNumber * _Nonnull arg2;
 @end
 
 @interface CHIPTestClusterClusterTestStructArrayArgumentRequestPayload : NSObject
-@property (strong) NSArray * _Nonnull Arg1;
-@property (strong) NSArray * _Nonnull Arg2;
-@property (strong) NSArray * _Nonnull Arg3;
-@property (strong) NSArray * _Nonnull Arg4;
-@property (strong) NSNumber * _Nonnull Arg5;
-@property (strong) NSNumber * _Nonnull Arg6;
+@property (strong, nonatomic) NSArray * _Nonnull arg1;
+@property (strong, nonatomic) NSArray * _Nonnull arg2;
+@property (strong, nonatomic) NSArray * _Nonnull arg3;
+@property (strong, nonatomic) NSArray * _Nonnull arg4;
+@property (strong, nonatomic) NSNumber * _Nonnull arg5;
+@property (strong, nonatomic) NSNumber * _Nonnull arg6;
 @end
 
 @interface CHIPTestClusterClusterTestNullableOptionalResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull WasPresent;
-@property (strong) NSNumber * _Nullable WasNull;
-@property (strong) NSNumber * _Nullable Value;
-@property (strong) NSNumber * _Nullable OriginalValue;
+@property (strong, nonatomic) NSNumber * _Nonnull wasPresent;
+@property (strong, nonatomic) NSNumber * _Nullable wasNull;
+@property (strong, nonatomic) NSNumber * _Nullable value;
+@property (strong, nonatomic) NSNumber * _Nullable originalValue;
 @end
 
 @interface CHIPTestClusterClusterTestStructArgumentRequestPayload : NSObject
-@property (strong) CHIPTestClusterClusterSimpleStruct * _Nonnull Arg1;
+@property (strong, nonatomic) CHIPTestClusterClusterSimpleStruct * _Nonnull arg1;
 @end
 
 @interface CHIPTestClusterClusterTestComplexNullableOptionalResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull NullableIntWasNull;
-@property (strong) NSNumber * _Nullable NullableIntValue;
-@property (strong) NSNumber * _Nonnull OptionalIntWasPresent;
-@property (strong) NSNumber * _Nullable OptionalIntValue;
-@property (strong) NSNumber * _Nonnull NullableOptionalIntWasPresent;
-@property (strong) NSNumber * _Nullable NullableOptionalIntWasNull;
-@property (strong) NSNumber * _Nullable NullableOptionalIntValue;
-@property (strong) NSNumber * _Nonnull NullableStringWasNull;
-@property (strong) NSString * _Nullable NullableStringValue;
-@property (strong) NSNumber * _Nonnull OptionalStringWasPresent;
-@property (strong) NSString * _Nullable OptionalStringValue;
-@property (strong) NSNumber * _Nonnull NullableOptionalStringWasPresent;
-@property (strong) NSNumber * _Nullable NullableOptionalStringWasNull;
-@property (strong) NSString * _Nullable NullableOptionalStringValue;
-@property (strong) NSNumber * _Nonnull NullableStructWasNull;
-@property (strong) CHIPTestClusterClusterSimpleStruct * _Nullable NullableStructValue;
-@property (strong) NSNumber * _Nonnull OptionalStructWasPresent;
-@property (strong) CHIPTestClusterClusterSimpleStruct * _Nullable OptionalStructValue;
-@property (strong) NSNumber * _Nonnull NullableOptionalStructWasPresent;
-@property (strong) NSNumber * _Nullable NullableOptionalStructWasNull;
-@property (strong) CHIPTestClusterClusterSimpleStruct * _Nullable NullableOptionalStructValue;
-@property (strong) NSNumber * _Nonnull NullableListWasNull;
-@property (strong) NSArray * _Nullable NullableListValue;
-@property (strong) NSNumber * _Nonnull OptionalListWasPresent;
-@property (strong) NSArray * _Nullable OptionalListValue;
-@property (strong) NSNumber * _Nonnull NullableOptionalListWasPresent;
-@property (strong) NSNumber * _Nullable NullableOptionalListWasNull;
-@property (strong) NSArray * _Nullable NullableOptionalListValue;
+@property (strong, nonatomic) NSNumber * _Nonnull nullableIntWasNull;
+@property (strong, nonatomic) NSNumber * _Nullable nullableIntValue;
+@property (strong, nonatomic) NSNumber * _Nonnull optionalIntWasPresent;
+@property (strong, nonatomic) NSNumber * _Nullable optionalIntValue;
+@property (strong, nonatomic) NSNumber * _Nonnull nullableOptionalIntWasPresent;
+@property (strong, nonatomic) NSNumber * _Nullable nullableOptionalIntWasNull;
+@property (strong, nonatomic) NSNumber * _Nullable nullableOptionalIntValue;
+@property (strong, nonatomic) NSNumber * _Nonnull nullableStringWasNull;
+@property (strong, nonatomic) NSString * _Nullable nullableStringValue;
+@property (strong, nonatomic) NSNumber * _Nonnull optionalStringWasPresent;
+@property (strong, nonatomic) NSString * _Nullable optionalStringValue;
+@property (strong, nonatomic) NSNumber * _Nonnull nullableOptionalStringWasPresent;
+@property (strong, nonatomic) NSNumber * _Nullable nullableOptionalStringWasNull;
+@property (strong, nonatomic) NSString * _Nullable nullableOptionalStringValue;
+@property (strong, nonatomic) NSNumber * _Nonnull nullableStructWasNull;
+@property (strong, nonatomic) CHIPTestClusterClusterSimpleStruct * _Nullable nullableStructValue;
+@property (strong, nonatomic) NSNumber * _Nonnull optionalStructWasPresent;
+@property (strong, nonatomic) CHIPTestClusterClusterSimpleStruct * _Nullable optionalStructValue;
+@property (strong, nonatomic) NSNumber * _Nonnull nullableOptionalStructWasPresent;
+@property (strong, nonatomic) NSNumber * _Nullable nullableOptionalStructWasNull;
+@property (strong, nonatomic) CHIPTestClusterClusterSimpleStruct * _Nullable nullableOptionalStructValue;
+@property (strong, nonatomic) NSNumber * _Nonnull nullableListWasNull;
+@property (strong, nonatomic) NSArray * _Nullable nullableListValue;
+@property (strong, nonatomic) NSNumber * _Nonnull optionalListWasPresent;
+@property (strong, nonatomic) NSArray * _Nullable optionalListValue;
+@property (strong, nonatomic) NSNumber * _Nonnull nullableOptionalListWasPresent;
+@property (strong, nonatomic) NSNumber * _Nullable nullableOptionalListWasNull;
+@property (strong, nonatomic) NSArray * _Nullable nullableOptionalListValue;
 @end
 
 @interface CHIPTestClusterClusterTestNestedStructArgumentRequestPayload : NSObject
-@property (strong) CHIPTestClusterClusterNestedStruct * _Nonnull Arg1;
+@property (strong, nonatomic) CHIPTestClusterClusterNestedStruct * _Nonnull arg1;
 @end
 
 @interface CHIPTestClusterClusterBooleanResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull Value;
+@property (strong, nonatomic) NSNumber * _Nonnull value;
 @end
 
 @interface CHIPTestClusterClusterTestListStructArgumentRequestPayload : NSObject
-@property (strong) NSArray * _Nonnull Arg1;
+@property (strong, nonatomic) NSArray * _Nonnull arg1;
 @end
 
 @interface CHIPTestClusterClusterTestListInt8UArgumentRequestPayload : NSObject
-@property (strong) NSArray * _Nonnull Arg1;
+@property (strong, nonatomic) NSArray * _Nonnull arg1;
 @end
 
 @interface CHIPTestClusterClusterTestNestedStructListArgumentRequestPayload : NSObject
-@property (strong) CHIPTestClusterClusterNestedStructList * _Nonnull Arg1;
+@property (strong, nonatomic) CHIPTestClusterClusterNestedStructList * _Nonnull arg1;
 @end
 
 @interface CHIPTestClusterClusterTestListNestedStructListArgumentRequestPayload : NSObject
-@property (strong) NSArray * _Nonnull Arg1;
+@property (strong, nonatomic) NSArray * _Nonnull arg1;
 @end
 
 @interface CHIPTestClusterClusterTestListInt8UReverseRequestPayload : NSObject
-@property (strong) NSArray * _Nonnull Arg1;
+@property (strong, nonatomic) NSArray * _Nonnull arg1;
 @end
 
 @interface CHIPTestClusterClusterTestEnumsRequestPayload : NSObject
-@property (strong) NSNumber * _Nonnull Arg1;
-@property (strong) NSNumber * _Nonnull Arg2;
+@property (strong, nonatomic) NSNumber * _Nonnull arg1;
+@property (strong, nonatomic) NSNumber * _Nonnull arg2;
 @end
 
 @interface CHIPTestClusterClusterTestNullableOptionalRequestPayload : NSObject
-@property (strong) NSNumber * _Nullable Arg1;
+@property (strong, nonatomic) NSNumber * _Nullable arg1;
 @end
 
 @interface CHIPTestClusterClusterTestComplexNullableOptionalRequestPayload : NSObject
-@property (strong) NSNumber * _Nullable NullableInt;
-@property (strong) NSNumber * _Nullable OptionalInt;
-@property (strong) NSNumber * _Nullable NullableOptionalInt;
-@property (strong) NSString * _Nullable NullableString;
-@property (strong) NSString * _Nullable OptionalString;
-@property (strong) NSString * _Nullable NullableOptionalString;
-@property (strong) CHIPTestClusterClusterSimpleStruct * _Nullable NullableStruct;
-@property (strong) CHIPTestClusterClusterSimpleStruct * _Nullable OptionalStruct;
-@property (strong) CHIPTestClusterClusterSimpleStruct * _Nullable NullableOptionalStruct;
-@property (strong) NSArray * _Nullable NullableList;
-@property (strong) NSArray * _Nullable OptionalList;
-@property (strong) NSArray * _Nullable NullableOptionalList;
+@property (strong, nonatomic) NSNumber * _Nullable nullableInt;
+@property (strong, nonatomic) NSNumber * _Nullable optionalInt;
+@property (strong, nonatomic) NSNumber * _Nullable nullableOptionalInt;
+@property (strong, nonatomic) NSString * _Nullable nullableString;
+@property (strong, nonatomic) NSString * _Nullable optionalString;
+@property (strong, nonatomic) NSString * _Nullable nullableOptionalString;
+@property (strong, nonatomic) CHIPTestClusterClusterSimpleStruct * _Nullable nullableStruct;
+@property (strong, nonatomic) CHIPTestClusterClusterSimpleStruct * _Nullable optionalStruct;
+@property (strong, nonatomic) CHIPTestClusterClusterSimpleStruct * _Nullable nullableOptionalStruct;
+@property (strong, nonatomic) NSArray * _Nullable nullableList;
+@property (strong, nonatomic) NSArray * _Nullable optionalList;
+@property (strong, nonatomic) NSArray * _Nullable nullableOptionalList;
 @end
 
 @interface CHIPMessagingClusterDisplayMessagePayload : NSObject
-@property (strong) NSNumber * _Nonnull MessageId;
-@property (strong) NSNumber * _Nonnull MessageControl;
-@property (strong) NSNumber * _Nonnull StartTime;
-@property (strong) NSNumber * _Nonnull DurationInMinutes;
-@property (strong) NSString * _Nonnull Message;
-@property (strong) NSNumber * _Nonnull OptionalExtendedMessageControl;
+@property (strong, nonatomic) NSNumber * _Nonnull messageId;
+@property (strong, nonatomic) NSNumber * _Nonnull messageControl;
+@property (strong, nonatomic) NSNumber * _Nonnull startTime;
+@property (strong, nonatomic) NSNumber * _Nonnull durationInMinutes;
+@property (strong, nonatomic) NSString * _Nonnull message;
+@property (strong, nonatomic) NSNumber * _Nonnull optionalExtendedMessageControl;
 @end
 
 @interface CHIPMessagingClusterGetLastMessagePayload : NSObject
 @end
 
 @interface CHIPMessagingClusterCancelMessagePayload : NSObject
-@property (strong) NSNumber * _Nonnull MessageId;
-@property (strong) NSNumber * _Nonnull MessageControl;
+@property (strong, nonatomic) NSNumber * _Nonnull messageId;
+@property (strong, nonatomic) NSNumber * _Nonnull messageControl;
 @end
 
 @interface CHIPMessagingClusterMessageConfirmationPayload : NSObject
-@property (strong) NSNumber * _Nonnull MessageId;
-@property (strong) NSNumber * _Nonnull ConfirmationTime;
-@property (strong) NSNumber * _Nonnull MessageConfirmationControl;
-@property (strong) NSData * _Nonnull MessageResponse;
+@property (strong, nonatomic) NSNumber * _Nonnull messageId;
+@property (strong, nonatomic) NSNumber * _Nonnull confirmationTime;
+@property (strong, nonatomic) NSNumber * _Nonnull messageConfirmationControl;
+@property (strong, nonatomic) NSData * _Nonnull messageResponse;
 @end
 
 @interface CHIPMessagingClusterDisplayProtectedMessagePayload : NSObject
-@property (strong) NSNumber * _Nonnull MessageId;
-@property (strong) NSNumber * _Nonnull MessageControl;
-@property (strong) NSNumber * _Nonnull StartTime;
-@property (strong) NSNumber * _Nonnull DurationInMinutes;
-@property (strong) NSString * _Nonnull Message;
-@property (strong) NSNumber * _Nonnull OptionalExtendedMessageControl;
+@property (strong, nonatomic) NSNumber * _Nonnull messageId;
+@property (strong, nonatomic) NSNumber * _Nonnull messageControl;
+@property (strong, nonatomic) NSNumber * _Nonnull startTime;
+@property (strong, nonatomic) NSNumber * _Nonnull durationInMinutes;
+@property (strong, nonatomic) NSString * _Nonnull message;
+@property (strong, nonatomic) NSNumber * _Nonnull optionalExtendedMessageControl;
 @end
 
 @interface CHIPMessagingClusterGetMessageCancellationPayload : NSObject
-@property (strong) NSNumber * _Nonnull EarliestImplementationTime;
+@property (strong, nonatomic) NSNumber * _Nonnull earliestImplementationTime;
 @end
 
 @interface CHIPMessagingClusterCancelAllMessagesPayload : NSObject
-@property (strong) NSNumber * _Nonnull ImplementationDateTime;
+@property (strong, nonatomic) NSNumber * _Nonnull implementationDateTime;
 @end
 
 @interface CHIPApplianceEventsAndAlertClusterGetAlertsPayload : NSObject
 @end
 
 @interface CHIPApplianceEventsAndAlertClusterGetAlertsResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull AlertsCount;
-@property (strong) NSArray * _Nonnull AlertStructures;
+@property (strong, nonatomic) NSNumber * _Nonnull alertsCount;
+@property (strong, nonatomic) NSArray * _Nonnull alertStructures;
 @end
 
 @interface CHIPApplianceEventsAndAlertClusterAlertsNotificationPayload : NSObject
-@property (strong) NSNumber * _Nonnull AlertsCount;
-@property (strong) NSArray * _Nonnull AlertStructures;
+@property (strong, nonatomic) NSNumber * _Nonnull alertsCount;
+@property (strong, nonatomic) NSArray * _Nonnull alertStructures;
 @end
 
 @interface CHIPApplianceEventsAndAlertClusterEventsNotificationPayload : NSObject
-@property (strong) NSNumber * _Nonnull EventHeader;
-@property (strong) NSNumber * _Nonnull EventId;
+@property (strong, nonatomic) NSNumber * _Nonnull eventHeader;
+@property (strong, nonatomic) NSNumber * _Nonnull eventId;
 @end
 
 @interface CHIPApplianceStatisticsClusterLogNotificationPayload : NSObject
-@property (strong) NSNumber * _Nonnull TimeStamp;
-@property (strong) NSNumber * _Nonnull LogId;
-@property (strong) NSNumber * _Nonnull LogLength;
-@property (strong) NSArray * _Nonnull LogPayload;
+@property (strong, nonatomic) NSNumber * _Nonnull timeStamp;
+@property (strong, nonatomic) NSNumber * _Nonnull logId;
+@property (strong, nonatomic) NSNumber * _Nonnull logLength;
+@property (strong, nonatomic) NSArray * _Nonnull logPayload;
 @end
 
 @interface CHIPApplianceStatisticsClusterLogRequestPayload : NSObject
-@property (strong) NSNumber * _Nonnull LogId;
+@property (strong, nonatomic) NSNumber * _Nonnull logId;
 @end
 
 @interface CHIPApplianceStatisticsClusterLogResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull TimeStamp;
-@property (strong) NSNumber * _Nonnull LogId;
-@property (strong) NSNumber * _Nonnull LogLength;
-@property (strong) NSArray * _Nonnull LogPayload;
+@property (strong, nonatomic) NSNumber * _Nonnull timeStamp;
+@property (strong, nonatomic) NSNumber * _Nonnull logId;
+@property (strong, nonatomic) NSNumber * _Nonnull logLength;
+@property (strong, nonatomic) NSArray * _Nonnull logPayload;
 @end
 
 @interface CHIPApplianceStatisticsClusterLogQueueRequestPayload : NSObject
 @end
 
 @interface CHIPApplianceStatisticsClusterLogQueueResponsePayload : NSObject
-@property (strong) NSNumber * _Nonnull LogQueueSize;
-@property (strong) NSArray * _Nonnull LogIds;
+@property (strong, nonatomic) NSNumber * _Nonnull logQueueSize;
+@property (strong, nonatomic) NSArray * _Nonnull logIds;
 @end
 
 @interface CHIPApplianceStatisticsClusterStatisticsAvailablePayload : NSObject
-@property (strong) NSNumber * _Nonnull LogQueueSize;
-@property (strong) NSArray * _Nonnull LogIds;
+@property (strong, nonatomic) NSNumber * _Nonnull logQueueSize;
+@property (strong, nonatomic) NSArray * _Nonnull logIds;
 @end
 
 @interface CHIPElectricalMeasurementClusterGetProfileInfoResponseCommandPayload : NSObject
-@property (strong) NSNumber * _Nonnull ProfileCount;
-@property (strong) NSNumber * _Nonnull ProfileIntervalPeriod;
-@property (strong) NSNumber * _Nonnull MaxNumberOfIntervals;
-@property (strong) NSArray * _Nonnull ListOfAttributes;
+@property (strong, nonatomic) NSNumber * _Nonnull profileCount;
+@property (strong, nonatomic) NSNumber * _Nonnull profileIntervalPeriod;
+@property (strong, nonatomic) NSNumber * _Nonnull maxNumberOfIntervals;
+@property (strong, nonatomic) NSArray * _Nonnull listOfAttributes;
 @end
 
 @interface CHIPElectricalMeasurementClusterGetProfileInfoCommandPayload : NSObject
 @end
 
 @interface CHIPElectricalMeasurementClusterGetMeasurementProfileResponseCommandPayload : NSObject
-@property (strong) NSNumber * _Nonnull StartTime;
-@property (strong) NSNumber * _Nonnull Status;
-@property (strong) NSNumber * _Nonnull ProfileIntervalPeriod;
-@property (strong) NSNumber * _Nonnull NumberOfIntervalsDelivered;
-@property (strong) NSNumber * _Nonnull AttributeId;
-@property (strong) NSArray * _Nonnull Intervals;
+@property (strong, nonatomic) NSNumber * _Nonnull startTime;
+@property (strong, nonatomic) NSNumber * _Nonnull status;
+@property (strong, nonatomic) NSNumber * _Nonnull profileIntervalPeriod;
+@property (strong, nonatomic) NSNumber * _Nonnull numberOfIntervalsDelivered;
+@property (strong, nonatomic) NSNumber * _Nonnull attributeId;
+@property (strong, nonatomic) NSArray * _Nonnull intervals;
 @end
 
 @interface CHIPElectricalMeasurementClusterGetMeasurementProfileCommandPayload : NSObject
-@property (strong) NSNumber * _Nonnull AttributeId;
-@property (strong) NSNumber * _Nonnull StartTime;
-@property (strong) NSNumber * _Nonnull NumberOfIntervals;
+@property (strong, nonatomic) NSNumber * _Nonnull attributeId;
+@property (strong, nonatomic) NSNumber * _Nonnull startTime;
+@property (strong, nonatomic) NSNumber * _Nonnull numberOfIntervals;
 @end
 
 @interface CHIPBindingClusterBindPayload : NSObject
-@property (strong) NSNumber * _Nonnull NodeId;
-@property (strong) NSNumber * _Nonnull GroupId;
-@property (strong) NSNumber * _Nonnull EndpointId;
-@property (strong) NSNumber * _Nonnull ClusterId;
+@property (strong, nonatomic) NSNumber * _Nonnull nodeId;
+@property (strong, nonatomic) NSNumber * _Nonnull groupId;
+@property (strong, nonatomic) NSNumber * _Nonnull endpointId;
+@property (strong, nonatomic) NSNumber * _Nonnull clusterId;
 @end
 
 @interface CHIPBindingClusterUnbindPayload : NSObject
-@property (strong) NSNumber * _Nonnull NodeId;
-@property (strong) NSNumber * _Nonnull GroupId;
-@property (strong) NSNumber * _Nonnull EndpointId;
-@property (strong) NSNumber * _Nonnull ClusterId;
+@property (strong, nonatomic) NSNumber * _Nonnull nodeId;
+@property (strong, nonatomic) NSNumber * _Nonnull groupId;
+@property (strong, nonatomic) NSNumber * _Nonnull endpointId;
+@property (strong, nonatomic) NSNumber * _Nonnull clusterId;
 @end
 
 @interface CHIPSampleMfgSpecificClusterClusterCommandOnePayload : NSObject
-@property (strong) NSNumber * _Nonnull ArgOne;
+@property (strong, nonatomic) NSNumber * _Nonnull argOne;
 @end
 
 @interface CHIPSampleMfgSpecificCluster2ClusterCommandTwoPayload : NSObject
-@property (strong) NSNumber * _Nonnull ArgOne;
+@property (strong, nonatomic) NSNumber * _Nonnull argOne;
 @end
 
 #endif /* CHIP_COMMAND_PAYLOADS_H */

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPStructsObjc.h
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPStructsObjc.h
@@ -23,313 +23,313 @@
 #import <Foundation/Foundation.h>
 
 @interface CHIPScenesClusterSceneExtensionFieldSet : NSObject
-@property (strong) NSNumber * _Nonnull ClusterId;
-@property (strong) NSNumber * _Nonnull Length;
-@property (strong) NSNumber * _Nonnull Value;
+@property (strong, nonatomic) NSNumber * _Nonnull clusterId;
+@property (strong, nonatomic) NSNumber * _Nonnull length;
+@property (strong, nonatomic) NSNumber * _Nonnull value;
 @end
 
 @interface CHIPPowerProfileClusterPowerProfileRecord : NSObject
-@property (strong) NSNumber * _Nonnull PowerProfileId;
-@property (strong) NSNumber * _Nonnull EnergyPhaseId;
-@property (strong) NSNumber * _Nonnull PowerProfileRemoteControl;
-@property (strong) NSNumber * _Nonnull PowerProfileState;
+@property (strong, nonatomic) NSNumber * _Nonnull powerProfileId;
+@property (strong, nonatomic) NSNumber * _Nonnull energyPhaseId;
+@property (strong, nonatomic) NSNumber * _Nonnull powerProfileRemoteControl;
+@property (strong, nonatomic) NSNumber * _Nonnull powerProfileState;
 @end
 
 @interface CHIPPowerProfileClusterScheduledPhase : NSObject
-@property (strong) NSNumber * _Nonnull EnergyPhaseId;
-@property (strong) NSNumber * _Nonnull ScheduledTime;
+@property (strong, nonatomic) NSNumber * _Nonnull energyPhaseId;
+@property (strong, nonatomic) NSNumber * _Nonnull scheduledTime;
 @end
 
 @interface CHIPPowerProfileClusterTransferredPhase : NSObject
-@property (strong) NSNumber * _Nonnull EnergyPhaseId;
-@property (strong) NSNumber * _Nonnull MacroPhaseId;
-@property (strong) NSNumber * _Nonnull ExpectedDuration;
-@property (strong) NSNumber * _Nonnull PeakPower;
-@property (strong) NSNumber * _Nonnull Energy;
-@property (strong) NSNumber * _Nonnull MaxActivationDelay;
+@property (strong, nonatomic) NSNumber * _Nonnull energyPhaseId;
+@property (strong, nonatomic) NSNumber * _Nonnull macroPhaseId;
+@property (strong, nonatomic) NSNumber * _Nonnull expectedDuration;
+@property (strong, nonatomic) NSNumber * _Nonnull peakPower;
+@property (strong, nonatomic) NSNumber * _Nonnull energy;
+@property (strong, nonatomic) NSNumber * _Nonnull maxActivationDelay;
 @end
 
 @interface CHIPDescriptorClusterDeviceType : NSObject
-@property (strong) NSNumber * _Nonnull Type;
-@property (strong) NSNumber * _Nonnull Revision;
+@property (strong, nonatomic) NSNumber * _Nonnull type;
+@property (strong, nonatomic) NSNumber * _Nonnull revision;
 @end
 
 @interface CHIPBridgedActionsClusterActionStruct : NSObject
-@property (strong) NSNumber * _Nonnull ActionID;
-@property (strong) NSString * _Nonnull Name;
-@property (strong) NSNumber * _Nonnull Type;
-@property (strong) NSNumber * _Nonnull EndpointListID;
-@property (strong) NSNumber * _Nonnull SupportedCommands;
-@property (strong) NSNumber * _Nonnull Status;
+@property (strong, nonatomic) NSNumber * _Nonnull actionID;
+@property (strong, nonatomic) NSString * _Nonnull name;
+@property (strong, nonatomic) NSNumber * _Nonnull type;
+@property (strong, nonatomic) NSNumber * _Nonnull endpointListID;
+@property (strong, nonatomic) NSNumber * _Nonnull supportedCommands;
+@property (strong, nonatomic) NSNumber * _Nonnull status;
 @end
 
 @interface CHIPBridgedActionsClusterEndpointListStruct : NSObject
-@property (strong) NSNumber * _Nonnull EndpointListID;
-@property (strong) NSString * _Nonnull Name;
-@property (strong) NSNumber * _Nonnull Type;
-@property (strong) NSData * _Nonnull Endpoints;
+@property (strong, nonatomic) NSNumber * _Nonnull endpointListID;
+@property (strong, nonatomic) NSString * _Nonnull name;
+@property (strong, nonatomic) NSNumber * _Nonnull type;
+@property (strong, nonatomic) NSData * _Nonnull endpoints;
 @end
 
 @interface CHIPGeneralCommissioningClusterBasicCommissioningInfoType : NSObject
-@property (strong) NSNumber * _Nonnull FailSafeExpiryLengthMs;
+@property (strong, nonatomic) NSNumber * _Nonnull failSafeExpiryLengthMs;
 @end
 
 @interface CHIPNetworkCommissioningClusterThreadInterfaceScanResult : NSObject
-@property (strong) NSData * _Nonnull DiscoveryResponse;
+@property (strong, nonatomic) NSData * _Nonnull discoveryResponse;
 @end
 
 @interface CHIPNetworkCommissioningClusterWiFiInterfaceScanResult : NSObject
-@property (strong) NSNumber * _Nonnull Security;
-@property (strong) NSData * _Nonnull Ssid;
-@property (strong) NSData * _Nonnull Bssid;
-@property (strong) NSNumber * _Nonnull Channel;
-@property (strong) NSNumber * _Nonnull FrequencyBand;
+@property (strong, nonatomic) NSNumber * _Nonnull security;
+@property (strong, nonatomic) NSData * _Nonnull ssid;
+@property (strong, nonatomic) NSData * _Nonnull bssid;
+@property (strong, nonatomic) NSNumber * _Nonnull channel;
+@property (strong, nonatomic) NSNumber * _Nonnull frequencyBand;
 @end
 
 @interface CHIPGeneralDiagnosticsClusterNetworkInterfaceType : NSObject
-@property (strong) NSString * _Nonnull Name;
-@property (strong) NSNumber * _Nonnull FabricConnected;
-@property (strong) NSNumber * _Nonnull OffPremiseServicesReachableIPv4;
-@property (strong) NSNumber * _Nonnull OffPremiseServicesReachableIPv6;
-@property (strong) NSData * _Nonnull HardwareAddress;
-@property (strong) NSNumber * _Nonnull Type;
+@property (strong, nonatomic) NSString * _Nonnull name;
+@property (strong, nonatomic) NSNumber * _Nonnull fabricConnected;
+@property (strong, nonatomic) NSNumber * _Nonnull offPremiseServicesReachableIPv4;
+@property (strong, nonatomic) NSNumber * _Nonnull offPremiseServicesReachableIPv6;
+@property (strong, nonatomic) NSData * _Nonnull hardwareAddress;
+@property (strong, nonatomic) NSNumber * _Nonnull type;
 @end
 
 @interface CHIPSoftwareDiagnosticsClusterSoftwareFault : NSObject
-@property (strong) NSNumber * _Nonnull Id;
-@property (strong) NSString * _Nonnull Name;
-@property (strong) NSData * _Nonnull FaultRecording;
+@property (strong, nonatomic) NSNumber * _Nonnull id;
+@property (strong, nonatomic) NSString * _Nonnull name;
+@property (strong, nonatomic) NSData * _Nonnull faultRecording;
 @end
 
 @interface CHIPSoftwareDiagnosticsClusterThreadMetrics : NSObject
-@property (strong) NSNumber * _Nonnull Id;
-@property (strong) NSString * _Nonnull Name;
-@property (strong) NSNumber * _Nonnull StackFreeCurrent;
-@property (strong) NSNumber * _Nonnull StackFreeMinimum;
-@property (strong) NSNumber * _Nonnull StackSize;
+@property (strong, nonatomic) NSNumber * _Nonnull id;
+@property (strong, nonatomic) NSString * _Nonnull name;
+@property (strong, nonatomic) NSNumber * _Nonnull stackFreeCurrent;
+@property (strong, nonatomic) NSNumber * _Nonnull stackFreeMinimum;
+@property (strong, nonatomic) NSNumber * _Nonnull stackSize;
 @end
 
 @interface CHIPThreadNetworkDiagnosticsClusterNeighborTable : NSObject
-@property (strong) NSNumber * _Nonnull ExtAddress;
-@property (strong) NSNumber * _Nonnull Age;
-@property (strong) NSNumber * _Nonnull Rloc16;
-@property (strong) NSNumber * _Nonnull LinkFrameCounter;
-@property (strong) NSNumber * _Nonnull MleFrameCounter;
-@property (strong) NSNumber * _Nonnull Lqi;
-@property (strong) NSNumber * _Nonnull AverageRssi;
-@property (strong) NSNumber * _Nonnull LastRssi;
-@property (strong) NSNumber * _Nonnull FrameErrorRate;
-@property (strong) NSNumber * _Nonnull MessageErrorRate;
-@property (strong) NSNumber * _Nonnull RxOnWhenIdle;
-@property (strong) NSNumber * _Nonnull FullThreadDevice;
-@property (strong) NSNumber * _Nonnull FullNetworkData;
-@property (strong) NSNumber * _Nonnull IsChild;
+@property (strong, nonatomic) NSNumber * _Nonnull extAddress;
+@property (strong, nonatomic) NSNumber * _Nonnull age;
+@property (strong, nonatomic) NSNumber * _Nonnull rloc16;
+@property (strong, nonatomic) NSNumber * _Nonnull linkFrameCounter;
+@property (strong, nonatomic) NSNumber * _Nonnull mleFrameCounter;
+@property (strong, nonatomic) NSNumber * _Nonnull lqi;
+@property (strong, nonatomic) NSNumber * _Nonnull averageRssi;
+@property (strong, nonatomic) NSNumber * _Nonnull lastRssi;
+@property (strong, nonatomic) NSNumber * _Nonnull frameErrorRate;
+@property (strong, nonatomic) NSNumber * _Nonnull messageErrorRate;
+@property (strong, nonatomic) NSNumber * _Nonnull rxOnWhenIdle;
+@property (strong, nonatomic) NSNumber * _Nonnull fullThreadDevice;
+@property (strong, nonatomic) NSNumber * _Nonnull fullNetworkData;
+@property (strong, nonatomic) NSNumber * _Nonnull isChild;
 @end
 
 @interface CHIPThreadNetworkDiagnosticsClusterOperationalDatasetComponents : NSObject
-@property (strong) NSNumber * _Nonnull ActiveTimestampPresent;
-@property (strong) NSNumber * _Nonnull PendingTimestampPresent;
-@property (strong) NSNumber * _Nonnull MasterKeyPresent;
-@property (strong) NSNumber * _Nonnull NetworkNamePresent;
-@property (strong) NSNumber * _Nonnull ExtendedPanIdPresent;
-@property (strong) NSNumber * _Nonnull MeshLocalPrefixPresent;
-@property (strong) NSNumber * _Nonnull DelayPresent;
-@property (strong) NSNumber * _Nonnull PanIdPresent;
-@property (strong) NSNumber * _Nonnull ChannelPresent;
-@property (strong) NSNumber * _Nonnull PskcPresent;
-@property (strong) NSNumber * _Nonnull SecurityPolicyPresent;
-@property (strong) NSNumber * _Nonnull ChannelMaskPresent;
+@property (strong, nonatomic) NSNumber * _Nonnull activeTimestampPresent;
+@property (strong, nonatomic) NSNumber * _Nonnull pendingTimestampPresent;
+@property (strong, nonatomic) NSNumber * _Nonnull masterKeyPresent;
+@property (strong, nonatomic) NSNumber * _Nonnull networkNamePresent;
+@property (strong, nonatomic) NSNumber * _Nonnull extendedPanIdPresent;
+@property (strong, nonatomic) NSNumber * _Nonnull meshLocalPrefixPresent;
+@property (strong, nonatomic) NSNumber * _Nonnull delayPresent;
+@property (strong, nonatomic) NSNumber * _Nonnull panIdPresent;
+@property (strong, nonatomic) NSNumber * _Nonnull channelPresent;
+@property (strong, nonatomic) NSNumber * _Nonnull pskcPresent;
+@property (strong, nonatomic) NSNumber * _Nonnull securityPolicyPresent;
+@property (strong, nonatomic) NSNumber * _Nonnull channelMaskPresent;
 @end
 
 @interface CHIPThreadNetworkDiagnosticsClusterRouteTable : NSObject
-@property (strong) NSNumber * _Nonnull ExtAddress;
-@property (strong) NSNumber * _Nonnull Rloc16;
-@property (strong) NSNumber * _Nonnull RouterId;
-@property (strong) NSNumber * _Nonnull NextHop;
-@property (strong) NSNumber * _Nonnull PathCost;
-@property (strong) NSNumber * _Nonnull LQIIn;
-@property (strong) NSNumber * _Nonnull LQIOut;
-@property (strong) NSNumber * _Nonnull Age;
-@property (strong) NSNumber * _Nonnull Allocated;
-@property (strong) NSNumber * _Nonnull LinkEstablished;
+@property (strong, nonatomic) NSNumber * _Nonnull extAddress;
+@property (strong, nonatomic) NSNumber * _Nonnull rloc16;
+@property (strong, nonatomic) NSNumber * _Nonnull routerId;
+@property (strong, nonatomic) NSNumber * _Nonnull nextHop;
+@property (strong, nonatomic) NSNumber * _Nonnull pathCost;
+@property (strong, nonatomic) NSNumber * _Nonnull lqiIn;
+@property (strong, nonatomic) NSNumber * _Nonnull lqiOut;
+@property (strong, nonatomic) NSNumber * _Nonnull age;
+@property (strong, nonatomic) NSNumber * _Nonnull allocated;
+@property (strong, nonatomic) NSNumber * _Nonnull linkEstablished;
 @end
 
 @interface CHIPThreadNetworkDiagnosticsClusterSecurityPolicy : NSObject
-@property (strong) NSNumber * _Nonnull RotationTime;
-@property (strong) NSNumber * _Nonnull Flags;
+@property (strong, nonatomic) NSNumber * _Nonnull rotationTime;
+@property (strong, nonatomic) NSNumber * _Nonnull flags;
 @end
 
 @interface CHIPOperationalCredentialsClusterFabricDescriptor : NSObject
-@property (strong) NSNumber * _Nonnull FabricIndex;
-@property (strong) NSData * _Nonnull RootPublicKey;
-@property (strong) NSNumber * _Nonnull VendorId;
-@property (strong) NSNumber * _Nonnull FabricId;
-@property (strong) NSNumber * _Nonnull NodeId;
-@property (strong) NSString * _Nonnull Label;
+@property (strong, nonatomic) NSNumber * _Nonnull fabricIndex;
+@property (strong, nonatomic) NSData * _Nonnull rootPublicKey;
+@property (strong, nonatomic) NSNumber * _Nonnull vendorId;
+@property (strong, nonatomic) NSNumber * _Nonnull fabricId;
+@property (strong, nonatomic) NSNumber * _Nonnull nodeId;
+@property (strong, nonatomic) NSString * _Nonnull label;
 @end
 
 @interface CHIPOperationalCredentialsClusterNOCStruct : NSObject
-@property (strong) NSNumber * _Nonnull FabricIndex;
-@property (strong) NSData * _Nonnull Noc;
+@property (strong, nonatomic) NSNumber * _Nonnull fabricIndex;
+@property (strong, nonatomic) NSData * _Nonnull noc;
 @end
 
 @interface CHIPFixedLabelClusterLabelStruct : NSObject
-@property (strong) NSString * _Nonnull Label;
-@property (strong) NSString * _Nonnull Value;
+@property (strong, nonatomic) NSString * _Nonnull label;
+@property (strong, nonatomic) NSString * _Nonnull value;
 @end
 
 @interface CHIPModeSelectClusterModeOptionStruct : NSObject
-@property (strong) NSString * _Nonnull Label;
-@property (strong) NSNumber * _Nonnull Mode;
-@property (strong) NSNumber * _Nonnull SemanticTag;
+@property (strong, nonatomic) NSString * _Nonnull label;
+@property (strong, nonatomic) NSNumber * _Nonnull mode;
+@property (strong, nonatomic) NSNumber * _Nonnull semanticTag;
 @end
 
 @interface CHIPModeSelectClusterSemanticTag : NSObject
-@property (strong) NSNumber * _Nonnull MfgCode;
-@property (strong) NSNumber * _Nonnull Value;
+@property (strong, nonatomic) NSNumber * _Nonnull mfgCode;
+@property (strong, nonatomic) NSNumber * _Nonnull value;
 @end
 
 @interface CHIPIasAceClusterIasAceZoneStatusResult : NSObject
-@property (strong) NSNumber * _Nonnull ZoneId;
-@property (strong) NSNumber * _Nonnull ZoneStatus;
+@property (strong, nonatomic) NSNumber * _Nonnull zoneId;
+@property (strong, nonatomic) NSNumber * _Nonnull zoneStatus;
 @end
 
 @interface CHIPTvChannelClusterTvChannelInfo : NSObject
-@property (strong) NSNumber * _Nonnull MajorNumber;
-@property (strong) NSNumber * _Nonnull MinorNumber;
-@property (strong) NSString * _Nonnull Name;
-@property (strong) NSString * _Nonnull CallSign;
-@property (strong) NSString * _Nonnull AffiliateCallSign;
+@property (strong, nonatomic) NSNumber * _Nonnull majorNumber;
+@property (strong, nonatomic) NSNumber * _Nonnull minorNumber;
+@property (strong, nonatomic) NSString * _Nonnull name;
+@property (strong, nonatomic) NSString * _Nonnull callSign;
+@property (strong, nonatomic) NSString * _Nonnull affiliateCallSign;
 @end
 
 @interface CHIPTvChannelClusterTvChannelLineupInfo : NSObject
-@property (strong) NSString * _Nonnull OperatorName;
-@property (strong) NSString * _Nonnull LineupName;
-@property (strong) NSString * _Nonnull PostalCode;
-@property (strong) NSNumber * _Nonnull LineupInfoType;
+@property (strong, nonatomic) NSString * _Nonnull operatorName;
+@property (strong, nonatomic) NSString * _Nonnull lineupName;
+@property (strong, nonatomic) NSString * _Nonnull postalCode;
+@property (strong, nonatomic) NSNumber * _Nonnull lineupInfoType;
 @end
 
 @interface CHIPTargetNavigatorClusterNavigateTargetTargetInfo : NSObject
-@property (strong) NSNumber * _Nonnull Identifier;
-@property (strong) NSString * _Nonnull Name;
+@property (strong, nonatomic) NSNumber * _Nonnull identifier;
+@property (strong, nonatomic) NSString * _Nonnull name;
 @end
 
 @interface CHIPMediaPlaybackClusterMediaPlaybackPosition : NSObject
-@property (strong) NSNumber * _Nonnull UpdatedAt;
-@property (strong) NSNumber * _Nonnull Position;
+@property (strong, nonatomic) NSNumber * _Nonnull updatedAt;
+@property (strong, nonatomic) NSNumber * _Nonnull position;
 @end
 
 @interface CHIPMediaInputClusterMediaInputInfo : NSObject
-@property (strong) NSNumber * _Nonnull Index;
-@property (strong) NSNumber * _Nonnull InputType;
-@property (strong) NSString * _Nonnull Name;
-@property (strong) NSString * _Nonnull Description;
+@property (strong, nonatomic) NSNumber * _Nonnull index;
+@property (strong, nonatomic) NSNumber * _Nonnull inputType;
+@property (strong, nonatomic) NSString * _Nonnull name;
+@property (strong, nonatomic) NSString * _Nonnull descriptionString;
 @end
 
 @interface CHIPContentLauncherClusterContentLaunchAdditionalInfo : NSObject
-@property (strong) NSString * _Nonnull Name;
-@property (strong) NSString * _Nonnull Value;
+@property (strong, nonatomic) NSString * _Nonnull name;
+@property (strong, nonatomic) NSString * _Nonnull value;
 @end
 
 @interface CHIPContentLauncherClusterContentLaunchParamater : NSObject
-@property (strong) NSNumber * _Nonnull Type;
-@property (strong) NSString * _Nonnull Value;
-@property (strong) NSArray * _Nonnull ExternalIDList;
+@property (strong, nonatomic) NSNumber * _Nonnull type;
+@property (strong, nonatomic) NSString * _Nonnull value;
+@property (strong, nonatomic) NSArray * _Nonnull externalIDList;
 @end
 
 @interface CHIPContentLauncherClusterContentLaunchBrandingInformation : NSObject
-@property (strong) NSString * _Nonnull ProviderName;
-@property (strong) NSNumber * _Nonnull Background;
-@property (strong) NSNumber * _Nonnull Logo;
-@property (strong) NSNumber * _Nonnull ProgressBar;
-@property (strong) NSNumber * _Nonnull Splash;
-@property (strong) NSNumber * _Nonnull WaterMark;
+@property (strong, nonatomic) NSString * _Nonnull providerName;
+@property (strong, nonatomic) NSNumber * _Nonnull background;
+@property (strong, nonatomic) NSNumber * _Nonnull logo;
+@property (strong, nonatomic) NSNumber * _Nonnull progressBar;
+@property (strong, nonatomic) NSNumber * _Nonnull splash;
+@property (strong, nonatomic) NSNumber * _Nonnull waterMark;
 @end
 
 @interface CHIPContentLauncherClusterContentLaunchDimension : NSObject
-@property (strong) NSString * _Nonnull Width;
-@property (strong) NSString * _Nonnull Height;
-@property (strong) NSNumber * _Nonnull Metric;
+@property (strong, nonatomic) NSString * _Nonnull width;
+@property (strong, nonatomic) NSString * _Nonnull height;
+@property (strong, nonatomic) NSNumber * _Nonnull metric;
 @end
 
 @interface CHIPContentLauncherClusterContentLaunchStyleInformation : NSObject
-@property (strong) NSString * _Nonnull ImageUrl;
-@property (strong) NSString * _Nonnull Color;
-@property (strong) NSNumber * _Nonnull Size;
+@property (strong, nonatomic) NSString * _Nonnull imageUrl;
+@property (strong, nonatomic) NSString * _Nonnull color;
+@property (strong, nonatomic) NSNumber * _Nonnull size;
 @end
 
 @interface CHIPAudioOutputClusterAudioOutputInfo : NSObject
-@property (strong) NSNumber * _Nonnull Index;
-@property (strong) NSNumber * _Nonnull OutputType;
-@property (strong) NSString * _Nonnull Name;
+@property (strong, nonatomic) NSNumber * _Nonnull index;
+@property (strong, nonatomic) NSNumber * _Nonnull outputType;
+@property (strong, nonatomic) NSString * _Nonnull name;
 @end
 
 @interface CHIPApplicationLauncherClusterApplicationLauncherApp : NSObject
-@property (strong) NSNumber * _Nonnull CatalogVendorId;
-@property (strong) NSString * _Nonnull ApplicationId;
+@property (strong, nonatomic) NSNumber * _Nonnull catalogVendorId;
+@property (strong, nonatomic) NSString * _Nonnull applicationId;
 @end
 
 @interface CHIPTestClusterClusterSimpleStruct : NSObject
-@property (strong) NSNumber * _Nonnull A;
-@property (strong) NSNumber * _Nonnull B;
-@property (strong) NSNumber * _Nonnull C;
-@property (strong) NSData * _Nonnull D;
-@property (strong) NSString * _Nonnull E;
-@property (strong) NSNumber * _Nonnull F;
+@property (strong, nonatomic) NSNumber * _Nonnull a;
+@property (strong, nonatomic) NSNumber * _Nonnull b;
+@property (strong, nonatomic) NSNumber * _Nonnull c;
+@property (strong, nonatomic) NSData * _Nonnull d;
+@property (strong, nonatomic) NSString * _Nonnull e;
+@property (strong, nonatomic) NSNumber * _Nonnull f;
 @end
 
 @interface CHIPTestClusterClusterNullablesAndOptionalsStruct : NSObject
-@property (strong) NSNumber * _Nullable NullableInt;
-@property (strong) NSNumber * _Nullable OptionalInt;
-@property (strong) NSNumber * _Nullable NullableOptionalInt;
-@property (strong) NSString * _Nullable NullableString;
-@property (strong) NSString * _Nullable OptionalString;
-@property (strong) NSString * _Nullable NullableOptionalString;
-@property (strong) CHIPTestClusterClusterSimpleStruct * _Nullable NullableStruct;
-@property (strong) CHIPTestClusterClusterSimpleStruct * _Nullable OptionalStruct;
-@property (strong) CHIPTestClusterClusterSimpleStruct * _Nullable NullableOptionalStruct;
-@property (strong) NSArray * _Nullable NullableList;
-@property (strong) NSArray * _Nullable OptionalList;
-@property (strong) NSArray * _Nullable NullableOptionalList;
+@property (strong, nonatomic) NSNumber * _Nullable nullableInt;
+@property (strong, nonatomic) NSNumber * _Nullable optionalInt;
+@property (strong, nonatomic) NSNumber * _Nullable nullableOptionalInt;
+@property (strong, nonatomic) NSString * _Nullable nullableString;
+@property (strong, nonatomic) NSString * _Nullable optionalString;
+@property (strong, nonatomic) NSString * _Nullable nullableOptionalString;
+@property (strong, nonatomic) CHIPTestClusterClusterSimpleStruct * _Nullable nullableStruct;
+@property (strong, nonatomic) CHIPTestClusterClusterSimpleStruct * _Nullable optionalStruct;
+@property (strong, nonatomic) CHIPTestClusterClusterSimpleStruct * _Nullable nullableOptionalStruct;
+@property (strong, nonatomic) NSArray * _Nullable nullableList;
+@property (strong, nonatomic) NSArray * _Nullable optionalList;
+@property (strong, nonatomic) NSArray * _Nullable nullableOptionalList;
 @end
 
 @interface CHIPTestClusterClusterNestedStruct : NSObject
-@property (strong) NSNumber * _Nonnull A;
-@property (strong) NSNumber * _Nonnull B;
-@property (strong) CHIPTestClusterClusterSimpleStruct * _Nonnull C;
+@property (strong, nonatomic) NSNumber * _Nonnull a;
+@property (strong, nonatomic) NSNumber * _Nonnull b;
+@property (strong, nonatomic) CHIPTestClusterClusterSimpleStruct * _Nonnull c;
 @end
 
 @interface CHIPTestClusterClusterNestedStructList : NSObject
-@property (strong) NSNumber * _Nonnull A;
-@property (strong) NSNumber * _Nonnull B;
-@property (strong) CHIPTestClusterClusterSimpleStruct * _Nonnull C;
-@property (strong) NSArray * _Nonnull D;
-@property (strong) NSArray * _Nonnull E;
-@property (strong) NSArray * _Nonnull F;
-@property (strong) NSArray * _Nonnull G;
+@property (strong, nonatomic) NSNumber * _Nonnull a;
+@property (strong, nonatomic) NSNumber * _Nonnull b;
+@property (strong, nonatomic) CHIPTestClusterClusterSimpleStruct * _Nonnull c;
+@property (strong, nonatomic) NSArray * _Nonnull d;
+@property (strong, nonatomic) NSArray * _Nonnull e;
+@property (strong, nonatomic) NSArray * _Nonnull f;
+@property (strong, nonatomic) NSArray * _Nonnull g;
 @end
 
 @interface CHIPTestClusterClusterDoubleNestedStructList : NSObject
-@property (strong) NSArray * _Nonnull A;
+@property (strong, nonatomic) NSArray * _Nonnull a;
 @end
 
 @interface CHIPTestClusterClusterTestListStructOctet : NSObject
-@property (strong) NSNumber * _Nonnull FabricIndex;
-@property (strong) NSData * _Nonnull OperationalCert;
+@property (strong, nonatomic) NSNumber * _Nonnull fabricIndex;
+@property (strong, nonatomic) NSData * _Nonnull operationalCert;
 @end
 
 @interface CHIPGroupKeyManagementClusterGroupKey : NSObject
-@property (strong) NSNumber * _Nonnull VendorId;
-@property (strong) NSNumber * _Nonnull GroupKeyIndex;
-@property (strong) NSData * _Nonnull GroupKeyRoot;
-@property (strong) NSNumber * _Nonnull GroupKeyEpochStartTime;
-@property (strong) NSNumber * _Nonnull GroupKeySecurityPolicy;
+@property (strong, nonatomic) NSNumber * _Nonnull vendorId;
+@property (strong, nonatomic) NSNumber * _Nonnull groupKeyIndex;
+@property (strong, nonatomic) NSData * _Nonnull groupKeyRoot;
+@property (strong, nonatomic) NSNumber * _Nonnull groupKeyEpochStartTime;
+@property (strong, nonatomic) NSNumber * _Nonnull groupKeySecurityPolicy;
 @end
 
 @interface CHIPGroupKeyManagementClusterGroupState : NSObject
-@property (strong) NSNumber * _Nonnull VendorId;
-@property (strong) NSNumber * _Nonnull VendorGroupId;
-@property (strong) NSNumber * _Nonnull GroupKeySetIndex;
+@property (strong, nonatomic) NSNumber * _Nonnull vendorId;
+@property (strong, nonatomic) NSNumber * _Nonnull vendorGroupId;
+@property (strong, nonatomic) NSNumber * _Nonnull groupKeySetIndex;
 @end
 
 #endif /* CHIP_STRUCTS_H */

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPTestClustersObjc.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPTestClustersObjc.mm
@@ -320,11 +320,11 @@ using namespace chip::app::Clusters;
                         return CHIP_ERROR_INVALID_ARGUMENT;
                     }
                     auto element_0 = (CHIPAudioOutputClusterAudioOutputInfo *) value[i];
-                    listHolder_0->mList[i].index = element_0.Index.unsignedCharValue;
+                    listHolder_0->mList[i].index = element_0.index.unsignedCharValue;
                     listHolder_0->mList[i].outputType
                         = static_cast<std::remove_reference_t<decltype(listHolder_0->mList[i].outputType)>>(
-                            element_0.OutputType.unsignedCharValue);
-                    listHolder_0->mList[i].name = [self asCharSpan:element_0.Name];
+                            element_0.outputType.unsignedCharValue);
+                    listHolder_0->mList[i].name = [self asCharSpan:element_0.name];
                 }
                 cppValue = ListType(listHolder_0->mList, value.count);
             } else {
@@ -800,14 +800,14 @@ using namespace chip::app::Clusters;
                         return CHIP_ERROR_INVALID_ARGUMENT;
                     }
                     auto element_0 = (CHIPBridgedActionsClusterActionStruct *) value[i];
-                    listHolder_0->mList[i].actionID = element_0.ActionID.unsignedShortValue;
-                    listHolder_0->mList[i].name = [self asCharSpan:element_0.Name];
+                    listHolder_0->mList[i].actionID = element_0.actionID.unsignedShortValue;
+                    listHolder_0->mList[i].name = [self asCharSpan:element_0.name];
                     listHolder_0->mList[i].type = static_cast<std::remove_reference_t<decltype(listHolder_0->mList[i].type)>>(
-                        element_0.Type.unsignedCharValue);
-                    listHolder_0->mList[i].endpointListID = element_0.EndpointListID.unsignedShortValue;
-                    listHolder_0->mList[i].supportedCommands = element_0.SupportedCommands.unsignedShortValue;
+                        element_0.type.unsignedCharValue);
+                    listHolder_0->mList[i].endpointListID = element_0.endpointListID.unsignedShortValue;
+                    listHolder_0->mList[i].supportedCommands = element_0.supportedCommands.unsignedShortValue;
                     listHolder_0->mList[i].status = static_cast<std::remove_reference_t<decltype(listHolder_0->mList[i].status)>>(
-                        element_0.Status.unsignedCharValue);
+                        element_0.status.unsignedCharValue);
                 }
                 cppValue = ListType(listHolder_0->mList, value.count);
             } else {
@@ -841,11 +841,11 @@ using namespace chip::app::Clusters;
                         return CHIP_ERROR_INVALID_ARGUMENT;
                     }
                     auto element_0 = (CHIPBridgedActionsClusterEndpointListStruct *) value[i];
-                    listHolder_0->mList[i].endpointListID = element_0.EndpointListID.unsignedShortValue;
-                    listHolder_0->mList[i].name = [self asCharSpan:element_0.Name];
+                    listHolder_0->mList[i].endpointListID = element_0.endpointListID.unsignedShortValue;
+                    listHolder_0->mList[i].name = [self asCharSpan:element_0.name];
                     listHolder_0->mList[i].type = static_cast<std::remove_reference_t<decltype(listHolder_0->mList[i].type)>>(
-                        element_0.Type.unsignedCharValue);
-                    listHolder_0->mList[i].endpoints = [self asByteSpan:element_0.Endpoints];
+                        element_0.type.unsignedCharValue);
+                    listHolder_0->mList[i].endpoints = [self asByteSpan:element_0.endpoints];
                 }
                 cppValue = ListType(listHolder_0->mList, value.count);
             } else {
@@ -1743,8 +1743,8 @@ using namespace chip::app::Clusters;
                         return CHIP_ERROR_INVALID_ARGUMENT;
                     }
                     auto element_0 = (CHIPDescriptorClusterDeviceType *) value[i];
-                    listHolder_0->mList[i].type = element_0.Type.unsignedIntValue;
-                    listHolder_0->mList[i].revision = element_0.Revision.unsignedShortValue;
+                    listHolder_0->mList[i].type = element_0.type.unsignedIntValue;
+                    listHolder_0->mList[i].revision = element_0.revision.unsignedShortValue;
                 }
                 cppValue = ListType(listHolder_0->mList, value.count);
             } else {
@@ -2296,8 +2296,8 @@ using namespace chip::app::Clusters;
                         return CHIP_ERROR_INVALID_ARGUMENT;
                     }
                     auto element_0 = (CHIPFixedLabelClusterLabelStruct *) value[i];
-                    listHolder_0->mList[i].label = [self asCharSpan:element_0.Label];
-                    listHolder_0->mList[i].value = [self asCharSpan:element_0.Value];
+                    listHolder_0->mList[i].label = [self asCharSpan:element_0.label];
+                    listHolder_0->mList[i].value = [self asCharSpan:element_0.value];
                 }
                 cppValue = ListType(listHolder_0->mList, value.count);
             } else {
@@ -2435,7 +2435,7 @@ using namespace chip::app::Clusters;
                         return CHIP_ERROR_INVALID_ARGUMENT;
                     }
                     auto element_0 = (CHIPGeneralCommissioningClusterBasicCommissioningInfoType *) value[i];
-                    listHolder_0->mList[i].failSafeExpiryLengthMs = element_0.FailSafeExpiryLengthMs.unsignedIntValue;
+                    listHolder_0->mList[i].failSafeExpiryLengthMs = element_0.failSafeExpiryLengthMs.unsignedIntValue;
                 }
                 cppValue = ListType(listHolder_0->mList, value.count);
             } else {
@@ -2495,13 +2495,13 @@ using namespace chip::app::Clusters;
                         return CHIP_ERROR_INVALID_ARGUMENT;
                     }
                     auto element_0 = (CHIPGeneralDiagnosticsClusterNetworkInterfaceType *) value[i];
-                    listHolder_0->mList[i].name = [self asCharSpan:element_0.Name];
-                    listHolder_0->mList[i].fabricConnected = element_0.FabricConnected.boolValue;
-                    listHolder_0->mList[i].offPremiseServicesReachableIPv4 = element_0.OffPremiseServicesReachableIPv4.boolValue;
-                    listHolder_0->mList[i].offPremiseServicesReachableIPv6 = element_0.OffPremiseServicesReachableIPv6.boolValue;
-                    listHolder_0->mList[i].hardwareAddress = [self asByteSpan:element_0.HardwareAddress];
+                    listHolder_0->mList[i].name = [self asCharSpan:element_0.name];
+                    listHolder_0->mList[i].fabricConnected = element_0.fabricConnected.boolValue;
+                    listHolder_0->mList[i].offPremiseServicesReachableIPv4 = element_0.offPremiseServicesReachableIPv4.boolValue;
+                    listHolder_0->mList[i].offPremiseServicesReachableIPv6 = element_0.offPremiseServicesReachableIPv6.boolValue;
+                    listHolder_0->mList[i].hardwareAddress = [self asByteSpan:element_0.hardwareAddress];
                     listHolder_0->mList[i].type = static_cast<std::remove_reference_t<decltype(listHolder_0->mList[i].type)>>(
-                        element_0.Type.unsignedCharValue);
+                        element_0.type.unsignedCharValue);
                 }
                 cppValue = ListType(listHolder_0->mList, value.count);
             } else {
@@ -2613,9 +2613,9 @@ using namespace chip::app::Clusters;
                         return CHIP_ERROR_INVALID_ARGUMENT;
                     }
                     auto element_0 = (CHIPGroupKeyManagementClusterGroupState *) value[i];
-                    listHolder_0->mList[i].vendorId = element_0.VendorId.unsignedShortValue;
-                    listHolder_0->mList[i].vendorGroupId = element_0.VendorGroupId.unsignedShortValue;
-                    listHolder_0->mList[i].groupKeySetIndex = element_0.GroupKeySetIndex.unsignedShortValue;
+                    listHolder_0->mList[i].vendorId = element_0.vendorId.unsignedShortValue;
+                    listHolder_0->mList[i].vendorGroupId = element_0.vendorGroupId.unsignedShortValue;
+                    listHolder_0->mList[i].groupKeySetIndex = element_0.groupKeySetIndex.unsignedShortValue;
                 }
                 cppValue = ListType(listHolder_0->mList, value.count);
             } else {
@@ -2649,13 +2649,13 @@ using namespace chip::app::Clusters;
                         return CHIP_ERROR_INVALID_ARGUMENT;
                     }
                     auto element_0 = (CHIPGroupKeyManagementClusterGroupKey *) value[i];
-                    listHolder_0->mList[i].vendorId = element_0.VendorId.unsignedShortValue;
-                    listHolder_0->mList[i].groupKeyIndex = element_0.GroupKeyIndex.unsignedShortValue;
-                    listHolder_0->mList[i].groupKeyRoot = [self asByteSpan:element_0.GroupKeyRoot];
-                    listHolder_0->mList[i].groupKeyEpochStartTime = element_0.GroupKeyEpochStartTime.unsignedLongLongValue;
+                    listHolder_0->mList[i].vendorId = element_0.vendorId.unsignedShortValue;
+                    listHolder_0->mList[i].groupKeyIndex = element_0.groupKeyIndex.unsignedShortValue;
+                    listHolder_0->mList[i].groupKeyRoot = [self asByteSpan:element_0.groupKeyRoot];
+                    listHolder_0->mList[i].groupKeyEpochStartTime = element_0.groupKeyEpochStartTime.unsignedLongLongValue;
                     listHolder_0->mList[i].groupKeySecurityPolicy
                         = static_cast<std::remove_reference_t<decltype(listHolder_0->mList[i].groupKeySecurityPolicy)>>(
-                            element_0.GroupKeySecurityPolicy.unsignedCharValue);
+                            element_0.groupKeySecurityPolicy.unsignedCharValue);
                 }
                 cppValue = ListType(listHolder_0->mList, value.count);
             } else {
@@ -3073,12 +3073,12 @@ using namespace chip::app::Clusters;
                         return CHIP_ERROR_INVALID_ARGUMENT;
                     }
                     auto element_0 = (CHIPMediaInputClusterMediaInputInfo *) value[i];
-                    listHolder_0->mList[i].index = element_0.Index.unsignedCharValue;
+                    listHolder_0->mList[i].index = element_0.index.unsignedCharValue;
                     listHolder_0->mList[i].inputType
                         = static_cast<std::remove_reference_t<decltype(listHolder_0->mList[i].inputType)>>(
-                            element_0.InputType.unsignedCharValue);
-                    listHolder_0->mList[i].name = [self asCharSpan:element_0.Name];
-                    listHolder_0->mList[i].description = [self asCharSpan:element_0.Description];
+                            element_0.inputType.unsignedCharValue);
+                    listHolder_0->mList[i].name = [self asCharSpan:element_0.name];
+                    listHolder_0->mList[i].description = [self asCharSpan:element_0.descriptionString];
                 }
                 cppValue = ListType(listHolder_0->mList, value.count);
             } else {
@@ -3294,9 +3294,9 @@ using namespace chip::app::Clusters;
                         return CHIP_ERROR_INVALID_ARGUMENT;
                     }
                     auto element_0 = (CHIPModeSelectClusterModeOptionStruct *) value[i];
-                    listHolder_0->mList[i].label = [self asCharSpan:element_0.Label];
-                    listHolder_0->mList[i].mode = element_0.Mode.unsignedCharValue;
-                    listHolder_0->mList[i].semanticTag = element_0.SemanticTag.unsignedIntValue;
+                    listHolder_0->mList[i].label = [self asCharSpan:element_0.label];
+                    listHolder_0->mList[i].mode = element_0.mode.unsignedCharValue;
+                    listHolder_0->mList[i].semanticTag = element_0.semanticTag.unsignedIntValue;
                 }
                 cppValue = ListType(listHolder_0->mList, value.count);
             } else {
@@ -3655,12 +3655,12 @@ using namespace chip::app::Clusters;
                         return CHIP_ERROR_INVALID_ARGUMENT;
                     }
                     auto element_0 = (CHIPOperationalCredentialsClusterFabricDescriptor *) value[i];
-                    listHolder_0->mList[i].fabricIndex = element_0.FabricIndex.unsignedCharValue;
-                    listHolder_0->mList[i].rootPublicKey = [self asByteSpan:element_0.RootPublicKey];
-                    listHolder_0->mList[i].vendorId = element_0.VendorId.unsignedShortValue;
-                    listHolder_0->mList[i].fabricId = element_0.FabricId.unsignedLongLongValue;
-                    listHolder_0->mList[i].nodeId = element_0.NodeId.unsignedLongLongValue;
-                    listHolder_0->mList[i].label = [self asCharSpan:element_0.Label];
+                    listHolder_0->mList[i].fabricIndex = element_0.fabricIndex.unsignedCharValue;
+                    listHolder_0->mList[i].rootPublicKey = [self asByteSpan:element_0.rootPublicKey];
+                    listHolder_0->mList[i].vendorId = element_0.vendorId.unsignedShortValue;
+                    listHolder_0->mList[i].fabricId = element_0.fabricId.unsignedLongLongValue;
+                    listHolder_0->mList[i].nodeId = element_0.nodeId.unsignedLongLongValue;
+                    listHolder_0->mList[i].label = [self asCharSpan:element_0.label];
                 }
                 cppValue = ListType(listHolder_0->mList, value.count);
             } else {
@@ -4503,11 +4503,11 @@ using namespace chip::app::Clusters;
                         return CHIP_ERROR_INVALID_ARGUMENT;
                     }
                     auto element_0 = (CHIPSoftwareDiagnosticsClusterThreadMetrics *) value[i];
-                    listHolder_0->mList[i].id = element_0.Id.unsignedLongLongValue;
-                    listHolder_0->mList[i].name = [self asCharSpan:element_0.Name];
-                    listHolder_0->mList[i].stackFreeCurrent = element_0.StackFreeCurrent.unsignedIntValue;
-                    listHolder_0->mList[i].stackFreeMinimum = element_0.StackFreeMinimum.unsignedIntValue;
-                    listHolder_0->mList[i].stackSize = element_0.StackSize.unsignedIntValue;
+                    listHolder_0->mList[i].id = element_0.id.unsignedLongLongValue;
+                    listHolder_0->mList[i].name = [self asCharSpan:element_0.name];
+                    listHolder_0->mList[i].stackFreeCurrent = element_0.stackFreeCurrent.unsignedIntValue;
+                    listHolder_0->mList[i].stackFreeMinimum = element_0.stackFreeMinimum.unsignedIntValue;
+                    listHolder_0->mList[i].stackSize = element_0.stackSize.unsignedIntValue;
                 }
                 cppValue = ListType(listHolder_0->mList, value.count);
             } else {
@@ -4684,11 +4684,11 @@ using namespace chip::app::Clusters;
                         return CHIP_ERROR_INVALID_ARGUMENT;
                     }
                     auto element_0 = (CHIPTvChannelClusterTvChannelInfo *) value[i];
-                    listHolder_0->mList[i].majorNumber = element_0.MajorNumber.unsignedShortValue;
-                    listHolder_0->mList[i].minorNumber = element_0.MinorNumber.unsignedShortValue;
-                    listHolder_0->mList[i].name = [self asCharSpan:element_0.Name];
-                    listHolder_0->mList[i].callSign = [self asCharSpan:element_0.CallSign];
-                    listHolder_0->mList[i].affiliateCallSign = [self asCharSpan:element_0.AffiliateCallSign];
+                    listHolder_0->mList[i].majorNumber = element_0.majorNumber.unsignedShortValue;
+                    listHolder_0->mList[i].minorNumber = element_0.minorNumber.unsignedShortValue;
+                    listHolder_0->mList[i].name = [self asCharSpan:element_0.name];
+                    listHolder_0->mList[i].callSign = [self asCharSpan:element_0.callSign];
+                    listHolder_0->mList[i].affiliateCallSign = [self asCharSpan:element_0.affiliateCallSign];
                 }
                 cppValue = ListType(listHolder_0->mList, value.count);
             } else {
@@ -4774,8 +4774,8 @@ using namespace chip::app::Clusters;
                         return CHIP_ERROR_INVALID_ARGUMENT;
                     }
                     auto element_0 = (CHIPTargetNavigatorClusterNavigateTargetTargetInfo *) value[i];
-                    listHolder_0->mList[i].identifier = element_0.Identifier.unsignedCharValue;
-                    listHolder_0->mList[i].name = [self asCharSpan:element_0.Name];
+                    listHolder_0->mList[i].identifier = element_0.identifier.unsignedCharValue;
+                    listHolder_0->mList[i].name = [self asCharSpan:element_0.name];
                 }
                 cppValue = ListType(listHolder_0->mList, value.count);
             } else {
@@ -4981,8 +4981,8 @@ using namespace chip::app::Clusters;
                         return CHIP_ERROR_INVALID_ARGUMENT;
                     }
                     auto element_0 = (CHIPTestClusterClusterTestListStructOctet *) value[i];
-                    listHolder_0->mList[i].fabricIndex = element_0.FabricIndex.unsignedLongLongValue;
-                    listHolder_0->mList[i].operationalCert = [self asByteSpan:element_0.OperationalCert];
+                    listHolder_0->mList[i].fabricIndex = element_0.fabricIndex.unsignedLongLongValue;
+                    listHolder_0->mList[i].operationalCert = [self asByteSpan:element_0.operationalCert];
                 }
                 cppValue = ListType(listHolder_0->mList, value.count);
             } else {
@@ -5017,164 +5017,164 @@ using namespace chip::app::Clusters;
                         return CHIP_ERROR_INVALID_ARGUMENT;
                     }
                     auto element_0 = (CHIPTestClusterClusterNullablesAndOptionalsStruct *) value[i];
-                    if (element_0.NullableInt == nil) {
+                    if (element_0.nullableInt == nil) {
                         listHolder_0->mList[i].nullableInt.SetNull();
                     } else {
                         auto & nonNullValue_2 = listHolder_0->mList[i].nullableInt.SetNonNull();
-                        nonNullValue_2 = element_0.NullableInt.unsignedShortValue;
+                        nonNullValue_2 = element_0.nullableInt.unsignedShortValue;
                     }
-                    if (element_0.OptionalInt != nil) {
+                    if (element_0.optionalInt != nil) {
                         auto & definedValue_2 = listHolder_0->mList[i].optionalInt.Emplace();
-                        definedValue_2 = element_0.OptionalInt.unsignedShortValue;
+                        definedValue_2 = element_0.optionalInt.unsignedShortValue;
                     }
-                    if (element_0.NullableOptionalInt != nil) {
+                    if (element_0.nullableOptionalInt != nil) {
                         auto & definedValue_2 = listHolder_0->mList[i].nullableOptionalInt.Emplace();
-                        if (element_0.NullableOptionalInt == nil) {
+                        if (element_0.nullableOptionalInt == nil) {
                             definedValue_2.SetNull();
                         } else {
                             auto & nonNullValue_3 = definedValue_2.SetNonNull();
-                            nonNullValue_3 = element_0.NullableOptionalInt.unsignedShortValue;
+                            nonNullValue_3 = element_0.nullableOptionalInt.unsignedShortValue;
                         }
                     }
-                    if (element_0.NullableString == nil) {
+                    if (element_0.nullableString == nil) {
                         listHolder_0->mList[i].nullableString.SetNull();
                     } else {
                         auto & nonNullValue_2 = listHolder_0->mList[i].nullableString.SetNonNull();
-                        nonNullValue_2 = [self asCharSpan:element_0.NullableString];
+                        nonNullValue_2 = [self asCharSpan:element_0.nullableString];
                     }
-                    if (element_0.OptionalString != nil) {
+                    if (element_0.optionalString != nil) {
                         auto & definedValue_2 = listHolder_0->mList[i].optionalString.Emplace();
-                        definedValue_2 = [self asCharSpan:element_0.OptionalString];
+                        definedValue_2 = [self asCharSpan:element_0.optionalString];
                     }
-                    if (element_0.NullableOptionalString != nil) {
+                    if (element_0.nullableOptionalString != nil) {
                         auto & definedValue_2 = listHolder_0->mList[i].nullableOptionalString.Emplace();
-                        if (element_0.NullableOptionalString == nil) {
+                        if (element_0.nullableOptionalString == nil) {
                             definedValue_2.SetNull();
                         } else {
                             auto & nonNullValue_3 = definedValue_2.SetNonNull();
-                            nonNullValue_3 = [self asCharSpan:element_0.NullableOptionalString];
+                            nonNullValue_3 = [self asCharSpan:element_0.nullableOptionalString];
                         }
                     }
-                    if (element_0.NullableStruct == nil) {
+                    if (element_0.nullableStruct == nil) {
                         listHolder_0->mList[i].nullableStruct.SetNull();
                     } else {
                         auto & nonNullValue_2 = listHolder_0->mList[i].nullableStruct.SetNonNull();
-                        nonNullValue_2.a = element_0.NullableStruct.A.unsignedCharValue;
-                        nonNullValue_2.b = element_0.NullableStruct.B.boolValue;
+                        nonNullValue_2.a = element_0.nullableStruct.a.unsignedCharValue;
+                        nonNullValue_2.b = element_0.nullableStruct.b.boolValue;
                         nonNullValue_2.c = static_cast<std::remove_reference_t<decltype(nonNullValue_2.c)>>(
-                            element_0.NullableStruct.C.unsignedCharValue);
-                        nonNullValue_2.d = [self asByteSpan:element_0.NullableStruct.D];
-                        nonNullValue_2.e = [self asCharSpan:element_0.NullableStruct.E];
+                            element_0.nullableStruct.c.unsignedCharValue);
+                        nonNullValue_2.d = [self asByteSpan:element_0.nullableStruct.d];
+                        nonNullValue_2.e = [self asCharSpan:element_0.nullableStruct.e];
                         nonNullValue_2.f = static_cast<std::remove_reference_t<decltype(nonNullValue_2.f)>>(
-                            element_0.NullableStruct.F.unsignedCharValue);
+                            element_0.nullableStruct.f.unsignedCharValue);
                     }
-                    if (element_0.OptionalStruct != nil) {
+                    if (element_0.optionalStruct != nil) {
                         auto & definedValue_2 = listHolder_0->mList[i].optionalStruct.Emplace();
-                        definedValue_2.a = element_0.OptionalStruct.A.unsignedCharValue;
-                        definedValue_2.b = element_0.OptionalStruct.B.boolValue;
+                        definedValue_2.a = element_0.optionalStruct.a.unsignedCharValue;
+                        definedValue_2.b = element_0.optionalStruct.b.boolValue;
                         definedValue_2.c = static_cast<std::remove_reference_t<decltype(definedValue_2.c)>>(
-                            element_0.OptionalStruct.C.unsignedCharValue);
-                        definedValue_2.d = [self asByteSpan:element_0.OptionalStruct.D];
-                        definedValue_2.e = [self asCharSpan:element_0.OptionalStruct.E];
+                            element_0.optionalStruct.c.unsignedCharValue);
+                        definedValue_2.d = [self asByteSpan:element_0.optionalStruct.d];
+                        definedValue_2.e = [self asCharSpan:element_0.optionalStruct.e];
                         definedValue_2.f = static_cast<std::remove_reference_t<decltype(definedValue_2.f)>>(
-                            element_0.OptionalStruct.F.unsignedCharValue);
+                            element_0.optionalStruct.f.unsignedCharValue);
                     }
-                    if (element_0.NullableOptionalStruct != nil) {
+                    if (element_0.nullableOptionalStruct != nil) {
                         auto & definedValue_2 = listHolder_0->mList[i].nullableOptionalStruct.Emplace();
-                        if (element_0.NullableOptionalStruct == nil) {
+                        if (element_0.nullableOptionalStruct == nil) {
                             definedValue_2.SetNull();
                         } else {
                             auto & nonNullValue_3 = definedValue_2.SetNonNull();
-                            nonNullValue_3.a = element_0.NullableOptionalStruct.A.unsignedCharValue;
-                            nonNullValue_3.b = element_0.NullableOptionalStruct.B.boolValue;
+                            nonNullValue_3.a = element_0.nullableOptionalStruct.a.unsignedCharValue;
+                            nonNullValue_3.b = element_0.nullableOptionalStruct.b.boolValue;
                             nonNullValue_3.c = static_cast<std::remove_reference_t<decltype(nonNullValue_3.c)>>(
-                                element_0.NullableOptionalStruct.C.unsignedCharValue);
-                            nonNullValue_3.d = [self asByteSpan:element_0.NullableOptionalStruct.D];
-                            nonNullValue_3.e = [self asCharSpan:element_0.NullableOptionalStruct.E];
+                                element_0.nullableOptionalStruct.c.unsignedCharValue);
+                            nonNullValue_3.d = [self asByteSpan:element_0.nullableOptionalStruct.d];
+                            nonNullValue_3.e = [self asCharSpan:element_0.nullableOptionalStruct.e];
                             nonNullValue_3.f = static_cast<std::remove_reference_t<decltype(nonNullValue_3.f)>>(
-                                element_0.NullableOptionalStruct.F.unsignedCharValue);
+                                element_0.nullableOptionalStruct.f.unsignedCharValue);
                         }
                     }
-                    if (element_0.NullableList == nil) {
+                    if (element_0.nullableList == nil) {
                         listHolder_0->mList[i].nullableList.SetNull();
                     } else {
                         auto & nonNullValue_2 = listHolder_0->mList[i].nullableList.SetNonNull();
                         {
                             using ListType = std::remove_reference_t<decltype(nonNullValue_2)>;
                             using ListMemberType = ListMemberTypeGetter<ListType>::Type;
-                            if (element_0.NullableList.count != 0) {
-                                auto * listHolder_3 = new ListHolder<ListMemberType>(element_0.NullableList.count);
+                            if (element_0.nullableList.count != 0) {
+                                auto * listHolder_3 = new ListHolder<ListMemberType>(element_0.nullableList.count);
                                 if (listHolder_3 == nullptr || listHolder_3->mList == nullptr) {
                                     return CHIP_ERROR_INVALID_ARGUMENT;
                                 }
                                 listFreer.add(listHolder_3);
-                                for (size_t i = 0; i < element_0.NullableList.count; ++i) {
-                                    if (![element_0.NullableList[i] isKindOfClass:[NSNumber class]]) {
+                                for (size_t i = 0; i < element_0.nullableList.count; ++i) {
+                                    if (![element_0.nullableList[i] isKindOfClass:[NSNumber class]]) {
                                         // Wrong kind of value.
                                         return CHIP_ERROR_INVALID_ARGUMENT;
                                     }
-                                    auto element_3 = (NSNumber *) element_0.NullableList[i];
+                                    auto element_3 = (NSNumber *) element_0.nullableList[i];
                                     listHolder_3->mList[i] = static_cast<std::remove_reference_t<decltype(listHolder_3->mList[i])>>(
                                         element_3.unsignedCharValue);
                                 }
-                                nonNullValue_2 = ListType(listHolder_3->mList, element_0.NullableList.count);
+                                nonNullValue_2 = ListType(listHolder_3->mList, element_0.nullableList.count);
                             } else {
                                 nonNullValue_2 = ListType();
                             }
                         }
                     }
-                    if (element_0.OptionalList != nil) {
+                    if (element_0.optionalList != nil) {
                         auto & definedValue_2 = listHolder_0->mList[i].optionalList.Emplace();
                         {
                             using ListType = std::remove_reference_t<decltype(definedValue_2)>;
                             using ListMemberType = ListMemberTypeGetter<ListType>::Type;
-                            if (element_0.OptionalList.count != 0) {
-                                auto * listHolder_3 = new ListHolder<ListMemberType>(element_0.OptionalList.count);
+                            if (element_0.optionalList.count != 0) {
+                                auto * listHolder_3 = new ListHolder<ListMemberType>(element_0.optionalList.count);
                                 if (listHolder_3 == nullptr || listHolder_3->mList == nullptr) {
                                     return CHIP_ERROR_INVALID_ARGUMENT;
                                 }
                                 listFreer.add(listHolder_3);
-                                for (size_t i = 0; i < element_0.OptionalList.count; ++i) {
-                                    if (![element_0.OptionalList[i] isKindOfClass:[NSNumber class]]) {
+                                for (size_t i = 0; i < element_0.optionalList.count; ++i) {
+                                    if (![element_0.optionalList[i] isKindOfClass:[NSNumber class]]) {
                                         // Wrong kind of value.
                                         return CHIP_ERROR_INVALID_ARGUMENT;
                                     }
-                                    auto element_3 = (NSNumber *) element_0.OptionalList[i];
+                                    auto element_3 = (NSNumber *) element_0.optionalList[i];
                                     listHolder_3->mList[i] = static_cast<std::remove_reference_t<decltype(listHolder_3->mList[i])>>(
                                         element_3.unsignedCharValue);
                                 }
-                                definedValue_2 = ListType(listHolder_3->mList, element_0.OptionalList.count);
+                                definedValue_2 = ListType(listHolder_3->mList, element_0.optionalList.count);
                             } else {
                                 definedValue_2 = ListType();
                             }
                         }
                     }
-                    if (element_0.NullableOptionalList != nil) {
+                    if (element_0.nullableOptionalList != nil) {
                         auto & definedValue_2 = listHolder_0->mList[i].nullableOptionalList.Emplace();
-                        if (element_0.NullableOptionalList == nil) {
+                        if (element_0.nullableOptionalList == nil) {
                             definedValue_2.SetNull();
                         } else {
                             auto & nonNullValue_3 = definedValue_2.SetNonNull();
                             {
                                 using ListType = std::remove_reference_t<decltype(nonNullValue_3)>;
                                 using ListMemberType = ListMemberTypeGetter<ListType>::Type;
-                                if (element_0.NullableOptionalList.count != 0) {
-                                    auto * listHolder_4 = new ListHolder<ListMemberType>(element_0.NullableOptionalList.count);
+                                if (element_0.nullableOptionalList.count != 0) {
+                                    auto * listHolder_4 = new ListHolder<ListMemberType>(element_0.nullableOptionalList.count);
                                     if (listHolder_4 == nullptr || listHolder_4->mList == nullptr) {
                                         return CHIP_ERROR_INVALID_ARGUMENT;
                                     }
                                     listFreer.add(listHolder_4);
-                                    for (size_t i = 0; i < element_0.NullableOptionalList.count; ++i) {
-                                        if (![element_0.NullableOptionalList[i] isKindOfClass:[NSNumber class]]) {
+                                    for (size_t i = 0; i < element_0.nullableOptionalList.count; ++i) {
+                                        if (![element_0.nullableOptionalList[i] isKindOfClass:[NSNumber class]]) {
                                             // Wrong kind of value.
                                             return CHIP_ERROR_INVALID_ARGUMENT;
                                         }
-                                        auto element_4 = (NSNumber *) element_0.NullableOptionalList[i];
+                                        auto element_4 = (NSNumber *) element_0.nullableOptionalList[i];
                                         listHolder_4->mList[i]
                                             = static_cast<std::remove_reference_t<decltype(listHolder_4->mList[i])>>(
                                                 element_4.unsignedCharValue);
                                     }
-                                    nonNullValue_3 = ListType(listHolder_4->mList, element_0.NullableOptionalList.count);
+                                    nonNullValue_3 = ListType(listHolder_4->mList, element_0.nullableOptionalList.count);
                                 } else {
                                     nonNullValue_3 = ListType();
                                 }
@@ -5500,20 +5500,20 @@ using namespace chip::app::Clusters;
                         return CHIP_ERROR_INVALID_ARGUMENT;
                     }
                     auto element_0 = (CHIPThreadNetworkDiagnosticsClusterNeighborTable *) value[i];
-                    listHolder_0->mList[i].extAddress = element_0.ExtAddress.unsignedLongLongValue;
-                    listHolder_0->mList[i].age = element_0.Age.unsignedIntValue;
-                    listHolder_0->mList[i].rloc16 = element_0.Rloc16.unsignedShortValue;
-                    listHolder_0->mList[i].linkFrameCounter = element_0.LinkFrameCounter.unsignedIntValue;
-                    listHolder_0->mList[i].mleFrameCounter = element_0.MleFrameCounter.unsignedIntValue;
-                    listHolder_0->mList[i].lqi = element_0.Lqi.unsignedCharValue;
-                    listHolder_0->mList[i].averageRssi = element_0.AverageRssi.charValue;
-                    listHolder_0->mList[i].lastRssi = element_0.LastRssi.charValue;
-                    listHolder_0->mList[i].frameErrorRate = element_0.FrameErrorRate.unsignedCharValue;
-                    listHolder_0->mList[i].messageErrorRate = element_0.MessageErrorRate.unsignedCharValue;
-                    listHolder_0->mList[i].rxOnWhenIdle = element_0.RxOnWhenIdle.boolValue;
-                    listHolder_0->mList[i].fullThreadDevice = element_0.FullThreadDevice.boolValue;
-                    listHolder_0->mList[i].fullNetworkData = element_0.FullNetworkData.boolValue;
-                    listHolder_0->mList[i].isChild = element_0.IsChild.boolValue;
+                    listHolder_0->mList[i].extAddress = element_0.extAddress.unsignedLongLongValue;
+                    listHolder_0->mList[i].age = element_0.age.unsignedIntValue;
+                    listHolder_0->mList[i].rloc16 = element_0.rloc16.unsignedShortValue;
+                    listHolder_0->mList[i].linkFrameCounter = element_0.linkFrameCounter.unsignedIntValue;
+                    listHolder_0->mList[i].mleFrameCounter = element_0.mleFrameCounter.unsignedIntValue;
+                    listHolder_0->mList[i].lqi = element_0.lqi.unsignedCharValue;
+                    listHolder_0->mList[i].averageRssi = element_0.averageRssi.charValue;
+                    listHolder_0->mList[i].lastRssi = element_0.lastRssi.charValue;
+                    listHolder_0->mList[i].frameErrorRate = element_0.frameErrorRate.unsignedCharValue;
+                    listHolder_0->mList[i].messageErrorRate = element_0.messageErrorRate.unsignedCharValue;
+                    listHolder_0->mList[i].rxOnWhenIdle = element_0.rxOnWhenIdle.boolValue;
+                    listHolder_0->mList[i].fullThreadDevice = element_0.fullThreadDevice.boolValue;
+                    listHolder_0->mList[i].fullNetworkData = element_0.fullNetworkData.boolValue;
+                    listHolder_0->mList[i].isChild = element_0.isChild.boolValue;
                 }
                 cppValue = ListType(listHolder_0->mList, value.count);
             } else {
@@ -5547,16 +5547,16 @@ using namespace chip::app::Clusters;
                         return CHIP_ERROR_INVALID_ARGUMENT;
                     }
                     auto element_0 = (CHIPThreadNetworkDiagnosticsClusterRouteTable *) value[i];
-                    listHolder_0->mList[i].extAddress = element_0.ExtAddress.unsignedLongLongValue;
-                    listHolder_0->mList[i].rloc16 = element_0.Rloc16.unsignedShortValue;
-                    listHolder_0->mList[i].routerId = element_0.RouterId.unsignedCharValue;
-                    listHolder_0->mList[i].nextHop = element_0.NextHop.unsignedCharValue;
-                    listHolder_0->mList[i].pathCost = element_0.PathCost.unsignedCharValue;
-                    listHolder_0->mList[i].LQIIn = element_0.LQIIn.unsignedCharValue;
-                    listHolder_0->mList[i].LQIOut = element_0.LQIOut.unsignedCharValue;
-                    listHolder_0->mList[i].age = element_0.Age.unsignedCharValue;
-                    listHolder_0->mList[i].allocated = element_0.Allocated.boolValue;
-                    listHolder_0->mList[i].linkEstablished = element_0.LinkEstablished.boolValue;
+                    listHolder_0->mList[i].extAddress = element_0.extAddress.unsignedLongLongValue;
+                    listHolder_0->mList[i].rloc16 = element_0.rloc16.unsignedShortValue;
+                    listHolder_0->mList[i].routerId = element_0.routerId.unsignedCharValue;
+                    listHolder_0->mList[i].nextHop = element_0.nextHop.unsignedCharValue;
+                    listHolder_0->mList[i].pathCost = element_0.pathCost.unsignedCharValue;
+                    listHolder_0->mList[i].LQIIn = element_0.lqiIn.unsignedCharValue;
+                    listHolder_0->mList[i].LQIOut = element_0.lqiOut.unsignedCharValue;
+                    listHolder_0->mList[i].age = element_0.age.unsignedCharValue;
+                    listHolder_0->mList[i].allocated = element_0.allocated.boolValue;
+                    listHolder_0->mList[i].linkEstablished = element_0.linkEstablished.boolValue;
                 }
                 cppValue = ListType(listHolder_0->mList, value.count);
             } else {
@@ -6243,8 +6243,8 @@ using namespace chip::app::Clusters;
                         return CHIP_ERROR_INVALID_ARGUMENT;
                     }
                     auto element_0 = (CHIPThreadNetworkDiagnosticsClusterSecurityPolicy *) value[i];
-                    listHolder_0->mList[i].rotationTime = element_0.RotationTime.unsignedShortValue;
-                    listHolder_0->mList[i].flags = element_0.Flags.unsignedShortValue;
+                    listHolder_0->mList[i].rotationTime = element_0.rotationTime.unsignedShortValue;
+                    listHolder_0->mList[i].flags = element_0.flags.unsignedShortValue;
                 }
                 cppValue = ListType(listHolder_0->mList, value.count);
             } else {
@@ -6292,18 +6292,18 @@ using namespace chip::app::Clusters;
                         return CHIP_ERROR_INVALID_ARGUMENT;
                     }
                     auto element_0 = (CHIPThreadNetworkDiagnosticsClusterOperationalDatasetComponents *) value[i];
-                    listHolder_0->mList[i].activeTimestampPresent = element_0.ActiveTimestampPresent.boolValue;
-                    listHolder_0->mList[i].pendingTimestampPresent = element_0.PendingTimestampPresent.boolValue;
-                    listHolder_0->mList[i].masterKeyPresent = element_0.MasterKeyPresent.boolValue;
-                    listHolder_0->mList[i].networkNamePresent = element_0.NetworkNamePresent.boolValue;
-                    listHolder_0->mList[i].extendedPanIdPresent = element_0.ExtendedPanIdPresent.boolValue;
-                    listHolder_0->mList[i].meshLocalPrefixPresent = element_0.MeshLocalPrefixPresent.boolValue;
-                    listHolder_0->mList[i].delayPresent = element_0.DelayPresent.boolValue;
-                    listHolder_0->mList[i].panIdPresent = element_0.PanIdPresent.boolValue;
-                    listHolder_0->mList[i].channelPresent = element_0.ChannelPresent.boolValue;
-                    listHolder_0->mList[i].pskcPresent = element_0.PskcPresent.boolValue;
-                    listHolder_0->mList[i].securityPolicyPresent = element_0.SecurityPolicyPresent.boolValue;
-                    listHolder_0->mList[i].channelMaskPresent = element_0.ChannelMaskPresent.boolValue;
+                    listHolder_0->mList[i].activeTimestampPresent = element_0.activeTimestampPresent.boolValue;
+                    listHolder_0->mList[i].pendingTimestampPresent = element_0.pendingTimestampPresent.boolValue;
+                    listHolder_0->mList[i].masterKeyPresent = element_0.masterKeyPresent.boolValue;
+                    listHolder_0->mList[i].networkNamePresent = element_0.networkNamePresent.boolValue;
+                    listHolder_0->mList[i].extendedPanIdPresent = element_0.extendedPanIdPresent.boolValue;
+                    listHolder_0->mList[i].meshLocalPrefixPresent = element_0.meshLocalPrefixPresent.boolValue;
+                    listHolder_0->mList[i].delayPresent = element_0.delayPresent.boolValue;
+                    listHolder_0->mList[i].panIdPresent = element_0.panIdPresent.boolValue;
+                    listHolder_0->mList[i].channelPresent = element_0.channelPresent.boolValue;
+                    listHolder_0->mList[i].pskcPresent = element_0.pskcPresent.boolValue;
+                    listHolder_0->mList[i].securityPolicyPresent = element_0.securityPolicyPresent.boolValue;
+                    listHolder_0->mList[i].channelMaskPresent = element_0.channelMaskPresent.boolValue;
                 }
                 cppValue = ListType(listHolder_0->mList, value.count);
             } else {

--- a/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
+++ b/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
@@ -4173,11 +4173,11 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPColorControlClusterMoveToHuePayload alloc] init];
-    payload.Hue = [NSNumber numberWithUnsignedChar:150];
-    payload.Direction = [NSNumber numberWithUnsignedChar:0];
-    payload.TransitionTime = [NSNumber numberWithUnsignedShort:100U];
-    payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
+    payload.hue = [NSNumber numberWithUnsignedChar:150];
+    payload.direction = [NSNumber numberWithUnsignedChar:0];
+    payload.transitionTime = [NSNumber numberWithUnsignedShort:100U];
+    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster moveToHue:payload
         responseHandler:^(NSError * err, NSDictionary * values) {
             NSLog(@"Move to hue shortest distance command Error: %@", err);
@@ -4199,11 +4199,11 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPColorControlClusterMoveToHuePayload alloc] init];
-    payload.Hue = [NSNumber numberWithUnsignedChar:200];
-    payload.Direction = [NSNumber numberWithUnsignedChar:1];
-    payload.TransitionTime = [NSNumber numberWithUnsignedShort:100U];
-    payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
+    payload.hue = [NSNumber numberWithUnsignedChar:200];
+    payload.direction = [NSNumber numberWithUnsignedChar:1];
+    payload.transitionTime = [NSNumber numberWithUnsignedShort:100U];
+    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster moveToHue:payload
         responseHandler:^(NSError * err, NSDictionary * values) {
             NSLog(@"Move to hue longest distance command Error: %@", err);
@@ -4225,11 +4225,11 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPColorControlClusterMoveToHuePayload alloc] init];
-    payload.Hue = [NSNumber numberWithUnsignedChar:250];
-    payload.Direction = [NSNumber numberWithUnsignedChar:2];
-    payload.TransitionTime = [NSNumber numberWithUnsignedShort:100U];
-    payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
+    payload.hue = [NSNumber numberWithUnsignedChar:250];
+    payload.direction = [NSNumber numberWithUnsignedChar:2];
+    payload.transitionTime = [NSNumber numberWithUnsignedShort:100U];
+    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster moveToHue:payload
         responseHandler:^(NSError * err, NSDictionary * values) {
             NSLog(@"Move to hue up command Error: %@", err);
@@ -4251,11 +4251,11 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPColorControlClusterMoveToHuePayload alloc] init];
-    payload.Hue = [NSNumber numberWithUnsignedChar:225];
-    payload.Direction = [NSNumber numberWithUnsignedChar:3];
-    payload.TransitionTime = [NSNumber numberWithUnsignedShort:100U];
-    payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
+    payload.hue = [NSNumber numberWithUnsignedChar:225];
+    payload.direction = [NSNumber numberWithUnsignedChar:3];
+    payload.transitionTime = [NSNumber numberWithUnsignedShort:100U];
+    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster moveToHue:payload
         responseHandler:^(NSError * err, NSDictionary * values) {
             NSLog(@"Move to hue down command Error: %@", err);
@@ -4368,10 +4368,10 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPColorControlClusterMoveHuePayload alloc] init];
-    payload.MoveMode = [NSNumber numberWithUnsignedChar:1];
-    payload.Rate = [NSNumber numberWithUnsignedChar:50];
-    payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
+    payload.moveMode = [NSNumber numberWithUnsignedChar:1];
+    payload.rate = [NSNumber numberWithUnsignedChar:50];
+    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster moveHue:payload
         responseHandler:^(NSError * err, NSDictionary * values) {
             NSLog(@"Move hue up command Error: %@", err);
@@ -4393,10 +4393,10 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPColorControlClusterMoveHuePayload alloc] init];
-    payload.MoveMode = [NSNumber numberWithUnsignedChar:0];
-    payload.Rate = [NSNumber numberWithUnsignedChar:50];
-    payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
+    payload.moveMode = [NSNumber numberWithUnsignedChar:0];
+    payload.rate = [NSNumber numberWithUnsignedChar:50];
+    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster moveHue:payload
         responseHandler:^(NSError * err, NSDictionary * values) {
             NSLog(@"Move hue stop command Error: %@", err);
@@ -4418,10 +4418,10 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPColorControlClusterMoveHuePayload alloc] init];
-    payload.MoveMode = [NSNumber numberWithUnsignedChar:3];
-    payload.Rate = [NSNumber numberWithUnsignedChar:50];
-    payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
+    payload.moveMode = [NSNumber numberWithUnsignedChar:3];
+    payload.rate = [NSNumber numberWithUnsignedChar:50];
+    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster moveHue:payload
         responseHandler:^(NSError * err, NSDictionary * values) {
             NSLog(@"Move hue down command Error: %@", err);
@@ -4443,10 +4443,10 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPColorControlClusterMoveHuePayload alloc] init];
-    payload.MoveMode = [NSNumber numberWithUnsignedChar:0];
-    payload.Rate = [NSNumber numberWithUnsignedChar:50];
-    payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
+    payload.moveMode = [NSNumber numberWithUnsignedChar:0];
+    payload.rate = [NSNumber numberWithUnsignedChar:50];
+    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster moveHue:payload
         responseHandler:^(NSError * err, NSDictionary * values) {
             NSLog(@"Move hue stop command Error: %@", err);
@@ -4559,11 +4559,11 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPColorControlClusterStepHuePayload alloc] init];
-    payload.StepMode = [NSNumber numberWithUnsignedChar:1];
-    payload.StepSize = [NSNumber numberWithUnsignedChar:5];
-    payload.TransitionTime = [NSNumber numberWithUnsignedChar:25];
-    payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
+    payload.stepMode = [NSNumber numberWithUnsignedChar:1];
+    payload.stepSize = [NSNumber numberWithUnsignedChar:5];
+    payload.transitionTime = [NSNumber numberWithUnsignedChar:25];
+    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster stepHue:payload
         responseHandler:^(NSError * err, NSDictionary * values) {
             NSLog(@"Step hue up command Error: %@", err);
@@ -4585,11 +4585,11 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPColorControlClusterStepHuePayload alloc] init];
-    payload.StepMode = [NSNumber numberWithUnsignedChar:3];
-    payload.StepSize = [NSNumber numberWithUnsignedChar:5];
-    payload.TransitionTime = [NSNumber numberWithUnsignedChar:25];
-    payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
+    payload.stepMode = [NSNumber numberWithUnsignedChar:3];
+    payload.stepSize = [NSNumber numberWithUnsignedChar:5];
+    payload.transitionTime = [NSNumber numberWithUnsignedChar:25];
+    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster stepHue:payload
         responseHandler:^(NSError * err, NSDictionary * values) {
             NSLog(@"Step hue down command Error: %@", err);
@@ -4702,10 +4702,10 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPColorControlClusterMoveToSaturationPayload alloc] init];
-    payload.Saturation = [NSNumber numberWithUnsignedChar:90];
-    payload.TransitionTime = [NSNumber numberWithUnsignedShort:10U];
-    payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
+    payload.saturation = [NSNumber numberWithUnsignedChar:90];
+    payload.transitionTime = [NSNumber numberWithUnsignedShort:10U];
+    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster moveToSaturation:payload
               responseHandler:^(NSError * err, NSDictionary * values) {
                   NSLog(@"Move to saturation command Error: %@", err);
@@ -4818,10 +4818,10 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPColorControlClusterMoveSaturationPayload alloc] init];
-    payload.MoveMode = [NSNumber numberWithUnsignedChar:1];
-    payload.Rate = [NSNumber numberWithUnsignedChar:5];
-    payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
+    payload.moveMode = [NSNumber numberWithUnsignedChar:1];
+    payload.rate = [NSNumber numberWithUnsignedChar:5];
+    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster moveSaturation:payload
             responseHandler:^(NSError * err, NSDictionary * values) {
                 NSLog(@"Move saturation up command Error: %@", err);
@@ -4843,10 +4843,10 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPColorControlClusterMoveSaturationPayload alloc] init];
-    payload.MoveMode = [NSNumber numberWithUnsignedChar:3];
-    payload.Rate = [NSNumber numberWithUnsignedChar:5];
-    payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
+    payload.moveMode = [NSNumber numberWithUnsignedChar:3];
+    payload.rate = [NSNumber numberWithUnsignedChar:5];
+    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster moveSaturation:payload
             responseHandler:^(NSError * err, NSDictionary * values) {
                 NSLog(@"Move saturation down command Error: %@", err);
@@ -4959,11 +4959,11 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPColorControlClusterStepSaturationPayload alloc] init];
-    payload.StepMode = [NSNumber numberWithUnsignedChar:1];
-    payload.StepSize = [NSNumber numberWithUnsignedChar:15];
-    payload.TransitionTime = [NSNumber numberWithUnsignedChar:10];
-    payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
+    payload.stepMode = [NSNumber numberWithUnsignedChar:1];
+    payload.stepSize = [NSNumber numberWithUnsignedChar:15];
+    payload.transitionTime = [NSNumber numberWithUnsignedChar:10];
+    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster stepSaturation:payload
             responseHandler:^(NSError * err, NSDictionary * values) {
                 NSLog(@"Step saturation up command Error: %@", err);
@@ -4985,11 +4985,11 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPColorControlClusterStepSaturationPayload alloc] init];
-    payload.StepMode = [NSNumber numberWithUnsignedChar:3];
-    payload.StepSize = [NSNumber numberWithUnsignedChar:20];
-    payload.TransitionTime = [NSNumber numberWithUnsignedChar:10];
-    payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
+    payload.stepMode = [NSNumber numberWithUnsignedChar:3];
+    payload.stepSize = [NSNumber numberWithUnsignedChar:20];
+    payload.transitionTime = [NSNumber numberWithUnsignedChar:10];
+    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster stepSaturation:payload
             responseHandler:^(NSError * err, NSDictionary * values) {
                 NSLog(@"Step saturation down command Error: %@", err);
@@ -5102,11 +5102,11 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPColorControlClusterMoveToHueAndSaturationPayload alloc] init];
-    payload.Hue = [NSNumber numberWithUnsignedChar:40];
-    payload.Saturation = [NSNumber numberWithUnsignedChar:160];
-    payload.TransitionTime = [NSNumber numberWithUnsignedShort:10U];
-    payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
+    payload.hue = [NSNumber numberWithUnsignedChar:40];
+    payload.saturation = [NSNumber numberWithUnsignedChar:160];
+    payload.transitionTime = [NSNumber numberWithUnsignedShort:10U];
+    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster moveToHueAndSaturation:payload
                     responseHandler:^(NSError * err, NSDictionary * values) {
                         NSLog(@"Move To current hue and saturation command Error: %@", err);
@@ -5219,11 +5219,11 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPColorControlClusterMoveToColorPayload alloc] init];
-    payload.ColorX = [NSNumber numberWithUnsignedShort:200U];
-    payload.ColorY = [NSNumber numberWithUnsignedShort:300U];
-    payload.TransitionTime = [NSNumber numberWithUnsignedShort:20U];
-    payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
+    payload.colorX = [NSNumber numberWithUnsignedShort:200U];
+    payload.colorY = [NSNumber numberWithUnsignedShort:300U];
+    payload.transitionTime = [NSNumber numberWithUnsignedShort:20U];
+    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster moveToColor:payload
          responseHandler:^(NSError * err, NSDictionary * values) {
              NSLog(@"Move to Color command Error: %@", err);
@@ -5336,10 +5336,10 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPColorControlClusterMoveColorPayload alloc] init];
-    payload.RateX = [NSNumber numberWithShort:15];
-    payload.RateY = [NSNumber numberWithShort:20];
-    payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
+    payload.rateX = [NSNumber numberWithShort:15];
+    payload.rateY = [NSNumber numberWithShort:20];
+    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster moveColor:payload
         responseHandler:^(NSError * err, NSDictionary * values) {
             NSLog(@"Move Color command Error: %@", err);
@@ -5361,8 +5361,8 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPColorControlClusterStopMoveStepPayload alloc] init];
-    payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
+    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster stopMoveStep:payload
           responseHandler:^(NSError * err, NSDictionary * values) {
               NSLog(@"Stop Move Step command Error: %@", err);
@@ -5475,11 +5475,11 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPColorControlClusterStepColorPayload alloc] init];
-    payload.StepX = [NSNumber numberWithShort:15];
-    payload.StepY = [NSNumber numberWithShort:20];
-    payload.TransitionTime = [NSNumber numberWithUnsignedShort:50U];
-    payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
+    payload.stepX = [NSNumber numberWithShort:15];
+    payload.stepY = [NSNumber numberWithShort:20];
+    payload.transitionTime = [NSNumber numberWithUnsignedShort:50U];
+    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster stepColor:payload
         responseHandler:^(NSError * err, NSDictionary * values) {
             NSLog(@"Step Color command Error: %@", err);
@@ -5592,10 +5592,10 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPColorControlClusterMoveToColorTemperaturePayload alloc] init];
-    payload.ColorTemperature = [NSNumber numberWithUnsignedShort:100U];
-    payload.TransitionTime = [NSNumber numberWithUnsignedShort:10U];
-    payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
+    payload.colorTemperature = [NSNumber numberWithUnsignedShort:100U];
+    payload.transitionTime = [NSNumber numberWithUnsignedShort:10U];
+    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster moveToColorTemperature:payload
                     responseHandler:^(NSError * err, NSDictionary * values) {
                         NSLog(@"Move To Color Temperature command Error: %@", err);
@@ -5708,12 +5708,12 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPColorControlClusterMoveColorTemperaturePayload alloc] init];
-    payload.MoveMode = [NSNumber numberWithUnsignedChar:1];
-    payload.Rate = [NSNumber numberWithUnsignedShort:10U];
-    payload.ColorTemperatureMinimum = [NSNumber numberWithUnsignedShort:1U];
-    payload.ColorTemperatureMaximum = [NSNumber numberWithUnsignedShort:255U];
-    payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
+    payload.moveMode = [NSNumber numberWithUnsignedChar:1];
+    payload.rate = [NSNumber numberWithUnsignedShort:10U];
+    payload.colorTemperatureMinimum = [NSNumber numberWithUnsignedShort:1U];
+    payload.colorTemperatureMaximum = [NSNumber numberWithUnsignedShort:255U];
+    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster moveColorTemperature:payload
                   responseHandler:^(NSError * err, NSDictionary * values) {
                       NSLog(@"Move up color temperature command Error: %@", err);
@@ -5735,12 +5735,12 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPColorControlClusterMoveColorTemperaturePayload alloc] init];
-    payload.MoveMode = [NSNumber numberWithUnsignedChar:0];
-    payload.Rate = [NSNumber numberWithUnsignedShort:10U];
-    payload.ColorTemperatureMinimum = [NSNumber numberWithUnsignedShort:1U];
-    payload.ColorTemperatureMaximum = [NSNumber numberWithUnsignedShort:255U];
-    payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
+    payload.moveMode = [NSNumber numberWithUnsignedChar:0];
+    payload.rate = [NSNumber numberWithUnsignedShort:10U];
+    payload.colorTemperatureMinimum = [NSNumber numberWithUnsignedShort:1U];
+    payload.colorTemperatureMaximum = [NSNumber numberWithUnsignedShort:255U];
+    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster moveColorTemperature:payload
                   responseHandler:^(NSError * err, NSDictionary * values) {
                       NSLog(@"Stop Color Temperature command Error: %@", err);
@@ -5762,12 +5762,12 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPColorControlClusterMoveColorTemperaturePayload alloc] init];
-    payload.MoveMode = [NSNumber numberWithUnsignedChar:3];
-    payload.Rate = [NSNumber numberWithUnsignedShort:20U];
-    payload.ColorTemperatureMinimum = [NSNumber numberWithUnsignedShort:1U];
-    payload.ColorTemperatureMaximum = [NSNumber numberWithUnsignedShort:255U];
-    payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
+    payload.moveMode = [NSNumber numberWithUnsignedChar:3];
+    payload.rate = [NSNumber numberWithUnsignedShort:20U];
+    payload.colorTemperatureMinimum = [NSNumber numberWithUnsignedShort:1U];
+    payload.colorTemperatureMaximum = [NSNumber numberWithUnsignedShort:255U];
+    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster moveColorTemperature:payload
                   responseHandler:^(NSError * err, NSDictionary * values) {
                       NSLog(@"Move down color temperature command Error: %@", err);
@@ -5880,13 +5880,13 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPColorControlClusterStepColorTemperaturePayload alloc] init];
-    payload.StepMode = [NSNumber numberWithUnsignedChar:1];
-    payload.StepSize = [NSNumber numberWithUnsignedShort:5U];
-    payload.TransitionTime = [NSNumber numberWithUnsignedShort:50U];
-    payload.ColorTemperatureMinimum = [NSNumber numberWithUnsignedShort:5U];
-    payload.ColorTemperatureMaximum = [NSNumber numberWithUnsignedShort:100U];
-    payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
+    payload.stepMode = [NSNumber numberWithUnsignedChar:1];
+    payload.stepSize = [NSNumber numberWithUnsignedShort:5U];
+    payload.transitionTime = [NSNumber numberWithUnsignedShort:50U];
+    payload.colorTemperatureMinimum = [NSNumber numberWithUnsignedShort:5U];
+    payload.colorTemperatureMaximum = [NSNumber numberWithUnsignedShort:100U];
+    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster stepColorTemperature:payload
                   responseHandler:^(NSError * err, NSDictionary * values) {
                       NSLog(@"Step up color temperature command Error: %@", err);
@@ -5908,13 +5908,13 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPColorControlClusterStepColorTemperaturePayload alloc] init];
-    payload.StepMode = [NSNumber numberWithUnsignedChar:3];
-    payload.StepSize = [NSNumber numberWithUnsignedShort:5U];
-    payload.TransitionTime = [NSNumber numberWithUnsignedShort:50U];
-    payload.ColorTemperatureMinimum = [NSNumber numberWithUnsignedShort:5U];
-    payload.ColorTemperatureMaximum = [NSNumber numberWithUnsignedShort:100U];
-    payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
+    payload.stepMode = [NSNumber numberWithUnsignedChar:3];
+    payload.stepSize = [NSNumber numberWithUnsignedShort:5U];
+    payload.transitionTime = [NSNumber numberWithUnsignedShort:50U];
+    payload.colorTemperatureMinimum = [NSNumber numberWithUnsignedShort:5U];
+    payload.colorTemperatureMaximum = [NSNumber numberWithUnsignedShort:100U];
+    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster stepColorTemperature:payload
                   responseHandler:^(NSError * err, NSDictionary * values) {
                       NSLog(@"Step down color temperature command Error: %@", err);
@@ -6027,11 +6027,11 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPColorControlClusterEnhancedMoveToHuePayload alloc] init];
-    payload.EnhancedHue = [NSNumber numberWithUnsignedShort:1025U];
-    payload.Direction = [NSNumber numberWithUnsignedChar:0];
-    payload.TransitionTime = [NSNumber numberWithUnsignedShort:1U];
-    payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
+    payload.enhancedHue = [NSNumber numberWithUnsignedShort:1025U];
+    payload.direction = [NSNumber numberWithUnsignedChar:0];
+    payload.transitionTime = [NSNumber numberWithUnsignedShort:1U];
+    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster enhancedMoveToHue:payload
                responseHandler:^(NSError * err, NSDictionary * values) {
                    NSLog(@"Enhanced Move To Hue command Error: %@", err);
@@ -6169,10 +6169,10 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPColorControlClusterEnhancedMoveHuePayload alloc] init];
-    payload.MoveMode = [NSNumber numberWithUnsignedChar:3];
-    payload.Rate = [NSNumber numberWithUnsignedShort:5U];
-    payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
+    payload.moveMode = [NSNumber numberWithUnsignedChar:3];
+    payload.rate = [NSNumber numberWithUnsignedShort:5U];
+    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster enhancedMoveHue:payload
              responseHandler:^(NSError * err, NSDictionary * values) {
                  NSLog(@"Enhanced Move Hue Down command  Error: %@", err);
@@ -6194,10 +6194,10 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPColorControlClusterEnhancedMoveHuePayload alloc] init];
-    payload.MoveMode = [NSNumber numberWithUnsignedChar:0];
-    payload.Rate = [NSNumber numberWithUnsignedShort:0U];
-    payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
+    payload.moveMode = [NSNumber numberWithUnsignedChar:0];
+    payload.rate = [NSNumber numberWithUnsignedShort:0U];
+    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster enhancedMoveHue:payload
              responseHandler:^(NSError * err, NSDictionary * values) {
                  NSLog(@"Enhanced Move Hue Stop command Error: %@", err);
@@ -6219,10 +6219,10 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPColorControlClusterEnhancedMoveHuePayload alloc] init];
-    payload.MoveMode = [NSNumber numberWithUnsignedChar:1];
-    payload.Rate = [NSNumber numberWithUnsignedShort:50U];
-    payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
+    payload.moveMode = [NSNumber numberWithUnsignedChar:1];
+    payload.rate = [NSNumber numberWithUnsignedShort:50U];
+    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster enhancedMoveHue:payload
              responseHandler:^(NSError * err, NSDictionary * values) {
                  NSLog(@"Enhanced Move Hue Up command Error: %@", err);
@@ -6244,10 +6244,10 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPColorControlClusterEnhancedMoveHuePayload alloc] init];
-    payload.MoveMode = [NSNumber numberWithUnsignedChar:0];
-    payload.Rate = [NSNumber numberWithUnsignedShort:0U];
-    payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
+    payload.moveMode = [NSNumber numberWithUnsignedChar:0];
+    payload.rate = [NSNumber numberWithUnsignedShort:0U];
+    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster enhancedMoveHue:payload
              responseHandler:^(NSError * err, NSDictionary * values) {
                  NSLog(@"Enhanced Move Hue Stop command Error: %@", err);
@@ -6360,11 +6360,11 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPColorControlClusterEnhancedStepHuePayload alloc] init];
-    payload.StepMode = [NSNumber numberWithUnsignedChar:0];
-    payload.StepSize = [NSNumber numberWithUnsignedShort:50U];
-    payload.TransitionTime = [NSNumber numberWithUnsignedShort:1U];
-    payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
+    payload.stepMode = [NSNumber numberWithUnsignedChar:0];
+    payload.stepSize = [NSNumber numberWithUnsignedShort:50U];
+    payload.transitionTime = [NSNumber numberWithUnsignedShort:1U];
+    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster enhancedStepHue:payload
              responseHandler:^(NSError * err, NSDictionary * values) {
                  NSLog(@"Enhanced Step Hue Up command Error: %@", err);
@@ -6386,11 +6386,11 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPColorControlClusterEnhancedStepHuePayload alloc] init];
-    payload.StepMode = [NSNumber numberWithUnsignedChar:1];
-    payload.StepSize = [NSNumber numberWithUnsignedShort:75U];
-    payload.TransitionTime = [NSNumber numberWithUnsignedShort:1U];
-    payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
+    payload.stepMode = [NSNumber numberWithUnsignedChar:1];
+    payload.stepSize = [NSNumber numberWithUnsignedShort:75U];
+    payload.transitionTime = [NSNumber numberWithUnsignedShort:1U];
+    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster enhancedStepHue:payload
              responseHandler:^(NSError * err, NSDictionary * values) {
                  NSLog(@"Enhanced Step Hue Down command Error: %@", err);
@@ -6503,11 +6503,11 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPColorControlClusterEnhancedMoveToHueAndSaturationPayload alloc] init];
-    payload.EnhancedHue = [NSNumber numberWithUnsignedShort:1200U];
-    payload.Saturation = [NSNumber numberWithUnsignedChar:90];
-    payload.TransitionTime = [NSNumber numberWithUnsignedShort:10U];
-    payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
+    payload.enhancedHue = [NSNumber numberWithUnsignedShort:1200U];
+    payload.saturation = [NSNumber numberWithUnsignedChar:90];
+    payload.transitionTime = [NSNumber numberWithUnsignedShort:10U];
+    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster enhancedMoveToHueAndSaturation:payload
                             responseHandler:^(NSError * err, NSDictionary * values) {
                                 NSLog(@"Enhanced move to hue and saturation command Error: %@", err);
@@ -6620,13 +6620,13 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPColorControlClusterColorLoopSetPayload alloc] init];
-    payload.UpdateFlags = [NSNumber numberWithUnsignedChar:14];
-    payload.Action = [NSNumber numberWithUnsignedChar:0];
-    payload.Direction = [NSNumber numberWithUnsignedChar:1];
-    payload.Time = [NSNumber numberWithUnsignedShort:100U];
-    payload.StartHue = [NSNumber numberWithUnsignedShort:500U];
-    payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
+    payload.updateFlags = [NSNumber numberWithUnsignedChar:14];
+    payload.action = [NSNumber numberWithUnsignedChar:0];
+    payload.direction = [NSNumber numberWithUnsignedChar:1];
+    payload.time = [NSNumber numberWithUnsignedShort:100U];
+    payload.startHue = [NSNumber numberWithUnsignedShort:500U];
+    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster colorLoopSet:payload
           responseHandler:^(NSError * err, NSDictionary * values) {
               NSLog(@"Color Loop Set Command - Set all Attributs Error: %@", err);
@@ -6744,13 +6744,13 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPColorControlClusterColorLoopSetPayload alloc] init];
-    payload.UpdateFlags = [NSNumber numberWithUnsignedChar:1];
-    payload.Action = [NSNumber numberWithUnsignedChar:1];
-    payload.Direction = [NSNumber numberWithUnsignedChar:0];
-    payload.Time = [NSNumber numberWithUnsignedShort:0U];
-    payload.StartHue = [NSNumber numberWithUnsignedShort:0U];
-    payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
+    payload.updateFlags = [NSNumber numberWithUnsignedChar:1];
+    payload.action = [NSNumber numberWithUnsignedChar:1];
+    payload.direction = [NSNumber numberWithUnsignedChar:0];
+    payload.time = [NSNumber numberWithUnsignedShort:0U];
+    payload.startHue = [NSNumber numberWithUnsignedShort:0U];
+    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster colorLoopSet:payload
           responseHandler:^(NSError * err, NSDictionary * values) {
               NSLog(@"Color Loop Set Command - Start Color Loop Error: %@", err);
@@ -6797,13 +6797,13 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPColorControlClusterColorLoopSetPayload alloc] init];
-    payload.UpdateFlags = [NSNumber numberWithUnsignedChar:6];
-    payload.Action = [NSNumber numberWithUnsignedChar:0];
-    payload.Direction = [NSNumber numberWithUnsignedChar:0];
-    payload.Time = [NSNumber numberWithUnsignedShort:3500U];
-    payload.StartHue = [NSNumber numberWithUnsignedShort:0U];
-    payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
+    payload.updateFlags = [NSNumber numberWithUnsignedChar:6];
+    payload.action = [NSNumber numberWithUnsignedChar:0];
+    payload.direction = [NSNumber numberWithUnsignedChar:0];
+    payload.time = [NSNumber numberWithUnsignedShort:3500U];
+    payload.startHue = [NSNumber numberWithUnsignedShort:0U];
+    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster colorLoopSet:payload
           responseHandler:^(NSError * err, NSDictionary * values) {
               NSLog(@"Color Loop Set Command - Set direction and time while running Error: %@", err);
@@ -6873,13 +6873,13 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPColorControlClusterColorLoopSetPayload alloc] init];
-    payload.UpdateFlags = [NSNumber numberWithUnsignedChar:2];
-    payload.Action = [NSNumber numberWithUnsignedChar:0];
-    payload.Direction = [NSNumber numberWithUnsignedChar:1];
-    payload.Time = [NSNumber numberWithUnsignedShort:0U];
-    payload.StartHue = [NSNumber numberWithUnsignedShort:0U];
-    payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
+    payload.updateFlags = [NSNumber numberWithUnsignedChar:2];
+    payload.action = [NSNumber numberWithUnsignedChar:0];
+    payload.direction = [NSNumber numberWithUnsignedChar:1];
+    payload.time = [NSNumber numberWithUnsignedShort:0U];
+    payload.startHue = [NSNumber numberWithUnsignedShort:0U];
+    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster colorLoopSet:payload
           responseHandler:^(NSError * err, NSDictionary * values) {
               NSLog(@"Color Loop Set Command - Set direction while running Error: %@", err);
@@ -7016,13 +7016,13 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPColorControlClusterColorLoopSetPayload alloc] init];
-    payload.UpdateFlags = [NSNumber numberWithUnsignedChar:1];
-    payload.Action = [NSNumber numberWithUnsignedChar:0];
-    payload.Direction = [NSNumber numberWithUnsignedChar:0];
-    payload.Time = [NSNumber numberWithUnsignedShort:0U];
-    payload.StartHue = [NSNumber numberWithUnsignedShort:0U];
-    payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
+    payload.updateFlags = [NSNumber numberWithUnsignedChar:1];
+    payload.action = [NSNumber numberWithUnsignedChar:0];
+    payload.direction = [NSNumber numberWithUnsignedChar:0];
+    payload.time = [NSNumber numberWithUnsignedShort:0U];
+    payload.startHue = [NSNumber numberWithUnsignedShort:0U];
+    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster colorLoopSet:payload
           responseHandler:^(NSError * err, NSDictionary * values) {
               NSLog(@"Sends ColorLoopSet Command - Set all Attributes Error: %@", err);
@@ -7068,13 +7068,13 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPColorControlClusterColorLoopSetPayload alloc] init];
-    payload.UpdateFlags = [NSNumber numberWithUnsignedChar:2];
-    payload.Action = [NSNumber numberWithUnsignedChar:0];
-    payload.Direction = [NSNumber numberWithUnsignedChar:0];
-    payload.Time = [NSNumber numberWithUnsignedShort:0U];
-    payload.StartHue = [NSNumber numberWithUnsignedShort:0U];
-    payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
+    payload.updateFlags = [NSNumber numberWithUnsignedChar:2];
+    payload.action = [NSNumber numberWithUnsignedChar:0];
+    payload.direction = [NSNumber numberWithUnsignedChar:0];
+    payload.time = [NSNumber numberWithUnsignedShort:0U];
+    payload.startHue = [NSNumber numberWithUnsignedShort:0U];
+    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster colorLoopSet:payload
           responseHandler:^(NSError * err, NSDictionary * values) {
               NSLog(@"Sends ColorLoopSet Command - Set all Attributes Error: %@", err);
@@ -7120,13 +7120,13 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPColorControlClusterColorLoopSetPayload alloc] init];
-    payload.UpdateFlags = [NSNumber numberWithUnsignedChar:4];
-    payload.Action = [NSNumber numberWithUnsignedChar:0];
-    payload.Direction = [NSNumber numberWithUnsignedChar:0];
-    payload.Time = [NSNumber numberWithUnsignedShort:30U];
-    payload.StartHue = [NSNumber numberWithUnsignedShort:0U];
-    payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
+    payload.updateFlags = [NSNumber numberWithUnsignedChar:4];
+    payload.action = [NSNumber numberWithUnsignedChar:0];
+    payload.direction = [NSNumber numberWithUnsignedChar:0];
+    payload.time = [NSNumber numberWithUnsignedShort:30U];
+    payload.startHue = [NSNumber numberWithUnsignedShort:0U];
+    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster colorLoopSet:payload
           responseHandler:^(NSError * err, NSDictionary * values) {
               NSLog(@"Sends ColorLoopSet Command - Set all Attributes Error: %@", err);
@@ -7172,13 +7172,13 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPColorControlClusterColorLoopSetPayload alloc] init];
-    payload.UpdateFlags = [NSNumber numberWithUnsignedChar:8];
-    payload.Action = [NSNumber numberWithUnsignedChar:0];
-    payload.Direction = [NSNumber numberWithUnsignedChar:0];
-    payload.Time = [NSNumber numberWithUnsignedShort:0U];
-    payload.StartHue = [NSNumber numberWithUnsignedShort:160U];
-    payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
+    payload.updateFlags = [NSNumber numberWithUnsignedChar:8];
+    payload.action = [NSNumber numberWithUnsignedChar:0];
+    payload.direction = [NSNumber numberWithUnsignedChar:0];
+    payload.time = [NSNumber numberWithUnsignedShort:0U];
+    payload.startHue = [NSNumber numberWithUnsignedShort:160U];
+    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster colorLoopSet:payload
           responseHandler:^(NSError * err, NSDictionary * values) {
               NSLog(@"Sends ColorLoopSet Command - Set all Attributes Error: %@", err);
@@ -7224,13 +7224,13 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPColorControlClusterColorLoopSetPayload alloc] init];
-    payload.UpdateFlags = [NSNumber numberWithUnsignedChar:1];
-    payload.Action = [NSNumber numberWithUnsignedChar:1];
-    payload.Direction = [NSNumber numberWithUnsignedChar:0];
-    payload.Time = [NSNumber numberWithUnsignedShort:0U];
-    payload.StartHue = [NSNumber numberWithUnsignedShort:0U];
-    payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
+    payload.updateFlags = [NSNumber numberWithUnsignedChar:1];
+    payload.action = [NSNumber numberWithUnsignedChar:1];
+    payload.direction = [NSNumber numberWithUnsignedChar:0];
+    payload.time = [NSNumber numberWithUnsignedShort:0U];
+    payload.startHue = [NSNumber numberWithUnsignedShort:0U];
+    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster colorLoopSet:payload
           responseHandler:^(NSError * err, NSDictionary * values) {
               NSLog(@"Sends ColorLoopSet Command - Set all Attributes Error: %@", err);
@@ -7276,13 +7276,13 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPColorControlClusterColorLoopSetPayload alloc] init];
-    payload.UpdateFlags = [NSNumber numberWithUnsignedChar:1];
-    payload.Action = [NSNumber numberWithUnsignedChar:0];
-    payload.Direction = [NSNumber numberWithUnsignedChar:0];
-    payload.Time = [NSNumber numberWithUnsignedShort:0U];
-    payload.StartHue = [NSNumber numberWithUnsignedShort:0U];
-    payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
+    payload.updateFlags = [NSNumber numberWithUnsignedChar:1];
+    payload.action = [NSNumber numberWithUnsignedChar:0];
+    payload.direction = [NSNumber numberWithUnsignedChar:0];
+    payload.time = [NSNumber numberWithUnsignedShort:0U];
+    payload.startHue = [NSNumber numberWithUnsignedShort:0U];
+    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster colorLoopSet:payload
           responseHandler:^(NSError * err, NSDictionary * values) {
               NSLog(@"Sends ColorLoopSet Command - Set all Attributes Error: %@", err);
@@ -7328,13 +7328,13 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPColorControlClusterColorLoopSetPayload alloc] init];
-    payload.UpdateFlags = [NSNumber numberWithUnsignedChar:2];
-    payload.Action = [NSNumber numberWithUnsignedChar:0];
-    payload.Direction = [NSNumber numberWithUnsignedChar:1];
-    payload.Time = [NSNumber numberWithUnsignedShort:0U];
-    payload.StartHue = [NSNumber numberWithUnsignedShort:0U];
-    payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
+    payload.updateFlags = [NSNumber numberWithUnsignedChar:2];
+    payload.action = [NSNumber numberWithUnsignedChar:0];
+    payload.direction = [NSNumber numberWithUnsignedChar:1];
+    payload.time = [NSNumber numberWithUnsignedShort:0U];
+    payload.startHue = [NSNumber numberWithUnsignedShort:0U];
+    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster colorLoopSet:payload
           responseHandler:^(NSError * err, NSDictionary * values) {
               NSLog(@"Sends ColorLoopSet Command - Set all Attributes Error: %@", err);
@@ -7380,13 +7380,13 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPColorControlClusterColorLoopSetPayload alloc] init];
-    payload.UpdateFlags = [NSNumber numberWithUnsignedChar:1];
-    payload.Action = [NSNumber numberWithUnsignedChar:1];
-    payload.Direction = [NSNumber numberWithUnsignedChar:0];
-    payload.Time = [NSNumber numberWithUnsignedShort:0U];
-    payload.StartHue = [NSNumber numberWithUnsignedShort:0U];
-    payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
+    payload.updateFlags = [NSNumber numberWithUnsignedChar:1];
+    payload.action = [NSNumber numberWithUnsignedChar:1];
+    payload.direction = [NSNumber numberWithUnsignedChar:0];
+    payload.time = [NSNumber numberWithUnsignedShort:0U];
+    payload.startHue = [NSNumber numberWithUnsignedShort:0U];
+    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster colorLoopSet:payload
           responseHandler:^(NSError * err, NSDictionary * values) {
               NSLog(@"Sends ColorLoopSet Command - Set all Attributes Error: %@", err);
@@ -7432,13 +7432,13 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPColorControlClusterColorLoopSetPayload alloc] init];
-    payload.UpdateFlags = [NSNumber numberWithUnsignedChar:1];
-    payload.Action = [NSNumber numberWithUnsignedChar:0];
-    payload.Direction = [NSNumber numberWithUnsignedChar:0];
-    payload.Time = [NSNumber numberWithUnsignedShort:0U];
-    payload.StartHue = [NSNumber numberWithUnsignedShort:0U];
-    payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
+    payload.updateFlags = [NSNumber numberWithUnsignedChar:1];
+    payload.action = [NSNumber numberWithUnsignedChar:0];
+    payload.direction = [NSNumber numberWithUnsignedChar:0];
+    payload.time = [NSNumber numberWithUnsignedShort:0U];
+    payload.startHue = [NSNumber numberWithUnsignedShort:0U];
+    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster colorLoopSet:payload
           responseHandler:^(NSError * err, NSDictionary * values) {
               NSLog(@"Sends ColorLoopSet Command - Set all Attributes Error: %@", err);
@@ -7484,11 +7484,11 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPColorControlClusterEnhancedMoveToHuePayload alloc] init];
-    payload.EnhancedHue = [NSNumber numberWithUnsignedShort:40960U];
-    payload.Direction = [NSNumber numberWithUnsignedChar:0];
-    payload.TransitionTime = [NSNumber numberWithUnsignedShort:0U];
-    payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
+    payload.enhancedHue = [NSNumber numberWithUnsignedShort:40960U];
+    payload.direction = [NSNumber numberWithUnsignedChar:0];
+    payload.transitionTime = [NSNumber numberWithUnsignedShort:0U];
+    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster enhancedMoveToHue:payload
                responseHandler:^(NSError * err, NSDictionary * values) {
                    NSLog(@"Enhanced Move To Hue command 10 Error: %@", err);
@@ -7542,13 +7542,13 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPColorControlClusterColorLoopSetPayload alloc] init];
-    payload.UpdateFlags = [NSNumber numberWithUnsignedChar:2];
-    payload.Action = [NSNumber numberWithUnsignedChar:0];
-    payload.Direction = [NSNumber numberWithUnsignedChar:0];
-    payload.Time = [NSNumber numberWithUnsignedShort:0U];
-    payload.StartHue = [NSNumber numberWithUnsignedShort:0U];
-    payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
+    payload.updateFlags = [NSNumber numberWithUnsignedChar:2];
+    payload.action = [NSNumber numberWithUnsignedChar:0];
+    payload.direction = [NSNumber numberWithUnsignedChar:0];
+    payload.time = [NSNumber numberWithUnsignedShort:0U];
+    payload.startHue = [NSNumber numberWithUnsignedShort:0U];
+    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster colorLoopSet:payload
           responseHandler:^(NSError * err, NSDictionary * values) {
               NSLog(@"Sends ColorLoopSet Command - Set all Attributes Error: %@", err);
@@ -7594,13 +7594,13 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPColorControlClusterColorLoopSetPayload alloc] init];
-    payload.UpdateFlags = [NSNumber numberWithUnsignedChar:1];
-    payload.Action = [NSNumber numberWithUnsignedChar:2];
-    payload.Direction = [NSNumber numberWithUnsignedChar:0];
-    payload.Time = [NSNumber numberWithUnsignedShort:0U];
-    payload.StartHue = [NSNumber numberWithUnsignedShort:0U];
-    payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
+    payload.updateFlags = [NSNumber numberWithUnsignedChar:1];
+    payload.action = [NSNumber numberWithUnsignedChar:2];
+    payload.direction = [NSNumber numberWithUnsignedChar:0];
+    payload.time = [NSNumber numberWithUnsignedShort:0U];
+    payload.startHue = [NSNumber numberWithUnsignedShort:0U];
+    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster colorLoopSet:payload
           responseHandler:^(NSError * err, NSDictionary * values) {
               NSLog(@"Sends ColorLoopSet Command - Set all Attributes Error: %@", err);
@@ -7646,13 +7646,13 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPColorControlClusterColorLoopSetPayload alloc] init];
-    payload.UpdateFlags = [NSNumber numberWithUnsignedChar:1];
-    payload.Action = [NSNumber numberWithUnsignedChar:0];
-    payload.Direction = [NSNumber numberWithUnsignedChar:0];
-    payload.Time = [NSNumber numberWithUnsignedShort:0U];
-    payload.StartHue = [NSNumber numberWithUnsignedShort:0U];
-    payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
+    payload.updateFlags = [NSNumber numberWithUnsignedChar:1];
+    payload.action = [NSNumber numberWithUnsignedChar:0];
+    payload.direction = [NSNumber numberWithUnsignedChar:0];
+    payload.time = [NSNumber numberWithUnsignedShort:0U];
+    payload.startHue = [NSNumber numberWithUnsignedShort:0U];
+    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster colorLoopSet:payload
           responseHandler:^(NSError * err, NSDictionary * values) {
               NSLog(@"Sends ColorLoopSet Command - Set all Attributes Error: %@", err);
@@ -7698,13 +7698,13 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPColorControlClusterColorLoopSetPayload alloc] init];
-    payload.UpdateFlags = [NSNumber numberWithUnsignedChar:2];
-    payload.Action = [NSNumber numberWithUnsignedChar:0];
-    payload.Direction = [NSNumber numberWithUnsignedChar:1];
-    payload.Time = [NSNumber numberWithUnsignedShort:0U];
-    payload.StartHue = [NSNumber numberWithUnsignedShort:0U];
-    payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
+    payload.updateFlags = [NSNumber numberWithUnsignedChar:2];
+    payload.action = [NSNumber numberWithUnsignedChar:0];
+    payload.direction = [NSNumber numberWithUnsignedChar:1];
+    payload.time = [NSNumber numberWithUnsignedShort:0U];
+    payload.startHue = [NSNumber numberWithUnsignedShort:0U];
+    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster colorLoopSet:payload
           responseHandler:^(NSError * err, NSDictionary * values) {
               NSLog(@"Sends ColorLoopSet Command - Set all Attributes Error: %@", err);
@@ -7750,13 +7750,13 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPColorControlClusterColorLoopSetPayload alloc] init];
-    payload.UpdateFlags = [NSNumber numberWithUnsignedChar:1];
-    payload.Action = [NSNumber numberWithUnsignedChar:2];
-    payload.Direction = [NSNumber numberWithUnsignedChar:0];
-    payload.Time = [NSNumber numberWithUnsignedShort:0U];
-    payload.StartHue = [NSNumber numberWithUnsignedShort:0U];
-    payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
+    payload.updateFlags = [NSNumber numberWithUnsignedChar:1];
+    payload.action = [NSNumber numberWithUnsignedChar:2];
+    payload.direction = [NSNumber numberWithUnsignedChar:0];
+    payload.time = [NSNumber numberWithUnsignedShort:0U];
+    payload.startHue = [NSNumber numberWithUnsignedShort:0U];
+    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster colorLoopSet:payload
           responseHandler:^(NSError * err, NSDictionary * values) {
               NSLog(@"Sends ColorLoopSet Command - Set all Attributes Error: %@", err);
@@ -7802,13 +7802,13 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPColorControlClusterColorLoopSetPayload alloc] init];
-    payload.UpdateFlags = [NSNumber numberWithUnsignedChar:1];
-    payload.Action = [NSNumber numberWithUnsignedChar:0];
-    payload.Direction = [NSNumber numberWithUnsignedChar:0];
-    payload.Time = [NSNumber numberWithUnsignedShort:0U];
-    payload.StartHue = [NSNumber numberWithUnsignedShort:0U];
-    payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
+    payload.updateFlags = [NSNumber numberWithUnsignedChar:1];
+    payload.action = [NSNumber numberWithUnsignedChar:0];
+    payload.direction = [NSNumber numberWithUnsignedChar:0];
+    payload.time = [NSNumber numberWithUnsignedShort:0U];
+    payload.startHue = [NSNumber numberWithUnsignedShort:0U];
+    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster colorLoopSet:payload
           responseHandler:^(NSError * err, NSDictionary * values) {
               NSLog(@"Sends ColorLoopSet Command - Set all Attributes Error: %@", err);
@@ -7922,13 +7922,13 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPColorControlClusterColorLoopSetPayload alloc] init];
-    payload.UpdateFlags = [NSNumber numberWithUnsignedChar:15];
-    payload.Action = [NSNumber numberWithUnsignedChar:0];
-    payload.Direction = [NSNumber numberWithUnsignedChar:0];
-    payload.Time = [NSNumber numberWithUnsignedShort:30U];
-    payload.StartHue = [NSNumber numberWithUnsignedShort:160U];
-    payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
+    payload.updateFlags = [NSNumber numberWithUnsignedChar:15];
+    payload.action = [NSNumber numberWithUnsignedChar:0];
+    payload.direction = [NSNumber numberWithUnsignedChar:0];
+    payload.time = [NSNumber numberWithUnsignedShort:30U];
+    payload.startHue = [NSNumber numberWithUnsignedShort:160U];
+    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster colorLoopSet:payload
           responseHandler:^(NSError * err, NSDictionary * values) {
               NSLog(@"Sends ColorLoopSet Command - Set all Attributes Error: %@", err);
@@ -8046,13 +8046,13 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPColorControlClusterColorLoopSetPayload alloc] init];
-    payload.UpdateFlags = [NSNumber numberWithUnsignedChar:1];
-    payload.Action = [NSNumber numberWithUnsignedChar:1];
-    payload.Direction = [NSNumber numberWithUnsignedChar:0];
-    payload.Time = [NSNumber numberWithUnsignedShort:0U];
-    payload.StartHue = [NSNumber numberWithUnsignedShort:0U];
-    payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
+    payload.updateFlags = [NSNumber numberWithUnsignedChar:1];
+    payload.action = [NSNumber numberWithUnsignedChar:1];
+    payload.direction = [NSNumber numberWithUnsignedChar:0];
+    payload.time = [NSNumber numberWithUnsignedShort:0U];
+    payload.startHue = [NSNumber numberWithUnsignedShort:0U];
+    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster colorLoopSet:payload
           responseHandler:^(NSError * err, NSDictionary * values) {
               NSLog(@"Color Loop Set Command - Set all Attributes Error: %@", err);
@@ -8098,13 +8098,13 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPColorControlClusterColorLoopSetPayload alloc] init];
-    payload.UpdateFlags = [NSNumber numberWithUnsignedChar:2];
-    payload.Action = [NSNumber numberWithUnsignedChar:0];
-    payload.Direction = [NSNumber numberWithUnsignedChar:1];
-    payload.Time = [NSNumber numberWithUnsignedShort:0U];
-    payload.StartHue = [NSNumber numberWithUnsignedShort:0U];
-    payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
+    payload.updateFlags = [NSNumber numberWithUnsignedChar:2];
+    payload.action = [NSNumber numberWithUnsignedChar:0];
+    payload.direction = [NSNumber numberWithUnsignedChar:1];
+    payload.time = [NSNumber numberWithUnsignedShort:0U];
+    payload.startHue = [NSNumber numberWithUnsignedShort:0U];
+    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster colorLoopSet:payload
           responseHandler:^(NSError * err, NSDictionary * values) {
               NSLog(@"Color Loop Set Command - Start Color Loop Error: %@", err);
@@ -8150,13 +8150,13 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPColorControlClusterColorLoopSetPayload alloc] init];
-    payload.UpdateFlags = [NSNumber numberWithUnsignedChar:1];
-    payload.Action = [NSNumber numberWithUnsignedChar:0];
-    payload.Direction = [NSNumber numberWithUnsignedChar:0];
-    payload.Time = [NSNumber numberWithUnsignedShort:0U];
-    payload.StartHue = [NSNumber numberWithUnsignedShort:0U];
-    payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
+    payload.updateFlags = [NSNumber numberWithUnsignedChar:1];
+    payload.action = [NSNumber numberWithUnsignedChar:0];
+    payload.direction = [NSNumber numberWithUnsignedChar:0];
+    payload.time = [NSNumber numberWithUnsignedShort:0U];
+    payload.startHue = [NSNumber numberWithUnsignedShort:0U];
+    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster colorLoopSet:payload
           responseHandler:^(NSError * err, NSDictionary * values) {
               NSLog(@"Color Loop Set Command - Start Color Loop Error: %@", err);
@@ -8270,13 +8270,13 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPColorControlClusterColorLoopSetPayload alloc] init];
-    payload.UpdateFlags = [NSNumber numberWithUnsignedChar:15];
-    payload.Action = [NSNumber numberWithUnsignedChar:0];
-    payload.Direction = [NSNumber numberWithUnsignedChar:0];
-    payload.Time = [NSNumber numberWithUnsignedShort:30U];
-    payload.StartHue = [NSNumber numberWithUnsignedShort:160U];
-    payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
+    payload.updateFlags = [NSNumber numberWithUnsignedChar:15];
+    payload.action = [NSNumber numberWithUnsignedChar:0];
+    payload.direction = [NSNumber numberWithUnsignedChar:0];
+    payload.time = [NSNumber numberWithUnsignedShort:30U];
+    payload.startHue = [NSNumber numberWithUnsignedShort:160U];
+    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster colorLoopSet:payload
           responseHandler:^(NSError * err, NSDictionary * values) {
               NSLog(@"Sends ColorLoopSet Command - Set all Attributes Error: %@", err);
@@ -8394,13 +8394,13 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPColorControlClusterColorLoopSetPayload alloc] init];
-    payload.UpdateFlags = [NSNumber numberWithUnsignedChar:1];
-    payload.Action = [NSNumber numberWithUnsignedChar:1];
-    payload.Direction = [NSNumber numberWithUnsignedChar:0];
-    payload.Time = [NSNumber numberWithUnsignedShort:0U];
-    payload.StartHue = [NSNumber numberWithUnsignedShort:0U];
-    payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
+    payload.updateFlags = [NSNumber numberWithUnsignedChar:1];
+    payload.action = [NSNumber numberWithUnsignedChar:1];
+    payload.direction = [NSNumber numberWithUnsignedChar:0];
+    payload.time = [NSNumber numberWithUnsignedShort:0U];
+    payload.startHue = [NSNumber numberWithUnsignedShort:0U];
+    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster colorLoopSet:payload
           responseHandler:^(NSError * err, NSDictionary * values) {
               NSLog(@"Color Loop Set Command - Set all Attributes Error: %@", err);
@@ -8446,13 +8446,13 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPColorControlClusterColorLoopSetPayload alloc] init];
-    payload.UpdateFlags = [NSNumber numberWithUnsignedChar:4];
-    payload.Action = [NSNumber numberWithUnsignedChar:0];
-    payload.Direction = [NSNumber numberWithUnsignedChar:0];
-    payload.Time = [NSNumber numberWithUnsignedShort:60U];
-    payload.StartHue = [NSNumber numberWithUnsignedShort:0U];
-    payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
+    payload.updateFlags = [NSNumber numberWithUnsignedChar:4];
+    payload.action = [NSNumber numberWithUnsignedChar:0];
+    payload.direction = [NSNumber numberWithUnsignedChar:0];
+    payload.time = [NSNumber numberWithUnsignedShort:60U];
+    payload.startHue = [NSNumber numberWithUnsignedShort:0U];
+    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster colorLoopSet:payload
           responseHandler:^(NSError * err, NSDictionary * values) {
               NSLog(@"Color Loop Set Command - Start Color Loop Error: %@", err);
@@ -8498,13 +8498,13 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPColorControlClusterColorLoopSetPayload alloc] init];
-    payload.UpdateFlags = [NSNumber numberWithUnsignedChar:1];
-    payload.Action = [NSNumber numberWithUnsignedChar:0];
-    payload.Direction = [NSNumber numberWithUnsignedChar:0];
-    payload.Time = [NSNumber numberWithUnsignedShort:0U];
-    payload.StartHue = [NSNumber numberWithUnsignedShort:0U];
-    payload.OptionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.OptionsOverride = [NSNumber numberWithUnsignedChar:0];
+    payload.updateFlags = [NSNumber numberWithUnsignedChar:1];
+    payload.action = [NSNumber numberWithUnsignedChar:0];
+    payload.direction = [NSNumber numberWithUnsignedChar:0];
+    payload.time = [NSNumber numberWithUnsignedShort:0U];
+    payload.startHue = [NSNumber numberWithUnsignedShort:0U];
+    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster colorLoopSet:payload
           responseHandler:^(NSError * err, NSDictionary * values) {
               NSLog(@"Color Loop Set Command - Start Color Loop Error: %@", err);
@@ -9395,10 +9395,10 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPLevelControlClusterMoveToLevelPayload alloc] init];
-    payload.Level = [NSNumber numberWithUnsignedChar:64];
-    payload.TransitionTime = [NSNumber numberWithUnsignedShort:0U];
-    payload.OptionMask = [NSNumber numberWithUnsignedChar:1];
-    payload.OptionOverride = [NSNumber numberWithUnsignedChar:1];
+    payload.level = [NSNumber numberWithUnsignedChar:64];
+    payload.transitionTime = [NSNumber numberWithUnsignedShort:0U];
+    payload.optionMask = [NSNumber numberWithUnsignedChar:1];
+    payload.optionOverride = [NSNumber numberWithUnsignedChar:1];
     [cluster moveToLevel:payload
          responseHandler:^(NSError * err, NSDictionary * values) {
              NSLog(@"sends a Move to level command Error: %@", err);
@@ -9452,10 +9452,10 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPLevelControlClusterMoveToLevelPayload alloc] init];
-    payload.Level = [NSNumber numberWithUnsignedChar:128];
-    payload.TransitionTime = [NSNumber numberWithUnsignedShort:1U];
-    payload.OptionMask = [NSNumber numberWithUnsignedChar:1];
-    payload.OptionOverride = [NSNumber numberWithUnsignedChar:1];
+    payload.level = [NSNumber numberWithUnsignedChar:128];
+    payload.transitionTime = [NSNumber numberWithUnsignedShort:1U];
+    payload.optionMask = [NSNumber numberWithUnsignedChar:1];
+    payload.optionOverride = [NSNumber numberWithUnsignedChar:1];
     [cluster moveToLevel:payload
          responseHandler:^(NSError * err, NSDictionary * values) {
              NSLog(@"sends a Move to level command Error: %@", err);
@@ -9533,10 +9533,10 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPLevelControlClusterMoveToLevelPayload alloc] init];
-    payload.Level = [NSNumber numberWithUnsignedChar:254];
-    payload.TransitionTime = [NSNumber numberWithUnsignedShort:65535U];
-    payload.OptionMask = [NSNumber numberWithUnsignedChar:1];
-    payload.OptionOverride = [NSNumber numberWithUnsignedChar:1];
+    payload.level = [NSNumber numberWithUnsignedChar:254];
+    payload.transitionTime = [NSNumber numberWithUnsignedShort:65535U];
+    payload.optionMask = [NSNumber numberWithUnsignedChar:1];
+    payload.optionOverride = [NSNumber numberWithUnsignedChar:1];
     [cluster moveToLevel:payload
          responseHandler:^(NSError * err, NSDictionary * values) {
              NSLog(@"sends a Move to level command Error: %@", err);
@@ -9590,10 +9590,10 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPLevelControlClusterMoveToLevelPayload alloc] init];
-    payload.Level = [NSNumber numberWithUnsignedChar:0];
-    payload.TransitionTime = [NSNumber numberWithUnsignedShort:0U];
-    payload.OptionMask = [NSNumber numberWithUnsignedChar:1];
-    payload.OptionOverride = [NSNumber numberWithUnsignedChar:1];
+    payload.level = [NSNumber numberWithUnsignedChar:0];
+    payload.transitionTime = [NSNumber numberWithUnsignedShort:0U];
+    payload.optionMask = [NSNumber numberWithUnsignedChar:1];
+    payload.optionOverride = [NSNumber numberWithUnsignedChar:1];
     [cluster moveToLevel:payload
          responseHandler:^(NSError * err, NSDictionary * values) {
              NSLog(@"Reset level to 0 Error: %@", err);
@@ -9672,10 +9672,10 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPLevelControlClusterMovePayload alloc] init];
-    payload.MoveMode = [NSNumber numberWithUnsignedChar:0];
-    payload.Rate = [NSNumber numberWithUnsignedChar:200];
-    payload.OptionMask = [NSNumber numberWithUnsignedChar:1];
-    payload.OptionOverride = [NSNumber numberWithUnsignedChar:1];
+    payload.moveMode = [NSNumber numberWithUnsignedChar:0];
+    payload.rate = [NSNumber numberWithUnsignedChar:200];
+    payload.optionMask = [NSNumber numberWithUnsignedChar:1];
+    payload.optionOverride = [NSNumber numberWithUnsignedChar:1];
     [cluster move:payload
         responseHandler:^(NSError * err, NSDictionary * values) {
             NSLog(@"sends a Move up command Error: %@", err);
@@ -9753,10 +9753,10 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPLevelControlClusterMovePayload alloc] init];
-    payload.MoveMode = [NSNumber numberWithUnsignedChar:1];
-    payload.Rate = [NSNumber numberWithUnsignedChar:250];
-    payload.OptionMask = [NSNumber numberWithUnsignedChar:1];
-    payload.OptionOverride = [NSNumber numberWithUnsignedChar:1];
+    payload.moveMode = [NSNumber numberWithUnsignedChar:1];
+    payload.rate = [NSNumber numberWithUnsignedChar:250];
+    payload.optionMask = [NSNumber numberWithUnsignedChar:1];
+    payload.optionOverride = [NSNumber numberWithUnsignedChar:1];
     [cluster move:payload
         responseHandler:^(NSError * err, NSDictionary * values) {
             NSLog(@"sends a Move down command Error: %@", err);
@@ -9856,10 +9856,10 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPLevelControlClusterMovePayload alloc] init];
-    payload.MoveMode = [NSNumber numberWithUnsignedChar:1];
-    payload.Rate = [NSNumber numberWithUnsignedChar:255];
-    payload.OptionMask = [NSNumber numberWithUnsignedChar:1];
-    payload.OptionOverride = [NSNumber numberWithUnsignedChar:1];
+    payload.moveMode = [NSNumber numberWithUnsignedChar:1];
+    payload.rate = [NSNumber numberWithUnsignedChar:255];
+    payload.optionMask = [NSNumber numberWithUnsignedChar:1];
+    payload.optionOverride = [NSNumber numberWithUnsignedChar:1];
     [cluster move:payload
         responseHandler:^(NSError * err, NSDictionary * values) {
             NSLog(@"sends a Move up command at default move rate Error: %@", err);
@@ -9932,11 +9932,11 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPLevelControlClusterStepPayload alloc] init];
-    payload.StepMode = [NSNumber numberWithUnsignedChar:0];
-    payload.StepSize = [NSNumber numberWithUnsignedChar:128];
-    payload.TransitionTime = [NSNumber numberWithUnsignedShort:20U];
-    payload.OptionMask = [NSNumber numberWithUnsignedChar:0];
-    payload.OptionOverride = [NSNumber numberWithUnsignedChar:0];
+    payload.stepMode = [NSNumber numberWithUnsignedChar:0];
+    payload.stepSize = [NSNumber numberWithUnsignedChar:128];
+    payload.transitionTime = [NSNumber numberWithUnsignedShort:20U];
+    payload.optionMask = [NSNumber numberWithUnsignedChar:0];
+    payload.optionOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster step:payload
         responseHandler:^(NSError * err, NSDictionary * values) {
             NSLog(@"Precondition: DUT level is set to 0x80 Error: %@", err);
@@ -9990,11 +9990,11 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPLevelControlClusterStepPayload alloc] init];
-    payload.StepMode = [NSNumber numberWithUnsignedChar:1];
-    payload.StepSize = [NSNumber numberWithUnsignedChar:64];
-    payload.TransitionTime = [NSNumber numberWithUnsignedShort:20U];
-    payload.OptionMask = [NSNumber numberWithUnsignedChar:0];
-    payload.OptionOverride = [NSNumber numberWithUnsignedChar:0];
+    payload.stepMode = [NSNumber numberWithUnsignedChar:1];
+    payload.stepSize = [NSNumber numberWithUnsignedChar:64];
+    payload.transitionTime = [NSNumber numberWithUnsignedShort:20U];
+    payload.optionMask = [NSNumber numberWithUnsignedChar:0];
+    payload.optionOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster step:payload
         responseHandler:^(NSError * err, NSDictionary * values) {
             NSLog(@"Sends step down command to DUT Error: %@", err);
@@ -10048,11 +10048,11 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPLevelControlClusterStepPayload alloc] init];
-    payload.StepMode = [NSNumber numberWithUnsignedChar:0];
-    payload.StepSize = [NSNumber numberWithUnsignedChar:64];
-    payload.TransitionTime = [NSNumber numberWithUnsignedShort:20U];
-    payload.OptionMask = [NSNumber numberWithUnsignedChar:0];
-    payload.OptionOverride = [NSNumber numberWithUnsignedChar:0];
+    payload.stepMode = [NSNumber numberWithUnsignedChar:0];
+    payload.stepSize = [NSNumber numberWithUnsignedChar:64];
+    payload.transitionTime = [NSNumber numberWithUnsignedShort:20U];
+    payload.optionMask = [NSNumber numberWithUnsignedChar:0];
+    payload.optionOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster step:payload
         responseHandler:^(NSError * err, NSDictionary * values) {
             NSLog(@"Sends a Step up command Error: %@", err);
@@ -10149,11 +10149,11 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPLevelControlClusterStepPayload alloc] init];
-    payload.StepMode = [NSNumber numberWithUnsignedChar:0];
-    payload.StepSize = [NSNumber numberWithUnsignedChar:128];
-    payload.TransitionTime = [NSNumber numberWithUnsignedShort:20U];
-    payload.OptionMask = [NSNumber numberWithUnsignedChar:0];
-    payload.OptionOverride = [NSNumber numberWithUnsignedChar:0];
+    payload.stepMode = [NSNumber numberWithUnsignedChar:0];
+    payload.stepSize = [NSNumber numberWithUnsignedChar:128];
+    payload.transitionTime = [NSNumber numberWithUnsignedShort:20U];
+    payload.optionMask = [NSNumber numberWithUnsignedChar:0];
+    payload.optionOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster step:payload
         responseHandler:^(NSError * err, NSDictionary * values) {
             NSLog(@"Precondition: DUT level is set to 0x80 Error: %@", err);
@@ -10183,10 +10183,10 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPLevelControlClusterMovePayload alloc] init];
-    payload.MoveMode = [NSNumber numberWithUnsignedChar:0];
-    payload.Rate = [NSNumber numberWithUnsignedChar:1];
-    payload.OptionMask = [NSNumber numberWithUnsignedChar:1];
-    payload.OptionOverride = [NSNumber numberWithUnsignedChar:1];
+    payload.moveMode = [NSNumber numberWithUnsignedChar:0];
+    payload.rate = [NSNumber numberWithUnsignedChar:1];
+    payload.optionMask = [NSNumber numberWithUnsignedChar:1];
+    payload.optionOverride = [NSNumber numberWithUnsignedChar:1];
     [cluster move:payload
         responseHandler:^(NSError * err, NSDictionary * values) {
             NSLog(@"Sends a move up command to DUT Error: %@", err);
@@ -10216,8 +10216,8 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPLevelControlClusterStopPayload alloc] init];
-    payload.OptionMask = [NSNumber numberWithUnsignedChar:0];
-    payload.OptionOverride = [NSNumber numberWithUnsignedChar:0];
+    payload.optionMask = [NSNumber numberWithUnsignedChar:0];
+    payload.optionOverride = [NSNumber numberWithUnsignedChar:0];
     [cluster stop:payload
         responseHandler:^(NSError * err, NSDictionary * values) {
             NSLog(@"Sends stop command to DUT Error: %@", err);
@@ -16082,7 +16082,7 @@ CHIPDevice * GetConnectedDevice()
               XCTAssertEqual(err.code, 0);
 
               {
-                  id actualValue = values[@"ReturnValue"];
+                  id actualValue = values[@"returnValue"];
                   XCTAssertEqual([actualValue unsignedCharValue], 7);
               }
 
@@ -16101,8 +16101,8 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPTestClusterClusterTestAddArgumentsPayload alloc] init];
-    payload.Arg1 = [NSNumber numberWithUnsignedChar:3];
-    payload.Arg2 = [NSNumber numberWithUnsignedChar:17];
+    payload.arg1 = [NSNumber numberWithUnsignedChar:3];
+    payload.arg2 = [NSNumber numberWithUnsignedChar:17];
     [cluster testAddArguments:payload
               responseHandler:^(NSError * err, NSDictionary * values) {
                   NSLog(@"Send Test Add Arguments Command Error: %@", err);
@@ -16110,7 +16110,7 @@ CHIPDevice * GetConnectedDevice()
                   XCTAssertEqual(err.code, 0);
 
                   {
-                      id actualValue = values[@"ReturnValue"];
+                      id actualValue = values[@"returnValue"];
                       XCTAssertEqual([actualValue unsignedCharValue], 20);
                   }
 
@@ -16129,8 +16129,8 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPTestClusterClusterTestAddArgumentsPayload alloc] init];
-    payload.Arg1 = [NSNumber numberWithUnsignedChar:250];
-    payload.Arg2 = [NSNumber numberWithUnsignedChar:6];
+    payload.arg1 = [NSNumber numberWithUnsignedChar:250];
+    payload.arg2 = [NSNumber numberWithUnsignedChar:6];
     [cluster testAddArguments:payload
               responseHandler:^(NSError * err, NSDictionary * values) {
                   NSLog(@"Send failing Test Add Arguments Command Error: %@", err);
@@ -18948,8 +18948,8 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPTestClusterClusterTestEnumsRequestPayload alloc] init];
-    payload.Arg1 = [NSNumber numberWithUnsignedShort:20003U];
-    payload.Arg2 = [NSNumber numberWithUnsignedChar:101];
+    payload.arg1 = [NSNumber numberWithUnsignedShort:20003U];
+    payload.arg2 = [NSNumber numberWithUnsignedChar:101];
     [cluster testEnumsRequest:payload
               responseHandler:^(NSError * err, NSDictionary * values) {
                   NSLog(@"Send a command with a vendor_id and enum Error: %@", err);
@@ -18957,11 +18957,11 @@ CHIPDevice * GetConnectedDevice()
                   XCTAssertEqual(err.code, 0);
 
                   {
-                      id actualValue = values[@"Arg1"];
+                      id actualValue = values[@"arg1"];
                       XCTAssertEqual([actualValue unsignedShortValue], 20003U);
                   }
                   {
-                      id actualValue = values[@"Arg2"];
+                      id actualValue = values[@"arg2"];
                       XCTAssertEqual([actualValue unsignedCharValue], 101);
                   }
 
@@ -18981,13 +18981,13 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPTestClusterClusterTestStructArgumentRequestPayload alloc] init];
-    payload.Arg1 = [[CHIPTestClusterClusterSimpleStruct alloc] init];
-    ((CHIPTestClusterClusterSimpleStruct *) payload.Arg1).A = [NSNumber numberWithUnsignedChar:0];
-    ((CHIPTestClusterClusterSimpleStruct *) payload.Arg1).B = [NSNumber numberWithBool:true];
-    ((CHIPTestClusterClusterSimpleStruct *) payload.Arg1).C = [NSNumber numberWithUnsignedChar:2];
-    ((CHIPTestClusterClusterSimpleStruct *) payload.Arg1).D = [[NSData alloc] initWithBytes:"octet_string" length:12];
-    ((CHIPTestClusterClusterSimpleStruct *) payload.Arg1).E = @"char_string";
-    ((CHIPTestClusterClusterSimpleStruct *) payload.Arg1).F = [NSNumber numberWithUnsignedChar:1];
+    payload.arg1 = [[CHIPTestClusterClusterSimpleStruct alloc] init];
+    ((CHIPTestClusterClusterSimpleStruct *) payload.arg1).a = [NSNumber numberWithUnsignedChar:0];
+    ((CHIPTestClusterClusterSimpleStruct *) payload.arg1).b = [NSNumber numberWithBool:true];
+    ((CHIPTestClusterClusterSimpleStruct *) payload.arg1).c = [NSNumber numberWithUnsignedChar:2];
+    ((CHIPTestClusterClusterSimpleStruct *) payload.arg1).d = [[NSData alloc] initWithBytes:"octet_string" length:12];
+    ((CHIPTestClusterClusterSimpleStruct *) payload.arg1).e = @"char_string";
+    ((CHIPTestClusterClusterSimpleStruct *) payload.arg1).f = [NSNumber numberWithUnsignedChar:1];
 
     [cluster testStructArgumentRequest:payload
                        responseHandler:^(NSError * err, NSDictionary * values) {
@@ -18996,7 +18996,7 @@ CHIPDevice * GetConnectedDevice()
                            XCTAssertEqual(err.code, 0);
 
                            {
-                               id actualValue = values[@"Value"];
+                               id actualValue = values[@"value"];
                                XCTAssertEqual([actualValue boolValue], true);
                            }
 
@@ -19016,13 +19016,13 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPTestClusterClusterTestStructArgumentRequestPayload alloc] init];
-    payload.Arg1 = [[CHIPTestClusterClusterSimpleStruct alloc] init];
-    ((CHIPTestClusterClusterSimpleStruct *) payload.Arg1).A = [NSNumber numberWithUnsignedChar:0];
-    ((CHIPTestClusterClusterSimpleStruct *) payload.Arg1).B = [NSNumber numberWithBool:false];
-    ((CHIPTestClusterClusterSimpleStruct *) payload.Arg1).C = [NSNumber numberWithUnsignedChar:2];
-    ((CHIPTestClusterClusterSimpleStruct *) payload.Arg1).D = [[NSData alloc] initWithBytes:"octet_string" length:12];
-    ((CHIPTestClusterClusterSimpleStruct *) payload.Arg1).E = @"char_string";
-    ((CHIPTestClusterClusterSimpleStruct *) payload.Arg1).F = [NSNumber numberWithUnsignedChar:1];
+    payload.arg1 = [[CHIPTestClusterClusterSimpleStruct alloc] init];
+    ((CHIPTestClusterClusterSimpleStruct *) payload.arg1).a = [NSNumber numberWithUnsignedChar:0];
+    ((CHIPTestClusterClusterSimpleStruct *) payload.arg1).b = [NSNumber numberWithBool:false];
+    ((CHIPTestClusterClusterSimpleStruct *) payload.arg1).c = [NSNumber numberWithUnsignedChar:2];
+    ((CHIPTestClusterClusterSimpleStruct *) payload.arg1).d = [[NSData alloc] initWithBytes:"octet_string" length:12];
+    ((CHIPTestClusterClusterSimpleStruct *) payload.arg1).e = @"char_string";
+    ((CHIPTestClusterClusterSimpleStruct *) payload.arg1).f = [NSNumber numberWithUnsignedChar:1];
 
     [cluster testStructArgumentRequest:payload
                        responseHandler:^(NSError * err, NSDictionary * values) {
@@ -19031,7 +19031,7 @@ CHIPDevice * GetConnectedDevice()
                            XCTAssertEqual(err.code, 0);
 
                            {
-                               id actualValue = values[@"Value"];
+                               id actualValue = values[@"value"];
                                XCTAssertEqual([actualValue boolValue], false);
                            }
 
@@ -19062,7 +19062,7 @@ CHIPDevice * GetConnectedDevice()
         temp[6] = [NSNumber numberWithUnsignedChar:7];
         temp[7] = [NSNumber numberWithUnsignedChar:8];
         temp[8] = [NSNumber numberWithUnsignedChar:9];
-        payload.Arg1 = temp;
+        payload.arg1 = temp;
     }
     [cluster testListInt8UArgumentRequest:payload
                           responseHandler:^(NSError * err, NSDictionary * values) {
@@ -19071,7 +19071,7 @@ CHIPDevice * GetConnectedDevice()
                               XCTAssertEqual(err.code, 0);
 
                               {
-                                  id actualValue = values[@"Value"];
+                                  id actualValue = values[@"value"];
                                   XCTAssertEqual([actualValue boolValue], true);
                               }
 
@@ -19103,7 +19103,7 @@ CHIPDevice * GetConnectedDevice()
         temp[7] = [NSNumber numberWithUnsignedChar:8];
         temp[8] = [NSNumber numberWithUnsignedChar:9];
         temp[9] = [NSNumber numberWithUnsignedChar:0];
-        payload.Arg1 = temp;
+        payload.arg1 = temp;
     }
     [cluster testListInt8UArgumentRequest:payload
                           responseHandler:^(NSError * err, NSDictionary * values) {
@@ -19112,7 +19112,7 @@ CHIPDevice * GetConnectedDevice()
                               XCTAssertEqual(err.code, 0);
 
                               {
-                                  id actualValue = values[@"Value"];
+                                  id actualValue = values[@"value"];
                                   XCTAssertEqual([actualValue boolValue], false);
                               }
 
@@ -19142,7 +19142,7 @@ CHIPDevice * GetConnectedDevice()
         temp[6] = [NSNumber numberWithUnsignedChar:7];
         temp[7] = [NSNumber numberWithUnsignedChar:8];
         temp[8] = [NSNumber numberWithUnsignedChar:9];
-        payload.Arg1 = temp;
+        payload.arg1 = temp;
     }
     [cluster testListInt8UReverseRequest:payload
                          responseHandler:^(NSError * err, NSDictionary * values) {
@@ -19151,7 +19151,7 @@ CHIPDevice * GetConnectedDevice()
                              XCTAssertEqual(err.code, 0);
 
                              {
-                                 id actualValue = values[@"Arg1"];
+                                 id actualValue = values[@"arg1"];
                                  XCTAssertEqual([actualValue count], 9);
                                  XCTAssertEqual([actualValue[0] unsignedCharValue], 9);
                                  XCTAssertEqual([actualValue[1] unsignedCharValue], 8);
@@ -19182,7 +19182,7 @@ CHIPDevice * GetConnectedDevice()
     __auto_type * payload = [[CHIPTestClusterClusterTestListInt8UReverseRequestPayload alloc] init];
     {
         NSMutableArray * temp = [[NSMutableArray alloc] init];
-        payload.Arg1 = temp;
+        payload.arg1 = temp;
     }
     [cluster testListInt8UReverseRequest:payload
                          responseHandler:^(NSError * err, NSDictionary * values) {
@@ -19191,7 +19191,7 @@ CHIPDevice * GetConnectedDevice()
                              XCTAssertEqual(err.code, 0);
 
                              {
-                                 id actualValue = values[@"Arg1"];
+                                 id actualValue = values[@"arg1"];
                                  XCTAssertEqual([actualValue count], 0);
                              }
 
@@ -19214,22 +19214,22 @@ CHIPDevice * GetConnectedDevice()
     {
         NSMutableArray * temp = [[NSMutableArray alloc] init];
         temp[0] = [[CHIPTestClusterClusterSimpleStruct alloc] init];
-        ((CHIPTestClusterClusterSimpleStruct *) temp[0]).A = [NSNumber numberWithUnsignedChar:0];
-        ((CHIPTestClusterClusterSimpleStruct *) temp[0]).B = [NSNumber numberWithBool:true];
-        ((CHIPTestClusterClusterSimpleStruct *) temp[0]).C = [NSNumber numberWithUnsignedChar:2];
-        ((CHIPTestClusterClusterSimpleStruct *) temp[0]).D = [[NSData alloc] initWithBytes:"first_octet_string" length:18];
-        ((CHIPTestClusterClusterSimpleStruct *) temp[0]).E = @"first_char_string";
-        ((CHIPTestClusterClusterSimpleStruct *) temp[0]).F = [NSNumber numberWithUnsignedChar:1];
+        ((CHIPTestClusterClusterSimpleStruct *) temp[0]).a = [NSNumber numberWithUnsignedChar:0];
+        ((CHIPTestClusterClusterSimpleStruct *) temp[0]).b = [NSNumber numberWithBool:true];
+        ((CHIPTestClusterClusterSimpleStruct *) temp[0]).c = [NSNumber numberWithUnsignedChar:2];
+        ((CHIPTestClusterClusterSimpleStruct *) temp[0]).d = [[NSData alloc] initWithBytes:"first_octet_string" length:18];
+        ((CHIPTestClusterClusterSimpleStruct *) temp[0]).e = @"first_char_string";
+        ((CHIPTestClusterClusterSimpleStruct *) temp[0]).f = [NSNumber numberWithUnsignedChar:1];
 
         temp[1] = [[CHIPTestClusterClusterSimpleStruct alloc] init];
-        ((CHIPTestClusterClusterSimpleStruct *) temp[1]).A = [NSNumber numberWithUnsignedChar:1];
-        ((CHIPTestClusterClusterSimpleStruct *) temp[1]).B = [NSNumber numberWithBool:true];
-        ((CHIPTestClusterClusterSimpleStruct *) temp[1]).C = [NSNumber numberWithUnsignedChar:3];
-        ((CHIPTestClusterClusterSimpleStruct *) temp[1]).D = [[NSData alloc] initWithBytes:"second_octet_string" length:19];
-        ((CHIPTestClusterClusterSimpleStruct *) temp[1]).E = @"second_char_string";
-        ((CHIPTestClusterClusterSimpleStruct *) temp[1]).F = [NSNumber numberWithUnsignedChar:1];
+        ((CHIPTestClusterClusterSimpleStruct *) temp[1]).a = [NSNumber numberWithUnsignedChar:1];
+        ((CHIPTestClusterClusterSimpleStruct *) temp[1]).b = [NSNumber numberWithBool:true];
+        ((CHIPTestClusterClusterSimpleStruct *) temp[1]).c = [NSNumber numberWithUnsignedChar:3];
+        ((CHIPTestClusterClusterSimpleStruct *) temp[1]).d = [[NSData alloc] initWithBytes:"second_octet_string" length:19];
+        ((CHIPTestClusterClusterSimpleStruct *) temp[1]).e = @"second_char_string";
+        ((CHIPTestClusterClusterSimpleStruct *) temp[1]).f = [NSNumber numberWithUnsignedChar:1];
 
-        payload.Arg1 = temp;
+        payload.arg1 = temp;
     }
     [cluster
         testListStructArgumentRequest:payload
@@ -19239,7 +19239,7 @@ CHIPDevice * GetConnectedDevice()
                           XCTAssertEqual(err.code, 0);
 
                           {
-                              id actualValue = values[@"Value"];
+                              id actualValue = values[@"value"];
                               XCTAssertEqual([actualValue boolValue], true);
                           }
 
@@ -19262,22 +19262,22 @@ CHIPDevice * GetConnectedDevice()
     {
         NSMutableArray * temp = [[NSMutableArray alloc] init];
         temp[0] = [[CHIPTestClusterClusterSimpleStruct alloc] init];
-        ((CHIPTestClusterClusterSimpleStruct *) temp[0]).A = [NSNumber numberWithUnsignedChar:1];
-        ((CHIPTestClusterClusterSimpleStruct *) temp[0]).B = [NSNumber numberWithBool:true];
-        ((CHIPTestClusterClusterSimpleStruct *) temp[0]).C = [NSNumber numberWithUnsignedChar:3];
-        ((CHIPTestClusterClusterSimpleStruct *) temp[0]).D = [[NSData alloc] initWithBytes:"second_octet_string" length:19];
-        ((CHIPTestClusterClusterSimpleStruct *) temp[0]).E = @"second_char_string";
-        ((CHIPTestClusterClusterSimpleStruct *) temp[0]).F = [NSNumber numberWithUnsignedChar:1];
+        ((CHIPTestClusterClusterSimpleStruct *) temp[0]).a = [NSNumber numberWithUnsignedChar:1];
+        ((CHIPTestClusterClusterSimpleStruct *) temp[0]).b = [NSNumber numberWithBool:true];
+        ((CHIPTestClusterClusterSimpleStruct *) temp[0]).c = [NSNumber numberWithUnsignedChar:3];
+        ((CHIPTestClusterClusterSimpleStruct *) temp[0]).d = [[NSData alloc] initWithBytes:"second_octet_string" length:19];
+        ((CHIPTestClusterClusterSimpleStruct *) temp[0]).e = @"second_char_string";
+        ((CHIPTestClusterClusterSimpleStruct *) temp[0]).f = [NSNumber numberWithUnsignedChar:1];
 
         temp[1] = [[CHIPTestClusterClusterSimpleStruct alloc] init];
-        ((CHIPTestClusterClusterSimpleStruct *) temp[1]).A = [NSNumber numberWithUnsignedChar:0];
-        ((CHIPTestClusterClusterSimpleStruct *) temp[1]).B = [NSNumber numberWithBool:false];
-        ((CHIPTestClusterClusterSimpleStruct *) temp[1]).C = [NSNumber numberWithUnsignedChar:2];
-        ((CHIPTestClusterClusterSimpleStruct *) temp[1]).D = [[NSData alloc] initWithBytes:"first_octet_string" length:18];
-        ((CHIPTestClusterClusterSimpleStruct *) temp[1]).E = @"first_char_string";
-        ((CHIPTestClusterClusterSimpleStruct *) temp[1]).F = [NSNumber numberWithUnsignedChar:1];
+        ((CHIPTestClusterClusterSimpleStruct *) temp[1]).a = [NSNumber numberWithUnsignedChar:0];
+        ((CHIPTestClusterClusterSimpleStruct *) temp[1]).b = [NSNumber numberWithBool:false];
+        ((CHIPTestClusterClusterSimpleStruct *) temp[1]).c = [NSNumber numberWithUnsignedChar:2];
+        ((CHIPTestClusterClusterSimpleStruct *) temp[1]).d = [[NSData alloc] initWithBytes:"first_octet_string" length:18];
+        ((CHIPTestClusterClusterSimpleStruct *) temp[1]).e = @"first_char_string";
+        ((CHIPTestClusterClusterSimpleStruct *) temp[1]).f = [NSNumber numberWithUnsignedChar:1];
 
-        payload.Arg1 = temp;
+        payload.arg1 = temp;
     }
     [cluster
         testListStructArgumentRequest:payload
@@ -19287,7 +19287,7 @@ CHIPDevice * GetConnectedDevice()
                           XCTAssertEqual(err.code, 0);
 
                           {
-                              id actualValue = values[@"Value"];
+                              id actualValue = values[@"value"];
                               XCTAssertEqual([actualValue boolValue], false);
                           }
 
@@ -19306,7 +19306,7 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPTestClusterClusterTestNullableOptionalRequestPayload alloc] init];
-    payload.Arg1 = [NSNumber numberWithUnsignedChar:5];
+    payload.arg1 = [NSNumber numberWithUnsignedChar:5];
     [cluster testNullableOptionalRequest:payload
                          responseHandler:^(NSError * err, NSDictionary * values) {
                              NSLog(@"Send Test Command with optional arg set. Error: %@", err);
@@ -19314,19 +19314,19 @@ CHIPDevice * GetConnectedDevice()
                              XCTAssertEqual(err.code, 0);
 
                              {
-                                 id actualValue = values[@"WasPresent"];
+                                 id actualValue = values[@"wasPresent"];
                                  XCTAssertEqual([actualValue boolValue], true);
                              }
                              {
-                                 id actualValue = values[@"WasNull"];
+                                 id actualValue = values[@"wasNull"];
                                  XCTAssertEqual([actualValue boolValue], false);
                              }
                              {
-                                 id actualValue = values[@"Value"];
+                                 id actualValue = values[@"value"];
                                  XCTAssertEqual([actualValue unsignedCharValue], 5);
                              }
                              {
-                                 id actualValue = values[@"OriginalValue"];
+                                 id actualValue = values[@"originalValue"];
                                  XCTAssertFalse([actualValue isKindOfClass:[NSNull class]]);
                                  XCTAssertEqual([actualValue unsignedCharValue], 5);
                              }
@@ -19353,7 +19353,7 @@ CHIPDevice * GetConnectedDevice()
                              XCTAssertEqual(err.code, 0);
 
                              {
-                                 id actualValue = values[@"WasPresent"];
+                                 id actualValue = values[@"wasPresent"];
                                  XCTAssertEqual([actualValue boolValue], false);
                              }
 
@@ -19476,14 +19476,14 @@ CHIPDevice * GetConnectedDevice()
             id actualValue = values[@"value"];
             XCTAssertEqual([actualValue count], 1);
             if ([actualValue[0] isKindOfClass:[NSDictionary class]]) {
-                XCTAssertEqual([actualValue[0][@"Type"] unsignedIntValue], 0UL);
+                XCTAssertEqual([actualValue[0][@"type"] unsignedIntValue], 0UL);
             } else {
-                XCTAssertEqual([[actualValue[0] Type] unsignedIntValue], 0UL);
+                XCTAssertEqual([((CHIPDescriptorClusterDeviceType *) actualValue[0]).type unsignedIntValue], 0UL);
             }
             if ([actualValue[0] isKindOfClass:[NSDictionary class]]) {
-                XCTAssertEqual([actualValue[0][@"Revision"] unsignedShortValue], 1U);
+                XCTAssertEqual([actualValue[0][@"revision"] unsignedShortValue], 1U);
             } else {
-                XCTAssertEqual([[actualValue[0] Revision] unsignedShortValue], 1U);
+                XCTAssertEqual([((CHIPDescriptorClusterDeviceType *) actualValue[0]).revision unsignedShortValue], 1U);
             }
         }
 
@@ -19688,7 +19688,7 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPIdentifyClusterIdentifyPayload alloc] init];
-    payload.IdentifyTime = [NSNumber numberWithUnsignedShort:0U];
+    payload.identifyTime = [NSNumber numberWithUnsignedShort:0U];
     [cluster identify:payload
         responseHandler:^(NSError * err, NSDictionary * values) {
             NSLog(@"Send Identify command and expect success response Error: %@", err);
@@ -19885,49 +19885,49 @@ CHIPDevice * GetConnectedDevice()
             id actualValue = values[@"value"];
             XCTAssertEqual([actualValue count], 3);
             if ([actualValue[0] isKindOfClass:[NSDictionary class]]) {
-                XCTAssertTrue([actualValue[0][@"Label"] isEqualToString:@"Black"]);
+                XCTAssertTrue([actualValue[0][@"label"] isEqualToString:@"Black"]);
             } else {
-                XCTAssertTrue([[actualValue[0] Label] isEqualToString:@"Black"]);
+                XCTAssertTrue([((CHIPModeSelectClusterModeOptionStruct *) actualValue[0]).label isEqualToString:@"Black"]);
             }
             if ([actualValue[0] isKindOfClass:[NSDictionary class]]) {
-                XCTAssertEqual([actualValue[0][@"Mode"] unsignedCharValue], 0);
+                XCTAssertEqual([actualValue[0][@"mode"] unsignedCharValue], 0);
             } else {
-                XCTAssertEqual([[actualValue[0] Mode] unsignedCharValue], 0);
+                XCTAssertEqual([((CHIPModeSelectClusterModeOptionStruct *) actualValue[0]).mode unsignedCharValue], 0);
             }
             if ([actualValue[0] isKindOfClass:[NSDictionary class]]) {
-                XCTAssertEqual([actualValue[0][@"SemanticTag"] unsignedIntValue], 0UL);
+                XCTAssertEqual([actualValue[0][@"semanticTag"] unsignedIntValue], 0UL);
             } else {
-                XCTAssertEqual([[actualValue[0] SemanticTag] unsignedIntValue], 0UL);
+                XCTAssertEqual([((CHIPModeSelectClusterModeOptionStruct *) actualValue[0]).semanticTag unsignedIntValue], 0UL);
             }
             if ([actualValue[1] isKindOfClass:[NSDictionary class]]) {
-                XCTAssertTrue([actualValue[1][@"Label"] isEqualToString:@"Cappuccino"]);
+                XCTAssertTrue([actualValue[1][@"label"] isEqualToString:@"Cappuccino"]);
             } else {
-                XCTAssertTrue([[actualValue[1] Label] isEqualToString:@"Cappuccino"]);
+                XCTAssertTrue([((CHIPModeSelectClusterModeOptionStruct *) actualValue[1]).label isEqualToString:@"Cappuccino"]);
             }
             if ([actualValue[1] isKindOfClass:[NSDictionary class]]) {
-                XCTAssertEqual([actualValue[1][@"Mode"] unsignedCharValue], 4);
+                XCTAssertEqual([actualValue[1][@"mode"] unsignedCharValue], 4);
             } else {
-                XCTAssertEqual([[actualValue[1] Mode] unsignedCharValue], 4);
+                XCTAssertEqual([((CHIPModeSelectClusterModeOptionStruct *) actualValue[1]).mode unsignedCharValue], 4);
             }
             if ([actualValue[1] isKindOfClass:[NSDictionary class]]) {
-                XCTAssertEqual([actualValue[1][@"SemanticTag"] unsignedIntValue], 0UL);
+                XCTAssertEqual([actualValue[1][@"semanticTag"] unsignedIntValue], 0UL);
             } else {
-                XCTAssertEqual([[actualValue[1] SemanticTag] unsignedIntValue], 0UL);
+                XCTAssertEqual([((CHIPModeSelectClusterModeOptionStruct *) actualValue[1]).semanticTag unsignedIntValue], 0UL);
             }
             if ([actualValue[2] isKindOfClass:[NSDictionary class]]) {
-                XCTAssertTrue([actualValue[2][@"Label"] isEqualToString:@"Espresso"]);
+                XCTAssertTrue([actualValue[2][@"label"] isEqualToString:@"Espresso"]);
             } else {
-                XCTAssertTrue([[actualValue[2] Label] isEqualToString:@"Espresso"]);
+                XCTAssertTrue([((CHIPModeSelectClusterModeOptionStruct *) actualValue[2]).label isEqualToString:@"Espresso"]);
             }
             if ([actualValue[2] isKindOfClass:[NSDictionary class]]) {
-                XCTAssertEqual([actualValue[2][@"Mode"] unsignedCharValue], 7);
+                XCTAssertEqual([actualValue[2][@"mode"] unsignedCharValue], 7);
             } else {
-                XCTAssertEqual([[actualValue[2] Mode] unsignedCharValue], 7);
+                XCTAssertEqual([((CHIPModeSelectClusterModeOptionStruct *) actualValue[2]).mode unsignedCharValue], 7);
             }
             if ([actualValue[2] isKindOfClass:[NSDictionary class]]) {
-                XCTAssertEqual([actualValue[2][@"SemanticTag"] unsignedIntValue], 0UL);
+                XCTAssertEqual([actualValue[2][@"semanticTag"] unsignedIntValue], 0UL);
             } else {
-                XCTAssertEqual([[actualValue[2] SemanticTag] unsignedIntValue], 0UL);
+                XCTAssertEqual([((CHIPModeSelectClusterModeOptionStruct *) actualValue[2]).semanticTag unsignedIntValue], 0UL);
             }
         }
 
@@ -19946,7 +19946,7 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPModeSelectClusterChangeToModePayload alloc] init];
-    payload.NewMode = [NSNumber numberWithUnsignedChar:4];
+    payload.newMode = [NSNumber numberWithUnsignedChar:4];
     [cluster changeToMode:payload
           responseHandler:^(NSError * err, NSDictionary * values) {
               NSLog(@"Change to Supported Mode Error: %@", err);
@@ -19992,7 +19992,7 @@ CHIPDevice * GetConnectedDevice()
     XCTAssertNotNil(cluster);
 
     __auto_type * payload = [[CHIPModeSelectClusterChangeToModePayload alloc] init];
-    payload.NewMode = [NSNumber numberWithUnsignedChar:2];
+    payload.newMode = [NSNumber numberWithUnsignedChar:2];
     [cluster changeToMode:payload
           responseHandler:^(NSError * err, NSDictionary * values) {
               NSLog(@"Change to Unsupported Mode Error: %@", err);


### PR DESCRIPTION
Change property names in structs to be lowerCamelCased.  This requires
three interesting changes:

1) Deal with property names that collide with NSObject properties by
   renaming them.
2) Deal with property names that start with several all-uppercase
   letters by lowercasing all but the last one.
3) Define getter names for some of the properties, because some start with
   'new', which makes the compiler complain.

Also change all the properties to be nonatomic.

#### Problem
See above.

#### Change overview
See above.

#### Testing
Ran existing tests. No behavior changes intended in this PR.