### PR TITLE
Add default timeout to fix KVS error when fetching ExtendedTimoutConfig

### DIFF
--- a/examples/lighting-app/qpg/src/AppTask.cpp
+++ b/examples/lighting-app/qpg/src/AppTask.cpp
@@ -27,7 +27,7 @@
 #include <app-common/zap-generated/attribute-id.h>
 #include <app-common/zap-generated/attribute-type.h>
 #include <app-common/zap-generated/cluster-id.h>
-#include <app/server/Mdns.h>
+#include <app/server/Dnssd.h>
 #include <app/server/Server.h>
 #include <app/util/attribute-storage.h>
 
@@ -115,7 +115,7 @@ CHIP_ERROR AppTask::Init()
     qvCHIP_SetBtnCallback(ButtonEventHandler);
 
 #if CHIP_DEVICE_CONFIG_ENABLE_EXTENDED_DISCOVERY
-    chip::app::MdnsServer::Instance().SetExtendedDiscoveryTimeoutSecs(extDiscTimeoutSecs);
+    chip::app::DnssdServer::Instance().SetExtendedDiscoveryTimeoutSecs(extDiscTimeoutSecs);
 #endif
 
     // Init ZCL Data Model

--- a/examples/lighting-app/qpg/src/AppTask.cpp
+++ b/examples/lighting-app/qpg/src/AppTask.cpp
@@ -27,6 +27,7 @@
 #include <app-common/zap-generated/attribute-id.h>
 #include <app-common/zap-generated/attribute-type.h>
 #include <app-common/zap-generated/cluster-id.h>
+#include <app/server/Mdns.h>
 #include <app/server/Server.h>
 #include <app/util/attribute-storage.h>
 
@@ -73,6 +74,10 @@ StaticTask_t appTaskStruct;
 
 AppTask AppTask::sAppTask;
 
