### PR TITLE
Add a libfuzzer config to the build system.

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -304,6 +304,9 @@ declare_args() {
   # enable undefined behavior sanitizer
   is_ubsan = false
 
+  # enable libfuzzer
+  is_libfuzzer = false
+
   # Exit on sanitize error. Generally standard libraries may get errors
   # so not stopping on the first error is often useful
   is_sanitize_fatal = true
@@ -374,7 +377,16 @@ config("sanitize_default") {
   }
 }
 
+config("libfuzzer_fuzzing") {
+  cflags = [ "-fsanitize=fuzzer" ]
+  ldflags = cflags
+}
+
 config("fuzzing_default") {
+  configs = []
+  if (is_libfuzzer) {
+    configs += [ ":libfuzzer_fuzzing" ]
+  }
 }
 
 declare_args() {


### PR DESCRIPTION
#### Problem
No easy way to build with `-fsanitize=fuzzer` when building with clang.

#### Change overview
Add a way to tell gn to include that build option.

#### Testing
Compiled locally, verified that the compile works (though the link fails for me because I don't actually have the libfuzzer library locally).