### PR TITLE
Report list attribute change with detailed operations

### DIFF
--- a/examples/bridge-app/esp32/main/main.cpp
+++ b/examples/bridge-app/esp32/main/main.cpp
@@ -36,6 +36,7 @@
 const char * TAG = "bridge-app";
 
 using namespace ::chip;
+using namespace ::chip::app;
 using namespace ::chip::Credentials;
 using namespace ::chip::DeviceManager;
 using namespace ::chip::DeviceLayer;

--- a/examples/bridge-app/linux/main.cpp
+++ b/examples/bridge-app/linux/main.cpp
@@ -45,6 +45,7 @@
 #include <iostream>
 
 using namespace chip;
+using namespace chip::app;
 using namespace chip::Credentials;
 using namespace chip::Inet;
 using namespace chip::Transport;

--- a/src/app/clusters/general_diagnostics_server/general_diagnostics_server.cpp
+++ b/src/app/clusters/general_diagnostics_server/general_diagnostics_server.cpp
@@ -144,8 +144,9 @@ class GeneralDiagnosticDelegate : public DeviceLayer::ConnectivityManagerDelegat
                 if (emberAfContainsServer(endpointId, GeneralDiagnostics::Id))
                 {
                     // If General Diagnostics cluster is implemented on this endpoint
-                    MatterReportingAttributeChangeCallback(endpointId, GeneralDiagnostics::Id,
-                                                           GeneralDiagnostics::Attributes::NetworkInterfaces::Id);
+                    MatterReportingListAttributeChangeCallback(endpointId, GeneralDiagnostics::Id,
+                                                               GeneralDiagnostics::Attributes::NetworkInterfaces::Id,
+                                                               ListOperation::ReplaceAll);
                 }
             }
         }

--- a/src/app/reporting/reporting.h
+++ b/src/app/reporting/reporting.h
@@ -41,6 +41,33 @@
 
 #include <app/util/af-types.h>
 
+namespace chip {
+namespace app {
+
+enum class ListOperation
+{
+    NotList,
+    ReplaceAll,
+    UpdateItem,
+    DeleteItem,
+    AppendItem
+};
+
+/** @brief Reporting List Attribute Change
+ *
+ * This function is called by the framework when a list attribute managed by the
+ * framework changes.  The application should call this function when an
+ * externally-managed list attribute changes.  The application should use the change
+ * notification to inform its reporting decisions.
+ *
+ * @param endpoint
+ * @param clusterId
+ * @param attributeId
+ * @param listOp
+ */
+void MatterReportingListAttributeChangeCallback(chip::EndpointId endpoint, chip::ClusterId clusterId, chip::AttributeId attributeId,
+                                                ListOperation listOp);
+
 /** @brief Reporting Attribute Change
  *
  * This function is called by the framework when an attribute managed by the
@@ -63,3 +90,6 @@ void MatterReportingAttributeChangeCallback(chip::EndpointId endpoint, chip::Clu
  * Same but with just an attribute path and no data available.
  */
 void MatterReportingAttributeChangeCallback(chip::EndpointId endpoint, chip::ClusterId clusterId, chip::AttributeId attributeId);
+
+}; // namespace app
+}; // namespace chip

--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -53,6 +53,7 @@
 #include <app-common/zap-generated/ids/Attributes.h>
 
 using namespace chip;
+using namespace chip::app;
 
 //------------------------------------------------------------------------------
 // Globals

--- a/src/app/util/attribute-table.cpp
+++ b/src/app/util/attribute-table.cpp
@@ -55,6 +55,7 @@
 #include <protocols/interaction_model/Constants.h>
 
 using namespace chip;
+using namespace chip::app;
 
 //------------------------------------------------------------------------------
 

--- a/src/app/util/ember-compatibility-functions.cpp
+++ b/src/app/util/ember-compatibility-functions.cpp
@@ -600,8 +600,13 @@ CHIP_ERROR WriteSingleClusterData(ClusterInfo & aClusterInfo, TLV::TLVReader & a
     return apWriteHandler->AddStatus(attributePathParams, imCode);
 }
 
-} // namespace app
-} // namespace chip
+void MatterReportingListAttributeChangeCallback(chip::EndpointId endpoint, chip::ClusterId clusterId, chip::AttributeId attributeId,
+                                                ListOperation listOp)
+{
+    // TODO: We need to trigger the reporting based on detailed list operations; delete/update/append...
+    // At this moment, we just mark the list attribute as dirty to send all fields in report.
+    MatterReportingAttributeChangeCallback(endpoint, clusterId, attributeId);
+}
 
 void MatterReportingAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
                                             uint16_t manufacturerCode, EmberAfAttributeType type, uint8_t * data)
@@ -628,3 +633,6 @@ void MatterReportingAttributeChangeCallback(EndpointId endpoint, ClusterId clust
     // context without requiring any explicit 'start' or 'end' change calls into the engine to book-end the change.
     InteractionModelEngine::GetInstance()->GetReportingEngine().ScheduleRun();
 }
+
+} // namespace app
+} // namespace chip


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* Currently, when a list attribute managed by the framework changes, we just mark the whole list attribute as dirty and include all entries of the list in the report.

* We need a new function is called by the framework when an list attribute managed by the framework changes.  The application should call this function when an externally-managed list attribute changes with detailed operation.  The application should make its reporting decisions based on the operation.
 
#### Change overview
Report list attribute change with detailed operation info.

Note: Only add the API, we still mark the whole list of attribute as dirty when an list attribute managed by the framework changes right now.

#### Testing
How was this tested? (at least one bullet point required)
* New API added,we still mark the whole list of attribute as dirty when an list attribute managed by the framework changes right now. The regression is covered by CI
