### PR TITLE
[InetLayer] handle source address for transport layer

### DIFF
--- a/examples/platform/linux/CommissioneeShellCommands.cpp
+++ b/examples/platform/linux/CommissioneeShellCommands.cpp
@@ -37,7 +37,7 @@ namespace chip {
 namespace Shell {
 
 #if CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY_CLIENT
-static CHIP_ERROR SendUDC(bool printHeader, chip::Transport::PeerAddress commissioner)
+static CHIP_ERROR SendUDC(bool printHeader, const chip::Transport::PeerAddress & peer, const chip::Transport::PeerAddress & local)
 {
     streamer_t * sout = streamer_get();
 
@@ -46,7 +46,7 @@ static CHIP_ERROR SendUDC(bool printHeader, chip::Transport::PeerAddress commiss
         streamer_printf(sout, "SendUDC:        ");
     }
 
-    Server::GetInstance().SendUserDirectedCommissioningRequest(commissioner);
+    Server::GetInstance().SendUserDirectedCommissioningRequest(peer, local);
 
     streamer_printf(sout, "done\r\n");
 
@@ -92,7 +92,7 @@ static CHIP_ERROR CommissioneeHandler(int argc, char ** argv)
         chip::Inet::IPAddress commissioner;
         chip::Inet::IPAddress::FromString(argv[1], commissioner);
         uint16_t port = (uint16_t) strtol(argv[2], &eptr, 10);
-        return error  = SendUDC(true, chip::Transport::PeerAddress::UDP(commissioner, port));
+        return error  = SendUDC(true, chip::Transport::PeerAddress::UDP(commissioner, port), chip::Transport::PeerAddress::UDP());
     }
 #endif // CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY_CLIENT
     else if (strcmp(argv[0], "setdiscoverytimeout") == 0)

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -192,7 +192,7 @@ void Server::Shutdown()
 // NOTE: UDC client is located in Server.cpp because it really only makes sense
 // to send UDC from a Matter device. The UDC message payload needs to include the device's
 // randomly generated service name.
-CHIP_ERROR Server::SendUserDirectedCommissioningRequest(chip::Transport::PeerAddress commissioner)
+CHIP_ERROR Server::SendUserDirectedCommissioningRequest(const chip::Transport::PeerAddress & peer, const chip::Transport::PeerAddress & local)
 {
     ChipLogDetail(AppServer, "SendUserDirectedCommissioningRequest2");
 
@@ -213,7 +213,7 @@ CHIP_ERROR Server::SendUserDirectedCommissioningRequest(chip::Transport::PeerAdd
         return CHIP_ERROR_NO_MEMORY;
     }
 
-    err = gUDCClient.SendUDCMessage(&mTransports, std::move(payloadBuf), commissioner);
+    err = gUDCClient.SendUDCMessage(&mTransports, std::move(payloadBuf), peer, local);
     if (err == CHIP_NO_ERROR)
     {
         ChipLogDetail(AppServer, "Send UDC request success");

--- a/src/app/server/Server.h
+++ b/src/app/server/Server.h
@@ -57,7 +57,7 @@ public:
                     uint16_t unsecureServicePort = CHIP_UDC_PORT);
 
 #if CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY_CLIENT
-    CHIP_ERROR SendUserDirectedCommissioningRequest(chip::Transport::PeerAddress commissioner);
+    CHIP_ERROR SendUserDirectedCommissioningRequest(const chip::Transport::PeerAddress & peer, const chip::Transport::PeerAddress & local);
 #endif // CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY_CLIENT
 
     CHIP_ERROR AddTestCommissioning();

--- a/src/channel/Channel.cpp
+++ b/src/channel/Channel.cpp
@@ -32,7 +32,7 @@ ChannelState ChannelHandle::GetState() const
 
 ExchangeContext * ChannelHandle::NewExchange(ExchangeDelegate * delegate)
 {
-    assert(mAssociation != nullptr);
+    VerifyOrDie(mAssociation != nullptr);
     return mAssociation->mChannelContext->NewExchange(delegate);
 }
 

--- a/src/channel/ChannelContext.cpp
+++ b/src/channel/ChannelContext.cpp
@@ -37,7 +37,7 @@ void ChannelContext::Start(const ChannelBuilder & builder)
 
 ExchangeContext * ChannelContext::NewExchange(ExchangeDelegate * delegate)
 {
-    assert(GetState() == ChannelState::kReady);
+    VerifyOrDie(GetState() == ChannelState::kReady);
     return mExchangeManager->NewContext(GetReadyVars().mSession, delegate);
 }
 

--- a/src/inet/IPPacketInfo.h
+++ b/src/inet/IPPacketInfo.h
@@ -1,0 +1,52 @@
+/*
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <inet/InetConfig.h>
+
+#include <inet/IPAddress.h>
+#include <inet/InetInterface.h>
+
+namespace chip {
+namespace Inet {
+
+/**
+ *  @class IPPacketInfo
+ *
+ *  @brief
+ *     Information about an incoming/outgoing message/connection.
+ *
+ *   @warning
+ *     Do not alter the contents of this class without first reading and understanding
+ *     the code/comments in UDPEndPoint::GetPacketInfo().
+ */
+class IPPacketInfo
+{
+public:
+    IPAddress SrcAddress;  /**< The source IPAddress in the packet. */
+    IPAddress DestAddress; /**< The destination IPAddress in the packet. */
+    InterfaceId Interface; /**< The interface identifier for the connection. */
+    uint16_t SrcPort;      /**< The source port in the packet. */
+    uint16_t DestPort;     /**< The destination port in the packet. */
+
+    void Clear();
+};
+
+static_assert(std::is_standard_layout<IPPacketInfo>::value, "IPPacketInfo must be standard layout, because its bytes represents is used in LwIP");
+
+} // namespace Inet
+} // namespace chip

--- a/src/inet/InetLayer.h
+++ b/src/inet/InetLayer.h
@@ -52,6 +52,7 @@
 #include <inet/EndPointBasis.h>
 #include <inet/IANAConstants.h>
 #include <inet/IPAddress.h>
+#include <inet/IPPacketInfo.h>
 #include <inet/IPPrefix.h>
 #include <inet/InetError.h>
 #include <inet/InetInterface.h>
@@ -139,28 +140,6 @@ private:
     chip::System::Layer * mSystemLayer;
 
     bool IsIdleTimerRunning();
-};
-
-/**
- *  @class IPPacketInfo
- *
- *  @brief
- *     Information about an incoming/outgoing message/connection.
- *
- *   @warning
- *     Do not alter the contents of this class without first reading and understanding
- *     the code/comments in UDPEndPoint::GetPacketInfo().
- */
-class IPPacketInfo
-{
-public:
-    IPAddress SrcAddress;  /**< The source IPAddress in the packet. */
-    IPAddress DestAddress; /**< The destination IPAddress in the packet. */
-    InterfaceId Interface; /**< The interface identifier for the connection. */
-    uint16_t SrcPort;      /**< The source port in the packet. */
-    uint16_t DestPort;     /**< The destination port in the packet. */
-
-    void Clear();
 };
 
 } // namespace Inet

