### PR TITLE
Size reports: Fix parent SHA race

### DIFF
--- a/.github/workflows/examples-efr32.yaml
+++ b/.github/workflows/examples-efr32.yaml
@@ -46,6 +46,16 @@ jobs:
               uses: actions/checkout@v2
               with:
                   submodules: true
+
+            - name: Get parent for size reports
+              run: |
+                MERGE_PARENT="$(git --no-pager log -1 --pretty=tformat:%s | sed -n -e 's/Merge [0-9a-f]\+ into //p')"
+                if [[ -z "${MERGE_PARENT}" || "${GH_EVENT_PR}" == 0 ]]
+                then
+                  MERGE_PARENT=$GH_EVENT_BASE
+                fi
+                echo "GH_EVENT_PARENT=$MERGE_PARENT" >>$GITHUB_ENV
+
             - name: Bootstrap
               timeout-minutes: 25
               run: scripts/build/gn_bootstrap.sh
@@ -82,15 +92,6 @@ jobs:
                   scripts/examples/gn_efr32_example.sh examples/window-app/efr32/ out/window_app_debug BRD4161A
                   .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py efr32 BRD4161A window-app \
                     out/window_app_debug/BRD4161A/chip-efr32-window-example.out /tmp/bloat_reports/
-
-            - name: Get parent for size reports
-              run: |
-                MERGE_PARENT="$(git --no-pager log -1 --pretty=tformat:%s | sed -n -e 's/Merge [0-9a-f]\+ into //p')"
-                if [[ -z "${MERGE_PARENT}" || "${GH_EVENT_PR}" == 0 ]]
-                then
-                  MERGE_PARENT=$GH_EVENT_BASE
-                fi
-                echo "GH_EVENT_PARENT=$MERGE_PARENT" >>$GITHUB_ENV
 
             - name: Uploading Size Reports
               uses: actions/upload-artifact@v2

--- a/.github/workflows/examples-efr32.yaml
+++ b/.github/workflows/examples-efr32.yaml
@@ -51,7 +51,7 @@ jobs:
               shell: bash
               run: |
                 MERGE_PARENT="$(git --no-pager log -1 --pretty=tformat:%s | sed -n -e 's/Merge [0-9a-f]\+ into //p')"
-                if test -z "${MERGE_PARENT}" || test "${GH_EVENT_PARENT}" == 0
+                if test -z "${MERGE_PARENT}" || test "${GH_EVENT_PARENT}" = 0
                 then
                   MERGE_PARENT=$GH_EVENT_BASE
                 fi

--- a/.github/workflows/examples-efr32.yaml
+++ b/.github/workflows/examples-efr32.yaml
@@ -48,9 +48,10 @@ jobs:
                   submodules: true
 
             - name: Get parent for size reports
+              shell: bash
               run: |
                 MERGE_PARENT="$(git --no-pager log -1 --pretty=tformat:%s | sed -n -e 's/Merge [0-9a-f]\+ into //p')"
-                if [[ -z "${MERGE_PARENT}" || "${GH_EVENT_PR}" == 0 ]]
+                if test -z "${MERGE_PARENT}" || test "${GH_EVENT_PARENT}" == 0
                 then
                   MERGE_PARENT=$GH_EVENT_BASE
                 fi

--- a/.github/workflows/examples-efr32.yaml
+++ b/.github/workflows/examples-efr32.yaml
@@ -32,7 +32,7 @@ jobs:
             BUILD_TYPE: gn_efr32
             GH_EVENT_PR: ${{ github.event_name == 'pull_request' && github.event.number || 0 }}
             GH_EVENT_HASH: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-            GH_EVENT_PARENT: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+            GH_EVENT_BASE: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
 
         runs-on: ubuntu-latest
         if: github.actor != 'restyled-io[bot]'
@@ -82,6 +82,16 @@ jobs:
                   scripts/examples/gn_efr32_example.sh examples/window-app/efr32/ out/window_app_debug BRD4161A
                   .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py efr32 BRD4161A window-app \
                     out/window_app_debug/BRD4161A/chip-efr32-window-example.out /tmp/bloat_reports/
+
+            - name: Get parent for size reports
+              run: |
+                MERGE_PARENT="$(git --no-pager log -1 --pretty=tformat:%s | sed -n -e 's/Merge [0-9a-f]\+ into //p')"
+                if [[ -z "${MERGE_PARENT}" || "${GH_EVENT_PR}" == 0 ]]
+                then
+                  MERGE_PARENT=$GH_EVENT_BASE
+                fi
+                echo "GH_EVENT_PARENT=$MERGE_PARENT" >>$GITHUB_ENV
+
             - name: Uploading Size Reports
               uses: actions/upload-artifact@v2
               if: ${{ !env.ACT }}

--- a/.github/workflows/examples-esp32.yaml
+++ b/.github/workflows/examples-esp32.yaml
@@ -51,7 +51,7 @@ jobs:
             - name: Get parent for size reports
               run: |
                 MERGE_PARENT="$(git --no-pager log -1 --pretty=tformat:%s | sed -n -e 's/Merge [0-9a-f]\+ into //p')"
