### PR TITLE
[YAML] Add a prompt command to the LogCommands cluster

### DIFF
--- a/examples/chip-tool/commands/tests/TestCommand.cpp
+++ b/examples/chip-tool/commands/tests/TestCommand.cpp
@@ -60,7 +60,14 @@ CHIP_ERROR TestCommand::Wait(chip::System::Clock::Timeout duration)
 CHIP_ERROR TestCommand::Log(const char * message)
 {
     ChipLogDetail(chipTool, "%s", message);
-    WaitForMs(0);
+    ReturnErrorOnFailure(ContinueOnChipMainThread());
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR TestCommand::UserPrompt(const char * message)
+{
+    ChipLogDetail(chipTool, "USER_PROMPT: %s", message);
+    ReturnErrorOnFailure(ContinueOnChipMainThread());
     return CHIP_NO_ERROR;
 }
 
@@ -175,7 +182,7 @@ bool TestCommand::ShouldSkip(const char * expression)
     if (shouldSkip)
     {
         ChipLogProgress(chipTool, " **** Skipping: %s == false\n", expression);
-        WaitForMs(0);
+        ContinueOnChipMainThread();
     }
     return shouldSkip;
 }

--- a/examples/chip-tool/commands/tests/TestCommand.h
+++ b/examples/chip-tool/commands/tests/TestCommand.h
@@ -60,7 +60,7 @@ public:
     CHIP_ERROR WaitForMs(uint16_t ms) { return Wait(chip::System::Clock::Milliseconds32(ms)); }
     CHIP_ERROR WaitForCommissionee();
     CHIP_ERROR Log(const char * message);
-    CHIP_ERROR Prompt(const char * message);
+    CHIP_ERROR UserPrompt(const char * message);
 
 protected:
     ChipDevice * mDevice;
@@ -69,6 +69,8 @@ protected:
     static void OnDeviceConnectedFn(void * context, chip::OperationalDeviceProxy * device);
     static void OnDeviceConnectionFailureFn(void * context, NodeId deviceId, CHIP_ERROR error);
     static void OnWaitForMsFn(chip::System::Layer * systemLayer, void * context);
+
+    CHIP_ERROR ContinueOnChipMainThread() { return WaitForMs(0); };
 
     void Exit(std::string message);
     void ThrowFailureResponse();

--- a/examples/placeholder/linux/include/TestCommand.h
+++ b/examples/placeholder/linux/include/TestCommand.h
@@ -51,6 +51,13 @@ public:
         return CHIP_NO_ERROR;
     }
 
+    CHIP_ERROR UserPrompt(const char * message)
+    {
+        ChipLogProgress(chipTool, "USER_PROMPT: %s", message);
+        NextTest();
+        return CHIP_NO_ERROR;
+    }
+
     CHIP_ERROR WaitForCommissioning()
     {
         isRunning = false;

--- a/src/app/tests/suites/TestLogCommands.yaml
+++ b/src/app/tests/suites/TestLogCommands.yaml
@@ -26,3 +26,11 @@ tests:
           values:
               - name: "message"
                 value: "This is a simple message"
+
+    - label: "Do a simple user prompt message"
+      cluster: "LogCommands"
+      command: "UserPrompt"
+      arguments:
+          values:
+              - name: "message"
+                value: "This is a simple message"

--- a/src/app/zap-templates/common/simulated-clusters/TestLogCommands.js
+++ b/src/app/zap-templates/common/simulated-clusters/TestLogCommands.js
@@ -30,9 +30,15 @@ const Log = {
   response : { arguments : [] }
 };
 
+const UserPrompt = {
+  name : 'UserPrompt',
+  arguments : [ { type : 'CHAR_STRING', name : 'message' } ],
+  response : { arguments : [] }
+};
+
 const LogCommands = {
   name : 'LogCommands',
-  commands : [ Log ],
+  commands : [ Log, UserPrompt ],
 };
 
 //

--- a/zzz_generated/chip-tool/zap-generated/test/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/test/Commands.h
@@ -40260,6 +40260,10 @@ public:
             ChipLogProgress(chipTool, " ***** Test Step 0 : Log a simple message\n");
             err = TestLogASimpleMessage_0();
             break;
+        case 1:
+            ChipLogProgress(chipTool, " ***** Test Step 1 : Do a simple user prompt message\n");
+            err = TestDoASimpleUserPromptMessage_1();
+            break;
         }
 
         if (CHIP_NO_ERROR != err)
@@ -40271,13 +40275,15 @@ public:
 
 private:
     std::atomic_uint16_t mTestIndex;
-    const uint16_t mTestCount = 1;
+    const uint16_t mTestCount = 2;
 
     //
     // Tests methods
     //
 
     CHIP_ERROR TestLogASimpleMessage_0() { return Log("This is a simple message"); }
+
+    CHIP_ERROR TestDoASimpleUserPromptMessage_1() { return UserPrompt("This is a simple message"); }
 };
 
 class TestSaveAs : public TestCommand


### PR DESCRIPTION
#### Problem

Needs a log command with a prefix that is always the same.

#### Change overview
* Add a `prompt` command to `LogCommands`

#### Testing
It has been added to `TestLogCommands.yaml`

#fixes #11853