--- a/src/inet/TCPEndPoint.h
+++ b/src/inet/TCPEndPoint.h
@@ -29,6 +29,7 @@
 
 #include <inet/EndPointBasis.h>
 #include <inet/IPAddress.h>
+#include <inet/IPPacketInfo.h>
 #include <inet/InetInterface.h>
 #include <lib/core/ReferenceCounted.h>
 #include <lib/support/Pool.h>
@@ -150,9 +151,7 @@ public:
     /**
      * @brief   Initiate a TCP connection.
      *
-     * @param[in]   addr        the destination IP address
-     * @param[in]   port        the destination TCP port
-     * @param[in]   intfId      an optional network interface indicator
+     * @param[in]   addrInfo  Specify the peer/local address/port, and interface to use
      *
      * @retval  CHIP_NO_ERROR       success: \c msg is queued for transmit.
      * @retval  CHIP_ERROR_NOT_IMPLEMENTED  system implementation not complete.
@@ -165,11 +164,10 @@ public:
      * @retval  other                   another system or platform error
      *
      * @details
-     *      If possible, then this method initiates a TCP connection to the
-     *      destination \c addr (with \c intfId used as the scope
-     *      identifier for IPv6 link-local destinations) and \c port.
+     *      This method initiates a TCP connection to the destination addr/port given by addrInfo, using source
+     *      addr/port given by addrInfo, using the given interface in addrInfo.
      */
-    CHIP_ERROR Connect(const IPAddress & addr, uint16_t port, InterfaceId intfId = InterfaceId::Null());
+    CHIP_ERROR Connect(const IPPacketInfo & addrInfo);
 
     /**
      * @brief   Extract IP address and TCP port of remote endpoint.
@@ -700,7 +698,7 @@ protected:
      */
     virtual CHIP_ERROR BindImpl(IPAddressType addrType, const IPAddress & addr, uint16_t port, bool reuseAddr) = 0;
     virtual CHIP_ERROR ListenImpl(uint16_t backlog)                                                            = 0;
-    virtual CHIP_ERROR ConnectImpl(const IPAddress & addr, uint16_t port, InterfaceId intfId)                  = 0;
+    virtual CHIP_ERROR ConnectImpl(const IPPacketInfo & addrInfo)                  = 0;
     virtual CHIP_ERROR SendQueuedImpl(bool queueWasEmpty)                                                      = 0;
     virtual CHIP_ERROR SetUserTimeoutImpl(uint32_t userTimeoutMillis)                                          = 0;
     virtual CHIP_ERROR DriveSendingImpl()                                                                      = 0;
@@ -741,7 +739,7 @@ private:
     // TCPEndPoint overrides.
     CHIP_ERROR BindImpl(IPAddressType addrType, const IPAddress & addr, uint16_t port, bool reuseAddr) override;
     CHIP_ERROR ListenImpl(uint16_t backlog) override;
-    CHIP_ERROR ConnectImpl(const IPAddress & addr, uint16_t port, InterfaceId intfId) override;
+    CHIP_ERROR ConnectImpl(const IPPacketInfo & addrInfo) override;
     CHIP_ERROR SendQueuedImpl(bool queueWasEmpty) override;
     CHIP_ERROR SetUserTimeoutImpl(uint32_t userTimeoutMillis) override;
     CHIP_ERROR DriveSendingImpl() override;
@@ -816,7 +814,7 @@ private:
     // TCPEndPoint overrides.
     CHIP_ERROR BindImpl(IPAddressType addrType, const IPAddress & addr, uint16_t port, bool reuseAddr) override;
     CHIP_ERROR ListenImpl(uint16_t backlog) override;
-    CHIP_ERROR ConnectImpl(const IPAddress & addr, uint16_t port, InterfaceId intfId) override;
+    CHIP_ERROR ConnectImpl(const IPPacketInfo & addrInfo) override;
     CHIP_ERROR SendQueuedImpl(bool queueWasEmpty) override;
     CHIP_ERROR SetUserTimeoutImpl(uint32_t userTimeoutMillis) override;
     CHIP_ERROR DriveSendingImpl() override;

--- a/src/inet/tests/TestInetEndPoint.cpp
+++ b/src/inet/tests/TestInetEndPoint.cpp
@@ -308,7 +308,14 @@ static void TestInetEndPointInternal(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INCORRECT_STATE);
     err = testTCPEP1->Listen(4);
 #if INET_CONFIG_ENABLE_IPV4
-    err = testTCPEP1->Connect(addr_v4, 4000, intId);
+    Inet::IPPacketInfo addrInfo;
+    addrInfo.Clear();
+    addrInfo.DestAddress = addr_v4;
+    addrInfo.DestPort    = 4000;
+    addrInfo.SrcAddress = IPAddress::Any;
+    addrInfo.SrcPort  = 0;
+    addrInfo.Interface = intId;
+    err = testTCPEP1->Connect(addrInfo);
     NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INCORRECT_STATE);
 #endif // INET_CONFIG_ENABLE_IPV4
 

