### PR TITLE
Remove more warnings when building with Xcode - part 3

### DIFF
--- a/src/app/ReadClient.h
+++ b/src/app/ReadClient.h
@@ -64,7 +64,7 @@ public:
          * The ReadClient object MUST continue to exist after this call is completed.
          *
          * @param[in]  apReadClient         The read client which initialized the read transaction.
-         * @param[in]  apEventReportsReader TLV reader positioned at the list that contains the events.  The
+         * @param[in]  aEventReports        TLV reader positioned at the list that contains the events.  The
          *                                  implementation of EventStreamReceived is expected to call Next() on the reader to
          *                                  advance it to the first element of the list, then process the elements from beginning to
          *                                  the end. The callee is expected to consume all events.
@@ -215,7 +215,7 @@ private:
      *      - SubscribeResponseProcessed
      *
      *  @param[in]    apExchangeMgr    A pointer to the ExchangeManager object.
-     *  @param[in]    apDelegate       InteractionModelDelegate set by application.
+     *  @param[in]    apCallback       InteractionModelDelegate set by application.
      *
      *  @retval #CHIP_ERROR_INCORRECT_STATE incorrect state if it is already initialized
      *  @retval #CHIP_NO_ERROR On success.

--- a/src/app/reporting/reporting.h
+++ b/src/app/reporting/reporting.h
@@ -47,14 +47,6 @@
  * framework changes.  The application should call this function when an
  * externally-managed attribute changes.  The application should use the change
  * notification to inform its reporting decisions.
- *
- * @param endpoint
- * @param clusterId
- * @param attributeId
- * @param mask
- * @param manufacturerCode
- * @param type
- * @param data
  */
 void MatterReportingAttributeChangeCallback(chip::EndpointId endpoint, chip::ClusterId clusterId, chip::AttributeId attributeId,
                                             uint8_t mask, uint16_t manufacturerCode, EmberAfAttributeType type, uint8_t * data);

