### PR TITLE
Migrate TCP::mPendingPackets to Pool interface

### DIFF
--- a/src/channel/Channel.cpp
+++ b/src/channel/Channel.cpp
@@ -32,7 +32,7 @@ ChannelState ChannelHandle::GetState() const
 
 ExchangeContext * ChannelHandle::NewExchange(ExchangeDelegate * delegate)
 {
-    assert(mAssociation != nullptr);
+    VerifyOrDie(mAssociation != nullptr);
     return mAssociation->mChannelContext->NewExchange(delegate);
 }
 

--- a/src/channel/ChannelContext.cpp
+++ b/src/channel/ChannelContext.cpp
@@ -37,7 +37,7 @@ void ChannelContext::Start(const ChannelBuilder & builder)
 
 ExchangeContext * ChannelContext::NewExchange(ExchangeDelegate * delegate)
 {
-    assert(GetState() == ChannelState::kReady);
+    VerifyOrDie(GetState() == ChannelState::kReady);
     return mExchangeManager->NewContext(GetReadyVars().mSession, delegate);
 }
 

--- a/src/lib/support/Pool.cpp
+++ b/src/lib/support/Pool.cpp
@@ -17,9 +17,8 @@
  *    limitations under the License.
  */
 
+#include <lib/support/CodeUtils.h>
 #include <lib/support/Pool.h>
-
-#include <nlassert.h>
 
 namespace chip {
 
@@ -68,20 +67,20 @@ void StaticAllocatorBitmap::Deallocate(void * element)
     size_t offset = index - (word * kBitChunkSize);
 
     // ensure the element is in the pool
-    assert(index < Capacity());
+    VerifyOrDie(index < Capacity());
 
     auto value = mUsage[word].fetch_and(~(kBit1 << offset));
-    nlASSERT((value & (kBit1 << offset)) != 0); // assert fail when free an unused slot
+    VerifyOrDie((value & (kBit1 << offset)) != 0); // assert fail when free an unused slot
     DecreaseUsage();
 }
 
 size_t StaticAllocatorBitmap::IndexOf(void * element)
 {
     std::ptrdiff_t diff = static_cast<uint8_t *>(element) - static_cast<uint8_t *>(mElements);
-    assert(diff >= 0);
-    assert(static_cast<size_t>(diff) % mElementSize == 0);
+    VerifyOrDie(diff >= 0);
+    VerifyOrDie(static_cast<size_t>(diff) % mElementSize == 0);
     auto index = static_cast<size_t>(diff) / mElementSize;
-    assert(index < Capacity());
+    VerifyOrDie(index < Capacity());
     return index;
 }
 

--- a/src/lib/support/Pool.h
+++ b/src/lib/support/Pool.h
@@ -22,9 +22,8 @@
 
 #pragma once
 
-#include <lib/support/CodeUtils.h>
+#include <system/SystemConfig.h>
 
-#include <assert.h>
 #include <atomic>
 #include <limits>
 #include <new>

--- a/src/lib/support/PoolWrapper.h
+++ b/src/lib/support/PoolWrapper.h
@@ -1,0 +1,112 @@
+/*
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <tuple>
+
+#include <lib/support/Pool.h>
+
+namespace chip {
+
+/// Provides an interface over a pool implementation which doesn't expose the size and the actual type of the pool.
+template <typename U, typename... ConstructorArguments>
+class PoolInterface
+{
+public:
+    // For convenient use in PoolImpl
+    using Interface = std::tuple<U, ConstructorArguments...>;
+
+    virtual ~PoolInterface() {}
+
+    virtual U * CreateObject(ConstructorArguments &&... args)              = 0;
+    virtual void ReleaseObject(U * element)                                = 0;
+    virtual void ResetObject(U * element, ConstructorArguments &&... args) = 0;
+
+    template <typename Function>
+    bool ForEachActiveObject(Function && function)
+    {
+        auto proxy = [&](U * target) -> bool { return function(target); };
+        return ForEachActiveObjectInner(
+            &proxy, [](void * context, U * target) -> bool { return (*static_cast<decltype(proxy) *>(context))(target); });
+    }
+
+protected:
+    using Lambda                                                         = bool (*)(void *, U *);
+    virtual bool ForEachActiveObjectInner(void * context, Lambda lambda) = 0;
+};
+
+template <class T, size_t N, typename Interface>
+class PoolProxy;
+
+template <class T, size_t N, typename U, typename... ConstructorArguments>
+class PoolProxy<T, N, std::tuple<U, ConstructorArguments...>> : public PoolInterface<U, ConstructorArguments...>
+{
+public:
+    static_assert(std::is_base_of<U, T>::value, "Interface type is not derived from Pool type");
+
+    PoolProxy() {}
+    virtual ~PoolProxy() override {}
+
+    virtual U * CreateObject(ConstructorArguments &&... args) override
+    {
+        return Impl().CreateObject(std::forward<ConstructorArguments>(args)...);
+    }
+
+    virtual void ReleaseObject(U * element) override { Impl().ReleaseObject(static_cast<T *>(element)); }
+
+    virtual void ResetObject(U * element, ConstructorArguments &&... args) override
+    {
+        return Impl().ResetObject(static_cast<T *>(element), std::forward<ConstructorArguments>(args)...);
+    }
+
+protected:
+    virtual bool ForEachActiveObjectInner(void * context,
+                                          typename PoolInterface<U, ConstructorArguments...>::Lambda lambda) override
+    {
+        return Impl().ForEachActiveObject([&](T * target) { return lambda(context, static_cast<U *>(target)); });
+    }
+
+    virtual BitMapObjectPool<T, N> & Impl() = 0;
+};
+
+/*
+ * @brief
+ *   Define a implementation of a pool which derive and expose PoolInterface's.
+ *
+ *  @tparam T          a subclass of element to be allocated.
+ *  @tparam N          a positive integer max number of elements the pool provides.
+ *  @tparam Interfaces a list of parameters which defines PoolInterface's. each interface is defined by a
+ *                     std::tuple<U, ConstructorArguments...>. The PoolImpl is derived from every
+ *                     PoolInterface<U, ConstructorArguments...>, the PoolImpl can be converted to the interface type
+ *                     and passed around
+ */
+template <class T, size_t N, typename... Interfaces>
+class PoolImpl : public PoolProxy<T, N, Interfaces>...
+{
+public:
+    PoolImpl() {}
+    virtual ~PoolImpl() override {}
+
+protected:
+    virtual BitMapObjectPool<T, N> & Impl() override { return mImpl; }
+
+private:
+    BitMapObjectPool<T, N> mImpl;
+};
+
+} // namespace chip