--- a/src/inet/tests/TestInetLayer.cpp
+++ b/src/inet/tests/TestInetLayer.cpp
@@ -700,7 +700,14 @@ static CHIP_ERROR PrepareTransportForSend()
             sTCPIPEndPoint->OnDataSent         = HandleTCPDataSent;
             sTCPIPEndPoint->OnDataReceived     = HandleTCPDataReceived;
 
-            lStatus = sTCPIPEndPoint->Connect(sDestinationAddress, kTCPPort, gInterfaceId);
+            Inet::IPPacketInfo addrInfo;
+            addrInfo.Clear();
+            addrInfo.DestAddress = sDestinationAddress;
+            addrInfo.DestPort    = kTCPPort;
+            addrInfo.SrcAddress = IPAddress::Any;
+            addrInfo.SrcPort  = 0;
+            addrInfo.Interface = gInterfaceId;
+            lStatus = sTCPIPEndPoint->Connect(addrInfo);
             INET_FAIL_ERROR(lStatus, "TCPEndPoint::Connect failed");
         }
     }

--- a/src/lib/support/Pool.cpp
+++ b/src/lib/support/Pool.cpp
@@ -18,8 +18,7 @@
  */
 
 #include <lib/support/Pool.h>
-
-#include <nlassert.h>
+#include <lib/support/CodeUtils.h>
 
 namespace chip {
 
@@ -66,20 +65,20 @@ void StaticAllocatorBitmap::Deallocate(void * element)
     size_t offset = index - (word * kBitChunkSize);
 
     // ensure the element is in the pool
-    assert(index < Capacity());
+    VerifyOrDie(index < Capacity());
 
     auto value = mUsage[word].fetch_and(~(kBit1 << offset));
-    nlASSERT((value & (kBit1 << offset)) != 0); // assert fail when free an unused slot
+    VerifyOrDie((value & (kBit1 << offset)) != 0); // assert fail when free an unused slot
     mAllocated--;
 }
 
 size_t StaticAllocatorBitmap::IndexOf(void * element)
 {
     std::ptrdiff_t diff = static_cast<uint8_t *>(element) - static_cast<uint8_t *>(mElements);
-    assert(diff >= 0);
-    assert(static_cast<size_t>(diff) % mElementSize == 0);
+    VerifyOrDie(diff >= 0);
+    VerifyOrDie(static_cast<size_t>(diff) % mElementSize == 0);
     auto index = static_cast<size_t>(diff) / mElementSize;
-    assert(index < Capacity());
+    VerifyOrDie(index < Capacity());
     return index;
 }
 

--- a/src/lib/support/Pool.h
+++ b/src/lib/support/Pool.h
@@ -23,12 +23,11 @@
 
 #pragma once
 
-#include <array>
-#include <assert.h>
 #include <atomic>
 #include <limits>
 #include <new>
 #include <stddef.h>
+#include <utility>
 
 namespace chip {
 

--- a/src/lib/support/PoolWrapper.h
+++ b/src/lib/support/PoolWrapper.h
@@ -1,0 +1,117 @@
+/*
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <tuple>
+
+#include <lib/support/Pool.h>
+
+namespace chip {
+
+/// Provides an interface over a pool implementation which doesn't expose the size and the actual type of the pool.
+template<typename U, typename... ConstructorArguments>
+class PoolInterface
+{
+public:
+    virtual ~PoolInterface() {}
+
+    virtual U * CreateObject(ConstructorArguments &&... args) = 0;
+    virtual void ReleaseObject(U * element) = 0;
+    virtual void ResetObject(U * element, ConstructorArguments &&... args) = 0;
+
+    template <typename Function>
+    bool ForEachActiveObject(Function && function)
+    {
+        auto proxy = [&] (U * target) -> bool { return function(target); };
+        return ForEachActiveObjectInner(&proxy, [](void * context, U * target) -> bool {
+            return (*static_cast<decltype(proxy)*>(context))(target);
+        });
+    }
+
+protected:
+    using Lambda = bool (*)(void *, U *);
+    virtual bool ForEachActiveObjectInner(void * context, Lambda lambda) = 0;
+};
+
+template <class T, size_t N, typename Interface>
+class PoolProxy;
+
+template <class T, size_t N, typename U, typename... ConstructorArguments>
+class PoolProxy<T, N, std::tuple<U, ConstructorArguments...>> : public PoolInterface<U, ConstructorArguments...>
+{
+public:
+    static_assert(std::is_base_of<U, T>::value, "Interface type is not derived from Pool type");
+
+    PoolProxy() {}
+    virtual ~PoolProxy() override {}
+
+    virtual U * CreateObject(ConstructorArguments &&... args) override
+    {
+        return Impl().CreateObject(std::forward<ConstructorArguments>(args)...);
+    }
+
+    virtual void ReleaseObject(U * element) override
+    {
+        Impl().ReleaseObject(static_cast<T*>(element));
+    }
+
+    virtual void ResetObject(U * element, ConstructorArguments &&... args) override
+    {
+        return Impl().ResetObject(static_cast<T*>(element), std::forward<ConstructorArguments>(args)...);
+    }
+
+protected:
+    virtual bool ForEachActiveObjectInner(void * context, typename PoolInterface<U, ConstructorArguments...>::Lambda lambda) override
+    {
+        return Impl().ForEachActiveObject([&] (T * target) {
+            return lambda(context, static_cast<U*>(target));
+        });
+    }
+
+    virtual BitMapObjectPool<T, N> & Impl() = 0;
+};
+
+/*
+ * @brief
+ *   Define a implementation of a pool which derive and expose PoolInterface's.
+ *
+ *  @tparam T          a subclass of element to be allocated.
+ *  @tparam N          a positive integer max number of elements the pool provides.
+ *  @tparam Interfaces a list of parameters which defines PoolInterface's. each interface is defined by a
+ *                     std::tuple<U, ConstructorArguments...>. The PoolImpl is derived from every
+ *                     PoolInterface<U, ConstructorArguments...>, the PoolImpl can be converted to the interface type
+ *                     and passed around
+ */
+template <class T, size_t N, typename... Interfaces>
+class PoolImpl : public PoolProxy<T, N, Interfaces>...
+{
+public:
+    PoolImpl() {}
+    virtual ~PoolImpl() override {}
+
+protected:
+    virtual BitMapObjectPool<T, N> & Impl() override
+    {
+        return mImpl;
+    }
+
+private:
+    BitMapObjectPool<T, N> mImpl;
+};
+
+} // namespace chip