--- a/src/app/zap-templates/templates/app/callback-stub-src.zapt
+++ b/src/app/zap-templates/templates/app/callback-stub-src.zapt
@@ -35,66 +35,10 @@ void __attribute__((weak)) emberAf{{asUpperCamelCase name}}ClusterInitCallback(E
 // Non-Cluster Related Callbacks
 //
 
-/** @brief Add To Current App Tasks
- *
- * This function is only useful to sleepy end devices.  This function will note
- * the passed item as part of a set of tasks the application has outstanding
- * (e.g. message sent requiring APS acknwoledgement).  This will affect how the
- * application behaves with regard to sleeping and polling.  Until the
- * outstanding task is completed, the device may poll more frequently and sleep
- * less often.
- *
- * @param tasks   Ver.: always
- */
 void __attribute__((weak)) emberAfAddToCurrentAppTasksCallback(EmberAfApplicationTask tasks) {}
 
-/** @brief Remove From Current App Tasks
- *
- * This function is only useful to sleepy end devices.  This function will
- * remove the passed item from the set of tasks the application has outstanding
- * (e.g. message sent requiring APS acknwoledgement).  This will affect how the
- * application behaves with regard to sleeping and polling.  Removing the item
- * from the list of outstanding tasks may allow the device to sleep longer and
- * poll less frequently.  If there are other outstanding tasks the system may
- * still have to stay away and poll more often.
- *
- * @param tasks   Ver.: always
- */
 void __attribute__((weak)) emberAfRemoveFromCurrentAppTasksCallback(EmberAfApplicationTask tasks) {}
 
-/** @brief Allow Network Write Attribute
- *
- * This function is called by the application framework before it writes an
- * attribute in response to a write attribute request from an external device.
- * The value passed into this callback is the value to which the attribute is to
- * be set by the framework.
-        Example:	In mirroring simple metering data
- * on an Energy Services Interface (ESI) (formerly called Energy Service Portal
- * (ESP) in SE 1.0).), a mirrored simple meter needs to write read-only
- * attributes on its mirror. The-meter-mirror sample application, located in
- * app/framework/sample-apps, uses this callback to allow the mirrored device to
- * write simple metering attributes on the mirror regardless of the fact that
- * most simple metering attributes are defined as read-only by the ZigBee
- * specification.
-        Note:	The ZCL specification does not (as of this
- * writing) specify any permission-level security for writing writeable
- * attributes. As far as the ZCL specification is concerned, if an attribute is
- * writeable, any device that has a link key for the device should be able to
- * write that attribute. Furthermore if an attribute is read only, it should not
- * be written over the air. Thus, if you implement permissions for writing
- * attributes as a feature, you MAY be operating outside the specification. This
- * is unlikely to be a problem for writing read-only attributes, but it may be a
- * problem for attributes that are writeable according to the specification but
- * restricted by the application implementing this callback.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeId   Ver.: always
- * @param mask   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param value   Ver.: always
- * @param type   Ver.: always
- */
 EmberAfAttributeWritePermission __attribute__((weak)) emberAfAllowNetworkWriteAttributeCallback(
     EndpointId endpoint, ClusterId clusterId,
                                                                           AttributeId attributeId, uint8_t mask,
@@ -103,16 +47,6 @@ EmberAfAttributeWritePermission __attribute__((weak)) emberAfAllowNetworkWriteAt
     return EMBER_ZCL_ATTRIBUTE_WRITE_PERMISSION_ALLOW_WRITE_NORMAL; // Default
 }
 
-/** @brief Attribute Read Access
- *
- * This function is called whenever the Application Framework needs to check
- * access permission for an attribute read.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param attributeId   Ver.: always
- */
 bool __attribute__((weak)) emberAfAttributeReadAccessCallback(
     EndpointId endpoint, ClusterId clusterId, uint16_t manufacturerCode,
                                         AttributeId attributeId)
@@ -120,16 +54,6 @@ bool __attribute__((weak)) emberAfAttributeReadAccessCallback(
     return true;
 }
 
-/** @brief Attribute Write Access
- *
- * This function is called whenever the Application Framework needs to check
- * access permission for an attribute write.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param attributeId   Ver.: always
- */
 bool __attribute__((weak)) emberAfAttributeWriteAccessCallback(
     EndpointId endpoint, ClusterId clusterId, uint16_t manufacturerCode,
                                          AttributeId attributeId)
@@ -137,67 +61,18 @@ bool __attribute__((weak)) emberAfAttributeWriteAccessCallback(
     return true;
 }
 
-/** @brief Default Response
- *
- * This function is called by the application framework when a Default Response
- * command is received from an external device.  The application should return
- * true if the message was processed or false if it was not.
- *
- * @param clusterId The cluster identifier of this response.  Ver.: always
- * @param commandId The command identifier to which this is a response.  Ver.:
- * always
- * @param status Specifies either SUCCESS or the nature of the error that was
- * detected in the received command.  Ver.: always
- */
 bool __attribute__((weak)) emberAfDefaultResponseCallback(
     ClusterId clusterId, CommandId commandId, EmberAfStatus status)
 {
     return false;
 }
 
-/** @brief Pre Message Send
- *
- * This function is called by the framework when it is about to pass a message
- * to the stack primitives for sending.   This message may or may not be ZCL,
- * ZDO, or some other protocol.  This is called prior to
-        any ZigBee
- * fragmentation that may be done.  If the function returns true it is assumed
- * the callback has consumed and processed the message.  The callback must also
- * set the EmberStatus status code to be passed back to the caller.  The
- * framework will do no further processing on the message.
-        If the
- * function returns false then it is assumed that the callback has not processed
- * the mesasge and the framework will continue to process accordingly.
- *
- * @param messageStruct The structure containing the parameters of the APS
- * message to be sent.  Ver.: always
- * @param status A pointer to the status code value that will be returned to the
- * caller.  Ver.: always
- */
 bool __attribute__((weak)) emberAfPreMessageSendCallback(
     EmberAfMessageStruct * messageStruct, EmberStatus * status)
 {
     return false;
 }
 
-/** @brief Message Sent
- *
- * This function is called by the application framework from the message sent
- * handler, when it is informed by the stack regarding the message sent status.
- * All of the values passed to the emberMessageSentHandler are passed on to this
- * callback. This provides an opportunity for the application to verify that its
- * message has been sent successfully and take the appropriate action. This
- * callback should return a bool value of true or false. A value of true
- * indicates that the message sent notification has been handled and should not
- * be handled by the application framework.
- *
- * @param type   Ver.: always
- * @param destination   Ver.: always
- * @param apsFrame   Ver.: always
- * @param msgLen   Ver.: always
- * @param message   Ver.: always
- * @param status   Ver.: always
- */
 bool __attribute__((weak)) emberAfMessageSentCallback(
     const MessageSendDestination & destination,
     EmberApsFrame * apsFrame, uint16_t msgLen, uint8_t * message,
@@ -206,43 +81,6 @@ bool __attribute__((weak)) emberAfMessageSentCallback(
     return false;
 }
 
-/** @brief External Attribute Read
- *
- * Like emberAfExternalAttributeWriteCallback above, this function is called
- * when the framework needs to read an attribute that is not stored within the
- * Application Framework's data structures.
-        All of the important
- * information about the attribute itself is passed as a pointer to an
- * EmberAfAttributeMetadata struct, which is stored within the application and
- * used to manage the attribute. A complete description of the
- * EmberAfAttributeMetadata struct is provided in
- * app/framework/include/af-types.h
-        This function assumes that the
- * application is able to read the attribute, write it into the passed buffer,
- * and return immediately. Any attributes that require a state machine for
- * reading and writing are not really candidates for externalization at the
- * present time. The Application Framework does not currently include a state
- * machine for reading or writing attributes that must take place across a
- * series of application ticks. Attributes that cannot be read in a timely
- * manner should be stored within the Application Framework and updated
- * occasionally by the application code from within the
- * emberAfMainTickCallback.
-        If the application was successfully able to
- * read the attribute and write it into the passed buffer, it should return a
- * value of EMBER_ZCL_STATUS_SUCCESS. Ensure that the size of the externally
- * managed attribute value is smaller than what the buffer can hold. In the case
- * of a buffer overflow throw an appropriate error such as
- * EMBER_ZCL_STATUS_INSUFFICIENT_SPACE. Any other return value indicates the
- * application was not able to read the attribute.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeMetadata   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param buffer   Ver.: always
- * @param maxReadLength   Ver.: always
- * @param index   Ver.: always
- */
 EmberAfStatus __attribute__((weak)) emberAfExternalAttributeReadCallback(
     EndpointId endpoint, ClusterId clusterId,
                                                    EmberAfAttributeMetadata * attributeMetadata, uint16_t manufacturerCode,
@@ -251,53 +89,6 @@ EmberAfStatus __attribute__((weak)) emberAfExternalAttributeReadCallback(
     return EMBER_ZCL_STATUS_FAILURE;
 }
 
-/** @brief External Attribute Write
- *
- * This function is called whenever the Application Framework needs to write an
- * attribute which is not stored within the data structures of the Application
- * Framework itself. One of the new features in Version 2 is the ability to
- * store attributes outside the Framework. This is particularly useful for
- * attributes that do not need to be stored because they can be read off the
- * hardware when they are needed, or are stored in some central location used by
- * many modules within the system. In this case, you can indicate that the
- * attribute is stored externally. When the framework needs to write an external
- * attribute, it makes a call to this callback.
-        This callback is very
- * useful for host micros which need to store attributes in persistent memory.
- * Because each host micro (used with an Ember NCP) has its own type of
- * persistent memory storage, the Application Framework does not include the
- * ability to mark attributes as stored in flash the way that it does for Ember
- * SoCs like the EM35x. On a host micro, any attributes that need to be stored
- * in persistent memory should be marked as external and accessed through the
- * external read and write callbacks. Any host code associated with the
- * persistent storage should be implemented within this callback.
-        All of
- * the important information about the attribute itself is passed as a pointer
- * to an EmberAfAttributeMetadata struct, which is stored within the application
- * and used to manage the attribute. A complete description of the
- * EmberAfAttributeMetadata struct is provided in
- * app/framework/include/af-types.h.
-        This function assumes that the
- * application is able to write the attribute and return immediately. Any
- * attributes that require a state machine for reading and writing are not
- * candidates for externalization at the present time. The Application Framework
- * does not currently include a state machine for reading or writing attributes
- * that must take place across a series of application ticks. Attributes that
- * cannot be written immediately should be stored within the Application
- * Framework and updated occasionally by the application code from within the
- * emberAfMainTickCallback.
-        If the application was successfully able to
- * write the attribute, it returns a value of EMBER_ZCL_STATUS_SUCCESS. Any
- * other return value indicates the application was not able to write the
- * attribute.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeMetadata   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param buffer   Ver.: always
- * @param index   Ver.: always
- */
 EmberAfStatus __attribute__((weak)) emberAfExternalAttributeWriteCallback(
     EndpointId endpoint, ClusterId clusterId,
                                                     EmberAfAttributeMetadata * attributeMetadata, uint16_t manufacturerCode,
@@ -306,37 +97,11 @@ EmberAfStatus __attribute__((weak)) emberAfExternalAttributeWriteCallback(
     return EMBER_ZCL_STATUS_FAILURE;
 }
 
-/** @brief Get Current Time
- *
- * This callback is called when device attempts to get current time from the
- * hardware. If this device has means to retrieve exact time, then this method
- * should implement it. If the callback can't provide the exact time it should
- * return 0 to indicate failure. Default action is to return 0, which indicates
- * that device does not have access to real time.
- *
- */
 uint32_t __attribute__((weak)) emberAfGetCurrentTimeCallback()
 {
     return 0;
 }
 
-/** @brief Get Endpoint Info
- *
- * This function is a callback to an application implemented endpoint that
- * operates outside the normal application framework.  When the framework wishes
- * to perform operations with that endpoint it uses this callback to retrieve
- * the endpoint's information.  If the endpoint exists and the application can
- * provide data then true shall be returned.  Otherwise the callback must return
- * false.
- *
- * @param endpoint The endpoint to retrieve data for.  Ver.: always
- * @param returnNetworkIndex The index corresponding to the ZigBee network the
- * endpoint belongs to.  If not using a multi-network device, 0 must be
- * returned.  Otherwise on a multi-network device the stack will switch to this
- * network before sending the message.  Ver.: always
- * @param returnEndpointInfo A pointer to a data struct that will be written
- * with information about the endpoint.  Ver.: always
- */
 bool __attribute__((weak)) emberAfGetEndpointInfoCallback(
     EndpointId endpoint, uint8_t * returnNetworkIndex,
     EmberAfEndpointInfoStruct * returnEndpointInfo)
@@ -344,55 +109,19 @@ bool __attribute__((weak)) emberAfGetEndpointInfoCallback(
     return false;
 }
 
-/** @brief Registration Abort
- *
- * This callback is called when the device should abort the registration
- * process.
- *
- */
 void __attribute__((weak)) emberAfRegistrationAbortCallback() {}
 
-/** @brief Interpan Send Message
- *
- * This function will send a raw MAC message with interpan frame format using
- * the passed parameters.
- *
- * @param header Interpan header info  Ver.: always
- * @param messageLength The length of the message received or to send  Ver.:
- * always
- * @param message The message data received or to send.  Ver.: always
- */
 EmberStatus __attribute__((weak)) emberAfInterpanSendMessageCallback(
     EmberAfInterpanHeader * header, uint16_t messageLength, uint8_t * message)
 {
     return EMBER_LIBRARY_NOT_PRESENT;
 }
 
-/** @brief Start Move
- *
- * This function is called to initiate the process for a device to move (rejoin)
- * to a new parent.
- *
- */
 bool __attribute__((weak)) emberAfStartMoveCallback()
 {
     return false;
 }
 
-/** @brief Pre Attribute Change
- *
- * This function is called by the application framework before it changes an
- * attribute value.  The value passed into this callback is the value to which
- * the attribute is to be set by the framework.  The application should return
- * chip::Protocols::InteractionModel::Status::Success to permit the change or
- * any other code to reject it.
- *
- * @param attributePath
- * @param mask
- * @param type
- * @param size
- * @param value
- */
 chip::Protocols::InteractionModel::Status __attribute__((weak)) MatterPreAttributeChangeCallback(
     const chip::app::ConcreteAttributePath & attributePath,
     uint8_t mask, uint8_t type, uint16_t size, uint8_t * value)
@@ -400,18 +129,6 @@ chip::Protocols::InteractionModel::Status __attribute__((weak)) MatterPreAttribu
     return chip::Protocols::InteractionModel::Status::Success;
 }
 
-/** @brief Post Attribute Change
- *
- * This function is called by the application framework after it changes an
- * attribute value. The value passed into this callback is the value to which
- * the attribute was set by the framework.
- *
- * @param attributePath
- * @param mask
- * @param type
- * @param size
- * @param value
- */
 void __attribute__((weak)) MatterPostAttributeChangeCallback(
     const chip::app::ConcreteAttributePath & attributePath,
     uint8_t mask, uint8_t type, uint16_t size, uint8_t * value)

--- a/src/app/zap-templates/templates/app/callback.zapt
+++ b/src/app/zap-templates/templates/app/callback.zapt
@@ -172,8 +172,6 @@ bool emberAf{{asUpperCamelCase parent.label}}Cluster{{asUpperCamelCase name}}Cal
  * application behaves with regard to sleeping and polling.  Until the
  * outstanding task is completed, the device may poll more frequently and sleep
  * less often.
- *
- * @param tasks   Ver.: always
  */
 void emberAfAddToCurrentAppTasksCallback(EmberAfApplicationTask tasks);
 
@@ -186,8 +184,6 @@ void emberAfAddToCurrentAppTasksCallback(EmberAfApplicationTask tasks);
  * from the list of outstanding tasks may allow the device to sleep longer and
  * poll less frequently.  If there are other outstanding tasks the system may
  * still have to stay away and poll more often.
- *
- * @param tasks   Ver.: always
  */
 void emberAfRemoveFromCurrentAppTasksCallback(EmberAfApplicationTask tasks);
 
@@ -215,14 +211,6 @@ void emberAfRemoveFromCurrentAppTasksCallback(EmberAfApplicationTask tasks);
  * is unlikely to be a problem for writing read-only attributes, but it may be a
  * problem for attributes that are writeable according to the specification but
  * restricted by the application implementing this callback.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeId   Ver.: always
- * @param mask   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param value   Ver.: always
- * @param type   Ver.: always
  */
 EmberAfAttributeWritePermission emberAfAllowNetworkWriteAttributeCallback(chip::EndpointId endpoint, chip::ClusterId clusterId,
                                                                           chip::AttributeId attributeId, uint8_t mask,
@@ -232,11 +220,6 @@ EmberAfAttributeWritePermission emberAfAllowNetworkWriteAttributeCallback(chip::
  *
  * This function is called whenever the Application Framework needs to check
  * access permission for an attribute read.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param attributeId   Ver.: always
  */
 bool emberAfAttributeReadAccessCallback(chip::EndpointId endpoint, chip::ClusterId clusterId, uint16_t manufacturerCode,
                                         chip::AttributeId attributeId);
@@ -245,11 +228,6 @@ bool emberAfAttributeReadAccessCallback(chip::EndpointId endpoint, chip::Cluster
  *
  * This function is called whenever the Application Framework needs to check
  * access permission for an attribute write.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param attributeId   Ver.: always
  */
 bool emberAfAttributeWriteAccessCallback(chip::EndpointId endpoint, chip::ClusterId clusterId, uint16_t manufacturerCode,
                                          chip::AttributeId attributeId);
@@ -260,11 +238,10 @@ bool emberAfAttributeWriteAccessCallback(chip::EndpointId endpoint, chip::Cluste
  * command is received from an external device.  The application should return
  * true if the message was processed or false if it was not.
  *
- * @param clusterId The cluster identifier of this response.  Ver.: always
- * @param commandId The command identifier to which this is a response.  Ver.:
- * always
+ * @param clusterId The cluster identifier of this response.
+ * @param commandId The command identifier to which this is a response.
  * @param status Specifies either SUCCESS or the nature of the error that was
- * detected in the received command.  Ver.: always
+ * detected in the received command.
  */
 bool emberAfDefaultResponseCallback(chip::ClusterId clusterId, chip::CommandId commandId, EmberAfStatus status);
 
@@ -283,9 +260,9 @@ bool emberAfDefaultResponseCallback(chip::ClusterId clusterId, chip::CommandId c
  * the mesasge and the framework will continue to process accordingly.
  *
  * @param messageStruct The structure containing the parameters of the APS
- * message to be sent.  Ver.: always
+ * message to be sent.
  * @param status A pointer to the status code value that will be returned to the
- * caller.  Ver.: always
+ * caller.
  */
 bool emberAfPreMessageSendCallback(EmberAfMessageStruct * messageStruct, EmberStatus * status);
 
@@ -299,12 +276,6 @@ bool emberAfPreMessageSendCallback(EmberAfMessageStruct * messageStruct, EmberSt
  * callback should return a bool value of true or false. A value of true
  * indicates that the message sent notification has been handled and should not
  * be handled by the application framework.
- *
- * @param destination   Ver.: always
- * @param apsFrame   Ver.: always
- * @param msgLen   Ver.: always
- * @param message   Ver.: always
- * @param status   Ver.: always
  */
 bool emberAfMessageSentCallback(const chip::MessageSendDestination & destination, EmberApsFrame * apsFrame,
                                 uint16_t msgLen, uint8_t * message, EmberStatus status);
@@ -337,14 +308,6 @@ bool emberAfMessageSentCallback(const chip::MessageSendDestination & destination
  * of a buffer overflow throw an appropriate error such as
  * EMBER_ZCL_STATUS_INSUFFICIENT_SPACE. Any other return value indicates the
  * application was not able to read the attribute.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeMetadata   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param buffer   Ver.: always
- * @param maxReadLength   Ver.: always
- * @param index   Ver.: always
  */
 EmberAfStatus emberAfExternalAttributeReadCallback(chip::EndpointId endpoint, chip::ClusterId clusterId,
                                                    EmberAfAttributeMetadata * attributeMetadata, uint16_t manufacturerCode,
@@ -389,13 +352,6 @@ EmberAfStatus emberAfExternalAttributeReadCallback(chip::EndpointId endpoint, ch
  * write the attribute, it returns a value of EMBER_ZCL_STATUS_SUCCESS. Any
  * other return value indicates the application was not able to write the
  * attribute.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeMetadata   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param buffer   Ver.: always
- * @param index   Ver.: always
  */
 EmberAfStatus emberAfExternalAttributeWriteCallback(chip::EndpointId endpoint, chip::ClusterId clusterId,
                                                     EmberAfAttributeMetadata * attributeMetadata, uint16_t manufacturerCode,
@@ -466,12 +422,6 @@ bool emberAfStartMoveCallback();
  * the attribute is to be set by the framework.  The application should return
  * chip::Protocols::InteractionModel::Status::Success to permit the change or
  * any other code to reject it.
- *
- * @param attributePath
- * @param mask
- * @param type
- * @param size
- * @param value
  */
 chip::Protocols::InteractionModel::Status MatterPreAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath,
                                                                            uint8_t mask, uint8_t type, uint16_t size, uint8_t * value);
@@ -481,12 +431,6 @@ chip::Protocols::InteractionModel::Status MatterPreAttributeChangeCallback(const
  * This function is called by the application framework after it changes an
  * attribute value. The value passed into this callback is the value to which
  * the attribute was set by the framework.
- *
- * @param attributePath
- * @param mask
- * @param type
- * @param size
- * @param value
  */
 void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath,
                                        uint8_t mask, uint8_t type, uint16_t size, uint8_t * value);

--- a/zzz_generated/all-clusters-app/zap-generated/callback-stub.cpp
+++ b/zzz_generated/all-clusters-app/zap-generated/callback-stub.cpp
@@ -504,66 +504,10 @@ void __attribute__((weak)) emberAfWindowCoveringClusterInitCallback(EndpointId e
 // Non-Cluster Related Callbacks
 //
 
-/** @brief Add To Current App Tasks
- *
- * This function is only useful to sleepy end devices.  This function will note
- * the passed item as part of a set of tasks the application has outstanding
- * (e.g. message sent requiring APS acknwoledgement).  This will affect how the
- * application behaves with regard to sleeping and polling.  Until the
- * outstanding task is completed, the device may poll more frequently and sleep
- * less often.
- *
- * @param tasks   Ver.: always
- */
 void __attribute__((weak)) emberAfAddToCurrentAppTasksCallback(EmberAfApplicationTask tasks) {}
 
-/** @brief Remove From Current App Tasks
- *
- * This function is only useful to sleepy end devices.  This function will
- * remove the passed item from the set of tasks the application has outstanding
- * (e.g. message sent requiring APS acknwoledgement).  This will affect how the
- * application behaves with regard to sleeping and polling.  Removing the item
- * from the list of outstanding tasks may allow the device to sleep longer and
- * poll less frequently.  If there are other outstanding tasks the system may
- * still have to stay away and poll more often.
- *
- * @param tasks   Ver.: always
- */
 void __attribute__((weak)) emberAfRemoveFromCurrentAppTasksCallback(EmberAfApplicationTask tasks) {}
 
-/** @brief Allow Network Write Attribute
- *
- * This function is called by the application framework before it writes an
- * attribute in response to a write attribute request from an external device.
- * The value passed into this callback is the value to which the attribute is to
- * be set by the framework.
-        Example:	In mirroring simple metering data
- * on an Energy Services Interface (ESI) (formerly called Energy Service Portal
- * (ESP) in SE 1.0).), a mirrored simple meter needs to write read-only
- * attributes on its mirror. The-meter-mirror sample application, located in
- * app/framework/sample-apps, uses this callback to allow the mirrored device to
- * write simple metering attributes on the mirror regardless of the fact that
- * most simple metering attributes are defined as read-only by the ZigBee
- * specification.
-        Note:	The ZCL specification does not (as of this
- * writing) specify any permission-level security for writing writeable
- * attributes. As far as the ZCL specification is concerned, if an attribute is
- * writeable, any device that has a link key for the device should be able to
- * write that attribute. Furthermore if an attribute is read only, it should not
- * be written over the air. Thus, if you implement permissions for writing
- * attributes as a feature, you MAY be operating outside the specification. This
- * is unlikely to be a problem for writing read-only attributes, but it may be a
- * problem for attributes that are writeable according to the specification but
- * restricted by the application implementing this callback.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeId   Ver.: always
- * @param mask   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param value   Ver.: always
- * @param type   Ver.: always
- */
 EmberAfAttributeWritePermission __attribute__((weak))
 emberAfAllowNetworkWriteAttributeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
                                           uint16_t manufacturerCode, uint8_t * value, uint8_t type)
@@ -571,140 +515,34 @@ emberAfAllowNetworkWriteAttributeCallback(EndpointId endpoint, ClusterId cluster
     return EMBER_ZCL_ATTRIBUTE_WRITE_PERMISSION_ALLOW_WRITE_NORMAL; // Default
 }
 
-/** @brief Attribute Read Access
- *
- * This function is called whenever the Application Framework needs to check
- * access permission for an attribute read.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param attributeId   Ver.: always
- */
 bool __attribute__((weak))
 emberAfAttributeReadAccessCallback(EndpointId endpoint, ClusterId clusterId, uint16_t manufacturerCode, AttributeId attributeId)
 {
     return true;
 }
 
-/** @brief Attribute Write Access
- *
- * This function is called whenever the Application Framework needs to check
- * access permission for an attribute write.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param attributeId   Ver.: always
- */
 bool __attribute__((weak))
 emberAfAttributeWriteAccessCallback(EndpointId endpoint, ClusterId clusterId, uint16_t manufacturerCode, AttributeId attributeId)
 {
     return true;
 }
 
-/** @brief Default Response
- *
- * This function is called by the application framework when a Default Response
- * command is received from an external device.  The application should return
- * true if the message was processed or false if it was not.
- *
- * @param clusterId The cluster identifier of this response.  Ver.: always
- * @param commandId The command identifier to which this is a response.  Ver.:
- * always
- * @param status Specifies either SUCCESS or the nature of the error that was
- * detected in the received command.  Ver.: always
- */
 bool __attribute__((weak)) emberAfDefaultResponseCallback(ClusterId clusterId, CommandId commandId, EmberAfStatus status)
 {
     return false;
 }
 
-/** @brief Pre Message Send
- *
- * This function is called by the framework when it is about to pass a message
- * to the stack primitives for sending.   This message may or may not be ZCL,
- * ZDO, or some other protocol.  This is called prior to
-        any ZigBee
- * fragmentation that may be done.  If the function returns true it is assumed
- * the callback has consumed and processed the message.  The callback must also
- * set the EmberStatus status code to be passed back to the caller.  The
- * framework will do no further processing on the message.
-        If the
- * function returns false then it is assumed that the callback has not processed
- * the mesasge and the framework will continue to process accordingly.
- *
- * @param messageStruct The structure containing the parameters of the APS
- * message to be sent.  Ver.: always
- * @param status A pointer to the status code value that will be returned to the
- * caller.  Ver.: always
- */
 bool __attribute__((weak)) emberAfPreMessageSendCallback(EmberAfMessageStruct * messageStruct, EmberStatus * status)
 {
     return false;
 }
 
-/** @brief Message Sent
- *
- * This function is called by the application framework from the message sent
- * handler, when it is informed by the stack regarding the message sent status.
- * All of the values passed to the emberMessageSentHandler are passed on to this
- * callback. This provides an opportunity for the application to verify that its
- * message has been sent successfully and take the appropriate action. This
- * callback should return a bool value of true or false. A value of true
- * indicates that the message sent notification has been handled and should not
- * be handled by the application framework.
- *
- * @param type   Ver.: always
- * @param destination   Ver.: always
- * @param apsFrame   Ver.: always
- * @param msgLen   Ver.: always
- * @param message   Ver.: always
- * @param status   Ver.: always
- */
 bool __attribute__((weak)) emberAfMessageSentCallback(const MessageSendDestination & destination, EmberApsFrame * apsFrame,
                                                       uint16_t msgLen, uint8_t * message, EmberStatus status)
 {
     return false;
 }
 
-/** @brief External Attribute Read
- *
- * Like emberAfExternalAttributeWriteCallback above, this function is called
- * when the framework needs to read an attribute that is not stored within the
- * Application Framework's data structures.
-        All of the important
- * information about the attribute itself is passed as a pointer to an
- * EmberAfAttributeMetadata struct, which is stored within the application and
- * used to manage the attribute. A complete description of the
- * EmberAfAttributeMetadata struct is provided in
- * app/framework/include/af-types.h
-        This function assumes that the
- * application is able to read the attribute, write it into the passed buffer,
- * and return immediately. Any attributes that require a state machine for
- * reading and writing are not really candidates for externalization at the
- * present time. The Application Framework does not currently include a state
- * machine for reading or writing attributes that must take place across a
- * series of application ticks. Attributes that cannot be read in a timely
- * manner should be stored within the Application Framework and updated
- * occasionally by the application code from within the
- * emberAfMainTickCallback.
-        If the application was successfully able to
- * read the attribute and write it into the passed buffer, it should return a
- * value of EMBER_ZCL_STATUS_SUCCESS. Ensure that the size of the externally
- * managed attribute value is smaller than what the buffer can hold. In the case
- * of a buffer overflow throw an appropriate error such as
- * EMBER_ZCL_STATUS_INSUFFICIENT_SPACE. Any other return value indicates the
- * application was not able to read the attribute.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeMetadata   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param buffer   Ver.: always
- * @param maxReadLength   Ver.: always
- * @param index   Ver.: always
- */
 EmberAfStatus __attribute__((weak))
 emberAfExternalAttributeReadCallback(EndpointId endpoint, ClusterId clusterId, EmberAfAttributeMetadata * attributeMetadata,
                                      uint16_t manufacturerCode, uint8_t * buffer, uint16_t maxReadLength, int32_t index)
@@ -712,53 +550,6 @@ emberAfExternalAttributeReadCallback(EndpointId endpoint, ClusterId clusterId, E
     return EMBER_ZCL_STATUS_FAILURE;
 }
 
-/** @brief External Attribute Write
- *
- * This function is called whenever the Application Framework needs to write an
- * attribute which is not stored within the data structures of the Application
- * Framework itself. One of the new features in Version 2 is the ability to
- * store attributes outside the Framework. This is particularly useful for
- * attributes that do not need to be stored because they can be read off the
- * hardware when they are needed, or are stored in some central location used by
- * many modules within the system. In this case, you can indicate that the
- * attribute is stored externally. When the framework needs to write an external
- * attribute, it makes a call to this callback.
-        This callback is very
- * useful for host micros which need to store attributes in persistent memory.
- * Because each host micro (used with an Ember NCP) has its own type of
- * persistent memory storage, the Application Framework does not include the
- * ability to mark attributes as stored in flash the way that it does for Ember
- * SoCs like the EM35x. On a host micro, any attributes that need to be stored
- * in persistent memory should be marked as external and accessed through the
- * external read and write callbacks. Any host code associated with the
- * persistent storage should be implemented within this callback.
-        All of
- * the important information about the attribute itself is passed as a pointer
- * to an EmberAfAttributeMetadata struct, which is stored within the application
- * and used to manage the attribute. A complete description of the
- * EmberAfAttributeMetadata struct is provided in
- * app/framework/include/af-types.h.
-        This function assumes that the
- * application is able to write the attribute and return immediately. Any
- * attributes that require a state machine for reading and writing are not
- * candidates for externalization at the present time. The Application Framework
- * does not currently include a state machine for reading or writing attributes
- * that must take place across a series of application ticks. Attributes that
- * cannot be written immediately should be stored within the Application
- * Framework and updated occasionally by the application code from within the
- * emberAfMainTickCallback.
-        If the application was successfully able to
- * write the attribute, it returns a value of EMBER_ZCL_STATUS_SUCCESS. Any
- * other return value indicates the application was not able to write the
- * attribute.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeMetadata   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param buffer   Ver.: always
- * @param index   Ver.: always
- */
 EmberAfStatus __attribute__((weak))
 emberAfExternalAttributeWriteCallback(EndpointId endpoint, ClusterId clusterId, EmberAfAttributeMetadata * attributeMetadata,
                                       uint16_t manufacturerCode, uint8_t * buffer, int32_t index)
@@ -766,92 +557,30 @@ emberAfExternalAttributeWriteCallback(EndpointId endpoint, ClusterId clusterId, 
     return EMBER_ZCL_STATUS_FAILURE;
 }
 
-/** @brief Get Current Time
- *
- * This callback is called when device attempts to get current time from the
- * hardware. If this device has means to retrieve exact time, then this method
- * should implement it. If the callback can't provide the exact time it should
- * return 0 to indicate failure. Default action is to return 0, which indicates
- * that device does not have access to real time.
- *
- */
 uint32_t __attribute__((weak)) emberAfGetCurrentTimeCallback()
 {
     return 0;
 }
 
-/** @brief Get Endpoint Info
- *
- * This function is a callback to an application implemented endpoint that
- * operates outside the normal application framework.  When the framework wishes
- * to perform operations with that endpoint it uses this callback to retrieve
- * the endpoint's information.  If the endpoint exists and the application can
- * provide data then true shall be returned.  Otherwise the callback must return
- * false.
- *
- * @param endpoint The endpoint to retrieve data for.  Ver.: always
- * @param returnNetworkIndex The index corresponding to the ZigBee network the
- * endpoint belongs to.  If not using a multi-network device, 0 must be
- * returned.  Otherwise on a multi-network device the stack will switch to this
- * network before sending the message.  Ver.: always
- * @param returnEndpointInfo A pointer to a data struct that will be written
- * with information about the endpoint.  Ver.: always
- */
 bool __attribute__((weak))
 emberAfGetEndpointInfoCallback(EndpointId endpoint, uint8_t * returnNetworkIndex, EmberAfEndpointInfoStruct * returnEndpointInfo)
 {
     return false;
 }
 
-/** @brief Registration Abort
- *
- * This callback is called when the device should abort the registration
- * process.
- *
- */
 void __attribute__((weak)) emberAfRegistrationAbortCallback() {}
 
-/** @brief Interpan Send Message
- *
- * This function will send a raw MAC message with interpan frame format using
- * the passed parameters.
- *
- * @param header Interpan header info  Ver.: always
- * @param messageLength The length of the message received or to send  Ver.:
- * always
- * @param message The message data received or to send.  Ver.: always
- */
 EmberStatus __attribute__((weak))
 emberAfInterpanSendMessageCallback(EmberAfInterpanHeader * header, uint16_t messageLength, uint8_t * message)
 {
     return EMBER_LIBRARY_NOT_PRESENT;
 }
 
-/** @brief Start Move
- *
- * This function is called to initiate the process for a device to move (rejoin)
- * to a new parent.
- *
- */
 bool __attribute__((weak)) emberAfStartMoveCallback()
 {
     return false;
 }
 
-/** @brief Pre Attribute Change
- *
- * This function is called by the application framework before it changes an
- * attribute value.  The value passed into this callback is the value to which
- * the attribute is to be set by the framework.  The application should return
- * chip::Protocols::InteractionModel::Status::Success to permit the change or
- * any other code to reject it.
- *
- * @param attributePath
- * @param mask
- * @param type
- * @param size
- * @param value
- */
 chip::Protocols::InteractionModel::Status __attribute__((weak))
 MatterPreAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t mask, uint8_t type, uint16_t size,
                                  uint8_t * value)
@@ -859,18 +588,6 @@ MatterPreAttributeChangeCallback(const chip::app::ConcreteAttributePath & attrib
     return chip::Protocols::InteractionModel::Status::Success;
 }
 
-/** @brief Post Attribute Change
- *
- * This function is called by the application framework after it changes an
- * attribute value. The value passed into this callback is the value to which
- * the attribute was set by the framework.
- *
- * @param attributePath
- * @param mask
- * @param type
- * @param size
- * @param value
- */
 void __attribute__((weak)) MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t mask,
                                                              uint8_t type, uint16_t size, uint8_t * value)
 {}

--- a/zzz_generated/app-common/app-common/zap-generated/callback.h
+++ b/zzz_generated/app-common/app-common/zap-generated/callback.h
@@ -14446,8 +14446,6 @@ bool emberAfSampleMfgSpecificCluster2ClusterCommandTwoCallback(
  * application behaves with regard to sleeping and polling.  Until the
  * outstanding task is completed, the device may poll more frequently and sleep
  * less often.
- *
- * @param tasks   Ver.: always
  */
 void emberAfAddToCurrentAppTasksCallback(EmberAfApplicationTask tasks);
 
@@ -14460,8 +14458,6 @@ void emberAfAddToCurrentAppTasksCallback(EmberAfApplicationTask tasks);
  * from the list of outstanding tasks may allow the device to sleep longer and
  * poll less frequently.  If there are other outstanding tasks the system may
  * still have to stay away and poll more often.
- *
- * @param tasks   Ver.: always
  */
 void emberAfRemoveFromCurrentAppTasksCallback(EmberAfApplicationTask tasks);
 
@@ -14489,14 +14485,6 @@ void emberAfRemoveFromCurrentAppTasksCallback(EmberAfApplicationTask tasks);
  * is unlikely to be a problem for writing read-only attributes, but it may be a
  * problem for attributes that are writeable according to the specification but
  * restricted by the application implementing this callback.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeId   Ver.: always
- * @param mask   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param value   Ver.: always
- * @param type   Ver.: always
  */
 EmberAfAttributeWritePermission emberAfAllowNetworkWriteAttributeCallback(chip::EndpointId endpoint, chip::ClusterId clusterId,
                                                                           chip::AttributeId attributeId, uint8_t mask,
@@ -14506,11 +14494,6 @@ EmberAfAttributeWritePermission emberAfAllowNetworkWriteAttributeCallback(chip::
  *
  * This function is called whenever the Application Framework needs to check
  * access permission for an attribute read.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param attributeId   Ver.: always
  */
 bool emberAfAttributeReadAccessCallback(chip::EndpointId endpoint, chip::ClusterId clusterId, uint16_t manufacturerCode,
                                         chip::AttributeId attributeId);
@@ -14519,11 +14502,6 @@ bool emberAfAttributeReadAccessCallback(chip::EndpointId endpoint, chip::Cluster
  *
  * This function is called whenever the Application Framework needs to check
  * access permission for an attribute write.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param attributeId   Ver.: always
  */
 bool emberAfAttributeWriteAccessCallback(chip::EndpointId endpoint, chip::ClusterId clusterId, uint16_t manufacturerCode,
                                          chip::AttributeId attributeId);
@@ -14534,11 +14512,10 @@ bool emberAfAttributeWriteAccessCallback(chip::EndpointId endpoint, chip::Cluste
  * command is received from an external device.  The application should return
  * true if the message was processed or false if it was not.
  *
- * @param clusterId The cluster identifier of this response.  Ver.: always
- * @param commandId The command identifier to which this is a response.  Ver.:
- * always
+ * @param clusterId The cluster identifier of this response.
+ * @param commandId The command identifier to which this is a response.
  * @param status Specifies either SUCCESS or the nature of the error that was
- * detected in the received command.  Ver.: always
+ * detected in the received command.
  */
 bool emberAfDefaultResponseCallback(chip::ClusterId clusterId, chip::CommandId commandId, EmberAfStatus status);
 
@@ -14557,9 +14534,9 @@ bool emberAfDefaultResponseCallback(chip::ClusterId clusterId, chip::CommandId c
  * the mesasge and the framework will continue to process accordingly.
  *
  * @param messageStruct The structure containing the parameters of the APS
- * message to be sent.  Ver.: always
+ * message to be sent.
  * @param status A pointer to the status code value that will be returned to the
- * caller.  Ver.: always
+ * caller.
  */
 bool emberAfPreMessageSendCallback(EmberAfMessageStruct * messageStruct, EmberStatus * status);
 
@@ -14573,12 +14550,6 @@ bool emberAfPreMessageSendCallback(EmberAfMessageStruct * messageStruct, EmberSt
  * callback should return a bool value of true or false. A value of true
  * indicates that the message sent notification has been handled and should not
  * be handled by the application framework.
- *
- * @param destination   Ver.: always
- * @param apsFrame   Ver.: always
- * @param msgLen   Ver.: always
- * @param message   Ver.: always
- * @param status   Ver.: always
  */
 bool emberAfMessageSentCallback(const chip::MessageSendDestination & destination, EmberApsFrame * apsFrame, uint16_t msgLen,
                                 uint8_t * message, EmberStatus status);
@@ -14611,14 +14582,6 @@ bool emberAfMessageSentCallback(const chip::MessageSendDestination & destination
  * of a buffer overflow throw an appropriate error such as
  * EMBER_ZCL_STATUS_INSUFFICIENT_SPACE. Any other return value indicates the
  * application was not able to read the attribute.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeMetadata   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param buffer   Ver.: always
- * @param maxReadLength   Ver.: always
- * @param index   Ver.: always
  */
 EmberAfStatus emberAfExternalAttributeReadCallback(chip::EndpointId endpoint, chip::ClusterId clusterId,
                                                    EmberAfAttributeMetadata * attributeMetadata, uint16_t manufacturerCode,
@@ -14663,13 +14626,6 @@ EmberAfStatus emberAfExternalAttributeReadCallback(chip::EndpointId endpoint, ch
  * write the attribute, it returns a value of EMBER_ZCL_STATUS_SUCCESS. Any
  * other return value indicates the application was not able to write the
  * attribute.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeMetadata   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param buffer   Ver.: always
- * @param index   Ver.: always
  */
 EmberAfStatus emberAfExternalAttributeWriteCallback(chip::EndpointId endpoint, chip::ClusterId clusterId,
                                                     EmberAfAttributeMetadata * attributeMetadata, uint16_t manufacturerCode,
@@ -14741,12 +14697,6 @@ bool emberAfStartMoveCallback();
  * the attribute is to be set by the framework.  The application should return
  * chip::Protocols::InteractionModel::Status::Success to permit the change or
  * any other code to reject it.
- *
- * @param attributePath
- * @param mask
- * @param type
- * @param size
- * @param value
  */
 chip::Protocols::InteractionModel::Status MatterPreAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath,
                                                                            uint8_t mask, uint8_t type, uint16_t size,
@@ -14757,12 +14707,6 @@ chip::Protocols::InteractionModel::Status MatterPreAttributeChangeCallback(const
  * This function is called by the application framework after it changes an
  * attribute value. The value passed into this callback is the value to which
  * the attribute was set by the framework.
- *
- * @param attributePath
- * @param mask
- * @param type
- * @param size
- * @param value
  */
 void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t mask, uint8_t type,
                                        uint16_t size, uint8_t * value);

--- a/zzz_generated/bridge-app/zap-generated/callback-stub.cpp
+++ b/zzz_generated/bridge-app/zap-generated/callback-stub.cpp
@@ -168,66 +168,10 @@ void __attribute__((weak)) emberAfWiFiNetworkDiagnosticsClusterInitCallback(Endp
 // Non-Cluster Related Callbacks
 //
 
-/** @brief Add To Current App Tasks
- *
- * This function is only useful to sleepy end devices.  This function will note
- * the passed item as part of a set of tasks the application has outstanding
- * (e.g. message sent requiring APS acknwoledgement).  This will affect how the
- * application behaves with regard to sleeping and polling.  Until the
- * outstanding task is completed, the device may poll more frequently and sleep
- * less often.
- *
- * @param tasks   Ver.: always
- */
 void __attribute__((weak)) emberAfAddToCurrentAppTasksCallback(EmberAfApplicationTask tasks) {}
 
-/** @brief Remove From Current App Tasks
- *
- * This function is only useful to sleepy end devices.  This function will
- * remove the passed item from the set of tasks the application has outstanding
- * (e.g. message sent requiring APS acknwoledgement).  This will affect how the
- * application behaves with regard to sleeping and polling.  Removing the item
- * from the list of outstanding tasks may allow the device to sleep longer and
- * poll less frequently.  If there are other outstanding tasks the system may
- * still have to stay away and poll more often.
- *
- * @param tasks   Ver.: always
- */
 void __attribute__((weak)) emberAfRemoveFromCurrentAppTasksCallback(EmberAfApplicationTask tasks) {}
 
-/** @brief Allow Network Write Attribute
- *
- * This function is called by the application framework before it writes an
- * attribute in response to a write attribute request from an external device.
- * The value passed into this callback is the value to which the attribute is to
- * be set by the framework.
-        Example:	In mirroring simple metering data
- * on an Energy Services Interface (ESI) (formerly called Energy Service Portal
- * (ESP) in SE 1.0).), a mirrored simple meter needs to write read-only
- * attributes on its mirror. The-meter-mirror sample application, located in
- * app/framework/sample-apps, uses this callback to allow the mirrored device to
- * write simple metering attributes on the mirror regardless of the fact that
- * most simple metering attributes are defined as read-only by the ZigBee
- * specification.
-        Note:	The ZCL specification does not (as of this
- * writing) specify any permission-level security for writing writeable
- * attributes. As far as the ZCL specification is concerned, if an attribute is
- * writeable, any device that has a link key for the device should be able to
- * write that attribute. Furthermore if an attribute is read only, it should not
- * be written over the air. Thus, if you implement permissions for writing
- * attributes as a feature, you MAY be operating outside the specification. This
- * is unlikely to be a problem for writing read-only attributes, but it may be a
- * problem for attributes that are writeable according to the specification but
- * restricted by the application implementing this callback.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeId   Ver.: always
- * @param mask   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param value   Ver.: always
- * @param type   Ver.: always
- */
 EmberAfAttributeWritePermission __attribute__((weak))
 emberAfAllowNetworkWriteAttributeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
                                           uint16_t manufacturerCode, uint8_t * value, uint8_t type)
@@ -235,140 +179,34 @@ emberAfAllowNetworkWriteAttributeCallback(EndpointId endpoint, ClusterId cluster
     return EMBER_ZCL_ATTRIBUTE_WRITE_PERMISSION_ALLOW_WRITE_NORMAL; // Default
 }
 
-/** @brief Attribute Read Access
- *
- * This function is called whenever the Application Framework needs to check
- * access permission for an attribute read.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param attributeId   Ver.: always
- */
 bool __attribute__((weak))
 emberAfAttributeReadAccessCallback(EndpointId endpoint, ClusterId clusterId, uint16_t manufacturerCode, AttributeId attributeId)
 {
     return true;
 }
 
-/** @brief Attribute Write Access
- *
- * This function is called whenever the Application Framework needs to check
- * access permission for an attribute write.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param attributeId   Ver.: always
- */
 bool __attribute__((weak))
 emberAfAttributeWriteAccessCallback(EndpointId endpoint, ClusterId clusterId, uint16_t manufacturerCode, AttributeId attributeId)
 {
     return true;
 }
 
-/** @brief Default Response
- *
- * This function is called by the application framework when a Default Response
- * command is received from an external device.  The application should return
- * true if the message was processed or false if it was not.
- *
- * @param clusterId The cluster identifier of this response.  Ver.: always
- * @param commandId The command identifier to which this is a response.  Ver.:
- * always
- * @param status Specifies either SUCCESS or the nature of the error that was
- * detected in the received command.  Ver.: always
- */
 bool __attribute__((weak)) emberAfDefaultResponseCallback(ClusterId clusterId, CommandId commandId, EmberAfStatus status)
 {
     return false;
 }
 
-/** @brief Pre Message Send
- *
- * This function is called by the framework when it is about to pass a message
- * to the stack primitives for sending.   This message may or may not be ZCL,
- * ZDO, or some other protocol.  This is called prior to
-        any ZigBee
- * fragmentation that may be done.  If the function returns true it is assumed
- * the callback has consumed and processed the message.  The callback must also
- * set the EmberStatus status code to be passed back to the caller.  The
- * framework will do no further processing on the message.
-        If the
- * function returns false then it is assumed that the callback has not processed
- * the mesasge and the framework will continue to process accordingly.
- *
- * @param messageStruct The structure containing the parameters of the APS
- * message to be sent.  Ver.: always
- * @param status A pointer to the status code value that will be returned to the
- * caller.  Ver.: always
- */
 bool __attribute__((weak)) emberAfPreMessageSendCallback(EmberAfMessageStruct * messageStruct, EmberStatus * status)
 {
     return false;
 }
 
-/** @brief Message Sent
- *
- * This function is called by the application framework from the message sent
- * handler, when it is informed by the stack regarding the message sent status.
- * All of the values passed to the emberMessageSentHandler are passed on to this
- * callback. This provides an opportunity for the application to verify that its
- * message has been sent successfully and take the appropriate action. This
- * callback should return a bool value of true or false. A value of true
- * indicates that the message sent notification has been handled and should not
- * be handled by the application framework.
- *
- * @param type   Ver.: always
- * @param destination   Ver.: always
- * @param apsFrame   Ver.: always
- * @param msgLen   Ver.: always
- * @param message   Ver.: always
- * @param status   Ver.: always
- */
 bool __attribute__((weak)) emberAfMessageSentCallback(const MessageSendDestination & destination, EmberApsFrame * apsFrame,
                                                       uint16_t msgLen, uint8_t * message, EmberStatus status)
 {
     return false;
 }
 
-/** @brief External Attribute Read
- *
- * Like emberAfExternalAttributeWriteCallback above, this function is called
- * when the framework needs to read an attribute that is not stored within the
- * Application Framework's data structures.
-        All of the important
- * information about the attribute itself is passed as a pointer to an
- * EmberAfAttributeMetadata struct, which is stored within the application and
- * used to manage the attribute. A complete description of the
- * EmberAfAttributeMetadata struct is provided in
- * app/framework/include/af-types.h
-        This function assumes that the
- * application is able to read the attribute, write it into the passed buffer,
- * and return immediately. Any attributes that require a state machine for
- * reading and writing are not really candidates for externalization at the
- * present time. The Application Framework does not currently include a state
- * machine for reading or writing attributes that must take place across a
- * series of application ticks. Attributes that cannot be read in a timely
- * manner should be stored within the Application Framework and updated
- * occasionally by the application code from within the
- * emberAfMainTickCallback.
-        If the application was successfully able to
- * read the attribute and write it into the passed buffer, it should return a
- * value of EMBER_ZCL_STATUS_SUCCESS. Ensure that the size of the externally
- * managed attribute value is smaller than what the buffer can hold. In the case
- * of a buffer overflow throw an appropriate error such as
- * EMBER_ZCL_STATUS_INSUFFICIENT_SPACE. Any other return value indicates the
- * application was not able to read the attribute.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeMetadata   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param buffer   Ver.: always
- * @param maxReadLength   Ver.: always
- * @param index   Ver.: always
- */
 EmberAfStatus __attribute__((weak))
 emberAfExternalAttributeReadCallback(EndpointId endpoint, ClusterId clusterId, EmberAfAttributeMetadata * attributeMetadata,
                                      uint16_t manufacturerCode, uint8_t * buffer, uint16_t maxReadLength, int32_t index)
@@ -376,53 +214,6 @@ emberAfExternalAttributeReadCallback(EndpointId endpoint, ClusterId clusterId, E
     return EMBER_ZCL_STATUS_FAILURE;
 }
 
-/** @brief External Attribute Write
- *
- * This function is called whenever the Application Framework needs to write an
- * attribute which is not stored within the data structures of the Application
- * Framework itself. One of the new features in Version 2 is the ability to
- * store attributes outside the Framework. This is particularly useful for
- * attributes that do not need to be stored because they can be read off the
- * hardware when they are needed, or are stored in some central location used by
- * many modules within the system. In this case, you can indicate that the
- * attribute is stored externally. When the framework needs to write an external
- * attribute, it makes a call to this callback.
-        This callback is very
- * useful for host micros which need to store attributes in persistent memory.
- * Because each host micro (used with an Ember NCP) has its own type of
- * persistent memory storage, the Application Framework does not include the
- * ability to mark attributes as stored in flash the way that it does for Ember
- * SoCs like the EM35x. On a host micro, any attributes that need to be stored
- * in persistent memory should be marked as external and accessed through the
- * external read and write callbacks. Any host code associated with the
- * persistent storage should be implemented within this callback.
-        All of
- * the important information about the attribute itself is passed as a pointer
- * to an EmberAfAttributeMetadata struct, which is stored within the application
- * and used to manage the attribute. A complete description of the
- * EmberAfAttributeMetadata struct is provided in
- * app/framework/include/af-types.h.
-        This function assumes that the
- * application is able to write the attribute and return immediately. Any
- * attributes that require a state machine for reading and writing are not
- * candidates for externalization at the present time. The Application Framework
- * does not currently include a state machine for reading or writing attributes
- * that must take place across a series of application ticks. Attributes that
- * cannot be written immediately should be stored within the Application
- * Framework and updated occasionally by the application code from within the
- * emberAfMainTickCallback.
-        If the application was successfully able to
- * write the attribute, it returns a value of EMBER_ZCL_STATUS_SUCCESS. Any
- * other return value indicates the application was not able to write the
- * attribute.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeMetadata   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param buffer   Ver.: always
- * @param index   Ver.: always
- */
 EmberAfStatus __attribute__((weak))
 emberAfExternalAttributeWriteCallback(EndpointId endpoint, ClusterId clusterId, EmberAfAttributeMetadata * attributeMetadata,
                                       uint16_t manufacturerCode, uint8_t * buffer, int32_t index)
@@ -430,92 +221,30 @@ emberAfExternalAttributeWriteCallback(EndpointId endpoint, ClusterId clusterId, 
     return EMBER_ZCL_STATUS_FAILURE;
 }
 
-/** @brief Get Current Time
- *
- * This callback is called when device attempts to get current time from the
- * hardware. If this device has means to retrieve exact time, then this method
- * should implement it. If the callback can't provide the exact time it should
- * return 0 to indicate failure. Default action is to return 0, which indicates
- * that device does not have access to real time.
- *
- */
 uint32_t __attribute__((weak)) emberAfGetCurrentTimeCallback()
 {
     return 0;
 }
 
-/** @brief Get Endpoint Info
- *
- * This function is a callback to an application implemented endpoint that
- * operates outside the normal application framework.  When the framework wishes
- * to perform operations with that endpoint it uses this callback to retrieve
- * the endpoint's information.  If the endpoint exists and the application can
- * provide data then true shall be returned.  Otherwise the callback must return
- * false.
- *
- * @param endpoint The endpoint to retrieve data for.  Ver.: always
- * @param returnNetworkIndex The index corresponding to the ZigBee network the
- * endpoint belongs to.  If not using a multi-network device, 0 must be
- * returned.  Otherwise on a multi-network device the stack will switch to this
- * network before sending the message.  Ver.: always
- * @param returnEndpointInfo A pointer to a data struct that will be written
- * with information about the endpoint.  Ver.: always
- */
 bool __attribute__((weak))
 emberAfGetEndpointInfoCallback(EndpointId endpoint, uint8_t * returnNetworkIndex, EmberAfEndpointInfoStruct * returnEndpointInfo)
 {
     return false;
 }
 
-/** @brief Registration Abort
- *
- * This callback is called when the device should abort the registration
- * process.
- *
- */
 void __attribute__((weak)) emberAfRegistrationAbortCallback() {}
 
-/** @brief Interpan Send Message
- *
- * This function will send a raw MAC message with interpan frame format using
- * the passed parameters.
- *
- * @param header Interpan header info  Ver.: always
- * @param messageLength The length of the message received or to send  Ver.:
- * always
- * @param message The message data received or to send.  Ver.: always
- */
 EmberStatus __attribute__((weak))
 emberAfInterpanSendMessageCallback(EmberAfInterpanHeader * header, uint16_t messageLength, uint8_t * message)
 {
     return EMBER_LIBRARY_NOT_PRESENT;
 }
 
-/** @brief Start Move
- *
- * This function is called to initiate the process for a device to move (rejoin)
- * to a new parent.
- *
- */
 bool __attribute__((weak)) emberAfStartMoveCallback()
 {
     return false;
 }
 
-/** @brief Pre Attribute Change
- *
- * This function is called by the application framework before it changes an
- * attribute value.  The value passed into this callback is the value to which
- * the attribute is to be set by the framework.  The application should return
- * chip::Protocols::InteractionModel::Status::Success to permit the change or
- * any other code to reject it.
- *
- * @param attributePath
- * @param mask
- * @param type
- * @param size
- * @param value
- */
 chip::Protocols::InteractionModel::Status __attribute__((weak))
 MatterPreAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t mask, uint8_t type, uint16_t size,
                                  uint8_t * value)
@@ -523,18 +252,6 @@ MatterPreAttributeChangeCallback(const chip::app::ConcreteAttributePath & attrib
     return chip::Protocols::InteractionModel::Status::Success;
 }
 
-/** @brief Post Attribute Change
- *
- * This function is called by the application framework after it changes an
- * attribute value. The value passed into this callback is the value to which
- * the attribute was set by the framework.
- *
- * @param attributePath
- * @param mask
- * @param type
- * @param size
- * @param value
- */
 void __attribute__((weak)) MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t mask,
                                                              uint8_t type, uint16_t size, uint8_t * value)
 {}

--- a/zzz_generated/controller-clusters/zap-generated/callback-stub.cpp
+++ b/zzz_generated/controller-clusters/zap-generated/callback-stub.cpp
@@ -496,66 +496,10 @@ void __attribute__((weak)) emberAfWindowCoveringClusterInitCallback(EndpointId e
 // Non-Cluster Related Callbacks
 //
 
-/** @brief Add To Current App Tasks
- *
- * This function is only useful to sleepy end devices.  This function will note
- * the passed item as part of a set of tasks the application has outstanding
- * (e.g. message sent requiring APS acknwoledgement).  This will affect how the
- * application behaves with regard to sleeping and polling.  Until the
- * outstanding task is completed, the device may poll more frequently and sleep
- * less often.
- *
- * @param tasks   Ver.: always
- */
 void __attribute__((weak)) emberAfAddToCurrentAppTasksCallback(EmberAfApplicationTask tasks) {}
 
-/** @brief Remove From Current App Tasks
- *
- * This function is only useful to sleepy end devices.  This function will
- * remove the passed item from the set of tasks the application has outstanding
- * (e.g. message sent requiring APS acknwoledgement).  This will affect how the
- * application behaves with regard to sleeping and polling.  Removing the item
- * from the list of outstanding tasks may allow the device to sleep longer and
- * poll less frequently.  If there are other outstanding tasks the system may
- * still have to stay away and poll more often.
- *
- * @param tasks   Ver.: always
- */
 void __attribute__((weak)) emberAfRemoveFromCurrentAppTasksCallback(EmberAfApplicationTask tasks) {}
 
-/** @brief Allow Network Write Attribute
- *
- * This function is called by the application framework before it writes an
- * attribute in response to a write attribute request from an external device.
- * The value passed into this callback is the value to which the attribute is to
- * be set by the framework.
-        Example:	In mirroring simple metering data
- * on an Energy Services Interface (ESI) (formerly called Energy Service Portal
- * (ESP) in SE 1.0).), a mirrored simple meter needs to write read-only
- * attributes on its mirror. The-meter-mirror sample application, located in
- * app/framework/sample-apps, uses this callback to allow the mirrored device to
- * write simple metering attributes on the mirror regardless of the fact that
- * most simple metering attributes are defined as read-only by the ZigBee
- * specification.
-        Note:	The ZCL specification does not (as of this
- * writing) specify any permission-level security for writing writeable
- * attributes. As far as the ZCL specification is concerned, if an attribute is
- * writeable, any device that has a link key for the device should be able to
- * write that attribute. Furthermore if an attribute is read only, it should not
- * be written over the air. Thus, if you implement permissions for writing
- * attributes as a feature, you MAY be operating outside the specification. This
- * is unlikely to be a problem for writing read-only attributes, but it may be a
- * problem for attributes that are writeable according to the specification but
- * restricted by the application implementing this callback.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeId   Ver.: always
- * @param mask   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param value   Ver.: always
- * @param type   Ver.: always
- */
 EmberAfAttributeWritePermission __attribute__((weak))
 emberAfAllowNetworkWriteAttributeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
                                           uint16_t manufacturerCode, uint8_t * value, uint8_t type)
@@ -563,140 +507,34 @@ emberAfAllowNetworkWriteAttributeCallback(EndpointId endpoint, ClusterId cluster
     return EMBER_ZCL_ATTRIBUTE_WRITE_PERMISSION_ALLOW_WRITE_NORMAL; // Default
 }
 
-/** @brief Attribute Read Access
- *
- * This function is called whenever the Application Framework needs to check
- * access permission for an attribute read.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param attributeId   Ver.: always
- */
 bool __attribute__((weak))
 emberAfAttributeReadAccessCallback(EndpointId endpoint, ClusterId clusterId, uint16_t manufacturerCode, AttributeId attributeId)
 {
     return true;
 }
 
-/** @brief Attribute Write Access
- *
- * This function is called whenever the Application Framework needs to check
- * access permission for an attribute write.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param attributeId   Ver.: always
- */
 bool __attribute__((weak))
 emberAfAttributeWriteAccessCallback(EndpointId endpoint, ClusterId clusterId, uint16_t manufacturerCode, AttributeId attributeId)
 {
     return true;
 }
 
-/** @brief Default Response
- *
- * This function is called by the application framework when a Default Response
- * command is received from an external device.  The application should return
- * true if the message was processed or false if it was not.
- *
- * @param clusterId The cluster identifier of this response.  Ver.: always
- * @param commandId The command identifier to which this is a response.  Ver.:
- * always
- * @param status Specifies either SUCCESS or the nature of the error that was
- * detected in the received command.  Ver.: always
- */
 bool __attribute__((weak)) emberAfDefaultResponseCallback(ClusterId clusterId, CommandId commandId, EmberAfStatus status)
 {
     return false;
 }
 
-/** @brief Pre Message Send
- *
- * This function is called by the framework when it is about to pass a message
- * to the stack primitives for sending.   This message may or may not be ZCL,
- * ZDO, or some other protocol.  This is called prior to
-        any ZigBee
- * fragmentation that may be done.  If the function returns true it is assumed
- * the callback has consumed and processed the message.  The callback must also
- * set the EmberStatus status code to be passed back to the caller.  The
- * framework will do no further processing on the message.
-        If the
- * function returns false then it is assumed that the callback has not processed
- * the mesasge and the framework will continue to process accordingly.
- *
- * @param messageStruct The structure containing the parameters of the APS
- * message to be sent.  Ver.: always
- * @param status A pointer to the status code value that will be returned to the
- * caller.  Ver.: always
- */
 bool __attribute__((weak)) emberAfPreMessageSendCallback(EmberAfMessageStruct * messageStruct, EmberStatus * status)
 {
     return false;
 }
 
-/** @brief Message Sent
- *
- * This function is called by the application framework from the message sent
- * handler, when it is informed by the stack regarding the message sent status.
- * All of the values passed to the emberMessageSentHandler are passed on to this
- * callback. This provides an opportunity for the application to verify that its
- * message has been sent successfully and take the appropriate action. This
- * callback should return a bool value of true or false. A value of true
- * indicates that the message sent notification has been handled and should not
- * be handled by the application framework.
- *
- * @param type   Ver.: always
- * @param destination   Ver.: always
- * @param apsFrame   Ver.: always
- * @param msgLen   Ver.: always
- * @param message   Ver.: always
- * @param status   Ver.: always
- */
 bool __attribute__((weak)) emberAfMessageSentCallback(const MessageSendDestination & destination, EmberApsFrame * apsFrame,
                                                       uint16_t msgLen, uint8_t * message, EmberStatus status)
 {
     return false;
 }
 
-/** @brief External Attribute Read
- *
- * Like emberAfExternalAttributeWriteCallback above, this function is called
- * when the framework needs to read an attribute that is not stored within the
- * Application Framework's data structures.
-        All of the important
- * information about the attribute itself is passed as a pointer to an
- * EmberAfAttributeMetadata struct, which is stored within the application and
- * used to manage the attribute. A complete description of the
- * EmberAfAttributeMetadata struct is provided in
- * app/framework/include/af-types.h
-        This function assumes that the
- * application is able to read the attribute, write it into the passed buffer,
- * and return immediately. Any attributes that require a state machine for
- * reading and writing are not really candidates for externalization at the
- * present time. The Application Framework does not currently include a state
- * machine for reading or writing attributes that must take place across a
- * series of application ticks. Attributes that cannot be read in a timely
- * manner should be stored within the Application Framework and updated
- * occasionally by the application code from within the
- * emberAfMainTickCallback.
-        If the application was successfully able to
- * read the attribute and write it into the passed buffer, it should return a
- * value of EMBER_ZCL_STATUS_SUCCESS. Ensure that the size of the externally
- * managed attribute value is smaller than what the buffer can hold. In the case
- * of a buffer overflow throw an appropriate error such as
- * EMBER_ZCL_STATUS_INSUFFICIENT_SPACE. Any other return value indicates the
- * application was not able to read the attribute.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeMetadata   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param buffer   Ver.: always
- * @param maxReadLength   Ver.: always
- * @param index   Ver.: always
- */
 EmberAfStatus __attribute__((weak))
 emberAfExternalAttributeReadCallback(EndpointId endpoint, ClusterId clusterId, EmberAfAttributeMetadata * attributeMetadata,
                                      uint16_t manufacturerCode, uint8_t * buffer, uint16_t maxReadLength, int32_t index)
@@ -704,53 +542,6 @@ emberAfExternalAttributeReadCallback(EndpointId endpoint, ClusterId clusterId, E
     return EMBER_ZCL_STATUS_FAILURE;
 }
 
-/** @brief External Attribute Write
- *
- * This function is called whenever the Application Framework needs to write an
- * attribute which is not stored within the data structures of the Application
- * Framework itself. One of the new features in Version 2 is the ability to
- * store attributes outside the Framework. This is particularly useful for
- * attributes that do not need to be stored because they can be read off the
- * hardware when they are needed, or are stored in some central location used by
- * many modules within the system. In this case, you can indicate that the
- * attribute is stored externally. When the framework needs to write an external
- * attribute, it makes a call to this callback.
-        This callback is very
- * useful for host micros which need to store attributes in persistent memory.
- * Because each host micro (used with an Ember NCP) has its own type of
- * persistent memory storage, the Application Framework does not include the
- * ability to mark attributes as stored in flash the way that it does for Ember
- * SoCs like the EM35x. On a host micro, any attributes that need to be stored
- * in persistent memory should be marked as external and accessed through the
- * external read and write callbacks. Any host code associated with the
- * persistent storage should be implemented within this callback.
-        All of
- * the important information about the attribute itself is passed as a pointer
- * to an EmberAfAttributeMetadata struct, which is stored within the application
- * and used to manage the attribute. A complete description of the
- * EmberAfAttributeMetadata struct is provided in
- * app/framework/include/af-types.h.
-        This function assumes that the
- * application is able to write the attribute and return immediately. Any
- * attributes that require a state machine for reading and writing are not
- * candidates for externalization at the present time. The Application Framework
- * does not currently include a state machine for reading or writing attributes
- * that must take place across a series of application ticks. Attributes that
- * cannot be written immediately should be stored within the Application
- * Framework and updated occasionally by the application code from within the
- * emberAfMainTickCallback.
-        If the application was successfully able to
- * write the attribute, it returns a value of EMBER_ZCL_STATUS_SUCCESS. Any
- * other return value indicates the application was not able to write the
- * attribute.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeMetadata   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param buffer   Ver.: always
- * @param index   Ver.: always
- */
 EmberAfStatus __attribute__((weak))
 emberAfExternalAttributeWriteCallback(EndpointId endpoint, ClusterId clusterId, EmberAfAttributeMetadata * attributeMetadata,
                                       uint16_t manufacturerCode, uint8_t * buffer, int32_t index)
@@ -758,92 +549,30 @@ emberAfExternalAttributeWriteCallback(EndpointId endpoint, ClusterId clusterId, 
     return EMBER_ZCL_STATUS_FAILURE;
 }
 
-/** @brief Get Current Time
- *
- * This callback is called when device attempts to get current time from the
- * hardware. If this device has means to retrieve exact time, then this method
- * should implement it. If the callback can't provide the exact time it should
- * return 0 to indicate failure. Default action is to return 0, which indicates
- * that device does not have access to real time.
- *
- */
 uint32_t __attribute__((weak)) emberAfGetCurrentTimeCallback()
 {
     return 0;
 }
 
-/** @brief Get Endpoint Info
- *
- * This function is a callback to an application implemented endpoint that
- * operates outside the normal application framework.  When the framework wishes
- * to perform operations with that endpoint it uses this callback to retrieve
- * the endpoint's information.  If the endpoint exists and the application can
- * provide data then true shall be returned.  Otherwise the callback must return
- * false.
- *
- * @param endpoint The endpoint to retrieve data for.  Ver.: always
- * @param returnNetworkIndex The index corresponding to the ZigBee network the
- * endpoint belongs to.  If not using a multi-network device, 0 must be
- * returned.  Otherwise on a multi-network device the stack will switch to this
- * network before sending the message.  Ver.: always
- * @param returnEndpointInfo A pointer to a data struct that will be written
- * with information about the endpoint.  Ver.: always
- */
 bool __attribute__((weak))
 emberAfGetEndpointInfoCallback(EndpointId endpoint, uint8_t * returnNetworkIndex, EmberAfEndpointInfoStruct * returnEndpointInfo)
 {
     return false;
 }
 
-/** @brief Registration Abort
- *
- * This callback is called when the device should abort the registration
- * process.
- *
- */
 void __attribute__((weak)) emberAfRegistrationAbortCallback() {}
 
-/** @brief Interpan Send Message
- *
- * This function will send a raw MAC message with interpan frame format using
- * the passed parameters.
- *
- * @param header Interpan header info  Ver.: always
- * @param messageLength The length of the message received or to send  Ver.:
- * always
- * @param message The message data received or to send.  Ver.: always
- */
 EmberStatus __attribute__((weak))
 emberAfInterpanSendMessageCallback(EmberAfInterpanHeader * header, uint16_t messageLength, uint8_t * message)
 {
     return EMBER_LIBRARY_NOT_PRESENT;
 }
 
-/** @brief Start Move
- *
- * This function is called to initiate the process for a device to move (rejoin)
- * to a new parent.
- *
- */
 bool __attribute__((weak)) emberAfStartMoveCallback()
 {
     return false;
 }
 
-/** @brief Pre Attribute Change
- *
- * This function is called by the application framework before it changes an
- * attribute value.  The value passed into this callback is the value to which
- * the attribute is to be set by the framework.  The application should return
- * chip::Protocols::InteractionModel::Status::Success to permit the change or
- * any other code to reject it.
- *
- * @param attributePath
- * @param mask
- * @param type
- * @param size
- * @param value
- */
 chip::Protocols::InteractionModel::Status __attribute__((weak))
 MatterPreAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t mask, uint8_t type, uint16_t size,
                                  uint8_t * value)
@@ -851,18 +580,6 @@ MatterPreAttributeChangeCallback(const chip::app::ConcreteAttributePath & attrib
     return chip::Protocols::InteractionModel::Status::Success;
 }
 
-/** @brief Post Attribute Change
- *
- * This function is called by the application framework after it changes an
- * attribute value. The value passed into this callback is the value to which
- * the attribute was set by the framework.
- *
- * @param attributePath
- * @param mask
- * @param type
- * @param size
- * @param value
- */
 void __attribute__((weak)) MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t mask,
                                                              uint8_t type, uint16_t size, uint8_t * value)
 {}

--- a/zzz_generated/lighting-app/zap-generated/callback-stub.cpp
+++ b/zzz_generated/lighting-app/zap-generated/callback-stub.cpp
@@ -184,66 +184,10 @@ void __attribute__((weak)) emberAfWiFiNetworkDiagnosticsClusterInitCallback(Endp
 // Non-Cluster Related Callbacks
 //
 
-/** @brief Add To Current App Tasks
- *
- * This function is only useful to sleepy end devices.  This function will note
- * the passed item as part of a set of tasks the application has outstanding
- * (e.g. message sent requiring APS acknwoledgement).  This will affect how the
- * application behaves with regard to sleeping and polling.  Until the
- * outstanding task is completed, the device may poll more frequently and sleep
- * less often.
- *
- * @param tasks   Ver.: always
- */
 void __attribute__((weak)) emberAfAddToCurrentAppTasksCallback(EmberAfApplicationTask tasks) {}
 
-/** @brief Remove From Current App Tasks
- *
- * This function is only useful to sleepy end devices.  This function will
- * remove the passed item from the set of tasks the application has outstanding
- * (e.g. message sent requiring APS acknwoledgement).  This will affect how the
- * application behaves with regard to sleeping and polling.  Removing the item
- * from the list of outstanding tasks may allow the device to sleep longer and
- * poll less frequently.  If there are other outstanding tasks the system may
- * still have to stay away and poll more often.
- *
- * @param tasks   Ver.: always
- */
 void __attribute__((weak)) emberAfRemoveFromCurrentAppTasksCallback(EmberAfApplicationTask tasks) {}
 
-/** @brief Allow Network Write Attribute
- *
- * This function is called by the application framework before it writes an
- * attribute in response to a write attribute request from an external device.
- * The value passed into this callback is the value to which the attribute is to
- * be set by the framework.
-        Example:	In mirroring simple metering data
- * on an Energy Services Interface (ESI) (formerly called Energy Service Portal
- * (ESP) in SE 1.0).), a mirrored simple meter needs to write read-only
- * attributes on its mirror. The-meter-mirror sample application, located in
- * app/framework/sample-apps, uses this callback to allow the mirrored device to
- * write simple metering attributes on the mirror regardless of the fact that
- * most simple metering attributes are defined as read-only by the ZigBee
- * specification.
-        Note:	The ZCL specification does not (as of this
- * writing) specify any permission-level security for writing writeable
- * attributes. As far as the ZCL specification is concerned, if an attribute is
- * writeable, any device that has a link key for the device should be able to
- * write that attribute. Furthermore if an attribute is read only, it should not
- * be written over the air. Thus, if you implement permissions for writing
- * attributes as a feature, you MAY be operating outside the specification. This
- * is unlikely to be a problem for writing read-only attributes, but it may be a
- * problem for attributes that are writeable according to the specification but
- * restricted by the application implementing this callback.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeId   Ver.: always
- * @param mask   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param value   Ver.: always
- * @param type   Ver.: always
- */
 EmberAfAttributeWritePermission __attribute__((weak))
 emberAfAllowNetworkWriteAttributeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
                                           uint16_t manufacturerCode, uint8_t * value, uint8_t type)
@@ -251,140 +195,34 @@ emberAfAllowNetworkWriteAttributeCallback(EndpointId endpoint, ClusterId cluster
     return EMBER_ZCL_ATTRIBUTE_WRITE_PERMISSION_ALLOW_WRITE_NORMAL; // Default
 }
 
-/** @brief Attribute Read Access
- *
- * This function is called whenever the Application Framework needs to check
- * access permission for an attribute read.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param attributeId   Ver.: always
- */
 bool __attribute__((weak))
 emberAfAttributeReadAccessCallback(EndpointId endpoint, ClusterId clusterId, uint16_t manufacturerCode, AttributeId attributeId)
 {
     return true;
 }
 
-/** @brief Attribute Write Access
- *
- * This function is called whenever the Application Framework needs to check
- * access permission for an attribute write.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param attributeId   Ver.: always
- */
 bool __attribute__((weak))
 emberAfAttributeWriteAccessCallback(EndpointId endpoint, ClusterId clusterId, uint16_t manufacturerCode, AttributeId attributeId)
 {
     return true;
 }
 
-/** @brief Default Response
- *
- * This function is called by the application framework when a Default Response
- * command is received from an external device.  The application should return
- * true if the message was processed or false if it was not.
- *
- * @param clusterId The cluster identifier of this response.  Ver.: always
- * @param commandId The command identifier to which this is a response.  Ver.:
- * always
- * @param status Specifies either SUCCESS or the nature of the error that was
- * detected in the received command.  Ver.: always
- */
 bool __attribute__((weak)) emberAfDefaultResponseCallback(ClusterId clusterId, CommandId commandId, EmberAfStatus status)
 {
     return false;
 }
 
-/** @brief Pre Message Send
- *
- * This function is called by the framework when it is about to pass a message
- * to the stack primitives for sending.   This message may or may not be ZCL,
- * ZDO, or some other protocol.  This is called prior to
-        any ZigBee
- * fragmentation that may be done.  If the function returns true it is assumed
- * the callback has consumed and processed the message.  The callback must also
- * set the EmberStatus status code to be passed back to the caller.  The
- * framework will do no further processing on the message.
-        If the
- * function returns false then it is assumed that the callback has not processed
- * the mesasge and the framework will continue to process accordingly.
- *
- * @param messageStruct The structure containing the parameters of the APS
- * message to be sent.  Ver.: always
- * @param status A pointer to the status code value that will be returned to the
- * caller.  Ver.: always
- */
 bool __attribute__((weak)) emberAfPreMessageSendCallback(EmberAfMessageStruct * messageStruct, EmberStatus * status)
 {
     return false;
 }
 
-/** @brief Message Sent
- *
- * This function is called by the application framework from the message sent
- * handler, when it is informed by the stack regarding the message sent status.
- * All of the values passed to the emberMessageSentHandler are passed on to this
- * callback. This provides an opportunity for the application to verify that its
- * message has been sent successfully and take the appropriate action. This
- * callback should return a bool value of true or false. A value of true
- * indicates that the message sent notification has been handled and should not
- * be handled by the application framework.
- *
- * @param type   Ver.: always
- * @param destination   Ver.: always
- * @param apsFrame   Ver.: always
- * @param msgLen   Ver.: always
- * @param message   Ver.: always
- * @param status   Ver.: always
- */
 bool __attribute__((weak)) emberAfMessageSentCallback(const MessageSendDestination & destination, EmberApsFrame * apsFrame,
                                                       uint16_t msgLen, uint8_t * message, EmberStatus status)
 {
     return false;
 }
 
-/** @brief External Attribute Read
- *
- * Like emberAfExternalAttributeWriteCallback above, this function is called
- * when the framework needs to read an attribute that is not stored within the
- * Application Framework's data structures.
-        All of the important
- * information about the attribute itself is passed as a pointer to an
- * EmberAfAttributeMetadata struct, which is stored within the application and
- * used to manage the attribute. A complete description of the
- * EmberAfAttributeMetadata struct is provided in
- * app/framework/include/af-types.h
-        This function assumes that the
- * application is able to read the attribute, write it into the passed buffer,
- * and return immediately. Any attributes that require a state machine for
- * reading and writing are not really candidates for externalization at the
- * present time. The Application Framework does not currently include a state
- * machine for reading or writing attributes that must take place across a
- * series of application ticks. Attributes that cannot be read in a timely
- * manner should be stored within the Application Framework and updated
- * occasionally by the application code from within the
- * emberAfMainTickCallback.
-        If the application was successfully able to
- * read the attribute and write it into the passed buffer, it should return a
- * value of EMBER_ZCL_STATUS_SUCCESS. Ensure that the size of the externally
- * managed attribute value is smaller than what the buffer can hold. In the case
- * of a buffer overflow throw an appropriate error such as
- * EMBER_ZCL_STATUS_INSUFFICIENT_SPACE. Any other return value indicates the
- * application was not able to read the attribute.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeMetadata   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param buffer   Ver.: always
- * @param maxReadLength   Ver.: always
- * @param index   Ver.: always
- */
 EmberAfStatus __attribute__((weak))
 emberAfExternalAttributeReadCallback(EndpointId endpoint, ClusterId clusterId, EmberAfAttributeMetadata * attributeMetadata,
                                      uint16_t manufacturerCode, uint8_t * buffer, uint16_t maxReadLength, int32_t index)
@@ -392,53 +230,6 @@ emberAfExternalAttributeReadCallback(EndpointId endpoint, ClusterId clusterId, E
     return EMBER_ZCL_STATUS_FAILURE;
 }
 
-/** @brief External Attribute Write
- *
- * This function is called whenever the Application Framework needs to write an
- * attribute which is not stored within the data structures of the Application
- * Framework itself. One of the new features in Version 2 is the ability to
- * store attributes outside the Framework. This is particularly useful for
- * attributes that do not need to be stored because they can be read off the
- * hardware when they are needed, or are stored in some central location used by
- * many modules within the system. In this case, you can indicate that the
- * attribute is stored externally. When the framework needs to write an external
- * attribute, it makes a call to this callback.
-        This callback is very
- * useful for host micros which need to store attributes in persistent memory.
- * Because each host micro (used with an Ember NCP) has its own type of
- * persistent memory storage, the Application Framework does not include the
- * ability to mark attributes as stored in flash the way that it does for Ember
- * SoCs like the EM35x. On a host micro, any attributes that need to be stored
- * in persistent memory should be marked as external and accessed through the
- * external read and write callbacks. Any host code associated with the
- * persistent storage should be implemented within this callback.
-        All of
- * the important information about the attribute itself is passed as a pointer
- * to an EmberAfAttributeMetadata struct, which is stored within the application
- * and used to manage the attribute. A complete description of the
- * EmberAfAttributeMetadata struct is provided in
- * app/framework/include/af-types.h.
-        This function assumes that the
- * application is able to write the attribute and return immediately. Any
- * attributes that require a state machine for reading and writing are not
- * candidates for externalization at the present time. The Application Framework
- * does not currently include a state machine for reading or writing attributes
- * that must take place across a series of application ticks. Attributes that
- * cannot be written immediately should be stored within the Application
- * Framework and updated occasionally by the application code from within the
- * emberAfMainTickCallback.
-        If the application was successfully able to
- * write the attribute, it returns a value of EMBER_ZCL_STATUS_SUCCESS. Any
- * other return value indicates the application was not able to write the
- * attribute.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeMetadata   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param buffer   Ver.: always
- * @param index   Ver.: always
- */
 EmberAfStatus __attribute__((weak))
 emberAfExternalAttributeWriteCallback(EndpointId endpoint, ClusterId clusterId, EmberAfAttributeMetadata * attributeMetadata,
                                       uint16_t manufacturerCode, uint8_t * buffer, int32_t index)
@@ -446,92 +237,30 @@ emberAfExternalAttributeWriteCallback(EndpointId endpoint, ClusterId clusterId, 
     return EMBER_ZCL_STATUS_FAILURE;
 }
 
-/** @brief Get Current Time
- *
- * This callback is called when device attempts to get current time from the
- * hardware. If this device has means to retrieve exact time, then this method
- * should implement it. If the callback can't provide the exact time it should
- * return 0 to indicate failure. Default action is to return 0, which indicates
- * that device does not have access to real time.
- *
- */
 uint32_t __attribute__((weak)) emberAfGetCurrentTimeCallback()
 {
     return 0;
 }
 
-/** @brief Get Endpoint Info
- *
- * This function is a callback to an application implemented endpoint that
- * operates outside the normal application framework.  When the framework wishes
- * to perform operations with that endpoint it uses this callback to retrieve
- * the endpoint's information.  If the endpoint exists and the application can
- * provide data then true shall be returned.  Otherwise the callback must return
- * false.
- *
- * @param endpoint The endpoint to retrieve data for.  Ver.: always
- * @param returnNetworkIndex The index corresponding to the ZigBee network the
- * endpoint belongs to.  If not using a multi-network device, 0 must be
- * returned.  Otherwise on a multi-network device the stack will switch to this
- * network before sending the message.  Ver.: always
- * @param returnEndpointInfo A pointer to a data struct that will be written
- * with information about the endpoint.  Ver.: always
- */
 bool __attribute__((weak))
 emberAfGetEndpointInfoCallback(EndpointId endpoint, uint8_t * returnNetworkIndex, EmberAfEndpointInfoStruct * returnEndpointInfo)
 {
     return false;
 }
 
-/** @brief Registration Abort
- *
- * This callback is called when the device should abort the registration
- * process.
- *
- */
 void __attribute__((weak)) emberAfRegistrationAbortCallback() {}
 
-/** @brief Interpan Send Message
- *
- * This function will send a raw MAC message with interpan frame format using
- * the passed parameters.
- *
- * @param header Interpan header info  Ver.: always
- * @param messageLength The length of the message received or to send  Ver.:
- * always
- * @param message The message data received or to send.  Ver.: always
- */
 EmberStatus __attribute__((weak))
 emberAfInterpanSendMessageCallback(EmberAfInterpanHeader * header, uint16_t messageLength, uint8_t * message)
 {
     return EMBER_LIBRARY_NOT_PRESENT;
 }
 
-/** @brief Start Move
- *
- * This function is called to initiate the process for a device to move (rejoin)
- * to a new parent.
- *
- */
 bool __attribute__((weak)) emberAfStartMoveCallback()
 {
     return false;
 }
 
-/** @brief Pre Attribute Change
- *
- * This function is called by the application framework before it changes an
- * attribute value.  The value passed into this callback is the value to which
- * the attribute is to be set by the framework.  The application should return
- * chip::Protocols::InteractionModel::Status::Success to permit the change or
- * any other code to reject it.
- *
- * @param attributePath
- * @param mask
- * @param type
- * @param size
- * @param value
- */
 chip::Protocols::InteractionModel::Status __attribute__((weak))
 MatterPreAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t mask, uint8_t type, uint16_t size,
                                  uint8_t * value)
@@ -539,18 +268,6 @@ MatterPreAttributeChangeCallback(const chip::app::ConcreteAttributePath & attrib
     return chip::Protocols::InteractionModel::Status::Success;
 }
 
-/** @brief Post Attribute Change
- *
- * This function is called by the application framework after it changes an
- * attribute value. The value passed into this callback is the value to which
- * the attribute was set by the framework.
- *
- * @param attributePath
- * @param mask
- * @param type
- * @param size
- * @param value
- */
 void __attribute__((weak)) MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t mask,
                                                              uint8_t type, uint16_t size, uint8_t * value)
 {}

--- a/zzz_generated/lock-app/zap-generated/callback-stub.cpp
+++ b/zzz_generated/lock-app/zap-generated/callback-stub.cpp
@@ -144,66 +144,10 @@ void __attribute__((weak)) emberAfWiFiNetworkDiagnosticsClusterInitCallback(Endp
 // Non-Cluster Related Callbacks
 //
 
-/** @brief Add To Current App Tasks
- *
- * This function is only useful to sleepy end devices.  This function will note
- * the passed item as part of a set of tasks the application has outstanding
- * (e.g. message sent requiring APS acknwoledgement).  This will affect how the
- * application behaves with regard to sleeping and polling.  Until the
- * outstanding task is completed, the device may poll more frequently and sleep
- * less often.
- *
- * @param tasks   Ver.: always
- */
 void __attribute__((weak)) emberAfAddToCurrentAppTasksCallback(EmberAfApplicationTask tasks) {}
 
-/** @brief Remove From Current App Tasks
- *
- * This function is only useful to sleepy end devices.  This function will
- * remove the passed item from the set of tasks the application has outstanding
- * (e.g. message sent requiring APS acknwoledgement).  This will affect how the
- * application behaves with regard to sleeping and polling.  Removing the item
- * from the list of outstanding tasks may allow the device to sleep longer and
- * poll less frequently.  If there are other outstanding tasks the system may
- * still have to stay away and poll more often.
- *
- * @param tasks   Ver.: always
- */
 void __attribute__((weak)) emberAfRemoveFromCurrentAppTasksCallback(EmberAfApplicationTask tasks) {}
 
-/** @brief Allow Network Write Attribute
- *
- * This function is called by the application framework before it writes an
- * attribute in response to a write attribute request from an external device.
- * The value passed into this callback is the value to which the attribute is to
- * be set by the framework.
-        Example:	In mirroring simple metering data
- * on an Energy Services Interface (ESI) (formerly called Energy Service Portal
- * (ESP) in SE 1.0).), a mirrored simple meter needs to write read-only
- * attributes on its mirror. The-meter-mirror sample application, located in
- * app/framework/sample-apps, uses this callback to allow the mirrored device to
- * write simple metering attributes on the mirror regardless of the fact that
- * most simple metering attributes are defined as read-only by the ZigBee
- * specification.
-        Note:	The ZCL specification does not (as of this
- * writing) specify any permission-level security for writing writeable
- * attributes. As far as the ZCL specification is concerned, if an attribute is
- * writeable, any device that has a link key for the device should be able to
- * write that attribute. Furthermore if an attribute is read only, it should not
- * be written over the air. Thus, if you implement permissions for writing
- * attributes as a feature, you MAY be operating outside the specification. This
- * is unlikely to be a problem for writing read-only attributes, but it may be a
- * problem for attributes that are writeable according to the specification but
- * restricted by the application implementing this callback.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeId   Ver.: always
- * @param mask   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param value   Ver.: always
- * @param type   Ver.: always
- */
 EmberAfAttributeWritePermission __attribute__((weak))
 emberAfAllowNetworkWriteAttributeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
                                           uint16_t manufacturerCode, uint8_t * value, uint8_t type)
@@ -211,140 +155,34 @@ emberAfAllowNetworkWriteAttributeCallback(EndpointId endpoint, ClusterId cluster
     return EMBER_ZCL_ATTRIBUTE_WRITE_PERMISSION_ALLOW_WRITE_NORMAL; // Default
 }
 
-/** @brief Attribute Read Access
- *
- * This function is called whenever the Application Framework needs to check
- * access permission for an attribute read.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param attributeId   Ver.: always
- */
 bool __attribute__((weak))
 emberAfAttributeReadAccessCallback(EndpointId endpoint, ClusterId clusterId, uint16_t manufacturerCode, AttributeId attributeId)
 {
     return true;
 }
 
-/** @brief Attribute Write Access
- *
- * This function is called whenever the Application Framework needs to check
- * access permission for an attribute write.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param attributeId   Ver.: always
- */
 bool __attribute__((weak))
 emberAfAttributeWriteAccessCallback(EndpointId endpoint, ClusterId clusterId, uint16_t manufacturerCode, AttributeId attributeId)
 {
     return true;
 }
 
-/** @brief Default Response
- *
- * This function is called by the application framework when a Default Response
- * command is received from an external device.  The application should return
- * true if the message was processed or false if it was not.
- *
- * @param clusterId The cluster identifier of this response.  Ver.: always
- * @param commandId The command identifier to which this is a response.  Ver.:
- * always
- * @param status Specifies either SUCCESS or the nature of the error that was
- * detected in the received command.  Ver.: always
- */
 bool __attribute__((weak)) emberAfDefaultResponseCallback(ClusterId clusterId, CommandId commandId, EmberAfStatus status)
 {
     return false;
 }
 
-/** @brief Pre Message Send
- *
- * This function is called by the framework when it is about to pass a message
- * to the stack primitives for sending.   This message may or may not be ZCL,
- * ZDO, or some other protocol.  This is called prior to
-        any ZigBee
- * fragmentation that may be done.  If the function returns true it is assumed
- * the callback has consumed and processed the message.  The callback must also
- * set the EmberStatus status code to be passed back to the caller.  The
- * framework will do no further processing on the message.
-        If the
- * function returns false then it is assumed that the callback has not processed
- * the mesasge and the framework will continue to process accordingly.
- *
- * @param messageStruct The structure containing the parameters of the APS
- * message to be sent.  Ver.: always
- * @param status A pointer to the status code value that will be returned to the
- * caller.  Ver.: always
- */
 bool __attribute__((weak)) emberAfPreMessageSendCallback(EmberAfMessageStruct * messageStruct, EmberStatus * status)
 {
     return false;
 }
 
-/** @brief Message Sent
- *
- * This function is called by the application framework from the message sent
- * handler, when it is informed by the stack regarding the message sent status.
- * All of the values passed to the emberMessageSentHandler are passed on to this
- * callback. This provides an opportunity for the application to verify that its
- * message has been sent successfully and take the appropriate action. This
- * callback should return a bool value of true or false. A value of true
- * indicates that the message sent notification has been handled and should not
- * be handled by the application framework.
- *
- * @param type   Ver.: always
- * @param destination   Ver.: always
- * @param apsFrame   Ver.: always
- * @param msgLen   Ver.: always
- * @param message   Ver.: always
- * @param status   Ver.: always
- */
 bool __attribute__((weak)) emberAfMessageSentCallback(const MessageSendDestination & destination, EmberApsFrame * apsFrame,
                                                       uint16_t msgLen, uint8_t * message, EmberStatus status)
 {
     return false;
 }
 
-/** @brief External Attribute Read
- *
- * Like emberAfExternalAttributeWriteCallback above, this function is called
- * when the framework needs to read an attribute that is not stored within the
- * Application Framework's data structures.
-        All of the important
- * information about the attribute itself is passed as a pointer to an
- * EmberAfAttributeMetadata struct, which is stored within the application and
- * used to manage the attribute. A complete description of the
- * EmberAfAttributeMetadata struct is provided in
- * app/framework/include/af-types.h
-        This function assumes that the
- * application is able to read the attribute, write it into the passed buffer,
- * and return immediately. Any attributes that require a state machine for
- * reading and writing are not really candidates for externalization at the
- * present time. The Application Framework does not currently include a state
- * machine for reading or writing attributes that must take place across a
- * series of application ticks. Attributes that cannot be read in a timely
- * manner should be stored within the Application Framework and updated
- * occasionally by the application code from within the
- * emberAfMainTickCallback.
-        If the application was successfully able to
- * read the attribute and write it into the passed buffer, it should return a
- * value of EMBER_ZCL_STATUS_SUCCESS. Ensure that the size of the externally
- * managed attribute value is smaller than what the buffer can hold. In the case
- * of a buffer overflow throw an appropriate error such as
- * EMBER_ZCL_STATUS_INSUFFICIENT_SPACE. Any other return value indicates the
- * application was not able to read the attribute.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeMetadata   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param buffer   Ver.: always
- * @param maxReadLength   Ver.: always
- * @param index   Ver.: always
- */
 EmberAfStatus __attribute__((weak))
 emberAfExternalAttributeReadCallback(EndpointId endpoint, ClusterId clusterId, EmberAfAttributeMetadata * attributeMetadata,
                                      uint16_t manufacturerCode, uint8_t * buffer, uint16_t maxReadLength, int32_t index)
@@ -352,53 +190,6 @@ emberAfExternalAttributeReadCallback(EndpointId endpoint, ClusterId clusterId, E
     return EMBER_ZCL_STATUS_FAILURE;
 }
 
-/** @brief External Attribute Write
- *
- * This function is called whenever the Application Framework needs to write an
- * attribute which is not stored within the data structures of the Application
- * Framework itself. One of the new features in Version 2 is the ability to
- * store attributes outside the Framework. This is particularly useful for
- * attributes that do not need to be stored because they can be read off the
- * hardware when they are needed, or are stored in some central location used by
- * many modules within the system. In this case, you can indicate that the
- * attribute is stored externally. When the framework needs to write an external
- * attribute, it makes a call to this callback.
-        This callback is very
- * useful for host micros which need to store attributes in persistent memory.
- * Because each host micro (used with an Ember NCP) has its own type of
- * persistent memory storage, the Application Framework does not include the
- * ability to mark attributes as stored in flash the way that it does for Ember
- * SoCs like the EM35x. On a host micro, any attributes that need to be stored
- * in persistent memory should be marked as external and accessed through the
- * external read and write callbacks. Any host code associated with the
- * persistent storage should be implemented within this callback.
-        All of
- * the important information about the attribute itself is passed as a pointer
- * to an EmberAfAttributeMetadata struct, which is stored within the application
- * and used to manage the attribute. A complete description of the
- * EmberAfAttributeMetadata struct is provided in
- * app/framework/include/af-types.h.
-        This function assumes that the
- * application is able to write the attribute and return immediately. Any
- * attributes that require a state machine for reading and writing are not
- * candidates for externalization at the present time. The Application Framework
- * does not currently include a state machine for reading or writing attributes
- * that must take place across a series of application ticks. Attributes that
- * cannot be written immediately should be stored within the Application
- * Framework and updated occasionally by the application code from within the
- * emberAfMainTickCallback.
-        If the application was successfully able to
- * write the attribute, it returns a value of EMBER_ZCL_STATUS_SUCCESS. Any
- * other return value indicates the application was not able to write the
- * attribute.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeMetadata   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param buffer   Ver.: always
- * @param index   Ver.: always
- */
 EmberAfStatus __attribute__((weak))
 emberAfExternalAttributeWriteCallback(EndpointId endpoint, ClusterId clusterId, EmberAfAttributeMetadata * attributeMetadata,
                                       uint16_t manufacturerCode, uint8_t * buffer, int32_t index)
@@ -406,92 +197,30 @@ emberAfExternalAttributeWriteCallback(EndpointId endpoint, ClusterId clusterId, 
     return EMBER_ZCL_STATUS_FAILURE;
 }
 
-/** @brief Get Current Time
- *
- * This callback is called when device attempts to get current time from the
- * hardware. If this device has means to retrieve exact time, then this method
- * should implement it. If the callback can't provide the exact time it should
- * return 0 to indicate failure. Default action is to return 0, which indicates
- * that device does not have access to real time.
- *
- */
 uint32_t __attribute__((weak)) emberAfGetCurrentTimeCallback()
 {
     return 0;
 }
 
-/** @brief Get Endpoint Info
- *
- * This function is a callback to an application implemented endpoint that
- * operates outside the normal application framework.  When the framework wishes
- * to perform operations with that endpoint it uses this callback to retrieve
- * the endpoint's information.  If the endpoint exists and the application can
- * provide data then true shall be returned.  Otherwise the callback must return
- * false.
- *
- * @param endpoint The endpoint to retrieve data for.  Ver.: always
- * @param returnNetworkIndex The index corresponding to the ZigBee network the
- * endpoint belongs to.  If not using a multi-network device, 0 must be
- * returned.  Otherwise on a multi-network device the stack will switch to this
- * network before sending the message.  Ver.: always
- * @param returnEndpointInfo A pointer to a data struct that will be written
- * with information about the endpoint.  Ver.: always
- */
 bool __attribute__((weak))
 emberAfGetEndpointInfoCallback(EndpointId endpoint, uint8_t * returnNetworkIndex, EmberAfEndpointInfoStruct * returnEndpointInfo)
 {
     return false;
 }
 
-/** @brief Registration Abort
- *
- * This callback is called when the device should abort the registration
- * process.
- *
- */
 void __attribute__((weak)) emberAfRegistrationAbortCallback() {}
 
-/** @brief Interpan Send Message
- *
- * This function will send a raw MAC message with interpan frame format using
- * the passed parameters.
- *
- * @param header Interpan header info  Ver.: always
- * @param messageLength The length of the message received or to send  Ver.:
- * always
- * @param message The message data received or to send.  Ver.: always
- */
 EmberStatus __attribute__((weak))
 emberAfInterpanSendMessageCallback(EmberAfInterpanHeader * header, uint16_t messageLength, uint8_t * message)
 {
     return EMBER_LIBRARY_NOT_PRESENT;
 }
 
-/** @brief Start Move
- *
- * This function is called to initiate the process for a device to move (rejoin)
- * to a new parent.
- *
- */
 bool __attribute__((weak)) emberAfStartMoveCallback()
 {
     return false;
 }
 
-/** @brief Pre Attribute Change
- *
- * This function is called by the application framework before it changes an
- * attribute value.  The value passed into this callback is the value to which
- * the attribute is to be set by the framework.  The application should return
- * chip::Protocols::InteractionModel::Status::Success to permit the change or
- * any other code to reject it.
- *
- * @param attributePath
- * @param mask
- * @param type
- * @param size
- * @param value
- */
 chip::Protocols::InteractionModel::Status __attribute__((weak))
 MatterPreAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t mask, uint8_t type, uint16_t size,
                                  uint8_t * value)
@@ -499,18 +228,6 @@ MatterPreAttributeChangeCallback(const chip::app::ConcreteAttributePath & attrib
     return chip::Protocols::InteractionModel::Status::Success;
 }
 
-/** @brief Post Attribute Change
- *
- * This function is called by the application framework after it changes an
- * attribute value. The value passed into this callback is the value to which
- * the attribute was set by the framework.
- *
- * @param attributePath
- * @param mask
- * @param type
- * @param size
- * @param value
- */
 void __attribute__((weak)) MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t mask,
                                                              uint8_t type, uint16_t size, uint8_t * value)
 {}

--- a/zzz_generated/ota-provider-app/zap-generated/callback-stub.cpp
+++ b/zzz_generated/ota-provider-app/zap-generated/callback-stub.cpp
@@ -72,66 +72,10 @@ void __attribute__((weak)) emberAfOperationalCredentialsClusterInitCallback(Endp
 // Non-Cluster Related Callbacks
 //
 
-/** @brief Add To Current App Tasks
- *
- * This function is only useful to sleepy end devices.  This function will note
- * the passed item as part of a set of tasks the application has outstanding
- * (e.g. message sent requiring APS acknwoledgement).  This will affect how the
- * application behaves with regard to sleeping and polling.  Until the
- * outstanding task is completed, the device may poll more frequently and sleep
- * less often.
- *
- * @param tasks   Ver.: always
- */
 void __attribute__((weak)) emberAfAddToCurrentAppTasksCallback(EmberAfApplicationTask tasks) {}
 
-/** @brief Remove From Current App Tasks
- *
- * This function is only useful to sleepy end devices.  This function will
- * remove the passed item from the set of tasks the application has outstanding
- * (e.g. message sent requiring APS acknwoledgement).  This will affect how the
- * application behaves with regard to sleeping and polling.  Removing the item
- * from the list of outstanding tasks may allow the device to sleep longer and
- * poll less frequently.  If there are other outstanding tasks the system may
- * still have to stay away and poll more often.
- *
- * @param tasks   Ver.: always
- */
 void __attribute__((weak)) emberAfRemoveFromCurrentAppTasksCallback(EmberAfApplicationTask tasks) {}
 
-/** @brief Allow Network Write Attribute
- *
- * This function is called by the application framework before it writes an
- * attribute in response to a write attribute request from an external device.
- * The value passed into this callback is the value to which the attribute is to
- * be set by the framework.
-        Example:	In mirroring simple metering data
- * on an Energy Services Interface (ESI) (formerly called Energy Service Portal
- * (ESP) in SE 1.0).), a mirrored simple meter needs to write read-only
- * attributes on its mirror. The-meter-mirror sample application, located in
- * app/framework/sample-apps, uses this callback to allow the mirrored device to
- * write simple metering attributes on the mirror regardless of the fact that
- * most simple metering attributes are defined as read-only by the ZigBee
- * specification.
-        Note:	The ZCL specification does not (as of this
- * writing) specify any permission-level security for writing writeable
- * attributes. As far as the ZCL specification is concerned, if an attribute is
- * writeable, any device that has a link key for the device should be able to
- * write that attribute. Furthermore if an attribute is read only, it should not
- * be written over the air. Thus, if you implement permissions for writing
- * attributes as a feature, you MAY be operating outside the specification. This
- * is unlikely to be a problem for writing read-only attributes, but it may be a
- * problem for attributes that are writeable according to the specification but
- * restricted by the application implementing this callback.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeId   Ver.: always
- * @param mask   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param value   Ver.: always
- * @param type   Ver.: always
- */
 EmberAfAttributeWritePermission __attribute__((weak))
 emberAfAllowNetworkWriteAttributeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
                                           uint16_t manufacturerCode, uint8_t * value, uint8_t type)
@@ -139,140 +83,34 @@ emberAfAllowNetworkWriteAttributeCallback(EndpointId endpoint, ClusterId cluster
     return EMBER_ZCL_ATTRIBUTE_WRITE_PERMISSION_ALLOW_WRITE_NORMAL; // Default
 }
 
-/** @brief Attribute Read Access
- *
- * This function is called whenever the Application Framework needs to check
- * access permission for an attribute read.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param attributeId   Ver.: always
- */
 bool __attribute__((weak))
 emberAfAttributeReadAccessCallback(EndpointId endpoint, ClusterId clusterId, uint16_t manufacturerCode, AttributeId attributeId)
 {
     return true;
 }
 
-/** @brief Attribute Write Access
- *
- * This function is called whenever the Application Framework needs to check
- * access permission for an attribute write.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param attributeId   Ver.: always
- */
 bool __attribute__((weak))
 emberAfAttributeWriteAccessCallback(EndpointId endpoint, ClusterId clusterId, uint16_t manufacturerCode, AttributeId attributeId)
 {
     return true;
 }
 
-/** @brief Default Response
- *
- * This function is called by the application framework when a Default Response
- * command is received from an external device.  The application should return
- * true if the message was processed or false if it was not.
- *
- * @param clusterId The cluster identifier of this response.  Ver.: always
- * @param commandId The command identifier to which this is a response.  Ver.:
- * always
- * @param status Specifies either SUCCESS or the nature of the error that was
- * detected in the received command.  Ver.: always
- */
 bool __attribute__((weak)) emberAfDefaultResponseCallback(ClusterId clusterId, CommandId commandId, EmberAfStatus status)
 {
     return false;
 }
 
-/** @brief Pre Message Send
- *
- * This function is called by the framework when it is about to pass a message
- * to the stack primitives for sending.   This message may or may not be ZCL,
- * ZDO, or some other protocol.  This is called prior to
-        any ZigBee
- * fragmentation that may be done.  If the function returns true it is assumed
- * the callback has consumed and processed the message.  The callback must also
- * set the EmberStatus status code to be passed back to the caller.  The
- * framework will do no further processing on the message.
-        If the
- * function returns false then it is assumed that the callback has not processed
- * the mesasge and the framework will continue to process accordingly.
- *
- * @param messageStruct The structure containing the parameters of the APS
- * message to be sent.  Ver.: always
- * @param status A pointer to the status code value that will be returned to the
- * caller.  Ver.: always
- */
 bool __attribute__((weak)) emberAfPreMessageSendCallback(EmberAfMessageStruct * messageStruct, EmberStatus * status)
 {
     return false;
 }
 
-/** @brief Message Sent
- *
- * This function is called by the application framework from the message sent
- * handler, when it is informed by the stack regarding the message sent status.
- * All of the values passed to the emberMessageSentHandler are passed on to this
- * callback. This provides an opportunity for the application to verify that its
- * message has been sent successfully and take the appropriate action. This
- * callback should return a bool value of true or false. A value of true
- * indicates that the message sent notification has been handled and should not
- * be handled by the application framework.
- *
- * @param type   Ver.: always
- * @param destination   Ver.: always
- * @param apsFrame   Ver.: always
- * @param msgLen   Ver.: always
- * @param message   Ver.: always
- * @param status   Ver.: always
- */
 bool __attribute__((weak)) emberAfMessageSentCallback(const MessageSendDestination & destination, EmberApsFrame * apsFrame,
                                                       uint16_t msgLen, uint8_t * message, EmberStatus status)
 {
     return false;
 }
 
-/** @brief External Attribute Read
- *
- * Like emberAfExternalAttributeWriteCallback above, this function is called
- * when the framework needs to read an attribute that is not stored within the
- * Application Framework's data structures.
-        All of the important
- * information about the attribute itself is passed as a pointer to an
- * EmberAfAttributeMetadata struct, which is stored within the application and
- * used to manage the attribute. A complete description of the
- * EmberAfAttributeMetadata struct is provided in
- * app/framework/include/af-types.h
-        This function assumes that the
- * application is able to read the attribute, write it into the passed buffer,
- * and return immediately. Any attributes that require a state machine for
- * reading and writing are not really candidates for externalization at the
- * present time. The Application Framework does not currently include a state
- * machine for reading or writing attributes that must take place across a
- * series of application ticks. Attributes that cannot be read in a timely
- * manner should be stored within the Application Framework and updated
- * occasionally by the application code from within the
- * emberAfMainTickCallback.
-        If the application was successfully able to
- * read the attribute and write it into the passed buffer, it should return a
- * value of EMBER_ZCL_STATUS_SUCCESS. Ensure that the size of the externally
- * managed attribute value is smaller than what the buffer can hold. In the case
- * of a buffer overflow throw an appropriate error such as
- * EMBER_ZCL_STATUS_INSUFFICIENT_SPACE. Any other return value indicates the
- * application was not able to read the attribute.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeMetadata   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param buffer   Ver.: always
- * @param maxReadLength   Ver.: always
- * @param index   Ver.: always
- */
 EmberAfStatus __attribute__((weak))
 emberAfExternalAttributeReadCallback(EndpointId endpoint, ClusterId clusterId, EmberAfAttributeMetadata * attributeMetadata,
                                      uint16_t manufacturerCode, uint8_t * buffer, uint16_t maxReadLength, int32_t index)
@@ -280,53 +118,6 @@ emberAfExternalAttributeReadCallback(EndpointId endpoint, ClusterId clusterId, E
     return EMBER_ZCL_STATUS_FAILURE;
 }
 
-/** @brief External Attribute Write
- *
- * This function is called whenever the Application Framework needs to write an
- * attribute which is not stored within the data structures of the Application
- * Framework itself. One of the new features in Version 2 is the ability to
- * store attributes outside the Framework. This is particularly useful for
- * attributes that do not need to be stored because they can be read off the
- * hardware when they are needed, or are stored in some central location used by
- * many modules within the system. In this case, you can indicate that the
- * attribute is stored externally. When the framework needs to write an external
- * attribute, it makes a call to this callback.
-        This callback is very
- * useful for host micros which need to store attributes in persistent memory.
- * Because each host micro (used with an Ember NCP) has its own type of
- * persistent memory storage, the Application Framework does not include the
- * ability to mark attributes as stored in flash the way that it does for Ember
- * SoCs like the EM35x. On a host micro, any attributes that need to be stored
- * in persistent memory should be marked as external and accessed through the
- * external read and write callbacks. Any host code associated with the
- * persistent storage should be implemented within this callback.
-        All of
- * the important information about the attribute itself is passed as a pointer
- * to an EmberAfAttributeMetadata struct, which is stored within the application
- * and used to manage the attribute. A complete description of the
- * EmberAfAttributeMetadata struct is provided in
- * app/framework/include/af-types.h.
-        This function assumes that the
- * application is able to write the attribute and return immediately. Any
- * attributes that require a state machine for reading and writing are not
- * candidates for externalization at the present time. The Application Framework
- * does not currently include a state machine for reading or writing attributes
- * that must take place across a series of application ticks. Attributes that
- * cannot be written immediately should be stored within the Application
- * Framework and updated occasionally by the application code from within the
- * emberAfMainTickCallback.
-        If the application was successfully able to
- * write the attribute, it returns a value of EMBER_ZCL_STATUS_SUCCESS. Any
- * other return value indicates the application was not able to write the
- * attribute.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeMetadata   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param buffer   Ver.: always
- * @param index   Ver.: always
- */
 EmberAfStatus __attribute__((weak))
 emberAfExternalAttributeWriteCallback(EndpointId endpoint, ClusterId clusterId, EmberAfAttributeMetadata * attributeMetadata,
                                       uint16_t manufacturerCode, uint8_t * buffer, int32_t index)
@@ -334,92 +125,30 @@ emberAfExternalAttributeWriteCallback(EndpointId endpoint, ClusterId clusterId, 
     return EMBER_ZCL_STATUS_FAILURE;
 }
 
-/** @brief Get Current Time
- *
- * This callback is called when device attempts to get current time from the
- * hardware. If this device has means to retrieve exact time, then this method
- * should implement it. If the callback can't provide the exact time it should
- * return 0 to indicate failure. Default action is to return 0, which indicates
- * that device does not have access to real time.
- *
- */
 uint32_t __attribute__((weak)) emberAfGetCurrentTimeCallback()
 {
     return 0;
 }
 
-/** @brief Get Endpoint Info
- *
- * This function is a callback to an application implemented endpoint that
- * operates outside the normal application framework.  When the framework wishes
- * to perform operations with that endpoint it uses this callback to retrieve
- * the endpoint's information.  If the endpoint exists and the application can
- * provide data then true shall be returned.  Otherwise the callback must return
- * false.
- *
- * @param endpoint The endpoint to retrieve data for.  Ver.: always
- * @param returnNetworkIndex The index corresponding to the ZigBee network the
- * endpoint belongs to.  If not using a multi-network device, 0 must be
- * returned.  Otherwise on a multi-network device the stack will switch to this
- * network before sending the message.  Ver.: always
- * @param returnEndpointInfo A pointer to a data struct that will be written
- * with information about the endpoint.  Ver.: always
- */
 bool __attribute__((weak))
 emberAfGetEndpointInfoCallback(EndpointId endpoint, uint8_t * returnNetworkIndex, EmberAfEndpointInfoStruct * returnEndpointInfo)
 {
     return false;
 }
 
-/** @brief Registration Abort
- *
- * This callback is called when the device should abort the registration
- * process.
- *
- */
 void __attribute__((weak)) emberAfRegistrationAbortCallback() {}
 
-/** @brief Interpan Send Message
- *
- * This function will send a raw MAC message with interpan frame format using
- * the passed parameters.
- *
- * @param header Interpan header info  Ver.: always
- * @param messageLength The length of the message received or to send  Ver.:
- * always
- * @param message The message data received or to send.  Ver.: always
- */
 EmberStatus __attribute__((weak))
 emberAfInterpanSendMessageCallback(EmberAfInterpanHeader * header, uint16_t messageLength, uint8_t * message)
 {
     return EMBER_LIBRARY_NOT_PRESENT;
 }
 
-/** @brief Start Move
- *
- * This function is called to initiate the process for a device to move (rejoin)
- * to a new parent.
- *
- */
 bool __attribute__((weak)) emberAfStartMoveCallback()
 {
     return false;
 }
 
-/** @brief Pre Attribute Change
- *
- * This function is called by the application framework before it changes an
- * attribute value.  The value passed into this callback is the value to which
- * the attribute is to be set by the framework.  The application should return
- * chip::Protocols::InteractionModel::Status::Success to permit the change or
- * any other code to reject it.
- *
- * @param attributePath
- * @param mask
- * @param type
- * @param size
- * @param value
- */
 chip::Protocols::InteractionModel::Status __attribute__((weak))
 MatterPreAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t mask, uint8_t type, uint16_t size,
                                  uint8_t * value)
@@ -427,18 +156,6 @@ MatterPreAttributeChangeCallback(const chip::app::ConcreteAttributePath & attrib
     return chip::Protocols::InteractionModel::Status::Success;
 }
 
-/** @brief Post Attribute Change
- *
- * This function is called by the application framework after it changes an
- * attribute value. The value passed into this callback is the value to which
- * the attribute was set by the framework.
- *
- * @param attributePath
- * @param mask
- * @param type
- * @param size
- * @param value
- */
 void __attribute__((weak)) MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t mask,
                                                              uint8_t type, uint16_t size, uint8_t * value)
 {}

--- a/zzz_generated/ota-requestor-app/zap-generated/callback-stub.cpp
+++ b/zzz_generated/ota-requestor-app/zap-generated/callback-stub.cpp
@@ -80,66 +80,10 @@ void __attribute__((weak)) emberAfOperationalCredentialsClusterInitCallback(Endp
 // Non-Cluster Related Callbacks
 //
 
-/** @brief Add To Current App Tasks
- *
- * This function is only useful to sleepy end devices.  This function will note
- * the passed item as part of a set of tasks the application has outstanding
- * (e.g. message sent requiring APS acknwoledgement).  This will affect how the
- * application behaves with regard to sleeping and polling.  Until the
- * outstanding task is completed, the device may poll more frequently and sleep
- * less often.
- *
- * @param tasks   Ver.: always
- */
 void __attribute__((weak)) emberAfAddToCurrentAppTasksCallback(EmberAfApplicationTask tasks) {}
 
-/** @brief Remove From Current App Tasks
- *
- * This function is only useful to sleepy end devices.  This function will
- * remove the passed item from the set of tasks the application has outstanding
- * (e.g. message sent requiring APS acknwoledgement).  This will affect how the
- * application behaves with regard to sleeping and polling.  Removing the item
- * from the list of outstanding tasks may allow the device to sleep longer and
- * poll less frequently.  If there are other outstanding tasks the system may
- * still have to stay away and poll more often.
- *
- * @param tasks   Ver.: always
- */
 void __attribute__((weak)) emberAfRemoveFromCurrentAppTasksCallback(EmberAfApplicationTask tasks) {}
 
-/** @brief Allow Network Write Attribute
- *
- * This function is called by the application framework before it writes an
- * attribute in response to a write attribute request from an external device.
- * The value passed into this callback is the value to which the attribute is to
- * be set by the framework.
-        Example:	In mirroring simple metering data
- * on an Energy Services Interface (ESI) (formerly called Energy Service Portal
- * (ESP) in SE 1.0).), a mirrored simple meter needs to write read-only
- * attributes on its mirror. The-meter-mirror sample application, located in
- * app/framework/sample-apps, uses this callback to allow the mirrored device to
- * write simple metering attributes on the mirror regardless of the fact that
- * most simple metering attributes are defined as read-only by the ZigBee
- * specification.
-        Note:	The ZCL specification does not (as of this
- * writing) specify any permission-level security for writing writeable
- * attributes. As far as the ZCL specification is concerned, if an attribute is
- * writeable, any device that has a link key for the device should be able to
- * write that attribute. Furthermore if an attribute is read only, it should not
- * be written over the air. Thus, if you implement permissions for writing
- * attributes as a feature, you MAY be operating outside the specification. This
- * is unlikely to be a problem for writing read-only attributes, but it may be a
- * problem for attributes that are writeable according to the specification but
- * restricted by the application implementing this callback.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeId   Ver.: always
- * @param mask   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param value   Ver.: always
- * @param type   Ver.: always
- */
 EmberAfAttributeWritePermission __attribute__((weak))
 emberAfAllowNetworkWriteAttributeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
                                           uint16_t manufacturerCode, uint8_t * value, uint8_t type)
@@ -147,140 +91,34 @@ emberAfAllowNetworkWriteAttributeCallback(EndpointId endpoint, ClusterId cluster
     return EMBER_ZCL_ATTRIBUTE_WRITE_PERMISSION_ALLOW_WRITE_NORMAL; // Default
 }
 
-/** @brief Attribute Read Access
- *
- * This function is called whenever the Application Framework needs to check
- * access permission for an attribute read.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param attributeId   Ver.: always
- */
 bool __attribute__((weak))
 emberAfAttributeReadAccessCallback(EndpointId endpoint, ClusterId clusterId, uint16_t manufacturerCode, AttributeId attributeId)
 {
     return true;
 }
 
-/** @brief Attribute Write Access
- *
- * This function is called whenever the Application Framework needs to check
- * access permission for an attribute write.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param attributeId   Ver.: always
- */
 bool __attribute__((weak))
 emberAfAttributeWriteAccessCallback(EndpointId endpoint, ClusterId clusterId, uint16_t manufacturerCode, AttributeId attributeId)
 {
     return true;
 }
 
-/** @brief Default Response
- *
- * This function is called by the application framework when a Default Response
- * command is received from an external device.  The application should return
- * true if the message was processed or false if it was not.
- *
- * @param clusterId The cluster identifier of this response.  Ver.: always
- * @param commandId The command identifier to which this is a response.  Ver.:
- * always
- * @param status Specifies either SUCCESS or the nature of the error that was
- * detected in the received command.  Ver.: always
- */
 bool __attribute__((weak)) emberAfDefaultResponseCallback(ClusterId clusterId, CommandId commandId, EmberAfStatus status)
 {
     return false;
 }
 
-/** @brief Pre Message Send
- *
- * This function is called by the framework when it is about to pass a message
- * to the stack primitives for sending.   This message may or may not be ZCL,
- * ZDO, or some other protocol.  This is called prior to
-        any ZigBee
- * fragmentation that may be done.  If the function returns true it is assumed
- * the callback has consumed and processed the message.  The callback must also
- * set the EmberStatus status code to be passed back to the caller.  The
- * framework will do no further processing on the message.
-        If the
- * function returns false then it is assumed that the callback has not processed
- * the mesasge and the framework will continue to process accordingly.
- *
- * @param messageStruct The structure containing the parameters of the APS
- * message to be sent.  Ver.: always
- * @param status A pointer to the status code value that will be returned to the
- * caller.  Ver.: always
- */
 bool __attribute__((weak)) emberAfPreMessageSendCallback(EmberAfMessageStruct * messageStruct, EmberStatus * status)
 {
     return false;
 }
 
-/** @brief Message Sent
- *
- * This function is called by the application framework from the message sent
- * handler, when it is informed by the stack regarding the message sent status.
- * All of the values passed to the emberMessageSentHandler are passed on to this
- * callback. This provides an opportunity for the application to verify that its
- * message has been sent successfully and take the appropriate action. This
- * callback should return a bool value of true or false. A value of true
- * indicates that the message sent notification has been handled and should not
- * be handled by the application framework.
- *
- * @param type   Ver.: always
- * @param destination   Ver.: always
- * @param apsFrame   Ver.: always
- * @param msgLen   Ver.: always
- * @param message   Ver.: always
- * @param status   Ver.: always
- */
 bool __attribute__((weak)) emberAfMessageSentCallback(const MessageSendDestination & destination, EmberApsFrame * apsFrame,
                                                       uint16_t msgLen, uint8_t * message, EmberStatus status)
 {
     return false;
 }
 
-/** @brief External Attribute Read
- *
- * Like emberAfExternalAttributeWriteCallback above, this function is called
- * when the framework needs to read an attribute that is not stored within the
- * Application Framework's data structures.
-        All of the important
- * information about the attribute itself is passed as a pointer to an
- * EmberAfAttributeMetadata struct, which is stored within the application and
- * used to manage the attribute. A complete description of the
- * EmberAfAttributeMetadata struct is provided in
- * app/framework/include/af-types.h
-        This function assumes that the
- * application is able to read the attribute, write it into the passed buffer,
- * and return immediately. Any attributes that require a state machine for
- * reading and writing are not really candidates for externalization at the
- * present time. The Application Framework does not currently include a state
- * machine for reading or writing attributes that must take place across a
- * series of application ticks. Attributes that cannot be read in a timely
- * manner should be stored within the Application Framework and updated
- * occasionally by the application code from within the
- * emberAfMainTickCallback.
-        If the application was successfully able to
- * read the attribute and write it into the passed buffer, it should return a
- * value of EMBER_ZCL_STATUS_SUCCESS. Ensure that the size of the externally
- * managed attribute value is smaller than what the buffer can hold. In the case
- * of a buffer overflow throw an appropriate error such as
- * EMBER_ZCL_STATUS_INSUFFICIENT_SPACE. Any other return value indicates the
- * application was not able to read the attribute.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeMetadata   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param buffer   Ver.: always
- * @param maxReadLength   Ver.: always
- * @param index   Ver.: always
- */
 EmberAfStatus __attribute__((weak))
 emberAfExternalAttributeReadCallback(EndpointId endpoint, ClusterId clusterId, EmberAfAttributeMetadata * attributeMetadata,
                                      uint16_t manufacturerCode, uint8_t * buffer, uint16_t maxReadLength, int32_t index)
@@ -288,53 +126,6 @@ emberAfExternalAttributeReadCallback(EndpointId endpoint, ClusterId clusterId, E
     return EMBER_ZCL_STATUS_FAILURE;
 }
 
-/** @brief External Attribute Write
- *
- * This function is called whenever the Application Framework needs to write an
- * attribute which is not stored within the data structures of the Application
- * Framework itself. One of the new features in Version 2 is the ability to
- * store attributes outside the Framework. This is particularly useful for
- * attributes that do not need to be stored because they can be read off the
- * hardware when they are needed, or are stored in some central location used by
- * many modules within the system. In this case, you can indicate that the
- * attribute is stored externally. When the framework needs to write an external
- * attribute, it makes a call to this callback.
-        This callback is very
- * useful for host micros which need to store attributes in persistent memory.
- * Because each host micro (used with an Ember NCP) has its own type of
- * persistent memory storage, the Application Framework does not include the
- * ability to mark attributes as stored in flash the way that it does for Ember
- * SoCs like the EM35x. On a host micro, any attributes that need to be stored
- * in persistent memory should be marked as external and accessed through the
- * external read and write callbacks. Any host code associated with the
- * persistent storage should be implemented within this callback.
-        All of
- * the important information about the attribute itself is passed as a pointer
- * to an EmberAfAttributeMetadata struct, which is stored within the application
- * and used to manage the attribute. A complete description of the
- * EmberAfAttributeMetadata struct is provided in
- * app/framework/include/af-types.h.
-        This function assumes that the
- * application is able to write the attribute and return immediately. Any
- * attributes that require a state machine for reading and writing are not
- * candidates for externalization at the present time. The Application Framework
- * does not currently include a state machine for reading or writing attributes
- * that must take place across a series of application ticks. Attributes that
- * cannot be written immediately should be stored within the Application
- * Framework and updated occasionally by the application code from within the
- * emberAfMainTickCallback.
-        If the application was successfully able to
- * write the attribute, it returns a value of EMBER_ZCL_STATUS_SUCCESS. Any
- * other return value indicates the application was not able to write the
- * attribute.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeMetadata   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param buffer   Ver.: always
- * @param index   Ver.: always
- */
 EmberAfStatus __attribute__((weak))
 emberAfExternalAttributeWriteCallback(EndpointId endpoint, ClusterId clusterId, EmberAfAttributeMetadata * attributeMetadata,
                                       uint16_t manufacturerCode, uint8_t * buffer, int32_t index)
@@ -342,92 +133,30 @@ emberAfExternalAttributeWriteCallback(EndpointId endpoint, ClusterId clusterId, 
     return EMBER_ZCL_STATUS_FAILURE;
 }
 
-/** @brief Get Current Time
- *
- * This callback is called when device attempts to get current time from the
- * hardware. If this device has means to retrieve exact time, then this method
- * should implement it. If the callback can't provide the exact time it should
- * return 0 to indicate failure. Default action is to return 0, which indicates
- * that device does not have access to real time.
- *
- */
 uint32_t __attribute__((weak)) emberAfGetCurrentTimeCallback()
 {
     return 0;
 }
 
-/** @brief Get Endpoint Info
- *
- * This function is a callback to an application implemented endpoint that
- * operates outside the normal application framework.  When the framework wishes
- * to perform operations with that endpoint it uses this callback to retrieve
- * the endpoint's information.  If the endpoint exists and the application can
- * provide data then true shall be returned.  Otherwise the callback must return
- * false.
- *
- * @param endpoint The endpoint to retrieve data for.  Ver.: always
- * @param returnNetworkIndex The index corresponding to the ZigBee network the
- * endpoint belongs to.  If not using a multi-network device, 0 must be
- * returned.  Otherwise on a multi-network device the stack will switch to this
- * network before sending the message.  Ver.: always
- * @param returnEndpointInfo A pointer to a data struct that will be written
- * with information about the endpoint.  Ver.: always
- */
 bool __attribute__((weak))
 emberAfGetEndpointInfoCallback(EndpointId endpoint, uint8_t * returnNetworkIndex, EmberAfEndpointInfoStruct * returnEndpointInfo)
 {
     return false;
 }
 
-/** @brief Registration Abort
- *
- * This callback is called when the device should abort the registration
- * process.
- *
- */
 void __attribute__((weak)) emberAfRegistrationAbortCallback() {}
 
-/** @brief Interpan Send Message
- *
- * This function will send a raw MAC message with interpan frame format using
- * the passed parameters.
- *
- * @param header Interpan header info  Ver.: always
- * @param messageLength The length of the message received or to send  Ver.:
- * always
- * @param message The message data received or to send.  Ver.: always
- */
 EmberStatus __attribute__((weak))
 emberAfInterpanSendMessageCallback(EmberAfInterpanHeader * header, uint16_t messageLength, uint8_t * message)
 {
     return EMBER_LIBRARY_NOT_PRESENT;
 }
 
-/** @brief Start Move
- *
- * This function is called to initiate the process for a device to move (rejoin)
- * to a new parent.
- *
- */
 bool __attribute__((weak)) emberAfStartMoveCallback()
 {
     return false;
 }
 
-/** @brief Pre Attribute Change
- *
- * This function is called by the application framework before it changes an
- * attribute value.  The value passed into this callback is the value to which
- * the attribute is to be set by the framework.  The application should return
- * chip::Protocols::InteractionModel::Status::Success to permit the change or
- * any other code to reject it.
- *
- * @param attributePath
- * @param mask
- * @param type
- * @param size
- * @param value
- */
 chip::Protocols::InteractionModel::Status __attribute__((weak))
 MatterPreAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t mask, uint8_t type, uint16_t size,
                                  uint8_t * value)
@@ -435,18 +164,6 @@ MatterPreAttributeChangeCallback(const chip::app::ConcreteAttributePath & attrib
     return chip::Protocols::InteractionModel::Status::Success;
 }
 
-/** @brief Post Attribute Change
- *
- * This function is called by the application framework after it changes an
- * attribute value. The value passed into this callback is the value to which
- * the attribute was set by the framework.
- *
- * @param attributePath
- * @param mask
- * @param type
- * @param size
- * @param value
- */
 void __attribute__((weak)) MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t mask,
                                                              uint8_t type, uint16_t size, uint8_t * value)
 {}

--- a/zzz_generated/pump-app/zap-generated/callback-stub.cpp
+++ b/zzz_generated/pump-app/zap-generated/callback-stub.cpp
@@ -184,66 +184,10 @@ void __attribute__((weak)) emberAfWiFiNetworkDiagnosticsClusterInitCallback(Endp
 // Non-Cluster Related Callbacks
 //
 
-/** @brief Add To Current App Tasks
- *
- * This function is only useful to sleepy end devices.  This function will note
- * the passed item as part of a set of tasks the application has outstanding
- * (e.g. message sent requiring APS acknwoledgement).  This will affect how the
- * application behaves with regard to sleeping and polling.  Until the
- * outstanding task is completed, the device may poll more frequently and sleep
- * less often.
- *
- * @param tasks   Ver.: always
- */
 void __attribute__((weak)) emberAfAddToCurrentAppTasksCallback(EmberAfApplicationTask tasks) {}
 
-/** @brief Remove From Current App Tasks
- *
- * This function is only useful to sleepy end devices.  This function will
- * remove the passed item from the set of tasks the application has outstanding
- * (e.g. message sent requiring APS acknwoledgement).  This will affect how the
- * application behaves with regard to sleeping and polling.  Removing the item
- * from the list of outstanding tasks may allow the device to sleep longer and
- * poll less frequently.  If there are other outstanding tasks the system may
- * still have to stay away and poll more often.
- *
- * @param tasks   Ver.: always
- */
 void __attribute__((weak)) emberAfRemoveFromCurrentAppTasksCallback(EmberAfApplicationTask tasks) {}
 
-/** @brief Allow Network Write Attribute
- *
- * This function is called by the application framework before it writes an
- * attribute in response to a write attribute request from an external device.
- * The value passed into this callback is the value to which the attribute is to
- * be set by the framework.
-        Example:	In mirroring simple metering data
- * on an Energy Services Interface (ESI) (formerly called Energy Service Portal
- * (ESP) in SE 1.0).), a mirrored simple meter needs to write read-only
- * attributes on its mirror. The-meter-mirror sample application, located in
- * app/framework/sample-apps, uses this callback to allow the mirrored device to
- * write simple metering attributes on the mirror regardless of the fact that
- * most simple metering attributes are defined as read-only by the ZigBee
- * specification.
-        Note:	The ZCL specification does not (as of this
- * writing) specify any permission-level security for writing writeable
- * attributes. As far as the ZCL specification is concerned, if an attribute is
- * writeable, any device that has a link key for the device should be able to
- * write that attribute. Furthermore if an attribute is read only, it should not
- * be written over the air. Thus, if you implement permissions for writing
- * attributes as a feature, you MAY be operating outside the specification. This
- * is unlikely to be a problem for writing read-only attributes, but it may be a
- * problem for attributes that are writeable according to the specification but
- * restricted by the application implementing this callback.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeId   Ver.: always
- * @param mask   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param value   Ver.: always
- * @param type   Ver.: always
- */
 EmberAfAttributeWritePermission __attribute__((weak))
 emberAfAllowNetworkWriteAttributeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
                                           uint16_t manufacturerCode, uint8_t * value, uint8_t type)
@@ -251,140 +195,34 @@ emberAfAllowNetworkWriteAttributeCallback(EndpointId endpoint, ClusterId cluster
     return EMBER_ZCL_ATTRIBUTE_WRITE_PERMISSION_ALLOW_WRITE_NORMAL; // Default
 }
 
-/** @brief Attribute Read Access
- *
- * This function is called whenever the Application Framework needs to check
- * access permission for an attribute read.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param attributeId   Ver.: always
- */
 bool __attribute__((weak))
 emberAfAttributeReadAccessCallback(EndpointId endpoint, ClusterId clusterId, uint16_t manufacturerCode, AttributeId attributeId)
 {
     return true;
 }
 
-/** @brief Attribute Write Access
- *
- * This function is called whenever the Application Framework needs to check
- * access permission for an attribute write.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param attributeId   Ver.: always
- */
 bool __attribute__((weak))
 emberAfAttributeWriteAccessCallback(EndpointId endpoint, ClusterId clusterId, uint16_t manufacturerCode, AttributeId attributeId)
 {
     return true;
 }
 
-/** @brief Default Response
- *
- * This function is called by the application framework when a Default Response
- * command is received from an external device.  The application should return
- * true if the message was processed or false if it was not.
- *
- * @param clusterId The cluster identifier of this response.  Ver.: always
- * @param commandId The command identifier to which this is a response.  Ver.:
- * always
- * @param status Specifies either SUCCESS or the nature of the error that was
- * detected in the received command.  Ver.: always
- */
 bool __attribute__((weak)) emberAfDefaultResponseCallback(ClusterId clusterId, CommandId commandId, EmberAfStatus status)
 {
     return false;
 }
 
-/** @brief Pre Message Send
- *
- * This function is called by the framework when it is about to pass a message
- * to the stack primitives for sending.   This message may or may not be ZCL,
- * ZDO, or some other protocol.  This is called prior to
-        any ZigBee
- * fragmentation that may be done.  If the function returns true it is assumed
- * the callback has consumed and processed the message.  The callback must also
- * set the EmberStatus status code to be passed back to the caller.  The
- * framework will do no further processing on the message.
-        If the
- * function returns false then it is assumed that the callback has not processed
- * the mesasge and the framework will continue to process accordingly.
- *
- * @param messageStruct The structure containing the parameters of the APS
- * message to be sent.  Ver.: always
- * @param status A pointer to the status code value that will be returned to the
- * caller.  Ver.: always
- */
 bool __attribute__((weak)) emberAfPreMessageSendCallback(EmberAfMessageStruct * messageStruct, EmberStatus * status)
 {
     return false;
 }
 
-/** @brief Message Sent
- *
- * This function is called by the application framework from the message sent
- * handler, when it is informed by the stack regarding the message sent status.
- * All of the values passed to the emberMessageSentHandler are passed on to this
- * callback. This provides an opportunity for the application to verify that its
- * message has been sent successfully and take the appropriate action. This
- * callback should return a bool value of true or false. A value of true
- * indicates that the message sent notification has been handled and should not
- * be handled by the application framework.
- *
- * @param type   Ver.: always
- * @param destination   Ver.: always
- * @param apsFrame   Ver.: always
- * @param msgLen   Ver.: always
- * @param message   Ver.: always
- * @param status   Ver.: always
- */
 bool __attribute__((weak)) emberAfMessageSentCallback(const MessageSendDestination & destination, EmberApsFrame * apsFrame,
                                                       uint16_t msgLen, uint8_t * message, EmberStatus status)
 {
     return false;
 }
 
-/** @brief External Attribute Read
- *
- * Like emberAfExternalAttributeWriteCallback above, this function is called
- * when the framework needs to read an attribute that is not stored within the
- * Application Framework's data structures.
-        All of the important
- * information about the attribute itself is passed as a pointer to an
- * EmberAfAttributeMetadata struct, which is stored within the application and
- * used to manage the attribute. A complete description of the
- * EmberAfAttributeMetadata struct is provided in
- * app/framework/include/af-types.h
-        This function assumes that the
- * application is able to read the attribute, write it into the passed buffer,
- * and return immediately. Any attributes that require a state machine for
- * reading and writing are not really candidates for externalization at the
- * present time. The Application Framework does not currently include a state
- * machine for reading or writing attributes that must take place across a
- * series of application ticks. Attributes that cannot be read in a timely
- * manner should be stored within the Application Framework and updated
- * occasionally by the application code from within the
- * emberAfMainTickCallback.
-        If the application was successfully able to
- * read the attribute and write it into the passed buffer, it should return a
- * value of EMBER_ZCL_STATUS_SUCCESS. Ensure that the size of the externally
- * managed attribute value is smaller than what the buffer can hold. In the case
- * of a buffer overflow throw an appropriate error such as
- * EMBER_ZCL_STATUS_INSUFFICIENT_SPACE. Any other return value indicates the
- * application was not able to read the attribute.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeMetadata   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param buffer   Ver.: always
- * @param maxReadLength   Ver.: always
- * @param index   Ver.: always
- */
 EmberAfStatus __attribute__((weak))
 emberAfExternalAttributeReadCallback(EndpointId endpoint, ClusterId clusterId, EmberAfAttributeMetadata * attributeMetadata,
                                      uint16_t manufacturerCode, uint8_t * buffer, uint16_t maxReadLength, int32_t index)
@@ -392,53 +230,6 @@ emberAfExternalAttributeReadCallback(EndpointId endpoint, ClusterId clusterId, E
     return EMBER_ZCL_STATUS_FAILURE;
 }
 
-/** @brief External Attribute Write
- *
- * This function is called whenever the Application Framework needs to write an
- * attribute which is not stored within the data structures of the Application
- * Framework itself. One of the new features in Version 2 is the ability to
- * store attributes outside the Framework. This is particularly useful for
- * attributes that do not need to be stored because they can be read off the
- * hardware when they are needed, or are stored in some central location used by
- * many modules within the system. In this case, you can indicate that the
- * attribute is stored externally. When the framework needs to write an external
- * attribute, it makes a call to this callback.
-        This callback is very
- * useful for host micros which need to store attributes in persistent memory.
- * Because each host micro (used with an Ember NCP) has its own type of
- * persistent memory storage, the Application Framework does not include the
- * ability to mark attributes as stored in flash the way that it does for Ember
- * SoCs like the EM35x. On a host micro, any attributes that need to be stored
- * in persistent memory should be marked as external and accessed through the
- * external read and write callbacks. Any host code associated with the
- * persistent storage should be implemented within this callback.
-        All of
- * the important information about the attribute itself is passed as a pointer
- * to an EmberAfAttributeMetadata struct, which is stored within the application
- * and used to manage the attribute. A complete description of the
- * EmberAfAttributeMetadata struct is provided in
- * app/framework/include/af-types.h.
-        This function assumes that the
- * application is able to write the attribute and return immediately. Any
- * attributes that require a state machine for reading and writing are not
- * candidates for externalization at the present time. The Application Framework
- * does not currently include a state machine for reading or writing attributes
- * that must take place across a series of application ticks. Attributes that
- * cannot be written immediately should be stored within the Application
- * Framework and updated occasionally by the application code from within the
- * emberAfMainTickCallback.
-        If the application was successfully able to
- * write the attribute, it returns a value of EMBER_ZCL_STATUS_SUCCESS. Any
- * other return value indicates the application was not able to write the
- * attribute.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeMetadata   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param buffer   Ver.: always
- * @param index   Ver.: always
- */
 EmberAfStatus __attribute__((weak))
 emberAfExternalAttributeWriteCallback(EndpointId endpoint, ClusterId clusterId, EmberAfAttributeMetadata * attributeMetadata,
                                       uint16_t manufacturerCode, uint8_t * buffer, int32_t index)
@@ -446,92 +237,30 @@ emberAfExternalAttributeWriteCallback(EndpointId endpoint, ClusterId clusterId, 
     return EMBER_ZCL_STATUS_FAILURE;
 }
 
-/** @brief Get Current Time
- *
- * This callback is called when device attempts to get current time from the
- * hardware. If this device has means to retrieve exact time, then this method
- * should implement it. If the callback can't provide the exact time it should
- * return 0 to indicate failure. Default action is to return 0, which indicates
- * that device does not have access to real time.
- *
- */
 uint32_t __attribute__((weak)) emberAfGetCurrentTimeCallback()
 {
     return 0;
 }
 
-/** @brief Get Endpoint Info
- *
- * This function is a callback to an application implemented endpoint that
- * operates outside the normal application framework.  When the framework wishes
- * to perform operations with that endpoint it uses this callback to retrieve
- * the endpoint's information.  If the endpoint exists and the application can
- * provide data then true shall be returned.  Otherwise the callback must return
- * false.
- *
- * @param endpoint The endpoint to retrieve data for.  Ver.: always
- * @param returnNetworkIndex The index corresponding to the ZigBee network the
- * endpoint belongs to.  If not using a multi-network device, 0 must be
- * returned.  Otherwise on a multi-network device the stack will switch to this
- * network before sending the message.  Ver.: always
- * @param returnEndpointInfo A pointer to a data struct that will be written
- * with information about the endpoint.  Ver.: always
- */
 bool __attribute__((weak))
 emberAfGetEndpointInfoCallback(EndpointId endpoint, uint8_t * returnNetworkIndex, EmberAfEndpointInfoStruct * returnEndpointInfo)
 {
     return false;
 }
 
-/** @brief Registration Abort
- *
- * This callback is called when the device should abort the registration
- * process.
- *
- */
 void __attribute__((weak)) emberAfRegistrationAbortCallback() {}
 
-/** @brief Interpan Send Message
- *
- * This function will send a raw MAC message with interpan frame format using
- * the passed parameters.
- *
- * @param header Interpan header info  Ver.: always
- * @param messageLength The length of the message received or to send  Ver.:
- * always
- * @param message The message data received or to send.  Ver.: always
- */
 EmberStatus __attribute__((weak))
 emberAfInterpanSendMessageCallback(EmberAfInterpanHeader * header, uint16_t messageLength, uint8_t * message)
 {
     return EMBER_LIBRARY_NOT_PRESENT;
 }
 
-/** @brief Start Move
- *
- * This function is called to initiate the process for a device to move (rejoin)
- * to a new parent.
- *
- */
 bool __attribute__((weak)) emberAfStartMoveCallback()
 {
     return false;
 }
 
-/** @brief Pre Attribute Change
- *
- * This function is called by the application framework before it changes an
- * attribute value.  The value passed into this callback is the value to which
- * the attribute is to be set by the framework.  The application should return
- * chip::Protocols::InteractionModel::Status::Success to permit the change or
- * any other code to reject it.
- *
- * @param attributePath
- * @param mask
- * @param type
- * @param size
- * @param value
- */
 chip::Protocols::InteractionModel::Status __attribute__((weak))
 MatterPreAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t mask, uint8_t type, uint16_t size,
                                  uint8_t * value)
@@ -539,18 +268,6 @@ MatterPreAttributeChangeCallback(const chip::app::ConcreteAttributePath & attrib
     return chip::Protocols::InteractionModel::Status::Success;
 }
 
-/** @brief Post Attribute Change
- *
- * This function is called by the application framework after it changes an
- * attribute value. The value passed into this callback is the value to which
- * the attribute was set by the framework.
- *
- * @param attributePath
- * @param mask
- * @param type
- * @param size
- * @param value
- */
 void __attribute__((weak)) MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t mask,
                                                              uint8_t type, uint16_t size, uint8_t * value)
 {}

--- a/zzz_generated/pump-controller-app/zap-generated/callback-stub.cpp
+++ b/zzz_generated/pump-controller-app/zap-generated/callback-stub.cpp
@@ -184,66 +184,10 @@ void __attribute__((weak)) emberAfWiFiNetworkDiagnosticsClusterInitCallback(Endp
 // Non-Cluster Related Callbacks
 //
 
-/** @brief Add To Current App Tasks
- *
- * This function is only useful to sleepy end devices.  This function will note
- * the passed item as part of a set of tasks the application has outstanding
- * (e.g. message sent requiring APS acknwoledgement).  This will affect how the
- * application behaves with regard to sleeping and polling.  Until the
- * outstanding task is completed, the device may poll more frequently and sleep
- * less often.
- *
- * @param tasks   Ver.: always
- */
 void __attribute__((weak)) emberAfAddToCurrentAppTasksCallback(EmberAfApplicationTask tasks) {}
 
-/** @brief Remove From Current App Tasks
- *
- * This function is only useful to sleepy end devices.  This function will
- * remove the passed item from the set of tasks the application has outstanding
- * (e.g. message sent requiring APS acknwoledgement).  This will affect how the
- * application behaves with regard to sleeping and polling.  Removing the item
- * from the list of outstanding tasks may allow the device to sleep longer and
- * poll less frequently.  If there are other outstanding tasks the system may
- * still have to stay away and poll more often.
- *
- * @param tasks   Ver.: always
- */
 void __attribute__((weak)) emberAfRemoveFromCurrentAppTasksCallback(EmberAfApplicationTask tasks) {}
 
-/** @brief Allow Network Write Attribute
- *
- * This function is called by the application framework before it writes an
- * attribute in response to a write attribute request from an external device.
- * The value passed into this callback is the value to which the attribute is to
- * be set by the framework.
-        Example:	In mirroring simple metering data
- * on an Energy Services Interface (ESI) (formerly called Energy Service Portal
- * (ESP) in SE 1.0).), a mirrored simple meter needs to write read-only
- * attributes on its mirror. The-meter-mirror sample application, located in
- * app/framework/sample-apps, uses this callback to allow the mirrored device to
- * write simple metering attributes on the mirror regardless of the fact that
- * most simple metering attributes are defined as read-only by the ZigBee
- * specification.
-        Note:	The ZCL specification does not (as of this
- * writing) specify any permission-level security for writing writeable
- * attributes. As far as the ZCL specification is concerned, if an attribute is
- * writeable, any device that has a link key for the device should be able to
- * write that attribute. Furthermore if an attribute is read only, it should not
- * be written over the air. Thus, if you implement permissions for writing
- * attributes as a feature, you MAY be operating outside the specification. This
- * is unlikely to be a problem for writing read-only attributes, but it may be a
- * problem for attributes that are writeable according to the specification but
- * restricted by the application implementing this callback.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeId   Ver.: always
- * @param mask   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param value   Ver.: always
- * @param type   Ver.: always
- */
 EmberAfAttributeWritePermission __attribute__((weak))
 emberAfAllowNetworkWriteAttributeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
                                           uint16_t manufacturerCode, uint8_t * value, uint8_t type)
@@ -251,140 +195,34 @@ emberAfAllowNetworkWriteAttributeCallback(EndpointId endpoint, ClusterId cluster
     return EMBER_ZCL_ATTRIBUTE_WRITE_PERMISSION_ALLOW_WRITE_NORMAL; // Default
 }
 
-/** @brief Attribute Read Access
- *
- * This function is called whenever the Application Framework needs to check
- * access permission for an attribute read.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param attributeId   Ver.: always
- */
 bool __attribute__((weak))
 emberAfAttributeReadAccessCallback(EndpointId endpoint, ClusterId clusterId, uint16_t manufacturerCode, AttributeId attributeId)
 {
     return true;
 }
 
-/** @brief Attribute Write Access
- *
- * This function is called whenever the Application Framework needs to check
- * access permission for an attribute write.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param attributeId   Ver.: always
- */
 bool __attribute__((weak))
 emberAfAttributeWriteAccessCallback(EndpointId endpoint, ClusterId clusterId, uint16_t manufacturerCode, AttributeId attributeId)
 {
     return true;
 }
 
-/** @brief Default Response
- *
- * This function is called by the application framework when a Default Response
- * command is received from an external device.  The application should return
- * true if the message was processed or false if it was not.
- *
- * @param clusterId The cluster identifier of this response.  Ver.: always
- * @param commandId The command identifier to which this is a response.  Ver.:
- * always
- * @param status Specifies either SUCCESS or the nature of the error that was
- * detected in the received command.  Ver.: always
- */
 bool __attribute__((weak)) emberAfDefaultResponseCallback(ClusterId clusterId, CommandId commandId, EmberAfStatus status)
 {
     return false;
 }
 
-/** @brief Pre Message Send
- *
- * This function is called by the framework when it is about to pass a message
- * to the stack primitives for sending.   This message may or may not be ZCL,
- * ZDO, or some other protocol.  This is called prior to
-        any ZigBee
- * fragmentation that may be done.  If the function returns true it is assumed
- * the callback has consumed and processed the message.  The callback must also
- * set the EmberStatus status code to be passed back to the caller.  The
- * framework will do no further processing on the message.
-        If the
- * function returns false then it is assumed that the callback has not processed
- * the mesasge and the framework will continue to process accordingly.
- *
- * @param messageStruct The structure containing the parameters of the APS
- * message to be sent.  Ver.: always
- * @param status A pointer to the status code value that will be returned to the
- * caller.  Ver.: always
- */
 bool __attribute__((weak)) emberAfPreMessageSendCallback(EmberAfMessageStruct * messageStruct, EmberStatus * status)
 {
     return false;
 }
 
-/** @brief Message Sent
- *
- * This function is called by the application framework from the message sent
- * handler, when it is informed by the stack regarding the message sent status.
- * All of the values passed to the emberMessageSentHandler are passed on to this
- * callback. This provides an opportunity for the application to verify that its
- * message has been sent successfully and take the appropriate action. This
- * callback should return a bool value of true or false. A value of true
- * indicates that the message sent notification has been handled and should not
- * be handled by the application framework.
- *
- * @param type   Ver.: always
- * @param destination   Ver.: always
- * @param apsFrame   Ver.: always
- * @param msgLen   Ver.: always
- * @param message   Ver.: always
- * @param status   Ver.: always
- */
 bool __attribute__((weak)) emberAfMessageSentCallback(const MessageSendDestination & destination, EmberApsFrame * apsFrame,
                                                       uint16_t msgLen, uint8_t * message, EmberStatus status)
 {
     return false;
 }
 
-/** @brief External Attribute Read
- *
- * Like emberAfExternalAttributeWriteCallback above, this function is called
- * when the framework needs to read an attribute that is not stored within the
- * Application Framework's data structures.
-        All of the important
- * information about the attribute itself is passed as a pointer to an
- * EmberAfAttributeMetadata struct, which is stored within the application and
- * used to manage the attribute. A complete description of the
- * EmberAfAttributeMetadata struct is provided in
- * app/framework/include/af-types.h
-        This function assumes that the
- * application is able to read the attribute, write it into the passed buffer,
- * and return immediately. Any attributes that require a state machine for
- * reading and writing are not really candidates for externalization at the
- * present time. The Application Framework does not currently include a state
- * machine for reading or writing attributes that must take place across a
- * series of application ticks. Attributes that cannot be read in a timely
- * manner should be stored within the Application Framework and updated
- * occasionally by the application code from within the
- * emberAfMainTickCallback.
-        If the application was successfully able to
- * read the attribute and write it into the passed buffer, it should return a
- * value of EMBER_ZCL_STATUS_SUCCESS. Ensure that the size of the externally
- * managed attribute value is smaller than what the buffer can hold. In the case
- * of a buffer overflow throw an appropriate error such as
- * EMBER_ZCL_STATUS_INSUFFICIENT_SPACE. Any other return value indicates the
- * application was not able to read the attribute.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeMetadata   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param buffer   Ver.: always
- * @param maxReadLength   Ver.: always
- * @param index   Ver.: always
- */
 EmberAfStatus __attribute__((weak))
 emberAfExternalAttributeReadCallback(EndpointId endpoint, ClusterId clusterId, EmberAfAttributeMetadata * attributeMetadata,
                                      uint16_t manufacturerCode, uint8_t * buffer, uint16_t maxReadLength, int32_t index)
@@ -392,53 +230,6 @@ emberAfExternalAttributeReadCallback(EndpointId endpoint, ClusterId clusterId, E
     return EMBER_ZCL_STATUS_FAILURE;
 }
 
-/** @brief External Attribute Write
- *
- * This function is called whenever the Application Framework needs to write an
- * attribute which is not stored within the data structures of the Application
- * Framework itself. One of the new features in Version 2 is the ability to
- * store attributes outside the Framework. This is particularly useful for
- * attributes that do not need to be stored because they can be read off the
- * hardware when they are needed, or are stored in some central location used by
- * many modules within the system. In this case, you can indicate that the
- * attribute is stored externally. When the framework needs to write an external
- * attribute, it makes a call to this callback.
-        This callback is very
- * useful for host micros which need to store attributes in persistent memory.
- * Because each host micro (used with an Ember NCP) has its own type of
- * persistent memory storage, the Application Framework does not include the
- * ability to mark attributes as stored in flash the way that it does for Ember
- * SoCs like the EM35x. On a host micro, any attributes that need to be stored
- * in persistent memory should be marked as external and accessed through the
- * external read and write callbacks. Any host code associated with the
- * persistent storage should be implemented within this callback.
-        All of
- * the important information about the attribute itself is passed as a pointer
- * to an EmberAfAttributeMetadata struct, which is stored within the application
- * and used to manage the attribute. A complete description of the
- * EmberAfAttributeMetadata struct is provided in
- * app/framework/include/af-types.h.
-        This function assumes that the
- * application is able to write the attribute and return immediately. Any
- * attributes that require a state machine for reading and writing are not
- * candidates for externalization at the present time. The Application Framework
- * does not currently include a state machine for reading or writing attributes
- * that must take place across a series of application ticks. Attributes that
- * cannot be written immediately should be stored within the Application
- * Framework and updated occasionally by the application code from within the
- * emberAfMainTickCallback.
-        If the application was successfully able to
- * write the attribute, it returns a value of EMBER_ZCL_STATUS_SUCCESS. Any
- * other return value indicates the application was not able to write the
- * attribute.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeMetadata   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param buffer   Ver.: always
- * @param index   Ver.: always
- */
 EmberAfStatus __attribute__((weak))
 emberAfExternalAttributeWriteCallback(EndpointId endpoint, ClusterId clusterId, EmberAfAttributeMetadata * attributeMetadata,
                                       uint16_t manufacturerCode, uint8_t * buffer, int32_t index)
@@ -446,92 +237,30 @@ emberAfExternalAttributeWriteCallback(EndpointId endpoint, ClusterId clusterId, 
     return EMBER_ZCL_STATUS_FAILURE;
 }
 
-/** @brief Get Current Time
- *
- * This callback is called when device attempts to get current time from the
- * hardware. If this device has means to retrieve exact time, then this method
- * should implement it. If the callback can't provide the exact time it should
- * return 0 to indicate failure. Default action is to return 0, which indicates
- * that device does not have access to real time.
- *
- */
 uint32_t __attribute__((weak)) emberAfGetCurrentTimeCallback()
 {
     return 0;
 }
 
-/** @brief Get Endpoint Info
- *
- * This function is a callback to an application implemented endpoint that
- * operates outside the normal application framework.  When the framework wishes
- * to perform operations with that endpoint it uses this callback to retrieve
- * the endpoint's information.  If the endpoint exists and the application can
- * provide data then true shall be returned.  Otherwise the callback must return
- * false.
- *
- * @param endpoint The endpoint to retrieve data for.  Ver.: always
- * @param returnNetworkIndex The index corresponding to the ZigBee network the
- * endpoint belongs to.  If not using a multi-network device, 0 must be
- * returned.  Otherwise on a multi-network device the stack will switch to this
- * network before sending the message.  Ver.: always
- * @param returnEndpointInfo A pointer to a data struct that will be written
- * with information about the endpoint.  Ver.: always
- */
 bool __attribute__((weak))
 emberAfGetEndpointInfoCallback(EndpointId endpoint, uint8_t * returnNetworkIndex, EmberAfEndpointInfoStruct * returnEndpointInfo)
 {
     return false;
 }
 
-/** @brief Registration Abort
- *
- * This callback is called when the device should abort the registration
- * process.
- *
- */
 void __attribute__((weak)) emberAfRegistrationAbortCallback() {}
 
-/** @brief Interpan Send Message
- *
- * This function will send a raw MAC message with interpan frame format using
- * the passed parameters.
- *
- * @param header Interpan header info  Ver.: always
- * @param messageLength The length of the message received or to send  Ver.:
- * always
- * @param message The message data received or to send.  Ver.: always
- */
 EmberStatus __attribute__((weak))
 emberAfInterpanSendMessageCallback(EmberAfInterpanHeader * header, uint16_t messageLength, uint8_t * message)
 {
     return EMBER_LIBRARY_NOT_PRESENT;
 }
 
-/** @brief Start Move
- *
- * This function is called to initiate the process for a device to move (rejoin)
- * to a new parent.
- *
- */
 bool __attribute__((weak)) emberAfStartMoveCallback()
 {
     return false;
 }
 
-/** @brief Pre Attribute Change
- *
- * This function is called by the application framework before it changes an
- * attribute value.  The value passed into this callback is the value to which
- * the attribute is to be set by the framework.  The application should return
- * chip::Protocols::InteractionModel::Status::Success to permit the change or
- * any other code to reject it.
- *
- * @param attributePath
- * @param mask
- * @param type
- * @param size
- * @param value
- */
 chip::Protocols::InteractionModel::Status __attribute__((weak))
 MatterPreAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t mask, uint8_t type, uint16_t size,
                                  uint8_t * value)
@@ -539,18 +268,6 @@ MatterPreAttributeChangeCallback(const chip::app::ConcreteAttributePath & attrib
     return chip::Protocols::InteractionModel::Status::Success;
 }
 
-/** @brief Post Attribute Change
- *
- * This function is called by the application framework after it changes an
- * attribute value. The value passed into this callback is the value to which
- * the attribute was set by the framework.
- *
- * @param attributePath
- * @param mask
- * @param type
- * @param size
- * @param value
- */
 void __attribute__((weak)) MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t mask,
                                                              uint8_t type, uint16_t size, uint8_t * value)
 {}

--- a/zzz_generated/temperature-measurement-app/zap-generated/callback-stub.cpp
+++ b/zzz_generated/temperature-measurement-app/zap-generated/callback-stub.cpp
@@ -136,66 +136,10 @@ void __attribute__((weak)) emberAfWiFiNetworkDiagnosticsClusterInitCallback(Endp
 // Non-Cluster Related Callbacks
 //
 
-/** @brief Add To Current App Tasks
- *
- * This function is only useful to sleepy end devices.  This function will note
- * the passed item as part of a set of tasks the application has outstanding
- * (e.g. message sent requiring APS acknwoledgement).  This will affect how the
- * application behaves with regard to sleeping and polling.  Until the
- * outstanding task is completed, the device may poll more frequently and sleep
- * less often.
- *
- * @param tasks   Ver.: always
- */
 void __attribute__((weak)) emberAfAddToCurrentAppTasksCallback(EmberAfApplicationTask tasks) {}
 
-/** @brief Remove From Current App Tasks
- *
- * This function is only useful to sleepy end devices.  This function will
- * remove the passed item from the set of tasks the application has outstanding
- * (e.g. message sent requiring APS acknwoledgement).  This will affect how the
- * application behaves with regard to sleeping and polling.  Removing the item
- * from the list of outstanding tasks may allow the device to sleep longer and
- * poll less frequently.  If there are other outstanding tasks the system may
- * still have to stay away and poll more often.
- *
- * @param tasks   Ver.: always
- */
 void __attribute__((weak)) emberAfRemoveFromCurrentAppTasksCallback(EmberAfApplicationTask tasks) {}
 
-/** @brief Allow Network Write Attribute
- *
- * This function is called by the application framework before it writes an
- * attribute in response to a write attribute request from an external device.
- * The value passed into this callback is the value to which the attribute is to
- * be set by the framework.
-        Example:	In mirroring simple metering data
- * on an Energy Services Interface (ESI) (formerly called Energy Service Portal
- * (ESP) in SE 1.0).), a mirrored simple meter needs to write read-only
- * attributes on its mirror. The-meter-mirror sample application, located in
- * app/framework/sample-apps, uses this callback to allow the mirrored device to
- * write simple metering attributes on the mirror regardless of the fact that
- * most simple metering attributes are defined as read-only by the ZigBee
- * specification.
-        Note:	The ZCL specification does not (as of this
- * writing) specify any permission-level security for writing writeable
- * attributes. As far as the ZCL specification is concerned, if an attribute is
- * writeable, any device that has a link key for the device should be able to
- * write that attribute. Furthermore if an attribute is read only, it should not
- * be written over the air. Thus, if you implement permissions for writing
- * attributes as a feature, you MAY be operating outside the specification. This
- * is unlikely to be a problem for writing read-only attributes, but it may be a
- * problem for attributes that are writeable according to the specification but
- * restricted by the application implementing this callback.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeId   Ver.: always
- * @param mask   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param value   Ver.: always
- * @param type   Ver.: always
- */
 EmberAfAttributeWritePermission __attribute__((weak))
 emberAfAllowNetworkWriteAttributeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
                                           uint16_t manufacturerCode, uint8_t * value, uint8_t type)
@@ -203,140 +147,34 @@ emberAfAllowNetworkWriteAttributeCallback(EndpointId endpoint, ClusterId cluster
     return EMBER_ZCL_ATTRIBUTE_WRITE_PERMISSION_ALLOW_WRITE_NORMAL; // Default
 }
 
-/** @brief Attribute Read Access
- *
- * This function is called whenever the Application Framework needs to check
- * access permission for an attribute read.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param attributeId   Ver.: always
- */
 bool __attribute__((weak))
 emberAfAttributeReadAccessCallback(EndpointId endpoint, ClusterId clusterId, uint16_t manufacturerCode, AttributeId attributeId)
 {
     return true;
 }
 
-/** @brief Attribute Write Access
- *
- * This function is called whenever the Application Framework needs to check
- * access permission for an attribute write.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param attributeId   Ver.: always
- */
 bool __attribute__((weak))
 emberAfAttributeWriteAccessCallback(EndpointId endpoint, ClusterId clusterId, uint16_t manufacturerCode, AttributeId attributeId)
 {
     return true;
 }
 
-/** @brief Default Response
- *
- * This function is called by the application framework when a Default Response
- * command is received from an external device.  The application should return
- * true if the message was processed or false if it was not.
- *
- * @param clusterId The cluster identifier of this response.  Ver.: always
- * @param commandId The command identifier to which this is a response.  Ver.:
- * always
- * @param status Specifies either SUCCESS or the nature of the error that was
- * detected in the received command.  Ver.: always
- */
 bool __attribute__((weak)) emberAfDefaultResponseCallback(ClusterId clusterId, CommandId commandId, EmberAfStatus status)
 {
     return false;
 }
 
-/** @brief Pre Message Send
- *
- * This function is called by the framework when it is about to pass a message
- * to the stack primitives for sending.   This message may or may not be ZCL,
- * ZDO, or some other protocol.  This is called prior to
-        any ZigBee
- * fragmentation that may be done.  If the function returns true it is assumed
- * the callback has consumed and processed the message.  The callback must also
- * set the EmberStatus status code to be passed back to the caller.  The
- * framework will do no further processing on the message.
-        If the
- * function returns false then it is assumed that the callback has not processed
- * the mesasge and the framework will continue to process accordingly.
- *
- * @param messageStruct The structure containing the parameters of the APS
- * message to be sent.  Ver.: always
- * @param status A pointer to the status code value that will be returned to the
- * caller.  Ver.: always
- */
 bool __attribute__((weak)) emberAfPreMessageSendCallback(EmberAfMessageStruct * messageStruct, EmberStatus * status)
 {
     return false;
 }
 
-/** @brief Message Sent
- *
- * This function is called by the application framework from the message sent
- * handler, when it is informed by the stack regarding the message sent status.
- * All of the values passed to the emberMessageSentHandler are passed on to this
- * callback. This provides an opportunity for the application to verify that its
- * message has been sent successfully and take the appropriate action. This
- * callback should return a bool value of true or false. A value of true
- * indicates that the message sent notification has been handled and should not
- * be handled by the application framework.
- *
- * @param type   Ver.: always
- * @param destination   Ver.: always
- * @param apsFrame   Ver.: always
- * @param msgLen   Ver.: always
- * @param message   Ver.: always
- * @param status   Ver.: always
- */
 bool __attribute__((weak)) emberAfMessageSentCallback(const MessageSendDestination & destination, EmberApsFrame * apsFrame,
                                                       uint16_t msgLen, uint8_t * message, EmberStatus status)
 {
     return false;
 }
 
-/** @brief External Attribute Read
- *
- * Like emberAfExternalAttributeWriteCallback above, this function is called
- * when the framework needs to read an attribute that is not stored within the
- * Application Framework's data structures.
-        All of the important
- * information about the attribute itself is passed as a pointer to an
- * EmberAfAttributeMetadata struct, which is stored within the application and
- * used to manage the attribute. A complete description of the
- * EmberAfAttributeMetadata struct is provided in
- * app/framework/include/af-types.h
-        This function assumes that the
- * application is able to read the attribute, write it into the passed buffer,
- * and return immediately. Any attributes that require a state machine for
- * reading and writing are not really candidates for externalization at the
- * present time. The Application Framework does not currently include a state
- * machine for reading or writing attributes that must take place across a
- * series of application ticks. Attributes that cannot be read in a timely
- * manner should be stored within the Application Framework and updated
- * occasionally by the application code from within the
- * emberAfMainTickCallback.
-        If the application was successfully able to
- * read the attribute and write it into the passed buffer, it should return a
- * value of EMBER_ZCL_STATUS_SUCCESS. Ensure that the size of the externally
- * managed attribute value is smaller than what the buffer can hold. In the case
- * of a buffer overflow throw an appropriate error such as
- * EMBER_ZCL_STATUS_INSUFFICIENT_SPACE. Any other return value indicates the
- * application was not able to read the attribute.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeMetadata   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param buffer   Ver.: always
- * @param maxReadLength   Ver.: always
- * @param index   Ver.: always
- */
 EmberAfStatus __attribute__((weak))
 emberAfExternalAttributeReadCallback(EndpointId endpoint, ClusterId clusterId, EmberAfAttributeMetadata * attributeMetadata,
                                      uint16_t manufacturerCode, uint8_t * buffer, uint16_t maxReadLength, int32_t index)
@@ -344,53 +182,6 @@ emberAfExternalAttributeReadCallback(EndpointId endpoint, ClusterId clusterId, E
     return EMBER_ZCL_STATUS_FAILURE;
 }
 
-/** @brief External Attribute Write
- *
- * This function is called whenever the Application Framework needs to write an
- * attribute which is not stored within the data structures of the Application
- * Framework itself. One of the new features in Version 2 is the ability to
- * store attributes outside the Framework. This is particularly useful for
- * attributes that do not need to be stored because they can be read off the
- * hardware when they are needed, or are stored in some central location used by
- * many modules within the system. In this case, you can indicate that the
- * attribute is stored externally. When the framework needs to write an external
- * attribute, it makes a call to this callback.
-        This callback is very
- * useful for host micros which need to store attributes in persistent memory.
- * Because each host micro (used with an Ember NCP) has its own type of
- * persistent memory storage, the Application Framework does not include the
- * ability to mark attributes as stored in flash the way that it does for Ember
- * SoCs like the EM35x. On a host micro, any attributes that need to be stored
- * in persistent memory should be marked as external and accessed through the
- * external read and write callbacks. Any host code associated with the
- * persistent storage should be implemented within this callback.
-        All of
- * the important information about the attribute itself is passed as a pointer
- * to an EmberAfAttributeMetadata struct, which is stored within the application
- * and used to manage the attribute. A complete description of the
- * EmberAfAttributeMetadata struct is provided in
- * app/framework/include/af-types.h.
-        This function assumes that the
- * application is able to write the attribute and return immediately. Any
- * attributes that require a state machine for reading and writing are not
- * candidates for externalization at the present time. The Application Framework
- * does not currently include a state machine for reading or writing attributes
- * that must take place across a series of application ticks. Attributes that
- * cannot be written immediately should be stored within the Application
- * Framework and updated occasionally by the application code from within the
- * emberAfMainTickCallback.
-        If the application was successfully able to
- * write the attribute, it returns a value of EMBER_ZCL_STATUS_SUCCESS. Any
- * other return value indicates the application was not able to write the
- * attribute.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeMetadata   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param buffer   Ver.: always
- * @param index   Ver.: always
- */
 EmberAfStatus __attribute__((weak))
 emberAfExternalAttributeWriteCallback(EndpointId endpoint, ClusterId clusterId, EmberAfAttributeMetadata * attributeMetadata,
                                       uint16_t manufacturerCode, uint8_t * buffer, int32_t index)
@@ -398,92 +189,30 @@ emberAfExternalAttributeWriteCallback(EndpointId endpoint, ClusterId clusterId, 
     return EMBER_ZCL_STATUS_FAILURE;
 }
 
-/** @brief Get Current Time
- *
- * This callback is called when device attempts to get current time from the
- * hardware. If this device has means to retrieve exact time, then this method
- * should implement it. If the callback can't provide the exact time it should
- * return 0 to indicate failure. Default action is to return 0, which indicates
- * that device does not have access to real time.
- *
- */
 uint32_t __attribute__((weak)) emberAfGetCurrentTimeCallback()
 {
     return 0;
 }
 
-/** @brief Get Endpoint Info
- *
- * This function is a callback to an application implemented endpoint that
- * operates outside the normal application framework.  When the framework wishes
- * to perform operations with that endpoint it uses this callback to retrieve
- * the endpoint's information.  If the endpoint exists and the application can
- * provide data then true shall be returned.  Otherwise the callback must return
- * false.
- *
- * @param endpoint The endpoint to retrieve data for.  Ver.: always
- * @param returnNetworkIndex The index corresponding to the ZigBee network the
- * endpoint belongs to.  If not using a multi-network device, 0 must be
- * returned.  Otherwise on a multi-network device the stack will switch to this
- * network before sending the message.  Ver.: always
- * @param returnEndpointInfo A pointer to a data struct that will be written
- * with information about the endpoint.  Ver.: always
- */
 bool __attribute__((weak))
 emberAfGetEndpointInfoCallback(EndpointId endpoint, uint8_t * returnNetworkIndex, EmberAfEndpointInfoStruct * returnEndpointInfo)
 {
     return false;
 }
 
-/** @brief Registration Abort
- *
- * This callback is called when the device should abort the registration
- * process.
- *
- */
 void __attribute__((weak)) emberAfRegistrationAbortCallback() {}
 
-/** @brief Interpan Send Message
- *
- * This function will send a raw MAC message with interpan frame format using
- * the passed parameters.
- *
- * @param header Interpan header info  Ver.: always
- * @param messageLength The length of the message received or to send  Ver.:
- * always
- * @param message The message data received or to send.  Ver.: always
- */
 EmberStatus __attribute__((weak))
 emberAfInterpanSendMessageCallback(EmberAfInterpanHeader * header, uint16_t messageLength, uint8_t * message)
 {
     return EMBER_LIBRARY_NOT_PRESENT;
 }
 
-/** @brief Start Move
- *
- * This function is called to initiate the process for a device to move (rejoin)
- * to a new parent.
- *
- */
 bool __attribute__((weak)) emberAfStartMoveCallback()
 {
     return false;
 }
 
-/** @brief Pre Attribute Change
- *
- * This function is called by the application framework before it changes an
- * attribute value.  The value passed into this callback is the value to which
- * the attribute is to be set by the framework.  The application should return
- * chip::Protocols::InteractionModel::Status::Success to permit the change or
- * any other code to reject it.
- *
- * @param attributePath
- * @param mask
- * @param type
- * @param size
- * @param value
- */
 chip::Protocols::InteractionModel::Status __attribute__((weak))
 MatterPreAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t mask, uint8_t type, uint16_t size,
                                  uint8_t * value)
@@ -491,18 +220,6 @@ MatterPreAttributeChangeCallback(const chip::app::ConcreteAttributePath & attrib
     return chip::Protocols::InteractionModel::Status::Success;
 }
 
-/** @brief Post Attribute Change
- *
- * This function is called by the application framework after it changes an
- * attribute value. The value passed into this callback is the value to which
- * the attribute was set by the framework.
- *
- * @param attributePath
- * @param mask
- * @param type
- * @param size
- * @param value
- */
 void __attribute__((weak)) MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t mask,
                                                              uint8_t type, uint16_t size, uint8_t * value)
 {}

--- a/zzz_generated/thermostat/zap-generated/callback-stub.cpp
+++ b/zzz_generated/thermostat/zap-generated/callback-stub.cpp
@@ -192,66 +192,10 @@ void __attribute__((weak)) emberAfWiFiNetworkDiagnosticsClusterInitCallback(Endp
 // Non-Cluster Related Callbacks
 //
 
-/** @brief Add To Current App Tasks
- *
- * This function is only useful to sleepy end devices.  This function will note
- * the passed item as part of a set of tasks the application has outstanding
- * (e.g. message sent requiring APS acknwoledgement).  This will affect how the
- * application behaves with regard to sleeping and polling.  Until the
- * outstanding task is completed, the device may poll more frequently and sleep
- * less often.
- *
- * @param tasks   Ver.: always
- */
 void __attribute__((weak)) emberAfAddToCurrentAppTasksCallback(EmberAfApplicationTask tasks) {}
 
-/** @brief Remove From Current App Tasks
- *
- * This function is only useful to sleepy end devices.  This function will
- * remove the passed item from the set of tasks the application has outstanding
- * (e.g. message sent requiring APS acknwoledgement).  This will affect how the
- * application behaves with regard to sleeping and polling.  Removing the item
- * from the list of outstanding tasks may allow the device to sleep longer and
- * poll less frequently.  If there are other outstanding tasks the system may
- * still have to stay away and poll more often.
- *
- * @param tasks   Ver.: always
- */
 void __attribute__((weak)) emberAfRemoveFromCurrentAppTasksCallback(EmberAfApplicationTask tasks) {}
 
-/** @brief Allow Network Write Attribute
- *
- * This function is called by the application framework before it writes an
- * attribute in response to a write attribute request from an external device.
- * The value passed into this callback is the value to which the attribute is to
- * be set by the framework.
-        Example:	In mirroring simple metering data
- * on an Energy Services Interface (ESI) (formerly called Energy Service Portal
- * (ESP) in SE 1.0).), a mirrored simple meter needs to write read-only
- * attributes on its mirror. The-meter-mirror sample application, located in
- * app/framework/sample-apps, uses this callback to allow the mirrored device to
- * write simple metering attributes on the mirror regardless of the fact that
- * most simple metering attributes are defined as read-only by the ZigBee
- * specification.
-        Note:	The ZCL specification does not (as of this
- * writing) specify any permission-level security for writing writeable
- * attributes. As far as the ZCL specification is concerned, if an attribute is
- * writeable, any device that has a link key for the device should be able to
- * write that attribute. Furthermore if an attribute is read only, it should not
- * be written over the air. Thus, if you implement permissions for writing
- * attributes as a feature, you MAY be operating outside the specification. This
- * is unlikely to be a problem for writing read-only attributes, but it may be a
- * problem for attributes that are writeable according to the specification but
- * restricted by the application implementing this callback.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeId   Ver.: always
- * @param mask   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param value   Ver.: always
- * @param type   Ver.: always
- */
 EmberAfAttributeWritePermission __attribute__((weak))
 emberAfAllowNetworkWriteAttributeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
                                           uint16_t manufacturerCode, uint8_t * value, uint8_t type)
@@ -259,140 +203,34 @@ emberAfAllowNetworkWriteAttributeCallback(EndpointId endpoint, ClusterId cluster
     return EMBER_ZCL_ATTRIBUTE_WRITE_PERMISSION_ALLOW_WRITE_NORMAL; // Default
 }
 
-/** @brief Attribute Read Access
- *
- * This function is called whenever the Application Framework needs to check
- * access permission for an attribute read.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param attributeId   Ver.: always
- */
 bool __attribute__((weak))
 emberAfAttributeReadAccessCallback(EndpointId endpoint, ClusterId clusterId, uint16_t manufacturerCode, AttributeId attributeId)
 {
     return true;
 }
 
-/** @brief Attribute Write Access
- *
- * This function is called whenever the Application Framework needs to check
- * access permission for an attribute write.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param attributeId   Ver.: always
- */
 bool __attribute__((weak))
 emberAfAttributeWriteAccessCallback(EndpointId endpoint, ClusterId clusterId, uint16_t manufacturerCode, AttributeId attributeId)
 {
     return true;
 }
 
-/** @brief Default Response
- *
- * This function is called by the application framework when a Default Response
- * command is received from an external device.  The application should return
- * true if the message was processed or false if it was not.
- *
- * @param clusterId The cluster identifier of this response.  Ver.: always
- * @param commandId The command identifier to which this is a response.  Ver.:
- * always
- * @param status Specifies either SUCCESS or the nature of the error that was
- * detected in the received command.  Ver.: always
- */
 bool __attribute__((weak)) emberAfDefaultResponseCallback(ClusterId clusterId, CommandId commandId, EmberAfStatus status)
 {
     return false;
 }
 
-/** @brief Pre Message Send
- *
- * This function is called by the framework when it is about to pass a message
- * to the stack primitives for sending.   This message may or may not be ZCL,
- * ZDO, or some other protocol.  This is called prior to
-        any ZigBee
- * fragmentation that may be done.  If the function returns true it is assumed
- * the callback has consumed and processed the message.  The callback must also
- * set the EmberStatus status code to be passed back to the caller.  The
- * framework will do no further processing on the message.
-        If the
- * function returns false then it is assumed that the callback has not processed
- * the mesasge and the framework will continue to process accordingly.
- *
- * @param messageStruct The structure containing the parameters of the APS
- * message to be sent.  Ver.: always
- * @param status A pointer to the status code value that will be returned to the
- * caller.  Ver.: always
- */
 bool __attribute__((weak)) emberAfPreMessageSendCallback(EmberAfMessageStruct * messageStruct, EmberStatus * status)
 {
     return false;
 }
 
-/** @brief Message Sent
- *
- * This function is called by the application framework from the message sent
- * handler, when it is informed by the stack regarding the message sent status.
- * All of the values passed to the emberMessageSentHandler are passed on to this
- * callback. This provides an opportunity for the application to verify that its
- * message has been sent successfully and take the appropriate action. This
- * callback should return a bool value of true or false. A value of true
- * indicates that the message sent notification has been handled and should not
- * be handled by the application framework.
- *
- * @param type   Ver.: always
- * @param destination   Ver.: always
- * @param apsFrame   Ver.: always
- * @param msgLen   Ver.: always
- * @param message   Ver.: always
- * @param status   Ver.: always
- */
 bool __attribute__((weak)) emberAfMessageSentCallback(const MessageSendDestination & destination, EmberApsFrame * apsFrame,
                                                       uint16_t msgLen, uint8_t * message, EmberStatus status)
 {
     return false;
 }
 
-/** @brief External Attribute Read
- *
- * Like emberAfExternalAttributeWriteCallback above, this function is called
- * when the framework needs to read an attribute that is not stored within the
- * Application Framework's data structures.
-        All of the important
- * information about the attribute itself is passed as a pointer to an
- * EmberAfAttributeMetadata struct, which is stored within the application and
- * used to manage the attribute. A complete description of the
- * EmberAfAttributeMetadata struct is provided in
- * app/framework/include/af-types.h
-        This function assumes that the
- * application is able to read the attribute, write it into the passed buffer,
- * and return immediately. Any attributes that require a state machine for
- * reading and writing are not really candidates for externalization at the
- * present time. The Application Framework does not currently include a state
- * machine for reading or writing attributes that must take place across a
- * series of application ticks. Attributes that cannot be read in a timely
- * manner should be stored within the Application Framework and updated
- * occasionally by the application code from within the
- * emberAfMainTickCallback.
-        If the application was successfully able to
- * read the attribute and write it into the passed buffer, it should return a
- * value of EMBER_ZCL_STATUS_SUCCESS. Ensure that the size of the externally
- * managed attribute value is smaller than what the buffer can hold. In the case
- * of a buffer overflow throw an appropriate error such as
- * EMBER_ZCL_STATUS_INSUFFICIENT_SPACE. Any other return value indicates the
- * application was not able to read the attribute.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeMetadata   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param buffer   Ver.: always
- * @param maxReadLength   Ver.: always
- * @param index   Ver.: always
- */
 EmberAfStatus __attribute__((weak))
 emberAfExternalAttributeReadCallback(EndpointId endpoint, ClusterId clusterId, EmberAfAttributeMetadata * attributeMetadata,
                                      uint16_t manufacturerCode, uint8_t * buffer, uint16_t maxReadLength, int32_t index)
@@ -400,53 +238,6 @@ emberAfExternalAttributeReadCallback(EndpointId endpoint, ClusterId clusterId, E
     return EMBER_ZCL_STATUS_FAILURE;
 }
 
-/** @brief External Attribute Write
- *
- * This function is called whenever the Application Framework needs to write an
- * attribute which is not stored within the data structures of the Application
- * Framework itself. One of the new features in Version 2 is the ability to
- * store attributes outside the Framework. This is particularly useful for
- * attributes that do not need to be stored because they can be read off the
- * hardware when they are needed, or are stored in some central location used by
- * many modules within the system. In this case, you can indicate that the
- * attribute is stored externally. When the framework needs to write an external
- * attribute, it makes a call to this callback.
-        This callback is very
- * useful for host micros which need to store attributes in persistent memory.
- * Because each host micro (used with an Ember NCP) has its own type of
- * persistent memory storage, the Application Framework does not include the
- * ability to mark attributes as stored in flash the way that it does for Ember
- * SoCs like the EM35x. On a host micro, any attributes that need to be stored
- * in persistent memory should be marked as external and accessed through the
- * external read and write callbacks. Any host code associated with the
- * persistent storage should be implemented within this callback.
-        All of
- * the important information about the attribute itself is passed as a pointer
- * to an EmberAfAttributeMetadata struct, which is stored within the application
- * and used to manage the attribute. A complete description of the
- * EmberAfAttributeMetadata struct is provided in
- * app/framework/include/af-types.h.
-        This function assumes that the
- * application is able to write the attribute and return immediately. Any
- * attributes that require a state machine for reading and writing are not
- * candidates for externalization at the present time. The Application Framework
- * does not currently include a state machine for reading or writing attributes
- * that must take place across a series of application ticks. Attributes that
- * cannot be written immediately should be stored within the Application
- * Framework and updated occasionally by the application code from within the
- * emberAfMainTickCallback.
-        If the application was successfully able to
- * write the attribute, it returns a value of EMBER_ZCL_STATUS_SUCCESS. Any
- * other return value indicates the application was not able to write the
- * attribute.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeMetadata   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param buffer   Ver.: always
- * @param index   Ver.: always
- */
 EmberAfStatus __attribute__((weak))
 emberAfExternalAttributeWriteCallback(EndpointId endpoint, ClusterId clusterId, EmberAfAttributeMetadata * attributeMetadata,
                                       uint16_t manufacturerCode, uint8_t * buffer, int32_t index)
@@ -454,92 +245,30 @@ emberAfExternalAttributeWriteCallback(EndpointId endpoint, ClusterId clusterId, 
     return EMBER_ZCL_STATUS_FAILURE;
 }
 
-/** @brief Get Current Time
- *
- * This callback is called when device attempts to get current time from the
- * hardware. If this device has means to retrieve exact time, then this method
- * should implement it. If the callback can't provide the exact time it should
- * return 0 to indicate failure. Default action is to return 0, which indicates
- * that device does not have access to real time.
- *
- */
 uint32_t __attribute__((weak)) emberAfGetCurrentTimeCallback()
 {
     return 0;
 }
 
-/** @brief Get Endpoint Info
- *
- * This function is a callback to an application implemented endpoint that
- * operates outside the normal application framework.  When the framework wishes
- * to perform operations with that endpoint it uses this callback to retrieve
- * the endpoint's information.  If the endpoint exists and the application can
- * provide data then true shall be returned.  Otherwise the callback must return
- * false.
- *
- * @param endpoint The endpoint to retrieve data for.  Ver.: always
- * @param returnNetworkIndex The index corresponding to the ZigBee network the
- * endpoint belongs to.  If not using a multi-network device, 0 must be
- * returned.  Otherwise on a multi-network device the stack will switch to this
- * network before sending the message.  Ver.: always
- * @param returnEndpointInfo A pointer to a data struct that will be written
- * with information about the endpoint.  Ver.: always
- */
 bool __attribute__((weak))
 emberAfGetEndpointInfoCallback(EndpointId endpoint, uint8_t * returnNetworkIndex, EmberAfEndpointInfoStruct * returnEndpointInfo)
 {
     return false;
 }
 
-/** @brief Registration Abort
- *
- * This callback is called when the device should abort the registration
- * process.
- *
- */
 void __attribute__((weak)) emberAfRegistrationAbortCallback() {}
 
-/** @brief Interpan Send Message
- *
- * This function will send a raw MAC message with interpan frame format using
- * the passed parameters.
- *
- * @param header Interpan header info  Ver.: always
- * @param messageLength The length of the message received or to send  Ver.:
- * always
- * @param message The message data received or to send.  Ver.: always
- */
 EmberStatus __attribute__((weak))
 emberAfInterpanSendMessageCallback(EmberAfInterpanHeader * header, uint16_t messageLength, uint8_t * message)
 {
     return EMBER_LIBRARY_NOT_PRESENT;
 }
 
-/** @brief Start Move
- *
- * This function is called to initiate the process for a device to move (rejoin)
- * to a new parent.
- *
- */
 bool __attribute__((weak)) emberAfStartMoveCallback()
 {
     return false;
 }
 
-/** @brief Pre Attribute Change
- *
- * This function is called by the application framework before it changes an
- * attribute value.  The value passed into this callback is the value to which
- * the attribute is to be set by the framework.  The application should return
- * chip::Protocols::InteractionModel::Status::Success to permit the change or
- * any other code to reject it.
- *
- * @param attributePath
- * @param mask
- * @param type
- * @param size
- * @param value
- */
 chip::Protocols::InteractionModel::Status __attribute__((weak))
 MatterPreAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t mask, uint8_t type, uint16_t size,
                                  uint8_t * value)
@@ -547,18 +276,6 @@ MatterPreAttributeChangeCallback(const chip::app::ConcreteAttributePath & attrib
     return chip::Protocols::InteractionModel::Status::Success;
 }
 
-/** @brief Post Attribute Change
- *
- * This function is called by the application framework after it changes an
- * attribute value. The value passed into this callback is the value to which
- * the attribute was set by the framework.
- *
- * @param attributePath
- * @param mask
- * @param type
- * @param size
- * @param value
- */
 void __attribute__((weak)) MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t mask,
                                                              uint8_t type, uint16_t size, uint8_t * value)
 {}

--- a/zzz_generated/tv-app/zap-generated/callback-stub.cpp
+++ b/zzz_generated/tv-app/zap-generated/callback-stub.cpp
@@ -280,66 +280,10 @@ void __attribute__((weak)) emberAfWiFiNetworkDiagnosticsClusterInitCallback(Endp
 // Non-Cluster Related Callbacks
 //
 
-/** @brief Add To Current App Tasks
- *
- * This function is only useful to sleepy end devices.  This function will note
- * the passed item as part of a set of tasks the application has outstanding
- * (e.g. message sent requiring APS acknwoledgement).  This will affect how the
- * application behaves with regard to sleeping and polling.  Until the
- * outstanding task is completed, the device may poll more frequently and sleep
- * less often.
- *
- * @param tasks   Ver.: always
- */
 void __attribute__((weak)) emberAfAddToCurrentAppTasksCallback(EmberAfApplicationTask tasks) {}
 
-/** @brief Remove From Current App Tasks
- *
- * This function is only useful to sleepy end devices.  This function will
- * remove the passed item from the set of tasks the application has outstanding
- * (e.g. message sent requiring APS acknwoledgement).  This will affect how the
- * application behaves with regard to sleeping and polling.  Removing the item
- * from the list of outstanding tasks may allow the device to sleep longer and
- * poll less frequently.  If there are other outstanding tasks the system may
- * still have to stay away and poll more often.
- *
- * @param tasks   Ver.: always
- */
 void __attribute__((weak)) emberAfRemoveFromCurrentAppTasksCallback(EmberAfApplicationTask tasks) {}
 
-/** @brief Allow Network Write Attribute
- *
- * This function is called by the application framework before it writes an
- * attribute in response to a write attribute request from an external device.
- * The value passed into this callback is the value to which the attribute is to
- * be set by the framework.
-        Example:	In mirroring simple metering data
- * on an Energy Services Interface (ESI) (formerly called Energy Service Portal
- * (ESP) in SE 1.0).), a mirrored simple meter needs to write read-only
- * attributes on its mirror. The-meter-mirror sample application, located in
- * app/framework/sample-apps, uses this callback to allow the mirrored device to
- * write simple metering attributes on the mirror regardless of the fact that
- * most simple metering attributes are defined as read-only by the ZigBee
- * specification.
-        Note:	The ZCL specification does not (as of this
- * writing) specify any permission-level security for writing writeable
- * attributes. As far as the ZCL specification is concerned, if an attribute is
- * writeable, any device that has a link key for the device should be able to
- * write that attribute. Furthermore if an attribute is read only, it should not
- * be written over the air. Thus, if you implement permissions for writing
- * attributes as a feature, you MAY be operating outside the specification. This
- * is unlikely to be a problem for writing read-only attributes, but it may be a
- * problem for attributes that are writeable according to the specification but
- * restricted by the application implementing this callback.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeId   Ver.: always
- * @param mask   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param value   Ver.: always
- * @param type   Ver.: always
- */
 EmberAfAttributeWritePermission __attribute__((weak))
 emberAfAllowNetworkWriteAttributeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
                                           uint16_t manufacturerCode, uint8_t * value, uint8_t type)
@@ -347,140 +291,34 @@ emberAfAllowNetworkWriteAttributeCallback(EndpointId endpoint, ClusterId cluster
     return EMBER_ZCL_ATTRIBUTE_WRITE_PERMISSION_ALLOW_WRITE_NORMAL; // Default
 }
 
-/** @brief Attribute Read Access
- *
- * This function is called whenever the Application Framework needs to check
- * access permission for an attribute read.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param attributeId   Ver.: always
- */
 bool __attribute__((weak))
 emberAfAttributeReadAccessCallback(EndpointId endpoint, ClusterId clusterId, uint16_t manufacturerCode, AttributeId attributeId)
 {
     return true;
 }
 
-/** @brief Attribute Write Access
- *
- * This function is called whenever the Application Framework needs to check
- * access permission for an attribute write.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param attributeId   Ver.: always
- */
 bool __attribute__((weak))
 emberAfAttributeWriteAccessCallback(EndpointId endpoint, ClusterId clusterId, uint16_t manufacturerCode, AttributeId attributeId)
 {
     return true;
 }
 
-/** @brief Default Response
- *
- * This function is called by the application framework when a Default Response
- * command is received from an external device.  The application should return
- * true if the message was processed or false if it was not.
- *
- * @param clusterId The cluster identifier of this response.  Ver.: always
- * @param commandId The command identifier to which this is a response.  Ver.:
- * always
- * @param status Specifies either SUCCESS or the nature of the error that was
- * detected in the received command.  Ver.: always
- */
 bool __attribute__((weak)) emberAfDefaultResponseCallback(ClusterId clusterId, CommandId commandId, EmberAfStatus status)
 {
     return false;
 }
 
-/** @brief Pre Message Send
- *
- * This function is called by the framework when it is about to pass a message
- * to the stack primitives for sending.   This message may or may not be ZCL,
- * ZDO, or some other protocol.  This is called prior to
-        any ZigBee
- * fragmentation that may be done.  If the function returns true it is assumed
- * the callback has consumed and processed the message.  The callback must also
- * set the EmberStatus status code to be passed back to the caller.  The
- * framework will do no further processing on the message.
-        If the
- * function returns false then it is assumed that the callback has not processed
- * the mesasge and the framework will continue to process accordingly.
- *
- * @param messageStruct The structure containing the parameters of the APS
- * message to be sent.  Ver.: always
- * @param status A pointer to the status code value that will be returned to the
- * caller.  Ver.: always
- */
 bool __attribute__((weak)) emberAfPreMessageSendCallback(EmberAfMessageStruct * messageStruct, EmberStatus * status)
 {
     return false;
 }
 
-/** @brief Message Sent
- *
- * This function is called by the application framework from the message sent
- * handler, when it is informed by the stack regarding the message sent status.
- * All of the values passed to the emberMessageSentHandler are passed on to this
- * callback. This provides an opportunity for the application to verify that its
- * message has been sent successfully and take the appropriate action. This
- * callback should return a bool value of true or false. A value of true
- * indicates that the message sent notification has been handled and should not
- * be handled by the application framework.
- *
- * @param type   Ver.: always
- * @param destination   Ver.: always
- * @param apsFrame   Ver.: always
- * @param msgLen   Ver.: always
- * @param message   Ver.: always
- * @param status   Ver.: always
- */
 bool __attribute__((weak)) emberAfMessageSentCallback(const MessageSendDestination & destination, EmberApsFrame * apsFrame,
                                                       uint16_t msgLen, uint8_t * message, EmberStatus status)
 {
     return false;
 }
 
-/** @brief External Attribute Read
- *
- * Like emberAfExternalAttributeWriteCallback above, this function is called
- * when the framework needs to read an attribute that is not stored within the
- * Application Framework's data structures.
-        All of the important
- * information about the attribute itself is passed as a pointer to an
- * EmberAfAttributeMetadata struct, which is stored within the application and
- * used to manage the attribute. A complete description of the
- * EmberAfAttributeMetadata struct is provided in
- * app/framework/include/af-types.h
-        This function assumes that the
- * application is able to read the attribute, write it into the passed buffer,
- * and return immediately. Any attributes that require a state machine for
- * reading and writing are not really candidates for externalization at the
- * present time. The Application Framework does not currently include a state
- * machine for reading or writing attributes that must take place across a
- * series of application ticks. Attributes that cannot be read in a timely
- * manner should be stored within the Application Framework and updated
- * occasionally by the application code from within the
- * emberAfMainTickCallback.
-        If the application was successfully able to
- * read the attribute and write it into the passed buffer, it should return a
- * value of EMBER_ZCL_STATUS_SUCCESS. Ensure that the size of the externally
- * managed attribute value is smaller than what the buffer can hold. In the case
- * of a buffer overflow throw an appropriate error such as
- * EMBER_ZCL_STATUS_INSUFFICIENT_SPACE. Any other return value indicates the
- * application was not able to read the attribute.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeMetadata   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param buffer   Ver.: always
- * @param maxReadLength   Ver.: always
- * @param index   Ver.: always
- */
 EmberAfStatus __attribute__((weak))
 emberAfExternalAttributeReadCallback(EndpointId endpoint, ClusterId clusterId, EmberAfAttributeMetadata * attributeMetadata,
                                      uint16_t manufacturerCode, uint8_t * buffer, uint16_t maxReadLength, int32_t index)
@@ -488,53 +326,6 @@ emberAfExternalAttributeReadCallback(EndpointId endpoint, ClusterId clusterId, E
     return EMBER_ZCL_STATUS_FAILURE;
 }
 
-/** @brief External Attribute Write
- *
- * This function is called whenever the Application Framework needs to write an
- * attribute which is not stored within the data structures of the Application
- * Framework itself. One of the new features in Version 2 is the ability to
- * store attributes outside the Framework. This is particularly useful for
- * attributes that do not need to be stored because they can be read off the
- * hardware when they are needed, or are stored in some central location used by
- * many modules within the system. In this case, you can indicate that the
- * attribute is stored externally. When the framework needs to write an external
- * attribute, it makes a call to this callback.
-        This callback is very
- * useful for host micros which need to store attributes in persistent memory.
- * Because each host micro (used with an Ember NCP) has its own type of
- * persistent memory storage, the Application Framework does not include the
- * ability to mark attributes as stored in flash the way that it does for Ember
- * SoCs like the EM35x. On a host micro, any attributes that need to be stored
- * in persistent memory should be marked as external and accessed through the
- * external read and write callbacks. Any host code associated with the
- * persistent storage should be implemented within this callback.
-        All of
- * the important information about the attribute itself is passed as a pointer
- * to an EmberAfAttributeMetadata struct, which is stored within the application
- * and used to manage the attribute. A complete description of the
- * EmberAfAttributeMetadata struct is provided in
- * app/framework/include/af-types.h.
-        This function assumes that the
- * application is able to write the attribute and return immediately. Any
- * attributes that require a state machine for reading and writing are not
- * candidates for externalization at the present time. The Application Framework
- * does not currently include a state machine for reading or writing attributes
- * that must take place across a series of application ticks. Attributes that
- * cannot be written immediately should be stored within the Application
- * Framework and updated occasionally by the application code from within the
- * emberAfMainTickCallback.
-        If the application was successfully able to
- * write the attribute, it returns a value of EMBER_ZCL_STATUS_SUCCESS. Any
- * other return value indicates the application was not able to write the
- * attribute.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeMetadata   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param buffer   Ver.: always
- * @param index   Ver.: always
- */
 EmberAfStatus __attribute__((weak))
 emberAfExternalAttributeWriteCallback(EndpointId endpoint, ClusterId clusterId, EmberAfAttributeMetadata * attributeMetadata,
                                       uint16_t manufacturerCode, uint8_t * buffer, int32_t index)
@@ -542,92 +333,30 @@ emberAfExternalAttributeWriteCallback(EndpointId endpoint, ClusterId clusterId, 
     return EMBER_ZCL_STATUS_FAILURE;
 }
 
-/** @brief Get Current Time
- *
- * This callback is called when device attempts to get current time from the
- * hardware. If this device has means to retrieve exact time, then this method
- * should implement it. If the callback can't provide the exact time it should
- * return 0 to indicate failure. Default action is to return 0, which indicates
- * that device does not have access to real time.
- *
- */
 uint32_t __attribute__((weak)) emberAfGetCurrentTimeCallback()
 {
     return 0;
 }
 
-/** @brief Get Endpoint Info
- *
- * This function is a callback to an application implemented endpoint that
- * operates outside the normal application framework.  When the framework wishes
- * to perform operations with that endpoint it uses this callback to retrieve
- * the endpoint's information.  If the endpoint exists and the application can
- * provide data then true shall be returned.  Otherwise the callback must return
- * false.
- *
- * @param endpoint The endpoint to retrieve data for.  Ver.: always
- * @param returnNetworkIndex The index corresponding to the ZigBee network the
- * endpoint belongs to.  If not using a multi-network device, 0 must be
- * returned.  Otherwise on a multi-network device the stack will switch to this
- * network before sending the message.  Ver.: always
- * @param returnEndpointInfo A pointer to a data struct that will be written
- * with information about the endpoint.  Ver.: always
- */
 bool __attribute__((weak))
 emberAfGetEndpointInfoCallback(EndpointId endpoint, uint8_t * returnNetworkIndex, EmberAfEndpointInfoStruct * returnEndpointInfo)
 {
     return false;
 }
 
-/** @brief Registration Abort
- *
- * This callback is called when the device should abort the registration
- * process.
- *
- */
 void __attribute__((weak)) emberAfRegistrationAbortCallback() {}
 
-/** @brief Interpan Send Message
- *
- * This function will send a raw MAC message with interpan frame format using
- * the passed parameters.
- *
- * @param header Interpan header info  Ver.: always
- * @param messageLength The length of the message received or to send  Ver.:
- * always
- * @param message The message data received or to send.  Ver.: always
- */
 EmberStatus __attribute__((weak))
 emberAfInterpanSendMessageCallback(EmberAfInterpanHeader * header, uint16_t messageLength, uint8_t * message)
 {
     return EMBER_LIBRARY_NOT_PRESENT;
 }
 
-/** @brief Start Move
- *
- * This function is called to initiate the process for a device to move (rejoin)
- * to a new parent.
- *
- */
 bool __attribute__((weak)) emberAfStartMoveCallback()
 {
     return false;
 }
 
-/** @brief Pre Attribute Change
- *
- * This function is called by the application framework before it changes an
- * attribute value.  The value passed into this callback is the value to which
- * the attribute is to be set by the framework.  The application should return
- * chip::Protocols::InteractionModel::Status::Success to permit the change or
- * any other code to reject it.
- *
- * @param attributePath
- * @param mask
- * @param type
- * @param size
- * @param value
- */
 chip::Protocols::InteractionModel::Status __attribute__((weak))
 MatterPreAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t mask, uint8_t type, uint16_t size,
                                  uint8_t * value)