+namespace {
+constexpr int extDiscTimeoutSecs = 20;
+}
+
 CHIP_ERROR AppTask::StartAppTask()
 {
     sAppEventQueue = xQueueCreateStatic(APP_EVENT_QUEUE_SIZE, sizeof(AppEvent), sAppEventQueueBuffer, &sAppEventQueueStruct);
@@ -108,6 +113,10 @@ CHIP_ERROR AppTask::Init()
 
     // Subscribe with our button callback to the qvCHIP button handler.
     qvCHIP_SetBtnCallback(ButtonEventHandler);
+
+#if CHIP_DEVICE_CONFIG_ENABLE_EXTENDED_DISCOVERY
+    chip::app::MdnsServer::Instance().SetExtendedDiscoveryTimeoutSecs(extDiscTimeoutSecs);
+#endif
 
     // Init ZCL Data Model
     chip::Server::GetInstance().Init();

--- a/examples/lock-app/qpg/src/AppTask.cpp
+++ b/examples/lock-app/qpg/src/AppTask.cpp
@@ -27,7 +27,7 @@
 #include <app-common/zap-generated/attribute-id.h>
 #include <app-common/zap-generated/attribute-type.h>
 #include <app-common/zap-generated/cluster-id.h>
-#include <app/server/Mdns.h>
+#include <app/server/Dnssd.h>
 #include <app/server/Server.h>
 #include <app/util/attribute-storage.h>
 
@@ -116,7 +116,7 @@ CHIP_ERROR AppTask::Init()
     qvCHIP_LedSet(LOCK_STATE_LED, !BoltLockMgr().IsUnlocked());
 
 #if CHIP_DEVICE_CONFIG_ENABLE_EXTENDED_DISCOVERY
-    chip::app::MdnsServer::Instance().SetExtendedDiscoveryTimeoutSecs(extDiscTimeoutSecs);
+    chip::app::DnssdServer::Instance().SetExtendedDiscoveryTimeoutSecs(extDiscTimeoutSecs);
 #endif
 
     // Init ZCL Data Model

--- a/examples/lock-app/qpg/src/AppTask.cpp
+++ b/examples/lock-app/qpg/src/AppTask.cpp
@@ -27,6 +27,7 @@
 #include <app-common/zap-generated/attribute-id.h>
 #include <app-common/zap-generated/attribute-type.h>
 #include <app-common/zap-generated/cluster-id.h>
+#include <app/server/Mdns.h>
 #include <app/server/Server.h>
 #include <app/util/attribute-storage.h>
 
@@ -72,6 +73,10 @@ StaticTask_t appTaskStruct;
 
 AppTask AppTask::sAppTask;
 
+namespace {
+constexpr int extDiscTimeoutSecs = 20;
+}
+
 CHIP_ERROR AppTask::StartAppTask()
 {
     sAppEventQueue = xQueueCreateStatic(APP_EVENT_QUEUE_SIZE, sizeof(AppEvent), sAppEventQueueBuffer, &sAppEventQueueStruct);
@@ -109,6 +114,10 @@ CHIP_ERROR AppTask::Init()
     qvCHIP_SetBtnCallback(ButtonEventHandler);
 
     qvCHIP_LedSet(LOCK_STATE_LED, !BoltLockMgr().IsUnlocked());
+
+#if CHIP_DEVICE_CONFIG_ENABLE_EXTENDED_DISCOVERY
+    chip::app::MdnsServer::Instance().SetExtendedDiscoveryTimeoutSecs(extDiscTimeoutSecs);
+#endif
 
     // Init ZCL Data Model
     chip::Server::GetInstance().Init();

--- a/examples/platform/qpg/app/main.cpp
+++ b/examples/platform/qpg/app/main.cpp
@@ -33,6 +33,7 @@
 #include "qvCHIP.h"
 
 // CHIP includes
+#include <app/server/Dnssd.h>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CHIPPlatformMemory.h>
 #include <lib/support/logging/CHIPLogging.h>
@@ -127,7 +128,7 @@ CHIP_ERROR CHIP_Init(void)
 #endif // CHIP_ENABLE_OPENTHREAD
 
 #if CHIP_DEVICE_CONFIG_ENABLE_EXTENDED_DISCOVERY
-    chip::app::MdnsServer::Instance().SetExtendedDiscoveryTimeoutSecs(extDiscTimeoutSecs);
+    chip::app::DnssdServer::Instance().SetExtendedDiscoveryTimeoutSecs(extDiscTimeoutSecs);
 #endif
 
     ChipLogProgress(NotSpecified, "Starting Platform Manager Event Loop");

--- a/examples/platform/qpg/app/main.cpp
+++ b/examples/platform/qpg/app/main.cpp
@@ -46,6 +46,10 @@ using namespace ::chip::Inet;
 using namespace ::chip::DeviceLayer;
 using namespace ::chip::DeviceLayer::Internal;
 
+namespace {
+constexpr int extDiscTimeoutSecs = 20;
+}
+
 /*****************************************************************************
  *                    Macro Definitions
  *****************************************************************************/
@@ -121,6 +125,10 @@ CHIP_ERROR CHIP_Init(void)
         goto exit;
     }
 #endif // CHIP_ENABLE_OPENTHREAD
+
+#if CHIP_DEVICE_CONFIG_ENABLE_EXTENDED_DISCOVERY
+    chip::app::MdnsServer::Instance().SetExtendedDiscoveryTimeoutSecs(extDiscTimeoutSecs);
+#endif
 
     ChipLogProgress(NotSpecified, "Starting Platform Manager Event Loop");
     ret = PlatformMgr().StartEventLoopTask();


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* Add default timeout value
* Replace Mdns with Dnssd

#### Change overview
Add call to SetExtendedDiscoveryTimeoutSecs() to set default value before use.

#### Testing
How was this tested?
* Sanity test check based on the value returned by the function GetExtendedDiscoveryTimeoutSecs()
