### PR TITLE
Fix ESP32 OTA image link used with Linux OTA provider

### DIFF
--- a/examples/ota-requestor-app/esp32/README.md
+++ b/examples/ota-requestor-app/esp32/README.md
@@ -65,11 +65,11 @@ After this step device should reboot and start running hello world example.
 
 -   Build the [Linux OTA Provider](../../ota-provider-app/linux)
 -   Run the Linux OTA Provider with
-    [hello world OTA image](http://shubhamdp.github.io/esp_ota/esp32/hello-world-flash-in-ota-provider-partition.bin).
+    [hello world OTA image](http://shubhamdp.github.io/esp_ota/esp32/hello-world-for-linux-provider.bin).
     This OTA image is built for ESP32, it will not work on other devices.
 
 ```
-./out/debug/chip-ota-provider-app -f hello-world-flash-in-ota-provider-partition.bin
+./out/debug/chip-ota-provider-app -f hello-world-for-linux-provider.bin
 ```
 
 -   Provision the Linux OTA Provider using chip-tool


### PR DESCRIPTION
#### Problem
* ESP32 OTA image prepends 4 byte image size to the image as we do not have a tool in place to prepend the full header. ESP32 OTA Provider skips those 4 bytes when sending the OTA image and Linux OTA Provider do not skip anything. When ESP32 OTA Requestor is used with Linux OTA Provider then OTA fails.

#### Change overview
Fixed the link to the OTA image that should be used with Linux OTA Provider. This is the temporary fix and will be fixed permanently once we have provision to prepend the Matter OTA header.

#### Testing
* Tested with ESP32 OTA Requestor example and Linux OTA Provider example