@@ -635,18 +364,6 @@ MatterPreAttributeChangeCallback(const chip::app::ConcreteAttributePath & attrib
     return chip::Protocols::InteractionModel::Status::Success;
 }
 
-/** @brief Post Attribute Change
- *
- * This function is called by the application framework after it changes an
- * attribute value. The value passed into this callback is the value to which
- * the attribute was set by the framework.
- *
- * @param attributePath
- * @param mask
- * @param type
- * @param size
- * @param value
- */
 void __attribute__((weak)) MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t mask,
                                                              uint8_t type, uint16_t size, uint8_t * value)
 {}

--- a/zzz_generated/tv-casting-app/zap-generated/callback-stub.cpp
+++ b/zzz_generated/tv-casting-app/zap-generated/callback-stub.cpp
@@ -416,66 +416,10 @@ void __attribute__((weak)) emberAfWindowCoveringClusterInitCallback(EndpointId e
 // Non-Cluster Related Callbacks
 //
 
-/** @brief Add To Current App Tasks
- *
- * This function is only useful to sleepy end devices.  This function will note
- * the passed item as part of a set of tasks the application has outstanding
- * (e.g. message sent requiring APS acknwoledgement).  This will affect how the
- * application behaves with regard to sleeping and polling.  Until the
- * outstanding task is completed, the device may poll more frequently and sleep
- * less often.
- *
- * @param tasks   Ver.: always
- */
 void __attribute__((weak)) emberAfAddToCurrentAppTasksCallback(EmberAfApplicationTask tasks) {}
 
-/** @brief Remove From Current App Tasks
- *
- * This function is only useful to sleepy end devices.  This function will
- * remove the passed item from the set of tasks the application has outstanding
- * (e.g. message sent requiring APS acknwoledgement).  This will affect how the
- * application behaves with regard to sleeping and polling.  Removing the item
- * from the list of outstanding tasks may allow the device to sleep longer and
- * poll less frequently.  If there are other outstanding tasks the system may
- * still have to stay away and poll more often.
- *
- * @param tasks   Ver.: always
- */
 void __attribute__((weak)) emberAfRemoveFromCurrentAppTasksCallback(EmberAfApplicationTask tasks) {}
 
-/** @brief Allow Network Write Attribute
- *
- * This function is called by the application framework before it writes an
- * attribute in response to a write attribute request from an external device.
- * The value passed into this callback is the value to which the attribute is to
- * be set by the framework.
-        Example:	In mirroring simple metering data
- * on an Energy Services Interface (ESI) (formerly called Energy Service Portal
- * (ESP) in SE 1.0).), a mirrored simple meter needs to write read-only
- * attributes on its mirror. The-meter-mirror sample application, located in
- * app/framework/sample-apps, uses this callback to allow the mirrored device to
- * write simple metering attributes on the mirror regardless of the fact that
- * most simple metering attributes are defined as read-only by the ZigBee
- * specification.
-        Note:	The ZCL specification does not (as of this
- * writing) specify any permission-level security for writing writeable
- * attributes. As far as the ZCL specification is concerned, if an attribute is
- * writeable, any device that has a link key for the device should be able to
- * write that attribute. Furthermore if an attribute is read only, it should not
- * be written over the air. Thus, if you implement permissions for writing
- * attributes as a feature, you MAY be operating outside the specification. This
- * is unlikely to be a problem for writing read-only attributes, but it may be a
- * problem for attributes that are writeable according to the specification but
- * restricted by the application implementing this callback.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeId   Ver.: always
- * @param mask   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param value   Ver.: always
- * @param type   Ver.: always
- */
 EmberAfAttributeWritePermission __attribute__((weak))
 emberAfAllowNetworkWriteAttributeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
                                           uint16_t manufacturerCode, uint8_t * value, uint8_t type)