-                if [[ -z "${MERGE_PARENT}" || "${GH_EVENT_PR}" == 0 ]]
+                if test -z "${MERGE_PARENT}" || test "${GH_EVENT_PARENT}" == 0
                 then
                   MERGE_PARENT=$GH_EVENT_BASE
                 fi

--- a/.github/workflows/examples-esp32.yaml
+++ b/.github/workflows/examples-esp32.yaml
@@ -51,7 +51,7 @@ jobs:
             - name: Get parent for size reports
               run: |
                 MERGE_PARENT="$(git --no-pager log -1 --pretty=tformat:%s | sed -n -e 's/Merge [0-9a-f]\+ into //p')"
-                if test -z "${MERGE_PARENT}" || test "${GH_EVENT_PARENT}" == 0
+                if test -z "${MERGE_PARENT}" || test "${GH_EVENT_PARENT}" = 0
                 then
                   MERGE_PARENT=$GH_EVENT_BASE
                 fi

--- a/.github/workflows/examples-esp32.yaml
+++ b/.github/workflows/examples-esp32.yaml
@@ -47,6 +47,16 @@ jobs:
               uses: actions/checkout@v2
               with:
                   submodules: true
+
+            - name: Get parent for size reports
+              run: |
+                MERGE_PARENT="$(git --no-pager log -1 --pretty=tformat:%s | sed -n -e 's/Merge [0-9a-f]\+ into //p')"
+                if [[ -z "${MERGE_PARENT}" || "${GH_EVENT_PR}" == 0 ]]
+                then
+                  MERGE_PARENT=$GH_EVENT_BASE
+                fi
+                echo "GH_EVENT_PARENT=$MERGE_PARENT" >>$GITHUB_ENV
+
             - name: Bootstrap
               timeout-minutes: 25
               run: scripts/build/gn_bootstrap.sh
@@ -103,15 +113,6 @@ jobs:
             - name: Build example IPv6 Only App
               timeout-minutes: 10
               run: scripts/examples/esp_example.sh ipv6only-app sdkconfig.defaults
-
-            - name: Get parent for size reports
-              run: |
-                MERGE_PARENT="$(git --no-pager log -1 --pretty=tformat:%s | sed -n -e 's/Merge [0-9a-f]\+ into //p')"
-                if [[ -z "${MERGE_PARENT}" || "${GH_EVENT_PR}" == 0 ]]
-                then
-                  MERGE_PARENT=$GH_EVENT_BASE
-                fi
-                echo "GH_EVENT_PARENT=$MERGE_PARENT" >>$GITHUB_ENV
 
             - name: Uploading Size Reports
               uses: actions/upload-artifact@v2

--- a/.github/workflows/examples-esp32.yaml
+++ b/.github/workflows/examples-esp32.yaml
@@ -32,7 +32,7 @@ jobs:
             BUILD_TYPE: esp32
             GH_EVENT_PR: ${{ github.event_name == 'pull_request' && github.event.number || 0 }}
             GH_EVENT_HASH: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-            GH_EVENT_PARENT: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+            GH_EVENT_BASE: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
 
         runs-on: ubuntu-latest
         if: github.actor != 'restyled-io[bot]'
@@ -103,6 +103,16 @@ jobs:
             - name: Build example IPv6 Only App
               timeout-minutes: 10
               run: scripts/examples/esp_example.sh ipv6only-app sdkconfig.defaults
+
+            - name: Get parent for size reports
+              run: |
+                MERGE_PARENT="$(git --no-pager log -1 --pretty=tformat:%s | sed -n -e 's/Merge [0-9a-f]\+ into //p')"
+                if [[ -z "${MERGE_PARENT}" || "${GH_EVENT_PR}" == 0 ]]
+                then
+                  MERGE_PARENT=$GH_EVENT_BASE
+                fi
+                echo "GH_EVENT_PARENT=$MERGE_PARENT" >>$GITHUB_ENV
+
             - name: Uploading Size Reports
               uses: actions/upload-artifact@v2
               if: ${{ !env.ACT }}

--- a/.github/workflows/examples-infineon.yaml
+++ b/.github/workflows/examples-infineon.yaml
@@ -48,7 +48,7 @@ jobs:
             - name: Get parent for size reports
               run: |
                 MERGE_PARENT="$(git --no-pager log -1 --pretty=tformat:%s | sed -n -e 's/Merge [0-9a-f]\+ into //p')"
-                if test -z "${MERGE_PARENT}" || test "${GH_EVENT_PARENT}" == 0
+                if test -z "${MERGE_PARENT}" || test "${GH_EVENT_PARENT}" = 0
                 then
                   MERGE_PARENT=$GH_EVENT_BASE
                 fi

--- a/.github/workflows/examples-infineon.yaml
+++ b/.github/workflows/examples-infineon.yaml
@@ -44,6 +44,16 @@ jobs:
               uses: actions/checkout@v2
               with:
                   submodules: true
