### PR TITLE
[YAML] Add a mechanism to specify the test timeout for a given YAML file

### DIFF
--- a/examples/chip-tool/commands/tests/TestCommand.h
+++ b/examples/chip-tool/commands/tests/TestCommand.h
@@ -29,6 +29,8 @@
 #include <type_traits>
 #include <zap-generated/tests/CHIPClustersTest.h>
 
+constexpr uint16_t kTimeoutInSeconds = 30;
+
 class TestCommand : public CHIPCommand
 {
 public:
@@ -38,20 +40,26 @@ public:
     {
         AddArgument("node-id", 0, UINT64_MAX, &mNodeId);
         AddArgument("delayInMs", 0, UINT64_MAX, &mDelayInMs);
+        AddArgument("timeout", 0, UINT16_MAX, &mTimeout);
         AddArgument("endpoint-id", CHIP_ZCL_ENDPOINT_MIN, CHIP_ZCL_ENDPOINT_MAX, &mEndpointId);
         AddArgument("PICS", &mPICSFilePath);
     }
 
     /////////// CHIPCommand Interface /////////
     CHIP_ERROR RunCommand() override;
-    chip::System::Clock::Timeout GetWaitDuration() const override { return chip::System::Clock::Seconds16(30); }
+    chip::System::Clock::Timeout GetWaitDuration() const override
+    {
+        return chip::System::Clock::Seconds16(mTimeout.HasValue() ? mTimeout.Value() : kTimeoutInSeconds);
+    }
 
     virtual void NextTest() = 0;
 
     /////////// GlobalCommands Interface /////////
     CHIP_ERROR Wait(chip::System::Clock::Timeout ms);
     CHIP_ERROR WaitForMs(uint16_t ms) { return Wait(chip::System::Clock::Milliseconds32(ms)); }
+    CHIP_ERROR WaitForCommissionee();
     CHIP_ERROR Log(const char * message);
+    CHIP_ERROR Prompt(const char * message);
 
 protected:
     ChipDevice * mDevice;
@@ -230,5 +238,6 @@ protected:
     chip::Optional<uint64_t> mDelayInMs;
     chip::Optional<char *> mPICSFilePath;
     chip::Optional<chip::EndpointId> mEndpointId;
+    chip::Optional<uint16_t> mTimeout;
     chip::Optional<std::map<std::string, bool>> PICS;
 };

--- a/examples/chip-tool/templates/partials/test_cluster.zapt
+++ b/examples/chip-tool/templates/partials/test_cluster.zapt
@@ -44,6 +44,9 @@ class {{filename}}: public TestCommand
       }
     }
 
+  {{#if timeout}}
+    chip::System::Clock::Timeout GetWaitDuration() const override { return chip::System::Clock::Seconds16(mTimeout.HasValue() : mTimeout.Value() : {{timeout}}); }
+  {{/if}}
 
   private:
     std::atomic_uint16_t mTestIndex;

--- a/src/app/zap-templates/common/ClusterTestGeneration.js
+++ b/src/app/zap-templates/common/ClusterTestGeneration.js
@@ -323,6 +323,7 @@ function parse(filename)
   });
 
   yaml.filename   = filename;
+  yaml.timeout    = yaml.config.timeout;
   yaml.totalTests = yaml.tests.length;
 
   return yaml;


### PR DESCRIPTION
#### Problem

Some YAML tests may requires more than 30 seconds to finalise.

#### Change overview
* Add a mechanism to specify the `timeout` for a given YAML file.

#### Testing
I locally checked that it works by getting `Test_SubscribeOnOff` to timeout