### PR TITLE
Enable asan for unit tests when compiling with clang.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -301,7 +301,7 @@ jobs:
               run: |
                   for BUILD_TYPE  in clang python_lib; do
                       case $BUILD_TYPE in
-                          "clang") GN_ARGS='is_clang=true target_os="all"';;
+                          "clang") GN_ARGS='is_clang=true target_os="all" is_asan=true';;
                           "python_lib") GN_ARGS='enable_rtti=true enable_pylib=true';;
                       esac
                       scripts/build/gn_gen.sh --args="$GN_ARGS"

--- a/src/access/tests/TestAccessControl.cpp
+++ b/src/access/tests/TestAccessControl.cpp
@@ -671,7 +671,7 @@ void TestDeleteEntry(nlTestSuite * inSuite, void * inContext)
             NL_TEST_ASSERT(inSuite, ClearAccessControl(accessControl) == CHIP_NO_ERROR);
             NL_TEST_ASSERT(inSuite, LoadAccessControl(accessControl, data, ArraySize(data)) == CHIP_NO_ERROR);
 
-            memcpy(&data[pos], &data[pos + count], (ArraySize(data) - count - pos) * sizeof(data[0]));
+            memmove(&data[pos], &data[pos + count], (ArraySize(data) - count - pos) * sizeof(data[0]));
 
             for (size_t i = 0; i < count; ++i)
             {

--- a/src/protocols/bdx/BdxMessages.cpp
+++ b/src/protocols/bdx/BdxMessages.cpp
@@ -170,7 +170,7 @@ size_t TransferInit::MessageSize() const
 void TransferInit::LogMessage(bdx::MessageType messageType) const
 {
     char fd[kMaxFileDesignatorLen];
-    snprintf(fd, sizeof(fd), "%s", FileDesignator);
+    snprintf(fd, sizeof(fd), "%.*s", static_cast<int>(FileDesLength), FileDesignator);
 
     switch (messageType)
     {

--- a/src/protocols/user_directed_commissioning/UserDirectedCommissioning.h
+++ b/src/protocols/user_directed_commissioning/UserDirectedCommissioning.h
@@ -183,7 +183,7 @@ public:
      * Get the cache of UDC Clients
      *
      */
-    UDCClients<kMaxUDCClients> GetUDCClients() { return mUdcClients; }
+    UDCClients<kMaxUDCClients> & GetUDCClients() { return mUdcClients; }
 
     /**
      * Print the cache of UDC Clients


### PR DESCRIPTION
This immediately caught two bugs in things that were being unit-tested.

#### Problem
ASAN not enabled anywhere in our CI.

#### Change overview
At least enable it for unit tests on the "Build" job for Darwin [Edit: tried Linux too, but it fails to link there].

#### Testing
Ran the relevant Darwin commands locally.