### PR TITLE
Fix status report ec nullout and suppress status response during read

### DIFF
--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -376,7 +376,7 @@ CHIP_ERROR InteractionModelEngine::OnUnsolicitedReportData(Messaging::ExchangeCo
 
     for (auto & readClient : mReadClients)
     {
-        if (!readClient.IsSubscriptionTypeIdle())
+        if (!readClient.IsSubscriptionIdle())
         {
             continue;
         }

--- a/src/app/ReadClient.h
+++ b/src/app/ReadClient.h
@@ -239,7 +239,7 @@ private:
      *
      */
     bool IsFree() const { return mState == ClientState::Uninitialized; }
-    bool IsSubscriptionTypeIdle() const { return mState == ClientState::SubscriptionActive; }
+    bool IsSubscriptionIdle() const { return mState == ClientState::SubscriptionActive; }
     bool IsAwaitingInitialReport() const { return mState == ClientState::AwaitingInitialReport; }
     bool IsAwaitingSubscribeResponse() const { return mState == ClientState::AwaitingSubscribeResponse; }
 

--- a/src/app/reporting/Engine.cpp
+++ b/src/app/reporting/Engine.cpp
@@ -324,6 +324,10 @@ CHIP_ERROR Engine::BuildAndSendSingleReportData(ReadHandler * apReadHandler)
     {
         reportDataBuilder.MoreChunkedMessages(hasMoreChunks);
     }
+    else if (apReadHandler->IsReadType())
+    {
+        reportDataBuilder.SuppressResponse(true);
+    }
 
     reportDataBuilder.EndOfReportDataMessage();
     SuccessOrExit(err = reportDataBuilder.GetError());
@@ -360,6 +364,10 @@ exit:
     if (err != CHIP_NO_ERROR)
     {
         apReadHandler->Shutdown(ReadHandler::ShutdownOptions::AbortCurrentExchange);
+    }
+    else if (apReadHandler->IsReadType() && !hasMoreChunks)
+    {
+        apReadHandler->Shutdown();
     }
     return err;
 }


### PR DESCRIPTION
#### Problem
--check the return value of SendStatusResponse in ProcessReportData and dropping our ref to the exchange context if it fails
--suppress status response for non-chunk report during read

#### Change overview
See above

#### Testing
Update existing test with suppress flag