+
+            - name: Get parent for size reports
+              run: |
+                MERGE_PARENT="$(git --no-pager log -1 --pretty=tformat:%s | sed -n -e 's/Merge [0-9a-f]\+ into //p')"
+                if [[ -z "${MERGE_PARENT}" || "${GH_EVENT_PR}" == 0 ]]
+                then
+                  MERGE_PARENT=$GH_EVENT_BASE
+                fi
+                echo "GH_EVENT_PARENT=$MERGE_PARENT" >>$GITHUB_ENV
+
             - name: Bootstrap
               timeout-minutes: 25
               run: scripts/build/gn_bootstrap.sh
@@ -71,15 +81,6 @@ jobs:
                 .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
                     p6 default all-clusters-app \
                     out/infineon-p6-all-clusters/chip-p6-clusters-example.out
-
-            - name: Get parent for size reports
-              run: |
-                MERGE_PARENT="$(git --no-pager log -1 --pretty=tformat:%s | sed -n -e 's/Merge [0-9a-f]\+ into //p')"
-                if [[ -z "${MERGE_PARENT}" || "${GH_EVENT_PR}" == 0 ]]
-                then
-                  MERGE_PARENT=$GH_EVENT_BASE
-                fi
-                echo "GH_EVENT_PARENT=$MERGE_PARENT" >>$GITHUB_ENV
 
             - name: Uploading Size Reports
               uses: actions/upload-artifact@v2

--- a/.github/workflows/examples-infineon.yaml
+++ b/.github/workflows/examples-infineon.yaml
@@ -31,7 +31,7 @@ jobs:
         env:
             GH_EVENT_PR: ${{ github.event_name == 'pull_request' && github.event.number || 0 }}
             GH_EVENT_HASH: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-            GH_EVENT_PARENT: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+            GH_EVENT_BASE: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
 
         runs-on: ubuntu-latest
         if: github.actor != 'restyled-io[bot]'
@@ -71,6 +71,16 @@ jobs:
                 .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
                     p6 default all-clusters-app \
                     out/infineon-p6-all-clusters/chip-p6-clusters-example.out
+
+            - name: Get parent for size reports
+              run: |
+                MERGE_PARENT="$(git --no-pager log -1 --pretty=tformat:%s | sed -n -e 's/Merge [0-9a-f]\+ into //p')"
+                if [[ -z "${MERGE_PARENT}" || "${GH_EVENT_PR}" == 0 ]]
+                then
+                  MERGE_PARENT=$GH_EVENT_BASE
+                fi
+                echo "GH_EVENT_PARENT=$MERGE_PARENT" >>$GITHUB_ENV
+
             - name: Uploading Size Reports
               uses: actions/upload-artifact@v2
               if: ${{ !env.ACT }}

--- a/.github/workflows/examples-infineon.yaml
+++ b/.github/workflows/examples-infineon.yaml
@@ -48,7 +48,7 @@ jobs:
             - name: Get parent for size reports
               run: |
                 MERGE_PARENT="$(git --no-pager log -1 --pretty=tformat:%s | sed -n -e 's/Merge [0-9a-f]\+ into //p')"
-                if [[ -z "${MERGE_PARENT}" || "${GH_EVENT_PR}" == 0 ]]
+                if test -z "${MERGE_PARENT}" || test "${GH_EVENT_PARENT}" == 0
                 then
                   MERGE_PARENT=$GH_EVENT_BASE
                 fi

--- a/.github/workflows/examples-k32w.yaml
+++ b/.github/workflows/examples-k32w.yaml
@@ -49,7 +49,7 @@ jobs:
             - name: Get parent for size reports
               run: |
                 MERGE_PARENT="$(git --no-pager log -1 --pretty=tformat:%s | sed -n -e 's/Merge [0-9a-f]\+ into //p')"
-                if [[ -z "${MERGE_PARENT}" || "${GH_EVENT_PR}" == 0 ]]
+                if test -z "${MERGE_PARENT}" || test "${GH_EVENT_PARENT}" == 0
                 then
                   MERGE_PARENT=$GH_EVENT_BASE
                 fi

--- a/.github/workflows/examples-k32w.yaml
+++ b/.github/workflows/examples-k32w.yaml
@@ -49,7 +49,7 @@ jobs:
             - name: Get parent for size reports
               run: |
                 MERGE_PARENT="$(git --no-pager log -1 --pretty=tformat:%s | sed -n -e 's/Merge [0-9a-f]\+ into //p')"
-                if test -z "${MERGE_PARENT}" || test "${GH_EVENT_PARENT}" == 0
+                if test -z "${MERGE_PARENT}" || test "${GH_EVENT_PARENT}" = 0
                 then
                   MERGE_PARENT=$GH_EVENT_BASE
                 fi

--- a/.github/workflows/examples-k32w.yaml
+++ b/.github/workflows/examples-k32w.yaml
@@ -45,6 +45,16 @@ jobs:
               uses: actions/checkout@v2
               with:
                   submodules: true
