### PR TITLE
Fix initialization of SoftwareVersion attribute (Basic Cluster)

### DIFF
--- a/src/app/clusters/basic/basic.cpp
+++ b/src/app/clusters/basic/basic.cpp
@@ -87,7 +87,7 @@ void emberAfBasicClusterServerInitCallback(chip::EndpointId endpoint)
     uint16_t firmwareRevision;
     if (ConfigurationMgr().GetFirmwareRevision(firmwareRevision) == CHIP_NO_ERROR)
     {
-        status = Attributes::HardwareVersion::Set(endpoint, firmwareRevision);
+        status = Attributes::SoftwareVersion::Set(endpoint, firmwareRevision);
         VerifyOrReturn(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(Zcl, "Error setting Software Version: 0x%02x", status));
     }
 }


### PR DESCRIPTION
#### Problem
- Hardware-Version attribute was incorrectly being initialized with FirmwareVersion default value
- Software-Version attribute was not being initialized with its default value.

#### Change overview
Fix initializations

#### Testing
* Manual testing with chip-tool and lighting example application