@@ -483,140 +427,34 @@ emberAfAllowNetworkWriteAttributeCallback(EndpointId endpoint, ClusterId cluster
     return EMBER_ZCL_ATTRIBUTE_WRITE_PERMISSION_ALLOW_WRITE_NORMAL; // Default
 }
 
-/** @brief Attribute Read Access
- *
- * This function is called whenever the Application Framework needs to check
- * access permission for an attribute read.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param attributeId   Ver.: always
- */
 bool __attribute__((weak))
 emberAfAttributeReadAccessCallback(EndpointId endpoint, ClusterId clusterId, uint16_t manufacturerCode, AttributeId attributeId)
 {
     return true;
 }
 
-/** @brief Attribute Write Access
- *
- * This function is called whenever the Application Framework needs to check
- * access permission for an attribute write.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param attributeId   Ver.: always
- */
 bool __attribute__((weak))
 emberAfAttributeWriteAccessCallback(EndpointId endpoint, ClusterId clusterId, uint16_t manufacturerCode, AttributeId attributeId)
 {
     return true;
 }
 
-/** @brief Default Response
- *
- * This function is called by the application framework when a Default Response
- * command is received from an external device.  The application should return
- * true if the message was processed or false if it was not.
- *
- * @param clusterId The cluster identifier of this response.  Ver.: always
- * @param commandId The command identifier to which this is a response.  Ver.:
- * always
- * @param status Specifies either SUCCESS or the nature of the error that was
- * detected in the received command.  Ver.: always
- */
 bool __attribute__((weak)) emberAfDefaultResponseCallback(ClusterId clusterId, CommandId commandId, EmberAfStatus status)
 {
     return false;
 }
 