+
+            - name: Get parent for size reports
+              run: |
+                MERGE_PARENT="$(git --no-pager log -1 --pretty=tformat:%s | sed -n -e 's/Merge [0-9a-f]\+ into //p')"
+                if [[ -z "${MERGE_PARENT}" || "${GH_EVENT_PR}" == 0 ]]
+                then
+                  MERGE_PARENT=$GH_EVENT_BASE
+                fi
+                echo "GH_EVENT_PARENT=$MERGE_PARENT" >>$GITHUB_ENV
+
             - name: Bootstrap
               timeout-minutes: 25
               run: scripts/build/gn_bootstrap.sh
@@ -83,15 +93,6 @@ jobs:
                     k32w k32w061+se05x+release lighting-app \
                     out/lighting_app_se_release/chip-k32w061-light-example \
                     /tmp/bloat_reports/
-
-            - name: Get parent for size reports
-              run: |
-                MERGE_PARENT="$(git --no-pager log -1 --pretty=tformat:%s | sed -n -e 's/Merge [0-9a-f]\+ into //p')"
-                if [[ -z "${MERGE_PARENT}" || "${GH_EVENT_PR}" == 0 ]]
-                then
-                  MERGE_PARENT=$GH_EVENT_BASE
-                fi
-                echo "GH_EVENT_PARENT=$MERGE_PARENT" >>$GITHUB_ENV
 
             - name: Uploading Size Reports
               uses: actions/upload-artifact@v2

--- a/.github/workflows/examples-k32w.yaml
+++ b/.github/workflows/examples-k32w.yaml
@@ -31,7 +31,7 @@ jobs:
             BUILD_TYPE: gn_k32w
             GH_EVENT_PR: ${{ github.event_name == 'pull_request' && github.event.number || 0 }}
             GH_EVENT_HASH: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-            GH_EVENT_PARENT: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+            GH_EVENT_BASE: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
 
         runs-on: ubuntu-latest
         if: github.actor != 'restyled-io[bot]'
@@ -83,6 +83,16 @@ jobs:
                     k32w k32w061+se05x+release lighting-app \
                     out/lighting_app_se_release/chip-k32w061-light-example \
                     /tmp/bloat_reports/
+
+            - name: Get parent for size reports
+              run: |
+                MERGE_PARENT="$(git --no-pager log -1 --pretty=tformat:%s | sed -n -e 's/Merge [0-9a-f]\+ into //p')"
+                if [[ -z "${MERGE_PARENT}" || "${GH_EVENT_PR}" == 0 ]]
+                then
+                  MERGE_PARENT=$GH_EVENT_BASE
+                fi
+                echo "GH_EVENT_PARENT=$MERGE_PARENT" >>$GITHUB_ENV
+
             - name: Uploading Size Reports
               uses: actions/upload-artifact@v2
               if: ${{ !env.ACT }}

--- a/.github/workflows/examples-linux-standalone.yaml
+++ b/.github/workflows/examples-linux-standalone.yaml
@@ -46,6 +46,16 @@ jobs:
               uses: actions/checkout@v2
               with:
                   submodules: true
+
+            - name: Get parent for size reports
+              run: |
+                MERGE_PARENT="$(git --no-pager log -1 --pretty=tformat:%s | sed -n -e 's/Merge [0-9a-f]\+ into //p')"
+                if [[ -z "${MERGE_PARENT}" || "${GH_EVENT_PR}" == 0 ]]
+                then
+                  MERGE_PARENT=$GH_EVENT_BASE
+                fi
+                echo "GH_EVENT_PARENT=$MERGE_PARENT" >>$GITHUB_ENV
+
             - name: Bootstrap
               timeout-minutes: 10
               run: scripts/build/gn_bootstrap.sh
@@ -123,15 +133,6 @@ jobs:
                     linux debug ota-requestor-app \
                     out/ota_requestor_debug/chip-ota-requestor-app \
                     /tmp/bloat_reports/
-
-            - name: Get parent for size reports
-              run: |
-                MERGE_PARENT="$(git --no-pager log -1 --pretty=tformat:%s | sed -n -e 's/Merge [0-9a-f]\+ into //p')"
-                if [[ -z "${MERGE_PARENT}" || "${GH_EVENT_PR}" == 0 ]]
-                then
-                  MERGE_PARENT=$GH_EVENT_BASE
-                fi
-                echo "GH_EVENT_PARENT=$MERGE_PARENT" >>$GITHUB_ENV
 
             - name: Uploading Size Reports
               uses: actions/upload-artifact@v2

--- a/.github/workflows/examples-linux-standalone.yaml
+++ b/.github/workflows/examples-linux-standalone.yaml
@@ -31,7 +31,7 @@ jobs:
             BUILD_TYPE: gn_linux
             GH_EVENT_PR: ${{ github.event_name == 'pull_request' && github.event.number || 0 }}
             GH_EVENT_HASH: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-            GH_EVENT_PARENT: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+            GH_EVENT_BASE: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
 
         runs-on: ubuntu-latest
         if: github.actor != 'restyled-io[bot]'
