### PR TITLE
Update documentation now that "bypass" rendezvous is gone.

### DIFF
--- a/.github/.wordlist.txt
+++ b/.github/.wordlist.txt
@@ -216,6 +216,7 @@ cppreference
 CPROTO
 cpuapp
 cpython
+CQM
 crypto
 cryptographic
 CSA

--- a/examples/all-clusters-app/ameba/README.md
+++ b/examples/all-clusters-app/ameba/README.md
@@ -10,7 +10,6 @@ control.
     -   [Building the Example Application](#building-the-example-application)
     -   [Commissioning and cluster control](#commissioning-and-cluster-control)
         -   [Commissioning](#commissioning)
-            -   [Bypass mode](#bypass-mode)
             -   [BLE mode](#ble-mode)
             -   [IP mode](#ip-mode)
         -   [Cluster control](#cluster-control)
@@ -59,26 +58,7 @@ The CHIP demo application is supported on
 
 ## Commissioning
 
-There are three commissioning modes supported by Ameba platform:
-
-### Bypass mode
-
-1. In "connectedhomeip/config/ameba/args.gni"
-
-    - set `chip_bypass_rendezvous = true`
-    - Set `chip_config_network_layer_ble = false`
-
-2. In "connectedhomeip/src/platform/Ameba/CHIPDevicePlatformConfig.h"
-
-    - Set `#define CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE 0`
-
-3. Build and Flash
-4. Use ATS\$ command to run all-cluster example.
-5. Connect to AP using `ATW0, ATW1, ATWC` commands
-6. Test with
-   [Chip-Tool](https://github.com/project-chip/connectedhomeip/tree/master/examples/chip-tool)
-   or
-   [Python Controller](https://github.com/project-chip/connectedhomeip/blob/master/docs/guides/python_chip_controller_building.md).
+There are two commissioning modes supported by Ameba platform:
 
 ### BLE mode
 

--- a/examples/bridge-app/linux/README.md
+++ b/examples/bridge-app/linux/README.md
@@ -129,16 +129,6 @@ value/label pair `"room"`/`[light name]`.
 
 ## Running the Complete Example on Raspberry Pi 4
 
-> If you want to test ZCL, please disable Rendezvous
->
->     gn gen out/debug --args='bypass_rendezvous=true'
->     ninja -C out/debug
->
-> Note that GN will set bypass_rendezvous for future builds, to enable
-> rendezvous, re-generate using
->
->     gn gen out/debug --args='chip_bypass_rendezvous=false'
-
 -   Prerequisites
 
     1. A Raspberry Pi 4 board

--- a/examples/chip-tool/README.md
+++ b/examples/chip-tool/README.md
@@ -42,13 +42,6 @@ configuration.
 To initiate a client commissioning request to a device, run the built executable
 and choose the pairing mode.
 
-##### Commission a device configured to bypass Rendezvous
-
-The command below commissions a device with the provided IP address and port of
-the server to talk to.
-
-    $ chip-tool pairing bypass ${NODE_ID_TO_ASSIGN} 192.168.0.30 5540
-
 #### Commission a device over BLE
 
 Run the built executable and pass it the discriminator and pairing code of the
@@ -433,7 +426,6 @@ Usage:
   | Commands:                                                                           |
   +-------------------------------------------------------------------------------------+
   | * unpair                                                                            |
-  | * bypass                                                                            |
   | * ble                                                                               |
   | * softap                                                                            |
   +-------------------------------------------------------------------------------------+

--- a/examples/lighting-app/linux/README.md
+++ b/examples/lighting-app/linux/README.md
@@ -73,20 +73,9 @@ To cross-compile this example on x64 host and run on **NXP i.MX 8M Mini**
 
 ## Running the Complete Example on Raspberry Pi 4
 
-> If you want to test ZCL, please disable Rendezvous
+> If you want to test Echo protocol, please enable Echo handler
 >
->     gn gen out/debug --args='chip_bypass_rendezvous=true'
->     ninja -C out/debug
->
-> Note that GN will set chip_bypass_rendezvous for future builds, to enable
-> rendezvous, re-generate using
->
->     gn gen out/debug --args='chip_bypass_rendezvous=false'
-
-> If you want to test Echo protocol, please disable Rendezvous and enable Echo
-> handler
->
->     gn gen out/debug --args='chip_bypass_rendezvous=true chip_app_use_echo=true'
+>     gn gen out/debug --args='chip_app_use_echo=true'
 >     ninja -C out/debug
 
 -   Prerequisites

--- a/examples/lighting-app/telink/Readme.md
+++ b/examples/lighting-app/telink/Readme.md
@@ -163,14 +163,12 @@ following states:
 1. Pair with device
 
     ```
-    ${CHIP_TOOL_DIR}/chip-tool pairing bypass ${NODE_ID_TO_ASSIGN} ${IP_ADDRESS_OF_CHIP_DEVICE} 5540
+    ${CHIP_TOOL_DIR}/chip-tool pairing qrcode ${NODE_ID_TO_ASSIGN} MT:D8XA0CQM00KA0648G00
     ```
 
     here:
 
     - \${NODE_ID_TO_ASSIGN} is the node id to assign to the lightbulb
-    - `${IP_ADDRESS_OF_CHIP_DEVICE}` is IPv6 address of CHIP device
-    - **5540** is the standard CHIP TCP port
 
 1. Switch on the light:
 

--- a/examples/tv-app/linux/README.md
+++ b/examples/tv-app/linux/README.md
@@ -38,16 +38,6 @@ Desktop 20.10 (aarch64)**
 
 ## Running the Complete Example on Raspberry Pi 4
 
-> If you want to test ZCL, please disable Rendezvous
->
->     gn gen out/debug --args='bypass_rendezvous=true'
->     ninja -C out/debug
->
-> Note that GN will set bypass_rendezvous for future builds, to enable
-> rendezvous, re-generate using
->
->     gn gen out/debug --args='chip_bypass_rendezvous=false'
-
 -   Prerequisites
 
     1. A Raspberry Pi 4 board


### PR DESCRIPTION
#### Problem
Docs claim you can do "bypass" rendezvous, but it's gone in the code.

#### Change overview
Update docs.

#### Testing
No behavior changes.