-/** @brief Pre Message Send
- *
- * This function is called by the framework when it is about to pass a message
- * to the stack primitives for sending.   This message may or may not be ZCL,
- * ZDO, or some other protocol.  This is called prior to
-        any ZigBee
- * fragmentation that may be done.  If the function returns true it is assumed
- * the callback has consumed and processed the message.  The callback must also
- * set the EmberStatus status code to be passed back to the caller.  The
- * framework will do no further processing on the message.
-        If the
- * function returns false then it is assumed that the callback has not processed
- * the mesasge and the framework will continue to process accordingly.
- *
- * @param messageStruct The structure containing the parameters of the APS
- * message to be sent.  Ver.: always
- * @param status A pointer to the status code value that will be returned to the
- * caller.  Ver.: always
- */
 bool __attribute__((weak)) emberAfPreMessageSendCallback(EmberAfMessageStruct * messageStruct, EmberStatus * status)
 {
     return false;
 }
 
-/** @brief Message Sent
- *
- * This function is called by the application framework from the message sent
- * handler, when it is informed by the stack regarding the message sent status.
- * All of the values passed to the emberMessageSentHandler are passed on to this
- * callback. This provides an opportunity for the application to verify that its
- * message has been sent successfully and take the appropriate action. This
- * callback should return a bool value of true or false. A value of true
- * indicates that the message sent notification has been handled and should not
- * be handled by the application framework.
- *
- * @param type   Ver.: always
- * @param destination   Ver.: always
- * @param apsFrame   Ver.: always
- * @param msgLen   Ver.: always
- * @param message   Ver.: always
- * @param status   Ver.: always
- */
 bool __attribute__((weak)) emberAfMessageSentCallback(const MessageSendDestination & destination, EmberApsFrame * apsFrame,
                                                       uint16_t msgLen, uint8_t * message, EmberStatus status)
 {
     return false;
 }
 