@@ -123,6 +123,16 @@ jobs:
                     linux debug ota-requestor-app \
                     out/ota_requestor_debug/chip-ota-requestor-app \
                     /tmp/bloat_reports/
+
+            - name: Get parent for size reports
+              run: |
+                MERGE_PARENT="$(git --no-pager log -1 --pretty=tformat:%s | sed -n -e 's/Merge [0-9a-f]\+ into //p')"
+                if [[ -z "${MERGE_PARENT}" || "${GH_EVENT_PR}" == 0 ]]
+                then
+                  MERGE_PARENT=$GH_EVENT_BASE
+                fi
+                echo "GH_EVENT_PARENT=$MERGE_PARENT" >>$GITHUB_ENV
+
             - name: Uploading Size Reports
               uses: actions/upload-artifact@v2
               if: ${{ !env.ACT }}

--- a/.github/workflows/examples-linux-standalone.yaml
+++ b/.github/workflows/examples-linux-standalone.yaml
@@ -50,7 +50,7 @@ jobs:
             - name: Get parent for size reports
               run: |
                 MERGE_PARENT="$(git --no-pager log -1 --pretty=tformat:%s | sed -n -e 's/Merge [0-9a-f]\+ into //p')"
-                if test -z "${MERGE_PARENT}" || test "${GH_EVENT_PARENT}" == 0
+                if test -z "${MERGE_PARENT}" || test "${GH_EVENT_PARENT}" = 0
                 then
                   MERGE_PARENT=$GH_EVENT_BASE
                 fi

--- a/.github/workflows/examples-linux-standalone.yaml
+++ b/.github/workflows/examples-linux-standalone.yaml
@@ -50,7 +50,7 @@ jobs:
             - name: Get parent for size reports
               run: |
                 MERGE_PARENT="$(git --no-pager log -1 --pretty=tformat:%s | sed -n -e 's/Merge [0-9a-f]\+ into //p')"
-                if [[ -z "${MERGE_PARENT}" || "${GH_EVENT_PR}" == 0 ]]
+                if test -z "${MERGE_PARENT}" || test "${GH_EVENT_PARENT}" == 0
                 then
                   MERGE_PARENT=$GH_EVENT_BASE
                 fi

--- a/.github/workflows/examples-mbed.yaml
+++ b/.github/workflows/examples-mbed.yaml
@@ -53,7 +53,7 @@ jobs:
             - name: Get parent for size reports
               run: |
                 MERGE_PARENT="$(git --no-pager log -1 --pretty=tformat:%s | sed -n -e 's/Merge [0-9a-f]\+ into //p')"
-                if test -z "${MERGE_PARENT}" || test "${GH_EVENT_PARENT}" == 0
+                if test -z "${MERGE_PARENT}" || test "${GH_EVENT_PARENT}" = 0
                 then
                   MERGE_PARENT=$GH_EVENT_BASE
                 fi

--- a/.github/workflows/examples-mbed.yaml
+++ b/.github/workflows/examples-mbed.yaml
@@ -53,7 +53,7 @@ jobs:
             - name: Get parent for size reports
               run: |
                 MERGE_PARENT="$(git --no-pager log -1 --pretty=tformat:%s | sed -n -e 's/Merge [0-9a-f]\+ into //p')"
-                if [[ -z "${MERGE_PARENT}" || "${GH_EVENT_PR}" == 0 ]]
+                if test -z "${MERGE_PARENT}" || test "${GH_EVENT_PARENT}" == 0
                 then
                   MERGE_PARENT=$GH_EVENT_BASE
                 fi

--- a/.github/workflows/examples-mbed.yaml
+++ b/.github/workflows/examples-mbed.yaml
@@ -50,6 +50,15 @@ jobs:
               with:
                   submodules: true
 
+            - name: Get parent for size reports
+              run: |
+                MERGE_PARENT="$(git --no-pager log -1 --pretty=tformat:%s | sed -n -e 's/Merge [0-9a-f]\+ into //p')"
+                if [[ -z "${MERGE_PARENT}" || "${GH_EVENT_PR}" == 0 ]]
+                then
+                  MERGE_PARENT=$GH_EVENT_BASE
+                fi
+                echo "GH_EVENT_PARENT=$MERGE_PARENT" >>$GITHUB_ENV
+
             - name: Bootstrap
               timeout-minutes: 10
               run: scripts/build/gn_bootstrap.sh
@@ -111,15 +120,6 @@ jobs:
             - name: Build unit tests
               timeout-minutes: 10
               run: scripts/tests/mbed/mbed_unit_tests.sh -b=$APP_TARGET -p=$APP_PROFILE
-
-            - name: Get parent for size reports
-              run: |
-                MERGE_PARENT="$(git --no-pager log -1 --pretty=tformat:%s | sed -n -e 's/Merge [0-9a-f]\+ into //p')"
-                if [[ -z "${MERGE_PARENT}" || "${GH_EVENT_PR}" == 0 ]]
-                then
-                  MERGE_PARENT=$GH_EVENT_BASE
-                fi
-                echo "GH_EVENT_PARENT=$MERGE_PARENT" >>$GITHUB_ENV
 
             - name: Uploading Size Reports
               uses: actions/upload-artifact@v2

