### PR TITLE
[chip-tool] Move OpenCommissioningWindowCommand to a dedicated file

### DIFF
--- a/examples/chip-tool/BUILD.gn
+++ b/examples/chip-tool/BUILD.gn
@@ -39,6 +39,8 @@ executable("chip-tool") {
     # TODO - enable CommissionedListCommand once DNS Cache is implemented
     #    "commands/pairing/CommissionedListCommand.cpp",
     #    "commands/pairing/CommissionedListCommand.h",
+    "commands/pairing/OpenCommissioningWindowCommand.cpp",
+    "commands/pairing/OpenCommissioningWindowCommand.h",
     "commands/pairing/PairingCommand.cpp",
     "commands/payload/AdditionalDataParseCommand.cpp",
     "commands/payload/SetupPayloadParseCommand.cpp",

--- a/examples/chip-tool/commands/clusters/ModelCommand.cpp
+++ b/examples/chip-tool/commands/clusters/ModelCommand.cpp
@@ -26,29 +26,21 @@ using namespace ::chip;
 CHIP_ERROR ModelCommand::RunCommand()
 {
     ChipLogProgress(chipTool, "Sending command to node 0x%" PRIx64, mNodeId);
-
-    CHIP_ERROR err =
-        CurrentCommissioner().GetConnectedDevice(mNodeId, &mOnDeviceConnectedCallback, &mOnDeviceConnectionFailureCallback);
-    VerifyOrExit(err == CHIP_NO_ERROR,
-                 ChipLogError(chipTool, "Failed in initiating connection to the device: %" PRIu64 ", error %" CHIP_ERROR_FORMAT,
-                              mNodeId, err.Format()));
-
-exit:
-    return err;
+    return CurrentCommissioner().GetConnectedDevice(mNodeId, &mOnDeviceConnectedCallback, &mOnDeviceConnectionFailureCallback);
 }
 
 void ModelCommand::OnDeviceConnectedFn(void * context, ChipDevice * device)
 {
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    VerifyOrReturn(command != nullptr,
-                   ChipLogError(chipTool, "Device connected, but cannot send the command, as the context is null"));
+    VerifyOrReturn(command != nullptr, ChipLogError(chipTool, "OnDeviceConnectedFn: context is null"));
     command->SendCommand(device, command->mEndPointId);
 }
 
-void ModelCommand::OnDeviceConnectionFailureFn(void * context, NodeId deviceId, CHIP_ERROR error)
+void ModelCommand::OnDeviceConnectionFailureFn(void * context, NodeId deviceId, CHIP_ERROR err)
 {
+    LogErrorOnFailure(err);
+
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    ChipLogError(chipTool, "Failed in connecting to the device %" PRIu64 ". Error %" CHIP_ERROR_FORMAT, deviceId, error.Format());
-    VerifyOrReturn(command != nullptr, ChipLogError(chipTool, "ModelCommand context is null"));
-    command->SetCommandExitStatus(error);
+    VerifyOrReturn(command != nullptr, ChipLogError(chipTool, "OnDeviceConnectionFailureFn: context is null"));
+    command->SetCommandExitStatus(err);
 }

--- a/examples/chip-tool/commands/pairing/Commands.h
+++ b/examples/chip-tool/commands/pairing/Commands.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include "CommissionedListCommand.h"
+#include "OpenCommissioningWindowCommand.h"
 #include "PairingCommand.h"
 
 #include <app/server/Dnssd.h>
@@ -143,14 +144,6 @@ public:
     Ethernet() : PairingCommand("ethernet", PairingMode::Ethernet, PairingNetworkType::Ethernet) {}
 };
 
-class OpenCommissioningWindow : public PairingCommand
-{
-public:
-    OpenCommissioningWindow() :
-        PairingCommand("open-commissioning-window", PairingMode::OpenCommissioningWindow, PairingNetworkType::None)
-    {}
-};
-
 class StartUdcServerCommand : public CHIPCommand
 {
 public:
@@ -185,10 +178,10 @@ void registerCommandsPairing(Commands & commands)
         make_unique<PairOnNetworkDeviceType>(),
         make_unique<PairOnNetworkDeviceType>(),
         make_unique<PairOnNetworkInstanceName>(),
-        make_unique<OpenCommissioningWindow>(),
         // TODO - enable CommissionedListCommand once DNS Cache is implemented
         //        make_unique<CommissionedListCommand>(),
         make_unique<StartUdcServerCommand>(),
+        make_unique<OpenCommissioningWindowCommand>(),
     };
 
     commands.Register(clusterName, clusterCommands);