-/** @brief External Attribute Read
- *
- * Like emberAfExternalAttributeWriteCallback above, this function is called
- * when the framework needs to read an attribute that is not stored within the
- * Application Framework's data structures.
-        All of the important
- * information about the attribute itself is passed as a pointer to an
- * EmberAfAttributeMetadata struct, which is stored within the application and
- * used to manage the attribute. A complete description of the
- * EmberAfAttributeMetadata struct is provided in
- * app/framework/include/af-types.h
-        This function assumes that the
- * application is able to read the attribute, write it into the passed buffer,
- * and return immediately. Any attributes that require a state machine for
- * reading and writing are not really candidates for externalization at the
- * present time. The Application Framework does not currently include a state
- * machine for reading or writing attributes that must take place across a
- * series of application ticks. Attributes that cannot be read in a timely
- * manner should be stored within the Application Framework and updated
- * occasionally by the application code from within the
- * emberAfMainTickCallback.
-        If the application was successfully able to
- * read the attribute and write it into the passed buffer, it should return a
- * value of EMBER_ZCL_STATUS_SUCCESS. Ensure that the size of the externally
- * managed attribute value is smaller than what the buffer can hold. In the case
- * of a buffer overflow throw an appropriate error such as
- * EMBER_ZCL_STATUS_INSUFFICIENT_SPACE. Any other return value indicates the
- * application was not able to read the attribute.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeMetadata   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param buffer   Ver.: always
- * @param maxReadLength   Ver.: always
- * @param index   Ver.: always
- */
 EmberAfStatus __attribute__((weak))
 emberAfExternalAttributeReadCallback(EndpointId endpoint, ClusterId clusterId, EmberAfAttributeMetadata * attributeMetadata,
                                      uint16_t manufacturerCode, uint8_t * buffer, uint16_t maxReadLength, int32_t index)