--- a/.github/workflows/examples-mbed.yaml
+++ b/.github/workflows/examples-mbed.yaml
@@ -34,7 +34,7 @@ jobs:
             APP_TARGET: CY8CPROTO_062_4343W
             GH_EVENT_PR: ${{ github.event_name == 'pull_request' && github.event.number || 0 }}
             GH_EVENT_HASH: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-            GH_EVENT_PARENT: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+            GH_EVENT_BASE: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
 
         runs-on: ubuntu-latest
         if: github.actor != 'restyled-io[bot]'
@@ -111,6 +111,15 @@ jobs:
             - name: Build unit tests
               timeout-minutes: 10
               run: scripts/tests/mbed/mbed_unit_tests.sh -b=$APP_TARGET -p=$APP_PROFILE
+
+            - name: Get parent for size reports
+              run: |
+                MERGE_PARENT="$(git --no-pager log -1 --pretty=tformat:%s | sed -n -e 's/Merge [0-9a-f]\+ into //p')"
+                if [[ -z "${MERGE_PARENT}" || "${GH_EVENT_PR}" == 0 ]]
+                then
+                  MERGE_PARENT=$GH_EVENT_BASE
+                fi
+                echo "GH_EVENT_PARENT=$MERGE_PARENT" >>$GITHUB_ENV
 
             - name: Uploading Size Reports
               uses: actions/upload-artifact@v2

--- a/.github/workflows/examples-nrfconnect.yaml
+++ b/.github/workflows/examples-nrfconnect.yaml
@@ -50,7 +50,7 @@ jobs:
             - name: Get parent for size reports
               run: |
                 MERGE_PARENT="$(git --no-pager log -1 --pretty=tformat:%s | sed -n -e 's/Merge [0-9a-f]\+ into //p')"
-                if test -z "${MERGE_PARENT}" || test "${GH_EVENT_PARENT}" == 0
+                if test -z "${MERGE_PARENT}" || test "${GH_EVENT_PARENT}" = 0
                 then
                   MERGE_PARENT=$GH_EVENT_BASE
                 fi

--- a/.github/workflows/examples-nrfconnect.yaml
+++ b/.github/workflows/examples-nrfconnect.yaml
@@ -50,7 +50,7 @@ jobs:
             - name: Get parent for size reports
               run: |
                 MERGE_PARENT="$(git --no-pager log -1 --pretty=tformat:%s | sed -n -e 's/Merge [0-9a-f]\+ into //p')"
-                if [[ -z "${MERGE_PARENT}" || "${GH_EVENT_PR}" == 0 ]]
+                if test -z "${MERGE_PARENT}" || test "${GH_EVENT_PARENT}" == 0
                 then
                   MERGE_PARENT=$GH_EVENT_BASE
                 fi

--- a/.github/workflows/examples-nrfconnect.yaml
+++ b/.github/workflows/examples-nrfconnect.yaml
@@ -46,6 +46,16 @@ jobs:
               uses: actions/checkout@v2
               with:
                   submodules: true
+
+            - name: Get parent for size reports
+              run: |
+                MERGE_PARENT="$(git --no-pager log -1 --pretty=tformat:%s | sed -n -e 's/Merge [0-9a-f]\+ into //p')"
+                if [[ -z "${MERGE_PARENT}" || "${GH_EVENT_PR}" == 0 ]]
+                then
+                  MERGE_PARENT=$GH_EVENT_BASE
+                fi
+                echo "GH_EVENT_PARENT=$MERGE_PARENT" >>$GITHUB_ENV
+
             - name: Bootstrap
               timeout-minutes: 25
               run: scripts/build/gn_bootstrap.sh
@@ -144,15 +154,6 @@ jobs:
               timeout-minutes: 10
               run: |
                   scripts/run_in_build_env.sh "scripts/tests/nrfconnect_native_posix_tests.sh native_posix_64"
-
-            - name: Get parent for size reports
-              run: |
-                MERGE_PARENT="$(git --no-pager log -1 --pretty=tformat:%s | sed -n -e 's/Merge [0-9a-f]\+ into //p')"
-                if [[ -z "${MERGE_PARENT}" || "${GH_EVENT_PR}" == 0 ]]
-                then
-                  MERGE_PARENT=$GH_EVENT_BASE
-                fi
-                echo "GH_EVENT_PARENT=$MERGE_PARENT" >>$GITHUB_ENV
 
             - name: Uploading Size Reports
               uses: actions/upload-artifact@v2

--- a/.github/workflows/examples-nrfconnect.yaml
+++ b/.github/workflows/examples-nrfconnect.yaml
@@ -31,7 +31,7 @@ jobs:
             BUILD_TYPE: nrfconnect
             GH_EVENT_PR: ${{ github.event_name == 'pull_request' && github.event.number || 0 }}
             GH_EVENT_HASH: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-            GH_EVENT_PARENT: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+            GH_EVENT_BASE: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
 
         runs-on: ubuntu-latest
         if: github.actor != 'restyled-io[bot]'