--- a/examples/chip-tool/commands/pairing/OpenCommissioningWindowCommand.cpp
+++ b/examples/chip-tool/commands/pairing/OpenCommissioningWindowCommand.cpp
@@ -1,0 +1,57 @@
+/*
+ *   Copyright (c) 2021 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+#include "OpenCommissioningWindowCommand.h"
+
+using namespace ::chip;
+
+CHIP_ERROR OpenCommissioningWindowCommand::RunCommand()
+{
+    return CurrentCommissioner().GetConnectedDevice(mNodeId, &mOnDeviceConnectedCallback, &mOnDeviceConnectionFailureCallback);
+}
+
+void OpenCommissioningWindowCommand::OnDeviceConnectedFn(void * context, chip::OperationalDeviceProxy * device)
+{
+    OpenCommissioningWindowCommand * command = reinterpret_cast<OpenCommissioningWindowCommand *>(context);
+    VerifyOrReturn(command != nullptr, ChipLogError(chipTool, "OnDeviceConnectedFn: context is null"));
+    command->OpenCommissioningWindow();
+}
+void OpenCommissioningWindowCommand::OnDeviceConnectionFailureFn(void * context, NodeId remoteId, CHIP_ERROR err)
+{
+    LogErrorOnFailure(err);
+
+    OpenCommissioningWindowCommand * command = reinterpret_cast<OpenCommissioningWindowCommand *>(context);
+    VerifyOrReturn(command != nullptr, ChipLogError(chipTool, "OnDeviceConnectionFailureFn: context is null"));
+    command->SetCommandExitStatus(err);
+}
+
+void OpenCommissioningWindowCommand::OnOpenCommissioningWindowResponse(void * context, NodeId remoteId, CHIP_ERROR err,
+                                                                       chip::SetupPayload payload)
+{
+    LogErrorOnFailure(err);
+
+    OpenCommissioningWindowCommand * command = reinterpret_cast<OpenCommissioningWindowCommand *>(context);
+    VerifyOrReturn(command != nullptr, ChipLogError(chipTool, "OnOpenCommissioningWindowCommand: context is null"));
+    command->SetCommandExitStatus(err);
+}
+
+CHIP_ERROR OpenCommissioningWindowCommand::OpenCommissioningWindow()
+{
+    return CurrentCommissioner().OpenCommissioningWindowWithCallback(
+        mNodeId, mTimeout, mIteration, mDiscriminator, mCommissioningWindowOption, &mOnOpenCommissioningWindowCallback);
+}

--- a/examples/chip-tool/commands/pairing/OpenCommissioningWindowCommand.h
+++ b/examples/chip-tool/commands/pairing/OpenCommissioningWindowCommand.h
@@ -1,0 +1,57 @@
+/*
+ *   Copyright (c) 2021 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+#pragma once
+
+#include "../common/CHIPCommand.h"
+
+class OpenCommissioningWindowCommand : public CHIPCommand
+{
+public:
+    OpenCommissioningWindowCommand() :
+        CHIPCommand("open-commissioning-window"), mOnDeviceConnectedCallback(OnDeviceConnectedFn, this),
+        mOnDeviceConnectionFailureCallback(OnDeviceConnectionFailureFn, this),
+        mOnOpenCommissioningWindowCallback(OnOpenCommissioningWindowResponse, this)
+    {
+        AddArgument("node-id", 0, UINT64_MAX, &mNodeId);
+        AddArgument("option", 0, UINT8_MAX, &mCommissioningWindowOption);
+        AddArgument("timeout", 0, UINT16_MAX, &mTimeout);
+        AddArgument("iteration", 0, UINT16_MAX, &mIteration);
+        AddArgument("discriminator", 0, 4096, &mDiscriminator);
+    }
+
+    /////////// CHIPCommand Interface /////////
+    CHIP_ERROR RunCommand() override;
+    chip::System::Clock::Timeout GetWaitDuration() const override { return chip::System::Clock::Seconds16(5); }
+
+private:
+    NodeId mNodeId;
+    uint8_t mCommissioningWindowOption;
+    uint16_t mTimeout;
+    uint16_t mIteration;
+    uint16_t mDiscriminator;
+
+    CHIP_ERROR OpenCommissioningWindow();
+    static void OnDeviceConnectedFn(void * context, chip::OperationalDeviceProxy * device);
+    static void OnDeviceConnectionFailureFn(void * context, NodeId deviceId, CHIP_ERROR error);
+    static void OnOpenCommissioningWindowResponse(void * context, NodeId deviceId, CHIP_ERROR status, chip::SetupPayload payload);
+
+    chip::Callback::Callback<chip::OnDeviceConnected> mOnDeviceConnectedCallback;
+    chip::Callback::Callback<chip::OnDeviceConnectionFailure> mOnDeviceConnectionFailureCallback;
+    chip::Callback::Callback<chip::Controller::OnOpenCommissioningWindow> mOnOpenCommissioningWindowCallback;
+};

--- a/examples/chip-tool/commands/pairing/PairingCommand.h
+++ b/examples/chip-tool/commands/pairing/PairingCommand.h
@@ -18,15 +18,12 @@
 
 #pragma once
 
-#include "../../config/PersistentStorage.h"
 #include "../common/CHIPCommand.h"
 #include <zap-generated/CHIPClientCallbacks.h>
 #include <zap-generated/CHIPClusters.h>
 
-#include <controller/ExampleOperationalCredentialsIssuer.h>
 #include <lib/support/Span.h>
 #include <lib/support/ThreadOperationalDataset.h>
-#include <setup_payload/SetupPayload.h>
 
 enum class PairingMode
 {
@@ -37,7 +34,6 @@ enum class PairingMode
     SoftAP,
     Ethernet,
     OnNetwork,
-    OpenCommissioningWindow,
 };
 
 enum class PairingNetworkType
@@ -59,9 +55,8 @@ public:
         CHIPCommand(commandName),
         mPairingMode(mode), mNetworkType(networkType),
         mFilterType(filterType), mRemoteAddr{ IPAddress::Any, chip::Inet::InterfaceId::Null() },
-        mOnDeviceConnectedCallback(OnDeviceConnectedFn, this),
-        mOnDeviceConnectionFailureCallback(OnDeviceConnectionFailureFn, this),
-        mOnOpenCommissioningWindowCallback(OnOpenCommissioningWindowResponse, this)
+        mOnAddThreadNetworkCallback(OnAddNetworkResponse, this), mOnAddWiFiNetworkCallback(OnAddNetworkResponse, this),
+        mOnEnableNetworkCallback(OnEnableNetworkResponse, this), mOnFailureCallback(OnDefaultFailureResponse, this)
     {
         AddArgument("node-id", 0, UINT64_MAX, &mNodeId);
 
@@ -88,7 +83,6 @@ public:
             AddArgument("payload", &mOnboardingPayload);
             break;
         case PairingMode::Ble:
-            AddArgument("fabric-id", 0, UINT64_MAX, &mFabricId);
             AddArgument("setup-pin-code", 0, 134217727, &mSetupPINCode);
             AddArgument("discriminator", 0, 4096, &mDiscriminator);
             break;
@@ -96,7 +90,6 @@ public:
             AddArgument("setup-pin-code", 0, 134217727, &mSetupPINCode);
             break;
         case PairingMode::SoftAP:
-            AddArgument("fabric-id", 0, UINT64_MAX, &mFabricId);
             AddArgument("setup-pin-code", 0, 134217727, &mSetupPINCode);
             AddArgument("discriminator", 0, 4096, &mDiscriminator);
             AddArgument("device-remote-ip", &mRemoteAddr);
@@ -107,12 +100,6 @@ public:
             AddArgument("discriminator", 0, 4096, &mDiscriminator);
             AddArgument("device-remote-ip", &mRemoteAddr);
             AddArgument("device-remote-port", 0, UINT16_MAX, &mRemotePort);
-            break;
-        case PairingMode::OpenCommissioningWindow:
-            AddArgument("option", 0, UINT8_MAX, &mCommissioningWindowOption);
-            AddArgument("timeout", 0, UINT16_MAX, &mTimeout);
-            AddArgument("iteration", 0, UINT16_MAX, &mIteration);
-            AddArgument("discriminator", 0, 4096, &mDiscriminator);
             break;
         }
 
@@ -147,7 +134,6 @@ public:
     /////////// CHIPCommand Interface /////////
     CHIP_ERROR RunCommand() override;
     chip::System::Clock::Timeout GetWaitDuration() const override { return chip::System::Clock::Seconds16(120); }
-    void Shutdown() override;
 
     /////////// DevicePairingDelegate Interface /////////
     void OnStatusUpdate(chip::Controller::DevicePairingDelegate::Status status) override;
@@ -174,9 +160,7 @@ private:
     CHIP_ERROR PairWithManualCode(NodeId remoteId);
     CHIP_ERROR PairWithCode(NodeId remoteId, chip::SetupPayload payload);
     CHIP_ERROR Unpair(NodeId remoteId);
-    CHIP_ERROR OpenCommissioningWindow();
 
-    void InitCallbacks();
     CHIP_ERROR SetupNetwork();
     CHIP_ERROR AddNetwork(PairingNetworkType networkType);
     CHIP_ERROR AddThreadNetwork();
@@ -192,12 +176,8 @@ private:
     Command::AddressWithInterface mRemoteAddr;
     NodeId mNodeId;
     uint16_t mRemotePort;
-    uint64_t mFabricId;
-    uint16_t mTimeout;
-    uint16_t mIteration;
     uint16_t mDiscriminator;
     uint32_t mSetupPINCode;
-    uint8_t mCommissioningWindowOption;
     chip::ByteSpan mOperationalDataset;
     uint8_t mExtendedPanId[chip::Thread::kSizeExtendedPanId];
     chip::ByteSpan mSSID;
@@ -206,19 +186,11 @@ private:
     uint64_t mDiscoveryFilterCode;
     char * mDiscoveryFilterInstanceName;
 
-    chip::Callback::Callback<NetworkCommissioningClusterAddThreadNetworkResponseCallback> * mOnAddThreadNetworkCallback = nullptr;
-    chip::Callback::Callback<NetworkCommissioningClusterAddWiFiNetworkResponseCallback> * mOnAddWiFiNetworkCallback     = nullptr;
-    chip::Callback::Callback<NetworkCommissioningClusterEnableNetworkResponseCallback> * mOnEnableNetworkCallback       = nullptr;
-    chip::Callback::Callback<DefaultFailureCallback> * mOnFailureCallback                                               = nullptr;
+    chip::Callback::Callback<NetworkCommissioningClusterAddThreadNetworkResponseCallback> mOnAddThreadNetworkCallback;
+    chip::Callback::Callback<NetworkCommissioningClusterAddWiFiNetworkResponseCallback> mOnAddWiFiNetworkCallback;
+    chip::Callback::Callback<NetworkCommissioningClusterEnableNetworkResponseCallback> mOnEnableNetworkCallback;
+    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback;
     chip::CommissioneeDeviceProxy * mDevice;
     chip::Controller::NetworkCommissioningCluster mCluster;
     chip::EndpointId mEndpointId = 0;
-
-    static void OnDeviceConnectedFn(void * context, chip::OperationalDeviceProxy * device);
-    static void OnDeviceConnectionFailureFn(void * context, NodeId deviceId, CHIP_ERROR error);
-    static void OnOpenCommissioningWindowResponse(void * context, NodeId deviceId, CHIP_ERROR status, chip::SetupPayload payload);
-
-    chip::Callback::Callback<chip::OnDeviceConnected> mOnDeviceConnectedCallback;
-    chip::Callback::Callback<chip::OnDeviceConnectionFailure> mOnDeviceConnectionFailureCallback;
-    chip::Callback::Callback<chip::Controller::OnOpenCommissioningWindow> mOnOpenCommissioningWindowCallback;
 };


### PR DESCRIPTION
#### Problem

`OpenCommissioningWindow` is not really part of the `PairingCommand.cpp` code flows and just makes it more complicated and distracting when trying to update this file.

#### Change overview
 * Move `OpenCommissioningWindowCommand` to a dedicated file.
