### PR TITLE
Send cluster specific errors from AdministratorCommissioning server

### DIFF
--- a/src/app/clusters/administrator-commissioning-server/administrator-commissioning-server.cpp
+++ b/src/app/clusters/administrator-commissioning-server/administrator-commissioning-server.cpp
@@ -46,7 +46,7 @@ bool emberAfAdministratorCommissioningClusterOpenCommissioningWindowCallback(
     auto & salt                 = commandData.salt;
     auto & passcodeID           = commandData.passcodeID;
 
-    Optional<StatusCode> status;
+    Optional<StatusCode> status = Optional<StatusCode>::Missing();
     PASEVerifier verifier;
     const uint8_t * verifierData = pakeVerifier.data();
 
@@ -90,7 +90,7 @@ bool emberAfAdministratorCommissioningClusterOpenBasicCommissioningWindowCallbac
 {
     auto & commissioningTimeout = commandData.commissioningTimeout;
 
-    Optional<StatusCode> status;
+    Optional<StatusCode> status = Optional<StatusCode>::Missing();
     ChipLogProgress(Zcl, "Received command to open basic commissioning window");
     VerifyOrExit(!Server::GetInstance().GetCommissioningWindowManager().IsCommissioningWindowOpen(),
                  status.Emplace(StatusCode::EMBER_ZCL_STATUS_CODE_BUSY));

--- a/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
+++ b/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
@@ -679,11 +679,11 @@ bool emberAfOperationalCredentialsClusterAddTrustedRootCertificateCallback(
 
     emberAfPrintln(EMBER_AF_PRINT_DEBUG, "OpCreds: commissioner has added a trusted root Cert");
 
-    VerifyOrExit(gFabricBeingCommissioned.SetRootCert(RootCertificate) == CHIP_NO_ERROR, status = EMBER_ZCL_STATUS_FAILURE);
+    VerifyOrExit(gFabricBeingCommissioned.SetRootCert(RootCertificate) == CHIP_NO_ERROR, status = EMBER_ZCL_STATUS_INVALID_FIELD);
 
 exit:
     emberAfSendImmediateDefaultResponse(status);
-    if (status == EMBER_ZCL_STATUS_FAILURE)
+    if (status != EMBER_ZCL_STATUS_SUCCESS)
     {
         gFabricBeingCommissioned.Reset();
         emberAfPrintln(EMBER_AF_PRINT_DEBUG, "OpCreds: Failed AddTrustedRootCert request.");

--- a/src/app/zap-templates/zcl/data-model/chip/administrator-commissioning-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/administrator-commissioning-cluster.xml
@@ -19,9 +19,9 @@ limitations under the License.
 
   <enum name="StatusCode" type="ENUM8">
     <cluster code="0x003c"/>
-     <item name="Success" value="0x00"/>
      <item name="Busy" value="0x01"/>
-     <item name="GeneralError" value="0x02"/>
+     <item name="PAKEParameterError" value="0x02"/>
+     <item name="WindowNotOpen" value="0x03"/>
   </enum>
 
   <cluster>

--- a/src/controller/python/chip/clusters/Objects.py
+++ b/src/controller/python/chip/clusters/Objects.py
@@ -8536,9 +8536,9 @@ class AdministratorCommissioning(Cluster):
 
     class Enums:
         class StatusCode(IntEnum):
-            kSuccess = 0x00
             kBusy = 0x01
-            kGeneralError = 0x02
+            kPAKEParameterError = 0x02
+            kWindowNotOpen = 0x03
 
     class Commands:
         @dataclass

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
@@ -11508,9 +11508,9 @@ namespace AdministratorCommissioning {
 // Enum for StatusCode
 enum class StatusCode : uint8_t
 {
-    kSuccess      = 0x00,
-    kBusy         = 0x01,
-    kGeneralError = 0x02,
+    kBusy               = 0x01,
+    kPAKEParameterError = 0x02,
+    kWindowNotOpen      = 0x03,
 };
 #else // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
 using StatusCode                           = EmberAfStatusCode;

--- a/zzz_generated/app-common/app-common/zap-generated/enums.h
+++ b/zzz_generated/app-common/app-common/zap-generated/enums.h
@@ -1497,9 +1497,9 @@ enum EmberAfStartUpOnOffValue : uint8_t
 // Enum for StatusCode
 enum EmberAfStatusCode : uint8_t
 {
-    EMBER_ZCL_STATUS_CODE_SUCCESS       = 0,
-    EMBER_ZCL_STATUS_CODE_BUSY          = 1,
-    EMBER_ZCL_STATUS_CODE_GENERAL_ERROR = 2,
+    EMBER_ZCL_STATUS_CODE_BUSY                 = 1,
+    EMBER_ZCL_STATUS_CODE_PAKE_PARAMETER_ERROR = 2,
+    EMBER_ZCL_STATUS_CODE_WINDOW_NOT_OPEN      = 3,
 };
 
 // Enum for StepMode


### PR DESCRIPTION
#### Problem
* Fixes #11715

#### Change overview
Use cluster specific error codes on command failures in AdministratorCommissioning cluster.

#### Testing
Tested using all-cluster-app and chip-tool. The following conditions were tested.
1. Try closing commissioning window while it is not open. Expected error `EMBER_ZCL_STATUS_CODE_WINDOW_NOT_OPEN` was returned.
2. Open commissioning window. While it's open try opening commissioning window again. Expected error `EMBER_ZCL_STATUS_CODE_BUSY` was returned.
3. Try opening commissioning window with incorrect parameters. Expected error `EMBER_ZCL_STATUS_CODE_PAKE_PARAMETER_ERROR` was returned.