@@ -144,6 +144,16 @@ jobs:
               timeout-minutes: 10
               run: |
                   scripts/run_in_build_env.sh "scripts/tests/nrfconnect_native_posix_tests.sh native_posix_64"
+
+            - name: Get parent for size reports
+              run: |
+                MERGE_PARENT="$(git --no-pager log -1 --pretty=tformat:%s | sed -n -e 's/Merge [0-9a-f]\+ into //p')"
+                if [[ -z "${MERGE_PARENT}" || "${GH_EVENT_PR}" == 0 ]]
+                then
+                  MERGE_PARENT=$GH_EVENT_BASE
+                fi
+                echo "GH_EVENT_PARENT=$MERGE_PARENT" >>$GITHUB_ENV
+
             - name: Uploading Size Reports
               uses: actions/upload-artifact@v2
               if: ${{ !env.ACT }}

--- a/.github/workflows/examples-qpg.yaml
+++ b/.github/workflows/examples-qpg.yaml
@@ -45,6 +45,16 @@ jobs:
               uses: actions/checkout@v2
               with:
                   submodules: true
+
+            - name: Get parent for size reports
+              run: |
+                MERGE_PARENT="$(git --no-pager log -1 --pretty=tformat:%s | sed -n -e 's/Merge [0-9a-f]\+ into //p')"
+                if [[ -z "${MERGE_PARENT}" || "${GH_EVENT_PR}" == 0 ]]
+                then
+                  MERGE_PARENT=$GH_EVENT_BASE
+                fi
+                echo "GH_EVENT_PARENT=$MERGE_PARENT" >>$GITHUB_ENV
+
             - name: Bootstrap
               timeout-minutes: 25
               run: scripts/build/gn_bootstrap.sh
@@ -85,15 +95,6 @@ jobs:
               timeout-minutes: 5
               run: |
                   config/qpg/chip-gn/build.sh
-
-            - name: Get parent for size reports
-              run: |
-                MERGE_PARENT="$(git --no-pager log -1 --pretty=tformat:%s | sed -n -e 's/Merge [0-9a-f]\+ into //p')"
-                if [[ -z "${MERGE_PARENT}" || "${GH_EVENT_PR}" == 0 ]]
-                then
-                  MERGE_PARENT=$GH_EVENT_BASE
-                fi
-                echo "GH_EVENT_PARENT=$MERGE_PARENT" >>$GITHUB_ENV
 
             - name: Uploading Size Reports
               uses: actions/upload-artifact@v2

--- a/.github/workflows/examples-qpg.yaml
+++ b/.github/workflows/examples-qpg.yaml
@@ -49,7 +49,7 @@ jobs:
             - name: Get parent for size reports
               run: |
                 MERGE_PARENT="$(git --no-pager log -1 --pretty=tformat:%s | sed -n -e 's/Merge [0-9a-f]\+ into //p')"
-                if [[ -z "${MERGE_PARENT}" || "${GH_EVENT_PR}" == 0 ]]
+                if test -z "${MERGE_PARENT}" || test "${GH_EVENT_PARENT}" == 0
                 then
                   MERGE_PARENT=$GH_EVENT_BASE
                 fi

--- a/.github/workflows/examples-qpg.yaml
+++ b/.github/workflows/examples-qpg.yaml
@@ -49,7 +49,7 @@ jobs:
             - name: Get parent for size reports
               run: |
                 MERGE_PARENT="$(git --no-pager log -1 --pretty=tformat:%s | sed -n -e 's/Merge [0-9a-f]\+ into //p')"
-                if test -z "${MERGE_PARENT}" || test "${GH_EVENT_PARENT}" == 0
+                if test -z "${MERGE_PARENT}" || test "${GH_EVENT_PARENT}" = 0
                 then
                   MERGE_PARENT=$GH_EVENT_BASE
                 fi

--- a/.github/workflows/examples-qpg.yaml
+++ b/.github/workflows/examples-qpg.yaml
@@ -31,7 +31,7 @@ jobs:
             BUILD_TYPE: gn_qpg
             GH_EVENT_PR: ${{ github.event_name == 'pull_request' && github.event.number || 0 }}
             GH_EVENT_HASH: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-            GH_EVENT_PARENT: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+            GH_EVENT_BASE: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
 
         runs-on: ubuntu-latest
         if: github.actor != 'restyled-io[bot]'
@@ -85,6 +85,16 @@ jobs:
               timeout-minutes: 5
               run: |
                   config/qpg/chip-gn/build.sh