--- a/src/lib/support/tests/TestPool.cpp
+++ b/src/lib/support/tests/TestPool.cpp
@@ -27,6 +27,7 @@
 
 #include <lib/support/Pool.h>
 #include <lib/support/UnitTestRegistration.h>
+#include <system/SystemConfig.h>
 
 #include <nlunit-test.h>
 

--- a/src/messaging/ExchangeMgr.cpp
+++ b/src/messaging/ExchangeMgr.cpp
@@ -100,7 +100,7 @@ CHIP_ERROR ExchangeManager::Shutdown()
 
     mContextPool.ForEachActiveObject([](auto * ec) {
         // There should be no active object in the pool
-        assert(false);
+        VerifyOrDie(false);
         return true;
     });
 

--- a/src/transport/raw/TCP.h
+++ b/src/transport/raw/TCP.h
@@ -33,6 +33,7 @@
 #include <inet/TCPEndPoint.h>
 #include <lib/core/CHIPCore.h>
 #include <lib/support/CodeUtils.h>
+#include <lib/support/PoolWrapper.h>
 #include <transport/raw/Base.h>
 
 namespace chip {
@@ -84,8 +85,12 @@ private:
  */
 struct PendingPacket
 {
-    PeerAddress peerAddress;                 // where the packet is being sent to
-    System::PacketBufferHandle packetBuffer; // what data needs to be sent
+    PendingPacket(const PeerAddress & peerAddress, System::PacketBufferHandle && packetBuffer) :
+        mPeerAddress(peerAddress), mPacketBuffer(std::move(packetBuffer))
+    {}
+
+    PeerAddress mPeerAddress;                 // where the packet is being sent to
+    System::PacketBufferHandle mPacketBuffer; // what data needs to be sent
 };
 
 /** Implements a transport using TCP. */
@@ -128,20 +133,11 @@ protected:
     };
 
 public:
-    TCPBase(ActiveConnectionState * activeConnectionsBuffer, size_t bufferSize, PendingPacket * packetBuffers,
-            size_t packetsBuffersSize) :
-        mActiveConnections(activeConnectionsBuffer),
-        mActiveConnectionsSize(bufferSize), mPendingPackets(packetBuffers), mPendingPacketsSize(packetsBuffersSize)
+    using PendingPacketPoolType = PoolInterface<PendingPacket, const PeerAddress &, System::PacketBufferHandle &&>;
+    TCPBase(ActiveConnectionState * activeConnectionsBuffer, size_t bufferSize, PendingPacketPoolType & packetBuffers) :
+        mActiveConnections(activeConnectionsBuffer), mActiveConnectionsSize(bufferSize), mPendingPackets(packetBuffers)
     {
         // activeConnectionsBuffer must be initialized by the caller.
-        for (size_t i = 0; i < mPendingPacketsSize; ++i)
-        {
-            mPendingPackets[i].peerAddress = PeerAddress::Uninitialized();
-            // In the typical case, the TCPBase constructor is invoked from the TCP constructor on its mPendingPackets,
-            // which has not yet been initialized. That means we can't do a normal move assignment or construction of
-            // the PacketBufferHandle, since that would call PacketBuffer::Free on the uninitialized data.
-            new (&mPendingPackets[i].packetBuffer) System::PacketBufferHandle();
-        }
     }
     ~TCPBase() override;
 
@@ -266,15 +262,14 @@ private:
     const size_t mActiveConnectionsSize;
 
     // Data to be sent when connections succeed
-    PendingPacket * mPendingPackets;
-    const size_t mPendingPacketsSize;
+    PendingPacketPoolType & mPendingPackets;
 };
 
 template <size_t kActiveConnectionsSize, size_t kPendingPacketSize>
 class TCP : public TCPBase
 {
 public:
-    TCP() : TCPBase(mConnectionsBuffer, kActiveConnectionsSize, mPendingPackets, kPendingPacketSize)
+    TCP() : TCPBase(mConnectionsBuffer, kActiveConnectionsSize, mPendingPackets)
     {
         for (size_t i = 0; i < kActiveConnectionsSize; ++i)
         {
@@ -285,7 +280,7 @@ public:
 private:
     friend class TCPTest;
     TCPBase::ActiveConnectionState mConnectionsBuffer[kActiveConnectionsSize];
-    PendingPacket mPendingPackets[kPendingPacketSize];
+    PoolImpl<PendingPacket, kPendingPacketSize, PendingPacketPoolType::Interface> mPendingPackets;
 };
 
 } // namespace Transport


### PR DESCRIPTION
#### Problem
Pool interface should be used instead of a static array

#### Change overview
Migrate TCP::mPendingPackets to Pool interface

TcpBase class uses the `TCP::mPendingPackets` field w/o knowing the actual size of the pool. Add a `PoolInterface` class to cover this scenario.

#### Testing
Verified by unit-tests