### PR TITLE
Remove esp32 rpc blacklist from build_examples.py

### DIFF
--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -128,8 +128,8 @@ def Esp32Targets():
 
     yield esp32_target.Extend('m5stack-all-clusters', board=Esp32Board.M5Stack, app=Esp32App.ALL_CLUSTERS)
     yield esp32_target.Extend('m5stack-all-clusters-ipv6only', board=Esp32Board.M5Stack, app=Esp32App.ALL_CLUSTERS, enable_ipv4=False)
-    yield esp32_target.Extend('m5stack-all-clusters-rpc', board=Esp32Board.M5Stack, app=Esp32App.ALL_CLUSTERS, enable_rpcs=True).GlobBlacklist('Generate error in v4.4 IDF SDK')
-    yield esp32_target.Extend('m5stack-all-clusters-rpc-ipv6only', board=Esp32Board.M5Stack, app=Esp32App.ALL_CLUSTERS, enable_rpcs=True, enable_ipv4=False).GlobBlacklist('Generate error in v4.4 IDF SDK')
+    yield esp32_target.Extend('m5stack-all-clusters-rpc', board=Esp32Board.M5Stack, app=Esp32App.ALL_CLUSTERS, enable_rpcs=True)
+    yield esp32_target.Extend('m5stack-all-clusters-rpc-ipv6only', board=Esp32Board.M5Stack, app=Esp32App.ALL_CLUSTERS, enable_rpcs=True, enable_ipv4=False)
 
     yield esp32_target.Extend('c3devkit-all-clusters', board=Esp32Board.C3DevKit, app=Esp32App.ALL_CLUSTERS)
 

--- a/scripts/build/testdata/all_targets_except_host.txt
+++ b/scripts/build/testdata/all_targets_except_host.txt
@@ -23,8 +23,8 @@ esp32-devkitc-shell
 esp32-devkitc-temperature-measurement
 esp32-m5stack-all-clusters
 esp32-m5stack-all-clusters-ipv6only
-esp32-m5stack-all-clusters-rpc (NOGLOB: Generate error in v4.4 IDF SDK)
-esp32-m5stack-all-clusters-rpc-ipv6only (NOGLOB: Generate error in v4.4 IDF SDK)
+esp32-m5stack-all-clusters-rpc
+esp32-m5stack-all-clusters-rpc-ipv6only
 infineon-p6-all-clusters
 infineon-p6-lock
 mbed-CY8CPROTO_062_4343W-all-clusters-debug (NOGLOB: Compile only for debugging purpose - https://os.mbed.com/docs/mbed-os/latest/program-setup/build-profiles-and-rules.html)

--- a/scripts/build/testdata/glob_star_targets_except_host.txt
+++ b/scripts/build/testdata/glob_star_targets_except_host.txt
@@ -23,6 +23,8 @@ esp32-devkitc-shell
 esp32-devkitc-temperature-measurement
 esp32-m5stack-all-clusters
 esp32-m5stack-all-clusters-ipv6only
+esp32-m5stack-all-clusters-rpc
+esp32-m5stack-all-clusters-rpc-ipv6only
 infineon-p6-all-clusters
 infineon-p6-lock
 mbed-CY8CPROTO_062_4343W-all-clusters-release


### PR DESCRIPTION
#### Problem
RPC builds were blacklisted however fix for rpc builds already in ToT

#### Change overview
Remove the blacklist and fix unit tests

#### Testing
```sh
./scripts/build/build_examples.py --target-glob '*m5*rpc*' build
```