### PR TITLE
Include VID/PID in ECM commissioning Setup Payload

### DIFF
--- a/examples/chip-tool/commands/pairing/OpenCommissioningWindowCommand.cpp
+++ b/examples/chip-tool/commands/pairing/OpenCommissioningWindowCommand.cpp
@@ -53,5 +53,6 @@ void OpenCommissioningWindowCommand::OnOpenCommissioningWindowResponse(void * co
 CHIP_ERROR OpenCommissioningWindowCommand::OpenCommissioningWindow()
 {
     return CurrentCommissioner().OpenCommissioningWindowWithCallback(
-        mNodeId, mTimeout, mIteration, mDiscriminator, mCommissioningWindowOption, &mOnOpenCommissioningWindowCallback);
+        mNodeId, mTimeout, mIteration, mDiscriminator, mCommissioningWindowOption, &mOnOpenCommissioningWindowCallback,
+        /* readVIDPIDAttributes */ true);
 }

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -109,7 +109,8 @@ constexpr uint32_t kSessionEstablishmentTimeout = 40 * kMillisecondsPerSecond;
 
 DeviceController::DeviceController() :
     mOpenPairingSuccessCallback(OnOpenPairingWindowSuccessResponse, this),
-    mOpenPairingFailureCallback(OnOpenPairingWindowFailureResponse, this)
+    mOpenPairingFailureCallback(OnOpenPairingWindowFailureResponse, this), mPIDReadCallback(OnPIDReadResponse, this),
+    mVIDReadCallback(OnVIDReadResponse, this), mVIDPIDReadFailureCallback(OnVIDPIDReadFailureResponse, this)
 {
     mState                    = State::NotInitialized;
     mStorageDelegate          = nullptr;
@@ -353,6 +354,45 @@ CHIP_ERROR DeviceController::GetPeerAddressAndPort(PeerId peerId, Inet::IPAddres
     return CHIP_NO_ERROR;
 }
 
+void DeviceController::OnPIDReadResponse(void * context, uint16_t value)
+{
+    ChipLogProgress(Controller, "Received PID for the device. Value %d", value);
+    DeviceController * controller       = reinterpret_cast<DeviceController *>(context);
+    controller->mSetupPayload.productID = value;
+
+    if (controller->OpenCommissioningWindowInternal() != CHIP_NO_ERROR)
+    {
+        OnOpenPairingWindowFailureResponse(context, 0);
+    }
+}
+
+void DeviceController::OnVIDReadResponse(void * context, uint16_t value)
+{
+    ChipLogProgress(Controller, "Received VID for the device. Value %d", value);
+
+    DeviceController * controller = reinterpret_cast<DeviceController *>(context);
+
+    controller->mSetupPayload.vendorID = value;
+
+    OperationalDeviceProxy * device =
+        controller->mCASESessionManager->FindExistingSession(controller->mDeviceWithCommissioningWindowOpen);
+    VerifyOrReturn(device != nullptr, ChipLogError(Controller, "Could not find device for opening commissioning window"));
+
+    constexpr EndpointId kBasicClusterEndpoint = 0;
+    chip::Controller::BasicCluster cluster;
+    cluster.Associate(device, kBasicClusterEndpoint);
+
+    Callback::Cancelable * successCallback = controller->mPIDReadCallback.Cancel();
+    Callback::Cancelable * failureCallback = controller->mVIDPIDReadFailureCallback.Cancel();
+    cluster.ReadAttributeProductID(successCallback, failureCallback);
+}
+
+void DeviceController::OnVIDPIDReadFailureResponse(void * context, uint8_t status)
+{
+    ChipLogProgress(Controller, "Failed to read VID/PID for the device. status %d", status);
+    OnOpenPairingWindowFailureResponse(context, status);
+}
+
 void DeviceController::OnOpenPairingWindowSuccessResponse(void * context)
 {
     ChipLogProgress(Controller, "Successfully opened pairing window on the device");
@@ -372,8 +412,7 @@ void DeviceController::OnOpenPairingWindowFailureResponse(void * context, uint8_
     if (controller->mCommissioningWindowCallback != nullptr)
     {
         CHIP_ERROR error = CHIP_ERROR_INVALID_PASE_PARAMETER;
-        // TODO - Use cluster enum chip::app::Clusters::AdministratorCommissioning::StatusCode::kBusy
-        if (status == 1)
+        if (status == EmberAfStatusCode::EMBER_ZCL_STATUS_CODE_BUSY)
         {
             error = CHIP_ERROR_ANOTHER_COMMISSIONING_IN_PROGRESS;
         }
@@ -395,35 +434,61 @@ CHIP_ERROR DeviceController::OpenCommissioningWindowWithCallback(NodeId deviceId
                                                                  uint16_t discriminator, uint8_t option,
                                                                  Callback::Callback<OnOpenCommissioningWindow> * callback)
 {
-    ChipLogProgress(Controller, "OpenCommissioningWindow for device ID %" PRIu64, deviceId);
-    VerifyOrReturnError(mState == State::Initialized, CHIP_ERROR_INCORRECT_STATE);
+    mSetupPayload = SetupPayload();
 
-    OperationalDeviceProxy * device = mCASESessionManager->FindExistingSession(deviceId);
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    mSetupPayload.version               = 0;
+    mSetupPayload.discriminator         = discriminator;
+    mSetupPayload.rendezvousInformation = RendezvousInformationFlags(RendezvousInformationFlag::kOnNetwork);
 
-    std::string QRCode;
-    std::string manualPairingCode;
-    SetupPayload payload;
-    CommissioningWindowOption commissioningWindowOption;
-    ByteSpan salt(reinterpret_cast<const uint8_t *>(kSpake2pKeyExchangeSalt), strlen(kSpake2pKeyExchangeSalt));
-
-    payload.discriminator = discriminator;
+    mCommissioningWindowCallback       = callback;
+    mDeviceWithCommissioningWindowOpen = deviceId;
+    mCommissioningWindowTimeout        = timeout;
+    mCommissioningWindowIteration      = iteration;
 
     switch (option)
     {
     case 0:
-        commissioningWindowOption = CommissioningWindowOption::kOriginalSetupCode;
+        mCommissioningWindowOption = CommissioningWindowOption::kOriginalSetupCode;
         break;
     case 1:
-        commissioningWindowOption = CommissioningWindowOption::kTokenWithRandomPIN;
+        mCommissioningWindowOption = CommissioningWindowOption::kTokenWithRandomPIN;
         break;
     case 2:
-        commissioningWindowOption = CommissioningWindowOption::kTokenWithProvidedPIN;
+        mCommissioningWindowOption = CommissioningWindowOption::kTokenWithProvidedPIN;
         break;
     default:
         ChipLogError(Controller, "Invalid Pairing Window option");
         return CHIP_ERROR_INVALID_ARGUMENT;
     }
+
+    if (callback != nullptr && option != 0)
+    {
+        OperationalDeviceProxy * device = mCASESessionManager->FindExistingSession(mDeviceWithCommissioningWindowOpen);
+        VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+
+        constexpr EndpointId kBasicClusterEndpoint = 0;
+        chip::Controller::BasicCluster cluster;
+        cluster.Associate(device, kBasicClusterEndpoint);
+
+        Callback::Cancelable * successCallback = mVIDReadCallback.Cancel();
+        Callback::Cancelable * failureCallback = mVIDPIDReadFailureCallback.Cancel();
+        return cluster.ReadAttributeVendorID(successCallback, failureCallback);
+    }
+
+    return OpenCommissioningWindowInternal();
+}
+
+CHIP_ERROR DeviceController::OpenCommissioningWindowInternal()
+{
+    ChipLogProgress(Controller, "OpenCommissioningWindow for device ID %" PRIu64, mDeviceWithCommissioningWindowOpen);
+    VerifyOrReturnError(mState == State::Initialized, CHIP_ERROR_INCORRECT_STATE);
+
+    OperationalDeviceProxy * device = mCASESessionManager->FindExistingSession(mDeviceWithCommissioningWindowOpen);
+    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+
+    std::string QRCode;
+    std::string manualPairingCode;
+    ByteSpan salt(reinterpret_cast<const uint8_t *>(kSpake2pKeyExchangeSalt), strlen(kSpake2pKeyExchangeSalt));
 
     constexpr EndpointId kAdministratorCommissioningClusterEndpoint = 0;
 
@@ -433,16 +498,13 @@ CHIP_ERROR DeviceController::OpenCommissioningWindowWithCallback(NodeId deviceId
     Callback::Cancelable * successCallback = mOpenPairingSuccessCallback.Cancel();
     Callback::Cancelable * failureCallback = mOpenPairingFailureCallback.Cancel();
 
-    payload.version               = 0;
-    payload.rendezvousInformation = RendezvousInformationFlags(RendezvousInformationFlag::kOnNetwork);
-
-    mCommissioningWindowCallback = callback;
-    if (commissioningWindowOption != CommissioningWindowOption::kOriginalSetupCode)
+    if (mCommissioningWindowOption != CommissioningWindowOption::kOriginalSetupCode)
     {
-        bool randomSetupPIN = (commissioningWindowOption == CommissioningWindowOption::kTokenWithRandomPIN);
+        bool randomSetupPIN = (mCommissioningWindowOption == CommissioningWindowOption::kTokenWithRandomPIN);
         PASEVerifier verifier;
 
-        ReturnErrorOnFailure(PASESession::GeneratePASEVerifier(verifier, iteration, salt, randomSetupPIN, payload.setUpPINCode));
+        ReturnErrorOnFailure(PASESession::GeneratePASEVerifier(verifier, mCommissioningWindowIteration, salt, randomSetupPIN,
+                                                               mSetupPayload.setUpPINCode));
 
         uint8_t serializedVerifier[2 * kSpake2p_WS_Length];
         VerifyOrReturnError(sizeof(serializedVerifier) == sizeof(verifier), CHIP_ERROR_INTERNAL);
@@ -450,23 +512,20 @@ CHIP_ERROR DeviceController::OpenCommissioningWindowWithCallback(NodeId deviceId
         memcpy(serializedVerifier, verifier.mW0, kSpake2p_WS_Length);
         memcpy(&serializedVerifier[kSpake2p_WS_Length], verifier.mL, kSpake2p_WS_Length);
 
-        ReturnErrorOnFailure(cluster.OpenCommissioningWindow(successCallback, failureCallback, timeout,
-                                                             ByteSpan(serializedVerifier, sizeof(serializedVerifier)),
-                                                             payload.discriminator, iteration, salt, mPAKEVerifierID++));
+        ReturnErrorOnFailure(cluster.OpenCommissioningWindow(
+            successCallback, failureCallback, mCommissioningWindowTimeout, ByteSpan(serializedVerifier, sizeof(serializedVerifier)),
+            mSetupPayload.discriminator, mCommissioningWindowIteration, salt, mPAKEVerifierID++));
 
-        ReturnErrorOnFailure(ManualSetupPayloadGenerator(payload).payloadDecimalStringRepresentation(manualPairingCode));
+        ReturnErrorOnFailure(ManualSetupPayloadGenerator(mSetupPayload).payloadDecimalStringRepresentation(manualPairingCode));
         ChipLogProgress(Controller, "Manual pairing code: [%s]", manualPairingCode.c_str());
 
-        ReturnErrorOnFailure(QRCodeSetupPayloadGenerator(payload).payloadBase38Representation(QRCode));
+        ReturnErrorOnFailure(QRCodeSetupPayloadGenerator(mSetupPayload).payloadBase38Representation(QRCode));
         ChipLogProgress(Controller, "SetupQRCode: [%s]", QRCode.c_str());
     }
     else
     {
-        ReturnErrorOnFailure(cluster.OpenBasicCommissioningWindow(successCallback, failureCallback, timeout));
+        ReturnErrorOnFailure(cluster.OpenBasicCommissioningWindow(successCallback, failureCallback, mCommissioningWindowTimeout));
     }
-
-    mSetupPayload                      = payload;
-    mDeviceWithCommissioningWindowOpen = deviceId;
 
     return CHIP_NO_ERROR;
 }

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -357,7 +357,7 @@ CHIP_ERROR DeviceController::GetPeerAddressAndPort(PeerId peerId, Inet::IPAddres
 void DeviceController::OnPIDReadResponse(void * context, uint16_t value)
 {
     ChipLogProgress(Controller, "Received PID for the device. Value %d", value);
-    DeviceController * controller       = reinterpret_cast<DeviceController *>(context);
+    DeviceController * controller       = static_cast<DeviceController *>(context);
     controller->mSetupPayload.productID = value;
 
     if (controller->OpenCommissioningWindowInternal() != CHIP_NO_ERROR)
@@ -370,7 +370,7 @@ void DeviceController::OnVIDReadResponse(void * context, uint16_t value)
 {
     ChipLogProgress(Controller, "Received VID for the device. Value %d", value);
 
-    DeviceController * controller = reinterpret_cast<DeviceController *>(context);
+    DeviceController * controller = static_cast<DeviceController *>(context);
 
     controller->mSetupPayload.vendorID = value;
 
@@ -396,7 +396,7 @@ void DeviceController::OnVIDPIDReadFailureResponse(void * context, uint8_t statu
 void DeviceController::OnOpenPairingWindowSuccessResponse(void * context)
 {
     ChipLogProgress(Controller, "Successfully opened pairing window on the device");
-    DeviceController * controller = reinterpret_cast<DeviceController *>(context);
+    DeviceController * controller = static_cast<DeviceController *>(context);
     if (controller->mCommissioningWindowCallback != nullptr)
     {
         controller->mCommissioningWindowCallback->mCall(controller->mCommissioningWindowCallback->mContext,
@@ -408,7 +408,7 @@ void DeviceController::OnOpenPairingWindowSuccessResponse(void * context)
 void DeviceController::OnOpenPairingWindowFailureResponse(void * context, uint8_t status)
 {
     ChipLogError(Controller, "Failed to open pairing window on the device. Status %d", status);
-    DeviceController * controller = reinterpret_cast<DeviceController *>(context);
+    DeviceController * controller = static_cast<DeviceController *>(context);
     if (controller->mCommissioningWindowCallback != nullptr)
     {
         CHIP_ERROR error = CHIP_ERROR_INVALID_PASE_PARAMETER;
@@ -488,7 +488,7 @@ CHIP_ERROR DeviceController::OpenCommissioningWindowInternal()
 
     std::string QRCode;
     std::string manualPairingCode;
-    ByteSpan salt(reinterpret_cast<const uint8_t *>(kSpake2pKeyExchangeSalt), strlen(kSpake2pKeyExchangeSalt));
+    ByteSpan salt(Uint8::from_const_char(kSpake2pKeyExchangeSalt), strlen(kSpake2pKeyExchangeSalt));
 
     constexpr EndpointId kAdministratorCommissioningClusterEndpoint = 0;
 

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -439,7 +439,8 @@ CHIP_ERROR DeviceController::ComputePASEVerifier(uint32_t iterations, uint32_t s
 
 CHIP_ERROR DeviceController::OpenCommissioningWindowWithCallback(NodeId deviceId, uint16_t timeout, uint16_t iteration,
                                                                  uint16_t discriminator, uint8_t option,
-                                                                 Callback::Callback<OnOpenCommissioningWindow> * callback)
+                                                                 Callback::Callback<OnOpenCommissioningWindow> * callback,
+                                                                 bool readVIDPIDAttributes)
 {
     mSetupPayload = SetupPayload();
 
@@ -468,7 +469,7 @@ CHIP_ERROR DeviceController::OpenCommissioningWindowWithCallback(NodeId deviceId
         return CHIP_ERROR_INVALID_ARGUMENT;
     }
 
-    if (callback != nullptr && mCommissioningWindowOption != CommissioningWindowOption::kOriginalSetupCode)
+    if (callback != nullptr && mCommissioningWindowOption != CommissioningWindowOption::kOriginalSetupCode && readVIDPIDAttributes)
     {
         OperationalDeviceProxy * device = mCASESessionManager->FindExistingSession(mDeviceWithCommissioningWindowOpen);
         VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -396,10 +396,25 @@ private:
     Callback::Callback<DefaultSuccessCallback> mOpenPairingSuccessCallback;
     Callback::Callback<DefaultFailureCallback> mOpenPairingFailureCallback;
 
+    Callback::Callback<Int16uAttributeCallback> mPIDReadCallback;
+    Callback::Callback<Int16uAttributeCallback> mVIDReadCallback;
+    Callback::Callback<DefaultFailureCallback> mVIDPIDReadFailureCallback;
+
+    static void OnPIDReadResponse(void * context, uint16_t value);
+    static void OnVIDReadResponse(void * context, uint16_t value);
+    static void OnVIDPIDReadFailureResponse(void * context, uint8_t status);
+
+    CHIP_ERROR OpenCommissioningWindowInternal();
+
     // TODO - Support opening commissioning window simultaneously on multiple devices
     Callback::Callback<OnOpenCommissioningWindow> * mCommissioningWindowCallback = nullptr;
     SetupPayload mSetupPayload;
     NodeId mDeviceWithCommissioningWindowOpen;
+
+    uint16_t mCommissioningWindowTimeout;
+    uint16_t mCommissioningWindowIteration;
+
+    CommissioningWindowOption mCommissioningWindowOption;
 
     static void OnOpenPairingWindowSuccessResponse(void * context);
     static void OnOpenPairingWindowFailureResponse(void * context, uint8_t status);

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -396,13 +396,9 @@ private:
     Callback::Callback<DefaultSuccessCallback> mOpenPairingSuccessCallback;
     Callback::Callback<DefaultFailureCallback> mOpenPairingFailureCallback;
 
-    Callback::Callback<Int16uAttributeCallback> mPIDReadCallback;
-    Callback::Callback<Int16uAttributeCallback> mVIDReadCallback;
-    Callback::Callback<DefaultFailureCallback> mVIDPIDReadFailureCallback;
-
     static void OnPIDReadResponse(void * context, uint16_t value);
     static void OnVIDReadResponse(void * context, uint16_t value);
-    static void OnVIDPIDReadFailureResponse(void * context, uint8_t status);
+    static void OnVIDPIDReadFailureResponse(void * context, EmberAfStatus status);
 
     CHIP_ERROR OpenCommissioningWindowInternal();
 

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -311,10 +311,16 @@ public:
      *                            the PIN code provied in the setupPayload).
      * @param[in] callback        The function to be called on success or failure of opening of commissioning window.
      *
+     * @param[in] readVIDPIDAttributes Should the API internally read VID and PID from the device while opening the
+     *                                 commissioning window. VID and PID is only needed for enchanced commissioning mode.
+     *                                 If this argument is `true`, and enhanced commissioning mode is used, the API will
+     *                                 read VID and PID from the device.
+     *
      * @return CHIP_ERROR         CHIP_NO_ERROR on success, or corresponding error
      */
     CHIP_ERROR OpenCommissioningWindowWithCallback(NodeId deviceId, uint16_t timeout, uint16_t iteration, uint16_t discriminator,
-                                                   uint8_t option, Callback::Callback<OnOpenCommissioningWindow> * callback);
+                                                   uint8_t option, Callback::Callback<OnOpenCommissioningWindow> * callback,
+                                                   bool readVIDPIDAttributes = false);
 
 #if CHIP_DEVICE_CONFIG_ENABLE_DNSSD
     void RegisterDeviceAddressUpdateDelegate(DeviceAddressUpdateDelegate * delegate) { mDeviceAddressUpdateDelegate = delegate; }

--- a/src/setup_payload/QRCodeSetupPayloadGenerator.h
+++ b/src/setup_payload/QRCodeSetupPayloadGenerator.h
@@ -114,6 +114,9 @@ public:
      *               producing the requested string.
      */
     CHIP_ERROR payloadBase38Representation(MutableCharSpan & outBuffer);
+
+    // TODO - Find the optimal value for maximum length of QR Code Base38 string
+    static constexpr uint16_t kMaxQRCodeBase38RepresentationLength = 128;
 };
 
 } // namespace chip


### PR DESCRIPTION
#### Problem
* Fixes #10687

#### Change overview
Include VID and PID in the generated Setup Payload when commissioning window is opened using ECM mode.
- Read VID and PID attributes from the basic cluster, before opening the commissioning window.
- Include these two values in the generated Setup Payload

#### Testing
Tested using all-cluster-app and chip-tool
1. Open the commissioning window using ECM mode.
2. Parse the generated QR code using `chip-tool payload parse-setup-payload` command. Check that VID and PID are part of the code.