@@ -624,53 +462,6 @@ emberAfExternalAttributeReadCallback(EndpointId endpoint, ClusterId clusterId, E
     return EMBER_ZCL_STATUS_FAILURE;
 }
 
-/** @brief External Attribute Write
- *
- * This function is called whenever the Application Framework needs to write an
- * attribute which is not stored within the data structures of the Application
- * Framework itself. One of the new features in Version 2 is the ability to
- * store attributes outside the Framework. This is particularly useful for
- * attributes that do not need to be stored because they can be read off the
- * hardware when they are needed, or are stored in some central location used by
- * many modules within the system. In this case, you can indicate that the
- * attribute is stored externally. When the framework needs to write an external
- * attribute, it makes a call to this callback.
-        This callback is very
- * useful for host micros which need to store attributes in persistent memory.
- * Because each host micro (used with an Ember NCP) has its own type of
- * persistent memory storage, the Application Framework does not include the
- * ability to mark attributes as stored in flash the way that it does for Ember
- * SoCs like the EM35x. On a host micro, any attributes that need to be stored
- * in persistent memory should be marked as external and accessed through the
- * external read and write callbacks. Any host code associated with the
- * persistent storage should be implemented within this callback.
-        All of
- * the important information about the attribute itself is passed as a pointer
- * to an EmberAfAttributeMetadata struct, which is stored within the application
- * and used to manage the attribute. A complete description of the
- * EmberAfAttributeMetadata struct is provided in
- * app/framework/include/af-types.h.
-        This function assumes that the
- * application is able to write the attribute and return immediately. Any
- * attributes that require a state machine for reading and writing are not
- * candidates for externalization at the present time. The Application Framework
- * does not currently include a state machine for reading or writing attributes
- * that must take place across a series of application ticks. Attributes that
- * cannot be written immediately should be stored within the Application
- * Framework and updated occasionally by the application code from within the
- * emberAfMainTickCallback.
-        If the application was successfully able to
- * write the attribute, it returns a value of EMBER_ZCL_STATUS_SUCCESS. Any
- * other return value indicates the application was not able to write the
- * attribute.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeMetadata   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param buffer   Ver.: always
- * @param index   Ver.: always
- */
 EmberAfStatus __attribute__((weak))
 emberAfExternalAttributeWriteCallback(EndpointId endpoint, ClusterId clusterId, EmberAfAttributeMetadata * attributeMetadata,
                                       uint16_t manufacturerCode, uint8_t * buffer, int32_t index)