+
+            - name: Get parent for size reports
+              run: |
+                MERGE_PARENT="$(git --no-pager log -1 --pretty=tformat:%s | sed -n -e 's/Merge [0-9a-f]\+ into //p')"
+                if [[ -z "${MERGE_PARENT}" || "${GH_EVENT_PR}" == 0 ]]
+                then
+                  MERGE_PARENT=$GH_EVENT_BASE
+                fi
+                echo "GH_EVENT_PARENT=$MERGE_PARENT" >>$GITHUB_ENV
+
             - name: Uploading Size Reports
               uses: actions/upload-artifact@v2
               if: ${{ !env.ACT }}

--- a/.github/workflows/examples-telink.yaml
+++ b/.github/workflows/examples-telink.yaml
@@ -48,7 +48,7 @@ jobs:
             - name: Get parent for size reports
               run: |
                 MERGE_PARENT="$(git --no-pager log -1 --pretty=tformat:%s | sed -n -e 's/Merge [0-9a-f]\+ into //p')"
-                if test -z "${MERGE_PARENT}" || test "${GH_EVENT_PARENT}" == 0
+                if test -z "${MERGE_PARENT}" || test "${GH_EVENT_PARENT}" = 0
                 then
                   MERGE_PARENT=$GH_EVENT_BASE
                 fi

--- a/.github/workflows/examples-telink.yaml
+++ b/.github/workflows/examples-telink.yaml
@@ -29,7 +29,7 @@ jobs:
             BUILD_TYPE: telink
             GH_EVENT_PR: ${{ github.event_name == 'pull_request' && github.event.number || 0 }}
             GH_EVENT_HASH: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-            GH_EVENT_PARENT: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+            GH_EVENT_BASE: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
 
         runs-on: ubuntu-latest
         if: github.actor != 'restyled-io[bot]'
@@ -52,6 +52,16 @@ jobs:
                   telink tlsr9518adk80d lighting-app \
                   out/telink-tlsr9518adk80d-light/zephyr/zephyr.elf \
                   /tmp/bloat_reports/
+
+            - name: Get parent for size reports
+              run: |
+                MERGE_PARENT="$(git --no-pager log -1 --pretty=tformat:%s | sed -n -e 's/Merge [0-9a-f]\+ into //p')"
+                if [[ -z "${MERGE_PARENT}" || "${GH_EVENT_PR}" == 0 ]]
+                then
+                  MERGE_PARENT=$GH_EVENT_BASE
+                fi
+                echo "GH_EVENT_PARENT=$MERGE_PARENT" >>$GITHUB_ENV
+
             - name: Uploading Size Reports
               uses: actions/upload-artifact@v2
               if: ${{ !env.ACT }}

--- a/.github/workflows/examples-telink.yaml
+++ b/.github/workflows/examples-telink.yaml
@@ -48,7 +48,7 @@ jobs:
             - name: Get parent for size reports
               run: |
                 MERGE_PARENT="$(git --no-pager log -1 --pretty=tformat:%s | sed -n -e 's/Merge [0-9a-f]\+ into //p')"
-                if [[ -z "${MERGE_PARENT}" || "${GH_EVENT_PR}" == 0 ]]
+                if test -z "${MERGE_PARENT}" || test "${GH_EVENT_PARENT}" == 0
                 then
                   MERGE_PARENT=$GH_EVENT_BASE
                 fi

--- a/.github/workflows/examples-telink.yaml
+++ b/.github/workflows/examples-telink.yaml
@@ -44,14 +44,6 @@ jobs:
               uses: actions/checkout@v2
               with:
                   submodules: true
-            - name: Build example Telink Lighting App
-              run: |
-                ./scripts/run_in_build_env.sh \
-                  "./scripts/build/build_examples.py --no-log-timestamps --target-glob 'telink-*' build"
-                .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
-                  telink tlsr9518adk80d lighting-app \
-                  out/telink-tlsr9518adk80d-light/zephyr/zephyr.elf \
-                  /tmp/bloat_reports/
 
             - name: Get parent for size reports
               run: |
@@ -61,6 +53,15 @@ jobs:
                   MERGE_PARENT=$GH_EVENT_BASE
                 fi
                 echo "GH_EVENT_PARENT=$MERGE_PARENT" >>$GITHUB_ENV
+
+            - name: Build example Telink Lighting App
+              run: |
+                ./scripts/run_in_build_env.sh \
+                  "./scripts/build/build_examples.py --no-log-timestamps --target-glob 'telink-*' build"
+                .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
+                  telink tlsr9518adk80d lighting-app \
+                  out/telink-tlsr9518adk80d-light/zephyr/zephyr.elf \
+                  /tmp/bloat_reports/
 
             - name: Uploading Size Reports
               uses: actions/upload-artifact@v2


### PR DESCRIPTION
#### Problem

For a GitHub PR, the actual parent may be different from the commit
given by `github.event.pull_request.base.sha` (see
https://github.com/actions/checkout/issues/27). In this case, size
reports incorrectly include changes from commit(s) between the purported
and actual parent.

#### Change overview

Extract the actual parent from the PR merge commit subject.

#### Testing

Manually checked externally
    https://github.com/kpschoedel/actiontest/runs/4226639507
Actual confirmation can only happen on live CI runs.