--- a/src/lib/support/PoolWrapper.h
+++ b/src/lib/support/PoolWrapper.h
@@ -28,6 +28,9 @@ template<typename U, typename... ConstructorArguments>
 class PoolInterface
 {
 public:
+    // For convenient use in PoolImpl
+    using Interface = std::tuple<U, ConstructorArguments...>;
+
     virtual ~PoolInterface() {}
 
     virtual U * CreateObject(ConstructorArguments &&... args) = 0;

--- a/src/messaging/ExchangeMgr.cpp
+++ b/src/messaging/ExchangeMgr.cpp
@@ -99,7 +99,7 @@ CHIP_ERROR ExchangeManager::Shutdown()
 
     mContextPool.ForEachActiveObject([](auto * ec) {
         // There should be no active object in the pool
-        assert(false);
+        VerifyOrDie(false);
         return true;
     });
 

--- a/src/protocols/secure_channel/MessageCounterManager.h
+++ b/src/protocols/secure_channel/MessageCounterManager.h
@@ -49,6 +49,7 @@ public:
     CHIP_ERROR StartSync(SessionHandle session, Transport::SecureSession * state) override;
     CHIP_ERROR QueueReceivedMessageAndStartSync(const PacketHeader & packetHeader, SessionHandle session,
                                                 Transport::SecureSession * state, const Transport::PeerAddress & peerAddress,
+                                                const Transport::PeerAddress & localAddress,
                                                 System::PacketBufferHandle && msgBuf) override;
 
     /**
@@ -74,7 +75,7 @@ public:
      *  @retval  #CHIP_ERROR_NO_MEMORY If there is no empty slot left in the table for addition.
      *  @retval  #CHIP_NO_ERROR On success.
      */
-    CHIP_ERROR AddToReceiveTable(const PacketHeader & packetHeader, const Transport::PeerAddress & peerAddress,
+    CHIP_ERROR AddToReceiveTable(const PacketHeader & packetHeader, const Transport::PeerAddress & peerAddress, const Transport::PeerAddress & localAddress,
                                  System::PacketBufferHandle && msgBuf);
 
 private:
@@ -91,6 +92,7 @@ private:
     struct ReceiveTableEntry
     {
         Transport::PeerAddress peerAddress; /**< The peer address for the message*/
+        Transport::PeerAddress localAddress; /**< The local address for the message*/
         System::PacketBufferHandle msgBuf;  /**< A handle to the PacketBuffer object holding the message data. */
     };
 

--- a/src/protocols/user_directed_commissioning/UserDirectedCommissioning.h
+++ b/src/protocols/user_directed_commissioning/UserDirectedCommissioning.h
@@ -95,15 +95,15 @@ public:
      *
      * @param transportMgr  A transport to use for sending the message.
      * @param payload       A PacketBufferHandle with the payload.
-     * @param peerAddress   Address of destination.
+     * @param peer          Address of destination.
+     * @param local         Source address to use.
      *
      * @return CHIP_ERROR_NO_MEMORY if allocation fails.
      *         Other CHIP_ERROR codes as returned by the lower layers.
      *
      */
 
-    CHIP_ERROR SendUDCMessage(TransportMgrBase * transportMgr, System::PacketBufferHandle && payload,
-                              chip::Transport::PeerAddress peerAddress);
+    CHIP_ERROR SendUDCMessage(TransportMgrBase * transportMgr, System::PacketBufferHandle && payload, const chip::Transport::PeerAddress & peer, const chip::Transport::PeerAddress & local);
 
     /**
      * Encode a User Directed Commissioning message.
@@ -195,7 +195,7 @@ private:
     InstanceNameResolver * mInstanceNameResolver         = nullptr;
     UserConfirmationProvider * mUserConfirmationProvider = nullptr;
 
-    void OnMessageReceived(const Transport::PeerAddress & source, System::PacketBufferHandle && msgBuf) override;
+    void OnMessageReceived(const Transport::PeerAddress & peer, const Transport::PeerAddress & local, System::PacketBufferHandle && message) override;
 
     UDCClients<kMaxUDCClients> mUdcClients; // < Active UDC clients
 };

--- a/src/protocols/user_directed_commissioning/UserDirectedCommissioningClient.cpp
+++ b/src/protocols/user_directed_commissioning/UserDirectedCommissioningClient.cpp
@@ -30,7 +30,7 @@ namespace Protocols {
 namespace UserDirectedCommissioning {
 
 CHIP_ERROR UserDirectedCommissioningClient::SendUDCMessage(TransportMgrBase * transportMgr, System::PacketBufferHandle && payload,
-                                                           chip::Transport::PeerAddress peerAddress)
+                                                           const chip::Transport::PeerAddress & peer, const chip::Transport::PeerAddress & local)
 {
     CHIP_ERROR err = EncodeUDCMessage(std::move(payload));
     if (err != CHIP_NO_ERROR)
@@ -42,7 +42,7 @@ CHIP_ERROR UserDirectedCommissioningClient::SendUDCMessage(TransportMgrBase * tr
     // send UDC message 5 times per spec (no ACK on this message)
     for (unsigned int i = 0; i < 5; i++)
     {
-        err = transportMgr->SendMessage(peerAddress, std::move(payload));
+        err = transportMgr->SendMessage(peer, local, std::move(payload));
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(AppServer, "UDC SendMessage failed, err: %s\n", chip::ErrorStr(err));

--- a/src/protocols/user_directed_commissioning/UserDirectedCommissioningServer.cpp
+++ b/src/protocols/user_directed_commissioning/UserDirectedCommissioningServer.cpp
@@ -30,13 +30,13 @@ namespace chip {
 namespace Protocols {
 namespace UserDirectedCommissioning {
 
-void UserDirectedCommissioningServer::OnMessageReceived(const Transport::PeerAddress & source, System::PacketBufferHandle && msg)
+void UserDirectedCommissioningServer::OnMessageReceived(const Transport::PeerAddress & peer, const Transport::PeerAddress & local, System::PacketBufferHandle && message)
 {
     ChipLogProgress(AppServer, "UserDirectedCommissioningServer::OnMessageReceived");
 
     PacketHeader packetHeader;
 
-    ReturnOnFailure(packetHeader.DecodeAndConsume(msg));
+    ReturnOnFailure(packetHeader.DecodeAndConsume(message));
 
     if (packetHeader.IsEncrypted())
     {
@@ -45,11 +45,11 @@ void UserDirectedCommissioningServer::OnMessageReceived(const Transport::PeerAdd
     }
 
     PayloadHeader payloadHeader;
-    ReturnOnFailure(payloadHeader.DecodeAndConsume(msg));
+    ReturnOnFailure(payloadHeader.DecodeAndConsume(message));
 
     char instanceName[Dnssd::Commissionable::kInstanceNameMaxLength + 1];
-    size_t instanceNameLength = std::min<size_t>(msg->DataLength(), Dnssd::Commissionable::kInstanceNameMaxLength);
-    msg->Read(Uint8::from_char(instanceName), instanceNameLength);
+    size_t instanceNameLength = std::min<size_t>(message->DataLength(), Dnssd::Commissionable::kInstanceNameMaxLength);
+    message->Read(Uint8::from_char(instanceName), instanceNameLength);
 
     instanceName[instanceNameLength] = '\0';
 

--- a/src/protocols/user_directed_commissioning/tests/TestUdcMessages.cpp
+++ b/src/protocols/user_directed_commissioning/tests/TestUdcMessages.cpp
@@ -147,11 +147,15 @@ void TestUDCServerInstanceNameResolver(nlTestSuite * inSuite, void * inContext)
     // prepare peerAddress for handleMessage
     Inet::IPAddress commissioner;
     Inet::IPAddress::FromString("127.0.0.1", commissioner);
-    uint16_t port                      = 11100;
-    Transport::PeerAddress peerAddress = Transport::PeerAddress::UDP(commissioner, port);
+    Transport::PeerAddress peerAddress = Transport::PeerAddress::UDP(commissioner, 11100);
+
+    // prepare localAddress for handleMessage
+    Inet::IPAddress device;
+    Inet::IPAddress::FromString("127.0.0.1", device);
+    Transport::PeerAddress localAddress = Transport::PeerAddress::UDP(device, 11101);
 
     // test OnMessageReceived
-    mUdcTransportMgr->HandleMessageReceived(peerAddress, std::move(payloadBuf));
+    mUdcTransportMgr->HandleMessageReceived(peerAddress, localAddress, std::move(payloadBuf));
 
     // check if the state is set for the instance name sent
     state = udcServer.GetUDCClients().FindUDCClientState(nameBuffer);
@@ -169,7 +173,7 @@ void TestUDCServerInstanceNameResolver(nlTestSuite * inSuite, void * inContext)
     udcClient.EncodeUDCMessage(std::move(payloadBuf));
 
     // test OnMessageReceived again
-    mUdcTransportMgr->HandleMessageReceived(peerAddress, std::move(payloadBuf));
+    mUdcTransportMgr->HandleMessageReceived(peerAddress, localAddress, std::move(payloadBuf));
 
     // verify it was not called
     NL_TEST_ASSERT(inSuite, !testCallback.mFindCommissionableNodeCalled);
@@ -181,7 +185,7 @@ void TestUDCServerInstanceNameResolver(nlTestSuite * inSuite, void * inContext)
     udcClient.EncodeUDCMessage(std::move(payloadBuf));
 
     // test OnMessageReceived again
-    mUdcTransportMgr->HandleMessageReceived(peerAddress, std::move(payloadBuf));
+    mUdcTransportMgr->HandleMessageReceived(peerAddress, localAddress, std::move(payloadBuf));
 
     // verify it was called
     NL_TEST_ASSERT(inSuite, testCallback.mFindCommissionableNodeCalled);

--- a/src/transport/MessageCounterManagerInterface.h
+++ b/src/transport/MessageCounterManagerInterface.h
@@ -40,6 +40,7 @@ public:
     virtual CHIP_ERROR QueueReceivedMessageAndStartSync(const PacketHeader & packetHeader, SessionHandle session,
                                                         Transport::SecureSession * state,
                                                         const Transport::PeerAddress & peerAddress,
+                                                        const Transport::PeerAddress & localAddress,
                                                         System::PacketBufferHandle && msgBuf) = 0;
 };
 

--- a/src/transport/SessionManager.h
+++ b/src/transport/SessionManager.h
@@ -253,14 +253,8 @@ public:
 
     TransportMgrBase * GetTransportManager() const { return mTransportMgr; }
 
-    /**
-     * @brief
-     *   Handle received secure message. Implements TransportMgrDelegate
-     *
-     * @param source    the source address of the package
-     * @param msgBuf    the buffer containing a full CHIP message (except for the optional length field).
-     */
-    void OnMessageReceived(const Transport::PeerAddress & source, System::PacketBufferHandle && msgBuf) override;
+    // Implementation TransportMgrDelegate Interface
+    void OnMessageReceived(const Transport::PeerAddress & peer, const Transport::PeerAddress & local, System::PacketBufferHandle && message) override;
 
     Optional<SessionHandle> CreateUnauthenticatedSession(const Transport::PeerAddress & peerAddress)
     {

--- a/src/transport/TransportMgr.h
+++ b/src/transport/TransportMgr.h
@@ -47,10 +47,11 @@ public:
      * @brief
      *   Handle received secure message.
      *
-     * @param source    the source address of the package
-     * @param msgBuf    the buffer containing a full CHIP message (except for the optional length field).
+     * @param peer   the source/peer address of the package
+     * @param local  the destination/local address of the package
+     * @param message the buffer containing a full CHIP message (except for the optional length field).
      */
-    virtual void OnMessageReceived(const Transport::PeerAddress & source, System::PacketBufferHandle && msgBuf) = 0;
+    virtual void OnMessageReceived(const Transport::PeerAddress & peer, const Transport::PeerAddress & local, System::PacketBufferHandle && message) = 0;
 };
 
 template <typename... TransportTypes>

--- a/src/transport/TransportMgrBase.h
+++ b/src/transport/TransportMgrBase.h
@@ -35,7 +35,7 @@ class TransportMgrBase : public Transport::RawTransportDelegate
 public:
     CHIP_ERROR Init(Transport::Base * transport);
 
-    CHIP_ERROR SendMessage(const Transport::PeerAddress & address, System::PacketBufferHandle && msgBuf);
+    CHIP_ERROR SendMessage(const Transport::PeerAddress & peer, const Transport::PeerAddress & local, System::PacketBufferHandle && message);
 
     void Close();
 
@@ -43,7 +43,7 @@ public:
 
     void SetSessionManager(TransportMgrDelegate * sessionManager) { mSessionManager = sessionManager; }
 
-    void HandleMessageReceived(const Transport::PeerAddress & peerAddress, System::PacketBufferHandle && msg) override;
+    void HandleMessageReceived(const Transport::PeerAddress & peer, const Transport::PeerAddress & local, System::PacketBufferHandle && message) override;
 
 private:
     TransportMgrDelegate * mSessionManager = nullptr;

--- a/src/transport/raw/BLE.cpp
+++ b/src/transport/raw/BLE.cpp
@@ -87,18 +87,19 @@ CHIP_ERROR BLEBase::SetEndPoint(Ble::BLEEndPoint * endPoint)
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR BLEBase::SendMessage(const Transport::PeerAddress & address, System::PacketBufferHandle && msgBuf)
+CHIP_ERROR BLEBase::SendMessage(const Transport::PeerAddress & peer, const Transport::PeerAddress & local, System::PacketBufferHandle && message)
 {
-    ReturnErrorCodeIf(address.GetTransportType() != Type::kBle, CHIP_ERROR_INVALID_ARGUMENT);
+    ReturnErrorCodeIf(peer.GetTransportType() != Type::kBle, CHIP_ERROR_INVALID_ARGUMENT);
+    ReturnErrorCodeIf(local.GetTransportType() != Type::kBle, CHIP_ERROR_INVALID_ARGUMENT);
     ReturnErrorCodeIf(mState == State::kNotReady, CHIP_ERROR_INCORRECT_STATE);
 
     if (mState == State::kConnected)
     {
-        ReturnErrorOnFailure(mBleEndPoint->Send(std::move(msgBuf)));
+        ReturnErrorOnFailure(mBleEndPoint->Send(std::move(message)));
     }
     else
     {
-        ReturnErrorOnFailure(SendAfterConnect(std::move(msgBuf)));
+        ReturnErrorOnFailure(SendAfterConnect(std::move(message)));
     }
 
     return CHIP_NO_ERROR;
@@ -153,7 +154,7 @@ void BLEBase::OnBleConnectionError(CHIP_ERROR err)
 
 void BLEBase::OnEndPointMessageReceived(BLEEndPoint * endPoint, PacketBufferHandle && buffer)
 {
-    HandleMessageReceived(Transport::PeerAddress(Transport::Type::kBle), std::move(buffer));
+    HandleMessageReceived(Transport::PeerAddress(Transport::Type::kBle), Transport::PeerAddress(Transport::Type::kBle), std::move(buffer));
 }
 
 void BLEBase::OnEndPointConnectComplete(BLEEndPoint * endPoint, CHIP_ERROR err)

--- a/src/transport/raw/BLE.h
+++ b/src/transport/raw/BLE.h
@@ -82,7 +82,7 @@ public:
      */
     CHIP_ERROR Init(const BleListenParameters & param);
 
-    CHIP_ERROR SendMessage(const Transport::PeerAddress & address, System::PacketBufferHandle && msgBuf) override;
+    CHIP_ERROR SendMessage(const Transport::PeerAddress & peer, const Transport::PeerAddress & local, System::PacketBufferHandle && message) override;
 
     bool CanSendToPeer(const Transport::PeerAddress & address) override
     {

--- a/src/transport/raw/Base.h
+++ b/src/transport/raw/Base.h
@@ -37,7 +37,7 @@ class RawTransportDelegate
 {
 public:
     virtual ~RawTransportDelegate() {}
-    virtual void HandleMessageReceived(const Transport::PeerAddress & peerAddress, System::PacketBufferHandle && msg) = 0;
+    virtual void HandleMessageReceived(const Transport::PeerAddress & peer, const Transport::PeerAddress & local, System::PacketBufferHandle && message) = 0;
 };
 
 /**
@@ -63,7 +63,7 @@ public:
      *
      * On connection-oriented transports, sending a message implies connecting to the target first.
      */
-    virtual CHIP_ERROR SendMessage(const PeerAddress & address, System::PacketBufferHandle && msgBuf) = 0;
+    virtual CHIP_ERROR SendMessage(const Transport::PeerAddress & peer, const Transport::PeerAddress & local, System::PacketBufferHandle && message) = 0;
 
     /**
      * Determine if this transport can SendMessage to the specified peer address.
@@ -87,9 +87,9 @@ protected:
      * Method used by subclasses to notify that a packet has been received after
      * any associated headers have been decoded.
      */
-    void HandleMessageReceived(const PeerAddress & source, System::PacketBufferHandle && buffer)
+    void HandleMessageReceived(const Transport::PeerAddress & peer, const Transport::PeerAddress & local, System::PacketBufferHandle && message)
     {
-        mDelegate->HandleMessageReceived(source, std::move(buffer));
+        mDelegate->HandleMessageReceived(peer, local, std::move(message));
     }
 
     RawTransportDelegate * mDelegate;

--- a/src/transport/raw/TCP.cpp
+++ b/src/transport/raw/TCP.cpp
@@ -59,11 +59,6 @@ TCPBase::~TCPBase()
     }
 
     CloseActiveConnections();
-
-    for (size_t i = 0; i < mPendingPacketsSize; i++)
-    {
-        mPendingPackets[i].packetBuffer = nullptr;
-    }
 }
 
 void TCPBase::CloseActiveConnections()
@@ -206,53 +201,39 @@ CHIP_ERROR TCPBase::SendMessage(const Transport::PeerAddress & address, System::
 CHIP_ERROR TCPBase::SendAfterConnect(const PeerAddress & addr, System::PacketBufferHandle && msg)
 {
     // This will initiate a connection to the specified peer
-    CHIP_ERROR err               = CHIP_NO_ERROR;
-    PendingPacket * packet       = nullptr;
     bool alreadyConnecting       = false;
-    Inet::TCPEndPoint * endPoint = nullptr;
 
     // Iterate through the ENTIRE array. If a pending packet for
     // the address already exists, this means a connection is pending and
     // does NOT need to be re-established.
-    for (size_t i = 0; i < mPendingPacketsSize; i++)
-    {
-        if (mPendingPackets[i].packetBuffer.IsNull())
-        {
-            if (packet == nullptr)
-            {
-                // found a slot to store the packet into
-                packet = mPendingPackets + i;
-            }
-        }
-        else if (mPendingPackets[i].peerAddress == addr)
+    mPendingPackets.ForEachActiveObject([&] (PendingPacket * pending) {
+        if (pending->mPeerAddress == addr)
         {
             // same destination exists.
             alreadyConnecting = true;
-
-            // ensure packets are ORDERED
-            if (packet != nullptr)
-            {
-                packet->peerAddress  = addr;
-                packet->packetBuffer = std::move(mPendingPackets[i].packetBuffer);
-                packet               = mPendingPackets + i;
-            }
+            pending->mPacketBuffer->AddToEnd(std::move(msg));
+            return false;
         }
-    }
-
-    VerifyOrExit(packet != nullptr, err = CHIP_ERROR_NO_MEMORY);
+        return true;
+    });
 
     // If already connecting, buffer was just enqueued for more sending
-    VerifyOrExit(!alreadyConnecting, err = CHIP_NO_ERROR);
+    if (alreadyConnecting)
+    {
+        return CHIP_NO_ERROR;
+    }
 
     // Ensures sufficient active connections size exist
-    VerifyOrExit(mUsedEndPointCount < mActiveConnectionsSize, err = CHIP_ERROR_NO_MEMORY);
+    VerifyOrReturnError(mUsedEndPointCount < mActiveConnectionsSize, CHIP_ERROR_NO_MEMORY);
 
+    Inet::TCPEndPoint * endPoint = nullptr;
 #if INET_CONFIG_ENABLE_TCP_ENDPOINT
-    err = mListenSocket->Layer().NewTCPEndPoint(&endPoint);
+    ReturnErrorOnFailure(mListenSocket->Layer().NewTCPEndPoint(&endPoint));
+    auto EndPointDeletor = [](Inet::TCPEndPoint * e) { e->Free(); };
+    std::unique_ptr<Inet::TCPEndPoint, decltype(EndPointDeletor)> endPointHolder(endPoint, EndPointDeletor);
 #else
-    err = CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 #endif
-    SuccessOrExit(err);
 
     endPoint->mAppState            = reinterpret_cast<void *>(this);
     endPoint->OnDataReceived       = OnTcpReceive;
@@ -262,23 +243,17 @@ CHIP_ERROR TCPBase::SendAfterConnect(const PeerAddress & addr, System::PacketBuf
     endPoint->OnAcceptError        = OnAcceptError;
     endPoint->OnPeerClose          = OnPeerClosed;
 
-    err = endPoint->Connect(addr.GetIPAddress(), addr.GetPort(), addr.GetInterface());
-    SuccessOrExit(err);
+    ReturnErrorOnFailure(endPoint->Connect(addr.GetIPAddress(), addr.GetPort(), addr.GetInterface()));
 
     // enqueue the packet once the connection succeeds
-    packet->peerAddress  = addr;
-    packet->packetBuffer = std::move(msg);
+    VerifyOrReturnError(mPendingPackets.CreateObject(addr, std::move(msg)) != nullptr, CHIP_ERROR_NO_MEMORY);
     mUsedEndPointCount++;
 
-exit:
-    if (err != CHIP_NO_ERROR)
-    {
-        if (endPoint != nullptr)
-        {
-            endPoint->Free();
-        }
-    }
-    return err;
+#if INET_CONFIG_ENABLE_TCP_ENDPOINT
+    endPointHolder.release();
+#endif
+
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR TCPBase::ProcessReceivedBuffer(Inet::TCPEndPoint * endPoint, const PeerAddress & peerAddress,
@@ -390,22 +365,19 @@ void TCPBase::OnConnectionComplete(Inet::TCPEndPoint * endPoint, CHIP_ERROR inet
     PeerAddress addr = PeerAddress::TCP(ipAddress, port, interfaceId);
 
     // Send any pending packets
-    for (size_t i = 0; i < tcp->mPendingPacketsSize; i++)
-    {
-        if ((tcp->mPendingPackets[i].peerAddress != addr) || (tcp->mPendingPackets[i].packetBuffer.IsNull()))
-        {
-            continue;
-        }
-        foundPendingPacket = true;
+    tcp->mPendingPackets.ForEachActiveObject([&] (PendingPacket * pending) {
+        if (pending->mPeerAddress == addr) {
+            foundPendingPacket = true;
+            System::PacketBufferHandle buffer   = std::move(pending->mPacketBuffer);
+            tcp->mPendingPackets.ReleaseObject(pending);
 
-        System::PacketBufferHandle buffer   = std::move(tcp->mPendingPackets[i].packetBuffer);
-        tcp->mPendingPackets[i].peerAddress = PeerAddress::Uninitialized();
-
-        if ((inetErr == CHIP_NO_ERROR) && (err == CHIP_NO_ERROR))
-        {
-            err = endPoint->Send(std::move(buffer));
+            if ((inetErr == CHIP_NO_ERROR) && (err == CHIP_NO_ERROR))
+            {
+                err = endPoint->Send(std::move(buffer));
+            }
         }
-    }
+        return true;
+    });
 
     if (err == CHIP_NO_ERROR)
     {

--- a/src/transport/raw/TCP.h
+++ b/src/transport/raw/TCP.h
@@ -33,6 +33,7 @@
 #include <inet/TCPEndPoint.h>
 #include <lib/core/CHIPCore.h>
 #include <lib/support/CodeUtils.h>
+#include <lib/support/PoolWrapper.h>
 #include <transport/raw/Base.h>
 
 namespace chip {
@@ -84,8 +85,10 @@ private:
  */
 struct PendingPacket
 {
-    PeerAddress peerAddress;                 // where the packet is being sent to
-    System::PacketBufferHandle packetBuffer; // what data needs to be sent
+    PendingPacket(const PeerAddress & peerAddress, System::PacketBufferHandle && packetBuffer) : mPeerAddress(peerAddress), mPacketBuffer(std::move(packetBuffer)) {}
+
+    PeerAddress mPeerAddress;                 // where the packet is being sent to
+    System::PacketBufferHandle mPacketBuffer; // what data needs to be sent
 };
 
 /** Implements a transport using TCP. */
@@ -128,20 +131,9 @@ protected:
     };
 
 public:
-    TCPBase(ActiveConnectionState * activeConnectionsBuffer, size_t bufferSize, PendingPacket * packetBuffers,
-            size_t packetsBuffersSize) :
-        mActiveConnections(activeConnectionsBuffer),
-        mActiveConnectionsSize(bufferSize), mPendingPackets(packetBuffers), mPendingPacketsSize(packetsBuffersSize)
+    TCPBase(ActiveConnectionState * activeConnectionsBuffer, size_t bufferSize, PoolInterface<PendingPacket, const PeerAddress &, System::PacketBufferHandle &&> & packetBuffers) : mActiveConnections(activeConnectionsBuffer), mActiveConnectionsSize(bufferSize), mPendingPackets(packetBuffers)
     {
         // activeConnectionsBuffer must be initialized by the caller.
-        for (size_t i = 0; i < mPendingPacketsSize; ++i)
-        {
-            mPendingPackets[i].peerAddress = PeerAddress::Uninitialized();
-            // In the typical case, the TCPBase constructor is invoked from the TCP constructor on its mPendingPackets,
-            // which has not yet been initialized. That means we can't do a normal move assignment or construction of
-            // the PacketBufferHandle, since that would call PacketBuffer::Free on the uninitialized data.
-            new (&mPendingPackets[i].packetBuffer) System::PacketBufferHandle();
-        }
     }
     ~TCPBase() override;
 
@@ -266,15 +258,14 @@ private:
     const size_t mActiveConnectionsSize;
 
     // Data to be sent when connections succeed
-    PendingPacket * mPendingPackets;
-    const size_t mPendingPacketsSize;
+    PoolInterface<PendingPacket, const PeerAddress &, System::PacketBufferHandle &&> & mPendingPackets;
 };
 
 template <size_t kActiveConnectionsSize, size_t kPendingPacketSize>
 class TCP : public TCPBase
 {
 public:
-    TCP() : TCPBase(mConnectionsBuffer, kActiveConnectionsSize, mPendingPackets, kPendingPacketSize)
+    TCP() : TCPBase(mConnectionsBuffer, kActiveConnectionsSize, mPendingPackets)
     {
         for (size_t i = 0; i < kActiveConnectionsSize; ++i)
         {
@@ -285,7 +276,7 @@ public:
 private:
     friend class TCPTest;
     TCPBase::ActiveConnectionState mConnectionsBuffer[kActiveConnectionsSize];
-    PendingPacket mPendingPackets[kPendingPacketSize];
+    PoolImpl<PendingPacket, kPendingPacketSize, std::tuple<PendingPacket, const PeerAddress &, System::PacketBufferHandle &&>> mPendingPackets;
 };
 
 } // namespace Transport

--- a/src/transport/raw/UDP.h
+++ b/src/transport/raw/UDP.h
@@ -112,7 +112,7 @@ public:
      */
     void Close() override;
 
-    CHIP_ERROR SendMessage(const Transport::PeerAddress & address, System::PacketBufferHandle && msgBuf) override;
+    CHIP_ERROR SendMessage(const Transport::PeerAddress & peer, const Transport::PeerAddress & local, System::PacketBufferHandle && message) override;
 
     bool CanSendToPeer(const Transport::PeerAddress & address) override
     {

--- a/src/transport/raw/tests/TestUDP.cpp
+++ b/src/transport/raw/tests/TestUDP.cpp
@@ -58,19 +58,19 @@ public:
     MockTransportMgrDelegate(nlTestSuite * inSuite) : mSuite(inSuite) {}
     ~MockTransportMgrDelegate() override {}
 
-    void OnMessageReceived(const Transport::PeerAddress & source, System::PacketBufferHandle && msgBuf) override
+    void OnMessageReceived(const Transport::PeerAddress & peer, const Transport::PeerAddress & local, System::PacketBufferHandle && message) override
     {
         PacketHeader packetHeader;
 
-        CHIP_ERROR err = packetHeader.DecodeAndConsume(msgBuf);
+        CHIP_ERROR err = packetHeader.DecodeAndConsume(message);
         NL_TEST_ASSERT(mSuite, err == CHIP_NO_ERROR);
 
         NL_TEST_ASSERT(mSuite, packetHeader.GetSourceNodeId() == Optional<NodeId>::Value(kSourceNodeId));
         NL_TEST_ASSERT(mSuite, packetHeader.GetDestinationNodeId() == Optional<NodeId>::Value(kDestinationNodeId));
         NL_TEST_ASSERT(mSuite, packetHeader.GetMessageCounter() == kMessageCounter);
 
-        size_t data_len = msgBuf->DataLength();
-        int compare     = memcmp(msgBuf->Start(), PAYLOAD, data_len);
+        size_t data_len = message->DataLength();
+        int compare     = memcmp(message->Start(), PAYLOAD, data_len);
         NL_TEST_ASSERT(mSuite, compare == 0);
 
         ReceiveHandlerCallCount++;


### PR DESCRIPTION
#### Problem
#11120 

This is the first step to solve referred issue, after this PR, we need another PR to put source address into the session matching tuple.

#### Change overview
[InetLayer] handle source address for transport layer
* When `SendMessage` take an extra argument of local address, send via this local address
* When `OnMessageReceived`, pass an extra argument of local address to the delegate object (the `SessionManager`)

#### Testing
WIP