@@ -678,92 +469,30 @@ emberAfExternalAttributeWriteCallback(EndpointId endpoint, ClusterId clusterId, 
     return EMBER_ZCL_STATUS_FAILURE;
 }
 
-/** @brief Get Current Time
- *
- * This callback is called when device attempts to get current time from the
- * hardware. If this device has means to retrieve exact time, then this method
- * should implement it. If the callback can't provide the exact time it should
- * return 0 to indicate failure. Default action is to return 0, which indicates
- * that device does not have access to real time.
- *
- */
 uint32_t __attribute__((weak)) emberAfGetCurrentTimeCallback()
 {
     return 0;
 }
 
-/** @brief Get Endpoint Info
- *
- * This function is a callback to an application implemented endpoint that
- * operates outside the normal application framework.  When the framework wishes
- * to perform operations with that endpoint it uses this callback to retrieve
- * the endpoint's information.  If the endpoint exists and the application can
- * provide data then true shall be returned.  Otherwise the callback must return
- * false.
- *
- * @param endpoint The endpoint to retrieve data for.  Ver.: always
- * @param returnNetworkIndex The index corresponding to the ZigBee network the
- * endpoint belongs to.  If not using a multi-network device, 0 must be
- * returned.  Otherwise on a multi-network device the stack will switch to this
- * network before sending the message.  Ver.: always
- * @param returnEndpointInfo A pointer to a data struct that will be written
- * with information about the endpoint.  Ver.: always
- */
 bool __attribute__((weak))
 emberAfGetEndpointInfoCallback(EndpointId endpoint, uint8_t * returnNetworkIndex, EmberAfEndpointInfoStruct * returnEndpointInfo)
 {
     return false;
 }
 
-/** @brief Registration Abort
- *
- * This callback is called when the device should abort the registration
- * process.
- *
- */
 void __attribute__((weak)) emberAfRegistrationAbortCallback() {}
 
-/** @brief Interpan Send Message
- *
- * This function will send a raw MAC message with interpan frame format using
- * the passed parameters.
- *
- * @param header Interpan header info  Ver.: always
- * @param messageLength The length of the message received or to send  Ver.:
- * always
- * @param message The message data received or to send.  Ver.: always
- */
 EmberStatus __attribute__((weak))
 emberAfInterpanSendMessageCallback(EmberAfInterpanHeader * header, uint16_t messageLength, uint8_t * message)
 {
     return EMBER_LIBRARY_NOT_PRESENT;
 }
 
-/** @brief Start Move
- *
- * This function is called to initiate the process for a device to move (rejoin)
- * to a new parent.
- *
- */
 bool __attribute__((weak)) emberAfStartMoveCallback()
 {
     return false;
 }
 
-/** @brief Pre Attribute Change
- *
- * This function is called by the application framework before it changes an
- * attribute value.  The value passed into this callback is the value to which
- * the attribute is to be set by the framework.  The application should return
- * chip::Protocols::InteractionModel::Status::Success to permit the change or
- * any other code to reject it.
- *
- * @param attributePath
- * @param mask
- * @param type
- * @param size
- * @param value
- */
 chip::Protocols::InteractionModel::Status __attribute__((weak))
 MatterPreAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t mask, uint8_t type, uint16_t size,
                                  uint8_t * value)
@@ -771,18 +500,6 @@ MatterPreAttributeChangeCallback(const chip::app::ConcreteAttributePath & attrib
     return chip::Protocols::InteractionModel::Status::Success;
 }
 
-/** @brief Post Attribute Change
- *
- * This function is called by the application framework after it changes an
- * attribute value. The value passed into this callback is the value to which
- * the attribute was set by the framework.
- *
- * @param attributePath
- * @param mask
- * @param type
- * @param size
- * @param value
- */
 void __attribute__((weak)) MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t mask,
                                                              uint8_t type, uint16_t size, uint8_t * value)
 {}

--- a/zzz_generated/window-app/zap-generated/callback-stub.cpp
+++ b/zzz_generated/window-app/zap-generated/callback-stub.cpp
@@ -136,66 +136,10 @@ void __attribute__((weak)) emberAfWindowCoveringClusterInitCallback(EndpointId e
 // Non-Cluster Related Callbacks
 //
 
-/** @brief Add To Current App Tasks
- *
- * This function is only useful to sleepy end devices.  This function will note
- * the passed item as part of a set of tasks the application has outstanding
- * (e.g. message sent requiring APS acknwoledgement).  This will affect how the
- * application behaves with regard to sleeping and polling.  Until the
- * outstanding task is completed, the device may poll more frequently and sleep
- * less often.
- *
- * @param tasks   Ver.: always
- */
 void __attribute__((weak)) emberAfAddToCurrentAppTasksCallback(EmberAfApplicationTask tasks) {}
 
-/** @brief Remove From Current App Tasks
- *
- * This function is only useful to sleepy end devices.  This function will
- * remove the passed item from the set of tasks the application has outstanding
- * (e.g. message sent requiring APS acknwoledgement).  This will affect how the
- * application behaves with regard to sleeping and polling.  Removing the item
- * from the list of outstanding tasks may allow the device to sleep longer and
- * poll less frequently.  If there are other outstanding tasks the system may
- * still have to stay away and poll more often.
- *
- * @param tasks   Ver.: always
- */
 void __attribute__((weak)) emberAfRemoveFromCurrentAppTasksCallback(EmberAfApplicationTask tasks) {}
 
-/** @brief Allow Network Write Attribute
- *
- * This function is called by the application framework before it writes an
- * attribute in response to a write attribute request from an external device.
- * The value passed into this callback is the value to which the attribute is to
- * be set by the framework.
-        Example:	In mirroring simple metering data
- * on an Energy Services Interface (ESI) (formerly called Energy Service Portal
- * (ESP) in SE 1.0).), a mirrored simple meter needs to write read-only
- * attributes on its mirror. The-meter-mirror sample application, located in
- * app/framework/sample-apps, uses this callback to allow the mirrored device to
- * write simple metering attributes on the mirror regardless of the fact that
- * most simple metering attributes are defined as read-only by the ZigBee
- * specification.
-        Note:	The ZCL specification does not (as of this
- * writing) specify any permission-level security for writing writeable
- * attributes. As far as the ZCL specification is concerned, if an attribute is
- * writeable, any device that has a link key for the device should be able to
- * write that attribute. Furthermore if an attribute is read only, it should not
- * be written over the air. Thus, if you implement permissions for writing
- * attributes as a feature, you MAY be operating outside the specification. This
- * is unlikely to be a problem for writing read-only attributes, but it may be a
- * problem for attributes that are writeable according to the specification but
- * restricted by the application implementing this callback.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeId   Ver.: always
- * @param mask   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param value   Ver.: always
- * @param type   Ver.: always
- */
 EmberAfAttributeWritePermission __attribute__((weak))
 emberAfAllowNetworkWriteAttributeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
                                           uint16_t manufacturerCode, uint8_t * value, uint8_t type)
@@ -203,140 +147,34 @@ emberAfAllowNetworkWriteAttributeCallback(EndpointId endpoint, ClusterId cluster
     return EMBER_ZCL_ATTRIBUTE_WRITE_PERMISSION_ALLOW_WRITE_NORMAL; // Default
 }
 
-/** @brief Attribute Read Access
- *
- * This function is called whenever the Application Framework needs to check
- * access permission for an attribute read.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param attributeId   Ver.: always
- */
 bool __attribute__((weak))
 emberAfAttributeReadAccessCallback(EndpointId endpoint, ClusterId clusterId, uint16_t manufacturerCode, AttributeId attributeId)
 {
     return true;
 }
 
-/** @brief Attribute Write Access
- *
- * This function is called whenever the Application Framework needs to check
- * access permission for an attribute write.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param attributeId   Ver.: always
- */
 bool __attribute__((weak))
 emberAfAttributeWriteAccessCallback(EndpointId endpoint, ClusterId clusterId, uint16_t manufacturerCode, AttributeId attributeId)
 {
     return true;
 }
 
-/** @brief Default Response
- *
- * This function is called by the application framework when a Default Response
- * command is received from an external device.  The application should return
- * true if the message was processed or false if it was not.
- *
- * @param clusterId The cluster identifier of this response.  Ver.: always
- * @param commandId The command identifier to which this is a response.  Ver.:
- * always
- * @param status Specifies either SUCCESS or the nature of the error that was
- * detected in the received command.  Ver.: always
- */
 bool __attribute__((weak)) emberAfDefaultResponseCallback(ClusterId clusterId, CommandId commandId, EmberAfStatus status)
 {
     return false;
 }
 
-/** @brief Pre Message Send
- *
- * This function is called by the framework when it is about to pass a message
- * to the stack primitives for sending.   This message may or may not be ZCL,
- * ZDO, or some other protocol.  This is called prior to
-        any ZigBee
- * fragmentation that may be done.  If the function returns true it is assumed
- * the callback has consumed and processed the message.  The callback must also
- * set the EmberStatus status code to be passed back to the caller.  The
- * framework will do no further processing on the message.
-        If the
- * function returns false then it is assumed that the callback has not processed
- * the mesasge and the framework will continue to process accordingly.
- *
- * @param messageStruct The structure containing the parameters of the APS
- * message to be sent.  Ver.: always
- * @param status A pointer to the status code value that will be returned to the
- * caller.  Ver.: always
- */
 bool __attribute__((weak)) emberAfPreMessageSendCallback(EmberAfMessageStruct * messageStruct, EmberStatus * status)
 {
     return false;
 }
 
-/** @brief Message Sent
- *
- * This function is called by the application framework from the message sent
- * handler, when it is informed by the stack regarding the message sent status.
- * All of the values passed to the emberMessageSentHandler are passed on to this
- * callback. This provides an opportunity for the application to verify that its
- * message has been sent successfully and take the appropriate action. This
- * callback should return a bool value of true or false. A value of true
- * indicates that the message sent notification has been handled and should not
- * be handled by the application framework.
- *
- * @param type   Ver.: always
- * @param destination   Ver.: always
- * @param apsFrame   Ver.: always
- * @param msgLen   Ver.: always
- * @param message   Ver.: always
- * @param status   Ver.: always
- */
 bool __attribute__((weak)) emberAfMessageSentCallback(const MessageSendDestination & destination, EmberApsFrame * apsFrame,
                                                       uint16_t msgLen, uint8_t * message, EmberStatus status)
 {
     return false;
 }
 
-/** @brief External Attribute Read
- *
- * Like emberAfExternalAttributeWriteCallback above, this function is called
- * when the framework needs to read an attribute that is not stored within the
- * Application Framework's data structures.
-        All of the important
- * information about the attribute itself is passed as a pointer to an
- * EmberAfAttributeMetadata struct, which is stored within the application and
- * used to manage the attribute. A complete description of the
- * EmberAfAttributeMetadata struct is provided in
- * app/framework/include/af-types.h
-        This function assumes that the
- * application is able to read the attribute, write it into the passed buffer,
- * and return immediately. Any attributes that require a state machine for
- * reading and writing are not really candidates for externalization at the
- * present time. The Application Framework does not currently include a state
- * machine for reading or writing attributes that must take place across a
- * series of application ticks. Attributes that cannot be read in a timely
- * manner should be stored within the Application Framework and updated
- * occasionally by the application code from within the
- * emberAfMainTickCallback.
-        If the application was successfully able to
- * read the attribute and write it into the passed buffer, it should return a
- * value of EMBER_ZCL_STATUS_SUCCESS. Ensure that the size of the externally
- * managed attribute value is smaller than what the buffer can hold. In the case
- * of a buffer overflow throw an appropriate error such as
- * EMBER_ZCL_STATUS_INSUFFICIENT_SPACE. Any other return value indicates the
- * application was not able to read the attribute.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeMetadata   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param buffer   Ver.: always
- * @param maxReadLength   Ver.: always
- * @param index   Ver.: always
- */
 EmberAfStatus __attribute__((weak))
 emberAfExternalAttributeReadCallback(EndpointId endpoint, ClusterId clusterId, EmberAfAttributeMetadata * attributeMetadata,
                                      uint16_t manufacturerCode, uint8_t * buffer, uint16_t maxReadLength, int32_t index)
@@ -344,53 +182,6 @@ emberAfExternalAttributeReadCallback(EndpointId endpoint, ClusterId clusterId, E
     return EMBER_ZCL_STATUS_FAILURE;
 }
 
-/** @brief External Attribute Write
- *
- * This function is called whenever the Application Framework needs to write an
- * attribute which is not stored within the data structures of the Application
- * Framework itself. One of the new features in Version 2 is the ability to
- * store attributes outside the Framework. This is particularly useful for
- * attributes that do not need to be stored because they can be read off the
- * hardware when they are needed, or are stored in some central location used by
- * many modules within the system. In this case, you can indicate that the
- * attribute is stored externally. When the framework needs to write an external
- * attribute, it makes a call to this callback.
-        This callback is very
- * useful for host micros which need to store attributes in persistent memory.
- * Because each host micro (used with an Ember NCP) has its own type of
- * persistent memory storage, the Application Framework does not include the
- * ability to mark attributes as stored in flash the way that it does for Ember
- * SoCs like the EM35x. On a host micro, any attributes that need to be stored
- * in persistent memory should be marked as external and accessed through the
- * external read and write callbacks. Any host code associated with the
- * persistent storage should be implemented within this callback.
-        All of
- * the important information about the attribute itself is passed as a pointer
- * to an EmberAfAttributeMetadata struct, which is stored within the application
- * and used to manage the attribute. A complete description of the
- * EmberAfAttributeMetadata struct is provided in
- * app/framework/include/af-types.h.
-        This function assumes that the
- * application is able to write the attribute and return immediately. Any
- * attributes that require a state machine for reading and writing are not
- * candidates for externalization at the present time. The Application Framework
- * does not currently include a state machine for reading or writing attributes
- * that must take place across a series of application ticks. Attributes that
- * cannot be written immediately should be stored within the Application
- * Framework and updated occasionally by the application code from within the
- * emberAfMainTickCallback.
-        If the application was successfully able to
- * write the attribute, it returns a value of EMBER_ZCL_STATUS_SUCCESS. Any
- * other return value indicates the application was not able to write the
- * attribute.
- *
- * @param endpoint   Ver.: always
- * @param clusterId   Ver.: always
- * @param attributeMetadata   Ver.: always
- * @param manufacturerCode   Ver.: always
- * @param buffer   Ver.: always
- * @param index   Ver.: always
- */
 EmberAfStatus __attribute__((weak))
 emberAfExternalAttributeWriteCallback(EndpointId endpoint, ClusterId clusterId, EmberAfAttributeMetadata * attributeMetadata,
                                       uint16_t manufacturerCode, uint8_t * buffer, int32_t index)
@@ -398,92 +189,30 @@ emberAfExternalAttributeWriteCallback(EndpointId endpoint, ClusterId clusterId, 
     return EMBER_ZCL_STATUS_FAILURE;
 }
 
-/** @brief Get Current Time
- *
- * This callback is called when device attempts to get current time from the
- * hardware. If this device has means to retrieve exact time, then this method
- * should implement it. If the callback can't provide the exact time it should
- * return 0 to indicate failure. Default action is to return 0, which indicates
- * that device does not have access to real time.
- *
- */
 uint32_t __attribute__((weak)) emberAfGetCurrentTimeCallback()
 {
     return 0;
 }
 
-/** @brief Get Endpoint Info
- *
- * This function is a callback to an application implemented endpoint that
- * operates outside the normal application framework.  When the framework wishes
- * to perform operations with that endpoint it uses this callback to retrieve
- * the endpoint's information.  If the endpoint exists and the application can
- * provide data then true shall be returned.  Otherwise the callback must return
- * false.
- *
- * @param endpoint The endpoint to retrieve data for.  Ver.: always
- * @param returnNetworkIndex The index corresponding to the ZigBee network the
- * endpoint belongs to.  If not using a multi-network device, 0 must be
- * returned.  Otherwise on a multi-network device the stack will switch to this
- * network before sending the message.  Ver.: always
- * @param returnEndpointInfo A pointer to a data struct that will be written
- * with information about the endpoint.  Ver.: always
- */
 bool __attribute__((weak))
 emberAfGetEndpointInfoCallback(EndpointId endpoint, uint8_t * returnNetworkIndex, EmberAfEndpointInfoStruct * returnEndpointInfo)
 {
     return false;
 }
 
-/** @brief Registration Abort
- *
- * This callback is called when the device should abort the registration
- * process.
- *
- */
 void __attribute__((weak)) emberAfRegistrationAbortCallback() {}
 
-/** @brief Interpan Send Message
- *
- * This function will send a raw MAC message with interpan frame format using
- * the passed parameters.
- *
- * @param header Interpan header info  Ver.: always
- * @param messageLength The length of the message received or to send  Ver.:
- * always
- * @param message The message data received or to send.  Ver.: always
- */
 EmberStatus __attribute__((weak))
 emberAfInterpanSendMessageCallback(EmberAfInterpanHeader * header, uint16_t messageLength, uint8_t * message)
 {
     return EMBER_LIBRARY_NOT_PRESENT;
 }
 
-/** @brief Start Move
- *
- * This function is called to initiate the process for a device to move (rejoin)
- * to a new parent.
- *
- */
 bool __attribute__((weak)) emberAfStartMoveCallback()
 {
     return false;
 }
 
-/** @brief Pre Attribute Change
- *
- * This function is called by the application framework before it changes an
- * attribute value.  The value passed into this callback is the value to which
- * the attribute is to be set by the framework.  The application should return
- * chip::Protocols::InteractionModel::Status::Success to permit the change or
- * any other code to reject it.
- *
- * @param attributePath
- * @param mask
- * @param type
- * @param size
- * @param value
- */
 chip::Protocols::InteractionModel::Status __attribute__((weak))
 MatterPreAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t mask, uint8_t type, uint16_t size,
                                  uint8_t * value)
@@ -491,18 +220,6 @@ MatterPreAttributeChangeCallback(const chip::app::ConcreteAttributePath & attrib
     return chip::Protocols::InteractionModel::Status::Success;
 }
 
-/** @brief Post Attribute Change
- *
- * This function is called by the application framework after it changes an
- * attribute value. The value passed into this callback is the value to which
- * the attribute was set by the framework.
- *
- * @param attributePath
- * @param mask
- * @param type
- * @param size
- * @param value
- */
 void __attribute__((weak)) MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t mask,
                                                              uint8_t type, uint16_t size, uint8_t * value)
 {}


### PR DESCRIPTION
#### Problem

There are plenty of warnings when building with Xcode, mostly related to doxygen...

#### Change overview
 * Fix some of them 
 * Remove useless documentation (where the name of the parameters are just used without any description)
 * Remove duplicate comments
