### PR TITLE
Improve Darwin framework APIs to follow Objective-C conventions better.

### DIFF
--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/Bindings/BindingsViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/Bindings/BindingsViewController.m
@@ -139,18 +139,18 @@
     if (CHIPGetConnectedDevice(^(CHIPDevice * _Nullable chipDevice, NSError * _Nullable error) {
             if (chipDevice) {
                 CHIPBinding * cluster = [[CHIPBinding alloc] initWithDevice:chipDevice endpoint:0 queue:dispatch_get_main_queue()];
-                __auto_type * payload = [[CHIPBindingClusterBindPayload alloc] init];
-                payload.NodeId = @(nodeId);
-                payload.GroupId = @(groupId);
-                payload.EndpointId = @(endpointId);
-                payload.ClusterId = @(clusterId);
-                [cluster bind:payload
-                    responseHandler:^(NSError * _Nullable error, NSDictionary * _Nullable values) {
-                        NSString * resultString = (error == nil)
-                            ? @"Bind command: success!"
-                            : [NSString stringWithFormat:@"An error occured: 0x%02lx", error.code];
-                        NSLog(resultString, nil);
-                    }];
+                __auto_type * params = [[CHIPBindingClusterBindParams alloc] init];
+                params.nodeId = @(nodeId);
+                params.groupId = @(groupId);
+                params.endpointId = @(endpointId);
+                params.clusterId = @(clusterId);
+                [cluster bindWithParams:params
+                      completionHandler:^(NSError * _Nullable error, NSDictionary * _Nullable values) {
+                          NSString * resultString = (error == nil)
+                              ? @"Bind command: success!"
+                              : [NSString stringWithFormat:@"An error occured: 0x%02lx", error.code];
+                          NSLog(resultString, nil);
+                      }];
             } else {
                 NSLog(@"Status: Failed to establish a connection with the device");
             }
@@ -171,18 +171,18 @@
     if (CHIPGetConnectedDevice(^(CHIPDevice * _Nullable chipDevice, NSError * _Nullable error) {
             if (chipDevice) {
                 CHIPBinding * cluster = [[CHIPBinding alloc] initWithDevice:chipDevice endpoint:0 queue:dispatch_get_main_queue()];
-                __auto_type * payload = [[CHIPBindingClusterUnbindPayload alloc] init];
-                payload.NodeId = @(nodeId);
-                payload.GroupId = @(groupId);
-                payload.EndpointId = @(endpointId);
-                payload.ClusterId = @(clusterId);
-                [cluster unbind:payload
-                    responseHandler:^(NSError * _Nullable error, NSDictionary * _Nullable values) {
-                        NSString * resultString = (error == nil)
-                            ? @"Unbind command: success!"
-                            : [NSString stringWithFormat:@"An error occured: 0x%02lx", error.code];
-                        NSLog(resultString, nil);
-                    }];
+                __auto_type * params = [[CHIPBindingClusterUnbindParams alloc] init];
+                params.nodeId = @(nodeId);
+                params.groupId = @(groupId);
+                params.endpointId = @(endpointId);
+                params.clusterId = @(clusterId);
+                [cluster unbindWithParams:params
+                        completionHandler:^(NSError * _Nullable error, NSDictionary * _Nullable values) {
+                            NSString * resultString = (error == nil)
+                                ? @"Unbind command: success!"
+                                : [NSString stringWithFormat:@"An error occured: 0x%02lx", error.code];
+                            NSLog(resultString, nil);
+                        }];
             } else {
                 NSLog(@"Status: Failed to establish a connection with the device");
             }

--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/Echo client/EchoViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/Echo client/EchoViewController.m
@@ -116,13 +116,11 @@
                 CHIPBasic * cluster = [[CHIPBasic alloc] initWithDevice:chipDevice endpoint:0 queue:dispatch_get_main_queue()];
                 [self updateResult:@"MfgSpecificPing command sent..."];
 
-                [cluster mfgSpecificPing:[[CHIPBasicClusterMfgSpecificPingPayload alloc] init]
-                         responseHandler:^(NSError * error, NSDictionary * values) {
-                             NSString * resultString = (error == nil)
-                                 ? @"MfgSpecificPing command: success!"
-                                 : [NSString stringWithFormat:@"An error occured: 0x%02lx", error.code];
-                             [self updateResult:resultString];
-                         }];
+                [cluster mfgSpecificPingWithCompletionHandler:^(NSError * error, NSDictionary * values) {
+                    NSString * resultString = (error == nil) ? @"MfgSpecificPing command: success!"
+                                                             : [NSString stringWithFormat:@"An error occured: 0x%02lx", error.code];
+                    [self updateResult:resultString];
+                }];
             } else {
                 [self updateResult:@"Failed to establish a connection with the device"];
             }

--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/Fabric/FabricUIViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/Fabric/FabricUIViewController.m
@@ -348,35 +348,37 @@
                 CHIPOperationalCredentials * cluster =
                     [[CHIPOperationalCredentials alloc] initWithDevice:chipDevice endpoint:0 queue:dispatch_get_main_queue()];
                 [self updateResult:[NSString stringWithFormat:@"updateFabricLabel command sent."] isError:NO];
-                __auto_type * payload = [[CHIPOperationalCredentialsClusterUpdateFabricLabelPayload alloc] init];
-                payload.Label = label;
+                __auto_type * params = [[CHIPOperationalCredentialsClusterUpdateFabricLabelParams alloc] init];
+                params.label = label;
 
                 [cluster
-                    updateFabricLabel:payload
-                      responseHandler:^(NSError * _Nullable error, NSDictionary * _Nullable values) {
-                          dispatch_async(dispatch_get_main_queue(), ^{
-                              if (error) {
-                                  NSLog(@"Got back error trying to updateFabricLabel %@", error);
+                    updateFabricLabelWithParams:params
+                              completionHandler:^(NSError * _Nullable error, NSDictionary * _Nullable values) {
                                   dispatch_async(dispatch_get_main_queue(), ^{
-                                      self->_updateFabricLabelTextField.text = @"";
-                                      [self
-                                          updateResult:[NSString stringWithFormat:@"Command updateFabricLabel failed with error %@",
-                                                                 error]
-                                               isError:YES];
-                                  });
-                              } else {
-                                  NSLog(@"Successfully updated the label: %@", values);
-                                  dispatch_async(dispatch_get_main_queue(), ^{
-                                      self->_updateFabricLabelTextField.text = @"";
-                                      [self updateResult:[NSString stringWithFormat:
+                                      if (error) {
+                                          NSLog(@"Got back error trying to updateFabricLabel %@", error);
+                                          dispatch_async(dispatch_get_main_queue(), ^{
+                                              self->_updateFabricLabelTextField.text = @"";
+                                              [self updateResult:[NSString
+                                                                     stringWithFormat:
+                                                                         @"Command updateFabricLabel failed with error %@", error]
+                                                         isError:YES];
+                                          });
+                                      } else {
+                                          NSLog(@"Successfully updated the label: %@", values);
+                                          dispatch_async(dispatch_get_main_queue(), ^{
+                                              self->_updateFabricLabelTextField.text = @"";
+                                              [self
+                                                  updateResult:[NSString
+                                                                   stringWithFormat:
                                                                        @"Command updateFabricLabel succeeded to update label to %@",
                                                                    label]
-                                                 isError:NO];
-                                      [self fetchFabricsList];
+                                                       isError:NO];
+                                              [self fetchFabricsList];
+                                          });
+                                      }
                                   });
-                              }
-                          });
-                      }];
+                              }];
             } else {
                 [self updateResult:[NSString stringWithFormat:@"Failed to establish a connection with the device"] isError:YES];
             }

--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/OnOffCluster/OnOffViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/OnOffCluster/OnOffViewController.m
@@ -242,13 +242,12 @@ NSString * const kCHIPNumLightOnOffCluster = @"OnOffViewController_NumLights";
                     CHIPOnOff * onOff = [[CHIPOnOff alloc] initWithDevice:chipDevice
                                                                  endpoint:endpoint
                                                                     queue:dispatch_get_main_queue()];
-                    [onOff on:[[CHIPOnOffClusterOnPayload alloc] init]
-                        responseHandler:^(NSError * error, NSDictionary * values) {
-                            NSString * resultString = (error != nil)
-                                ? [NSString stringWithFormat:@"An error occured: 0x%02lx", error.code]
-                                : @"On command success";
-                            [self updateResult:resultString];
-                        }];
+                    [onOff onWithCompletionHandler:^(NSError * error, NSDictionary * values) {
+                        NSString * resultString = (error != nil)
+                            ? [NSString stringWithFormat:@"An error occured: 0x%02lx", error.code]
+                            : @"On command success";
+                        [self updateResult:resultString];
+                    }];
                 } else {
                     [self updateResult:[NSString stringWithFormat:@"Failed to establish a connection with the device"]];
                 }
@@ -272,13 +271,12 @@ NSString * const kCHIPNumLightOnOffCluster = @"OnOffViewController_NumLights";
                     CHIPOnOff * onOff = [[CHIPOnOff alloc] initWithDevice:chipDevice
                                                                  endpoint:endpoint
                                                                     queue:dispatch_get_main_queue()];
-                    [onOff off:[[CHIPOnOffClusterOffPayload alloc] init]
-                        responseHandler:^(NSError * error, NSDictionary * values) {
-                            NSString * resultString = (error != nil)
-                                ? [NSString stringWithFormat:@"An error occured: 0x%02lx", error.code]
-                                : @"Off command success";
-                            [self updateResult:resultString];
-                        }];
+                    [onOff offWithCompletionHandler:^(NSError * error, NSDictionary * values) {
+                        NSString * resultString = (error != nil)
+                            ? [NSString stringWithFormat:@"An error occured: 0x%02lx", error.code]
+                            : @"Off command success";
+                        [self updateResult:resultString];
+                    }];
                 } else {
                     [self updateResult:[NSString stringWithFormat:@"Failed to establish a connection with the device"]];
                 }
@@ -302,13 +300,12 @@ NSString * const kCHIPNumLightOnOffCluster = @"OnOffViewController_NumLights";
                     CHIPOnOff * onOff = [[CHIPOnOff alloc] initWithDevice:chipDevice
                                                                  endpoint:endpoint
                                                                     queue:dispatch_get_main_queue()];
-                    [onOff toggle:[[CHIPOnOffClusterTogglePayload alloc] init]
-                        responseHandler:^(NSError * error, NSDictionary * values) {
-                            NSString * resultString = (error != nil)
-                                ? [NSString stringWithFormat:@"An error occured: 0x%02lx", error.code]
-                                : @"Toggle command success";
-                            [self updateResult:resultString];
-                        }];
+                    [onOff toggleWithCompletionHandler:^(NSError * error, NSDictionary * values) {
+                        NSString * resultString = (error != nil)
+                            ? [NSString stringWithFormat:@"An error occured: 0x%02lx", error.code]
+                            : @"Toggle command success";
+                        [self updateResult:resultString];
+                    }];
                 } else {
                     [self updateResult:[NSString stringWithFormat:@"Failed to establish a connection with the device"]];
                 }

--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/QRCode/QRCodeViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/QRCode/QRCodeViewController.m
@@ -541,17 +541,17 @@
                 self.cluster = [[CHIPNetworkCommissioning alloc] initWithDevice:chipDevice
                                                                        endpoint:0
                                                                           queue:dispatch_get_main_queue()];
-                __auto_type * payload = [[CHIPNetworkCommissioningClusterAddWiFiNetworkPayload alloc] init];
-                payload.Ssid = [ssid dataUsingEncoding:NSUTF8StringEncoding];
-                payload.Credentials = [password dataUsingEncoding:NSUTF8StringEncoding];
-                payload.Breadcrumb = @(0);
-                payload.TimeoutMs = @(3000);
+                __auto_type * params = [[CHIPNetworkCommissioningClusterAddWiFiNetworkParams alloc] init];
+                params.ssid = [ssid dataUsingEncoding:NSUTF8StringEncoding];
+                params.credentials = [password dataUsingEncoding:NSUTF8StringEncoding];
+                params.breadcrumb = @(0);
+                params.timeoutMs = @(3000);
 
                 __weak typeof(self) weakSelf = self;
-                [self->_cluster addWiFiNetwork:payload
-                               responseHandler:^(NSError * error, NSDictionary * values) {
-                                   [weakSelf onAddNetworkResponse:error isWiFi:YES];
-                               }];
+                [self->_cluster addWiFiNetworkWithParams:params
+                                       completionHandler:^(NSError * error, NSDictionary * values) {
+                                           [weakSelf onAddNetworkResponse:error isWiFi:YES];
+                                       }];
             } else {
                 NSLog(@"Status: Failed to establish a connection with the device");
             }
@@ -569,16 +569,16 @@
                 self.cluster = [[CHIPNetworkCommissioning alloc] initWithDevice:chipDevice
                                                                        endpoint:0
                                                                           queue:dispatch_get_main_queue()];
-                __auto_type * payload = [[CHIPNetworkCommissioningClusterAddThreadNetworkPayload alloc] init];
-                payload.OperationalDataset = threadDataSet;
-                payload.Breadcrumb = @(0);
-                payload.TimeoutMs = @(3000);
+                __auto_type * params = [[CHIPNetworkCommissioningClusterAddThreadNetworkParams alloc] init];
+                params.operationalDataset = threadDataSet;
+                params.breadcrumb = @(0);
+                params.timeoutMs = @(3000);
 
                 __weak typeof(self) weakSelf = self;
-                [self->_cluster addThreadNetwork:payload
-                                 responseHandler:^(NSError * error, NSDictionary * values) {
-                                     [weakSelf onAddNetworkResponse:error isWiFi:NO];
-                                 }];
+                [self->_cluster addThreadNetworkWithParams:params
+                                         completionHandler:^(NSError * error, NSDictionary * values) {
+                                             [weakSelf onAddNetworkResponse:error isWiFi:NO];
+                                         }];
             } else {
                 NSLog(@"Status: Failed to establish a connection with the device");
             }
@@ -596,22 +596,22 @@
         return;
     }
 
-    __auto_type * payload = [[CHIPNetworkCommissioningClusterEnableNetworkPayload alloc] init];
+    __auto_type * params = [[CHIPNetworkCommissioningClusterEnableNetworkParams alloc] init];
     if (isWiFi) {
         NSString * ssid = CHIPGetDomainValueForKey(kCHIPToolDefaultsDomain, kNetworkSSIDDefaultsKey);
-        payload.NetworkID = [ssid dataUsingEncoding:NSUTF8StringEncoding];
+        params.networkID = [ssid dataUsingEncoding:NSUTF8StringEncoding];
     } else {
         uint8_t tempThreadNetworkId[] = { 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef };
-        payload.NetworkID = [NSData dataWithBytes:tempThreadNetworkId length:sizeof(tempThreadNetworkId)];
+        params.networkID = [NSData dataWithBytes:tempThreadNetworkId length:sizeof(tempThreadNetworkId)];
     }
-    payload.Breadcrumb = @(0);
-    payload.TimeoutMs = @(3000);
+    params.breadcrumb = @(0);
+    params.timeoutMs = @(3000);
 
     __weak typeof(self) weakSelf = self;
-    [_cluster enableNetwork:payload
-            responseHandler:^(NSError * err, NSDictionary * values) {
-                [weakSelf onEnableNetworkResponse:err];
-            }];
+    [_cluster enableNetworkWithParams:params
+                    completionHandler:^(NSError * err, NSDictionary * values) {
+                        [weakSelf onEnableNetworkResponse:err];
+                    }];
 }
 
 - (void)onEnableNetworkResponse:(NSError *)error

--- a/src/darwin/Framework/CHIP/templates/CHIPClustersObjc-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/CHIPClustersObjc-src.zapt
@@ -28,15 +28,34 @@ using namespace chip::app::Clusters;
 
 {{#chip_cluster_commands}}
 {{#*inline "callbackName"}}{{#if hasSpecificResponse}}{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase responseName}}{{else}}CommandSuccess{{/if}}{{/inline}}
-- (void){{asLowerCamelCase name}}:(CHIP{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}Payload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler
+{{! zcl_command_arguments_count is unreliable when used in a conditional.  As
+    a workaround, just use iteration over the arguments directly to see if we
+    have any. }}
+{{#chip_cluster_command_arguments}}
+{{#first}}
+- (void){{asLowerCamelCase parent.name}}WithParams:(CHIP{{asUpperCamelCase parent.parent.name}}Cluster{{asUpperCamelCase parent.name}}Params * {{#unless (commandHasRequiredField parent)}}_Nullable{{/unless}})params completionHandler:(CompletionHandler)completionHandler
+{{/first}}
+{{else}}
+- (void){{asLowerCamelCase parent.name}}WithCompletionHandler:(CompletionHandler)completionHandler
+{{/chip_cluster_command_arguments}}
 {
     ListFreer listFreer;
     {{asUpperCamelCase parent.name}}::Commands::{{asUpperCamelCase name}}::Type request;
     {{#chip_cluster_command_arguments}}
-    {{>encode_value target=(concat "request." (asLowerCamelCase label)) source=(concat "payload." (asStructPropertyName label)) cluster=parent.parent.name errorCode="return;" depth=0}}
+      {{#first}}
+        {{#unless (commandHasRequiredField parent)}}
+        if (params != nil) {
+        {{/unless}}
+      {{/first}}
+      {{>encode_value target=(concat "request." (asLowerCamelCase label)) source=(concat "params." (asStructPropertyName label)) cluster=parent.parent.name errorCode="return;" depth=0}}
+      {{#last}}
+        {{#unless (commandHasRequiredField parent)}}
+        }
+       {{/unless}}
+      {{/last}}
     {{/chip_cluster_command_arguments}}
 
-    new CHIP{{>callbackName}}CallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIP{{>callbackName}}CallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIP{{>callbackName}}CallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);

--- a/src/darwin/Framework/CHIP/templates/CHIPClustersObjc.zapt
+++ b/src/darwin/Framework/CHIP/templates/CHIPClustersObjc.zapt
@@ -9,7 +9,11 @@
 #include <CHIP/CHIPCluster.h>
 #include <CHIP/CHIPCommandPayloadsObjc.h>
 
+/* We need to sort out our handlers, but for now just define both
+   ResponseHandler and CompletionHandler to look the same way.  Eventually we
+   will want different completion handlers for different return types. */
 typedef void (^ResponseHandler)(NSError * _Nullable error, NSDictionary * _Nullable values);
+typedef void (^CompletionHandler)(NSError * _Nullable error, NSDictionary * _Nullable values);
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -23,7 +27,16 @@ NS_ASSUME_NONNULL_BEGIN
 @interface CHIP{{asUpperCamelCase name}} : CHIPCluster
 
 {{#chip_cluster_commands}}
-- (void){{asLowerCamelCase name}}:(CHIP{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}Payload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler;
+{{! zcl_command_arguments_count is unreliable when used in a conditional.  As
+    a workaround, just use iteration over the arguments directly to see if we
+    have any. }}
+{{#chip_cluster_command_arguments}}
+{{#first}}
+- (void){{asLowerCamelCase parent.name}}WithParams:(CHIP{{asUpperCamelCase parent.parent.name}}Cluster{{asUpperCamelCase parent.name}}Params * {{#unless (commandHasRequiredField parent)}}_Nullable{{/unless}})params completionHandler:(CompletionHandler)completionHandler;
+{{/first}}
+{{else}}
+- (void){{asLowerCamelCase parent.name}}WithCompletionHandler:(CompletionHandler)completionHandler;
+{{/chip_cluster_command_arguments}}
 {{/chip_cluster_commands}}
 
 {{#chip_server_cluster_attributes}}

--- a/src/darwin/Framework/CHIP/templates/CHIPCommandPayloadsObjc-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/CHIPCommandPayloadsObjc-src.zapt
@@ -6,17 +6,21 @@ NS_ASSUME_NONNULL_BEGIN
 
 {{#zcl_clusters}}
 {{#zcl_commands}}
-@implementation CHIP{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}Payload
+{{#zcl_command_arguments}}
+{{#first}}
+@implementation CHIP{{asUpperCamelCase parent.parent.name}}Cluster{{asUpperCamelCase parent.name}}Params
 - (instancetype)init
 {
   if (self = [super init]) {
-    {{#zcl_command_arguments}}
+{{/first}}
     {{>init_struct_member label=label type=type cluster=parent.parent.name}}
-    {{/zcl_command_arguments}}
+{{#last}}
   }
   return self;
 }
 @end
+{{/last}}
+{{/zcl_command_arguments}}
 
 {{/zcl_commands}}
 {{/zcl_clusters}}

--- a/src/darwin/Framework/CHIP/templates/CHIPCommandPayloadsObjc.zapt
+++ b/src/darwin/Framework/CHIP/templates/CHIPCommandPayloadsObjc.zapt
@@ -10,14 +10,18 @@ NS_ASSUME_NONNULL_BEGIN
 
 {{#zcl_clusters}}
 {{#zcl_commands}}
-@interface CHIP{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}Payload : NSObject
+{{#zcl_command_arguments}}
+{{#first}}
+@interface CHIP{{asUpperCamelCase parent.parent.name}}Cluster{{asUpperCamelCase parent.name}}Params : NSObject
+{{/first}}
 {{! Override the getter name because some of our properties start with things
     like "new" or "init" }}
-{{#zcl_command_arguments}}
 @property (strong, nonatomic{{#unless (isStrEqual (asGetterName label) (asStructPropertyName label))}}, getter={{asGetterName label}}{{/unless}}) {{asObjectiveCType type parent.parent.name}} {{asStructPropertyName label}};
-{{/zcl_command_arguments}}
+{{#last}}
  - (instancetype)init;
- @end
+@end
+{{/last}}
+{{/zcl_command_arguments}}
 
 {{/zcl_commands}}
 {{/zcl_clusters}}

--- a/src/darwin/Framework/CHIP/templates/clusters-tests.zapt
+++ b/src/darwin/Framework/CHIP/templates/clusters-tests.zapt
@@ -139,7 +139,7 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestCluster * cluster = [[CHIPTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    [cluster test:[[CHIPTestClusterClusterTestPayload alloc] init] responseHandler:^(NSError * err, NSDictionary * values) {
+    [cluster testWithCompletionHandler:^(NSError * err, NSDictionary * values) {
         NSLog(@"ReuseCHIPClusterObject test Error: %@", err);
         XCTAssertEqual(err.code, 0);
         [expectation fulfill];
@@ -151,7 +151,7 @@ CHIPDevice * GetConnectedDevice()
 
     // Reuse the CHIPCluster Object for multiple times.
 
-    [cluster test:[[CHIPTestClusterClusterTestPayload alloc] init] responseHandler:^(NSError * err, NSDictionary * values) {
+    [cluster testWithCompletionHandler:^(NSError * err, NSDictionary * values) {
         NSLog(@"ReuseCHIPClusterObject test Error: %@", err);
         XCTAssertEqual(err.code, 0);
         [expectation fulfill];

--- a/src/darwin/Framework/CHIP/templates/helper.js
+++ b/src/darwin/Framework/CHIP/templates/helper.js
@@ -188,6 +188,11 @@ function asGetterName(prop)
   return propName;
 }
 
+function commandHasRequiredField(command)
+{
+  return command.arguments.some(arg => !arg.isOptional);
+}
+
 //
 // Module exports
 //
@@ -202,3 +207,4 @@ exports.arrayElementObjectiveCClass  = arrayElementObjectiveCClass;
 exports.incrementDepth               = incrementDepth;
 exports.asStructPropertyName         = asStructPropertyName;
 exports.asGetterName                 = asGetterName;
+exports.commandHasRequiredField      = commandHasRequiredField;

--- a/src/darwin/Framework/CHIP/templates/partials/test_cluster.zapt
+++ b/src/darwin/Framework/CHIP/templates/partials/test_cluster.zapt
@@ -19,11 +19,38 @@ bool testSendCluster{{parent.filename}}_{{asTestIndex index}}_{{asUpperCamelCase
     XCTAssertNotNil(cluster);
 
     {{#if isCommand}}
-    __auto_type * payload = [[CHIP{{asUpperCamelCase cluster}}Cluster{{asUpperCamelCase command}}Payload alloc] init];
-    {{#chip_tests_item_parameters}}
-      {{>test_value target=(concat "payload." (asStructPropertyName label)) definedValue=definedValue cluster=parent.cluster}}
-    {{/chip_tests_item_parameters}}
-    [cluster {{asLowerCamelCase command}}:payload responseHandler:^(NSError * err, NSDictionary * values) {
+      {{! We need a way to easily do something based on whether the command has
+          fields. There are cases when chip_tests_item_parameters has nothing
+          in it even when the command does have fields (e.g. if they are all
+          optional and we are not sending any of them) but the name of our
+          command depends on whether it _could_ have fields. }}
+      {{#*inline "checkForFields"}}
+        {{~#chip_client_clusters}}
+          {{~#if (isStrEqual (asUpperCamelCase name) (asUpperCamelCase ../clusterName))}}
+            {{~#chip_cluster_commands}}
+              {{~#if (isStrEqual (asUpperCamelCase name) (asUpperCamelCase ../../commandName))}}
+                {{~#chip_cluster_command_arguments}}
+                {{~#first}}
+                  {{~../../../textIfFields}}
+                {{/first}}
+                {{else}}
+                  {{~../../../textIfNoFields}}
+                {{/chip_cluster_command_arguments}}
+              {{/if}}
+            {{/chip_cluster_commands}}
+          {{/if}}
+        {{/chip_client_clusters}}
+      {{/inline}}
+      {{> checkForFields clusterName=cluster commandName=command
+          textIfFields=(concat "__auto_type * params = [[CHIP" (asUpperCamelCase cluster) "Cluster" (asUpperCamelCase command) "Params alloc] init];")
+          textIfNoFields=""}}
+      {{#chip_tests_item_parameters}}
+        {{>test_value target=(concat "params." (asStructPropertyName label)) definedValue=definedValue cluster=parent.cluster}}
+      {{/chip_tests_item_parameters}}
+      [cluster {{asLowerCamelCase command}}With
+      {{~> checkForFields clusterName=cluster commandName=command
+           textIfFields="Params:params completionHandler"
+           textIfNoFields="CompletionHandler"}}:^(NSError * err, NSDictionary * values) {
     {{else if isSubscribeAttribute}}
     {{#chip_tests_item_parameters}}
     {{#if (isString type)}}

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPClustersObjc.h
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPClustersObjc.h
@@ -25,7 +25,11 @@
 #include <CHIP/CHIPCluster.h>
 #include <CHIP/CHIPCommandPayloadsObjc.h>
 
+/* We need to sort out our handlers, but for now just define both
+   ResponseHandler and CompletionHandler to look the same way.  Eventually we
+   will want different completion handlers for different return types. */
 typedef void (^ResponseHandler)(NSError * _Nullable error, NSDictionary * _Nullable values);
+typedef void (^CompletionHandler)(NSError * _Nullable error, NSDictionary * _Nullable values);
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -35,8 +39,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPAccountLogin : CHIPCluster
 
-- (void)getSetupPIN:(CHIPAccountLoginClusterGetSetupPINPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler;
-- (void)login:(CHIPAccountLoginClusterLoginPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler;
+- (void)getSetupPINWithParams:(CHIPAccountLoginClusterGetSetupPINParams *)params
+            completionHandler:(CompletionHandler)completionHandler;
+- (void)loginWithParams:(CHIPAccountLoginClusterLoginParams *)params completionHandler:(CompletionHandler)completionHandler;
 
 - (void)readAttributeClusterRevisionWithResponseHandler:(ResponseHandler)responseHandler;
 - (void)subscribeAttributeClusterRevisionWithMinInterval:(uint16_t)minInterval
@@ -52,12 +57,11 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPAdministratorCommissioning : CHIPCluster
 
-- (void)openBasicCommissioningWindow:(CHIPAdministratorCommissioningClusterOpenBasicCommissioningWindowPayload * _Nonnull)payload
-                     responseHandler:(ResponseHandler)responseHandler;
-- (void)openCommissioningWindow:(CHIPAdministratorCommissioningClusterOpenCommissioningWindowPayload * _Nonnull)payload
-                responseHandler:(ResponseHandler)responseHandler;
-- (void)revokeCommissioning:(CHIPAdministratorCommissioningClusterRevokeCommissioningPayload * _Nonnull)payload
-            responseHandler:(ResponseHandler)responseHandler;
+- (void)openBasicCommissioningWindowWithParams:(CHIPAdministratorCommissioningClusterOpenBasicCommissioningWindowParams *)params
+                             completionHandler:(CompletionHandler)completionHandler;
+- (void)openCommissioningWindowWithParams:(CHIPAdministratorCommissioningClusterOpenCommissioningWindowParams *)params
+                        completionHandler:(CompletionHandler)completionHandler;
+- (void)revokeCommissioningWithCompletionHandler:(CompletionHandler)completionHandler;
 
 - (void)readAttributeClusterRevisionWithResponseHandler:(ResponseHandler)responseHandler;
 - (void)subscribeAttributeClusterRevisionWithMinInterval:(uint16_t)minInterval
@@ -73,8 +77,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPApplicationBasic : CHIPCluster
 
-- (void)changeStatus:(CHIPApplicationBasicClusterChangeStatusPayload * _Nonnull)payload
-     responseHandler:(ResponseHandler)responseHandler;
+- (void)changeStatusWithParams:(CHIPApplicationBasicClusterChangeStatusParams *)params
+             completionHandler:(CompletionHandler)completionHandler;
 
 - (void)readAttributeVendorNameWithResponseHandler:(ResponseHandler)responseHandler;
 - (void)subscribeAttributeVendorNameWithMinInterval:(uint16_t)minInterval
@@ -132,8 +136,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPApplicationLauncher : CHIPCluster
 
-- (void)launchApp:(CHIPApplicationLauncherClusterLaunchAppPayload * _Nonnull)payload
-    responseHandler:(ResponseHandler)responseHandler;
+- (void)launchAppWithParams:(CHIPApplicationLauncherClusterLaunchAppParams *)params
+          completionHandler:(CompletionHandler)completionHandler;
 
 - (void)readAttributeApplicationLauncherListWithResponseHandler:(ResponseHandler)responseHandler;
 
@@ -163,8 +167,10 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPAudioOutput : CHIPCluster
 
-- (void)renameOutput:(CHIPAudioOutputClusterRenameOutputPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler;
-- (void)selectOutput:(CHIPAudioOutputClusterSelectOutputPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler;
+- (void)renameOutputWithParams:(CHIPAudioOutputClusterRenameOutputParams *)params
+             completionHandler:(CompletionHandler)completionHandler;
+- (void)selectOutputWithParams:(CHIPAudioOutputClusterSelectOutputParams *)params
+             completionHandler:(CompletionHandler)completionHandler;
 
 - (void)readAttributeAudioOutputListWithResponseHandler:(ResponseHandler)responseHandler;
 
@@ -188,10 +194,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPBarrierControl : CHIPCluster
 
-- (void)barrierControlGoToPercent:(CHIPBarrierControlClusterBarrierControlGoToPercentPayload * _Nonnull)payload
-                  responseHandler:(ResponseHandler)responseHandler;
-- (void)barrierControlStop:(CHIPBarrierControlClusterBarrierControlStopPayload * _Nonnull)payload
-           responseHandler:(ResponseHandler)responseHandler;
+- (void)barrierControlGoToPercentWithParams:(CHIPBarrierControlClusterBarrierControlGoToPercentParams *)params
+                          completionHandler:(CompletionHandler)completionHandler;
+- (void)barrierControlStopWithCompletionHandler:(CompletionHandler)completionHandler;
 
 - (void)readAttributeBarrierMovingStateWithResponseHandler:(ResponseHandler)responseHandler;
 - (void)subscribeAttributeBarrierMovingStateWithMinInterval:(uint16_t)minInterval
@@ -231,7 +236,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPBasic : CHIPCluster
 
-- (void)mfgSpecificPing:(CHIPBasicClusterMfgSpecificPingPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler;
+- (void)mfgSpecificPingWithCompletionHandler:(CompletionHandler)completionHandler;
 
 - (void)readAttributeInteractionModelVersionWithResponseHandler:(ResponseHandler)responseHandler;
 - (void)subscribeAttributeInteractionModelVersionWithMinInterval:(uint16_t)minInterval
@@ -392,8 +397,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPBinding : CHIPCluster
 
-- (void)bind:(CHIPBindingClusterBindPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler;
-- (void)unbind:(CHIPBindingClusterUnbindPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler;
+- (void)bindWithParams:(CHIPBindingClusterBindParams *)params completionHandler:(CompletionHandler)completionHandler;
+- (void)unbindWithParams:(CHIPBindingClusterUnbindParams *)params completionHandler:(CompletionHandler)completionHandler;
 
 - (void)readAttributeClusterRevisionWithResponseHandler:(ResponseHandler)responseHandler;
 - (void)subscribeAttributeClusterRevisionWithMinInterval:(uint16_t)minInterval
@@ -429,29 +434,30 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPBridgedActions : CHIPCluster
 
-- (void)disableAction:(CHIPBridgedActionsClusterDisableActionPayload * _Nonnull)payload
-      responseHandler:(ResponseHandler)responseHandler;
-- (void)disableActionWithDuration:(CHIPBridgedActionsClusterDisableActionWithDurationPayload * _Nonnull)payload
-                  responseHandler:(ResponseHandler)responseHandler;
-- (void)enableAction:(CHIPBridgedActionsClusterEnableActionPayload * _Nonnull)payload
-     responseHandler:(ResponseHandler)responseHandler;
-- (void)enableActionWithDuration:(CHIPBridgedActionsClusterEnableActionWithDurationPayload * _Nonnull)payload
-                 responseHandler:(ResponseHandler)responseHandler;
-- (void)instantAction:(CHIPBridgedActionsClusterInstantActionPayload * _Nonnull)payload
-      responseHandler:(ResponseHandler)responseHandler;
-- (void)instantActionWithTransition:(CHIPBridgedActionsClusterInstantActionWithTransitionPayload * _Nonnull)payload
-                    responseHandler:(ResponseHandler)responseHandler;
-- (void)pauseAction:(CHIPBridgedActionsClusterPauseActionPayload * _Nonnull)payload
-    responseHandler:(ResponseHandler)responseHandler;
-- (void)pauseActionWithDuration:(CHIPBridgedActionsClusterPauseActionWithDurationPayload * _Nonnull)payload
-                responseHandler:(ResponseHandler)responseHandler;
-- (void)resumeAction:(CHIPBridgedActionsClusterResumeActionPayload * _Nonnull)payload
-     responseHandler:(ResponseHandler)responseHandler;
-- (void)startAction:(CHIPBridgedActionsClusterStartActionPayload * _Nonnull)payload
-    responseHandler:(ResponseHandler)responseHandler;
-- (void)startActionWithDuration:(CHIPBridgedActionsClusterStartActionWithDurationPayload * _Nonnull)payload
-                responseHandler:(ResponseHandler)responseHandler;
-- (void)stopAction:(CHIPBridgedActionsClusterStopActionPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler;
+- (void)disableActionWithParams:(CHIPBridgedActionsClusterDisableActionParams *)params
+              completionHandler:(CompletionHandler)completionHandler;
+- (void)disableActionWithDurationWithParams:(CHIPBridgedActionsClusterDisableActionWithDurationParams *)params
+                          completionHandler:(CompletionHandler)completionHandler;
+- (void)enableActionWithParams:(CHIPBridgedActionsClusterEnableActionParams *)params
+             completionHandler:(CompletionHandler)completionHandler;
+- (void)enableActionWithDurationWithParams:(CHIPBridgedActionsClusterEnableActionWithDurationParams *)params
+                         completionHandler:(CompletionHandler)completionHandler;
+- (void)instantActionWithParams:(CHIPBridgedActionsClusterInstantActionParams *)params
+              completionHandler:(CompletionHandler)completionHandler;
+- (void)instantActionWithTransitionWithParams:(CHIPBridgedActionsClusterInstantActionWithTransitionParams *)params
+                            completionHandler:(CompletionHandler)completionHandler;
+- (void)pauseActionWithParams:(CHIPBridgedActionsClusterPauseActionParams *)params
+            completionHandler:(CompletionHandler)completionHandler;
+- (void)pauseActionWithDurationWithParams:(CHIPBridgedActionsClusterPauseActionWithDurationParams *)params
+                        completionHandler:(CompletionHandler)completionHandler;
+- (void)resumeActionWithParams:(CHIPBridgedActionsClusterResumeActionParams *)params
+             completionHandler:(CompletionHandler)completionHandler;
+- (void)startActionWithParams:(CHIPBridgedActionsClusterStartActionParams *)params
+            completionHandler:(CompletionHandler)completionHandler;
+- (void)startActionWithDurationWithParams:(CHIPBridgedActionsClusterStartActionWithDurationParams *)params
+                        completionHandler:(CompletionHandler)completionHandler;
+- (void)stopActionWithParams:(CHIPBridgedActionsClusterStopActionParams *)params
+           completionHandler:(CompletionHandler)completionHandler;
 
 - (void)readAttributeActionListWithResponseHandler:(ResponseHandler)responseHandler;
 
@@ -491,38 +497,39 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPColorControl : CHIPCluster
 
-- (void)colorLoopSet:(CHIPColorControlClusterColorLoopSetPayload * _Nonnull)payload
-     responseHandler:(ResponseHandler)responseHandler;
-- (void)enhancedMoveHue:(CHIPColorControlClusterEnhancedMoveHuePayload * _Nonnull)payload
-        responseHandler:(ResponseHandler)responseHandler;
-- (void)enhancedMoveToHue:(CHIPColorControlClusterEnhancedMoveToHuePayload * _Nonnull)payload
-          responseHandler:(ResponseHandler)responseHandler;
-- (void)enhancedMoveToHueAndSaturation:(CHIPColorControlClusterEnhancedMoveToHueAndSaturationPayload * _Nonnull)payload
-                       responseHandler:(ResponseHandler)responseHandler;
-- (void)enhancedStepHue:(CHIPColorControlClusterEnhancedStepHuePayload * _Nonnull)payload
-        responseHandler:(ResponseHandler)responseHandler;
-- (void)moveColor:(CHIPColorControlClusterMoveColorPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler;
-- (void)moveColorTemperature:(CHIPColorControlClusterMoveColorTemperaturePayload * _Nonnull)payload
-             responseHandler:(ResponseHandler)responseHandler;
-- (void)moveHue:(CHIPColorControlClusterMoveHuePayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler;
-- (void)moveSaturation:(CHIPColorControlClusterMoveSaturationPayload * _Nonnull)payload
-       responseHandler:(ResponseHandler)responseHandler;
-- (void)moveToColor:(CHIPColorControlClusterMoveToColorPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler;
-- (void)moveToColorTemperature:(CHIPColorControlClusterMoveToColorTemperaturePayload * _Nonnull)payload
-               responseHandler:(ResponseHandler)responseHandler;
-- (void)moveToHue:(CHIPColorControlClusterMoveToHuePayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler;
-- (void)moveToHueAndSaturation:(CHIPColorControlClusterMoveToHueAndSaturationPayload * _Nonnull)payload
-               responseHandler:(ResponseHandler)responseHandler;
-- (void)moveToSaturation:(CHIPColorControlClusterMoveToSaturationPayload * _Nonnull)payload
-         responseHandler:(ResponseHandler)responseHandler;
-- (void)stepColor:(CHIPColorControlClusterStepColorPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler;
-- (void)stepColorTemperature:(CHIPColorControlClusterStepColorTemperaturePayload * _Nonnull)payload
-             responseHandler:(ResponseHandler)responseHandler;
-- (void)stepHue:(CHIPColorControlClusterStepHuePayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler;
-- (void)stepSaturation:(CHIPColorControlClusterStepSaturationPayload * _Nonnull)payload
-       responseHandler:(ResponseHandler)responseHandler;
-- (void)stopMoveStep:(CHIPColorControlClusterStopMoveStepPayload * _Nonnull)payload
-     responseHandler:(ResponseHandler)responseHandler;
+- (void)colorLoopSetWithParams:(CHIPColorControlClusterColorLoopSetParams *)params
+             completionHandler:(CompletionHandler)completionHandler;
+- (void)enhancedMoveHueWithParams:(CHIPColorControlClusterEnhancedMoveHueParams *)params
+                completionHandler:(CompletionHandler)completionHandler;
+- (void)enhancedMoveToHueWithParams:(CHIPColorControlClusterEnhancedMoveToHueParams *)params
+                  completionHandler:(CompletionHandler)completionHandler;
+- (void)enhancedMoveToHueAndSaturationWithParams:(CHIPColorControlClusterEnhancedMoveToHueAndSaturationParams *)params
+                               completionHandler:(CompletionHandler)completionHandler;
+- (void)enhancedStepHueWithParams:(CHIPColorControlClusterEnhancedStepHueParams *)params
+                completionHandler:(CompletionHandler)completionHandler;
+- (void)moveColorWithParams:(CHIPColorControlClusterMoveColorParams *)params completionHandler:(CompletionHandler)completionHandler;
+- (void)moveColorTemperatureWithParams:(CHIPColorControlClusterMoveColorTemperatureParams *)params
+                     completionHandler:(CompletionHandler)completionHandler;
+- (void)moveHueWithParams:(CHIPColorControlClusterMoveHueParams *)params completionHandler:(CompletionHandler)completionHandler;
+- (void)moveSaturationWithParams:(CHIPColorControlClusterMoveSaturationParams *)params
+               completionHandler:(CompletionHandler)completionHandler;
+- (void)moveToColorWithParams:(CHIPColorControlClusterMoveToColorParams *)params
+            completionHandler:(CompletionHandler)completionHandler;
+- (void)moveToColorTemperatureWithParams:(CHIPColorControlClusterMoveToColorTemperatureParams *)params
+                       completionHandler:(CompletionHandler)completionHandler;
+- (void)moveToHueWithParams:(CHIPColorControlClusterMoveToHueParams *)params completionHandler:(CompletionHandler)completionHandler;
+- (void)moveToHueAndSaturationWithParams:(CHIPColorControlClusterMoveToHueAndSaturationParams *)params
+                       completionHandler:(CompletionHandler)completionHandler;
+- (void)moveToSaturationWithParams:(CHIPColorControlClusterMoveToSaturationParams *)params
+                 completionHandler:(CompletionHandler)completionHandler;
+- (void)stepColorWithParams:(CHIPColorControlClusterStepColorParams *)params completionHandler:(CompletionHandler)completionHandler;
+- (void)stepColorTemperatureWithParams:(CHIPColorControlClusterStepColorTemperatureParams *)params
+                     completionHandler:(CompletionHandler)completionHandler;
+- (void)stepHueWithParams:(CHIPColorControlClusterStepHueParams *)params completionHandler:(CompletionHandler)completionHandler;
+- (void)stepSaturationWithParams:(CHIPColorControlClusterStepSaturationParams *)params
+               completionHandler:(CompletionHandler)completionHandler;
+- (void)stopMoveStepWithParams:(CHIPColorControlClusterStopMoveStepParams *)params
+             completionHandler:(CompletionHandler)completionHandler;
 
 - (void)readAttributeCurrentHueWithResponseHandler:(ResponseHandler)responseHandler;
 - (void)subscribeAttributeCurrentHueWithMinInterval:(uint16_t)minInterval
@@ -864,9 +871,10 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPContentLauncher : CHIPCluster
 
-- (void)launchContent:(CHIPContentLauncherClusterLaunchContentPayload * _Nonnull)payload
-      responseHandler:(ResponseHandler)responseHandler;
-- (void)launchURL:(CHIPContentLauncherClusterLaunchURLPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler;
+- (void)launchContentWithParams:(CHIPContentLauncherClusterLaunchContentParams *)params
+              completionHandler:(CompletionHandler)completionHandler;
+- (void)launchURLWithParams:(CHIPContentLauncherClusterLaunchURLParams *)params
+          completionHandler:(CompletionHandler)completionHandler;
 
 - (void)readAttributeAcceptsHeaderListWithResponseHandler:(ResponseHandler)responseHandler;
 
@@ -908,8 +916,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPDiagnosticLogs : CHIPCluster
 
-- (void)retrieveLogsRequest:(CHIPDiagnosticLogsClusterRetrieveLogsRequestPayload * _Nonnull)payload
-            responseHandler:(ResponseHandler)responseHandler;
+- (void)retrieveLogsRequestWithParams:(CHIPDiagnosticLogsClusterRetrieveLogsRequestParams *)params
+                    completionHandler:(CompletionHandler)completionHandler;
 
 @end
 
@@ -919,39 +927,40 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPDoorLock : CHIPCluster
 
-- (void)clearAllPins:(CHIPDoorLockClusterClearAllPinsPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler;
-- (void)clearAllRfids:(CHIPDoorLockClusterClearAllRfidsPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler;
-- (void)clearHolidaySchedule:(CHIPDoorLockClusterClearHolidaySchedulePayload * _Nonnull)payload
-             responseHandler:(ResponseHandler)responseHandler;
-- (void)clearPin:(CHIPDoorLockClusterClearPinPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler;
-- (void)clearRfid:(CHIPDoorLockClusterClearRfidPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler;
-- (void)clearWeekdaySchedule:(CHIPDoorLockClusterClearWeekdaySchedulePayload * _Nonnull)payload
-             responseHandler:(ResponseHandler)responseHandler;
-- (void)clearYeardaySchedule:(CHIPDoorLockClusterClearYeardaySchedulePayload * _Nonnull)payload
-             responseHandler:(ResponseHandler)responseHandler;
-- (void)getHolidaySchedule:(CHIPDoorLockClusterGetHolidaySchedulePayload * _Nonnull)payload
-           responseHandler:(ResponseHandler)responseHandler;
-- (void)getLogRecord:(CHIPDoorLockClusterGetLogRecordPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler;
-- (void)getPin:(CHIPDoorLockClusterGetPinPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler;
-- (void)getRfid:(CHIPDoorLockClusterGetRfidPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler;
-- (void)getUserType:(CHIPDoorLockClusterGetUserTypePayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler;
-- (void)getWeekdaySchedule:(CHIPDoorLockClusterGetWeekdaySchedulePayload * _Nonnull)payload
-           responseHandler:(ResponseHandler)responseHandler;
-- (void)getYeardaySchedule:(CHIPDoorLockClusterGetYeardaySchedulePayload * _Nonnull)payload
-           responseHandler:(ResponseHandler)responseHandler;
-- (void)lockDoor:(CHIPDoorLockClusterLockDoorPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler;
-- (void)setHolidaySchedule:(CHIPDoorLockClusterSetHolidaySchedulePayload * _Nonnull)payload
-           responseHandler:(ResponseHandler)responseHandler;
-- (void)setPin:(CHIPDoorLockClusterSetPinPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler;
-- (void)setRfid:(CHIPDoorLockClusterSetRfidPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler;
-- (void)setUserType:(CHIPDoorLockClusterSetUserTypePayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler;
-- (void)setWeekdaySchedule:(CHIPDoorLockClusterSetWeekdaySchedulePayload * _Nonnull)payload
-           responseHandler:(ResponseHandler)responseHandler;
-- (void)setYeardaySchedule:(CHIPDoorLockClusterSetYeardaySchedulePayload * _Nonnull)payload
-           responseHandler:(ResponseHandler)responseHandler;
-- (void)unlockDoor:(CHIPDoorLockClusterUnlockDoorPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler;
-- (void)unlockWithTimeout:(CHIPDoorLockClusterUnlockWithTimeoutPayload * _Nonnull)payload
-          responseHandler:(ResponseHandler)responseHandler;
+- (void)clearAllPinsWithCompletionHandler:(CompletionHandler)completionHandler;
+- (void)clearAllRfidsWithCompletionHandler:(CompletionHandler)completionHandler;
+- (void)clearHolidayScheduleWithParams:(CHIPDoorLockClusterClearHolidayScheduleParams *)params
+                     completionHandler:(CompletionHandler)completionHandler;
+- (void)clearPinWithParams:(CHIPDoorLockClusterClearPinParams *)params completionHandler:(CompletionHandler)completionHandler;
+- (void)clearRfidWithParams:(CHIPDoorLockClusterClearRfidParams *)params completionHandler:(CompletionHandler)completionHandler;
+- (void)clearWeekdayScheduleWithParams:(CHIPDoorLockClusterClearWeekdayScheduleParams *)params
+                     completionHandler:(CompletionHandler)completionHandler;
+- (void)clearYeardayScheduleWithParams:(CHIPDoorLockClusterClearYeardayScheduleParams *)params
+                     completionHandler:(CompletionHandler)completionHandler;
+- (void)getHolidayScheduleWithParams:(CHIPDoorLockClusterGetHolidayScheduleParams *)params
+                   completionHandler:(CompletionHandler)completionHandler;
+- (void)getLogRecordWithParams:(CHIPDoorLockClusterGetLogRecordParams *)params
+             completionHandler:(CompletionHandler)completionHandler;
+- (void)getPinWithParams:(CHIPDoorLockClusterGetPinParams *)params completionHandler:(CompletionHandler)completionHandler;
+- (void)getRfidWithParams:(CHIPDoorLockClusterGetRfidParams *)params completionHandler:(CompletionHandler)completionHandler;
+- (void)getUserTypeWithParams:(CHIPDoorLockClusterGetUserTypeParams *)params completionHandler:(CompletionHandler)completionHandler;
+- (void)getWeekdayScheduleWithParams:(CHIPDoorLockClusterGetWeekdayScheduleParams *)params
+                   completionHandler:(CompletionHandler)completionHandler;
+- (void)getYeardayScheduleWithParams:(CHIPDoorLockClusterGetYeardayScheduleParams *)params
+                   completionHandler:(CompletionHandler)completionHandler;
+- (void)lockDoorWithParams:(CHIPDoorLockClusterLockDoorParams *)params completionHandler:(CompletionHandler)completionHandler;
+- (void)setHolidayScheduleWithParams:(CHIPDoorLockClusterSetHolidayScheduleParams *)params
+                   completionHandler:(CompletionHandler)completionHandler;
+- (void)setPinWithParams:(CHIPDoorLockClusterSetPinParams *)params completionHandler:(CompletionHandler)completionHandler;
+- (void)setRfidWithParams:(CHIPDoorLockClusterSetRfidParams *)params completionHandler:(CompletionHandler)completionHandler;
+- (void)setUserTypeWithParams:(CHIPDoorLockClusterSetUserTypeParams *)params completionHandler:(CompletionHandler)completionHandler;
+- (void)setWeekdayScheduleWithParams:(CHIPDoorLockClusterSetWeekdayScheduleParams *)params
+                   completionHandler:(CompletionHandler)completionHandler;
+- (void)setYeardayScheduleWithParams:(CHIPDoorLockClusterSetYeardayScheduleParams *)params
+                   completionHandler:(CompletionHandler)completionHandler;
+- (void)unlockDoorWithParams:(CHIPDoorLockClusterUnlockDoorParams *)params completionHandler:(CompletionHandler)completionHandler;
+- (void)unlockWithTimeoutWithParams:(CHIPDoorLockClusterUnlockWithTimeoutParams *)params
+                  completionHandler:(CompletionHandler)completionHandler;
 
 - (void)readAttributeLockStateWithResponseHandler:(ResponseHandler)responseHandler;
 - (void)subscribeAttributeLockStateWithMinInterval:(uint16_t)minInterval
@@ -1065,8 +1074,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPEthernetNetworkDiagnostics : CHIPCluster
 
-- (void)resetCounts:(CHIPEthernetNetworkDiagnosticsClusterResetCountsPayload * _Nonnull)payload
-    responseHandler:(ResponseHandler)responseHandler;
+- (void)resetCountsWithCompletionHandler:(CompletionHandler)completionHandler;
 
 - (void)readAttributePHYRateWithResponseHandler:(ResponseHandler)responseHandler;
 - (void)subscribeAttributePHYRateWithMinInterval:(uint16_t)minInterval
@@ -1190,12 +1198,11 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPGeneralCommissioning : CHIPCluster
 
-- (void)armFailSafe:(CHIPGeneralCommissioningClusterArmFailSafePayload * _Nonnull)payload
-    responseHandler:(ResponseHandler)responseHandler;
-- (void)commissioningComplete:(CHIPGeneralCommissioningClusterCommissioningCompletePayload * _Nonnull)payload
-              responseHandler:(ResponseHandler)responseHandler;
-- (void)setRegulatoryConfig:(CHIPGeneralCommissioningClusterSetRegulatoryConfigPayload * _Nonnull)payload
-            responseHandler:(ResponseHandler)responseHandler;
+- (void)armFailSafeWithParams:(CHIPGeneralCommissioningClusterArmFailSafeParams *)params
+            completionHandler:(CompletionHandler)completionHandler;
+- (void)commissioningCompleteWithCompletionHandler:(CompletionHandler)completionHandler;
+- (void)setRegulatoryConfigWithParams:(CHIPGeneralCommissioningClusterSetRegulatoryConfigParams *)params
+                    completionHandler:(CompletionHandler)completionHandler;
 
 - (void)readAttributeBreadcrumbWithResponseHandler:(ResponseHandler)responseHandler;
 - (void)writeAttributeBreadcrumbWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
@@ -1284,15 +1291,14 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPGroups : CHIPCluster
 
-- (void)addGroup:(CHIPGroupsClusterAddGroupPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler;
-- (void)addGroupIfIdentifying:(CHIPGroupsClusterAddGroupIfIdentifyingPayload * _Nonnull)payload
-              responseHandler:(ResponseHandler)responseHandler;
-- (void)getGroupMembership:(CHIPGroupsClusterGetGroupMembershipPayload * _Nonnull)payload
-           responseHandler:(ResponseHandler)responseHandler;
-- (void)removeAllGroups:(CHIPGroupsClusterRemoveAllGroupsPayload * _Nonnull)payload
-        responseHandler:(ResponseHandler)responseHandler;
-- (void)removeGroup:(CHIPGroupsClusterRemoveGroupPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler;
-- (void)viewGroup:(CHIPGroupsClusterViewGroupPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler;
+- (void)addGroupWithParams:(CHIPGroupsClusterAddGroupParams *)params completionHandler:(CompletionHandler)completionHandler;
+- (void)addGroupIfIdentifyingWithParams:(CHIPGroupsClusterAddGroupIfIdentifyingParams *)params
+                      completionHandler:(CompletionHandler)completionHandler;
+- (void)getGroupMembershipWithParams:(CHIPGroupsClusterGetGroupMembershipParams *)params
+                   completionHandler:(CompletionHandler)completionHandler;
+- (void)removeAllGroupsWithCompletionHandler:(CompletionHandler)completionHandler;
+- (void)removeGroupWithParams:(CHIPGroupsClusterRemoveGroupParams *)params completionHandler:(CompletionHandler)completionHandler;
+- (void)viewGroupWithParams:(CHIPGroupsClusterViewGroupParams *)params completionHandler:(CompletionHandler)completionHandler;
 
 - (void)readAttributeNameSupportWithResponseHandler:(ResponseHandler)responseHandler;
 - (void)subscribeAttributeNameSupportWithMinInterval:(uint16_t)minInterval
@@ -1314,9 +1320,10 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPIdentify : CHIPCluster
 
-- (void)identify:(CHIPIdentifyClusterIdentifyPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler;
-- (void)identifyQuery:(CHIPIdentifyClusterIdentifyQueryPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler;
-- (void)triggerEffect:(CHIPIdentifyClusterTriggerEffectPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler;
+- (void)identifyWithParams:(CHIPIdentifyClusterIdentifyParams *)params completionHandler:(CompletionHandler)completionHandler;
+- (void)identifyQueryWithCompletionHandler:(CompletionHandler)completionHandler;
+- (void)triggerEffectWithParams:(CHIPIdentifyClusterTriggerEffectParams *)params
+              completionHandler:(CompletionHandler)completionHandler;
 
 - (void)readAttributeIdentifyTimeWithResponseHandler:(ResponseHandler)responseHandler;
 - (void)writeAttributeIdentifyTimeWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
@@ -1389,7 +1396,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPKeypadInput : CHIPCluster
 
-- (void)sendKey:(CHIPKeypadInputClusterSendKeyPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler;
+- (void)sendKeyWithParams:(CHIPKeypadInputClusterSendKeyParams *)params completionHandler:(CompletionHandler)completionHandler;
 
 - (void)readAttributeClusterRevisionWithResponseHandler:(ResponseHandler)responseHandler;
 - (void)subscribeAttributeClusterRevisionWithMinInterval:(uint16_t)minInterval
@@ -1405,18 +1412,18 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPLevelControl : CHIPCluster
 
-- (void)move:(CHIPLevelControlClusterMovePayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler;
-- (void)moveToLevel:(CHIPLevelControlClusterMoveToLevelPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler;
-- (void)moveToLevelWithOnOff:(CHIPLevelControlClusterMoveToLevelWithOnOffPayload * _Nonnull)payload
-             responseHandler:(ResponseHandler)responseHandler;
-- (void)moveWithOnOff:(CHIPLevelControlClusterMoveWithOnOffPayload * _Nonnull)payload
-      responseHandler:(ResponseHandler)responseHandler;
-- (void)step:(CHIPLevelControlClusterStepPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler;
-- (void)stepWithOnOff:(CHIPLevelControlClusterStepWithOnOffPayload * _Nonnull)payload
-      responseHandler:(ResponseHandler)responseHandler;
-- (void)stop:(CHIPLevelControlClusterStopPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler;
-- (void)stopWithOnOff:(CHIPLevelControlClusterStopWithOnOffPayload * _Nonnull)payload
-      responseHandler:(ResponseHandler)responseHandler;
+- (void)moveWithParams:(CHIPLevelControlClusterMoveParams *)params completionHandler:(CompletionHandler)completionHandler;
+- (void)moveToLevelWithParams:(CHIPLevelControlClusterMoveToLevelParams *)params
+            completionHandler:(CompletionHandler)completionHandler;
+- (void)moveToLevelWithOnOffWithParams:(CHIPLevelControlClusterMoveToLevelWithOnOffParams *)params
+                     completionHandler:(CompletionHandler)completionHandler;
+- (void)moveWithOnOffWithParams:(CHIPLevelControlClusterMoveWithOnOffParams *)params
+              completionHandler:(CompletionHandler)completionHandler;
+- (void)stepWithParams:(CHIPLevelControlClusterStepParams *)params completionHandler:(CompletionHandler)completionHandler;
+- (void)stepWithOnOffWithParams:(CHIPLevelControlClusterStepWithOnOffParams *)params
+              completionHandler:(CompletionHandler)completionHandler;
+- (void)stopWithParams:(CHIPLevelControlClusterStopParams *)params completionHandler:(CompletionHandler)completionHandler;
+- (void)stopWithOnOffWithCompletionHandler:(CompletionHandler)completionHandler;
 
 - (void)readAttributeCurrentLevelWithResponseHandler:(ResponseHandler)responseHandler;
 - (void)subscribeAttributeCurrentLevelWithMinInterval:(uint16_t)minInterval
@@ -1523,7 +1530,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPLowPower : CHIPCluster
 
-- (void)sleep:(CHIPLowPowerClusterSleepPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler;
+- (void)sleepWithCompletionHandler:(CompletionHandler)completionHandler;
 
 - (void)readAttributeClusterRevisionWithResponseHandler:(ResponseHandler)responseHandler;
 - (void)subscribeAttributeClusterRevisionWithMinInterval:(uint16_t)minInterval
@@ -1539,12 +1546,12 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPMediaInput : CHIPCluster
 
-- (void)hideInputStatus:(CHIPMediaInputClusterHideInputStatusPayload * _Nonnull)payload
-        responseHandler:(ResponseHandler)responseHandler;
-- (void)renameInput:(CHIPMediaInputClusterRenameInputPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler;
-- (void)selectInput:(CHIPMediaInputClusterSelectInputPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler;
-- (void)showInputStatus:(CHIPMediaInputClusterShowInputStatusPayload * _Nonnull)payload
-        responseHandler:(ResponseHandler)responseHandler;
+- (void)hideInputStatusWithCompletionHandler:(CompletionHandler)completionHandler;
+- (void)renameInputWithParams:(CHIPMediaInputClusterRenameInputParams *)params
+            completionHandler:(CompletionHandler)completionHandler;
+- (void)selectInputWithParams:(CHIPMediaInputClusterSelectInputParams *)params
+            completionHandler:(CompletionHandler)completionHandler;
+- (void)showInputStatusWithCompletionHandler:(CompletionHandler)completionHandler;
 
 - (void)readAttributeMediaInputListWithResponseHandler:(ResponseHandler)responseHandler;
 
@@ -1568,22 +1575,20 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPMediaPlayback : CHIPCluster
 
-- (void)mediaFastForward:(CHIPMediaPlaybackClusterMediaFastForwardPayload * _Nonnull)payload
-         responseHandler:(ResponseHandler)responseHandler;
-- (void)mediaNext:(CHIPMediaPlaybackClusterMediaNextPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler;
-- (void)mediaPause:(CHIPMediaPlaybackClusterMediaPausePayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler;
-- (void)mediaPlay:(CHIPMediaPlaybackClusterMediaPlayPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler;
-- (void)mediaPrevious:(CHIPMediaPlaybackClusterMediaPreviousPayload * _Nonnull)payload
-      responseHandler:(ResponseHandler)responseHandler;
-- (void)mediaRewind:(CHIPMediaPlaybackClusterMediaRewindPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler;
-- (void)mediaSeek:(CHIPMediaPlaybackClusterMediaSeekPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler;
-- (void)mediaSkipBackward:(CHIPMediaPlaybackClusterMediaSkipBackwardPayload * _Nonnull)payload
-          responseHandler:(ResponseHandler)responseHandler;
-- (void)mediaSkipForward:(CHIPMediaPlaybackClusterMediaSkipForwardPayload * _Nonnull)payload
-         responseHandler:(ResponseHandler)responseHandler;
-- (void)mediaStartOver:(CHIPMediaPlaybackClusterMediaStartOverPayload * _Nonnull)payload
-       responseHandler:(ResponseHandler)responseHandler;
-- (void)mediaStop:(CHIPMediaPlaybackClusterMediaStopPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler;
+- (void)mediaFastForwardWithCompletionHandler:(CompletionHandler)completionHandler;
+- (void)mediaNextWithCompletionHandler:(CompletionHandler)completionHandler;
+- (void)mediaPauseWithCompletionHandler:(CompletionHandler)completionHandler;
+- (void)mediaPlayWithCompletionHandler:(CompletionHandler)completionHandler;
+- (void)mediaPreviousWithCompletionHandler:(CompletionHandler)completionHandler;
+- (void)mediaRewindWithCompletionHandler:(CompletionHandler)completionHandler;
+- (void)mediaSeekWithParams:(CHIPMediaPlaybackClusterMediaSeekParams *)params
+          completionHandler:(CompletionHandler)completionHandler;
+- (void)mediaSkipBackwardWithParams:(CHIPMediaPlaybackClusterMediaSkipBackwardParams *)params
+                  completionHandler:(CompletionHandler)completionHandler;
+- (void)mediaSkipForwardWithParams:(CHIPMediaPlaybackClusterMediaSkipForwardParams *)params
+                 completionHandler:(CompletionHandler)completionHandler;
+- (void)mediaStartOverWithCompletionHandler:(CompletionHandler)completionHandler;
+- (void)mediaStopWithCompletionHandler:(CompletionHandler)completionHandler;
 
 - (void)readAttributePlaybackStateWithResponseHandler:(ResponseHandler)responseHandler;
 - (void)subscribeAttributePlaybackStateWithMinInterval:(uint16_t)minInterval
@@ -1647,7 +1652,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPModeSelect : CHIPCluster
 
-- (void)changeToMode:(CHIPModeSelectClusterChangeToModePayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler;
+- (void)changeToModeWithParams:(CHIPModeSelectClusterChangeToModeParams *)params
+             completionHandler:(CompletionHandler)completionHandler;
 
 - (void)readAttributeCurrentModeWithResponseHandler:(ResponseHandler)responseHandler;
 - (void)subscribeAttributeCurrentModeWithMinInterval:(uint16_t)minInterval
@@ -1690,22 +1696,22 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPNetworkCommissioning : CHIPCluster
 
-- (void)addThreadNetwork:(CHIPNetworkCommissioningClusterAddThreadNetworkPayload * _Nonnull)payload
-         responseHandler:(ResponseHandler)responseHandler;
-- (void)addWiFiNetwork:(CHIPNetworkCommissioningClusterAddWiFiNetworkPayload * _Nonnull)payload
-       responseHandler:(ResponseHandler)responseHandler;
-- (void)disableNetwork:(CHIPNetworkCommissioningClusterDisableNetworkPayload * _Nonnull)payload
-       responseHandler:(ResponseHandler)responseHandler;
-- (void)enableNetwork:(CHIPNetworkCommissioningClusterEnableNetworkPayload * _Nonnull)payload
-      responseHandler:(ResponseHandler)responseHandler;
-- (void)removeNetwork:(CHIPNetworkCommissioningClusterRemoveNetworkPayload * _Nonnull)payload
-      responseHandler:(ResponseHandler)responseHandler;
-- (void)scanNetworks:(CHIPNetworkCommissioningClusterScanNetworksPayload * _Nonnull)payload
-     responseHandler:(ResponseHandler)responseHandler;
-- (void)updateThreadNetwork:(CHIPNetworkCommissioningClusterUpdateThreadNetworkPayload * _Nonnull)payload
-            responseHandler:(ResponseHandler)responseHandler;
-- (void)updateWiFiNetwork:(CHIPNetworkCommissioningClusterUpdateWiFiNetworkPayload * _Nonnull)payload
-          responseHandler:(ResponseHandler)responseHandler;
+- (void)addThreadNetworkWithParams:(CHIPNetworkCommissioningClusterAddThreadNetworkParams *)params
+                 completionHandler:(CompletionHandler)completionHandler;
+- (void)addWiFiNetworkWithParams:(CHIPNetworkCommissioningClusterAddWiFiNetworkParams *)params
+               completionHandler:(CompletionHandler)completionHandler;
+- (void)disableNetworkWithParams:(CHIPNetworkCommissioningClusterDisableNetworkParams *)params
+               completionHandler:(CompletionHandler)completionHandler;
+- (void)enableNetworkWithParams:(CHIPNetworkCommissioningClusterEnableNetworkParams *)params
+              completionHandler:(CompletionHandler)completionHandler;
+- (void)removeNetworkWithParams:(CHIPNetworkCommissioningClusterRemoveNetworkParams *)params
+              completionHandler:(CompletionHandler)completionHandler;
+- (void)scanNetworksWithParams:(CHIPNetworkCommissioningClusterScanNetworksParams *)params
+             completionHandler:(CompletionHandler)completionHandler;
+- (void)updateThreadNetworkWithParams:(CHIPNetworkCommissioningClusterUpdateThreadNetworkParams *)params
+                    completionHandler:(CompletionHandler)completionHandler;
+- (void)updateWiFiNetworkWithParams:(CHIPNetworkCommissioningClusterUpdateWiFiNetworkParams *)params
+                  completionHandler:(CompletionHandler)completionHandler;
 
 - (void)readAttributeFeatureMapWithResponseHandler:(ResponseHandler)responseHandler;
 - (void)subscribeAttributeFeatureMapWithMinInterval:(uint16_t)minInterval
@@ -1727,12 +1733,12 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPOtaSoftwareUpdateProvider : CHIPCluster
 
-- (void)applyUpdateRequest:(CHIPOtaSoftwareUpdateProviderClusterApplyUpdateRequestPayload * _Nonnull)payload
-           responseHandler:(ResponseHandler)responseHandler;
-- (void)notifyUpdateApplied:(CHIPOtaSoftwareUpdateProviderClusterNotifyUpdateAppliedPayload * _Nonnull)payload
-            responseHandler:(ResponseHandler)responseHandler;
-- (void)queryImage:(CHIPOtaSoftwareUpdateProviderClusterQueryImagePayload * _Nonnull)payload
-    responseHandler:(ResponseHandler)responseHandler;
+- (void)applyUpdateRequestWithParams:(CHIPOtaSoftwareUpdateProviderClusterApplyUpdateRequestParams *)params
+                   completionHandler:(CompletionHandler)completionHandler;
+- (void)notifyUpdateAppliedWithParams:(CHIPOtaSoftwareUpdateProviderClusterNotifyUpdateAppliedParams *)params
+                    completionHandler:(CompletionHandler)completionHandler;
+- (void)queryImageWithParams:(CHIPOtaSoftwareUpdateProviderClusterQueryImageParams *)params
+           completionHandler:(CompletionHandler)completionHandler;
 
 - (void)readAttributeClusterRevisionWithResponseHandler:(ResponseHandler)responseHandler;
 - (void)subscribeAttributeClusterRevisionWithMinInterval:(uint16_t)minInterval
@@ -1748,8 +1754,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPOtaSoftwareUpdateRequestor : CHIPCluster
 
-- (void)announceOtaProvider:(CHIPOtaSoftwareUpdateRequestorClusterAnnounceOtaProviderPayload * _Nonnull)payload
-            responseHandler:(ResponseHandler)responseHandler;
+- (void)announceOtaProviderWithParams:(CHIPOtaSoftwareUpdateRequestorClusterAnnounceOtaProviderParams *)params
+                    completionHandler:(CompletionHandler)completionHandler;
 
 - (void)readAttributeDefaultOtaProviderWithResponseHandler:(ResponseHandler)responseHandler;
 - (void)writeAttributeDefaultOtaProviderWithValue:(NSData * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
@@ -1810,13 +1816,14 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPOnOff : CHIPCluster
 
-- (void)off:(CHIPOnOffClusterOffPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler;
-- (void)offWithEffect:(CHIPOnOffClusterOffWithEffectPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler;
-- (void)on:(CHIPOnOffClusterOnPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler;
-- (void)onWithRecallGlobalScene:(CHIPOnOffClusterOnWithRecallGlobalScenePayload * _Nonnull)payload
-                responseHandler:(ResponseHandler)responseHandler;
-- (void)onWithTimedOff:(CHIPOnOffClusterOnWithTimedOffPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler;
-- (void)toggle:(CHIPOnOffClusterTogglePayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler;
+- (void)offWithCompletionHandler:(CompletionHandler)completionHandler;
+- (void)offWithEffectWithParams:(CHIPOnOffClusterOffWithEffectParams *)params
+              completionHandler:(CompletionHandler)completionHandler;
+- (void)onWithCompletionHandler:(CompletionHandler)completionHandler;
+- (void)onWithRecallGlobalSceneWithCompletionHandler:(CompletionHandler)completionHandler;
+- (void)onWithTimedOffWithParams:(CHIPOnOffClusterOnWithTimedOffParams *)params
+               completionHandler:(CompletionHandler)completionHandler;
+- (void)toggleWithCompletionHandler:(CompletionHandler)completionHandler;
 
 - (void)readAttributeOnOffWithResponseHandler:(ResponseHandler)responseHandler;
 - (void)subscribeAttributeOnOffWithMinInterval:(uint16_t)minInterval
@@ -1898,23 +1905,24 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPOperationalCredentials : CHIPCluster
 
-- (void)addNOC:(CHIPOperationalCredentialsClusterAddNOCPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler;
-- (void)addTrustedRootCertificate:(CHIPOperationalCredentialsClusterAddTrustedRootCertificatePayload * _Nonnull)payload
-                  responseHandler:(ResponseHandler)responseHandler;
-- (void)attestationRequest:(CHIPOperationalCredentialsClusterAttestationRequestPayload * _Nonnull)payload
-           responseHandler:(ResponseHandler)responseHandler;
-- (void)certificateChainRequest:(CHIPOperationalCredentialsClusterCertificateChainRequestPayload * _Nonnull)payload
-                responseHandler:(ResponseHandler)responseHandler;
-- (void)opCSRRequest:(CHIPOperationalCredentialsClusterOpCSRRequestPayload * _Nonnull)payload
-     responseHandler:(ResponseHandler)responseHandler;
-- (void)removeFabric:(CHIPOperationalCredentialsClusterRemoveFabricPayload * _Nonnull)payload
-     responseHandler:(ResponseHandler)responseHandler;
-- (void)removeTrustedRootCertificate:(CHIPOperationalCredentialsClusterRemoveTrustedRootCertificatePayload * _Nonnull)payload
-                     responseHandler:(ResponseHandler)responseHandler;
-- (void)updateFabricLabel:(CHIPOperationalCredentialsClusterUpdateFabricLabelPayload * _Nonnull)payload
-          responseHandler:(ResponseHandler)responseHandler;
-- (void)updateNOC:(CHIPOperationalCredentialsClusterUpdateNOCPayload * _Nonnull)payload
-    responseHandler:(ResponseHandler)responseHandler;
+- (void)addNOCWithParams:(CHIPOperationalCredentialsClusterAddNOCParams *)params
+       completionHandler:(CompletionHandler)completionHandler;
+- (void)addTrustedRootCertificateWithParams:(CHIPOperationalCredentialsClusterAddTrustedRootCertificateParams *)params
+                          completionHandler:(CompletionHandler)completionHandler;
+- (void)attestationRequestWithParams:(CHIPOperationalCredentialsClusterAttestationRequestParams *)params
+                   completionHandler:(CompletionHandler)completionHandler;
+- (void)certificateChainRequestWithParams:(CHIPOperationalCredentialsClusterCertificateChainRequestParams *)params
+                        completionHandler:(CompletionHandler)completionHandler;
+- (void)opCSRRequestWithParams:(CHIPOperationalCredentialsClusterOpCSRRequestParams *)params
+             completionHandler:(CompletionHandler)completionHandler;
+- (void)removeFabricWithParams:(CHIPOperationalCredentialsClusterRemoveFabricParams *)params
+             completionHandler:(CompletionHandler)completionHandler;
+- (void)removeTrustedRootCertificateWithParams:(CHIPOperationalCredentialsClusterRemoveTrustedRootCertificateParams *)params
+                             completionHandler:(CompletionHandler)completionHandler;
+- (void)updateFabricLabelWithParams:(CHIPOperationalCredentialsClusterUpdateFabricLabelParams *)params
+                  completionHandler:(CompletionHandler)completionHandler;
+- (void)updateNOCWithParams:(CHIPOperationalCredentialsClusterUpdateNOCParams *)params
+          completionHandler:(CompletionHandler)completionHandler;
 
 - (void)readAttributeFabricsListWithResponseHandler:(ResponseHandler)responseHandler;
 
@@ -2246,15 +2254,15 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPScenes : CHIPCluster
 
-- (void)addScene:(CHIPScenesClusterAddScenePayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler;
-- (void)getSceneMembership:(CHIPScenesClusterGetSceneMembershipPayload * _Nonnull)payload
-           responseHandler:(ResponseHandler)responseHandler;
-- (void)recallScene:(CHIPScenesClusterRecallScenePayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler;
-- (void)removeAllScenes:(CHIPScenesClusterRemoveAllScenesPayload * _Nonnull)payload
-        responseHandler:(ResponseHandler)responseHandler;
-- (void)removeScene:(CHIPScenesClusterRemoveScenePayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler;
-- (void)storeScene:(CHIPScenesClusterStoreScenePayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler;
-- (void)viewScene:(CHIPScenesClusterViewScenePayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler;
+- (void)addSceneWithParams:(CHIPScenesClusterAddSceneParams *)params completionHandler:(CompletionHandler)completionHandler;
+- (void)getSceneMembershipWithParams:(CHIPScenesClusterGetSceneMembershipParams *)params
+                   completionHandler:(CompletionHandler)completionHandler;
+- (void)recallSceneWithParams:(CHIPScenesClusterRecallSceneParams *)params completionHandler:(CompletionHandler)completionHandler;
+- (void)removeAllScenesWithParams:(CHIPScenesClusterRemoveAllScenesParams *)params
+                completionHandler:(CompletionHandler)completionHandler;
+- (void)removeSceneWithParams:(CHIPScenesClusterRemoveSceneParams *)params completionHandler:(CompletionHandler)completionHandler;
+- (void)storeSceneWithParams:(CHIPScenesClusterStoreSceneParams *)params completionHandler:(CompletionHandler)completionHandler;
+- (void)viewSceneWithParams:(CHIPScenesClusterViewSceneParams *)params completionHandler:(CompletionHandler)completionHandler;
 
 - (void)readAttributeSceneCountWithResponseHandler:(ResponseHandler)responseHandler;
 - (void)subscribeAttributeSceneCountWithMinInterval:(uint16_t)minInterval
@@ -2300,8 +2308,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPSoftwareDiagnostics : CHIPCluster
 
-- (void)resetWatermarks:(CHIPSoftwareDiagnosticsClusterResetWatermarksPayload * _Nonnull)payload
-        responseHandler:(ResponseHandler)responseHandler;
+- (void)resetWatermarksWithCompletionHandler:(CompletionHandler)completionHandler;
 
 - (void)readAttributeThreadMetricsWithResponseHandler:(ResponseHandler)responseHandler;
 
@@ -2375,10 +2382,12 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPTvChannel : CHIPCluster
 
-- (void)changeChannel:(CHIPTvChannelClusterChangeChannelPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler;
-- (void)changeChannelByNumber:(CHIPTvChannelClusterChangeChannelByNumberPayload * _Nonnull)payload
-              responseHandler:(ResponseHandler)responseHandler;
-- (void)skipChannel:(CHIPTvChannelClusterSkipChannelPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler;
+- (void)changeChannelWithParams:(CHIPTvChannelClusterChangeChannelParams *)params
+              completionHandler:(CompletionHandler)completionHandler;
+- (void)changeChannelByNumberWithParams:(CHIPTvChannelClusterChangeChannelByNumberParams *)params
+                      completionHandler:(CompletionHandler)completionHandler;
+- (void)skipChannelWithParams:(CHIPTvChannelClusterSkipChannelParams *)params
+            completionHandler:(CompletionHandler)completionHandler;
 
 - (void)readAttributeTvChannelListWithResponseHandler:(ResponseHandler)responseHandler;
 
@@ -2408,8 +2417,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPTargetNavigator : CHIPCluster
 
-- (void)navigateTarget:(CHIPTargetNavigatorClusterNavigateTargetPayload * _Nonnull)payload
-       responseHandler:(ResponseHandler)responseHandler;
+- (void)navigateTargetWithParams:(CHIPTargetNavigatorClusterNavigateTargetParams *)params
+               completionHandler:(CompletionHandler)completionHandler;
 
 - (void)readAttributeTargetNavigatorListWithResponseHandler:(ResponseHandler)responseHandler;
 
@@ -2465,26 +2474,24 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPTestCluster : CHIPCluster
 
-- (void)test:(CHIPTestClusterClusterTestPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler;
-- (void)testAddArguments:(CHIPTestClusterClusterTestAddArgumentsPayload * _Nonnull)payload
-         responseHandler:(ResponseHandler)responseHandler;
-- (void)testEnumsRequest:(CHIPTestClusterClusterTestEnumsRequestPayload * _Nonnull)payload
-         responseHandler:(ResponseHandler)responseHandler;
-- (void)testListInt8UArgumentRequest:(CHIPTestClusterClusterTestListInt8UArgumentRequestPayload * _Nonnull)payload
-                     responseHandler:(ResponseHandler)responseHandler;
-- (void)testListInt8UReverseRequest:(CHIPTestClusterClusterTestListInt8UReverseRequestPayload * _Nonnull)payload
-                    responseHandler:(ResponseHandler)responseHandler;
-- (void)testListStructArgumentRequest:(CHIPTestClusterClusterTestListStructArgumentRequestPayload * _Nonnull)payload
-                      responseHandler:(ResponseHandler)responseHandler;
-- (void)testNotHandled:(CHIPTestClusterClusterTestNotHandledPayload * _Nonnull)payload
-       responseHandler:(ResponseHandler)responseHandler;
-- (void)testNullableOptionalRequest:(CHIPTestClusterClusterTestNullableOptionalRequestPayload * _Nonnull)payload
-                    responseHandler:(ResponseHandler)responseHandler;
-- (void)testSpecific:(CHIPTestClusterClusterTestSpecificPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler;
-- (void)testStructArgumentRequest:(CHIPTestClusterClusterTestStructArgumentRequestPayload * _Nonnull)payload
-                  responseHandler:(ResponseHandler)responseHandler;
-- (void)testUnknownCommand:(CHIPTestClusterClusterTestUnknownCommandPayload * _Nonnull)payload
-           responseHandler:(ResponseHandler)responseHandler;
+- (void)testWithCompletionHandler:(CompletionHandler)completionHandler;
+- (void)testAddArgumentsWithParams:(CHIPTestClusterClusterTestAddArgumentsParams *)params
+                 completionHandler:(CompletionHandler)completionHandler;
+- (void)testEnumsRequestWithParams:(CHIPTestClusterClusterTestEnumsRequestParams *)params
+                 completionHandler:(CompletionHandler)completionHandler;
+- (void)testListInt8UArgumentRequestWithParams:(CHIPTestClusterClusterTestListInt8UArgumentRequestParams *)params
+                             completionHandler:(CompletionHandler)completionHandler;
+- (void)testListInt8UReverseRequestWithParams:(CHIPTestClusterClusterTestListInt8UReverseRequestParams *)params
+                            completionHandler:(CompletionHandler)completionHandler;
+- (void)testListStructArgumentRequestWithParams:(CHIPTestClusterClusterTestListStructArgumentRequestParams *)params
+                              completionHandler:(CompletionHandler)completionHandler;
+- (void)testNotHandledWithCompletionHandler:(CompletionHandler)completionHandler;
+- (void)testNullableOptionalRequestWithParams:(CHIPTestClusterClusterTestNullableOptionalRequestParams * _Nullable)params
+                            completionHandler:(CompletionHandler)completionHandler;
+- (void)testSpecificWithCompletionHandler:(CompletionHandler)completionHandler;
+- (void)testStructArgumentRequestWithParams:(CHIPTestClusterClusterTestStructArgumentRequestParams *)params
+                          completionHandler:(CompletionHandler)completionHandler;
+- (void)testUnknownCommandWithCompletionHandler:(CompletionHandler)completionHandler;
 
 - (void)readAttributeBooleanWithResponseHandler:(ResponseHandler)responseHandler;
 - (void)writeAttributeBooleanWithValue:(NSNumber * _Nonnull)value responseHandler:(ResponseHandler)responseHandler;
@@ -2791,16 +2798,14 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPThermostat : CHIPCluster
 
-- (void)clearWeeklySchedule:(CHIPThermostatClusterClearWeeklySchedulePayload * _Nonnull)payload
-            responseHandler:(ResponseHandler)responseHandler;
-- (void)getRelayStatusLog:(CHIPThermostatClusterGetRelayStatusLogPayload * _Nonnull)payload
-          responseHandler:(ResponseHandler)responseHandler;
-- (void)getWeeklySchedule:(CHIPThermostatClusterGetWeeklySchedulePayload * _Nonnull)payload
-          responseHandler:(ResponseHandler)responseHandler;
-- (void)setWeeklySchedule:(CHIPThermostatClusterSetWeeklySchedulePayload * _Nonnull)payload
-          responseHandler:(ResponseHandler)responseHandler;
-- (void)setpointRaiseLower:(CHIPThermostatClusterSetpointRaiseLowerPayload * _Nonnull)payload
-           responseHandler:(ResponseHandler)responseHandler;
+- (void)clearWeeklyScheduleWithCompletionHandler:(CompletionHandler)completionHandler;
+- (void)getRelayStatusLogWithCompletionHandler:(CompletionHandler)completionHandler;
+- (void)getWeeklyScheduleWithParams:(CHIPThermostatClusterGetWeeklyScheduleParams *)params
+                  completionHandler:(CompletionHandler)completionHandler;
+- (void)setWeeklyScheduleWithParams:(CHIPThermostatClusterSetWeeklyScheduleParams *)params
+                  completionHandler:(CompletionHandler)completionHandler;
+- (void)setpointRaiseLowerWithParams:(CHIPThermostatClusterSetpointRaiseLowerParams *)params
+                   completionHandler:(CompletionHandler)completionHandler;
 
 - (void)readAttributeLocalTemperatureWithResponseHandler:(ResponseHandler)responseHandler;
 - (void)subscribeAttributeLocalTemperatureWithMinInterval:(uint16_t)minInterval
@@ -2970,8 +2975,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPThreadNetworkDiagnostics : CHIPCluster
 
-- (void)resetCounts:(CHIPThreadNetworkDiagnosticsClusterResetCountsPayload * _Nonnull)payload
-    responseHandler:(ResponseHandler)responseHandler;
+- (void)resetCountsWithCompletionHandler:(CompletionHandler)completionHandler;
 
 - (void)readAttributeChannelWithResponseHandler:(ResponseHandler)responseHandler;
 - (void)subscribeAttributeChannelWithMinInterval:(uint16_t)minInterval
@@ -3365,8 +3369,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPWiFiNetworkDiagnostics : CHIPCluster
 
-- (void)resetCounts:(CHIPWiFiNetworkDiagnosticsClusterResetCountsPayload * _Nonnull)payload
-    responseHandler:(ResponseHandler)responseHandler;
+- (void)resetCountsWithCompletionHandler:(CompletionHandler)completionHandler;
 
 - (void)readAttributeBssidWithResponseHandler:(ResponseHandler)responseHandler;
 - (void)subscribeAttributeBssidWithMinInterval:(uint16_t)minInterval
@@ -3460,18 +3463,17 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPWindowCovering : CHIPCluster
 
-- (void)downOrClose:(CHIPWindowCoveringClusterDownOrClosePayload * _Nonnull)payload
-    responseHandler:(ResponseHandler)responseHandler;
-- (void)goToLiftPercentage:(CHIPWindowCoveringClusterGoToLiftPercentagePayload * _Nonnull)payload
-           responseHandler:(ResponseHandler)responseHandler;
-- (void)goToLiftValue:(CHIPWindowCoveringClusterGoToLiftValuePayload * _Nonnull)payload
-      responseHandler:(ResponseHandler)responseHandler;
-- (void)goToTiltPercentage:(CHIPWindowCoveringClusterGoToTiltPercentagePayload * _Nonnull)payload
-           responseHandler:(ResponseHandler)responseHandler;
-- (void)goToTiltValue:(CHIPWindowCoveringClusterGoToTiltValuePayload * _Nonnull)payload
-      responseHandler:(ResponseHandler)responseHandler;
-- (void)stopMotion:(CHIPWindowCoveringClusterStopMotionPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler;
-- (void)upOrOpen:(CHIPWindowCoveringClusterUpOrOpenPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler;
+- (void)downOrCloseWithCompletionHandler:(CompletionHandler)completionHandler;
+- (void)goToLiftPercentageWithParams:(CHIPWindowCoveringClusterGoToLiftPercentageParams *)params
+                   completionHandler:(CompletionHandler)completionHandler;
+- (void)goToLiftValueWithParams:(CHIPWindowCoveringClusterGoToLiftValueParams *)params
+              completionHandler:(CompletionHandler)completionHandler;
+- (void)goToTiltPercentageWithParams:(CHIPWindowCoveringClusterGoToTiltPercentageParams *)params
+                   completionHandler:(CompletionHandler)completionHandler;
+- (void)goToTiltValueWithParams:(CHIPWindowCoveringClusterGoToTiltValueParams *)params
+              completionHandler:(CompletionHandler)completionHandler;
+- (void)stopMotionWithCompletionHandler:(CompletionHandler)completionHandler;
+- (void)upOrOpenWithCompletionHandler:(CompletionHandler)completionHandler;
 
 - (void)readAttributeTypeWithResponseHandler:(ResponseHandler)responseHandler;
 - (void)subscribeAttributeTypeWithMinInterval:(uint16_t)minInterval

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPClustersObjc.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPClustersObjc.mm
@@ -41,28 +41,29 @@ using namespace chip::app::Clusters;
     return &_cppCluster;
 }
 
-- (void)getSetupPIN:(CHIPAccountLoginClusterGetSetupPINPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler
+- (void)getSetupPINWithParams:(CHIPAccountLoginClusterGetSetupPINParams *)params
+            completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     AccountLogin::Commands::GetSetupPIN::Type request;
-    request.tempAccountIdentifier = [self asCharSpan:payload.tempAccountIdentifier];
+    request.tempAccountIdentifier = [self asCharSpan:params.tempAccountIdentifier];
 
     new CHIPAccountLoginClusterGetSetupPINResponseCallbackBridge(
-        self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
             auto successFn = Callback<CHIPAccountLoginClusterGetSetupPINResponseCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
-- (void)login:(CHIPAccountLoginClusterLoginPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler
+- (void)loginWithParams:(CHIPAccountLoginClusterLoginParams *)params completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     AccountLogin::Commands::Login::Type request;
-    request.tempAccountIdentifier = [self asCharSpan:payload.tempAccountIdentifier];
-    request.setupPIN = [self asCharSpan:payload.setupPIN];
+    request.tempAccountIdentifier = [self asCharSpan:params.tempAccountIdentifier];
+    request.setupPIN = [self asCharSpan:params.setupPIN];
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
@@ -104,46 +105,45 @@ using namespace chip::app::Clusters;
     return &_cppCluster;
 }
 
-- (void)openBasicCommissioningWindow:(CHIPAdministratorCommissioningClusterOpenBasicCommissioningWindowPayload * _Nonnull)payload
-                     responseHandler:(ResponseHandler)responseHandler
+- (void)openBasicCommissioningWindowWithParams:(CHIPAdministratorCommissioningClusterOpenBasicCommissioningWindowParams *)params
+                             completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     AdministratorCommissioning::Commands::OpenBasicCommissioningWindow::Type request;
-    request.commissioningTimeout = payload.commissioningTimeout.unsignedShortValue;
+    request.commissioningTimeout = params.commissioningTimeout.unsignedShortValue;
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)openCommissioningWindow:(CHIPAdministratorCommissioningClusterOpenCommissioningWindowPayload * _Nonnull)payload
-                responseHandler:(ResponseHandler)responseHandler
+- (void)openCommissioningWindowWithParams:(CHIPAdministratorCommissioningClusterOpenCommissioningWindowParams *)params
+                        completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     AdministratorCommissioning::Commands::OpenCommissioningWindow::Type request;
-    request.commissioningTimeout = payload.commissioningTimeout.unsignedShortValue;
-    request.PAKEVerifier = [self asByteSpan:payload.pakeVerifier];
-    request.discriminator = payload.discriminator.unsignedShortValue;
-    request.iterations = payload.iterations.unsignedIntValue;
-    request.salt = [self asByteSpan:payload.salt];
-    request.passcodeID = payload.passcodeID.unsignedShortValue;
+    request.commissioningTimeout = params.commissioningTimeout.unsignedShortValue;
+    request.PAKEVerifier = [self asByteSpan:params.pakeVerifier];
+    request.discriminator = params.discriminator.unsignedShortValue;
+    request.iterations = params.iterations.unsignedIntValue;
+    request.salt = [self asByteSpan:params.salt];
+    request.passcodeID = params.passcodeID.unsignedShortValue;
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)revokeCommissioning:(CHIPAdministratorCommissioningClusterRevokeCommissioningPayload * _Nonnull)payload
-            responseHandler:(ResponseHandler)responseHandler
+- (void)revokeCommissioningWithCompletionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     AdministratorCommissioning::Commands::RevokeCommissioning::Type request;
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
@@ -185,14 +185,14 @@ using namespace chip::app::Clusters;
     return &_cppCluster;
 }
 
-- (void)changeStatus:(CHIPApplicationBasicClusterChangeStatusPayload * _Nonnull)payload
-     responseHandler:(ResponseHandler)responseHandler
+- (void)changeStatusWithParams:(CHIPApplicationBasicClusterChangeStatusParams *)params
+             completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     ApplicationBasic::Commands::ChangeStatus::Type request;
-    request.status = static_cast<std::remove_reference_t<decltype(request.status)>>(payload.status.unsignedCharValue);
+    request.status = static_cast<std::remove_reference_t<decltype(request.status)>>(params.status.unsignedCharValue);
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
@@ -416,17 +416,17 @@ using namespace chip::app::Clusters;
     return &_cppCluster;
 }
 
-- (void)launchApp:(CHIPApplicationLauncherClusterLaunchAppPayload * _Nonnull)payload
-    responseHandler:(ResponseHandler)responseHandler
+- (void)launchAppWithParams:(CHIPApplicationLauncherClusterLaunchAppParams *)params
+          completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     ApplicationLauncher::Commands::LaunchApp::Type request;
-    request.data = [self asCharSpan:payload.data];
-    request.catalogVendorId = payload.catalogVendorId.unsignedShortValue;
-    request.applicationId = [self asCharSpan:payload.applicationId];
+    request.data = [self asCharSpan:params.data];
+    request.catalogVendorId = params.catalogVendorId.unsignedShortValue;
+    request.applicationId = [self asCharSpan:params.applicationId];
 
     new CHIPApplicationLauncherClusterLaunchAppResponseCallbackBridge(
-        self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
             auto successFn = Callback<CHIPApplicationLauncherClusterLaunchAppResponseCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
@@ -528,27 +528,29 @@ using namespace chip::app::Clusters;
     return &_cppCluster;
 }
 
-- (void)renameOutput:(CHIPAudioOutputClusterRenameOutputPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler
+- (void)renameOutputWithParams:(CHIPAudioOutputClusterRenameOutputParams *)params
+             completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     AudioOutput::Commands::RenameOutput::Type request;
-    request.index = payload.index.unsignedCharValue;
-    request.name = [self asCharSpan:payload.name];
+    request.index = params.index.unsignedCharValue;
+    request.name = [self asCharSpan:params.name];
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)selectOutput:(CHIPAudioOutputClusterSelectOutputPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler
+- (void)selectOutputWithParams:(CHIPAudioOutputClusterSelectOutputParams *)params
+             completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     AudioOutput::Commands::SelectOutput::Type request;
-    request.index = payload.index.unsignedCharValue;
+    request.index = params.index.unsignedCharValue;
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
@@ -624,27 +626,26 @@ using namespace chip::app::Clusters;
     return &_cppCluster;
 }
 
-- (void)barrierControlGoToPercent:(CHIPBarrierControlClusterBarrierControlGoToPercentPayload * _Nonnull)payload
-                  responseHandler:(ResponseHandler)responseHandler
+- (void)barrierControlGoToPercentWithParams:(CHIPBarrierControlClusterBarrierControlGoToPercentParams *)params
+                          completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     BarrierControl::Commands::BarrierControlGoToPercent::Type request;
-    request.percentOpen = payload.percentOpen.unsignedCharValue;
+    request.percentOpen = params.percentOpen.unsignedCharValue;
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)barrierControlStop:(CHIPBarrierControlClusterBarrierControlStopPayload * _Nonnull)payload
-           responseHandler:(ResponseHandler)responseHandler
+- (void)barrierControlStopWithCompletionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     BarrierControl::Commands::BarrierControlStop::Type request;
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
@@ -790,12 +791,12 @@ using namespace chip::app::Clusters;
     return &_cppCluster;
 }
 
-- (void)mfgSpecificPing:(CHIPBasicClusterMfgSpecificPingPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler
+- (void)mfgSpecificPingWithCompletionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     Basic::Commands::MfgSpecificPing::Type request;
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
@@ -1483,32 +1484,32 @@ using namespace chip::app::Clusters;
     return &_cppCluster;
 }
 
-- (void)bind:(CHIPBindingClusterBindPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler
+- (void)bindWithParams:(CHIPBindingClusterBindParams *)params completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     Binding::Commands::Bind::Type request;
-    request.nodeId = payload.nodeId.unsignedLongLongValue;
-    request.groupId = payload.groupId.unsignedShortValue;
-    request.endpointId = payload.endpointId.unsignedShortValue;
-    request.clusterId = payload.clusterId.unsignedIntValue;
+    request.nodeId = params.nodeId.unsignedLongLongValue;
+    request.groupId = params.groupId.unsignedShortValue;
+    request.endpointId = params.endpointId.unsignedShortValue;
+    request.clusterId = params.clusterId.unsignedIntValue;
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)unbind:(CHIPBindingClusterUnbindPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler
+- (void)unbindWithParams:(CHIPBindingClusterUnbindParams *)params completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     Binding::Commands::Unbind::Type request;
-    request.nodeId = payload.nodeId.unsignedLongLongValue;
-    request.groupId = payload.groupId.unsignedShortValue;
-    request.endpointId = payload.endpointId.unsignedShortValue;
-    request.clusterId = payload.clusterId.unsignedIntValue;
+    request.nodeId = params.nodeId.unsignedLongLongValue;
+    request.groupId = params.groupId.unsignedShortValue;
+    request.endpointId = params.endpointId.unsignedShortValue;
+    request.clusterId = params.clusterId.unsignedIntValue;
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
@@ -1611,218 +1612,221 @@ using namespace chip::app::Clusters;
     return &_cppCluster;
 }
 
-- (void)disableAction:(CHIPBridgedActionsClusterDisableActionPayload * _Nonnull)payload
-      responseHandler:(ResponseHandler)responseHandler
+- (void)disableActionWithParams:(CHIPBridgedActionsClusterDisableActionParams *)params
+              completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     BridgedActions::Commands::DisableAction::Type request;
-    request.actionID = payload.actionID.unsignedShortValue;
-    if (payload.invokeID != nil) {
+    request.actionID = params.actionID.unsignedShortValue;
+    if (params.invokeID != nil) {
         auto & definedValue_0 = request.invokeID.Emplace();
-        definedValue_0 = payload.invokeID.unsignedIntValue;
+        definedValue_0 = params.invokeID.unsignedIntValue;
     }
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)disableActionWithDuration:(CHIPBridgedActionsClusterDisableActionWithDurationPayload * _Nonnull)payload
-                  responseHandler:(ResponseHandler)responseHandler
+- (void)disableActionWithDurationWithParams:(CHIPBridgedActionsClusterDisableActionWithDurationParams *)params
+                          completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     BridgedActions::Commands::DisableActionWithDuration::Type request;
-    request.actionID = payload.actionID.unsignedShortValue;
-    if (payload.invokeID != nil) {
+    request.actionID = params.actionID.unsignedShortValue;
+    if (params.invokeID != nil) {
         auto & definedValue_0 = request.invokeID.Emplace();
-        definedValue_0 = payload.invokeID.unsignedIntValue;
+        definedValue_0 = params.invokeID.unsignedIntValue;
     }
-    request.duration = payload.duration.unsignedIntValue;
+    request.duration = params.duration.unsignedIntValue;
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)enableAction:(CHIPBridgedActionsClusterEnableActionPayload * _Nonnull)payload
-     responseHandler:(ResponseHandler)responseHandler
+- (void)enableActionWithParams:(CHIPBridgedActionsClusterEnableActionParams *)params
+             completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     BridgedActions::Commands::EnableAction::Type request;
-    request.actionID = payload.actionID.unsignedShortValue;
-    if (payload.invokeID != nil) {
+    request.actionID = params.actionID.unsignedShortValue;
+    if (params.invokeID != nil) {
         auto & definedValue_0 = request.invokeID.Emplace();
-        definedValue_0 = payload.invokeID.unsignedIntValue;
+        definedValue_0 = params.invokeID.unsignedIntValue;
     }
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)enableActionWithDuration:(CHIPBridgedActionsClusterEnableActionWithDurationPayload * _Nonnull)payload
-                 responseHandler:(ResponseHandler)responseHandler
+- (void)enableActionWithDurationWithParams:(CHIPBridgedActionsClusterEnableActionWithDurationParams *)params
+                         completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     BridgedActions::Commands::EnableActionWithDuration::Type request;
-    request.actionID = payload.actionID.unsignedShortValue;
-    if (payload.invokeID != nil) {
+    request.actionID = params.actionID.unsignedShortValue;
+    if (params.invokeID != nil) {
         auto & definedValue_0 = request.invokeID.Emplace();
-        definedValue_0 = payload.invokeID.unsignedIntValue;
+        definedValue_0 = params.invokeID.unsignedIntValue;
     }
-    request.duration = payload.duration.unsignedIntValue;
+    request.duration = params.duration.unsignedIntValue;
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)instantAction:(CHIPBridgedActionsClusterInstantActionPayload * _Nonnull)payload
-      responseHandler:(ResponseHandler)responseHandler
+- (void)instantActionWithParams:(CHIPBridgedActionsClusterInstantActionParams *)params
+              completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     BridgedActions::Commands::InstantAction::Type request;
-    request.actionID = payload.actionID.unsignedShortValue;
-    if (payload.invokeID != nil) {
+    request.actionID = params.actionID.unsignedShortValue;
+    if (params.invokeID != nil) {
         auto & definedValue_0 = request.invokeID.Emplace();
-        definedValue_0 = payload.invokeID.unsignedIntValue;
+        definedValue_0 = params.invokeID.unsignedIntValue;
     }
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)instantActionWithTransition:(CHIPBridgedActionsClusterInstantActionWithTransitionPayload * _Nonnull)payload
-                    responseHandler:(ResponseHandler)responseHandler
+- (void)instantActionWithTransitionWithParams:(CHIPBridgedActionsClusterInstantActionWithTransitionParams *)params
+                            completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     BridgedActions::Commands::InstantActionWithTransition::Type request;
-    request.actionID = payload.actionID.unsignedShortValue;
-    if (payload.invokeID != nil) {
+    request.actionID = params.actionID.unsignedShortValue;
+    if (params.invokeID != nil) {
         auto & definedValue_0 = request.invokeID.Emplace();
-        definedValue_0 = payload.invokeID.unsignedIntValue;
+        definedValue_0 = params.invokeID.unsignedIntValue;
     }
-    request.transitionTime = payload.transitionTime.unsignedShortValue;
+    request.transitionTime = params.transitionTime.unsignedShortValue;
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)pauseAction:(CHIPBridgedActionsClusterPauseActionPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler
+- (void)pauseActionWithParams:(CHIPBridgedActionsClusterPauseActionParams *)params
+            completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     BridgedActions::Commands::PauseAction::Type request;
-    request.actionID = payload.actionID.unsignedShortValue;
-    if (payload.invokeID != nil) {
+    request.actionID = params.actionID.unsignedShortValue;
+    if (params.invokeID != nil) {
         auto & definedValue_0 = request.invokeID.Emplace();
-        definedValue_0 = payload.invokeID.unsignedIntValue;
+        definedValue_0 = params.invokeID.unsignedIntValue;
     }
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)pauseActionWithDuration:(CHIPBridgedActionsClusterPauseActionWithDurationPayload * _Nonnull)payload
-                responseHandler:(ResponseHandler)responseHandler
+- (void)pauseActionWithDurationWithParams:(CHIPBridgedActionsClusterPauseActionWithDurationParams *)params
+                        completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     BridgedActions::Commands::PauseActionWithDuration::Type request;
-    request.actionID = payload.actionID.unsignedShortValue;
-    if (payload.invokeID != nil) {
+    request.actionID = params.actionID.unsignedShortValue;
+    if (params.invokeID != nil) {
         auto & definedValue_0 = request.invokeID.Emplace();
-        definedValue_0 = payload.invokeID.unsignedIntValue;
+        definedValue_0 = params.invokeID.unsignedIntValue;
     }
-    request.duration = payload.duration.unsignedIntValue;
+    request.duration = params.duration.unsignedIntValue;
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)resumeAction:(CHIPBridgedActionsClusterResumeActionPayload * _Nonnull)payload
-     responseHandler:(ResponseHandler)responseHandler
+- (void)resumeActionWithParams:(CHIPBridgedActionsClusterResumeActionParams *)params
+             completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     BridgedActions::Commands::ResumeAction::Type request;
-    request.actionID = payload.actionID.unsignedShortValue;
-    if (payload.invokeID != nil) {
+    request.actionID = params.actionID.unsignedShortValue;
+    if (params.invokeID != nil) {
         auto & definedValue_0 = request.invokeID.Emplace();
-        definedValue_0 = payload.invokeID.unsignedIntValue;
+        definedValue_0 = params.invokeID.unsignedIntValue;
     }
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)startAction:(CHIPBridgedActionsClusterStartActionPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler
+- (void)startActionWithParams:(CHIPBridgedActionsClusterStartActionParams *)params
+            completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     BridgedActions::Commands::StartAction::Type request;
-    request.actionID = payload.actionID.unsignedShortValue;
-    if (payload.invokeID != nil) {
+    request.actionID = params.actionID.unsignedShortValue;
+    if (params.invokeID != nil) {
         auto & definedValue_0 = request.invokeID.Emplace();
-        definedValue_0 = payload.invokeID.unsignedIntValue;
+        definedValue_0 = params.invokeID.unsignedIntValue;
     }
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)startActionWithDuration:(CHIPBridgedActionsClusterStartActionWithDurationPayload * _Nonnull)payload
-                responseHandler:(ResponseHandler)responseHandler
+- (void)startActionWithDurationWithParams:(CHIPBridgedActionsClusterStartActionWithDurationParams *)params
+                        completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     BridgedActions::Commands::StartActionWithDuration::Type request;
-    request.actionID = payload.actionID.unsignedShortValue;
-    if (payload.invokeID != nil) {
+    request.actionID = params.actionID.unsignedShortValue;
+    if (params.invokeID != nil) {
         auto & definedValue_0 = request.invokeID.Emplace();
-        definedValue_0 = payload.invokeID.unsignedIntValue;
+        definedValue_0 = params.invokeID.unsignedIntValue;
     }
-    request.duration = payload.duration.unsignedIntValue;
+    request.duration = params.duration.unsignedIntValue;
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)stopAction:(CHIPBridgedActionsClusterStopActionPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler
+- (void)stopActionWithParams:(CHIPBridgedActionsClusterStopActionParams *)params
+           completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     BridgedActions::Commands::StopAction::Type request;
-    request.actionID = payload.actionID.unsignedShortValue;
-    if (payload.invokeID != nil) {
+    request.actionID = params.actionID.unsignedShortValue;
+    if (params.invokeID != nil) {
         auto & definedValue_0 = request.invokeID.Emplace();
-        definedValue_0 = payload.invokeID.unsignedIntValue;
+        definedValue_0 = params.invokeID.unsignedIntValue;
     }
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
@@ -1941,331 +1945,333 @@ using namespace chip::app::Clusters;
     return &_cppCluster;
 }
 
-- (void)colorLoopSet:(CHIPColorControlClusterColorLoopSetPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler
+- (void)colorLoopSetWithParams:(CHIPColorControlClusterColorLoopSetParams *)params
+             completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     ColorControl::Commands::ColorLoopSet::Type request;
-    request.updateFlags
-        = static_cast<std::remove_reference_t<decltype(request.updateFlags)>>(payload.updateFlags.unsignedCharValue);
-    request.action = static_cast<std::remove_reference_t<decltype(request.action)>>(payload.action.unsignedCharValue);
-    request.direction = static_cast<std::remove_reference_t<decltype(request.direction)>>(payload.direction.unsignedCharValue);
-    request.time = payload.time.unsignedShortValue;
-    request.startHue = payload.startHue.unsignedShortValue;
-    request.optionsMask = payload.optionsMask.unsignedCharValue;
-    request.optionsOverride = payload.optionsOverride.unsignedCharValue;
+    request.updateFlags = static_cast<std::remove_reference_t<decltype(request.updateFlags)>>(params.updateFlags.unsignedCharValue);
+    request.action = static_cast<std::remove_reference_t<decltype(request.action)>>(params.action.unsignedCharValue);
+    request.direction = static_cast<std::remove_reference_t<decltype(request.direction)>>(params.direction.unsignedCharValue);
+    request.time = params.time.unsignedShortValue;
+    request.startHue = params.startHue.unsignedShortValue;
+    request.optionsMask = params.optionsMask.unsignedCharValue;
+    request.optionsOverride = params.optionsOverride.unsignedCharValue;
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)enhancedMoveHue:(CHIPColorControlClusterEnhancedMoveHuePayload * _Nonnull)payload
-        responseHandler:(ResponseHandler)responseHandler
+- (void)enhancedMoveHueWithParams:(CHIPColorControlClusterEnhancedMoveHueParams *)params
+                completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     ColorControl::Commands::EnhancedMoveHue::Type request;
-    request.moveMode = static_cast<std::remove_reference_t<decltype(request.moveMode)>>(payload.moveMode.unsignedCharValue);
-    request.rate = payload.rate.unsignedShortValue;
-    request.optionsMask = payload.optionsMask.unsignedCharValue;
-    request.optionsOverride = payload.optionsOverride.unsignedCharValue;
+    request.moveMode = static_cast<std::remove_reference_t<decltype(request.moveMode)>>(params.moveMode.unsignedCharValue);
+    request.rate = params.rate.unsignedShortValue;
+    request.optionsMask = params.optionsMask.unsignedCharValue;
+    request.optionsOverride = params.optionsOverride.unsignedCharValue;
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)enhancedMoveToHue:(CHIPColorControlClusterEnhancedMoveToHuePayload * _Nonnull)payload
-          responseHandler:(ResponseHandler)responseHandler
+- (void)enhancedMoveToHueWithParams:(CHIPColorControlClusterEnhancedMoveToHueParams *)params
+                  completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     ColorControl::Commands::EnhancedMoveToHue::Type request;
-    request.enhancedHue = payload.enhancedHue.unsignedShortValue;
-    request.direction = static_cast<std::remove_reference_t<decltype(request.direction)>>(payload.direction.unsignedCharValue);
-    request.transitionTime = payload.transitionTime.unsignedShortValue;
-    request.optionsMask = payload.optionsMask.unsignedCharValue;
-    request.optionsOverride = payload.optionsOverride.unsignedCharValue;
+    request.enhancedHue = params.enhancedHue.unsignedShortValue;
+    request.direction = static_cast<std::remove_reference_t<decltype(request.direction)>>(params.direction.unsignedCharValue);
+    request.transitionTime = params.transitionTime.unsignedShortValue;
+    request.optionsMask = params.optionsMask.unsignedCharValue;
+    request.optionsOverride = params.optionsOverride.unsignedCharValue;
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)enhancedMoveToHueAndSaturation:(CHIPColorControlClusterEnhancedMoveToHueAndSaturationPayload * _Nonnull)payload
-                       responseHandler:(ResponseHandler)responseHandler
+- (void)enhancedMoveToHueAndSaturationWithParams:(CHIPColorControlClusterEnhancedMoveToHueAndSaturationParams *)params
+                               completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     ColorControl::Commands::EnhancedMoveToHueAndSaturation::Type request;
-    request.enhancedHue = payload.enhancedHue.unsignedShortValue;
-    request.saturation = payload.saturation.unsignedCharValue;
-    request.transitionTime = payload.transitionTime.unsignedShortValue;
-    request.optionsMask = payload.optionsMask.unsignedCharValue;
-    request.optionsOverride = payload.optionsOverride.unsignedCharValue;
+    request.enhancedHue = params.enhancedHue.unsignedShortValue;
+    request.saturation = params.saturation.unsignedCharValue;
+    request.transitionTime = params.transitionTime.unsignedShortValue;
+    request.optionsMask = params.optionsMask.unsignedCharValue;
+    request.optionsOverride = params.optionsOverride.unsignedCharValue;
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)enhancedStepHue:(CHIPColorControlClusterEnhancedStepHuePayload * _Nonnull)payload
-        responseHandler:(ResponseHandler)responseHandler
+- (void)enhancedStepHueWithParams:(CHIPColorControlClusterEnhancedStepHueParams *)params
+                completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     ColorControl::Commands::EnhancedStepHue::Type request;
-    request.stepMode = static_cast<std::remove_reference_t<decltype(request.stepMode)>>(payload.stepMode.unsignedCharValue);
-    request.stepSize = payload.stepSize.unsignedShortValue;
-    request.transitionTime = payload.transitionTime.unsignedShortValue;
-    request.optionsMask = payload.optionsMask.unsignedCharValue;
-    request.optionsOverride = payload.optionsOverride.unsignedCharValue;
+    request.stepMode = static_cast<std::remove_reference_t<decltype(request.stepMode)>>(params.stepMode.unsignedCharValue);
+    request.stepSize = params.stepSize.unsignedShortValue;
+    request.transitionTime = params.transitionTime.unsignedShortValue;
+    request.optionsMask = params.optionsMask.unsignedCharValue;
+    request.optionsOverride = params.optionsOverride.unsignedCharValue;
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)moveColor:(CHIPColorControlClusterMoveColorPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler
+- (void)moveColorWithParams:(CHIPColorControlClusterMoveColorParams *)params completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     ColorControl::Commands::MoveColor::Type request;
-    request.rateX = payload.rateX.shortValue;
-    request.rateY = payload.rateY.shortValue;
-    request.optionsMask = payload.optionsMask.unsignedCharValue;
-    request.optionsOverride = payload.optionsOverride.unsignedCharValue;
+    request.rateX = params.rateX.shortValue;
+    request.rateY = params.rateY.shortValue;
+    request.optionsMask = params.optionsMask.unsignedCharValue;
+    request.optionsOverride = params.optionsOverride.unsignedCharValue;
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)moveColorTemperature:(CHIPColorControlClusterMoveColorTemperaturePayload * _Nonnull)payload
-             responseHandler:(ResponseHandler)responseHandler
+- (void)moveColorTemperatureWithParams:(CHIPColorControlClusterMoveColorTemperatureParams *)params
+                     completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     ColorControl::Commands::MoveColorTemperature::Type request;
-    request.moveMode = static_cast<std::remove_reference_t<decltype(request.moveMode)>>(payload.moveMode.unsignedCharValue);
-    request.rate = payload.rate.unsignedShortValue;
-    request.colorTemperatureMinimum = payload.colorTemperatureMinimum.unsignedShortValue;
-    request.colorTemperatureMaximum = payload.colorTemperatureMaximum.unsignedShortValue;
-    request.optionsMask = payload.optionsMask.unsignedCharValue;
-    request.optionsOverride = payload.optionsOverride.unsignedCharValue;
+    request.moveMode = static_cast<std::remove_reference_t<decltype(request.moveMode)>>(params.moveMode.unsignedCharValue);
+    request.rate = params.rate.unsignedShortValue;
+    request.colorTemperatureMinimum = params.colorTemperatureMinimum.unsignedShortValue;
+    request.colorTemperatureMaximum = params.colorTemperatureMaximum.unsignedShortValue;
+    request.optionsMask = params.optionsMask.unsignedCharValue;
+    request.optionsOverride = params.optionsOverride.unsignedCharValue;
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)moveHue:(CHIPColorControlClusterMoveHuePayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler
+- (void)moveHueWithParams:(CHIPColorControlClusterMoveHueParams *)params completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     ColorControl::Commands::MoveHue::Type request;
-    request.moveMode = static_cast<std::remove_reference_t<decltype(request.moveMode)>>(payload.moveMode.unsignedCharValue);
-    request.rate = payload.rate.unsignedCharValue;
-    request.optionsMask = payload.optionsMask.unsignedCharValue;
-    request.optionsOverride = payload.optionsOverride.unsignedCharValue;
+    request.moveMode = static_cast<std::remove_reference_t<decltype(request.moveMode)>>(params.moveMode.unsignedCharValue);
+    request.rate = params.rate.unsignedCharValue;
+    request.optionsMask = params.optionsMask.unsignedCharValue;
+    request.optionsOverride = params.optionsOverride.unsignedCharValue;
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)moveSaturation:(CHIPColorControlClusterMoveSaturationPayload * _Nonnull)payload
-       responseHandler:(ResponseHandler)responseHandler
+- (void)moveSaturationWithParams:(CHIPColorControlClusterMoveSaturationParams *)params
+               completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     ColorControl::Commands::MoveSaturation::Type request;
-    request.moveMode = static_cast<std::remove_reference_t<decltype(request.moveMode)>>(payload.moveMode.unsignedCharValue);
-    request.rate = payload.rate.unsignedCharValue;
-    request.optionsMask = payload.optionsMask.unsignedCharValue;
-    request.optionsOverride = payload.optionsOverride.unsignedCharValue;
+    request.moveMode = static_cast<std::remove_reference_t<decltype(request.moveMode)>>(params.moveMode.unsignedCharValue);
+    request.rate = params.rate.unsignedCharValue;
+    request.optionsMask = params.optionsMask.unsignedCharValue;
+    request.optionsOverride = params.optionsOverride.unsignedCharValue;
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)moveToColor:(CHIPColorControlClusterMoveToColorPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler
+- (void)moveToColorWithParams:(CHIPColorControlClusterMoveToColorParams *)params
+            completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     ColorControl::Commands::MoveToColor::Type request;
-    request.colorX = payload.colorX.unsignedShortValue;
-    request.colorY = payload.colorY.unsignedShortValue;
-    request.transitionTime = payload.transitionTime.unsignedShortValue;
-    request.optionsMask = payload.optionsMask.unsignedCharValue;
-    request.optionsOverride = payload.optionsOverride.unsignedCharValue;
+    request.colorX = params.colorX.unsignedShortValue;
+    request.colorY = params.colorY.unsignedShortValue;
+    request.transitionTime = params.transitionTime.unsignedShortValue;
+    request.optionsMask = params.optionsMask.unsignedCharValue;
+    request.optionsOverride = params.optionsOverride.unsignedCharValue;
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)moveToColorTemperature:(CHIPColorControlClusterMoveToColorTemperaturePayload * _Nonnull)payload
-               responseHandler:(ResponseHandler)responseHandler
+- (void)moveToColorTemperatureWithParams:(CHIPColorControlClusterMoveToColorTemperatureParams *)params
+                       completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     ColorControl::Commands::MoveToColorTemperature::Type request;
-    request.colorTemperature = payload.colorTemperature.unsignedShortValue;
-    request.transitionTime = payload.transitionTime.unsignedShortValue;
-    request.optionsMask = payload.optionsMask.unsignedCharValue;
-    request.optionsOverride = payload.optionsOverride.unsignedCharValue;
+    request.colorTemperature = params.colorTemperature.unsignedShortValue;
+    request.transitionTime = params.transitionTime.unsignedShortValue;
+    request.optionsMask = params.optionsMask.unsignedCharValue;
+    request.optionsOverride = params.optionsOverride.unsignedCharValue;
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)moveToHue:(CHIPColorControlClusterMoveToHuePayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler
+- (void)moveToHueWithParams:(CHIPColorControlClusterMoveToHueParams *)params completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     ColorControl::Commands::MoveToHue::Type request;
-    request.hue = payload.hue.unsignedCharValue;
-    request.direction = static_cast<std::remove_reference_t<decltype(request.direction)>>(payload.direction.unsignedCharValue);
-    request.transitionTime = payload.transitionTime.unsignedShortValue;
-    request.optionsMask = payload.optionsMask.unsignedCharValue;
-    request.optionsOverride = payload.optionsOverride.unsignedCharValue;
+    request.hue = params.hue.unsignedCharValue;
+    request.direction = static_cast<std::remove_reference_t<decltype(request.direction)>>(params.direction.unsignedCharValue);
+    request.transitionTime = params.transitionTime.unsignedShortValue;
+    request.optionsMask = params.optionsMask.unsignedCharValue;
+    request.optionsOverride = params.optionsOverride.unsignedCharValue;
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)moveToHueAndSaturation:(CHIPColorControlClusterMoveToHueAndSaturationPayload * _Nonnull)payload
-               responseHandler:(ResponseHandler)responseHandler
+- (void)moveToHueAndSaturationWithParams:(CHIPColorControlClusterMoveToHueAndSaturationParams *)params
+                       completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     ColorControl::Commands::MoveToHueAndSaturation::Type request;
-    request.hue = payload.hue.unsignedCharValue;
-    request.saturation = payload.saturation.unsignedCharValue;
-    request.transitionTime = payload.transitionTime.unsignedShortValue;
-    request.optionsMask = payload.optionsMask.unsignedCharValue;
-    request.optionsOverride = payload.optionsOverride.unsignedCharValue;
+    request.hue = params.hue.unsignedCharValue;
+    request.saturation = params.saturation.unsignedCharValue;
+    request.transitionTime = params.transitionTime.unsignedShortValue;
+    request.optionsMask = params.optionsMask.unsignedCharValue;
+    request.optionsOverride = params.optionsOverride.unsignedCharValue;
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)moveToSaturation:(CHIPColorControlClusterMoveToSaturationPayload * _Nonnull)payload
-         responseHandler:(ResponseHandler)responseHandler
+- (void)moveToSaturationWithParams:(CHIPColorControlClusterMoveToSaturationParams *)params
+                 completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     ColorControl::Commands::MoveToSaturation::Type request;
-    request.saturation = payload.saturation.unsignedCharValue;
-    request.transitionTime = payload.transitionTime.unsignedShortValue;
-    request.optionsMask = payload.optionsMask.unsignedCharValue;
-    request.optionsOverride = payload.optionsOverride.unsignedCharValue;
+    request.saturation = params.saturation.unsignedCharValue;
+    request.transitionTime = params.transitionTime.unsignedShortValue;
+    request.optionsMask = params.optionsMask.unsignedCharValue;
+    request.optionsOverride = params.optionsOverride.unsignedCharValue;
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)stepColor:(CHIPColorControlClusterStepColorPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler
+- (void)stepColorWithParams:(CHIPColorControlClusterStepColorParams *)params completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     ColorControl::Commands::StepColor::Type request;
-    request.stepX = payload.stepX.shortValue;
-    request.stepY = payload.stepY.shortValue;
-    request.transitionTime = payload.transitionTime.unsignedShortValue;
-    request.optionsMask = payload.optionsMask.unsignedCharValue;
-    request.optionsOverride = payload.optionsOverride.unsignedCharValue;
+    request.stepX = params.stepX.shortValue;
+    request.stepY = params.stepY.shortValue;
+    request.transitionTime = params.transitionTime.unsignedShortValue;
+    request.optionsMask = params.optionsMask.unsignedCharValue;
+    request.optionsOverride = params.optionsOverride.unsignedCharValue;
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)stepColorTemperature:(CHIPColorControlClusterStepColorTemperaturePayload * _Nonnull)payload
-             responseHandler:(ResponseHandler)responseHandler
+- (void)stepColorTemperatureWithParams:(CHIPColorControlClusterStepColorTemperatureParams *)params
+                     completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     ColorControl::Commands::StepColorTemperature::Type request;
-    request.stepMode = static_cast<std::remove_reference_t<decltype(request.stepMode)>>(payload.stepMode.unsignedCharValue);
-    request.stepSize = payload.stepSize.unsignedShortValue;
-    request.transitionTime = payload.transitionTime.unsignedShortValue;
-    request.colorTemperatureMinimum = payload.colorTemperatureMinimum.unsignedShortValue;
-    request.colorTemperatureMaximum = payload.colorTemperatureMaximum.unsignedShortValue;
-    request.optionsMask = payload.optionsMask.unsignedCharValue;
-    request.optionsOverride = payload.optionsOverride.unsignedCharValue;
+    request.stepMode = static_cast<std::remove_reference_t<decltype(request.stepMode)>>(params.stepMode.unsignedCharValue);
+    request.stepSize = params.stepSize.unsignedShortValue;
+    request.transitionTime = params.transitionTime.unsignedShortValue;
+    request.colorTemperatureMinimum = params.colorTemperatureMinimum.unsignedShortValue;
+    request.colorTemperatureMaximum = params.colorTemperatureMaximum.unsignedShortValue;
+    request.optionsMask = params.optionsMask.unsignedCharValue;
+    request.optionsOverride = params.optionsOverride.unsignedCharValue;
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)stepHue:(CHIPColorControlClusterStepHuePayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler
+- (void)stepHueWithParams:(CHIPColorControlClusterStepHueParams *)params completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     ColorControl::Commands::StepHue::Type request;
-    request.stepMode = static_cast<std::remove_reference_t<decltype(request.stepMode)>>(payload.stepMode.unsignedCharValue);
-    request.stepSize = payload.stepSize.unsignedCharValue;
-    request.transitionTime = payload.transitionTime.unsignedCharValue;
-    request.optionsMask = payload.optionsMask.unsignedCharValue;
-    request.optionsOverride = payload.optionsOverride.unsignedCharValue;
+    request.stepMode = static_cast<std::remove_reference_t<decltype(request.stepMode)>>(params.stepMode.unsignedCharValue);
+    request.stepSize = params.stepSize.unsignedCharValue;
+    request.transitionTime = params.transitionTime.unsignedCharValue;
+    request.optionsMask = params.optionsMask.unsignedCharValue;
+    request.optionsOverride = params.optionsOverride.unsignedCharValue;
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)stepSaturation:(CHIPColorControlClusterStepSaturationPayload * _Nonnull)payload
-       responseHandler:(ResponseHandler)responseHandler
+- (void)stepSaturationWithParams:(CHIPColorControlClusterStepSaturationParams *)params
+               completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     ColorControl::Commands::StepSaturation::Type request;
-    request.stepMode = static_cast<std::remove_reference_t<decltype(request.stepMode)>>(payload.stepMode.unsignedCharValue);
-    request.stepSize = payload.stepSize.unsignedCharValue;
-    request.transitionTime = payload.transitionTime.unsignedCharValue;
-    request.optionsMask = payload.optionsMask.unsignedCharValue;
-    request.optionsOverride = payload.optionsOverride.unsignedCharValue;
+    request.stepMode = static_cast<std::remove_reference_t<decltype(request.stepMode)>>(params.stepMode.unsignedCharValue);
+    request.stepSize = params.stepSize.unsignedCharValue;
+    request.transitionTime = params.transitionTime.unsignedCharValue;
+    request.optionsMask = params.optionsMask.unsignedCharValue;
+    request.optionsOverride = params.optionsOverride.unsignedCharValue;
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)stopMoveStep:(CHIPColorControlClusterStopMoveStepPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler
+- (void)stopMoveStepWithParams:(CHIPColorControlClusterStopMoveStepParams *)params
+             completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     ColorControl::Commands::StopMoveStep::Type request;
-    request.optionsMask = payload.optionsMask.unsignedCharValue;
-    request.optionsOverride = payload.optionsOverride.unsignedCharValue;
+    request.optionsMask = params.optionsMask.unsignedCharValue;
+    request.optionsOverride = params.optionsOverride.unsignedCharValue;
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
@@ -3829,31 +3835,32 @@ using namespace chip::app::Clusters;
     return &_cppCluster;
 }
 
-- (void)launchContent:(CHIPContentLauncherClusterLaunchContentPayload * _Nonnull)payload
-      responseHandler:(ResponseHandler)responseHandler
+- (void)launchContentWithParams:(CHIPContentLauncherClusterLaunchContentParams *)params
+              completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     ContentLauncher::Commands::LaunchContent::Type request;
-    request.autoPlay = payload.autoPlay.boolValue;
-    request.data = [self asCharSpan:payload.data];
+    request.autoPlay = params.autoPlay.boolValue;
+    request.data = [self asCharSpan:params.data];
 
     new CHIPContentLauncherClusterLaunchContentResponseCallbackBridge(
-        self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
             auto successFn = Callback<CHIPContentLauncherClusterLaunchContentResponseCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
-- (void)launchURL:(CHIPContentLauncherClusterLaunchURLPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler
+- (void)launchURLWithParams:(CHIPContentLauncherClusterLaunchURLParams *)params
+          completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     ContentLauncher::Commands::LaunchURL::Type request;
-    request.contentURL = [self asCharSpan:payload.contentURL];
-    request.displayString = [self asCharSpan:payload.displayString];
+    request.contentURL = [self asCharSpan:params.contentURL];
+    request.displayString = [self asCharSpan:params.displayString];
 
     new CHIPContentLauncherClusterLaunchURLResponseCallbackBridge(
-        self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
             auto successFn = Callback<CHIPContentLauncherClusterLaunchURLResponseCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
@@ -3978,18 +3985,18 @@ using namespace chip::app::Clusters;
     return &_cppCluster;
 }
 
-- (void)retrieveLogsRequest:(CHIPDiagnosticLogsClusterRetrieveLogsRequestPayload * _Nonnull)payload
-            responseHandler:(ResponseHandler)responseHandler
+- (void)retrieveLogsRequestWithParams:(CHIPDiagnosticLogsClusterRetrieveLogsRequestParams *)params
+                    completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     DiagnosticLogs::Commands::RetrieveLogsRequest::Type request;
-    request.intent = static_cast<std::remove_reference_t<decltype(request.intent)>>(payload.intent.unsignedCharValue);
+    request.intent = static_cast<std::remove_reference_t<decltype(request.intent)>>(params.intent.unsignedCharValue);
     request.requestedProtocol
-        = static_cast<std::remove_reference_t<decltype(request.requestedProtocol)>>(payload.requestedProtocol.unsignedCharValue);
-    request.transferFileDesignator = [self asByteSpan:payload.transferFileDesignator];
+        = static_cast<std::remove_reference_t<decltype(request.requestedProtocol)>>(params.requestedProtocol.unsignedCharValue);
+    request.transferFileDesignator = [self asByteSpan:params.transferFileDesignator];
 
     new CHIPDiagnosticLogsClusterRetrieveLogsResponseCallbackBridge(
-        self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
             auto successFn = Callback<CHIPDiagnosticLogsClusterRetrieveLogsResponseCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
@@ -4005,354 +4012,355 @@ using namespace chip::app::Clusters;
     return &_cppCluster;
 }
 
-- (void)clearAllPins:(CHIPDoorLockClusterClearAllPinsPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler
+- (void)clearAllPinsWithCompletionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     DoorLock::Commands::ClearAllPins::Type request;
 
     new CHIPDoorLockClusterClearAllPinsResponseCallbackBridge(
-        self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
             auto successFn = Callback<CHIPDoorLockClusterClearAllPinsResponseCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
-- (void)clearAllRfids:(CHIPDoorLockClusterClearAllRfidsPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler
+- (void)clearAllRfidsWithCompletionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     DoorLock::Commands::ClearAllRfids::Type request;
 
     new CHIPDoorLockClusterClearAllRfidsResponseCallbackBridge(
-        self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
             auto successFn = Callback<CHIPDoorLockClusterClearAllRfidsResponseCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
-- (void)clearHolidaySchedule:(CHIPDoorLockClusterClearHolidaySchedulePayload * _Nonnull)payload
-             responseHandler:(ResponseHandler)responseHandler
+- (void)clearHolidayScheduleWithParams:(CHIPDoorLockClusterClearHolidayScheduleParams *)params
+                     completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     DoorLock::Commands::ClearHolidaySchedule::Type request;
-    request.scheduleId = payload.scheduleId.unsignedCharValue;
+    request.scheduleId = params.scheduleId.unsignedCharValue;
 
     new CHIPDoorLockClusterClearHolidayScheduleResponseCallbackBridge(
-        self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
             auto successFn = Callback<CHIPDoorLockClusterClearHolidayScheduleResponseCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
-- (void)clearPin:(CHIPDoorLockClusterClearPinPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler
+- (void)clearPinWithParams:(CHIPDoorLockClusterClearPinParams *)params completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     DoorLock::Commands::ClearPin::Type request;
-    request.userId = payload.userId.unsignedShortValue;
+    request.userId = params.userId.unsignedShortValue;
 
     new CHIPDoorLockClusterClearPinResponseCallbackBridge(
-        self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
             auto successFn = Callback<CHIPDoorLockClusterClearPinResponseCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
-- (void)clearRfid:(CHIPDoorLockClusterClearRfidPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler
+- (void)clearRfidWithParams:(CHIPDoorLockClusterClearRfidParams *)params completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     DoorLock::Commands::ClearRfid::Type request;
-    request.userId = payload.userId.unsignedShortValue;
+    request.userId = params.userId.unsignedShortValue;
 
     new CHIPDoorLockClusterClearRfidResponseCallbackBridge(
-        self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
             auto successFn = Callback<CHIPDoorLockClusterClearRfidResponseCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
-- (void)clearWeekdaySchedule:(CHIPDoorLockClusterClearWeekdaySchedulePayload * _Nonnull)payload
-             responseHandler:(ResponseHandler)responseHandler
+- (void)clearWeekdayScheduleWithParams:(CHIPDoorLockClusterClearWeekdayScheduleParams *)params
+                     completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     DoorLock::Commands::ClearWeekdaySchedule::Type request;
-    request.scheduleId = payload.scheduleId.unsignedCharValue;
-    request.userId = payload.userId.unsignedShortValue;
+    request.scheduleId = params.scheduleId.unsignedCharValue;
+    request.userId = params.userId.unsignedShortValue;
 
     new CHIPDoorLockClusterClearWeekdayScheduleResponseCallbackBridge(
-        self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
             auto successFn = Callback<CHIPDoorLockClusterClearWeekdayScheduleResponseCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
-- (void)clearYeardaySchedule:(CHIPDoorLockClusterClearYeardaySchedulePayload * _Nonnull)payload
-             responseHandler:(ResponseHandler)responseHandler
+- (void)clearYeardayScheduleWithParams:(CHIPDoorLockClusterClearYeardayScheduleParams *)params
+                     completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     DoorLock::Commands::ClearYeardaySchedule::Type request;
-    request.scheduleId = payload.scheduleId.unsignedCharValue;
-    request.userId = payload.userId.unsignedShortValue;
+    request.scheduleId = params.scheduleId.unsignedCharValue;
+    request.userId = params.userId.unsignedShortValue;
 
     new CHIPDoorLockClusterClearYeardayScheduleResponseCallbackBridge(
-        self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
             auto successFn = Callback<CHIPDoorLockClusterClearYeardayScheduleResponseCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
-- (void)getHolidaySchedule:(CHIPDoorLockClusterGetHolidaySchedulePayload * _Nonnull)payload
-           responseHandler:(ResponseHandler)responseHandler
+- (void)getHolidayScheduleWithParams:(CHIPDoorLockClusterGetHolidayScheduleParams *)params
+                   completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     DoorLock::Commands::GetHolidaySchedule::Type request;
-    request.scheduleId = payload.scheduleId.unsignedCharValue;
+    request.scheduleId = params.scheduleId.unsignedCharValue;
 
     new CHIPDoorLockClusterGetHolidayScheduleResponseCallbackBridge(
-        self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
             auto successFn = Callback<CHIPDoorLockClusterGetHolidayScheduleResponseCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
-- (void)getLogRecord:(CHIPDoorLockClusterGetLogRecordPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler
+- (void)getLogRecordWithParams:(CHIPDoorLockClusterGetLogRecordParams *)params
+             completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     DoorLock::Commands::GetLogRecord::Type request;
-    request.logIndex = payload.logIndex.unsignedShortValue;
+    request.logIndex = params.logIndex.unsignedShortValue;
 
     new CHIPDoorLockClusterGetLogRecordResponseCallbackBridge(
-        self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
             auto successFn = Callback<CHIPDoorLockClusterGetLogRecordResponseCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
-- (void)getPin:(CHIPDoorLockClusterGetPinPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler
+- (void)getPinWithParams:(CHIPDoorLockClusterGetPinParams *)params completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     DoorLock::Commands::GetPin::Type request;
-    request.userId = payload.userId.unsignedShortValue;
+    request.userId = params.userId.unsignedShortValue;
 
     new CHIPDoorLockClusterGetPinResponseCallbackBridge(
-        self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
             auto successFn = Callback<CHIPDoorLockClusterGetPinResponseCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
-- (void)getRfid:(CHIPDoorLockClusterGetRfidPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler
+- (void)getRfidWithParams:(CHIPDoorLockClusterGetRfidParams *)params completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     DoorLock::Commands::GetRfid::Type request;
-    request.userId = payload.userId.unsignedShortValue;
+    request.userId = params.userId.unsignedShortValue;
 
     new CHIPDoorLockClusterGetRfidResponseCallbackBridge(
-        self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
             auto successFn = Callback<CHIPDoorLockClusterGetRfidResponseCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
-- (void)getUserType:(CHIPDoorLockClusterGetUserTypePayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler
+- (void)getUserTypeWithParams:(CHIPDoorLockClusterGetUserTypeParams *)params completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     DoorLock::Commands::GetUserType::Type request;
-    request.userId = payload.userId.unsignedShortValue;
+    request.userId = params.userId.unsignedShortValue;
 
     new CHIPDoorLockClusterGetUserTypeResponseCallbackBridge(
-        self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
             auto successFn = Callback<CHIPDoorLockClusterGetUserTypeResponseCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
-- (void)getWeekdaySchedule:(CHIPDoorLockClusterGetWeekdaySchedulePayload * _Nonnull)payload
-           responseHandler:(ResponseHandler)responseHandler
+- (void)getWeekdayScheduleWithParams:(CHIPDoorLockClusterGetWeekdayScheduleParams *)params
+                   completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     DoorLock::Commands::GetWeekdaySchedule::Type request;
-    request.scheduleId = payload.scheduleId.unsignedCharValue;
-    request.userId = payload.userId.unsignedShortValue;
+    request.scheduleId = params.scheduleId.unsignedCharValue;
+    request.userId = params.userId.unsignedShortValue;
 
     new CHIPDoorLockClusterGetWeekdayScheduleResponseCallbackBridge(
-        self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
             auto successFn = Callback<CHIPDoorLockClusterGetWeekdayScheduleResponseCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
-- (void)getYeardaySchedule:(CHIPDoorLockClusterGetYeardaySchedulePayload * _Nonnull)payload
-           responseHandler:(ResponseHandler)responseHandler
+- (void)getYeardayScheduleWithParams:(CHIPDoorLockClusterGetYeardayScheduleParams *)params
+                   completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     DoorLock::Commands::GetYeardaySchedule::Type request;
-    request.scheduleId = payload.scheduleId.unsignedCharValue;
-    request.userId = payload.userId.unsignedShortValue;
+    request.scheduleId = params.scheduleId.unsignedCharValue;
+    request.userId = params.userId.unsignedShortValue;
 
     new CHIPDoorLockClusterGetYeardayScheduleResponseCallbackBridge(
-        self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
             auto successFn = Callback<CHIPDoorLockClusterGetYeardayScheduleResponseCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
-- (void)lockDoor:(CHIPDoorLockClusterLockDoorPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler
+- (void)lockDoorWithParams:(CHIPDoorLockClusterLockDoorParams *)params completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     DoorLock::Commands::LockDoor::Type request;
-    request.pin = [self asByteSpan:payload.pin];
+    request.pin = [self asByteSpan:params.pin];
 
     new CHIPDoorLockClusterLockDoorResponseCallbackBridge(
-        self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
             auto successFn = Callback<CHIPDoorLockClusterLockDoorResponseCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
-- (void)setHolidaySchedule:(CHIPDoorLockClusterSetHolidaySchedulePayload * _Nonnull)payload
-           responseHandler:(ResponseHandler)responseHandler
+- (void)setHolidayScheduleWithParams:(CHIPDoorLockClusterSetHolidayScheduleParams *)params
+                   completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     DoorLock::Commands::SetHolidaySchedule::Type request;
-    request.scheduleId = payload.scheduleId.unsignedCharValue;
-    request.localStartTime = payload.localStartTime.unsignedIntValue;
-    request.localEndTime = payload.localEndTime.unsignedIntValue;
-    request.operatingModeDuringHoliday = payload.operatingModeDuringHoliday.unsignedCharValue;
+    request.scheduleId = params.scheduleId.unsignedCharValue;
+    request.localStartTime = params.localStartTime.unsignedIntValue;
+    request.localEndTime = params.localEndTime.unsignedIntValue;
+    request.operatingModeDuringHoliday = params.operatingModeDuringHoliday.unsignedCharValue;
 
     new CHIPDoorLockClusterSetHolidayScheduleResponseCallbackBridge(
-        self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
             auto successFn = Callback<CHIPDoorLockClusterSetHolidayScheduleResponseCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
-- (void)setPin:(CHIPDoorLockClusterSetPinPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler
+- (void)setPinWithParams:(CHIPDoorLockClusterSetPinParams *)params completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     DoorLock::Commands::SetPin::Type request;
-    request.userId = payload.userId.unsignedShortValue;
-    request.userStatus = static_cast<std::remove_reference_t<decltype(request.userStatus)>>(payload.userStatus.unsignedCharValue);
-    request.userType = static_cast<std::remove_reference_t<decltype(request.userType)>>(payload.userType.unsignedCharValue);
-    request.pin = [self asByteSpan:payload.pin];
+    request.userId = params.userId.unsignedShortValue;
+    request.userStatus = static_cast<std::remove_reference_t<decltype(request.userStatus)>>(params.userStatus.unsignedCharValue);
+    request.userType = static_cast<std::remove_reference_t<decltype(request.userType)>>(params.userType.unsignedCharValue);
+    request.pin = [self asByteSpan:params.pin];
 
     new CHIPDoorLockClusterSetPinResponseCallbackBridge(
-        self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
             auto successFn = Callback<CHIPDoorLockClusterSetPinResponseCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
-- (void)setRfid:(CHIPDoorLockClusterSetRfidPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler
+- (void)setRfidWithParams:(CHIPDoorLockClusterSetRfidParams *)params completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     DoorLock::Commands::SetRfid::Type request;
-    request.userId = payload.userId.unsignedShortValue;
-    request.userStatus = static_cast<std::remove_reference_t<decltype(request.userStatus)>>(payload.userStatus.unsignedCharValue);
-    request.userType = static_cast<std::remove_reference_t<decltype(request.userType)>>(payload.userType.unsignedCharValue);
-    request.id = [self asByteSpan:payload.id];
+    request.userId = params.userId.unsignedShortValue;
+    request.userStatus = static_cast<std::remove_reference_t<decltype(request.userStatus)>>(params.userStatus.unsignedCharValue);
+    request.userType = static_cast<std::remove_reference_t<decltype(request.userType)>>(params.userType.unsignedCharValue);
+    request.id = [self asByteSpan:params.id];
 
     new CHIPDoorLockClusterSetRfidResponseCallbackBridge(
-        self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
             auto successFn = Callback<CHIPDoorLockClusterSetRfidResponseCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
-- (void)setUserType:(CHIPDoorLockClusterSetUserTypePayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler
+- (void)setUserTypeWithParams:(CHIPDoorLockClusterSetUserTypeParams *)params completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     DoorLock::Commands::SetUserType::Type request;
-    request.userId = payload.userId.unsignedShortValue;
-    request.userType = static_cast<std::remove_reference_t<decltype(request.userType)>>(payload.userType.unsignedCharValue);
+    request.userId = params.userId.unsignedShortValue;
+    request.userType = static_cast<std::remove_reference_t<decltype(request.userType)>>(params.userType.unsignedCharValue);
 
     new CHIPDoorLockClusterSetUserTypeResponseCallbackBridge(
-        self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
             auto successFn = Callback<CHIPDoorLockClusterSetUserTypeResponseCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
-- (void)setWeekdaySchedule:(CHIPDoorLockClusterSetWeekdaySchedulePayload * _Nonnull)payload
-           responseHandler:(ResponseHandler)responseHandler
+- (void)setWeekdayScheduleWithParams:(CHIPDoorLockClusterSetWeekdayScheduleParams *)params
+                   completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     DoorLock::Commands::SetWeekdaySchedule::Type request;
-    request.scheduleId = payload.scheduleId.unsignedCharValue;
-    request.userId = payload.userId.unsignedShortValue;
-    request.daysMask = static_cast<std::remove_reference_t<decltype(request.daysMask)>>(payload.daysMask.unsignedCharValue);
-    request.startHour = payload.startHour.unsignedCharValue;
-    request.startMinute = payload.startMinute.unsignedCharValue;
-    request.endHour = payload.endHour.unsignedCharValue;
-    request.endMinute = payload.endMinute.unsignedCharValue;
+    request.scheduleId = params.scheduleId.unsignedCharValue;
+    request.userId = params.userId.unsignedShortValue;
+    request.daysMask = static_cast<std::remove_reference_t<decltype(request.daysMask)>>(params.daysMask.unsignedCharValue);
+    request.startHour = params.startHour.unsignedCharValue;
+    request.startMinute = params.startMinute.unsignedCharValue;
+    request.endHour = params.endHour.unsignedCharValue;
+    request.endMinute = params.endMinute.unsignedCharValue;
 
     new CHIPDoorLockClusterSetWeekdayScheduleResponseCallbackBridge(
-        self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
             auto successFn = Callback<CHIPDoorLockClusterSetWeekdayScheduleResponseCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
-- (void)setYeardaySchedule:(CHIPDoorLockClusterSetYeardaySchedulePayload * _Nonnull)payload
-           responseHandler:(ResponseHandler)responseHandler
+- (void)setYeardayScheduleWithParams:(CHIPDoorLockClusterSetYeardayScheduleParams *)params
+                   completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     DoorLock::Commands::SetYeardaySchedule::Type request;
-    request.scheduleId = payload.scheduleId.unsignedCharValue;
-    request.userId = payload.userId.unsignedShortValue;
-    request.localStartTime = payload.localStartTime.unsignedIntValue;
-    request.localEndTime = payload.localEndTime.unsignedIntValue;
+    request.scheduleId = params.scheduleId.unsignedCharValue;
+    request.userId = params.userId.unsignedShortValue;
+    request.localStartTime = params.localStartTime.unsignedIntValue;
+    request.localEndTime = params.localEndTime.unsignedIntValue;
 
     new CHIPDoorLockClusterSetYeardayScheduleResponseCallbackBridge(
-        self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
             auto successFn = Callback<CHIPDoorLockClusterSetYeardayScheduleResponseCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
-- (void)unlockDoor:(CHIPDoorLockClusterUnlockDoorPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler
+- (void)unlockDoorWithParams:(CHIPDoorLockClusterUnlockDoorParams *)params completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     DoorLock::Commands::UnlockDoor::Type request;
-    request.pin = [self asByteSpan:payload.pin];
+    request.pin = [self asByteSpan:params.pin];
 
     new CHIPDoorLockClusterUnlockDoorResponseCallbackBridge(
-        self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
             auto successFn = Callback<CHIPDoorLockClusterUnlockDoorResponseCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
-- (void)unlockWithTimeout:(CHIPDoorLockClusterUnlockWithTimeoutPayload * _Nonnull)payload
-          responseHandler:(ResponseHandler)responseHandler
+- (void)unlockWithTimeoutWithParams:(CHIPDoorLockClusterUnlockWithTimeoutParams *)params
+                  completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     DoorLock::Commands::UnlockWithTimeout::Type request;
-    request.timeoutInSeconds = payload.timeoutInSeconds.unsignedShortValue;
-    request.pin = [self asByteSpan:payload.pin];
+    request.timeoutInSeconds = params.timeoutInSeconds.unsignedShortValue;
+    request.pin = [self asByteSpan:params.pin];
 
     new CHIPDoorLockClusterUnlockWithTimeoutResponseCallbackBridge(
-        self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
             auto successFn = Callback<CHIPDoorLockClusterUnlockWithTimeoutResponseCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
@@ -4793,13 +4801,12 @@ using namespace chip::app::Clusters;
     return &_cppCluster;
 }
 
-- (void)resetCounts:(CHIPEthernetNetworkDiagnosticsClusterResetCountsPayload * _Nonnull)payload
-    responseHandler:(ResponseHandler)responseHandler
+- (void)resetCountsWithCompletionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     EthernetNetworkDiagnostics::Commands::ResetCounts::Type request;
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
@@ -5257,31 +5264,30 @@ using namespace chip::app::Clusters;
     return &_cppCluster;
 }
 
-- (void)armFailSafe:(CHIPGeneralCommissioningClusterArmFailSafePayload * _Nonnull)payload
-    responseHandler:(ResponseHandler)responseHandler
+- (void)armFailSafeWithParams:(CHIPGeneralCommissioningClusterArmFailSafeParams *)params
+            completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     GeneralCommissioning::Commands::ArmFailSafe::Type request;
-    request.expiryLengthSeconds = payload.expiryLengthSeconds.unsignedShortValue;
-    request.breadcrumb = payload.breadcrumb.unsignedLongLongValue;
-    request.timeoutMs = payload.timeoutMs.unsignedIntValue;
+    request.expiryLengthSeconds = params.expiryLengthSeconds.unsignedShortValue;
+    request.breadcrumb = params.breadcrumb.unsignedLongLongValue;
+    request.timeoutMs = params.timeoutMs.unsignedIntValue;
 
     new CHIPGeneralCommissioningClusterArmFailSafeResponseCallbackBridge(
-        self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
             auto successFn = Callback<CHIPGeneralCommissioningClusterArmFailSafeResponseCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
-- (void)commissioningComplete:(CHIPGeneralCommissioningClusterCommissioningCompletePayload * _Nonnull)payload
-              responseHandler:(ResponseHandler)responseHandler
+- (void)commissioningCompleteWithCompletionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     GeneralCommissioning::Commands::CommissioningComplete::Type request;
 
     new CHIPGeneralCommissioningClusterCommissioningCompleteResponseCallbackBridge(
-        self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
             auto successFn
                 = Callback<CHIPGeneralCommissioningClusterCommissioningCompleteResponseCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
@@ -5289,18 +5295,18 @@ using namespace chip::app::Clusters;
         });
 }
 
-- (void)setRegulatoryConfig:(CHIPGeneralCommissioningClusterSetRegulatoryConfigPayload * _Nonnull)payload
-            responseHandler:(ResponseHandler)responseHandler
+- (void)setRegulatoryConfigWithParams:(CHIPGeneralCommissioningClusterSetRegulatoryConfigParams *)params
+                    completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     GeneralCommissioning::Commands::SetRegulatoryConfig::Type request;
-    request.location = static_cast<std::remove_reference_t<decltype(request.location)>>(payload.location.unsignedCharValue);
-    request.countryCode = [self asCharSpan:payload.countryCode];
-    request.breadcrumb = payload.breadcrumb.unsignedLongLongValue;
-    request.timeoutMs = payload.timeoutMs.unsignedIntValue;
+    request.location = static_cast<std::remove_reference_t<decltype(request.location)>>(params.location.unsignedCharValue);
+    request.countryCode = [self asCharSpan:params.countryCode];
+    request.breadcrumb = params.breadcrumb.unsignedLongLongValue;
+    request.timeoutMs = params.timeoutMs.unsignedIntValue;
 
     new CHIPGeneralCommissioningClusterSetRegulatoryConfigResponseCallbackBridge(
-        self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
             auto successFn
                 = Callback<CHIPGeneralCommissioningClusterSetRegulatoryConfigResponseCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
@@ -5612,106 +5618,106 @@ using namespace chip::app::Clusters;
     return &_cppCluster;
 }
 
-- (void)addGroup:(CHIPGroupsClusterAddGroupPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler
+- (void)addGroupWithParams:(CHIPGroupsClusterAddGroupParams *)params completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     Groups::Commands::AddGroup::Type request;
-    request.groupId = payload.groupId.unsignedShortValue;
-    request.groupName = [self asCharSpan:payload.groupName];
+    request.groupId = params.groupId.unsignedShortValue;
+    request.groupName = [self asCharSpan:params.groupName];
 
     new CHIPGroupsClusterAddGroupResponseCallbackBridge(
-        self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
             auto successFn = Callback<CHIPGroupsClusterAddGroupResponseCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
-- (void)addGroupIfIdentifying:(CHIPGroupsClusterAddGroupIfIdentifyingPayload * _Nonnull)payload
-              responseHandler:(ResponseHandler)responseHandler
+- (void)addGroupIfIdentifyingWithParams:(CHIPGroupsClusterAddGroupIfIdentifyingParams *)params
+                      completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     Groups::Commands::AddGroupIfIdentifying::Type request;
-    request.groupId = payload.groupId.unsignedShortValue;
-    request.groupName = [self asCharSpan:payload.groupName];
+    request.groupId = params.groupId.unsignedShortValue;
+    request.groupName = [self asCharSpan:params.groupName];
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)getGroupMembership:(CHIPGroupsClusterGetGroupMembershipPayload * _Nonnull)payload
-           responseHandler:(ResponseHandler)responseHandler
+- (void)getGroupMembershipWithParams:(CHIPGroupsClusterGetGroupMembershipParams *)params
+                   completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     Groups::Commands::GetGroupMembership::Type request;
     {
         using ListType = std::remove_reference_t<decltype(request.groupList)>;
         using ListMemberType = ListMemberTypeGetter<ListType>::Type;
-        if (payload.groupList.count != 0) {
-            auto * listHolder_0 = new ListHolder<ListMemberType>(payload.groupList.count);
+        if (params.groupList.count != 0) {
+            auto * listHolder_0 = new ListHolder<ListMemberType>(params.groupList.count);
             if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
                 return;
             }
             listFreer.add(listHolder_0);
-            for (size_t i = 0; i < payload.groupList.count; ++i) {
-                if (![payload.groupList[i] isKindOfClass:[NSNumber class]]) {
+            for (size_t i = 0; i < params.groupList.count; ++i) {
+                if (![params.groupList[i] isKindOfClass:[NSNumber class]]) {
                     // Wrong kind of value.
                     return;
                 }
-                auto element_0 = (NSNumber *) payload.groupList[i];
+                auto element_0 = (NSNumber *) params.groupList[i];
                 listHolder_0->mList[i] = element_0.unsignedShortValue;
             }
-            request.groupList = ListType(listHolder_0->mList, payload.groupList.count);
+            request.groupList = ListType(listHolder_0->mList, params.groupList.count);
         } else {
             request.groupList = ListType();
         }
     }
 
     new CHIPGroupsClusterGetGroupMembershipResponseCallbackBridge(
-        self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
             auto successFn = Callback<CHIPGroupsClusterGetGroupMembershipResponseCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
-- (void)removeAllGroups:(CHIPGroupsClusterRemoveAllGroupsPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler
+- (void)removeAllGroupsWithCompletionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     Groups::Commands::RemoveAllGroups::Type request;
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)removeGroup:(CHIPGroupsClusterRemoveGroupPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler
+- (void)removeGroupWithParams:(CHIPGroupsClusterRemoveGroupParams *)params completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     Groups::Commands::RemoveGroup::Type request;
-    request.groupId = payload.groupId.unsignedShortValue;
+    request.groupId = params.groupId.unsignedShortValue;
 
     new CHIPGroupsClusterRemoveGroupResponseCallbackBridge(
-        self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
             auto successFn = Callback<CHIPGroupsClusterRemoveGroupResponseCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
-- (void)viewGroup:(CHIPGroupsClusterViewGroupPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler
+- (void)viewGroupWithParams:(CHIPGroupsClusterViewGroupParams *)params completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     Groups::Commands::ViewGroup::Type request;
-    request.groupId = payload.groupId.unsignedShortValue;
+    request.groupId = params.groupId.unsignedShortValue;
 
     new CHIPGroupsClusterViewGroupResponseCallbackBridge(
-        self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
             auto successFn = Callback<CHIPGroupsClusterViewGroupResponseCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
@@ -5779,42 +5785,43 @@ using namespace chip::app::Clusters;
     return &_cppCluster;
 }
 
-- (void)identify:(CHIPIdentifyClusterIdentifyPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler
+- (void)identifyWithParams:(CHIPIdentifyClusterIdentifyParams *)params completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     Identify::Commands::Identify::Type request;
-    request.identifyTime = payload.identifyTime.unsignedShortValue;
+    request.identifyTime = params.identifyTime.unsignedShortValue;
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)identifyQuery:(CHIPIdentifyClusterIdentifyQueryPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler
+- (void)identifyQueryWithCompletionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     Identify::Commands::IdentifyQuery::Type request;
 
     new CHIPIdentifyClusterIdentifyQueryResponseCallbackBridge(
-        self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
             auto successFn = Callback<CHIPIdentifyClusterIdentifyQueryResponseCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
-- (void)triggerEffect:(CHIPIdentifyClusterTriggerEffectPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler
+- (void)triggerEffectWithParams:(CHIPIdentifyClusterTriggerEffectParams *)params
+              completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     Identify::Commands::TriggerEffect::Type request;
     request.effectIdentifier
-        = static_cast<std::remove_reference_t<decltype(request.effectIdentifier)>>(payload.effectIdentifier.unsignedCharValue);
+        = static_cast<std::remove_reference_t<decltype(request.effectIdentifier)>>(params.effectIdentifier.unsignedCharValue);
     request.effectVariant
-        = static_cast<std::remove_reference_t<decltype(request.effectVariant)>>(payload.effectVariant.unsignedCharValue);
+        = static_cast<std::remove_reference_t<decltype(request.effectVariant)>>(params.effectVariant.unsignedCharValue);
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
@@ -6086,14 +6093,14 @@ using namespace chip::app::Clusters;
     return &_cppCluster;
 }
 
-- (void)sendKey:(CHIPKeypadInputClusterSendKeyPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler
+- (void)sendKeyWithParams:(CHIPKeypadInputClusterSendKeyParams *)params completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     KeypadInput::Commands::SendKey::Type request;
-    request.keyCode = static_cast<std::remove_reference_t<decltype(request.keyCode)>>(payload.keyCode.unsignedCharValue);
+    request.keyCode = static_cast<std::remove_reference_t<decltype(request.keyCode)>>(params.keyCode.unsignedCharValue);
 
     new CHIPKeypadInputClusterSendKeyResponseCallbackBridge(
-        self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
             auto successFn = Callback<CHIPKeypadInputClusterSendKeyResponseCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
@@ -6135,122 +6142,122 @@ using namespace chip::app::Clusters;
     return &_cppCluster;
 }
 
-- (void)move:(CHIPLevelControlClusterMovePayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler
+- (void)moveWithParams:(CHIPLevelControlClusterMoveParams *)params completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     LevelControl::Commands::Move::Type request;
-    request.moveMode = static_cast<std::remove_reference_t<decltype(request.moveMode)>>(payload.moveMode.unsignedCharValue);
-    request.rate = payload.rate.unsignedCharValue;
-    request.optionMask = payload.optionMask.unsignedCharValue;
-    request.optionOverride = payload.optionOverride.unsignedCharValue;
+    request.moveMode = static_cast<std::remove_reference_t<decltype(request.moveMode)>>(params.moveMode.unsignedCharValue);
+    request.rate = params.rate.unsignedCharValue;
+    request.optionMask = params.optionMask.unsignedCharValue;
+    request.optionOverride = params.optionOverride.unsignedCharValue;
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)moveToLevel:(CHIPLevelControlClusterMoveToLevelPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler
+- (void)moveToLevelWithParams:(CHIPLevelControlClusterMoveToLevelParams *)params
+            completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     LevelControl::Commands::MoveToLevel::Type request;
-    request.level = payload.level.unsignedCharValue;
-    request.transitionTime = payload.transitionTime.unsignedShortValue;
-    request.optionMask = payload.optionMask.unsignedCharValue;
-    request.optionOverride = payload.optionOverride.unsignedCharValue;
+    request.level = params.level.unsignedCharValue;
+    request.transitionTime = params.transitionTime.unsignedShortValue;
+    request.optionMask = params.optionMask.unsignedCharValue;
+    request.optionOverride = params.optionOverride.unsignedCharValue;
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)moveToLevelWithOnOff:(CHIPLevelControlClusterMoveToLevelWithOnOffPayload * _Nonnull)payload
-             responseHandler:(ResponseHandler)responseHandler
+- (void)moveToLevelWithOnOffWithParams:(CHIPLevelControlClusterMoveToLevelWithOnOffParams *)params
+                     completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     LevelControl::Commands::MoveToLevelWithOnOff::Type request;
-    request.level = payload.level.unsignedCharValue;
-    request.transitionTime = payload.transitionTime.unsignedShortValue;
+    request.level = params.level.unsignedCharValue;
+    request.transitionTime = params.transitionTime.unsignedShortValue;
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)moveWithOnOff:(CHIPLevelControlClusterMoveWithOnOffPayload * _Nonnull)payload
-      responseHandler:(ResponseHandler)responseHandler
+- (void)moveWithOnOffWithParams:(CHIPLevelControlClusterMoveWithOnOffParams *)params
+              completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     LevelControl::Commands::MoveWithOnOff::Type request;
-    request.moveMode = static_cast<std::remove_reference_t<decltype(request.moveMode)>>(payload.moveMode.unsignedCharValue);
-    request.rate = payload.rate.unsignedCharValue;
+    request.moveMode = static_cast<std::remove_reference_t<decltype(request.moveMode)>>(params.moveMode.unsignedCharValue);
+    request.rate = params.rate.unsignedCharValue;
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)step:(CHIPLevelControlClusterStepPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler
+- (void)stepWithParams:(CHIPLevelControlClusterStepParams *)params completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     LevelControl::Commands::Step::Type request;
-    request.stepMode = static_cast<std::remove_reference_t<decltype(request.stepMode)>>(payload.stepMode.unsignedCharValue);
-    request.stepSize = payload.stepSize.unsignedCharValue;
-    request.transitionTime = payload.transitionTime.unsignedShortValue;
-    request.optionMask = payload.optionMask.unsignedCharValue;
-    request.optionOverride = payload.optionOverride.unsignedCharValue;
+    request.stepMode = static_cast<std::remove_reference_t<decltype(request.stepMode)>>(params.stepMode.unsignedCharValue);
+    request.stepSize = params.stepSize.unsignedCharValue;
+    request.transitionTime = params.transitionTime.unsignedShortValue;
+    request.optionMask = params.optionMask.unsignedCharValue;
+    request.optionOverride = params.optionOverride.unsignedCharValue;
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)stepWithOnOff:(CHIPLevelControlClusterStepWithOnOffPayload * _Nonnull)payload
-      responseHandler:(ResponseHandler)responseHandler
+- (void)stepWithOnOffWithParams:(CHIPLevelControlClusterStepWithOnOffParams *)params
+              completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     LevelControl::Commands::StepWithOnOff::Type request;
-    request.stepMode = static_cast<std::remove_reference_t<decltype(request.stepMode)>>(payload.stepMode.unsignedCharValue);
-    request.stepSize = payload.stepSize.unsignedCharValue;
-    request.transitionTime = payload.transitionTime.unsignedShortValue;
+    request.stepMode = static_cast<std::remove_reference_t<decltype(request.stepMode)>>(params.stepMode.unsignedCharValue);
+    request.stepSize = params.stepSize.unsignedCharValue;
+    request.transitionTime = params.transitionTime.unsignedShortValue;
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)stop:(CHIPLevelControlClusterStopPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler
+- (void)stopWithParams:(CHIPLevelControlClusterStopParams *)params completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     LevelControl::Commands::Stop::Type request;
-    request.optionMask = payload.optionMask.unsignedCharValue;
-    request.optionOverride = payload.optionOverride.unsignedCharValue;
+    request.optionMask = params.optionMask.unsignedCharValue;
+    request.optionOverride = params.optionOverride.unsignedCharValue;
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)stopWithOnOff:(CHIPLevelControlClusterStopWithOnOffPayload * _Nonnull)payload
-      responseHandler:(ResponseHandler)responseHandler
+- (void)stopWithOnOffWithCompletionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     LevelControl::Commands::StopWithOnOff::Type request;
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
@@ -6747,12 +6754,12 @@ using namespace chip::app::Clusters;
     return &_cppCluster;
 }
 
-- (void)sleep:(CHIPLowPowerClusterSleepPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler
+- (void)sleepWithCompletionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     LowPower::Commands::Sleep::Type request;
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
@@ -6794,53 +6801,53 @@ using namespace chip::app::Clusters;
     return &_cppCluster;
 }
 
-- (void)hideInputStatus:(CHIPMediaInputClusterHideInputStatusPayload * _Nonnull)payload
-        responseHandler:(ResponseHandler)responseHandler
+- (void)hideInputStatusWithCompletionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     MediaInput::Commands::HideInputStatus::Type request;
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)renameInput:(CHIPMediaInputClusterRenameInputPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler
+- (void)renameInputWithParams:(CHIPMediaInputClusterRenameInputParams *)params
+            completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     MediaInput::Commands::RenameInput::Type request;
-    request.index = payload.index.unsignedCharValue;
-    request.name = [self asCharSpan:payload.name];
+    request.index = params.index.unsignedCharValue;
+    request.name = [self asCharSpan:params.name];
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)selectInput:(CHIPMediaInputClusterSelectInputPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler
+- (void)selectInputWithParams:(CHIPMediaInputClusterSelectInputParams *)params
+            completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     MediaInput::Commands::SelectInput::Type request;
-    request.index = payload.index.unsignedCharValue;
+    request.index = params.index.unsignedCharValue;
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)showInputStatus:(CHIPMediaInputClusterShowInputStatusPayload * _Nonnull)payload
-        responseHandler:(ResponseHandler)responseHandler
+- (void)showInputStatusWithCompletionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     MediaInput::Commands::ShowInputStatus::Type request;
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
@@ -6916,151 +6923,148 @@ using namespace chip::app::Clusters;
     return &_cppCluster;
 }
 
-- (void)mediaFastForward:(CHIPMediaPlaybackClusterMediaFastForwardPayload * _Nonnull)payload
-         responseHandler:(ResponseHandler)responseHandler
+- (void)mediaFastForwardWithCompletionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     MediaPlayback::Commands::MediaFastForward::Type request;
 
     new CHIPMediaPlaybackClusterMediaFastForwardResponseCallbackBridge(
-        self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
             auto successFn = Callback<CHIPMediaPlaybackClusterMediaFastForwardResponseCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
-- (void)mediaNext:(CHIPMediaPlaybackClusterMediaNextPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler
+- (void)mediaNextWithCompletionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     MediaPlayback::Commands::MediaNext::Type request;
 
     new CHIPMediaPlaybackClusterMediaNextResponseCallbackBridge(
-        self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
             auto successFn = Callback<CHIPMediaPlaybackClusterMediaNextResponseCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
-- (void)mediaPause:(CHIPMediaPlaybackClusterMediaPausePayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler
+- (void)mediaPauseWithCompletionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     MediaPlayback::Commands::MediaPause::Type request;
 
     new CHIPMediaPlaybackClusterMediaPauseResponseCallbackBridge(
-        self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
             auto successFn = Callback<CHIPMediaPlaybackClusterMediaPauseResponseCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
-- (void)mediaPlay:(CHIPMediaPlaybackClusterMediaPlayPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler
+- (void)mediaPlayWithCompletionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     MediaPlayback::Commands::MediaPlay::Type request;
 
     new CHIPMediaPlaybackClusterMediaPlayResponseCallbackBridge(
-        self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
             auto successFn = Callback<CHIPMediaPlaybackClusterMediaPlayResponseCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
-- (void)mediaPrevious:(CHIPMediaPlaybackClusterMediaPreviousPayload * _Nonnull)payload
-      responseHandler:(ResponseHandler)responseHandler
+- (void)mediaPreviousWithCompletionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     MediaPlayback::Commands::MediaPrevious::Type request;
 
     new CHIPMediaPlaybackClusterMediaPreviousResponseCallbackBridge(
-        self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
             auto successFn = Callback<CHIPMediaPlaybackClusterMediaPreviousResponseCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
-- (void)mediaRewind:(CHIPMediaPlaybackClusterMediaRewindPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler
+- (void)mediaRewindWithCompletionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     MediaPlayback::Commands::MediaRewind::Type request;
 
     new CHIPMediaPlaybackClusterMediaRewindResponseCallbackBridge(
-        self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
             auto successFn = Callback<CHIPMediaPlaybackClusterMediaRewindResponseCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
-- (void)mediaSeek:(CHIPMediaPlaybackClusterMediaSeekPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler
+- (void)mediaSeekWithParams:(CHIPMediaPlaybackClusterMediaSeekParams *)params completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     MediaPlayback::Commands::MediaSeek::Type request;
-    request.position = payload.position.unsignedLongLongValue;
+    request.position = params.position.unsignedLongLongValue;
 
     new CHIPMediaPlaybackClusterMediaSeekResponseCallbackBridge(
-        self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
             auto successFn = Callback<CHIPMediaPlaybackClusterMediaSeekResponseCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
-- (void)mediaSkipBackward:(CHIPMediaPlaybackClusterMediaSkipBackwardPayload * _Nonnull)payload
-          responseHandler:(ResponseHandler)responseHandler
+- (void)mediaSkipBackwardWithParams:(CHIPMediaPlaybackClusterMediaSkipBackwardParams *)params
+                  completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     MediaPlayback::Commands::MediaSkipBackward::Type request;
-    request.deltaPositionMilliseconds = payload.deltaPositionMilliseconds.unsignedLongLongValue;
+    request.deltaPositionMilliseconds = params.deltaPositionMilliseconds.unsignedLongLongValue;
 
     new CHIPMediaPlaybackClusterMediaSkipBackwardResponseCallbackBridge(
-        self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
             auto successFn = Callback<CHIPMediaPlaybackClusterMediaSkipBackwardResponseCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
-- (void)mediaSkipForward:(CHIPMediaPlaybackClusterMediaSkipForwardPayload * _Nonnull)payload
-         responseHandler:(ResponseHandler)responseHandler
+- (void)mediaSkipForwardWithParams:(CHIPMediaPlaybackClusterMediaSkipForwardParams *)params
+                 completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     MediaPlayback::Commands::MediaSkipForward::Type request;
-    request.deltaPositionMilliseconds = payload.deltaPositionMilliseconds.unsignedLongLongValue;
+    request.deltaPositionMilliseconds = params.deltaPositionMilliseconds.unsignedLongLongValue;
 
     new CHIPMediaPlaybackClusterMediaSkipForwardResponseCallbackBridge(
-        self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
             auto successFn = Callback<CHIPMediaPlaybackClusterMediaSkipForwardResponseCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
-- (void)mediaStartOver:(CHIPMediaPlaybackClusterMediaStartOverPayload * _Nonnull)payload
-       responseHandler:(ResponseHandler)responseHandler
+- (void)mediaStartOverWithCompletionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     MediaPlayback::Commands::MediaStartOver::Type request;
 
     new CHIPMediaPlaybackClusterMediaStartOverResponseCallbackBridge(
-        self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
             auto successFn = Callback<CHIPMediaPlaybackClusterMediaStartOverResponseCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
-- (void)mediaStop:(CHIPMediaPlaybackClusterMediaStopPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler
+- (void)mediaStopWithCompletionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     MediaPlayback::Commands::MediaStop::Type request;
 
     new CHIPMediaPlaybackClusterMediaStopResponseCallbackBridge(
-        self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
             auto successFn = Callback<CHIPMediaPlaybackClusterMediaStopResponseCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
@@ -7310,13 +7314,14 @@ using namespace chip::app::Clusters;
     return &_cppCluster;
 }
 
-- (void)changeToMode:(CHIPModeSelectClusterChangeToModePayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler
+- (void)changeToModeWithParams:(CHIPModeSelectClusterChangeToModeParams *)params
+             completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     ModeSelect::Commands::ChangeToMode::Type request;
-    request.newMode = payload.newMode.unsignedCharValue;
+    request.newMode = params.newMode.unsignedCharValue;
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
@@ -7483,120 +7488,120 @@ using namespace chip::app::Clusters;
     return &_cppCluster;
 }
 
-- (void)addThreadNetwork:(CHIPNetworkCommissioningClusterAddThreadNetworkPayload * _Nonnull)payload
-         responseHandler:(ResponseHandler)responseHandler
+- (void)addThreadNetworkWithParams:(CHIPNetworkCommissioningClusterAddThreadNetworkParams *)params
+                 completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     NetworkCommissioning::Commands::AddThreadNetwork::Type request;
-    request.operationalDataset = [self asByteSpan:payload.operationalDataset];
-    request.breadcrumb = payload.breadcrumb.unsignedLongLongValue;
-    request.timeoutMs = payload.timeoutMs.unsignedIntValue;
+    request.operationalDataset = [self asByteSpan:params.operationalDataset];
+    request.breadcrumb = params.breadcrumb.unsignedLongLongValue;
+    request.timeoutMs = params.timeoutMs.unsignedIntValue;
 
     new CHIPNetworkCommissioningClusterAddThreadNetworkResponseCallbackBridge(
-        self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
             auto successFn = Callback<CHIPNetworkCommissioningClusterAddThreadNetworkResponseCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
-- (void)addWiFiNetwork:(CHIPNetworkCommissioningClusterAddWiFiNetworkPayload * _Nonnull)payload
-       responseHandler:(ResponseHandler)responseHandler
+- (void)addWiFiNetworkWithParams:(CHIPNetworkCommissioningClusterAddWiFiNetworkParams *)params
+               completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     NetworkCommissioning::Commands::AddWiFiNetwork::Type request;
-    request.ssid = [self asByteSpan:payload.ssid];
-    request.credentials = [self asByteSpan:payload.credentials];
-    request.breadcrumb = payload.breadcrumb.unsignedLongLongValue;
-    request.timeoutMs = payload.timeoutMs.unsignedIntValue;
+    request.ssid = [self asByteSpan:params.ssid];
+    request.credentials = [self asByteSpan:params.credentials];
+    request.breadcrumb = params.breadcrumb.unsignedLongLongValue;
+    request.timeoutMs = params.timeoutMs.unsignedIntValue;
 
     new CHIPNetworkCommissioningClusterAddWiFiNetworkResponseCallbackBridge(
-        self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
             auto successFn = Callback<CHIPNetworkCommissioningClusterAddWiFiNetworkResponseCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
-- (void)disableNetwork:(CHIPNetworkCommissioningClusterDisableNetworkPayload * _Nonnull)payload
-       responseHandler:(ResponseHandler)responseHandler
+- (void)disableNetworkWithParams:(CHIPNetworkCommissioningClusterDisableNetworkParams *)params
+               completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     NetworkCommissioning::Commands::DisableNetwork::Type request;
-    request.networkID = [self asByteSpan:payload.networkID];
-    request.breadcrumb = payload.breadcrumb.unsignedLongLongValue;
-    request.timeoutMs = payload.timeoutMs.unsignedIntValue;
+    request.networkID = [self asByteSpan:params.networkID];
+    request.breadcrumb = params.breadcrumb.unsignedLongLongValue;
+    request.timeoutMs = params.timeoutMs.unsignedIntValue;
 
     new CHIPNetworkCommissioningClusterDisableNetworkResponseCallbackBridge(
-        self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
             auto successFn = Callback<CHIPNetworkCommissioningClusterDisableNetworkResponseCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
-- (void)enableNetwork:(CHIPNetworkCommissioningClusterEnableNetworkPayload * _Nonnull)payload
-      responseHandler:(ResponseHandler)responseHandler
+- (void)enableNetworkWithParams:(CHIPNetworkCommissioningClusterEnableNetworkParams *)params
+              completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     NetworkCommissioning::Commands::EnableNetwork::Type request;
-    request.networkID = [self asByteSpan:payload.networkID];
-    request.breadcrumb = payload.breadcrumb.unsignedLongLongValue;
-    request.timeoutMs = payload.timeoutMs.unsignedIntValue;
+    request.networkID = [self asByteSpan:params.networkID];
+    request.breadcrumb = params.breadcrumb.unsignedLongLongValue;
+    request.timeoutMs = params.timeoutMs.unsignedIntValue;
 
     new CHIPNetworkCommissioningClusterEnableNetworkResponseCallbackBridge(
-        self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
             auto successFn = Callback<CHIPNetworkCommissioningClusterEnableNetworkResponseCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
-- (void)removeNetwork:(CHIPNetworkCommissioningClusterRemoveNetworkPayload * _Nonnull)payload
-      responseHandler:(ResponseHandler)responseHandler
+- (void)removeNetworkWithParams:(CHIPNetworkCommissioningClusterRemoveNetworkParams *)params
+              completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     NetworkCommissioning::Commands::RemoveNetwork::Type request;
-    request.networkID = [self asByteSpan:payload.networkID];
-    request.breadcrumb = payload.breadcrumb.unsignedLongLongValue;
-    request.timeoutMs = payload.timeoutMs.unsignedIntValue;
+    request.networkID = [self asByteSpan:params.networkID];
+    request.breadcrumb = params.breadcrumb.unsignedLongLongValue;
+    request.timeoutMs = params.timeoutMs.unsignedIntValue;
 
     new CHIPNetworkCommissioningClusterRemoveNetworkResponseCallbackBridge(
-        self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
             auto successFn = Callback<CHIPNetworkCommissioningClusterRemoveNetworkResponseCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
-- (void)scanNetworks:(CHIPNetworkCommissioningClusterScanNetworksPayload * _Nonnull)payload
-     responseHandler:(ResponseHandler)responseHandler
+- (void)scanNetworksWithParams:(CHIPNetworkCommissioningClusterScanNetworksParams *)params
+             completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     NetworkCommissioning::Commands::ScanNetworks::Type request;
-    request.ssid = [self asByteSpan:payload.ssid];
-    request.breadcrumb = payload.breadcrumb.unsignedLongLongValue;
-    request.timeoutMs = payload.timeoutMs.unsignedIntValue;
+    request.ssid = [self asByteSpan:params.ssid];
+    request.breadcrumb = params.breadcrumb.unsignedLongLongValue;
+    request.timeoutMs = params.timeoutMs.unsignedIntValue;
 
     new CHIPNetworkCommissioningClusterScanNetworksResponseCallbackBridge(
-        self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
             auto successFn = Callback<CHIPNetworkCommissioningClusterScanNetworksResponseCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
-- (void)updateThreadNetwork:(CHIPNetworkCommissioningClusterUpdateThreadNetworkPayload * _Nonnull)payload
-            responseHandler:(ResponseHandler)responseHandler
+- (void)updateThreadNetworkWithParams:(CHIPNetworkCommissioningClusterUpdateThreadNetworkParams *)params
+                    completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     NetworkCommissioning::Commands::UpdateThreadNetwork::Type request;
-    request.operationalDataset = [self asByteSpan:payload.operationalDataset];
-    request.breadcrumb = payload.breadcrumb.unsignedLongLongValue;
-    request.timeoutMs = payload.timeoutMs.unsignedIntValue;
+    request.operationalDataset = [self asByteSpan:params.operationalDataset];
+    request.breadcrumb = params.breadcrumb.unsignedLongLongValue;
+    request.timeoutMs = params.timeoutMs.unsignedIntValue;
 
     new CHIPNetworkCommissioningClusterUpdateThreadNetworkResponseCallbackBridge(
-        self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
             auto successFn
                 = Callback<CHIPNetworkCommissioningClusterUpdateThreadNetworkResponseCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
@@ -7604,18 +7609,18 @@ using namespace chip::app::Clusters;
         });
 }
 
-- (void)updateWiFiNetwork:(CHIPNetworkCommissioningClusterUpdateWiFiNetworkPayload * _Nonnull)payload
-          responseHandler:(ResponseHandler)responseHandler
+- (void)updateWiFiNetworkWithParams:(CHIPNetworkCommissioningClusterUpdateWiFiNetworkParams *)params
+                  completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     NetworkCommissioning::Commands::UpdateWiFiNetwork::Type request;
-    request.ssid = [self asByteSpan:payload.ssid];
-    request.credentials = [self asByteSpan:payload.credentials];
-    request.breadcrumb = payload.breadcrumb.unsignedLongLongValue;
-    request.timeoutMs = payload.timeoutMs.unsignedIntValue;
+    request.ssid = [self asByteSpan:params.ssid];
+    request.credentials = [self asByteSpan:params.credentials];
+    request.breadcrumb = params.breadcrumb.unsignedLongLongValue;
+    request.timeoutMs = params.timeoutMs.unsignedIntValue;
 
     new CHIPNetworkCommissioningClusterUpdateWiFiNetworkResponseCallbackBridge(
-        self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
             auto successFn
                 = Callback<CHIPNetworkCommissioningClusterUpdateWiFiNetworkResponseCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
@@ -7684,87 +7689,87 @@ using namespace chip::app::Clusters;
     return &_cppCluster;
 }
 
-- (void)applyUpdateRequest:(CHIPOtaSoftwareUpdateProviderClusterApplyUpdateRequestPayload * _Nonnull)payload
-           responseHandler:(ResponseHandler)responseHandler
+- (void)applyUpdateRequestWithParams:(CHIPOtaSoftwareUpdateProviderClusterApplyUpdateRequestParams *)params
+                   completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     OtaSoftwareUpdateProvider::Commands::ApplyUpdateRequest::Type request;
-    request.updateToken = [self asByteSpan:payload.updateToken];
-    request.newVersion = payload.newVersion.unsignedIntValue;
+    request.updateToken = [self asByteSpan:params.updateToken];
+    request.newVersion = params.newVersion.unsignedIntValue;
 
     new CHIPOtaSoftwareUpdateProviderClusterApplyUpdateResponseCallbackBridge(
-        self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
             auto successFn = Callback<CHIPOtaSoftwareUpdateProviderClusterApplyUpdateResponseCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
-- (void)notifyUpdateApplied:(CHIPOtaSoftwareUpdateProviderClusterNotifyUpdateAppliedPayload * _Nonnull)payload
-            responseHandler:(ResponseHandler)responseHandler
+- (void)notifyUpdateAppliedWithParams:(CHIPOtaSoftwareUpdateProviderClusterNotifyUpdateAppliedParams *)params
+                    completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     OtaSoftwareUpdateProvider::Commands::NotifyUpdateApplied::Type request;
-    request.updateToken = [self asByteSpan:payload.updateToken];
-    request.softwareVersion = payload.softwareVersion.unsignedIntValue;
+    request.updateToken = [self asByteSpan:params.updateToken];
+    request.softwareVersion = params.softwareVersion.unsignedIntValue;
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)queryImage:(CHIPOtaSoftwareUpdateProviderClusterQueryImagePayload * _Nonnull)payload
-    responseHandler:(ResponseHandler)responseHandler
+- (void)queryImageWithParams:(CHIPOtaSoftwareUpdateProviderClusterQueryImageParams *)params
+           completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     OtaSoftwareUpdateProvider::Commands::QueryImage::Type request;
-    request.vendorId = static_cast<std::remove_reference_t<decltype(request.vendorId)>>(payload.vendorId.unsignedShortValue);
-    request.productId = payload.productId.unsignedShortValue;
-    request.softwareVersion = payload.softwareVersion.unsignedIntValue;
+    request.vendorId = static_cast<std::remove_reference_t<decltype(request.vendorId)>>(params.vendorId.unsignedShortValue);
+    request.productId = params.productId.unsignedShortValue;
+    request.softwareVersion = params.softwareVersion.unsignedIntValue;
     {
         using ListType = std::remove_reference_t<decltype(request.protocolsSupported)>;
         using ListMemberType = ListMemberTypeGetter<ListType>::Type;
-        if (payload.protocolsSupported.count != 0) {
-            auto * listHolder_0 = new ListHolder<ListMemberType>(payload.protocolsSupported.count);
+        if (params.protocolsSupported.count != 0) {
+            auto * listHolder_0 = new ListHolder<ListMemberType>(params.protocolsSupported.count);
             if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
                 return;
             }
             listFreer.add(listHolder_0);
-            for (size_t i = 0; i < payload.protocolsSupported.count; ++i) {
-                if (![payload.protocolsSupported[i] isKindOfClass:[NSNumber class]]) {
+            for (size_t i = 0; i < params.protocolsSupported.count; ++i) {
+                if (![params.protocolsSupported[i] isKindOfClass:[NSNumber class]]) {
                     // Wrong kind of value.
                     return;
                 }
-                auto element_0 = (NSNumber *) payload.protocolsSupported[i];
+                auto element_0 = (NSNumber *) params.protocolsSupported[i];
                 listHolder_0->mList[i]
                     = static_cast<std::remove_reference_t<decltype(listHolder_0->mList[i])>>(element_0.unsignedCharValue);
             }
-            request.protocolsSupported = ListType(listHolder_0->mList, payload.protocolsSupported.count);
+            request.protocolsSupported = ListType(listHolder_0->mList, params.protocolsSupported.count);
         } else {
             request.protocolsSupported = ListType();
         }
     }
-    if (payload.hardwareVersion != nil) {
+    if (params.hardwareVersion != nil) {
         auto & definedValue_0 = request.hardwareVersion.Emplace();
-        definedValue_0 = payload.hardwareVersion.unsignedShortValue;
+        definedValue_0 = params.hardwareVersion.unsignedShortValue;
     }
-    if (payload.location != nil) {
+    if (params.location != nil) {
         auto & definedValue_0 = request.location.Emplace();
-        definedValue_0 = [self asCharSpan:payload.location];
+        definedValue_0 = [self asCharSpan:params.location];
     }
-    if (payload.requestorCanConsent != nil) {
+    if (params.requestorCanConsent != nil) {
         auto & definedValue_0 = request.requestorCanConsent.Emplace();
-        definedValue_0 = payload.requestorCanConsent.boolValue;
+        definedValue_0 = params.requestorCanConsent.boolValue;
     }
-    if (payload.metadataForProvider != nil) {
+    if (params.metadataForProvider != nil) {
         auto & definedValue_0 = request.metadataForProvider.Emplace();
-        definedValue_0 = [self asByteSpan:payload.metadataForProvider];
+        definedValue_0 = [self asByteSpan:params.metadataForProvider];
     }
 
     new CHIPOtaSoftwareUpdateProviderClusterQueryImageResponseCallbackBridge(
-        self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
             auto successFn = Callback<CHIPOtaSoftwareUpdateProviderClusterQueryImageResponseCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
@@ -7806,21 +7811,21 @@ using namespace chip::app::Clusters;
     return &_cppCluster;
 }
 
-- (void)announceOtaProvider:(CHIPOtaSoftwareUpdateRequestorClusterAnnounceOtaProviderPayload * _Nonnull)payload
-            responseHandler:(ResponseHandler)responseHandler
+- (void)announceOtaProviderWithParams:(CHIPOtaSoftwareUpdateRequestorClusterAnnounceOtaProviderParams *)params
+                    completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     OtaSoftwareUpdateRequestor::Commands::AnnounceOtaProvider::Type request;
-    request.providerLocation = payload.providerLocation.unsignedLongLongValue;
-    request.vendorId = static_cast<std::remove_reference_t<decltype(request.vendorId)>>(payload.vendorId.unsignedShortValue);
+    request.providerLocation = params.providerLocation.unsignedLongLongValue;
+    request.vendorId = static_cast<std::remove_reference_t<decltype(request.vendorId)>>(params.vendorId.unsignedShortValue);
     request.announcementReason
-        = static_cast<std::remove_reference_t<decltype(request.announcementReason)>>(payload.announcementReason.unsignedCharValue);
-    if (payload.metadataForNode != nil) {
+        = static_cast<std::remove_reference_t<decltype(request.announcementReason)>>(params.announcementReason.unsignedCharValue);
+    if (params.metadataForNode != nil) {
         auto & definedValue_0 = request.metadataForNode.Emplace();
-        definedValue_0 = [self asByteSpan:payload.metadataForNode];
+        definedValue_0 = [self asByteSpan:params.metadataForNode];
     }
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
@@ -8040,80 +8045,80 @@ using namespace chip::app::Clusters;
     return &_cppCluster;
 }
 
-- (void)off:(CHIPOnOffClusterOffPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler
+- (void)offWithCompletionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     OnOff::Commands::Off::Type request;
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)offWithEffect:(CHIPOnOffClusterOffWithEffectPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler
+- (void)offWithEffectWithParams:(CHIPOnOffClusterOffWithEffectParams *)params completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     OnOff::Commands::OffWithEffect::Type request;
-    request.effectId = static_cast<std::remove_reference_t<decltype(request.effectId)>>(payload.effectId.unsignedCharValue);
+    request.effectId = static_cast<std::remove_reference_t<decltype(request.effectId)>>(params.effectId.unsignedCharValue);
     request.effectVariant
-        = static_cast<std::remove_reference_t<decltype(request.effectVariant)>>(payload.effectVariant.unsignedCharValue);
+        = static_cast<std::remove_reference_t<decltype(request.effectVariant)>>(params.effectVariant.unsignedCharValue);
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)on:(CHIPOnOffClusterOnPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler
+- (void)onWithCompletionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     OnOff::Commands::On::Type request;
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)onWithRecallGlobalScene:(CHIPOnOffClusterOnWithRecallGlobalScenePayload * _Nonnull)payload
-                responseHandler:(ResponseHandler)responseHandler
+- (void)onWithRecallGlobalSceneWithCompletionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     OnOff::Commands::OnWithRecallGlobalScene::Type request;
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)onWithTimedOff:(CHIPOnOffClusterOnWithTimedOffPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler
+- (void)onWithTimedOffWithParams:(CHIPOnOffClusterOnWithTimedOffParams *)params
+               completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     OnOff::Commands::OnWithTimedOff::Type request;
     request.onOffControl
-        = static_cast<std::remove_reference_t<decltype(request.onOffControl)>>(payload.onOffControl.unsignedCharValue);
-    request.onTime = payload.onTime.unsignedShortValue;
-    request.offWaitTime = payload.offWaitTime.unsignedShortValue;
+        = static_cast<std::remove_reference_t<decltype(request.onOffControl)>>(params.onOffControl.unsignedCharValue);
+    request.onTime = params.onTime.unsignedShortValue;
+    request.offWaitTime = params.offWaitTime.unsignedShortValue;
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)toggle:(CHIPOnOffClusterTogglePayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler
+- (void)toggleWithCompletionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     OnOff::Commands::Toggle::Type request;
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
@@ -8450,65 +8455,66 @@ using namespace chip::app::Clusters;
     return &_cppCluster;
 }
 
-- (void)addNOC:(CHIPOperationalCredentialsClusterAddNOCPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler
+- (void)addNOCWithParams:(CHIPOperationalCredentialsClusterAddNOCParams *)params
+       completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     OperationalCredentials::Commands::AddNOC::Type request;
-    request.NOCValue = [self asByteSpan:payload.nocValue];
-    if (payload.icacValue != nil) {
+    request.NOCValue = [self asByteSpan:params.nocValue];
+    if (params.icacValue != nil) {
         auto & definedValue_0 = request.ICACValue.Emplace();
-        definedValue_0 = [self asByteSpan:payload.icacValue];
+        definedValue_0 = [self asByteSpan:params.icacValue];
     }
-    request.IPKValue = [self asByteSpan:payload.ipkValue];
-    request.caseAdminNode = payload.caseAdminNode.unsignedLongLongValue;
-    request.adminVendorId = payload.adminVendorId.unsignedShortValue;
+    request.IPKValue = [self asByteSpan:params.ipkValue];
+    request.caseAdminNode = params.caseAdminNode.unsignedLongLongValue;
+    request.adminVendorId = params.adminVendorId.unsignedShortValue;
 
     new CHIPOperationalCredentialsClusterNOCResponseCallbackBridge(
-        self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
             auto successFn = Callback<CHIPOperationalCredentialsClusterNOCResponseCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
-- (void)addTrustedRootCertificate:(CHIPOperationalCredentialsClusterAddTrustedRootCertificatePayload * _Nonnull)payload
-                  responseHandler:(ResponseHandler)responseHandler
+- (void)addTrustedRootCertificateWithParams:(CHIPOperationalCredentialsClusterAddTrustedRootCertificateParams *)params
+                          completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     OperationalCredentials::Commands::AddTrustedRootCertificate::Type request;
-    request.rootCertificate = [self asByteSpan:payload.rootCertificate];
+    request.rootCertificate = [self asByteSpan:params.rootCertificate];
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)attestationRequest:(CHIPOperationalCredentialsClusterAttestationRequestPayload * _Nonnull)payload
-           responseHandler:(ResponseHandler)responseHandler
+- (void)attestationRequestWithParams:(CHIPOperationalCredentialsClusterAttestationRequestParams *)params
+                   completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     OperationalCredentials::Commands::AttestationRequest::Type request;
-    request.attestationNonce = [self asByteSpan:payload.attestationNonce];
+    request.attestationNonce = [self asByteSpan:params.attestationNonce];
 
     new CHIPOperationalCredentialsClusterAttestationResponseCallbackBridge(
-        self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
             auto successFn = Callback<CHIPOperationalCredentialsClusterAttestationResponseCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
-- (void)certificateChainRequest:(CHIPOperationalCredentialsClusterCertificateChainRequestPayload * _Nonnull)payload
-                responseHandler:(ResponseHandler)responseHandler
+- (void)certificateChainRequestWithParams:(CHIPOperationalCredentialsClusterCertificateChainRequestParams *)params
+                        completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     OperationalCredentials::Commands::CertificateChainRequest::Type request;
-    request.certificateType = payload.certificateType.unsignedCharValue;
+    request.certificateType = params.certificateType.unsignedCharValue;
 
     new CHIPOperationalCredentialsClusterCertificateChainResponseCallbackBridge(
-        self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
             auto successFn
                 = Callback<CHIPOperationalCredentialsClusterCertificateChainResponseCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
@@ -8516,78 +8522,78 @@ using namespace chip::app::Clusters;
         });
 }
 
-- (void)opCSRRequest:(CHIPOperationalCredentialsClusterOpCSRRequestPayload * _Nonnull)payload
-     responseHandler:(ResponseHandler)responseHandler
+- (void)opCSRRequestWithParams:(CHIPOperationalCredentialsClusterOpCSRRequestParams *)params
+             completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     OperationalCredentials::Commands::OpCSRRequest::Type request;
-    request.CSRNonce = [self asByteSpan:payload.csrNonce];
+    request.CSRNonce = [self asByteSpan:params.csrNonce];
 
     new CHIPOperationalCredentialsClusterOpCSRResponseCallbackBridge(
-        self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
             auto successFn = Callback<CHIPOperationalCredentialsClusterOpCSRResponseCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
-- (void)removeFabric:(CHIPOperationalCredentialsClusterRemoveFabricPayload * _Nonnull)payload
-     responseHandler:(ResponseHandler)responseHandler
+- (void)removeFabricWithParams:(CHIPOperationalCredentialsClusterRemoveFabricParams *)params
+             completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     OperationalCredentials::Commands::RemoveFabric::Type request;
-    request.fabricIndex = payload.fabricIndex.unsignedCharValue;
+    request.fabricIndex = params.fabricIndex.unsignedCharValue;
 
     new CHIPOperationalCredentialsClusterNOCResponseCallbackBridge(
-        self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
             auto successFn = Callback<CHIPOperationalCredentialsClusterNOCResponseCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
-- (void)removeTrustedRootCertificate:(CHIPOperationalCredentialsClusterRemoveTrustedRootCertificatePayload * _Nonnull)payload
-                     responseHandler:(ResponseHandler)responseHandler
+- (void)removeTrustedRootCertificateWithParams:(CHIPOperationalCredentialsClusterRemoveTrustedRootCertificateParams *)params
+                             completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     OperationalCredentials::Commands::RemoveTrustedRootCertificate::Type request;
-    request.trustedRootIdentifier = [self asByteSpan:payload.trustedRootIdentifier];
+    request.trustedRootIdentifier = [self asByteSpan:params.trustedRootIdentifier];
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)updateFabricLabel:(CHIPOperationalCredentialsClusterUpdateFabricLabelPayload * _Nonnull)payload
-          responseHandler:(ResponseHandler)responseHandler
+- (void)updateFabricLabelWithParams:(CHIPOperationalCredentialsClusterUpdateFabricLabelParams *)params
+                  completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     OperationalCredentials::Commands::UpdateFabricLabel::Type request;
-    request.label = [self asCharSpan:payload.label];
+    request.label = [self asCharSpan:params.label];
 
     new CHIPOperationalCredentialsClusterNOCResponseCallbackBridge(
-        self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
             auto successFn = Callback<CHIPOperationalCredentialsClusterNOCResponseCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
-- (void)updateNOC:(CHIPOperationalCredentialsClusterUpdateNOCPayload * _Nonnull)payload
-    responseHandler:(ResponseHandler)responseHandler
+- (void)updateNOCWithParams:(CHIPOperationalCredentialsClusterUpdateNOCParams *)params
+          completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     OperationalCredentials::Commands::UpdateNOC::Type request;
-    request.NOCValue = [self asByteSpan:payload.nocValue];
-    if (payload.icacValue != nil) {
+    request.NOCValue = [self asByteSpan:params.nocValue];
+    if (params.icacValue != nil) {
         auto & definedValue_0 = request.ICACValue.Emplace();
-        definedValue_0 = [self asByteSpan:payload.icacValue];
+        definedValue_0 = [self asByteSpan:params.icacValue];
     }
 
     new CHIPOperationalCredentialsClusterNOCResponseCallbackBridge(
-        self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
             auto successFn = Callback<CHIPOperationalCredentialsClusterNOCResponseCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
@@ -9911,130 +9917,131 @@ using namespace chip::app::Clusters;
     return &_cppCluster;
 }
 
-- (void)addScene:(CHIPScenesClusterAddScenePayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler
+- (void)addSceneWithParams:(CHIPScenesClusterAddSceneParams *)params completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     Scenes::Commands::AddScene::Type request;
-    request.groupId = payload.groupId.unsignedShortValue;
-    request.sceneId = payload.sceneId.unsignedCharValue;
-    request.transitionTime = payload.transitionTime.unsignedShortValue;
-    request.sceneName = [self asCharSpan:payload.sceneName];
+    request.groupId = params.groupId.unsignedShortValue;
+    request.sceneId = params.sceneId.unsignedCharValue;
+    request.transitionTime = params.transitionTime.unsignedShortValue;
+    request.sceneName = [self asCharSpan:params.sceneName];
     {
         using ListType = std::remove_reference_t<decltype(request.extensionFieldSets)>;
         using ListMemberType = ListMemberTypeGetter<ListType>::Type;
-        if (payload.extensionFieldSets.count != 0) {
-            auto * listHolder_0 = new ListHolder<ListMemberType>(payload.extensionFieldSets.count);
+        if (params.extensionFieldSets.count != 0) {
+            auto * listHolder_0 = new ListHolder<ListMemberType>(params.extensionFieldSets.count);
             if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
                 return;
             }
             listFreer.add(listHolder_0);
-            for (size_t i = 0; i < payload.extensionFieldSets.count; ++i) {
-                if (![payload.extensionFieldSets[i] isKindOfClass:[CHIPScenesClusterSceneExtensionFieldSet class]]) {
+            for (size_t i = 0; i < params.extensionFieldSets.count; ++i) {
+                if (![params.extensionFieldSets[i] isKindOfClass:[CHIPScenesClusterSceneExtensionFieldSet class]]) {
                     // Wrong kind of value.
                     return;
                 }
-                auto element_0 = (CHIPScenesClusterSceneExtensionFieldSet *) payload.extensionFieldSets[i];
+                auto element_0 = (CHIPScenesClusterSceneExtensionFieldSet *) params.extensionFieldSets[i];
                 listHolder_0->mList[i].clusterId = element_0.clusterId.unsignedIntValue;
                 listHolder_0->mList[i].length = element_0.length.unsignedCharValue;
                 listHolder_0->mList[i].value = element_0.value.unsignedCharValue;
             }
-            request.extensionFieldSets = ListType(listHolder_0->mList, payload.extensionFieldSets.count);
+            request.extensionFieldSets = ListType(listHolder_0->mList, params.extensionFieldSets.count);
         } else {
             request.extensionFieldSets = ListType();
         }
     }
 
     new CHIPScenesClusterAddSceneResponseCallbackBridge(
-        self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
             auto successFn = Callback<CHIPScenesClusterAddSceneResponseCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
-- (void)getSceneMembership:(CHIPScenesClusterGetSceneMembershipPayload * _Nonnull)payload
-           responseHandler:(ResponseHandler)responseHandler
+- (void)getSceneMembershipWithParams:(CHIPScenesClusterGetSceneMembershipParams *)params
+                   completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     Scenes::Commands::GetSceneMembership::Type request;
-    request.groupId = payload.groupId.unsignedShortValue;
+    request.groupId = params.groupId.unsignedShortValue;
 
     new CHIPScenesClusterGetSceneMembershipResponseCallbackBridge(
-        self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
             auto successFn = Callback<CHIPScenesClusterGetSceneMembershipResponseCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
-- (void)recallScene:(CHIPScenesClusterRecallScenePayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler
+- (void)recallSceneWithParams:(CHIPScenesClusterRecallSceneParams *)params completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     Scenes::Commands::RecallScene::Type request;
-    request.groupId = payload.groupId.unsignedShortValue;
-    request.sceneId = payload.sceneId.unsignedCharValue;
-    request.transitionTime = payload.transitionTime.unsignedShortValue;
+    request.groupId = params.groupId.unsignedShortValue;
+    request.sceneId = params.sceneId.unsignedCharValue;
+    request.transitionTime = params.transitionTime.unsignedShortValue;
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)removeAllScenes:(CHIPScenesClusterRemoveAllScenesPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler
+- (void)removeAllScenesWithParams:(CHIPScenesClusterRemoveAllScenesParams *)params
+                completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     Scenes::Commands::RemoveAllScenes::Type request;
-    request.groupId = payload.groupId.unsignedShortValue;
+    request.groupId = params.groupId.unsignedShortValue;
 
     new CHIPScenesClusterRemoveAllScenesResponseCallbackBridge(
-        self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
             auto successFn = Callback<CHIPScenesClusterRemoveAllScenesResponseCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
-- (void)removeScene:(CHIPScenesClusterRemoveScenePayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler
+- (void)removeSceneWithParams:(CHIPScenesClusterRemoveSceneParams *)params completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     Scenes::Commands::RemoveScene::Type request;
-    request.groupId = payload.groupId.unsignedShortValue;
-    request.sceneId = payload.sceneId.unsignedCharValue;
+    request.groupId = params.groupId.unsignedShortValue;
+    request.sceneId = params.sceneId.unsignedCharValue;
 
     new CHIPScenesClusterRemoveSceneResponseCallbackBridge(
-        self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
             auto successFn = Callback<CHIPScenesClusterRemoveSceneResponseCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
-- (void)storeScene:(CHIPScenesClusterStoreScenePayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler
+- (void)storeSceneWithParams:(CHIPScenesClusterStoreSceneParams *)params completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     Scenes::Commands::StoreScene::Type request;
-    request.groupId = payload.groupId.unsignedShortValue;
-    request.sceneId = payload.sceneId.unsignedCharValue;
+    request.groupId = params.groupId.unsignedShortValue;
+    request.sceneId = params.sceneId.unsignedCharValue;
 
     new CHIPScenesClusterStoreSceneResponseCallbackBridge(
-        self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
             auto successFn = Callback<CHIPScenesClusterStoreSceneResponseCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
-- (void)viewScene:(CHIPScenesClusterViewScenePayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler
+- (void)viewSceneWithParams:(CHIPScenesClusterViewSceneParams *)params completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     Scenes::Commands::ViewScene::Type request;
-    request.groupId = payload.groupId.unsignedShortValue;
-    request.sceneId = payload.sceneId.unsignedCharValue;
+    request.groupId = params.groupId.unsignedShortValue;
+    request.sceneId = params.sceneId.unsignedCharValue;
 
     new CHIPScenesClusterViewSceneResponseCallbackBridge(
-        self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
             auto successFn = Callback<CHIPScenesClusterViewSceneResponseCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
@@ -10206,13 +10213,12 @@ using namespace chip::app::Clusters;
     return &_cppCluster;
 }
 
-- (void)resetWatermarks:(CHIPSoftwareDiagnosticsClusterResetWatermarksPayload * _Nonnull)payload
-        responseHandler:(ResponseHandler)responseHandler
+- (void)resetWatermarksWithCompletionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     SoftwareDiagnostics::Commands::ResetWatermarks::Type request;
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
@@ -10479,42 +10485,43 @@ using namespace chip::app::Clusters;
     return &_cppCluster;
 }
 
-- (void)changeChannel:(CHIPTvChannelClusterChangeChannelPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler
+- (void)changeChannelWithParams:(CHIPTvChannelClusterChangeChannelParams *)params
+              completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     TvChannel::Commands::ChangeChannel::Type request;
-    request.match = [self asCharSpan:payload.match];
+    request.match = [self asCharSpan:params.match];
 
     new CHIPTvChannelClusterChangeChannelResponseCallbackBridge(
-        self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
             auto successFn = Callback<CHIPTvChannelClusterChangeChannelResponseCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
-- (void)changeChannelByNumber:(CHIPTvChannelClusterChangeChannelByNumberPayload * _Nonnull)payload
-              responseHandler:(ResponseHandler)responseHandler
+- (void)changeChannelByNumberWithParams:(CHIPTvChannelClusterChangeChannelByNumberParams *)params
+                      completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     TvChannel::Commands::ChangeChannelByNumber::Type request;
-    request.majorNumber = payload.majorNumber.unsignedShortValue;
-    request.minorNumber = payload.minorNumber.unsignedShortValue;
+    request.majorNumber = params.majorNumber.unsignedShortValue;
+    request.minorNumber = params.minorNumber.unsignedShortValue;
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)skipChannel:(CHIPTvChannelClusterSkipChannelPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler
+- (void)skipChannelWithParams:(CHIPTvChannelClusterSkipChannelParams *)params completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     TvChannel::Commands::SkipChannel::Type request;
-    request.count = payload.count.unsignedShortValue;
+    request.count = params.count.unsignedShortValue;
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
@@ -10616,16 +10623,16 @@ using namespace chip::app::Clusters;
     return &_cppCluster;
 }
 
-- (void)navigateTarget:(CHIPTargetNavigatorClusterNavigateTargetPayload * _Nonnull)payload
-       responseHandler:(ResponseHandler)responseHandler
+- (void)navigateTargetWithParams:(CHIPTargetNavigatorClusterNavigateTargetParams *)params
+               completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     TargetNavigator::Commands::NavigateTarget::Type request;
-    request.target = payload.target.unsignedCharValue;
-    request.data = [self asCharSpan:payload.data];
+    request.target = params.target.unsignedCharValue;
+    request.data = [self asCharSpan:params.data];
 
     new CHIPTargetNavigatorClusterNavigateTargetResponseCallbackBridge(
-        self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
             auto successFn = Callback<CHIPTargetNavigatorClusterNavigateTargetResponseCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
@@ -10814,142 +10821,142 @@ using namespace chip::app::Clusters;
     return &_cppCluster;
 }
 
-- (void)test:(CHIPTestClusterClusterTestPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler
+- (void)testWithCompletionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     TestCluster::Commands::Test::Type request;
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)testAddArguments:(CHIPTestClusterClusterTestAddArgumentsPayload * _Nonnull)payload
-         responseHandler:(ResponseHandler)responseHandler
+- (void)testAddArgumentsWithParams:(CHIPTestClusterClusterTestAddArgumentsParams *)params
+                 completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     TestCluster::Commands::TestAddArguments::Type request;
-    request.arg1 = payload.arg1.unsignedCharValue;
-    request.arg2 = payload.arg2.unsignedCharValue;
+    request.arg1 = params.arg1.unsignedCharValue;
+    request.arg2 = params.arg2.unsignedCharValue;
 
     new CHIPTestClusterClusterTestAddArgumentsResponseCallbackBridge(
-        self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
             auto successFn = Callback<CHIPTestClusterClusterTestAddArgumentsResponseCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
-- (void)testEnumsRequest:(CHIPTestClusterClusterTestEnumsRequestPayload * _Nonnull)payload
-         responseHandler:(ResponseHandler)responseHandler
+- (void)testEnumsRequestWithParams:(CHIPTestClusterClusterTestEnumsRequestParams *)params
+                 completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     TestCluster::Commands::TestEnumsRequest::Type request;
-    request.arg1 = static_cast<std::remove_reference_t<decltype(request.arg1)>>(payload.arg1.unsignedShortValue);
-    request.arg2 = static_cast<std::remove_reference_t<decltype(request.arg2)>>(payload.arg2.unsignedCharValue);
+    request.arg1 = static_cast<std::remove_reference_t<decltype(request.arg1)>>(params.arg1.unsignedShortValue);
+    request.arg2 = static_cast<std::remove_reference_t<decltype(request.arg2)>>(params.arg2.unsignedCharValue);
 
     new CHIPTestClusterClusterTestEnumsResponseCallbackBridge(
-        self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
             auto successFn = Callback<CHIPTestClusterClusterTestEnumsResponseCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
-- (void)testListInt8UArgumentRequest:(CHIPTestClusterClusterTestListInt8UArgumentRequestPayload * _Nonnull)payload
-                     responseHandler:(ResponseHandler)responseHandler
+- (void)testListInt8UArgumentRequestWithParams:(CHIPTestClusterClusterTestListInt8UArgumentRequestParams *)params
+                             completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     TestCluster::Commands::TestListInt8UArgumentRequest::Type request;
     {
         using ListType = std::remove_reference_t<decltype(request.arg1)>;
         using ListMemberType = ListMemberTypeGetter<ListType>::Type;
-        if (payload.arg1.count != 0) {
-            auto * listHolder_0 = new ListHolder<ListMemberType>(payload.arg1.count);
+        if (params.arg1.count != 0) {
+            auto * listHolder_0 = new ListHolder<ListMemberType>(params.arg1.count);
             if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
                 return;
             }
             listFreer.add(listHolder_0);
-            for (size_t i = 0; i < payload.arg1.count; ++i) {
-                if (![payload.arg1[i] isKindOfClass:[NSNumber class]]) {
+            for (size_t i = 0; i < params.arg1.count; ++i) {
+                if (![params.arg1[i] isKindOfClass:[NSNumber class]]) {
                     // Wrong kind of value.
                     return;
                 }
-                auto element_0 = (NSNumber *) payload.arg1[i];
+                auto element_0 = (NSNumber *) params.arg1[i];
                 listHolder_0->mList[i] = element_0.unsignedCharValue;
             }
-            request.arg1 = ListType(listHolder_0->mList, payload.arg1.count);
+            request.arg1 = ListType(listHolder_0->mList, params.arg1.count);
         } else {
             request.arg1 = ListType();
         }
     }
 
     new CHIPTestClusterClusterBooleanResponseCallbackBridge(
-        self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
             auto successFn = Callback<CHIPTestClusterClusterBooleanResponseCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
-- (void)testListInt8UReverseRequest:(CHIPTestClusterClusterTestListInt8UReverseRequestPayload * _Nonnull)payload
-                    responseHandler:(ResponseHandler)responseHandler
+- (void)testListInt8UReverseRequestWithParams:(CHIPTestClusterClusterTestListInt8UReverseRequestParams *)params
+                            completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     TestCluster::Commands::TestListInt8UReverseRequest::Type request;
     {
         using ListType = std::remove_reference_t<decltype(request.arg1)>;
         using ListMemberType = ListMemberTypeGetter<ListType>::Type;
-        if (payload.arg1.count != 0) {
-            auto * listHolder_0 = new ListHolder<ListMemberType>(payload.arg1.count);
+        if (params.arg1.count != 0) {
+            auto * listHolder_0 = new ListHolder<ListMemberType>(params.arg1.count);
             if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
                 return;
             }
             listFreer.add(listHolder_0);
-            for (size_t i = 0; i < payload.arg1.count; ++i) {
-                if (![payload.arg1[i] isKindOfClass:[NSNumber class]]) {
+            for (size_t i = 0; i < params.arg1.count; ++i) {
+                if (![params.arg1[i] isKindOfClass:[NSNumber class]]) {
                     // Wrong kind of value.
                     return;
                 }
-                auto element_0 = (NSNumber *) payload.arg1[i];
+                auto element_0 = (NSNumber *) params.arg1[i];
                 listHolder_0->mList[i] = element_0.unsignedCharValue;
             }
-            request.arg1 = ListType(listHolder_0->mList, payload.arg1.count);
+            request.arg1 = ListType(listHolder_0->mList, params.arg1.count);
         } else {
             request.arg1 = ListType();
         }
     }
 
     new CHIPTestClusterClusterTestListInt8UReverseResponseCallbackBridge(
-        self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
             auto successFn = Callback<CHIPTestClusterClusterTestListInt8UReverseResponseCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
-- (void)testListStructArgumentRequest:(CHIPTestClusterClusterTestListStructArgumentRequestPayload * _Nonnull)payload
-                      responseHandler:(ResponseHandler)responseHandler
+- (void)testListStructArgumentRequestWithParams:(CHIPTestClusterClusterTestListStructArgumentRequestParams *)params
+                              completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     TestCluster::Commands::TestListStructArgumentRequest::Type request;
     {
         using ListType = std::remove_reference_t<decltype(request.arg1)>;
         using ListMemberType = ListMemberTypeGetter<ListType>::Type;
-        if (payload.arg1.count != 0) {
-            auto * listHolder_0 = new ListHolder<ListMemberType>(payload.arg1.count);
+        if (params.arg1.count != 0) {
+            auto * listHolder_0 = new ListHolder<ListMemberType>(params.arg1.count);
             if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
                 return;
             }
             listFreer.add(listHolder_0);
-            for (size_t i = 0; i < payload.arg1.count; ++i) {
-                if (![payload.arg1[i] isKindOfClass:[CHIPTestClusterClusterSimpleStruct class]]) {
+            for (size_t i = 0; i < params.arg1.count; ++i) {
+                if (![params.arg1[i] isKindOfClass:[CHIPTestClusterClusterSimpleStruct class]]) {
                     // Wrong kind of value.
                     return;
                 }
-                auto element_0 = (CHIPTestClusterClusterSimpleStruct *) payload.arg1[i];
+                auto element_0 = (CHIPTestClusterClusterSimpleStruct *) params.arg1[i];
                 listHolder_0->mList[i].a = element_0.a.unsignedCharValue;
                 listHolder_0->mList[i].b = element_0.b.boolValue;
                 listHolder_0->mList[i].c
@@ -10959,96 +10966,96 @@ using namespace chip::app::Clusters;
                 listHolder_0->mList[i].f
                     = static_cast<std::remove_reference_t<decltype(listHolder_0->mList[i].f)>>(element_0.f.unsignedCharValue);
             }
-            request.arg1 = ListType(listHolder_0->mList, payload.arg1.count);
+            request.arg1 = ListType(listHolder_0->mList, params.arg1.count);
         } else {
             request.arg1 = ListType();
         }
     }
 
     new CHIPTestClusterClusterBooleanResponseCallbackBridge(
-        self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
             auto successFn = Callback<CHIPTestClusterClusterBooleanResponseCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
-- (void)testNotHandled:(CHIPTestClusterClusterTestNotHandledPayload * _Nonnull)payload
-       responseHandler:(ResponseHandler)responseHandler
+- (void)testNotHandledWithCompletionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     TestCluster::Commands::TestNotHandled::Type request;
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)testNullableOptionalRequest:(CHIPTestClusterClusterTestNullableOptionalRequestPayload * _Nonnull)payload
-                    responseHandler:(ResponseHandler)responseHandler
+- (void)testNullableOptionalRequestWithParams:(CHIPTestClusterClusterTestNullableOptionalRequestParams * _Nullable)params
+                            completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     TestCluster::Commands::TestNullableOptionalRequest::Type request;
-    if (payload.arg1 != nil) {
-        auto & definedValue_0 = request.arg1.Emplace();
-        if (payload.arg1 == nil) {
-            definedValue_0.SetNull();
-        } else {
-            auto & nonNullValue_1 = definedValue_0.SetNonNull();
-            nonNullValue_1 = payload.arg1.unsignedCharValue;
+    if (params != nil) {
+        if (params.arg1 != nil) {
+            auto & definedValue_0 = request.arg1.Emplace();
+            if (params.arg1 == nil) {
+                definedValue_0.SetNull();
+            } else {
+                auto & nonNullValue_1 = definedValue_0.SetNonNull();
+                nonNullValue_1 = params.arg1.unsignedCharValue;
+            }
         }
     }
 
     new CHIPTestClusterClusterTestNullableOptionalResponseCallbackBridge(
-        self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
             auto successFn = Callback<CHIPTestClusterClusterTestNullableOptionalResponseCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
-- (void)testSpecific:(CHIPTestClusterClusterTestSpecificPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler
+- (void)testSpecificWithCompletionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     TestCluster::Commands::TestSpecific::Type request;
 
     new CHIPTestClusterClusterTestSpecificResponseCallbackBridge(
-        self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
             auto successFn = Callback<CHIPTestClusterClusterTestSpecificResponseCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
-- (void)testStructArgumentRequest:(CHIPTestClusterClusterTestStructArgumentRequestPayload * _Nonnull)payload
-                  responseHandler:(ResponseHandler)responseHandler
+- (void)testStructArgumentRequestWithParams:(CHIPTestClusterClusterTestStructArgumentRequestParams *)params
+                          completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     TestCluster::Commands::TestStructArgumentRequest::Type request;
-    request.arg1.a = payload.arg1.a.unsignedCharValue;
-    request.arg1.b = payload.arg1.b.boolValue;
-    request.arg1.c = static_cast<std::remove_reference_t<decltype(request.arg1.c)>>(payload.arg1.c.unsignedCharValue);
-    request.arg1.d = [self asByteSpan:payload.arg1.d];
-    request.arg1.e = [self asCharSpan:payload.arg1.e];
-    request.arg1.f = static_cast<std::remove_reference_t<decltype(request.arg1.f)>>(payload.arg1.f.unsignedCharValue);
+    request.arg1.a = params.arg1.a.unsignedCharValue;
+    request.arg1.b = params.arg1.b.boolValue;
+    request.arg1.c = static_cast<std::remove_reference_t<decltype(request.arg1.c)>>(params.arg1.c.unsignedCharValue);
+    request.arg1.d = [self asByteSpan:params.arg1.d];
+    request.arg1.e = [self asCharSpan:params.arg1.e];
+    request.arg1.f = static_cast<std::remove_reference_t<decltype(request.arg1.f)>>(params.arg1.f.unsignedCharValue);
 
     new CHIPTestClusterClusterBooleanResponseCallbackBridge(
-        self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+        self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
             auto successFn = Callback<CHIPTestClusterClusterBooleanResponseCallbackType>::FromCancelable(success);
             auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
             return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
         });
 }
 
-- (void)testUnknownCommand:(CHIPTestClusterClusterTestUnknownCommandPayload * _Nonnull)payload
-           responseHandler:(ResponseHandler)responseHandler
+- (void)testUnknownCommandWithCompletionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     TestCluster::Commands::TestUnknownCommand::Type request;
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
@@ -12870,98 +12877,96 @@ using namespace chip::app::Clusters;
     return &_cppCluster;
 }
 
-- (void)clearWeeklySchedule:(CHIPThermostatClusterClearWeeklySchedulePayload * _Nonnull)payload
-            responseHandler:(ResponseHandler)responseHandler
+- (void)clearWeeklyScheduleWithCompletionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     Thermostat::Commands::ClearWeeklySchedule::Type request;
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)getRelayStatusLog:(CHIPThermostatClusterGetRelayStatusLogPayload * _Nonnull)payload
-          responseHandler:(ResponseHandler)responseHandler
+- (void)getRelayStatusLogWithCompletionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     Thermostat::Commands::GetRelayStatusLog::Type request;
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)getWeeklySchedule:(CHIPThermostatClusterGetWeeklySchedulePayload * _Nonnull)payload
-          responseHandler:(ResponseHandler)responseHandler
+- (void)getWeeklyScheduleWithParams:(CHIPThermostatClusterGetWeeklyScheduleParams *)params
+                  completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     Thermostat::Commands::GetWeeklySchedule::Type request;
     request.daysToReturn
-        = static_cast<std::remove_reference_t<decltype(request.daysToReturn)>>(payload.daysToReturn.unsignedCharValue);
+        = static_cast<std::remove_reference_t<decltype(request.daysToReturn)>>(params.daysToReturn.unsignedCharValue);
     request.modeToReturn
-        = static_cast<std::remove_reference_t<decltype(request.modeToReturn)>>(payload.modeToReturn.unsignedCharValue);
+        = static_cast<std::remove_reference_t<decltype(request.modeToReturn)>>(params.modeToReturn.unsignedCharValue);
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)setWeeklySchedule:(CHIPThermostatClusterSetWeeklySchedulePayload * _Nonnull)payload
-          responseHandler:(ResponseHandler)responseHandler
+- (void)setWeeklyScheduleWithParams:(CHIPThermostatClusterSetWeeklyScheduleParams *)params
+                  completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     Thermostat::Commands::SetWeeklySchedule::Type request;
-    request.numberOfTransitionsForSequence = payload.numberOfTransitionsForSequence.unsignedCharValue;
+    request.numberOfTransitionsForSequence = params.numberOfTransitionsForSequence.unsignedCharValue;
     request.dayOfWeekForSequence = static_cast<std::remove_reference_t<decltype(request.dayOfWeekForSequence)>>(
-        payload.dayOfWeekForSequence.unsignedCharValue);
+        params.dayOfWeekForSequence.unsignedCharValue);
     request.modeForSequence
-        = static_cast<std::remove_reference_t<decltype(request.modeForSequence)>>(payload.modeForSequence.unsignedCharValue);
+        = static_cast<std::remove_reference_t<decltype(request.modeForSequence)>>(params.modeForSequence.unsignedCharValue);
     {
         using ListType = std::remove_reference_t<decltype(request.payload)>;
         using ListMemberType = ListMemberTypeGetter<ListType>::Type;
-        if (payload.payload.count != 0) {
-            auto * listHolder_0 = new ListHolder<ListMemberType>(payload.payload.count);
+        if (params.payload.count != 0) {
+            auto * listHolder_0 = new ListHolder<ListMemberType>(params.payload.count);
             if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
                 return;
             }
             listFreer.add(listHolder_0);
-            for (size_t i = 0; i < payload.payload.count; ++i) {
-                if (![payload.payload[i] isKindOfClass:[NSNumber class]]) {
+            for (size_t i = 0; i < params.payload.count; ++i) {
+                if (![params.payload[i] isKindOfClass:[NSNumber class]]) {
                     // Wrong kind of value.
                     return;
                 }
-                auto element_0 = (NSNumber *) payload.payload[i];
+                auto element_0 = (NSNumber *) params.payload[i];
                 listHolder_0->mList[i] = element_0.unsignedCharValue;
             }
-            request.payload = ListType(listHolder_0->mList, payload.payload.count);
+            request.payload = ListType(listHolder_0->mList, params.payload.count);
         } else {
             request.payload = ListType();
         }
     }
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)setpointRaiseLower:(CHIPThermostatClusterSetpointRaiseLowerPayload * _Nonnull)payload
-           responseHandler:(ResponseHandler)responseHandler
+- (void)setpointRaiseLowerWithParams:(CHIPThermostatClusterSetpointRaiseLowerParams *)params
+                   completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     Thermostat::Commands::SetpointRaiseLower::Type request;
-    request.mode = static_cast<std::remove_reference_t<decltype(request.mode)>>(payload.mode.unsignedCharValue);
-    request.amount = payload.amount.charValue;
+    request.mode = static_cast<std::remove_reference_t<decltype(request.mode)>>(params.mode.unsignedCharValue);
+    request.amount = params.amount.charValue;
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
@@ -13742,13 +13747,12 @@ using namespace chip::app::Clusters;
     return &_cppCluster;
 }
 
-- (void)resetCounts:(CHIPThreadNetworkDiagnosticsClusterResetCountsPayload * _Nonnull)payload
-    responseHandler:(ResponseHandler)responseHandler
+- (void)resetCountsWithCompletionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     ThreadNetworkDiagnostics::Commands::ResetCounts::Type request;
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
@@ -15399,13 +15403,12 @@ using namespace chip::app::Clusters;
     return &_cppCluster;
 }
 
-- (void)resetCounts:(CHIPWiFiNetworkDiagnosticsClusterResetCountsPayload * _Nonnull)payload
-    responseHandler:(ResponseHandler)responseHandler
+- (void)resetCountsWithCompletionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     WiFiNetworkDiagnostics::Commands::ResetCounts::Type request;
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
@@ -15785,94 +15788,94 @@ using namespace chip::app::Clusters;
     return &_cppCluster;
 }
 
-- (void)downOrClose:(CHIPWindowCoveringClusterDownOrClosePayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler
+- (void)downOrCloseWithCompletionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     WindowCovering::Commands::DownOrClose::Type request;
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)goToLiftPercentage:(CHIPWindowCoveringClusterGoToLiftPercentagePayload * _Nonnull)payload
-           responseHandler:(ResponseHandler)responseHandler
+- (void)goToLiftPercentageWithParams:(CHIPWindowCoveringClusterGoToLiftPercentageParams *)params
+                   completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     WindowCovering::Commands::GoToLiftPercentage::Type request;
-    request.liftPercentageValue = payload.liftPercentageValue.unsignedCharValue;
-    request.liftPercent100thsValue = payload.liftPercent100thsValue.unsignedShortValue;
+    request.liftPercentageValue = params.liftPercentageValue.unsignedCharValue;
+    request.liftPercent100thsValue = params.liftPercent100thsValue.unsignedShortValue;
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)goToLiftValue:(CHIPWindowCoveringClusterGoToLiftValuePayload * _Nonnull)payload
-      responseHandler:(ResponseHandler)responseHandler
+- (void)goToLiftValueWithParams:(CHIPWindowCoveringClusterGoToLiftValueParams *)params
+              completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     WindowCovering::Commands::GoToLiftValue::Type request;
-    request.liftValue = payload.liftValue.unsignedShortValue;
+    request.liftValue = params.liftValue.unsignedShortValue;
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)goToTiltPercentage:(CHIPWindowCoveringClusterGoToTiltPercentagePayload * _Nonnull)payload
-           responseHandler:(ResponseHandler)responseHandler
+- (void)goToTiltPercentageWithParams:(CHIPWindowCoveringClusterGoToTiltPercentageParams *)params
+                   completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     WindowCovering::Commands::GoToTiltPercentage::Type request;
-    request.tiltPercentageValue = payload.tiltPercentageValue.unsignedCharValue;
-    request.tiltPercent100thsValue = payload.tiltPercent100thsValue.unsignedShortValue;
+    request.tiltPercentageValue = params.tiltPercentageValue.unsignedCharValue;
+    request.tiltPercent100thsValue = params.tiltPercent100thsValue.unsignedShortValue;
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)goToTiltValue:(CHIPWindowCoveringClusterGoToTiltValuePayload * _Nonnull)payload
-      responseHandler:(ResponseHandler)responseHandler
+- (void)goToTiltValueWithParams:(CHIPWindowCoveringClusterGoToTiltValueParams *)params
+              completionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     WindowCovering::Commands::GoToTiltValue::Type request;
-    request.tiltValue = payload.tiltValue.unsignedShortValue;
+    request.tiltValue = params.tiltValue.unsignedShortValue;
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)stopMotion:(CHIPWindowCoveringClusterStopMotionPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler
+- (void)stopMotionWithCompletionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     WindowCovering::Commands::StopMotion::Type request;
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
     });
 }
 
-- (void)upOrOpen:(CHIPWindowCoveringClusterUpOrOpenPayload * _Nonnull)payload responseHandler:(ResponseHandler)responseHandler
+- (void)upOrOpenWithCompletionHandler:(CompletionHandler)completionHandler
 {
     ListFreer listFreer;
     WindowCovering::Commands::UpOrOpen::Type request;
 
-    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, responseHandler, ^(Cancelable * success, Cancelable * failure) {
+    new CHIPCommandSuccessCallbackBridge(self.callbackQueue, completionHandler, ^(Cancelable * success, Cancelable * failure) {
         auto successFn = Callback<CHIPCommandSuccessCallbackType>::FromCancelable(success);
         auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
         return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPCommandPayloadsObjc.h
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPCommandPayloadsObjc.h
@@ -25,83 +25,75 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface CHIPIdentifyClusterIdentifyPayload : NSObject
+@interface CHIPIdentifyClusterIdentifyParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull identifyTime;
 - (instancetype)init;
 @end
 
-@interface CHIPIdentifyClusterIdentifyQueryResponsePayload : NSObject
+@interface CHIPIdentifyClusterIdentifyQueryResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull timeout;
 - (instancetype)init;
 @end
 
-@interface CHIPIdentifyClusterIdentifyQueryPayload : NSObject
-- (instancetype)init;
-@end
-
-@interface CHIPIdentifyClusterTriggerEffectPayload : NSObject
+@interface CHIPIdentifyClusterTriggerEffectParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull effectIdentifier;
 @property (strong, nonatomic) NSNumber * _Nonnull effectVariant;
 - (instancetype)init;
 @end
 
-@interface CHIPGroupsClusterAddGroupPayload : NSObject
+@interface CHIPGroupsClusterAddGroupParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull groupId;
 @property (strong, nonatomic) NSString * _Nonnull groupName;
 - (instancetype)init;
 @end
 
-@interface CHIPGroupsClusterAddGroupResponsePayload : NSObject
+@interface CHIPGroupsClusterAddGroupResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull status;
 @property (strong, nonatomic) NSNumber * _Nonnull groupId;
 - (instancetype)init;
 @end
 
-@interface CHIPGroupsClusterViewGroupPayload : NSObject
+@interface CHIPGroupsClusterViewGroupParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull groupId;
 - (instancetype)init;
 @end
 
-@interface CHIPGroupsClusterViewGroupResponsePayload : NSObject
+@interface CHIPGroupsClusterViewGroupResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull status;
 @property (strong, nonatomic) NSNumber * _Nonnull groupId;
 @property (strong, nonatomic) NSString * _Nonnull groupName;
 - (instancetype)init;
 @end
 
-@interface CHIPGroupsClusterGetGroupMembershipPayload : NSObject
+@interface CHIPGroupsClusterGetGroupMembershipParams : NSObject
 @property (strong, nonatomic) NSArray * _Nonnull groupList;
 - (instancetype)init;
 @end
 
-@interface CHIPGroupsClusterGetGroupMembershipResponsePayload : NSObject
+@interface CHIPGroupsClusterGetGroupMembershipResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull capacity;
 @property (strong, nonatomic) NSArray * _Nonnull groupList;
 - (instancetype)init;
 @end
 
-@interface CHIPGroupsClusterRemoveGroupPayload : NSObject
+@interface CHIPGroupsClusterRemoveGroupParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull groupId;
 - (instancetype)init;
 @end
 
-@interface CHIPGroupsClusterRemoveGroupResponsePayload : NSObject
+@interface CHIPGroupsClusterRemoveGroupResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull status;
 @property (strong, nonatomic) NSNumber * _Nonnull groupId;
 - (instancetype)init;
 @end
 
-@interface CHIPGroupsClusterRemoveAllGroupsPayload : NSObject
-- (instancetype)init;
-@end
-
-@interface CHIPGroupsClusterAddGroupIfIdentifyingPayload : NSObject
+@interface CHIPGroupsClusterAddGroupIfIdentifyingParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull groupId;
 @property (strong, nonatomic) NSString * _Nonnull groupName;
 - (instancetype)init;
 @end
 
-@interface CHIPScenesClusterAddScenePayload : NSObject
+@interface CHIPScenesClusterAddSceneParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull groupId;
 @property (strong, nonatomic) NSNumber * _Nonnull sceneId;
 @property (strong, nonatomic) NSNumber * _Nonnull transitionTime;
@@ -110,20 +102,20 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 @end
 
-@interface CHIPScenesClusterAddSceneResponsePayload : NSObject
+@interface CHIPScenesClusterAddSceneResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull status;
 @property (strong, nonatomic) NSNumber * _Nonnull groupId;
 @property (strong, nonatomic) NSNumber * _Nonnull sceneId;
 - (instancetype)init;
 @end
 
-@interface CHIPScenesClusterViewScenePayload : NSObject
+@interface CHIPScenesClusterViewSceneParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull groupId;
 @property (strong, nonatomic) NSNumber * _Nonnull sceneId;
 - (instancetype)init;
 @end
 
-@interface CHIPScenesClusterViewSceneResponsePayload : NSObject
+@interface CHIPScenesClusterViewSceneResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull status;
 @property (strong, nonatomic) NSNumber * _Nonnull groupId;
 @property (strong, nonatomic) NSNumber * _Nonnull sceneId;
@@ -133,56 +125,56 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 @end
 
-@interface CHIPScenesClusterRemoveScenePayload : NSObject
+@interface CHIPScenesClusterRemoveSceneParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull groupId;
 @property (strong, nonatomic) NSNumber * _Nonnull sceneId;
 - (instancetype)init;
 @end
 
-@interface CHIPScenesClusterRemoveSceneResponsePayload : NSObject
+@interface CHIPScenesClusterRemoveSceneResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull status;
 @property (strong, nonatomic) NSNumber * _Nonnull groupId;
 @property (strong, nonatomic) NSNumber * _Nonnull sceneId;
 - (instancetype)init;
 @end
 
-@interface CHIPScenesClusterRemoveAllScenesPayload : NSObject
+@interface CHIPScenesClusterRemoveAllScenesParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull groupId;
 - (instancetype)init;
 @end
 
-@interface CHIPScenesClusterRemoveAllScenesResponsePayload : NSObject
+@interface CHIPScenesClusterRemoveAllScenesResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull status;
 @property (strong, nonatomic) NSNumber * _Nonnull groupId;
 - (instancetype)init;
 @end
 
-@interface CHIPScenesClusterStoreScenePayload : NSObject
+@interface CHIPScenesClusterStoreSceneParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull groupId;
 @property (strong, nonatomic) NSNumber * _Nonnull sceneId;
 - (instancetype)init;
 @end
 
-@interface CHIPScenesClusterStoreSceneResponsePayload : NSObject
+@interface CHIPScenesClusterStoreSceneResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull status;
 @property (strong, nonatomic) NSNumber * _Nonnull groupId;
 @property (strong, nonatomic) NSNumber * _Nonnull sceneId;
 - (instancetype)init;
 @end
 
-@interface CHIPScenesClusterRecallScenePayload : NSObject
+@interface CHIPScenesClusterRecallSceneParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull groupId;
 @property (strong, nonatomic) NSNumber * _Nonnull sceneId;
 @property (strong, nonatomic) NSNumber * _Nonnull transitionTime;
 - (instancetype)init;
 @end
 
-@interface CHIPScenesClusterGetSceneMembershipPayload : NSObject
+@interface CHIPScenesClusterGetSceneMembershipParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull groupId;
 - (instancetype)init;
 @end
 
-@interface CHIPScenesClusterGetSceneMembershipResponsePayload : NSObject
+@interface CHIPScenesClusterGetSceneMembershipResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull status;
 @property (strong, nonatomic) NSNumber * _Nonnull capacity;
 @property (strong, nonatomic) NSNumber * _Nonnull groupId;
@@ -191,7 +183,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 @end
 
-@interface CHIPScenesClusterEnhancedAddScenePayload : NSObject
+@interface CHIPScenesClusterEnhancedAddSceneParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull groupId;
 @property (strong, nonatomic) NSNumber * _Nonnull sceneId;
 @property (strong, nonatomic) NSNumber * _Nonnull transitionTime;
@@ -200,20 +192,20 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 @end
 
-@interface CHIPScenesClusterEnhancedAddSceneResponsePayload : NSObject
+@interface CHIPScenesClusterEnhancedAddSceneResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull status;
 @property (strong, nonatomic) NSNumber * _Nonnull groupId;
 @property (strong, nonatomic) NSNumber * _Nonnull sceneId;
 - (instancetype)init;
 @end
 
-@interface CHIPScenesClusterEnhancedViewScenePayload : NSObject
+@interface CHIPScenesClusterEnhancedViewSceneParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull groupId;
 @property (strong, nonatomic) NSNumber * _Nonnull sceneId;
 - (instancetype)init;
 @end
 
-@interface CHIPScenesClusterEnhancedViewSceneResponsePayload : NSObject
+@interface CHIPScenesClusterEnhancedViewSceneResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull status;
 @property (strong, nonatomic) NSNumber * _Nonnull groupId;
 @property (strong, nonatomic) NSNumber * _Nonnull sceneId;
@@ -223,7 +215,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 @end
 
-@interface CHIPScenesClusterCopyScenePayload : NSObject
+@interface CHIPScenesClusterCopySceneParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull mode;
 @property (strong, nonatomic) NSNumber * _Nonnull groupIdFrom;
 @property (strong, nonatomic) NSNumber * _Nonnull sceneIdFrom;
@@ -232,63 +224,27 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 @end
 
-@interface CHIPScenesClusterCopySceneResponsePayload : NSObject
+@interface CHIPScenesClusterCopySceneResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull status;
 @property (strong, nonatomic) NSNumber * _Nonnull groupIdFrom;
 @property (strong, nonatomic) NSNumber * _Nonnull sceneIdFrom;
 - (instancetype)init;
 @end
 
-@interface CHIPOnOffClusterOffPayload : NSObject
-- (instancetype)init;
-@end
-
-@interface CHIPOnOffClusterSampleMfgSpecificOffWithTransitionPayload : NSObject
-- (instancetype)init;
-@end
-
-@interface CHIPOnOffClusterOnPayload : NSObject
-- (instancetype)init;
-@end
-
-@interface CHIPOnOffClusterSampleMfgSpecificOnWithTransitionPayload : NSObject
-- (instancetype)init;
-@end
-
-@interface CHIPOnOffClusterSampleMfgSpecificOnWithTransition2Payload : NSObject
-- (instancetype)init;
-@end
-
-@interface CHIPOnOffClusterTogglePayload : NSObject
-- (instancetype)init;
-@end
-
-@interface CHIPOnOffClusterSampleMfgSpecificToggleWithTransitionPayload : NSObject
-- (instancetype)init;
-@end
-
-@interface CHIPOnOffClusterSampleMfgSpecificToggleWithTransition2Payload : NSObject
-- (instancetype)init;
-@end
-
-@interface CHIPOnOffClusterOffWithEffectPayload : NSObject
+@interface CHIPOnOffClusterOffWithEffectParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull effectId;
 @property (strong, nonatomic) NSNumber * _Nonnull effectVariant;
 - (instancetype)init;
 @end
 
-@interface CHIPOnOffClusterOnWithRecallGlobalScenePayload : NSObject
-- (instancetype)init;
-@end
-
-@interface CHIPOnOffClusterOnWithTimedOffPayload : NSObject
+@interface CHIPOnOffClusterOnWithTimedOffParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull onOffControl;
 @property (strong, nonatomic) NSNumber * _Nonnull onTime;
 @property (strong, nonatomic) NSNumber * _Nonnull offWaitTime;
 - (instancetype)init;
 @end
 
-@interface CHIPLevelControlClusterMoveToLevelPayload : NSObject
+@interface CHIPLevelControlClusterMoveToLevelParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull level;
 @property (strong, nonatomic) NSNumber * _Nonnull transitionTime;
 @property (strong, nonatomic) NSNumber * _Nonnull optionMask;
@@ -296,7 +252,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 @end
 
-@interface CHIPLevelControlClusterMovePayload : NSObject
+@interface CHIPLevelControlClusterMoveParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull moveMode;
 @property (strong, nonatomic) NSNumber * _Nonnull rate;
 @property (strong, nonatomic) NSNumber * _Nonnull optionMask;
@@ -304,7 +260,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 @end
 
-@interface CHIPLevelControlClusterStepPayload : NSObject
+@interface CHIPLevelControlClusterStepParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull stepMode;
 @property (strong, nonatomic) NSNumber * _Nonnull stepSize;
 @property (strong, nonatomic) NSNumber * _Nonnull transitionTime;
@@ -313,52 +269,44 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 @end
 
-@interface CHIPLevelControlClusterStopPayload : NSObject
+@interface CHIPLevelControlClusterStopParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull optionMask;
 @property (strong, nonatomic) NSNumber * _Nonnull optionOverride;
 - (instancetype)init;
 @end
 
-@interface CHIPLevelControlClusterMoveToLevelWithOnOffPayload : NSObject
+@interface CHIPLevelControlClusterMoveToLevelWithOnOffParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull level;
 @property (strong, nonatomic) NSNumber * _Nonnull transitionTime;
 - (instancetype)init;
 @end
 
-@interface CHIPLevelControlClusterMoveWithOnOffPayload : NSObject
+@interface CHIPLevelControlClusterMoveWithOnOffParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull moveMode;
 @property (strong, nonatomic) NSNumber * _Nonnull rate;
 - (instancetype)init;
 @end
 
-@interface CHIPLevelControlClusterStepWithOnOffPayload : NSObject
+@interface CHIPLevelControlClusterStepWithOnOffParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull stepMode;
 @property (strong, nonatomic) NSNumber * _Nonnull stepSize;
 @property (strong, nonatomic) NSNumber * _Nonnull transitionTime;
 - (instancetype)init;
 @end
 
-@interface CHIPLevelControlClusterStopWithOnOffPayload : NSObject
-- (instancetype)init;
-@end
-
-@interface CHIPAlarmsClusterResetAlarmPayload : NSObject
+@interface CHIPAlarmsClusterResetAlarmParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull alarmCode;
 @property (strong, nonatomic) NSNumber * _Nonnull clusterId;
 - (instancetype)init;
 @end
 
-@interface CHIPAlarmsClusterAlarmPayload : NSObject
+@interface CHIPAlarmsClusterAlarmParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull alarmCode;
 @property (strong, nonatomic) NSNumber * _Nonnull clusterId;
 - (instancetype)init;
 @end
 
-@interface CHIPAlarmsClusterResetAllAlarmsPayload : NSObject
-- (instancetype)init;
-@end
-
-@interface CHIPAlarmsClusterGetAlarmResponsePayload : NSObject
+@interface CHIPAlarmsClusterGetAlarmResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull status;
 @property (strong, nonatomic) NSNumber * _Nonnull alarmCode;
 @property (strong, nonatomic) NSNumber * _Nonnull clusterId;
@@ -366,20 +314,12 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 @end
 
-@interface CHIPAlarmsClusterGetAlarmPayload : NSObject
-- (instancetype)init;
-@end
-
-@interface CHIPAlarmsClusterResetAlarmLogPayload : NSObject
-- (instancetype)init;
-@end
-
-@interface CHIPPowerProfileClusterPowerProfileRequestPayload : NSObject
+@interface CHIPPowerProfileClusterPowerProfileRequestParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull powerProfileId;
 - (instancetype)init;
 @end
 
-@interface CHIPPowerProfileClusterPowerProfileNotificationPayload : NSObject
+@interface CHIPPowerProfileClusterPowerProfileNotificationParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull totalProfileNum;
 @property (strong, nonatomic) NSNumber * _Nonnull powerProfileId;
 @property (strong, nonatomic) NSNumber * _Nonnull numOfTransferredPhases;
@@ -387,11 +327,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 @end
 
-@interface CHIPPowerProfileClusterPowerProfileStateRequestPayload : NSObject
-- (instancetype)init;
-@end
-
-@interface CHIPPowerProfileClusterPowerProfileResponsePayload : NSObject
+@interface CHIPPowerProfileClusterPowerProfileResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull totalProfileNum;
 @property (strong, nonatomic) NSNumber * _Nonnull powerProfileId;
 @property (strong, nonatomic) NSNumber * _Nonnull numOfTransferredPhases;
@@ -399,7 +335,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 @end
 
-@interface CHIPPowerProfileClusterGetPowerProfilePriceResponsePayload : NSObject
+@interface CHIPPowerProfileClusterGetPowerProfilePriceResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull powerProfileId;
 @property (strong, nonatomic) NSNumber * _Nonnull currency;
 @property (strong, nonatomic) NSNumber * _Nonnull price;
@@ -407,71 +343,67 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 @end
 
-@interface CHIPPowerProfileClusterPowerProfileStateResponsePayload : NSObject
+@interface CHIPPowerProfileClusterPowerProfileStateResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull powerProfileCount;
 @property (strong, nonatomic) NSArray * _Nonnull powerProfileRecords;
 - (instancetype)init;
 @end
 
-@interface CHIPPowerProfileClusterGetOverallSchedulePriceResponsePayload : NSObject
+@interface CHIPPowerProfileClusterGetOverallSchedulePriceResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull currency;
 @property (strong, nonatomic) NSNumber * _Nonnull price;
 @property (strong, nonatomic) NSNumber * _Nonnull priceTrailingDigit;
 - (instancetype)init;
 @end
 
-@interface CHIPPowerProfileClusterGetPowerProfilePricePayload : NSObject
+@interface CHIPPowerProfileClusterGetPowerProfilePriceParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull powerProfileId;
 - (instancetype)init;
 @end
 
-@interface CHIPPowerProfileClusterEnergyPhasesScheduleNotificationPayload : NSObject
+@interface CHIPPowerProfileClusterEnergyPhasesScheduleNotificationParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull powerProfileId;
 @property (strong, nonatomic) NSNumber * _Nonnull numOfScheduledPhases;
 @property (strong, nonatomic) NSArray * _Nonnull scheduledPhases;
 - (instancetype)init;
 @end
 
-@interface CHIPPowerProfileClusterPowerProfilesStateNotificationPayload : NSObject
+@interface CHIPPowerProfileClusterPowerProfilesStateNotificationParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull powerProfileCount;
 @property (strong, nonatomic) NSArray * _Nonnull powerProfileRecords;
 - (instancetype)init;
 @end
 
-@interface CHIPPowerProfileClusterEnergyPhasesScheduleResponsePayload : NSObject
+@interface CHIPPowerProfileClusterEnergyPhasesScheduleResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull powerProfileId;
 @property (strong, nonatomic) NSNumber * _Nonnull numOfScheduledPhases;
 @property (strong, nonatomic) NSArray * _Nonnull scheduledPhases;
 - (instancetype)init;
 @end
 
-@interface CHIPPowerProfileClusterGetOverallSchedulePricePayload : NSObject
-- (instancetype)init;
-@end
-
-@interface CHIPPowerProfileClusterPowerProfileScheduleConstraintsRequestPayload : NSObject
+@interface CHIPPowerProfileClusterPowerProfileScheduleConstraintsRequestParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull powerProfileId;
 - (instancetype)init;
 @end
 
-@interface CHIPPowerProfileClusterEnergyPhasesScheduleRequestPayload : NSObject
+@interface CHIPPowerProfileClusterEnergyPhasesScheduleRequestParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull powerProfileId;
 - (instancetype)init;
 @end
 
-@interface CHIPPowerProfileClusterEnergyPhasesScheduleStateRequestPayload : NSObject
+@interface CHIPPowerProfileClusterEnergyPhasesScheduleStateRequestParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull powerProfileId;
 - (instancetype)init;
 @end
 
-@interface CHIPPowerProfileClusterEnergyPhasesScheduleStateResponsePayload : NSObject
+@interface CHIPPowerProfileClusterEnergyPhasesScheduleStateResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull powerProfileId;
 @property (strong, nonatomic) NSNumber * _Nonnull numOfScheduledPhases;
 @property (strong, nonatomic) NSArray * _Nonnull scheduledPhases;
 - (instancetype)init;
 @end
 
-@interface CHIPPowerProfileClusterGetPowerProfilePriceExtendedResponsePayload : NSObject
+@interface CHIPPowerProfileClusterGetPowerProfilePriceExtendedResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull powerProfileId;
 @property (strong, nonatomic) NSNumber * _Nonnull currency;
 @property (strong, nonatomic) NSNumber * _Nonnull price;
@@ -479,195 +411,159 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 @end
 
-@interface CHIPPowerProfileClusterEnergyPhasesScheduleStateNotificationPayload : NSObject
+@interface CHIPPowerProfileClusterEnergyPhasesScheduleStateNotificationParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull powerProfileId;
 @property (strong, nonatomic) NSNumber * _Nonnull numOfScheduledPhases;
 @property (strong, nonatomic) NSArray * _Nonnull scheduledPhases;
 - (instancetype)init;
 @end
 
-@interface CHIPPowerProfileClusterPowerProfileScheduleConstraintsNotificationPayload : NSObject
+@interface CHIPPowerProfileClusterPowerProfileScheduleConstraintsNotificationParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull powerProfileId;
 @property (strong, nonatomic) NSNumber * _Nonnull startAfter;
 @property (strong, nonatomic) NSNumber * _Nonnull stopBefore;
 - (instancetype)init;
 @end
 
-@interface CHIPPowerProfileClusterPowerProfileScheduleConstraintsResponsePayload : NSObject
+@interface CHIPPowerProfileClusterPowerProfileScheduleConstraintsResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull powerProfileId;
 @property (strong, nonatomic) NSNumber * _Nonnull startAfter;
 @property (strong, nonatomic) NSNumber * _Nonnull stopBefore;
 - (instancetype)init;
 @end
 
-@interface CHIPPowerProfileClusterGetPowerProfilePriceExtendedPayload : NSObject
+@interface CHIPPowerProfileClusterGetPowerProfilePriceExtendedParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull options;
 @property (strong, nonatomic) NSNumber * _Nonnull powerProfileId;
 @property (strong, nonatomic) NSNumber * _Nonnull powerProfileStartTime;
 - (instancetype)init;
 @end
 
-@interface CHIPApplianceControlClusterExecutionOfACommandPayload : NSObject
+@interface CHIPApplianceControlClusterExecutionOfACommandParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull commandId;
 - (instancetype)init;
 @end
 
-@interface CHIPApplianceControlClusterSignalStateResponsePayload : NSObject
+@interface CHIPApplianceControlClusterSignalStateResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull applianceStatus;
 @property (strong, nonatomic) NSNumber * _Nonnull remoteEnableFlagsAndDeviceStatus2;
 @property (strong, nonatomic) NSNumber * _Nonnull applianceStatus2;
 - (instancetype)init;
 @end
 
-@interface CHIPApplianceControlClusterSignalStatePayload : NSObject
-- (instancetype)init;
-@end
-
-@interface CHIPApplianceControlClusterSignalStateNotificationPayload : NSObject
+@interface CHIPApplianceControlClusterSignalStateNotificationParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull applianceStatus;
 @property (strong, nonatomic) NSNumber * _Nonnull remoteEnableFlagsAndDeviceStatus2;
 @property (strong, nonatomic) NSNumber * _Nonnull applianceStatus2;
 - (instancetype)init;
 @end
 
-@interface CHIPApplianceControlClusterWriteFunctionsPayload : NSObject
+@interface CHIPApplianceControlClusterWriteFunctionsParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull functionId;
 @property (strong, nonatomic) NSNumber * _Nonnull functionDataType;
 @property (strong, nonatomic) NSArray * _Nonnull functionData;
 - (instancetype)init;
 @end
 
-@interface CHIPApplianceControlClusterOverloadPauseResumePayload : NSObject
-- (instancetype)init;
-@end
-
-@interface CHIPApplianceControlClusterOverloadPausePayload : NSObject
-- (instancetype)init;
-@end
-
-@interface CHIPApplianceControlClusterOverloadWarningPayload : NSObject
+@interface CHIPApplianceControlClusterOverloadWarningParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull warningEvent;
 - (instancetype)init;
 @end
 
-@interface CHIPPollControlClusterCheckInPayload : NSObject
-- (instancetype)init;
-@end
-
-@interface CHIPPollControlClusterCheckInResponsePayload : NSObject
+@interface CHIPPollControlClusterCheckInResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull startFastPolling;
 @property (strong, nonatomic) NSNumber * _Nonnull fastPollTimeout;
 - (instancetype)init;
 @end
 
-@interface CHIPPollControlClusterFastPollStopPayload : NSObject
-- (instancetype)init;
-@end
-
-@interface CHIPPollControlClusterSetLongPollIntervalPayload : NSObject
+@interface CHIPPollControlClusterSetLongPollIntervalParams : NSObject
 @property (strong, nonatomic, getter=getNewLongPollInterval) NSNumber * _Nonnull newLongPollInterval;
 - (instancetype)init;
 @end
 
-@interface CHIPPollControlClusterSetShortPollIntervalPayload : NSObject
+@interface CHIPPollControlClusterSetShortPollIntervalParams : NSObject
 @property (strong, nonatomic, getter=getNewShortPollInterval) NSNumber * _Nonnull newShortPollInterval;
 - (instancetype)init;
 @end
 
-@interface CHIPBridgedActionsClusterInstantActionPayload : NSObject
+@interface CHIPBridgedActionsClusterInstantActionParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull actionID;
 @property (strong, nonatomic) NSNumber * _Nullable invokeID;
 - (instancetype)init;
 @end
 
-@interface CHIPBridgedActionsClusterInstantActionWithTransitionPayload : NSObject
+@interface CHIPBridgedActionsClusterInstantActionWithTransitionParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull actionID;
 @property (strong, nonatomic) NSNumber * _Nullable invokeID;
 @property (strong, nonatomic) NSNumber * _Nonnull transitionTime;
 - (instancetype)init;
 @end
 
-@interface CHIPBridgedActionsClusterStartActionPayload : NSObject
+@interface CHIPBridgedActionsClusterStartActionParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull actionID;
 @property (strong, nonatomic) NSNumber * _Nullable invokeID;
 - (instancetype)init;
 @end
 
-@interface CHIPBridgedActionsClusterStartActionWithDurationPayload : NSObject
-@property (strong, nonatomic) NSNumber * _Nonnull actionID;
-@property (strong, nonatomic) NSNumber * _Nullable invokeID;
-@property (strong, nonatomic) NSNumber * _Nonnull duration;
-- (instancetype)init;
-@end
-
-@interface CHIPBridgedActionsClusterStopActionPayload : NSObject
-@property (strong, nonatomic) NSNumber * _Nonnull actionID;
-@property (strong, nonatomic) NSNumber * _Nullable invokeID;
-- (instancetype)init;
-@end
-
-@interface CHIPBridgedActionsClusterPauseActionPayload : NSObject
-@property (strong, nonatomic) NSNumber * _Nonnull actionID;
-@property (strong, nonatomic) NSNumber * _Nullable invokeID;
-- (instancetype)init;
-@end
-
-@interface CHIPBridgedActionsClusterPauseActionWithDurationPayload : NSObject
+@interface CHIPBridgedActionsClusterStartActionWithDurationParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull actionID;
 @property (strong, nonatomic) NSNumber * _Nullable invokeID;
 @property (strong, nonatomic) NSNumber * _Nonnull duration;
 - (instancetype)init;
 @end
 
-@interface CHIPBridgedActionsClusterResumeActionPayload : NSObject
+@interface CHIPBridgedActionsClusterStopActionParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull actionID;
 @property (strong, nonatomic) NSNumber * _Nullable invokeID;
 - (instancetype)init;
 @end
 
-@interface CHIPBridgedActionsClusterEnableActionPayload : NSObject
+@interface CHIPBridgedActionsClusterPauseActionParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull actionID;
 @property (strong, nonatomic) NSNumber * _Nullable invokeID;
 - (instancetype)init;
 @end
 
-@interface CHIPBridgedActionsClusterEnableActionWithDurationPayload : NSObject
-@property (strong, nonatomic) NSNumber * _Nonnull actionID;
-@property (strong, nonatomic) NSNumber * _Nullable invokeID;
-@property (strong, nonatomic) NSNumber * _Nonnull duration;
-- (instancetype)init;
-@end
-
-@interface CHIPBridgedActionsClusterDisableActionPayload : NSObject
-@property (strong, nonatomic) NSNumber * _Nonnull actionID;
-@property (strong, nonatomic) NSNumber * _Nullable invokeID;
-- (instancetype)init;
-@end
-
-@interface CHIPBridgedActionsClusterDisableActionWithDurationPayload : NSObject
+@interface CHIPBridgedActionsClusterPauseActionWithDurationParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull actionID;
 @property (strong, nonatomic) NSNumber * _Nullable invokeID;
 @property (strong, nonatomic) NSNumber * _Nonnull duration;
 - (instancetype)init;
 @end
 
-@interface CHIPBasicClusterStartUpPayload : NSObject
+@interface CHIPBridgedActionsClusterResumeActionParams : NSObject
+@property (strong, nonatomic) NSNumber * _Nonnull actionID;
+@property (strong, nonatomic) NSNumber * _Nullable invokeID;
 - (instancetype)init;
 @end
 
-@interface CHIPBasicClusterMfgSpecificPingPayload : NSObject
+@interface CHIPBridgedActionsClusterEnableActionParams : NSObject
+@property (strong, nonatomic) NSNumber * _Nonnull actionID;
+@property (strong, nonatomic) NSNumber * _Nullable invokeID;
 - (instancetype)init;
 @end
 
-@interface CHIPBasicClusterShutDownPayload : NSObject
+@interface CHIPBridgedActionsClusterEnableActionWithDurationParams : NSObject
+@property (strong, nonatomic) NSNumber * _Nonnull actionID;
+@property (strong, nonatomic) NSNumber * _Nullable invokeID;
+@property (strong, nonatomic) NSNumber * _Nonnull duration;
 - (instancetype)init;
 @end
 
-@interface CHIPBasicClusterLeavePayload : NSObject
+@interface CHIPBridgedActionsClusterDisableActionParams : NSObject
+@property (strong, nonatomic) NSNumber * _Nonnull actionID;
+@property (strong, nonatomic) NSNumber * _Nullable invokeID;
 - (instancetype)init;
 @end
 
-@interface CHIPOtaSoftwareUpdateProviderClusterQueryImagePayload : NSObject
+@interface CHIPBridgedActionsClusterDisableActionWithDurationParams : NSObject
+@property (strong, nonatomic) NSNumber * _Nonnull actionID;
+@property (strong, nonatomic) NSNumber * _Nullable invokeID;
+@property (strong, nonatomic) NSNumber * _Nonnull duration;
+- (instancetype)init;
+@end
+
+@interface CHIPOtaSoftwareUpdateProviderClusterQueryImageParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull vendorId;
 @property (strong, nonatomic) NSNumber * _Nonnull productId;
 @property (strong, nonatomic) NSNumber * _Nonnull softwareVersion;
@@ -679,19 +575,19 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 @end
 
-@interface CHIPOtaSoftwareUpdateProviderClusterApplyUpdateRequestPayload : NSObject
+@interface CHIPOtaSoftwareUpdateProviderClusterApplyUpdateRequestParams : NSObject
 @property (strong, nonatomic) NSData * _Nonnull updateToken;
 @property (strong, nonatomic, getter=getNewVersion) NSNumber * _Nonnull newVersion;
 - (instancetype)init;
 @end
 
-@interface CHIPOtaSoftwareUpdateProviderClusterNotifyUpdateAppliedPayload : NSObject
+@interface CHIPOtaSoftwareUpdateProviderClusterNotifyUpdateAppliedParams : NSObject
 @property (strong, nonatomic) NSData * _Nonnull updateToken;
 @property (strong, nonatomic) NSNumber * _Nonnull softwareVersion;
 - (instancetype)init;
 @end
 
-@interface CHIPOtaSoftwareUpdateProviderClusterQueryImageResponsePayload : NSObject
+@interface CHIPOtaSoftwareUpdateProviderClusterQueryImageResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull status;
 @property (strong, nonatomic) NSNumber * _Nullable delayedActionTime;
 @property (strong, nonatomic) NSString * _Nullable imageURI;
@@ -703,13 +599,13 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 @end
 
-@interface CHIPOtaSoftwareUpdateProviderClusterApplyUpdateResponsePayload : NSObject
+@interface CHIPOtaSoftwareUpdateProviderClusterApplyUpdateResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull action;
 @property (strong, nonatomic) NSNumber * _Nonnull delayedActionTime;
 - (instancetype)init;
 @end
 
-@interface CHIPOtaSoftwareUpdateRequestorClusterAnnounceOtaProviderPayload : NSObject
+@interface CHIPOtaSoftwareUpdateRequestorClusterAnnounceOtaProviderParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull providerLocation;
 @property (strong, nonatomic) NSNumber * _Nonnull vendorId;
 @property (strong, nonatomic) NSNumber * _Nonnull announcementReason;
@@ -717,20 +613,20 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 @end
 
-@interface CHIPGeneralCommissioningClusterArmFailSafePayload : NSObject
+@interface CHIPGeneralCommissioningClusterArmFailSafeParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull expiryLengthSeconds;
 @property (strong, nonatomic) NSNumber * _Nonnull breadcrumb;
 @property (strong, nonatomic) NSNumber * _Nonnull timeoutMs;
 - (instancetype)init;
 @end
 
-@interface CHIPGeneralCommissioningClusterArmFailSafeResponsePayload : NSObject
+@interface CHIPGeneralCommissioningClusterArmFailSafeResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull errorCode;
 @property (strong, nonatomic) NSString * _Nonnull debugText;
 - (instancetype)init;
 @end
 
-@interface CHIPGeneralCommissioningClusterSetRegulatoryConfigPayload : NSObject
+@interface CHIPGeneralCommissioningClusterSetRegulatoryConfigParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull location;
 @property (strong, nonatomic) NSString * _Nonnull countryCode;
 @property (strong, nonatomic) NSNumber * _Nonnull breadcrumb;
@@ -738,30 +634,26 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 @end
 
-@interface CHIPGeneralCommissioningClusterSetRegulatoryConfigResponsePayload : NSObject
+@interface CHIPGeneralCommissioningClusterSetRegulatoryConfigResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull errorCode;
 @property (strong, nonatomic) NSString * _Nonnull debugText;
 - (instancetype)init;
 @end
 
-@interface CHIPGeneralCommissioningClusterCommissioningCompletePayload : NSObject
-- (instancetype)init;
-@end
-
-@interface CHIPGeneralCommissioningClusterCommissioningCompleteResponsePayload : NSObject
+@interface CHIPGeneralCommissioningClusterCommissioningCompleteResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull errorCode;
 @property (strong, nonatomic) NSString * _Nonnull debugText;
 - (instancetype)init;
 @end
 
-@interface CHIPNetworkCommissioningClusterScanNetworksPayload : NSObject
+@interface CHIPNetworkCommissioningClusterScanNetworksParams : NSObject
 @property (strong, nonatomic) NSData * _Nonnull ssid;
 @property (strong, nonatomic) NSNumber * _Nonnull breadcrumb;
 @property (strong, nonatomic) NSNumber * _Nonnull timeoutMs;
 - (instancetype)init;
 @end
 
-@interface CHIPNetworkCommissioningClusterScanNetworksResponsePayload : NSObject
+@interface CHIPNetworkCommissioningClusterScanNetworksResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull errorCode;
 @property (strong, nonatomic) NSString * _Nonnull debugText;
 @property (strong, nonatomic) NSArray * _Nonnull wifiScanResults;
@@ -769,7 +661,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 @end
 
-@interface CHIPNetworkCommissioningClusterAddWiFiNetworkPayload : NSObject
+@interface CHIPNetworkCommissioningClusterAddWiFiNetworkParams : NSObject
 @property (strong, nonatomic) NSData * _Nonnull ssid;
 @property (strong, nonatomic) NSData * _Nonnull credentials;
 @property (strong, nonatomic) NSNumber * _Nonnull breadcrumb;
@@ -777,13 +669,13 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 @end
 
-@interface CHIPNetworkCommissioningClusterAddWiFiNetworkResponsePayload : NSObject
+@interface CHIPNetworkCommissioningClusterAddWiFiNetworkResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull errorCode;
 @property (strong, nonatomic) NSString * _Nonnull debugText;
 - (instancetype)init;
 @end
 
-@interface CHIPNetworkCommissioningClusterUpdateWiFiNetworkPayload : NSObject
+@interface CHIPNetworkCommissioningClusterUpdateWiFiNetworkParams : NSObject
 @property (strong, nonatomic) NSData * _Nonnull ssid;
 @property (strong, nonatomic) NSData * _Nonnull credentials;
 @property (strong, nonatomic) NSNumber * _Nonnull breadcrumb;
@@ -791,85 +683,85 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 @end
 
-@interface CHIPNetworkCommissioningClusterUpdateWiFiNetworkResponsePayload : NSObject
+@interface CHIPNetworkCommissioningClusterUpdateWiFiNetworkResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull errorCode;
 @property (strong, nonatomic) NSString * _Nonnull debugText;
 - (instancetype)init;
 @end
 
-@interface CHIPNetworkCommissioningClusterAddThreadNetworkPayload : NSObject
+@interface CHIPNetworkCommissioningClusterAddThreadNetworkParams : NSObject
 @property (strong, nonatomic) NSData * _Nonnull operationalDataset;
 @property (strong, nonatomic) NSNumber * _Nonnull breadcrumb;
 @property (strong, nonatomic) NSNumber * _Nonnull timeoutMs;
 - (instancetype)init;
 @end
 
-@interface CHIPNetworkCommissioningClusterAddThreadNetworkResponsePayload : NSObject
+@interface CHIPNetworkCommissioningClusterAddThreadNetworkResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull errorCode;
 @property (strong, nonatomic) NSString * _Nonnull debugText;
 - (instancetype)init;
 @end
 
-@interface CHIPNetworkCommissioningClusterUpdateThreadNetworkPayload : NSObject
+@interface CHIPNetworkCommissioningClusterUpdateThreadNetworkParams : NSObject
 @property (strong, nonatomic) NSData * _Nonnull operationalDataset;
 @property (strong, nonatomic) NSNumber * _Nonnull breadcrumb;
 @property (strong, nonatomic) NSNumber * _Nonnull timeoutMs;
 - (instancetype)init;
 @end
 
-@interface CHIPNetworkCommissioningClusterUpdateThreadNetworkResponsePayload : NSObject
+@interface CHIPNetworkCommissioningClusterUpdateThreadNetworkResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull errorCode;
 @property (strong, nonatomic) NSString * _Nonnull debugText;
 - (instancetype)init;
 @end
 
-@interface CHIPNetworkCommissioningClusterRemoveNetworkPayload : NSObject
+@interface CHIPNetworkCommissioningClusterRemoveNetworkParams : NSObject
 @property (strong, nonatomic) NSData * _Nonnull networkID;
 @property (strong, nonatomic) NSNumber * _Nonnull breadcrumb;
 @property (strong, nonatomic) NSNumber * _Nonnull timeoutMs;
 - (instancetype)init;
 @end
 
-@interface CHIPNetworkCommissioningClusterRemoveNetworkResponsePayload : NSObject
+@interface CHIPNetworkCommissioningClusterRemoveNetworkResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull errorCode;
 @property (strong, nonatomic) NSString * _Nonnull debugText;
 - (instancetype)init;
 @end
 
-@interface CHIPNetworkCommissioningClusterEnableNetworkPayload : NSObject
+@interface CHIPNetworkCommissioningClusterEnableNetworkParams : NSObject
 @property (strong, nonatomic) NSData * _Nonnull networkID;
 @property (strong, nonatomic) NSNumber * _Nonnull breadcrumb;
 @property (strong, nonatomic) NSNumber * _Nonnull timeoutMs;
 - (instancetype)init;
 @end
 
-@interface CHIPNetworkCommissioningClusterEnableNetworkResponsePayload : NSObject
+@interface CHIPNetworkCommissioningClusterEnableNetworkResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull errorCode;
 @property (strong, nonatomic) NSString * _Nonnull debugText;
 - (instancetype)init;
 @end
 
-@interface CHIPNetworkCommissioningClusterDisableNetworkPayload : NSObject
+@interface CHIPNetworkCommissioningClusterDisableNetworkParams : NSObject
 @property (strong, nonatomic) NSData * _Nonnull networkID;
 @property (strong, nonatomic) NSNumber * _Nonnull breadcrumb;
 @property (strong, nonatomic) NSNumber * _Nonnull timeoutMs;
 - (instancetype)init;
 @end
 
-@interface CHIPNetworkCommissioningClusterDisableNetworkResponsePayload : NSObject
+@interface CHIPNetworkCommissioningClusterDisableNetworkResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull errorCode;
 @property (strong, nonatomic) NSString * _Nonnull debugText;
 - (instancetype)init;
 @end
 
-@interface CHIPDiagnosticLogsClusterRetrieveLogsRequestPayload : NSObject
+@interface CHIPDiagnosticLogsClusterRetrieveLogsRequestParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull intent;
 @property (strong, nonatomic) NSNumber * _Nonnull requestedProtocol;
 @property (strong, nonatomic) NSData * _Nonnull transferFileDesignator;
 - (instancetype)init;
 @end
 
-@interface CHIPDiagnosticLogsClusterRetrieveLogsResponsePayload : NSObject
+@interface CHIPDiagnosticLogsClusterRetrieveLogsResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull status;
 @property (strong, nonatomic) NSData * _Nonnull content;
 @property (strong, nonatomic) NSNumber * _Nonnull timeStamp;
@@ -877,39 +769,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 @end
 
-@interface CHIPSoftwareDiagnosticsClusterResetWatermarksPayload : NSObject
-- (instancetype)init;
-@end
-
-@interface CHIPThreadNetworkDiagnosticsClusterResetCountsPayload : NSObject
-- (instancetype)init;
-@end
-
-@interface CHIPWiFiNetworkDiagnosticsClusterResetCountsPayload : NSObject
-- (instancetype)init;
-@end
-
-@interface CHIPEthernetNetworkDiagnosticsClusterResetCountsPayload : NSObject
-- (instancetype)init;
-@end
-
-@interface CHIPBridgedDeviceBasicClusterStartUpPayload : NSObject
-- (instancetype)init;
-@end
-
-@interface CHIPBridgedDeviceBasicClusterShutDownPayload : NSObject
-- (instancetype)init;
-@end
-
-@interface CHIPBridgedDeviceBasicClusterLeavePayload : NSObject
-- (instancetype)init;
-@end
-
-@interface CHIPBridgedDeviceBasicClusterReachableChangedPayload : NSObject
-- (instancetype)init;
-@end
-
-@interface CHIPAdministratorCommissioningClusterOpenCommissioningWindowPayload : NSObject
+@interface CHIPAdministratorCommissioningClusterOpenCommissioningWindowParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull commissioningTimeout;
 @property (strong, nonatomic) NSData * _Nonnull pakeVerifier;
 @property (strong, nonatomic) NSNumber * _Nonnull discriminator;
@@ -919,48 +779,44 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 @end
 
-@interface CHIPAdministratorCommissioningClusterOpenBasicCommissioningWindowPayload : NSObject
+@interface CHIPAdministratorCommissioningClusterOpenBasicCommissioningWindowParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull commissioningTimeout;
 - (instancetype)init;
 @end
 
-@interface CHIPAdministratorCommissioningClusterRevokeCommissioningPayload : NSObject
-- (instancetype)init;
-@end
-
-@interface CHIPOperationalCredentialsClusterAttestationRequestPayload : NSObject
+@interface CHIPOperationalCredentialsClusterAttestationRequestParams : NSObject
 @property (strong, nonatomic) NSData * _Nonnull attestationNonce;
 - (instancetype)init;
 @end
 
-@interface CHIPOperationalCredentialsClusterAttestationResponsePayload : NSObject
+@interface CHIPOperationalCredentialsClusterAttestationResponseParams : NSObject
 @property (strong, nonatomic) NSData * _Nonnull attestationElements;
 @property (strong, nonatomic) NSData * _Nonnull signature;
 - (instancetype)init;
 @end
 
-@interface CHIPOperationalCredentialsClusterCertificateChainRequestPayload : NSObject
+@interface CHIPOperationalCredentialsClusterCertificateChainRequestParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull certificateType;
 - (instancetype)init;
 @end
 
-@interface CHIPOperationalCredentialsClusterCertificateChainResponsePayload : NSObject
+@interface CHIPOperationalCredentialsClusterCertificateChainResponseParams : NSObject
 @property (strong, nonatomic) NSData * _Nonnull certificate;
 - (instancetype)init;
 @end
 
-@interface CHIPOperationalCredentialsClusterOpCSRRequestPayload : NSObject
+@interface CHIPOperationalCredentialsClusterOpCSRRequestParams : NSObject
 @property (strong, nonatomic) NSData * _Nonnull csrNonce;
 - (instancetype)init;
 @end
 
-@interface CHIPOperationalCredentialsClusterOpCSRResponsePayload : NSObject
+@interface CHIPOperationalCredentialsClusterOpCSRResponseParams : NSObject
 @property (strong, nonatomic) NSData * _Nonnull nocsrElements;
 @property (strong, nonatomic) NSData * _Nonnull attestationSignature;
 - (instancetype)init;
 @end
 
-@interface CHIPOperationalCredentialsClusterAddNOCPayload : NSObject
+@interface CHIPOperationalCredentialsClusterAddNOCParams : NSObject
 @property (strong, nonatomic) NSData * _Nonnull nocValue;
 @property (strong, nonatomic) NSData * _Nullable icacValue;
 @property (strong, nonatomic) NSData * _Nonnull ipkValue;
@@ -969,91 +825,91 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 @end
 
-@interface CHIPOperationalCredentialsClusterUpdateNOCPayload : NSObject
+@interface CHIPOperationalCredentialsClusterUpdateNOCParams : NSObject
 @property (strong, nonatomic) NSData * _Nonnull nocValue;
 @property (strong, nonatomic) NSData * _Nullable icacValue;
 - (instancetype)init;
 @end
 
-@interface CHIPOperationalCredentialsClusterNOCResponsePayload : NSObject
+@interface CHIPOperationalCredentialsClusterNOCResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull statusCode;
 @property (strong, nonatomic) NSNumber * _Nonnull fabricIndex;
 @property (strong, nonatomic) NSString * _Nonnull debugText;
 - (instancetype)init;
 @end
 
-@interface CHIPOperationalCredentialsClusterUpdateFabricLabelPayload : NSObject
+@interface CHIPOperationalCredentialsClusterUpdateFabricLabelParams : NSObject
 @property (strong, nonatomic) NSString * _Nonnull label;
 - (instancetype)init;
 @end
 
-@interface CHIPOperationalCredentialsClusterRemoveFabricPayload : NSObject
+@interface CHIPOperationalCredentialsClusterRemoveFabricParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull fabricIndex;
 - (instancetype)init;
 @end
 
-@interface CHIPOperationalCredentialsClusterAddTrustedRootCertificatePayload : NSObject
+@interface CHIPOperationalCredentialsClusterAddTrustedRootCertificateParams : NSObject
 @property (strong, nonatomic) NSData * _Nonnull rootCertificate;
 - (instancetype)init;
 @end
 
-@interface CHIPOperationalCredentialsClusterRemoveTrustedRootCertificatePayload : NSObject
+@interface CHIPOperationalCredentialsClusterRemoveTrustedRootCertificateParams : NSObject
 @property (strong, nonatomic) NSData * _Nonnull trustedRootIdentifier;
 - (instancetype)init;
 @end
 
-@interface CHIPModeSelectClusterChangeToModePayload : NSObject
+@interface CHIPModeSelectClusterChangeToModeParams : NSObject
 @property (strong, nonatomic, getter=getNewMode) NSNumber * _Nonnull newMode;
 - (instancetype)init;
 @end
 
-@interface CHIPDoorLockClusterLockDoorPayload : NSObject
+@interface CHIPDoorLockClusterLockDoorParams : NSObject
 @property (strong, nonatomic) NSData * _Nonnull pin;
 - (instancetype)init;
 @end
 
-@interface CHIPDoorLockClusterLockDoorResponsePayload : NSObject
+@interface CHIPDoorLockClusterLockDoorResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull status;
 - (instancetype)init;
 @end
 
-@interface CHIPDoorLockClusterUnlockDoorPayload : NSObject
+@interface CHIPDoorLockClusterUnlockDoorParams : NSObject
 @property (strong, nonatomic) NSData * _Nonnull pin;
 - (instancetype)init;
 @end
 
-@interface CHIPDoorLockClusterUnlockDoorResponsePayload : NSObject
+@interface CHIPDoorLockClusterUnlockDoorResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull status;
 - (instancetype)init;
 @end
 
-@interface CHIPDoorLockClusterTogglePayload : NSObject
+@interface CHIPDoorLockClusterToggleParams : NSObject
 @property (strong, nonatomic) NSString * _Nonnull pin;
 - (instancetype)init;
 @end
 
-@interface CHIPDoorLockClusterToggleResponsePayload : NSObject
+@interface CHIPDoorLockClusterToggleResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull status;
 - (instancetype)init;
 @end
 
-@interface CHIPDoorLockClusterUnlockWithTimeoutPayload : NSObject
+@interface CHIPDoorLockClusterUnlockWithTimeoutParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull timeoutInSeconds;
 @property (strong, nonatomic) NSData * _Nonnull pin;
 - (instancetype)init;
 @end
 
-@interface CHIPDoorLockClusterUnlockWithTimeoutResponsePayload : NSObject
+@interface CHIPDoorLockClusterUnlockWithTimeoutResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull status;
 - (instancetype)init;
 @end
 
-@interface CHIPDoorLockClusterGetLogRecordPayload : NSObject
+@interface CHIPDoorLockClusterGetLogRecordParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull logIndex;
 - (instancetype)init;
 @end
 
-@interface CHIPDoorLockClusterGetLogRecordResponsePayload : NSObject
+@interface CHIPDoorLockClusterGetLogRecordResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull logEntryId;
 @property (strong, nonatomic) NSNumber * _Nonnull timestamp;
 @property (strong, nonatomic) NSNumber * _Nonnull eventType;
@@ -1064,7 +920,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 @end
 
-@interface CHIPDoorLockClusterSetPinPayload : NSObject
+@interface CHIPDoorLockClusterSetPinParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull userId;
 @property (strong, nonatomic) NSNumber * _Nonnull userStatus;
 @property (strong, nonatomic) NSNumber * _Nonnull userType;
@@ -1072,17 +928,17 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 @end
 
-@interface CHIPDoorLockClusterSetPinResponsePayload : NSObject
+@interface CHIPDoorLockClusterSetPinResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull status;
 - (instancetype)init;
 @end
 
-@interface CHIPDoorLockClusterGetPinPayload : NSObject
+@interface CHIPDoorLockClusterGetPinParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull userId;
 - (instancetype)init;
 @end
 
-@interface CHIPDoorLockClusterGetPinResponsePayload : NSObject
+@interface CHIPDoorLockClusterGetPinResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull userId;
 @property (strong, nonatomic) NSNumber * _Nonnull userStatus;
 @property (strong, nonatomic) NSNumber * _Nonnull userType;
@@ -1090,48 +946,44 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 @end
 
-@interface CHIPDoorLockClusterClearPinPayload : NSObject
+@interface CHIPDoorLockClusterClearPinParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull userId;
 - (instancetype)init;
 @end
 
-@interface CHIPDoorLockClusterClearPinResponsePayload : NSObject
+@interface CHIPDoorLockClusterClearPinResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull status;
 - (instancetype)init;
 @end
 
-@interface CHIPDoorLockClusterClearAllPinsPayload : NSObject
-- (instancetype)init;
-@end
-
-@interface CHIPDoorLockClusterClearAllPinsResponsePayload : NSObject
+@interface CHIPDoorLockClusterClearAllPinsResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull status;
 - (instancetype)init;
 @end
 
-@interface CHIPDoorLockClusterSetUserStatusPayload : NSObject
+@interface CHIPDoorLockClusterSetUserStatusParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull userId;
 @property (strong, nonatomic) NSNumber * _Nonnull userStatus;
 - (instancetype)init;
 @end
 
-@interface CHIPDoorLockClusterSetUserStatusResponsePayload : NSObject
+@interface CHIPDoorLockClusterSetUserStatusResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull status;
 - (instancetype)init;
 @end
 
-@interface CHIPDoorLockClusterGetUserStatusPayload : NSObject
+@interface CHIPDoorLockClusterGetUserStatusParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull userId;
 - (instancetype)init;
 @end
 
-@interface CHIPDoorLockClusterGetUserStatusResponsePayload : NSObject
+@interface CHIPDoorLockClusterGetUserStatusResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull userId;
 @property (strong, nonatomic) NSNumber * _Nonnull status;
 - (instancetype)init;
 @end
 
-@interface CHIPDoorLockClusterSetWeekdaySchedulePayload : NSObject
+@interface CHIPDoorLockClusterSetWeekdayScheduleParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull scheduleId;
 @property (strong, nonatomic) NSNumber * _Nonnull userId;
 @property (strong, nonatomic) NSNumber * _Nonnull daysMask;
@@ -1142,18 +994,18 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 @end
 
-@interface CHIPDoorLockClusterSetWeekdayScheduleResponsePayload : NSObject
+@interface CHIPDoorLockClusterSetWeekdayScheduleResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull status;
 - (instancetype)init;
 @end
 
-@interface CHIPDoorLockClusterGetWeekdaySchedulePayload : NSObject
+@interface CHIPDoorLockClusterGetWeekdayScheduleParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull scheduleId;
 @property (strong, nonatomic) NSNumber * _Nonnull userId;
 - (instancetype)init;
 @end
 
-@interface CHIPDoorLockClusterGetWeekdayScheduleResponsePayload : NSObject
+@interface CHIPDoorLockClusterGetWeekdayScheduleResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull scheduleId;
 @property (strong, nonatomic) NSNumber * _Nonnull userId;
 @property (strong, nonatomic) NSNumber * _Nonnull status;
@@ -1165,18 +1017,18 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 @end
 
-@interface CHIPDoorLockClusterClearWeekdaySchedulePayload : NSObject
+@interface CHIPDoorLockClusterClearWeekdayScheduleParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull scheduleId;
 @property (strong, nonatomic) NSNumber * _Nonnull userId;
 - (instancetype)init;
 @end
 
-@interface CHIPDoorLockClusterClearWeekdayScheduleResponsePayload : NSObject
+@interface CHIPDoorLockClusterClearWeekdayScheduleResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull status;
 - (instancetype)init;
 @end
 
-@interface CHIPDoorLockClusterSetYeardaySchedulePayload : NSObject
+@interface CHIPDoorLockClusterSetYeardayScheduleParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull scheduleId;
 @property (strong, nonatomic) NSNumber * _Nonnull userId;
 @property (strong, nonatomic) NSNumber * _Nonnull localStartTime;
@@ -1184,18 +1036,18 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 @end
 
-@interface CHIPDoorLockClusterSetYeardayScheduleResponsePayload : NSObject
+@interface CHIPDoorLockClusterSetYeardayScheduleResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull status;
 - (instancetype)init;
 @end
 
-@interface CHIPDoorLockClusterGetYeardaySchedulePayload : NSObject
+@interface CHIPDoorLockClusterGetYeardayScheduleParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull scheduleId;
 @property (strong, nonatomic) NSNumber * _Nonnull userId;
 - (instancetype)init;
 @end
 
-@interface CHIPDoorLockClusterGetYeardayScheduleResponsePayload : NSObject
+@interface CHIPDoorLockClusterGetYeardayScheduleResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull scheduleId;
 @property (strong, nonatomic) NSNumber * _Nonnull userId;
 @property (strong, nonatomic) NSNumber * _Nonnull status;
@@ -1204,77 +1056,77 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 @end
 
-@interface CHIPDoorLockClusterClearYeardaySchedulePayload : NSObject
+@interface CHIPDoorLockClusterClearYeardayScheduleParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull scheduleId;
 @property (strong, nonatomic) NSNumber * _Nonnull userId;
 - (instancetype)init;
 @end
 
-@interface CHIPDoorLockClusterClearYeardayScheduleResponsePayload : NSObject
+@interface CHIPDoorLockClusterClearYeardayScheduleResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull status;
 - (instancetype)init;
 @end
 
-@interface CHIPDoorLockClusterSetHolidaySchedulePayload : NSObject
+@interface CHIPDoorLockClusterSetHolidayScheduleParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull scheduleId;
-@property (strong, nonatomic) NSNumber * _Nonnull localStartTime;
-@property (strong, nonatomic) NSNumber * _Nonnull localEndTime;
-@property (strong, nonatomic) NSNumber * _Nonnull operatingModeDuringHoliday;
-- (instancetype)init;
-@end
-
-@interface CHIPDoorLockClusterSetHolidayScheduleResponsePayload : NSObject
-@property (strong, nonatomic) NSNumber * _Nonnull status;
-- (instancetype)init;
-@end
-
-@interface CHIPDoorLockClusterGetHolidaySchedulePayload : NSObject
-@property (strong, nonatomic) NSNumber * _Nonnull scheduleId;
-- (instancetype)init;
-@end
-
-@interface CHIPDoorLockClusterGetHolidayScheduleResponsePayload : NSObject
-@property (strong, nonatomic) NSNumber * _Nonnull scheduleId;
-@property (strong, nonatomic) NSNumber * _Nonnull status;
 @property (strong, nonatomic) NSNumber * _Nonnull localStartTime;
 @property (strong, nonatomic) NSNumber * _Nonnull localEndTime;
 @property (strong, nonatomic) NSNumber * _Nonnull operatingModeDuringHoliday;
 - (instancetype)init;
 @end
 
-@interface CHIPDoorLockClusterClearHolidaySchedulePayload : NSObject
+@interface CHIPDoorLockClusterSetHolidayScheduleResponseParams : NSObject
+@property (strong, nonatomic) NSNumber * _Nonnull status;
+- (instancetype)init;
+@end
+
+@interface CHIPDoorLockClusterGetHolidayScheduleParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull scheduleId;
 - (instancetype)init;
 @end
 
-@interface CHIPDoorLockClusterClearHolidayScheduleResponsePayload : NSObject
+@interface CHIPDoorLockClusterGetHolidayScheduleResponseParams : NSObject
+@property (strong, nonatomic) NSNumber * _Nonnull scheduleId;
+@property (strong, nonatomic) NSNumber * _Nonnull status;
+@property (strong, nonatomic) NSNumber * _Nonnull localStartTime;
+@property (strong, nonatomic) NSNumber * _Nonnull localEndTime;
+@property (strong, nonatomic) NSNumber * _Nonnull operatingModeDuringHoliday;
+- (instancetype)init;
+@end
+
+@interface CHIPDoorLockClusterClearHolidayScheduleParams : NSObject
+@property (strong, nonatomic) NSNumber * _Nonnull scheduleId;
+- (instancetype)init;
+@end
+
+@interface CHIPDoorLockClusterClearHolidayScheduleResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull status;
 - (instancetype)init;
 @end
 
-@interface CHIPDoorLockClusterSetUserTypePayload : NSObject
+@interface CHIPDoorLockClusterSetUserTypeParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull userId;
 @property (strong, nonatomic) NSNumber * _Nonnull userType;
 - (instancetype)init;
 @end
 
-@interface CHIPDoorLockClusterSetUserTypeResponsePayload : NSObject
+@interface CHIPDoorLockClusterSetUserTypeResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull status;
 - (instancetype)init;
 @end
 
-@interface CHIPDoorLockClusterGetUserTypePayload : NSObject
+@interface CHIPDoorLockClusterGetUserTypeParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull userId;
 - (instancetype)init;
 @end
 
-@interface CHIPDoorLockClusterGetUserTypeResponsePayload : NSObject
+@interface CHIPDoorLockClusterGetUserTypeResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull userId;
 @property (strong, nonatomic) NSNumber * _Nonnull userType;
 - (instancetype)init;
 @end
 
-@interface CHIPDoorLockClusterSetRfidPayload : NSObject
+@interface CHIPDoorLockClusterSetRfidParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull userId;
 @property (strong, nonatomic) NSNumber * _Nonnull userStatus;
 @property (strong, nonatomic) NSNumber * _Nonnull userType;
@@ -1282,17 +1134,17 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 @end
 
-@interface CHIPDoorLockClusterSetRfidResponsePayload : NSObject
+@interface CHIPDoorLockClusterSetRfidResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull status;
 - (instancetype)init;
 @end
 
-@interface CHIPDoorLockClusterGetRfidPayload : NSObject
+@interface CHIPDoorLockClusterGetRfidParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull userId;
 - (instancetype)init;
 @end
 
-@interface CHIPDoorLockClusterGetRfidResponsePayload : NSObject
+@interface CHIPDoorLockClusterGetRfidResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull userId;
 @property (strong, nonatomic) NSNumber * _Nonnull userStatus;
 @property (strong, nonatomic) NSNumber * _Nonnull userType;
@@ -1300,26 +1152,22 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 @end
 
-@interface CHIPDoorLockClusterClearRfidPayload : NSObject
+@interface CHIPDoorLockClusterClearRfidParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull userId;
 - (instancetype)init;
 @end
 
-@interface CHIPDoorLockClusterClearRfidResponsePayload : NSObject
+@interface CHIPDoorLockClusterClearRfidResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull status;
 - (instancetype)init;
 @end
 
-@interface CHIPDoorLockClusterClearAllRfidsPayload : NSObject
-- (instancetype)init;
-@end
-
-@interface CHIPDoorLockClusterClearAllRfidsResponsePayload : NSObject
+@interface CHIPDoorLockClusterClearAllRfidsResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull status;
 - (instancetype)init;
 @end
 
-@interface CHIPDoorLockClusterOperationEventNotificationPayload : NSObject
+@interface CHIPDoorLockClusterOperationEventNotificationParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull source;
 @property (strong, nonatomic) NSNumber * _Nonnull eventCode;
 @property (strong, nonatomic) NSNumber * _Nonnull userId;
@@ -1329,7 +1177,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 @end
 
-@interface CHIPDoorLockClusterProgrammingEventNotificationPayload : NSObject
+@interface CHIPDoorLockClusterProgrammingEventNotificationParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull source;
 @property (strong, nonatomic) NSNumber * _Nonnull eventCode;
 @property (strong, nonatomic) NSNumber * _Nonnull userId;
@@ -1341,56 +1189,40 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 @end
 
-@interface CHIPWindowCoveringClusterUpOrOpenPayload : NSObject
-- (instancetype)init;
-@end
-
-@interface CHIPWindowCoveringClusterDownOrClosePayload : NSObject
-- (instancetype)init;
-@end
-
-@interface CHIPWindowCoveringClusterStopMotionPayload : NSObject
-- (instancetype)init;
-@end
-
-@interface CHIPWindowCoveringClusterGoToLiftValuePayload : NSObject
+@interface CHIPWindowCoveringClusterGoToLiftValueParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull liftValue;
 - (instancetype)init;
 @end
 
-@interface CHIPWindowCoveringClusterGoToLiftPercentagePayload : NSObject
+@interface CHIPWindowCoveringClusterGoToLiftPercentageParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull liftPercentageValue;
 @property (strong, nonatomic) NSNumber * _Nonnull liftPercent100thsValue;
 - (instancetype)init;
 @end
 
-@interface CHIPWindowCoveringClusterGoToTiltValuePayload : NSObject
+@interface CHIPWindowCoveringClusterGoToTiltValueParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull tiltValue;
 - (instancetype)init;
 @end
 
-@interface CHIPWindowCoveringClusterGoToTiltPercentagePayload : NSObject
+@interface CHIPWindowCoveringClusterGoToTiltPercentageParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull tiltPercentageValue;
 @property (strong, nonatomic) NSNumber * _Nonnull tiltPercent100thsValue;
 - (instancetype)init;
 @end
 
-@interface CHIPBarrierControlClusterBarrierControlGoToPercentPayload : NSObject
+@interface CHIPBarrierControlClusterBarrierControlGoToPercentParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull percentOpen;
 - (instancetype)init;
 @end
 
-@interface CHIPBarrierControlClusterBarrierControlStopPayload : NSObject
-- (instancetype)init;
-@end
-
-@interface CHIPThermostatClusterSetpointRaiseLowerPayload : NSObject
+@interface CHIPThermostatClusterSetpointRaiseLowerParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull mode;
 @property (strong, nonatomic) NSNumber * _Nonnull amount;
 - (instancetype)init;
 @end
 
-@interface CHIPThermostatClusterCurrentWeeklySchedulePayload : NSObject
+@interface CHIPThermostatClusterCurrentWeeklyScheduleParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull numberOfTransitionsForSequence;
 @property (strong, nonatomic) NSNumber * _Nonnull dayOfWeekForSequence;
 @property (strong, nonatomic) NSNumber * _Nonnull modeForSequence;
@@ -1398,7 +1230,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 @end
 
-@interface CHIPThermostatClusterSetWeeklySchedulePayload : NSObject
+@interface CHIPThermostatClusterSetWeeklyScheduleParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull numberOfTransitionsForSequence;
 @property (strong, nonatomic) NSNumber * _Nonnull dayOfWeekForSequence;
 @property (strong, nonatomic) NSNumber * _Nonnull modeForSequence;
@@ -1406,7 +1238,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 @end
 
-@interface CHIPThermostatClusterRelayStatusLogPayload : NSObject
+@interface CHIPThermostatClusterRelayStatusLogParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull timeOfDay;
 @property (strong, nonatomic) NSNumber * _Nonnull relayStatus;
 @property (strong, nonatomic) NSNumber * _Nonnull localTemperature;
@@ -1416,21 +1248,13 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 @end
 
-@interface CHIPThermostatClusterGetWeeklySchedulePayload : NSObject
+@interface CHIPThermostatClusterGetWeeklyScheduleParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull daysToReturn;
 @property (strong, nonatomic) NSNumber * _Nonnull modeToReturn;
 - (instancetype)init;
 @end
 
-@interface CHIPThermostatClusterClearWeeklySchedulePayload : NSObject
-- (instancetype)init;
-@end
-
-@interface CHIPThermostatClusterGetRelayStatusLogPayload : NSObject
-- (instancetype)init;
-@end
-
-@interface CHIPColorControlClusterMoveToHuePayload : NSObject
+@interface CHIPColorControlClusterMoveToHueParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull hue;
 @property (strong, nonatomic) NSNumber * _Nonnull direction;
 @property (strong, nonatomic) NSNumber * _Nonnull transitionTime;
@@ -1439,7 +1263,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 @end
 
-@interface CHIPColorControlClusterMoveHuePayload : NSObject
+@interface CHIPColorControlClusterMoveHueParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull moveMode;
 @property (strong, nonatomic) NSNumber * _Nonnull rate;
 @property (strong, nonatomic) NSNumber * _Nonnull optionsMask;
@@ -1447,7 +1271,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 @end
 
-@interface CHIPColorControlClusterStepHuePayload : NSObject
+@interface CHIPColorControlClusterStepHueParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull stepMode;
 @property (strong, nonatomic) NSNumber * _Nonnull stepSize;
 @property (strong, nonatomic) NSNumber * _Nonnull transitionTime;
@@ -1456,7 +1280,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 @end
 
-@interface CHIPColorControlClusterMoveToSaturationPayload : NSObject
+@interface CHIPColorControlClusterMoveToSaturationParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull saturation;
 @property (strong, nonatomic) NSNumber * _Nonnull transitionTime;
 @property (strong, nonatomic) NSNumber * _Nonnull optionsMask;
@@ -1464,7 +1288,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 @end
 
-@interface CHIPColorControlClusterMoveSaturationPayload : NSObject
+@interface CHIPColorControlClusterMoveSaturationParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull moveMode;
 @property (strong, nonatomic) NSNumber * _Nonnull rate;
 @property (strong, nonatomic) NSNumber * _Nonnull optionsMask;
@@ -1472,7 +1296,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 @end
 
-@interface CHIPColorControlClusterStepSaturationPayload : NSObject
+@interface CHIPColorControlClusterStepSaturationParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull stepMode;
 @property (strong, nonatomic) NSNumber * _Nonnull stepSize;
 @property (strong, nonatomic) NSNumber * _Nonnull transitionTime;
@@ -1481,7 +1305,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 @end
 
-@interface CHIPColorControlClusterMoveToHueAndSaturationPayload : NSObject
+@interface CHIPColorControlClusterMoveToHueAndSaturationParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull hue;
 @property (strong, nonatomic) NSNumber * _Nonnull saturation;
 @property (strong, nonatomic) NSNumber * _Nonnull transitionTime;
@@ -1490,7 +1314,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 @end
 
-@interface CHIPColorControlClusterMoveToColorPayload : NSObject
+@interface CHIPColorControlClusterMoveToColorParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull colorX;
 @property (strong, nonatomic) NSNumber * _Nonnull colorY;
 @property (strong, nonatomic) NSNumber * _Nonnull transitionTime;
@@ -1499,7 +1323,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 @end
 
-@interface CHIPColorControlClusterMoveColorPayload : NSObject
+@interface CHIPColorControlClusterMoveColorParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull rateX;
 @property (strong, nonatomic) NSNumber * _Nonnull rateY;
 @property (strong, nonatomic) NSNumber * _Nonnull optionsMask;
@@ -1507,7 +1331,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 @end
 
-@interface CHIPColorControlClusterStepColorPayload : NSObject
+@interface CHIPColorControlClusterStepColorParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull stepX;
 @property (strong, nonatomic) NSNumber * _Nonnull stepY;
 @property (strong, nonatomic) NSNumber * _Nonnull transitionTime;
@@ -1516,7 +1340,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 @end
 
-@interface CHIPColorControlClusterMoveToColorTemperaturePayload : NSObject
+@interface CHIPColorControlClusterMoveToColorTemperatureParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull colorTemperature;
 @property (strong, nonatomic) NSNumber * _Nonnull transitionTime;
 @property (strong, nonatomic) NSNumber * _Nonnull optionsMask;
@@ -1524,7 +1348,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 @end
 
-@interface CHIPColorControlClusterEnhancedMoveToHuePayload : NSObject
+@interface CHIPColorControlClusterEnhancedMoveToHueParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull enhancedHue;
 @property (strong, nonatomic) NSNumber * _Nonnull direction;
 @property (strong, nonatomic) NSNumber * _Nonnull transitionTime;
@@ -1533,7 +1357,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 @end
 
-@interface CHIPColorControlClusterEnhancedMoveHuePayload : NSObject
+@interface CHIPColorControlClusterEnhancedMoveHueParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull moveMode;
 @property (strong, nonatomic) NSNumber * _Nonnull rate;
 @property (strong, nonatomic) NSNumber * _Nonnull optionsMask;
@@ -1541,7 +1365,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 @end
 
-@interface CHIPColorControlClusterEnhancedStepHuePayload : NSObject
+@interface CHIPColorControlClusterEnhancedStepHueParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull stepMode;
 @property (strong, nonatomic) NSNumber * _Nonnull stepSize;
 @property (strong, nonatomic) NSNumber * _Nonnull transitionTime;
@@ -1550,7 +1374,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 @end
 
-@interface CHIPColorControlClusterEnhancedMoveToHueAndSaturationPayload : NSObject
+@interface CHIPColorControlClusterEnhancedMoveToHueAndSaturationParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull enhancedHue;
 @property (strong, nonatomic) NSNumber * _Nonnull saturation;
 @property (strong, nonatomic) NSNumber * _Nonnull transitionTime;
@@ -1559,7 +1383,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 @end
 
-@interface CHIPColorControlClusterColorLoopSetPayload : NSObject
+@interface CHIPColorControlClusterColorLoopSetParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull updateFlags;
 @property (strong, nonatomic) NSNumber * _Nonnull action;
 @property (strong, nonatomic) NSNumber * _Nonnull direction;
@@ -1570,13 +1394,13 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 @end
 
-@interface CHIPColorControlClusterStopMoveStepPayload : NSObject
+@interface CHIPColorControlClusterStopMoveStepParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull optionsMask;
 @property (strong, nonatomic) NSNumber * _Nonnull optionsOverride;
 - (instancetype)init;
 @end
 
-@interface CHIPColorControlClusterMoveColorTemperaturePayload : NSObject
+@interface CHIPColorControlClusterMoveColorTemperatureParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull moveMode;
 @property (strong, nonatomic) NSNumber * _Nonnull rate;
 @property (strong, nonatomic) NSNumber * _Nonnull colorTemperatureMinimum;
@@ -1586,7 +1410,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 @end
 
-@interface CHIPColorControlClusterStepColorTemperaturePayload : NSObject
+@interface CHIPColorControlClusterStepColorTemperatureParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull stepMode;
 @property (strong, nonatomic) NSNumber * _Nonnull stepSize;
 @property (strong, nonatomic) NSNumber * _Nonnull transitionTime;
@@ -1597,13 +1421,13 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 @end
 
-@interface CHIPIasZoneClusterZoneEnrollResponsePayload : NSObject
+@interface CHIPIasZoneClusterZoneEnrollResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull enrollResponseCode;
 @property (strong, nonatomic) NSNumber * _Nonnull zoneId;
 - (instancetype)init;
 @end
 
-@interface CHIPIasZoneClusterZoneStatusChangeNotificationPayload : NSObject
+@interface CHIPIasZoneClusterZoneStatusChangeNotificationParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull zoneStatus;
 @property (strong, nonatomic) NSNumber * _Nonnull extendedStatus;
 @property (strong, nonatomic) NSNumber * _Nonnull zoneId;
@@ -1611,50 +1435,38 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 @end
 
-@interface CHIPIasZoneClusterInitiateNormalOperationModePayload : NSObject
-- (instancetype)init;
-@end
-
-@interface CHIPIasZoneClusterZoneEnrollRequestPayload : NSObject
+@interface CHIPIasZoneClusterZoneEnrollRequestParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull zoneType;
 @property (strong, nonatomic) NSNumber * _Nonnull manufacturerCode;
 - (instancetype)init;
 @end
 
-@interface CHIPIasZoneClusterInitiateTestModePayload : NSObject
+@interface CHIPIasZoneClusterInitiateTestModeParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull testModeDuration;
 @property (strong, nonatomic) NSNumber * _Nonnull currentZoneSensitivityLevel;
 - (instancetype)init;
 @end
 
-@interface CHIPIasZoneClusterInitiateNormalOperationModeResponsePayload : NSObject
-- (instancetype)init;
-@end
-
-@interface CHIPIasZoneClusterInitiateTestModeResponsePayload : NSObject
-- (instancetype)init;
-@end
-
-@interface CHIPIasAceClusterArmPayload : NSObject
+@interface CHIPIasAceClusterArmParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull armMode;
 @property (strong, nonatomic) NSString * _Nonnull armDisarmCode;
 @property (strong, nonatomic) NSNumber * _Nonnull zoneId;
 - (instancetype)init;
 @end
 
-@interface CHIPIasAceClusterArmResponsePayload : NSObject
+@interface CHIPIasAceClusterArmResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull armNotification;
 - (instancetype)init;
 @end
 
-@interface CHIPIasAceClusterBypassPayload : NSObject
+@interface CHIPIasAceClusterBypassParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull numberOfZones;
 @property (strong, nonatomic) NSArray * _Nonnull zoneIds;
 @property (strong, nonatomic) NSString * _Nonnull armDisarmCode;
 - (instancetype)init;
 @end
 
-@interface CHIPIasAceClusterGetZoneIdMapResponsePayload : NSObject
+@interface CHIPIasAceClusterGetZoneIdMapResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull section0;
 @property (strong, nonatomic) NSNumber * _Nonnull section1;
 @property (strong, nonatomic) NSNumber * _Nonnull section2;
@@ -1674,11 +1486,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 @end
 
-@interface CHIPIasAceClusterEmergencyPayload : NSObject
-- (instancetype)init;
-@end
-
-@interface CHIPIasAceClusterGetZoneInformationResponsePayload : NSObject
+@interface CHIPIasAceClusterGetZoneInformationResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull zoneId;
 @property (strong, nonatomic) NSNumber * _Nonnull zoneType;
 @property (strong, nonatomic) NSNumber * _Nonnull ieeeAddress;
@@ -1686,11 +1494,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 @end
 
-@interface CHIPIasAceClusterFirePayload : NSObject
-- (instancetype)init;
-@end
-
-@interface CHIPIasAceClusterZoneStatusChangedPayload : NSObject
+@interface CHIPIasAceClusterZoneStatusChangedParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull zoneId;
 @property (strong, nonatomic) NSNumber * _Nonnull zoneStatus;
 @property (strong, nonatomic) NSNumber * _Nonnull audibleNotification;
@@ -1698,11 +1502,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 @end
 
-@interface CHIPIasAceClusterPanicPayload : NSObject
-- (instancetype)init;
-@end
-
-@interface CHIPIasAceClusterPanelStatusChangedPayload : NSObject
+@interface CHIPIasAceClusterPanelStatusChangedParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull panelStatus;
 @property (strong, nonatomic) NSNumber * _Nonnull secondsRemaining;
 @property (strong, nonatomic) NSNumber * _Nonnull audibleNotification;
@@ -1710,11 +1510,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 @end
 
-@interface CHIPIasAceClusterGetZoneIdMapPayload : NSObject
-- (instancetype)init;
-@end
-
-@interface CHIPIasAceClusterGetPanelStatusResponsePayload : NSObject
+@interface CHIPIasAceClusterGetPanelStatusResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull panelStatus;
 @property (strong, nonatomic) NSNumber * _Nonnull secondsRemaining;
 @property (strong, nonatomic) NSNumber * _Nonnull audibleNotification;
@@ -1722,39 +1518,31 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 @end
 
-@interface CHIPIasAceClusterGetZoneInformationPayload : NSObject
+@interface CHIPIasAceClusterGetZoneInformationParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull zoneId;
 - (instancetype)init;
 @end
 
-@interface CHIPIasAceClusterSetBypassedZoneListPayload : NSObject
+@interface CHIPIasAceClusterSetBypassedZoneListParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull numberOfZones;
 @property (strong, nonatomic) NSArray * _Nonnull zoneIds;
 - (instancetype)init;
 @end
 
-@interface CHIPIasAceClusterGetPanelStatusPayload : NSObject
-- (instancetype)init;
-@end
-
-@interface CHIPIasAceClusterBypassResponsePayload : NSObject
+@interface CHIPIasAceClusterBypassResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull numberOfZones;
 @property (strong, nonatomic) NSArray * _Nonnull bypassResult;
 - (instancetype)init;
 @end
 
-@interface CHIPIasAceClusterGetBypassedZoneListPayload : NSObject
-- (instancetype)init;
-@end
-
-@interface CHIPIasAceClusterGetZoneStatusResponsePayload : NSObject
+@interface CHIPIasAceClusterGetZoneStatusResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull zoneStatusComplete;
 @property (strong, nonatomic) NSNumber * _Nonnull numberOfZones;
 @property (strong, nonatomic) NSArray * _Nonnull zoneStatusResult;
 - (instancetype)init;
 @end
 
-@interface CHIPIasAceClusterGetZoneStatusPayload : NSObject
+@interface CHIPIasAceClusterGetZoneStatusParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull startingZoneId;
 @property (strong, nonatomic) NSNumber * _Nonnull maxNumberOfZoneIds;
 @property (strong, nonatomic) NSNumber * _Nonnull zoneStatusMaskFlag;
@@ -1762,7 +1550,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 @end
 
-@interface CHIPIasWdClusterStartWarningPayload : NSObject
+@interface CHIPIasWdClusterStartWarningParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull warningInfo;
 @property (strong, nonatomic) NSNumber * _Nonnull warningDuration;
 @property (strong, nonatomic) NSNumber * _Nonnull strobeDutyCycle;
@@ -1770,281 +1558,221 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 @end
 
-@interface CHIPIasWdClusterSquawkPayload : NSObject
+@interface CHIPIasWdClusterSquawkParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull squawkInfo;
 - (instancetype)init;
 @end
 
-@interface CHIPTvChannelClusterChangeChannelPayload : NSObject
+@interface CHIPTvChannelClusterChangeChannelParams : NSObject
 @property (strong, nonatomic) NSString * _Nonnull match;
 - (instancetype)init;
 @end
 
-@interface CHIPTvChannelClusterChangeChannelResponsePayload : NSObject
+@interface CHIPTvChannelClusterChangeChannelResponseParams : NSObject
 @property (strong, nonatomic) NSArray * _Nonnull channelMatch;
 @property (strong, nonatomic) NSNumber * _Nonnull errorType;
 - (instancetype)init;
 @end
 
-@interface CHIPTvChannelClusterChangeChannelByNumberPayload : NSObject
+@interface CHIPTvChannelClusterChangeChannelByNumberParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull majorNumber;
 @property (strong, nonatomic) NSNumber * _Nonnull minorNumber;
 - (instancetype)init;
 @end
 
-@interface CHIPTvChannelClusterSkipChannelPayload : NSObject
+@interface CHIPTvChannelClusterSkipChannelParams : NSObject
 @property (strong, nonatomic, getter=getCount) NSNumber * _Nonnull count;
 - (instancetype)init;
 @end
 
-@interface CHIPTargetNavigatorClusterNavigateTargetPayload : NSObject
+@interface CHIPTargetNavigatorClusterNavigateTargetParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull target;
 @property (strong, nonatomic) NSString * _Nonnull data;
 - (instancetype)init;
 @end
 
-@interface CHIPTargetNavigatorClusterNavigateTargetResponsePayload : NSObject
+@interface CHIPTargetNavigatorClusterNavigateTargetResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull status;
 @property (strong, nonatomic) NSString * _Nonnull data;
 - (instancetype)init;
 @end
 
-@interface CHIPMediaPlaybackClusterMediaPlayPayload : NSObject
-- (instancetype)init;
-@end
-
-@interface CHIPMediaPlaybackClusterMediaPlayResponsePayload : NSObject
+@interface CHIPMediaPlaybackClusterMediaPlayResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull mediaPlaybackStatus;
 - (instancetype)init;
 @end
 
-@interface CHIPMediaPlaybackClusterMediaPausePayload : NSObject
-- (instancetype)init;
-@end
-
-@interface CHIPMediaPlaybackClusterMediaPauseResponsePayload : NSObject
+@interface CHIPMediaPlaybackClusterMediaPauseResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull mediaPlaybackStatus;
 - (instancetype)init;
 @end
 
-@interface CHIPMediaPlaybackClusterMediaStopPayload : NSObject
-- (instancetype)init;
-@end
-
-@interface CHIPMediaPlaybackClusterMediaStopResponsePayload : NSObject
+@interface CHIPMediaPlaybackClusterMediaStopResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull mediaPlaybackStatus;
 - (instancetype)init;
 @end
 
-@interface CHIPMediaPlaybackClusterMediaStartOverPayload : NSObject
-- (instancetype)init;
-@end
-
-@interface CHIPMediaPlaybackClusterMediaStartOverResponsePayload : NSObject
+@interface CHIPMediaPlaybackClusterMediaStartOverResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull mediaPlaybackStatus;
 - (instancetype)init;
 @end
 
-@interface CHIPMediaPlaybackClusterMediaPreviousPayload : NSObject
-- (instancetype)init;
-@end
-
-@interface CHIPMediaPlaybackClusterMediaPreviousResponsePayload : NSObject
+@interface CHIPMediaPlaybackClusterMediaPreviousResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull mediaPlaybackStatus;
 - (instancetype)init;
 @end
 
-@interface CHIPMediaPlaybackClusterMediaNextPayload : NSObject
-- (instancetype)init;
-@end
-
-@interface CHIPMediaPlaybackClusterMediaNextResponsePayload : NSObject
+@interface CHIPMediaPlaybackClusterMediaNextResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull mediaPlaybackStatus;
 - (instancetype)init;
 @end
 
-@interface CHIPMediaPlaybackClusterMediaRewindPayload : NSObject
-- (instancetype)init;
-@end
-
-@interface CHIPMediaPlaybackClusterMediaRewindResponsePayload : NSObject
+@interface CHIPMediaPlaybackClusterMediaRewindResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull mediaPlaybackStatus;
 - (instancetype)init;
 @end
 
-@interface CHIPMediaPlaybackClusterMediaFastForwardPayload : NSObject
-- (instancetype)init;
-@end
-
-@interface CHIPMediaPlaybackClusterMediaFastForwardResponsePayload : NSObject
+@interface CHIPMediaPlaybackClusterMediaFastForwardResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull mediaPlaybackStatus;
 - (instancetype)init;
 @end
 
-@interface CHIPMediaPlaybackClusterMediaSkipForwardPayload : NSObject
+@interface CHIPMediaPlaybackClusterMediaSkipForwardParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull deltaPositionMilliseconds;
 - (instancetype)init;
 @end
 
-@interface CHIPMediaPlaybackClusterMediaSkipForwardResponsePayload : NSObject
+@interface CHIPMediaPlaybackClusterMediaSkipForwardResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull mediaPlaybackStatus;
 - (instancetype)init;
 @end
 
-@interface CHIPMediaPlaybackClusterMediaSkipBackwardPayload : NSObject
+@interface CHIPMediaPlaybackClusterMediaSkipBackwardParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull deltaPositionMilliseconds;
 - (instancetype)init;
 @end
 
-@interface CHIPMediaPlaybackClusterMediaSkipBackwardResponsePayload : NSObject
+@interface CHIPMediaPlaybackClusterMediaSkipBackwardResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull mediaPlaybackStatus;
 - (instancetype)init;
 @end
 
-@interface CHIPMediaPlaybackClusterMediaSeekPayload : NSObject
+@interface CHIPMediaPlaybackClusterMediaSeekParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull position;
 - (instancetype)init;
 @end
 
-@interface CHIPMediaPlaybackClusterMediaSeekResponsePayload : NSObject
+@interface CHIPMediaPlaybackClusterMediaSeekResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull mediaPlaybackStatus;
 - (instancetype)init;
 @end
 
-@interface CHIPMediaInputClusterSelectInputPayload : NSObject
+@interface CHIPMediaInputClusterSelectInputParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull index;
 - (instancetype)init;
 @end
 
-@interface CHIPMediaInputClusterShowInputStatusPayload : NSObject
-- (instancetype)init;
-@end
-
-@interface CHIPMediaInputClusterHideInputStatusPayload : NSObject
-- (instancetype)init;
-@end
-
-@interface CHIPMediaInputClusterRenameInputPayload : NSObject
+@interface CHIPMediaInputClusterRenameInputParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull index;
 @property (strong, nonatomic) NSString * _Nonnull name;
 - (instancetype)init;
 @end
 
-@interface CHIPLowPowerClusterSleepPayload : NSObject
-- (instancetype)init;
-@end
-
-@interface CHIPKeypadInputClusterSendKeyPayload : NSObject
+@interface CHIPKeypadInputClusterSendKeyParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull keyCode;
 - (instancetype)init;
 @end
 
-@interface CHIPKeypadInputClusterSendKeyResponsePayload : NSObject
+@interface CHIPKeypadInputClusterSendKeyResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull status;
 - (instancetype)init;
 @end
 
-@interface CHIPContentLauncherClusterLaunchContentPayload : NSObject
+@interface CHIPContentLauncherClusterLaunchContentParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull autoPlay;
 @property (strong, nonatomic) NSString * _Nonnull data;
 - (instancetype)init;
 @end
 
-@interface CHIPContentLauncherClusterLaunchContentResponsePayload : NSObject
+@interface CHIPContentLauncherClusterLaunchContentResponseParams : NSObject
 @property (strong, nonatomic) NSString * _Nonnull data;
 @property (strong, nonatomic) NSNumber * _Nonnull contentLaunchStatus;
 - (instancetype)init;
 @end
 
-@interface CHIPContentLauncherClusterLaunchURLPayload : NSObject
+@interface CHIPContentLauncherClusterLaunchURLParams : NSObject
 @property (strong, nonatomic) NSString * _Nonnull contentURL;
 @property (strong, nonatomic) NSString * _Nonnull displayString;
 - (instancetype)init;
 @end
 
-@interface CHIPContentLauncherClusterLaunchURLResponsePayload : NSObject
+@interface CHIPContentLauncherClusterLaunchURLResponseParams : NSObject
 @property (strong, nonatomic) NSString * _Nonnull data;
 @property (strong, nonatomic) NSNumber * _Nonnull contentLaunchStatus;
 - (instancetype)init;
 @end
 
-@interface CHIPAudioOutputClusterSelectOutputPayload : NSObject
+@interface CHIPAudioOutputClusterSelectOutputParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull index;
 - (instancetype)init;
 @end
 
-@interface CHIPAudioOutputClusterRenameOutputPayload : NSObject
+@interface CHIPAudioOutputClusterRenameOutputParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull index;
 @property (strong, nonatomic) NSString * _Nonnull name;
 - (instancetype)init;
 @end
 
-@interface CHIPApplicationLauncherClusterLaunchAppPayload : NSObject
+@interface CHIPApplicationLauncherClusterLaunchAppParams : NSObject
 @property (strong, nonatomic) NSString * _Nonnull data;
 @property (strong, nonatomic) NSNumber * _Nonnull catalogVendorId;
 @property (strong, nonatomic) NSString * _Nonnull applicationId;
 - (instancetype)init;
 @end
 
-@interface CHIPApplicationLauncherClusterLaunchAppResponsePayload : NSObject
+@interface CHIPApplicationLauncherClusterLaunchAppResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull status;
 @property (strong, nonatomic) NSString * _Nonnull data;
 - (instancetype)init;
 @end
 
-@interface CHIPApplicationBasicClusterChangeStatusPayload : NSObject
+@interface CHIPApplicationBasicClusterChangeStatusParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull status;
 - (instancetype)init;
 @end
 
-@interface CHIPAccountLoginClusterGetSetupPINPayload : NSObject
+@interface CHIPAccountLoginClusterGetSetupPINParams : NSObject
 @property (strong, nonatomic) NSString * _Nonnull tempAccountIdentifier;
 - (instancetype)init;
 @end
 
-@interface CHIPAccountLoginClusterGetSetupPINResponsePayload : NSObject
+@interface CHIPAccountLoginClusterGetSetupPINResponseParams : NSObject
 @property (strong, nonatomic) NSString * _Nonnull setupPIN;
 - (instancetype)init;
 @end
 
-@interface CHIPAccountLoginClusterLoginPayload : NSObject
+@interface CHIPAccountLoginClusterLoginParams : NSObject
 @property (strong, nonatomic) NSString * _Nonnull tempAccountIdentifier;
 @property (strong, nonatomic) NSString * _Nonnull setupPIN;
 - (instancetype)init;
 @end
 
-@interface CHIPTestClusterClusterTestPayload : NSObject
-- (instancetype)init;
-@end
-
-@interface CHIPTestClusterClusterTestSpecificResponsePayload : NSObject
+@interface CHIPTestClusterClusterTestSpecificResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull returnValue;
 - (instancetype)init;
 @end
 
-@interface CHIPTestClusterClusterTestNotHandledPayload : NSObject
-- (instancetype)init;
-@end
-
-@interface CHIPTestClusterClusterTestAddArgumentsResponsePayload : NSObject
+@interface CHIPTestClusterClusterTestAddArgumentsResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull returnValue;
 - (instancetype)init;
 @end
 
-@interface CHIPTestClusterClusterTestSpecificPayload : NSObject
-- (instancetype)init;
-@end
-
-@interface CHIPTestClusterClusterTestSimpleArgumentResponsePayload : NSObject
+@interface CHIPTestClusterClusterTestSimpleArgumentResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull returnValue;
 - (instancetype)init;
 @end
 
-@interface CHIPTestClusterClusterTestUnknownCommandPayload : NSObject
-- (instancetype)init;
-@end
-
-@interface CHIPTestClusterClusterTestStructArrayArgumentResponsePayload : NSObject
+@interface CHIPTestClusterClusterTestStructArrayArgumentResponseParams : NSObject
 @property (strong, nonatomic) NSArray * _Nonnull arg1;
 @property (strong, nonatomic) NSArray * _Nonnull arg2;
 @property (strong, nonatomic) NSArray * _Nonnull arg3;
@@ -2054,29 +1782,29 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 @end
 
-@interface CHIPTestClusterClusterTestAddArgumentsPayload : NSObject
+@interface CHIPTestClusterClusterTestAddArgumentsParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull arg1;
 @property (strong, nonatomic) NSNumber * _Nonnull arg2;
 - (instancetype)init;
 @end
 
-@interface CHIPTestClusterClusterTestListInt8UReverseResponsePayload : NSObject
+@interface CHIPTestClusterClusterTestListInt8UReverseResponseParams : NSObject
 @property (strong, nonatomic) NSArray * _Nonnull arg1;
 - (instancetype)init;
 @end
 
-@interface CHIPTestClusterClusterTestSimpleArgumentRequestPayload : NSObject
+@interface CHIPTestClusterClusterTestSimpleArgumentRequestParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull arg1;
 - (instancetype)init;
 @end
 
-@interface CHIPTestClusterClusterTestEnumsResponsePayload : NSObject
+@interface CHIPTestClusterClusterTestEnumsResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull arg1;
 @property (strong, nonatomic) NSNumber * _Nonnull arg2;
 - (instancetype)init;
 @end
 
-@interface CHIPTestClusterClusterTestStructArrayArgumentRequestPayload : NSObject
+@interface CHIPTestClusterClusterTestStructArrayArgumentRequestParams : NSObject
 @property (strong, nonatomic) NSArray * _Nonnull arg1;
 @property (strong, nonatomic) NSArray * _Nonnull arg2;
 @property (strong, nonatomic) NSArray * _Nonnull arg3;
@@ -2086,7 +1814,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 @end
 
-@interface CHIPTestClusterClusterTestNullableOptionalResponsePayload : NSObject
+@interface CHIPTestClusterClusterTestNullableOptionalResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull wasPresent;
 @property (strong, nonatomic) NSNumber * _Nullable wasNull;
 @property (strong, nonatomic) NSNumber * _Nullable value;
@@ -2094,12 +1822,12 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 @end
 
-@interface CHIPTestClusterClusterTestStructArgumentRequestPayload : NSObject
+@interface CHIPTestClusterClusterTestStructArgumentRequestParams : NSObject
 @property (strong, nonatomic) CHIPTestClusterClusterSimpleStruct * _Nonnull arg1;
 - (instancetype)init;
 @end
 
-@interface CHIPTestClusterClusterTestComplexNullableOptionalResponsePayload : NSObject
+@interface CHIPTestClusterClusterTestComplexNullableOptionalResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull nullableIntWasNull;
 @property (strong, nonatomic) NSNumber * _Nullable nullableIntValue;
 @property (strong, nonatomic) NSNumber * _Nonnull optionalIntWasPresent;
@@ -2131,53 +1859,53 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 @end
 
-@interface CHIPTestClusterClusterTestNestedStructArgumentRequestPayload : NSObject
+@interface CHIPTestClusterClusterTestNestedStructArgumentRequestParams : NSObject
 @property (strong, nonatomic) CHIPTestClusterClusterNestedStruct * _Nonnull arg1;
 - (instancetype)init;
 @end
 
-@interface CHIPTestClusterClusterBooleanResponsePayload : NSObject
+@interface CHIPTestClusterClusterBooleanResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull value;
 - (instancetype)init;
 @end
 
-@interface CHIPTestClusterClusterTestListStructArgumentRequestPayload : NSObject
+@interface CHIPTestClusterClusterTestListStructArgumentRequestParams : NSObject
 @property (strong, nonatomic) NSArray * _Nonnull arg1;
 - (instancetype)init;
 @end
 
-@interface CHIPTestClusterClusterTestListInt8UArgumentRequestPayload : NSObject
+@interface CHIPTestClusterClusterTestListInt8UArgumentRequestParams : NSObject
 @property (strong, nonatomic) NSArray * _Nonnull arg1;
 - (instancetype)init;
 @end
 
-@interface CHIPTestClusterClusterTestNestedStructListArgumentRequestPayload : NSObject
+@interface CHIPTestClusterClusterTestNestedStructListArgumentRequestParams : NSObject
 @property (strong, nonatomic) CHIPTestClusterClusterNestedStructList * _Nonnull arg1;
 - (instancetype)init;
 @end
 
-@interface CHIPTestClusterClusterTestListNestedStructListArgumentRequestPayload : NSObject
+@interface CHIPTestClusterClusterTestListNestedStructListArgumentRequestParams : NSObject
 @property (strong, nonatomic) NSArray * _Nonnull arg1;
 - (instancetype)init;
 @end
 
-@interface CHIPTestClusterClusterTestListInt8UReverseRequestPayload : NSObject
+@interface CHIPTestClusterClusterTestListInt8UReverseRequestParams : NSObject
 @property (strong, nonatomic) NSArray * _Nonnull arg1;
 - (instancetype)init;
 @end
 
-@interface CHIPTestClusterClusterTestEnumsRequestPayload : NSObject
+@interface CHIPTestClusterClusterTestEnumsRequestParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull arg1;
 @property (strong, nonatomic) NSNumber * _Nonnull arg2;
 - (instancetype)init;
 @end
 
-@interface CHIPTestClusterClusterTestNullableOptionalRequestPayload : NSObject
+@interface CHIPTestClusterClusterTestNullableOptionalRequestParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nullable arg1;
 - (instancetype)init;
 @end
 
-@interface CHIPTestClusterClusterTestComplexNullableOptionalRequestPayload : NSObject
+@interface CHIPTestClusterClusterTestComplexNullableOptionalRequestParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nullable nullableInt;
 @property (strong, nonatomic) NSNumber * _Nullable optionalInt;
 @property (strong, nonatomic) NSNumber * _Nullable nullableOptionalInt;
@@ -2193,7 +1921,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 @end
 
-@interface CHIPMessagingClusterDisplayMessagePayload : NSObject
+@interface CHIPMessagingClusterDisplayMessageParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull messageId;
 @property (strong, nonatomic) NSNumber * _Nonnull messageControl;
 @property (strong, nonatomic) NSNumber * _Nonnull startTime;
@@ -2203,17 +1931,13 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 @end
 
-@interface CHIPMessagingClusterGetLastMessagePayload : NSObject
-- (instancetype)init;
-@end
-
-@interface CHIPMessagingClusterCancelMessagePayload : NSObject
+@interface CHIPMessagingClusterCancelMessageParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull messageId;
 @property (strong, nonatomic) NSNumber * _Nonnull messageControl;
 - (instancetype)init;
 @end
 
-@interface CHIPMessagingClusterMessageConfirmationPayload : NSObject
+@interface CHIPMessagingClusterMessageConfirmationParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull messageId;
 @property (strong, nonatomic) NSNumber * _Nonnull confirmationTime;
 @property (strong, nonatomic) NSNumber * _Nonnull messageConfirmationControl;
@@ -2221,7 +1945,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 @end
 
-@interface CHIPMessagingClusterDisplayProtectedMessagePayload : NSObject
+@interface CHIPMessagingClusterDisplayProtectedMessageParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull messageId;
 @property (strong, nonatomic) NSNumber * _Nonnull messageControl;
 @property (strong, nonatomic) NSNumber * _Nonnull startTime;
@@ -2231,39 +1955,35 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 @end
 
-@interface CHIPMessagingClusterGetMessageCancellationPayload : NSObject
+@interface CHIPMessagingClusterGetMessageCancellationParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull earliestImplementationTime;
 - (instancetype)init;
 @end
 
-@interface CHIPMessagingClusterCancelAllMessagesPayload : NSObject
+@interface CHIPMessagingClusterCancelAllMessagesParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull implementationDateTime;
 - (instancetype)init;
 @end
 
-@interface CHIPApplianceEventsAndAlertClusterGetAlertsPayload : NSObject
-- (instancetype)init;
-@end
-
-@interface CHIPApplianceEventsAndAlertClusterGetAlertsResponsePayload : NSObject
+@interface CHIPApplianceEventsAndAlertClusterGetAlertsResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull alertsCount;
 @property (strong, nonatomic) NSArray * _Nonnull alertStructures;
 - (instancetype)init;
 @end
 
-@interface CHIPApplianceEventsAndAlertClusterAlertsNotificationPayload : NSObject
+@interface CHIPApplianceEventsAndAlertClusterAlertsNotificationParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull alertsCount;
 @property (strong, nonatomic) NSArray * _Nonnull alertStructures;
 - (instancetype)init;
 @end
 
-@interface CHIPApplianceEventsAndAlertClusterEventsNotificationPayload : NSObject
+@interface CHIPApplianceEventsAndAlertClusterEventsNotificationParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull eventHeader;
 @property (strong, nonatomic) NSNumber * _Nonnull eventId;
 - (instancetype)init;
 @end
 
-@interface CHIPApplianceStatisticsClusterLogNotificationPayload : NSObject
+@interface CHIPApplianceStatisticsClusterLogNotificationParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull timeStamp;
 @property (strong, nonatomic) NSNumber * _Nonnull logId;
 @property (strong, nonatomic) NSNumber * _Nonnull logLength;
@@ -2271,12 +1991,12 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 @end
 
-@interface CHIPApplianceStatisticsClusterLogRequestPayload : NSObject
+@interface CHIPApplianceStatisticsClusterLogRequestParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull logId;
 - (instancetype)init;
 @end
 
-@interface CHIPApplianceStatisticsClusterLogResponsePayload : NSObject
+@interface CHIPApplianceStatisticsClusterLogResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull timeStamp;
 @property (strong, nonatomic) NSNumber * _Nonnull logId;
 @property (strong, nonatomic) NSNumber * _Nonnull logLength;
@@ -2284,23 +2004,19 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 @end
 
-@interface CHIPApplianceStatisticsClusterLogQueueRequestPayload : NSObject
-- (instancetype)init;
-@end
-
-@interface CHIPApplianceStatisticsClusterLogQueueResponsePayload : NSObject
+@interface CHIPApplianceStatisticsClusterLogQueueResponseParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull logQueueSize;
 @property (strong, nonatomic) NSArray * _Nonnull logIds;
 - (instancetype)init;
 @end
 
-@interface CHIPApplianceStatisticsClusterStatisticsAvailablePayload : NSObject
+@interface CHIPApplianceStatisticsClusterStatisticsAvailableParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull logQueueSize;
 @property (strong, nonatomic) NSArray * _Nonnull logIds;
 - (instancetype)init;
 @end
 
-@interface CHIPElectricalMeasurementClusterGetProfileInfoResponseCommandPayload : NSObject
+@interface CHIPElectricalMeasurementClusterGetProfileInfoResponseCommandParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull profileCount;
 @property (strong, nonatomic) NSNumber * _Nonnull profileIntervalPeriod;
 @property (strong, nonatomic) NSNumber * _Nonnull maxNumberOfIntervals;
@@ -2308,11 +2024,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 @end
 
-@interface CHIPElectricalMeasurementClusterGetProfileInfoCommandPayload : NSObject
-- (instancetype)init;
-@end
-
-@interface CHIPElectricalMeasurementClusterGetMeasurementProfileResponseCommandPayload : NSObject
+@interface CHIPElectricalMeasurementClusterGetMeasurementProfileResponseCommandParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull startTime;
 @property (strong, nonatomic) NSNumber * _Nonnull status;
 @property (strong, nonatomic) NSNumber * _Nonnull profileIntervalPeriod;
@@ -2322,14 +2034,14 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 @end
 
-@interface CHIPElectricalMeasurementClusterGetMeasurementProfileCommandPayload : NSObject
+@interface CHIPElectricalMeasurementClusterGetMeasurementProfileCommandParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull attributeId;
 @property (strong, nonatomic) NSNumber * _Nonnull startTime;
 @property (strong, nonatomic) NSNumber * _Nonnull numberOfIntervals;
 - (instancetype)init;
 @end
 
-@interface CHIPBindingClusterBindPayload : NSObject
+@interface CHIPBindingClusterBindParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull nodeId;
 @property (strong, nonatomic) NSNumber * _Nonnull groupId;
 @property (strong, nonatomic) NSNumber * _Nonnull endpointId;
@@ -2337,7 +2049,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 @end
 
-@interface CHIPBindingClusterUnbindPayload : NSObject
+@interface CHIPBindingClusterUnbindParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull nodeId;
 @property (strong, nonatomic) NSNumber * _Nonnull groupId;
 @property (strong, nonatomic) NSNumber * _Nonnull endpointId;
@@ -2345,12 +2057,12 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 @end
 
-@interface CHIPSampleMfgSpecificClusterClusterCommandOnePayload : NSObject
+@interface CHIPSampleMfgSpecificClusterClusterCommandOneParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull argOne;
 - (instancetype)init;
 @end
 
-@interface CHIPSampleMfgSpecificCluster2ClusterCommandTwoPayload : NSObject
+@interface CHIPSampleMfgSpecificCluster2ClusterCommandTwoParams : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull argOne;
 - (instancetype)init;
 @end

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPCommandPayloadsObjc.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPCommandPayloadsObjc.mm
@@ -21,7 +21,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@implementation CHIPIdentifyClusterIdentifyPayload
+@implementation CHIPIdentifyClusterIdentifyParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -32,7 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPIdentifyClusterIdentifyQueryResponsePayload
+@implementation CHIPIdentifyClusterIdentifyQueryResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -43,16 +43,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPIdentifyClusterIdentifyQueryPayload
-- (instancetype)init
-{
-    if (self = [super init]) {
-    }
-    return self;
-}
-@end
-
-@implementation CHIPIdentifyClusterTriggerEffectPayload
+@implementation CHIPIdentifyClusterTriggerEffectParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -65,7 +56,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPGroupsClusterAddGroupPayload
+@implementation CHIPGroupsClusterAddGroupParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -78,7 +69,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPGroupsClusterAddGroupResponsePayload
+@implementation CHIPGroupsClusterAddGroupResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -91,7 +82,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPGroupsClusterViewGroupPayload
+@implementation CHIPGroupsClusterViewGroupParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -102,7 +93,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPGroupsClusterViewGroupResponsePayload
+@implementation CHIPGroupsClusterViewGroupResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -117,7 +108,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPGroupsClusterGetGroupMembershipPayload
+@implementation CHIPGroupsClusterGetGroupMembershipParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -128,7 +119,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPGroupsClusterGetGroupMembershipResponsePayload
+@implementation CHIPGroupsClusterGetGroupMembershipResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -141,7 +132,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPGroupsClusterRemoveGroupPayload
+@implementation CHIPGroupsClusterRemoveGroupParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -152,7 +143,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPGroupsClusterRemoveGroupResponsePayload
+@implementation CHIPGroupsClusterRemoveGroupResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -165,16 +156,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPGroupsClusterRemoveAllGroupsPayload
-- (instancetype)init
-{
-    if (self = [super init]) {
-    }
-    return self;
-}
-@end
-
-@implementation CHIPGroupsClusterAddGroupIfIdentifyingPayload
+@implementation CHIPGroupsClusterAddGroupIfIdentifyingParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -187,7 +169,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPScenesClusterAddScenePayload
+@implementation CHIPScenesClusterAddSceneParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -206,7 +188,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPScenesClusterAddSceneResponsePayload
+@implementation CHIPScenesClusterAddSceneResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -221,7 +203,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPScenesClusterViewScenePayload
+@implementation CHIPScenesClusterViewSceneParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -234,7 +216,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPScenesClusterViewSceneResponsePayload
+@implementation CHIPScenesClusterViewSceneResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -255,7 +237,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPScenesClusterRemoveScenePayload
+@implementation CHIPScenesClusterRemoveSceneParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -268,7 +250,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPScenesClusterRemoveSceneResponsePayload
+@implementation CHIPScenesClusterRemoveSceneResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -283,7 +265,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPScenesClusterRemoveAllScenesPayload
+@implementation CHIPScenesClusterRemoveAllScenesParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -294,7 +276,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPScenesClusterRemoveAllScenesResponsePayload
+@implementation CHIPScenesClusterRemoveAllScenesResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -307,7 +289,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPScenesClusterStoreScenePayload
+@implementation CHIPScenesClusterStoreSceneParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -320,7 +302,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPScenesClusterStoreSceneResponsePayload
+@implementation CHIPScenesClusterStoreSceneResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -335,7 +317,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPScenesClusterRecallScenePayload
+@implementation CHIPScenesClusterRecallSceneParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -350,7 +332,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPScenesClusterGetSceneMembershipPayload
+@implementation CHIPScenesClusterGetSceneMembershipParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -361,7 +343,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPScenesClusterGetSceneMembershipResponsePayload
+@implementation CHIPScenesClusterGetSceneMembershipResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -380,7 +362,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPScenesClusterEnhancedAddScenePayload
+@implementation CHIPScenesClusterEnhancedAddSceneParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -399,7 +381,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPScenesClusterEnhancedAddSceneResponsePayload
+@implementation CHIPScenesClusterEnhancedAddSceneResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -414,7 +396,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPScenesClusterEnhancedViewScenePayload
+@implementation CHIPScenesClusterEnhancedViewSceneParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -427,7 +409,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPScenesClusterEnhancedViewSceneResponsePayload
+@implementation CHIPScenesClusterEnhancedViewSceneResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -448,7 +430,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPScenesClusterCopyScenePayload
+@implementation CHIPScenesClusterCopySceneParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -467,7 +449,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPScenesClusterCopySceneResponsePayload
+@implementation CHIPScenesClusterCopySceneResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -482,79 +464,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPOnOffClusterOffPayload
-- (instancetype)init
-{
-    if (self = [super init]) {
-    }
-    return self;
-}
-@end
-
-@implementation CHIPOnOffClusterSampleMfgSpecificOffWithTransitionPayload
-- (instancetype)init
-{
-    if (self = [super init]) {
-    }
-    return self;
-}
-@end
-
-@implementation CHIPOnOffClusterOnPayload
-- (instancetype)init
-{
-    if (self = [super init]) {
-    }
-    return self;
-}
-@end
-
-@implementation CHIPOnOffClusterSampleMfgSpecificOnWithTransitionPayload
-- (instancetype)init
-{
-    if (self = [super init]) {
-    }
-    return self;
-}
-@end
-
-@implementation CHIPOnOffClusterSampleMfgSpecificOnWithTransition2Payload
-- (instancetype)init
-{
-    if (self = [super init]) {
-    }
-    return self;
-}
-@end
-
-@implementation CHIPOnOffClusterTogglePayload
-- (instancetype)init
-{
-    if (self = [super init]) {
-    }
-    return self;
-}
-@end
-
-@implementation CHIPOnOffClusterSampleMfgSpecificToggleWithTransitionPayload
-- (instancetype)init
-{
-    if (self = [super init]) {
-    }
-    return self;
-}
-@end
-
-@implementation CHIPOnOffClusterSampleMfgSpecificToggleWithTransition2Payload
-- (instancetype)init
-{
-    if (self = [super init]) {
-    }
-    return self;
-}
-@end
-
-@implementation CHIPOnOffClusterOffWithEffectPayload
+@implementation CHIPOnOffClusterOffWithEffectParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -567,16 +477,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPOnOffClusterOnWithRecallGlobalScenePayload
-- (instancetype)init
-{
-    if (self = [super init]) {
-    }
-    return self;
-}
-@end
-
-@implementation CHIPOnOffClusterOnWithTimedOffPayload
+@implementation CHIPOnOffClusterOnWithTimedOffParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -591,7 +492,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPLevelControlClusterMoveToLevelPayload
+@implementation CHIPLevelControlClusterMoveToLevelParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -608,7 +509,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPLevelControlClusterMovePayload
+@implementation CHIPLevelControlClusterMoveParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -625,7 +526,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPLevelControlClusterStepPayload
+@implementation CHIPLevelControlClusterStepParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -644,7 +545,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPLevelControlClusterStopPayload
+@implementation CHIPLevelControlClusterStopParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -657,7 +558,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPLevelControlClusterMoveToLevelWithOnOffPayload
+@implementation CHIPLevelControlClusterMoveToLevelWithOnOffParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -670,7 +571,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPLevelControlClusterMoveWithOnOffPayload
+@implementation CHIPLevelControlClusterMoveWithOnOffParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -683,7 +584,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPLevelControlClusterStepWithOnOffPayload
+@implementation CHIPLevelControlClusterStepWithOnOffParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -698,16 +599,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPLevelControlClusterStopWithOnOffPayload
-- (instancetype)init
-{
-    if (self = [super init]) {
-    }
-    return self;
-}
-@end
-
-@implementation CHIPAlarmsClusterResetAlarmPayload
+@implementation CHIPAlarmsClusterResetAlarmParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -720,7 +612,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPAlarmsClusterAlarmPayload
+@implementation CHIPAlarmsClusterAlarmParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -733,16 +625,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPAlarmsClusterResetAllAlarmsPayload
-- (instancetype)init
-{
-    if (self = [super init]) {
-    }
-    return self;
-}
-@end
-
-@implementation CHIPAlarmsClusterGetAlarmResponsePayload
+@implementation CHIPAlarmsClusterGetAlarmResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -759,25 +642,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPAlarmsClusterGetAlarmPayload
-- (instancetype)init
-{
-    if (self = [super init]) {
-    }
-    return self;
-}
-@end
-
-@implementation CHIPAlarmsClusterResetAlarmLogPayload
-- (instancetype)init
-{
-    if (self = [super init]) {
-    }
-    return self;
-}
-@end
-
-@implementation CHIPPowerProfileClusterPowerProfileRequestPayload
+@implementation CHIPPowerProfileClusterPowerProfileRequestParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -788,7 +653,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPPowerProfileClusterPowerProfileNotificationPayload
+@implementation CHIPPowerProfileClusterPowerProfileNotificationParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -805,16 +670,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPPowerProfileClusterPowerProfileStateRequestPayload
-- (instancetype)init
-{
-    if (self = [super init]) {
-    }
-    return self;
-}
-@end
-
-@implementation CHIPPowerProfileClusterPowerProfileResponsePayload
+@implementation CHIPPowerProfileClusterPowerProfileResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -831,7 +687,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPPowerProfileClusterGetPowerProfilePriceResponsePayload
+@implementation CHIPPowerProfileClusterGetPowerProfilePriceResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -848,7 +704,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPPowerProfileClusterPowerProfileStateResponsePayload
+@implementation CHIPPowerProfileClusterPowerProfileStateResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -861,7 +717,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPPowerProfileClusterGetOverallSchedulePriceResponsePayload
+@implementation CHIPPowerProfileClusterGetOverallSchedulePriceResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -876,7 +732,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPPowerProfileClusterGetPowerProfilePricePayload
+@implementation CHIPPowerProfileClusterGetPowerProfilePriceParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -887,7 +743,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPPowerProfileClusterEnergyPhasesScheduleNotificationPayload
+@implementation CHIPPowerProfileClusterEnergyPhasesScheduleNotificationParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -902,7 +758,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPPowerProfileClusterPowerProfilesStateNotificationPayload
+@implementation CHIPPowerProfileClusterPowerProfilesStateNotificationParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -915,7 +771,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPPowerProfileClusterEnergyPhasesScheduleResponsePayload
+@implementation CHIPPowerProfileClusterEnergyPhasesScheduleResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -930,16 +786,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPPowerProfileClusterGetOverallSchedulePricePayload
-- (instancetype)init
-{
-    if (self = [super init]) {
-    }
-    return self;
-}
-@end
-
-@implementation CHIPPowerProfileClusterPowerProfileScheduleConstraintsRequestPayload
+@implementation CHIPPowerProfileClusterPowerProfileScheduleConstraintsRequestParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -950,7 +797,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPPowerProfileClusterEnergyPhasesScheduleRequestPayload
+@implementation CHIPPowerProfileClusterEnergyPhasesScheduleRequestParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -961,7 +808,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPPowerProfileClusterEnergyPhasesScheduleStateRequestPayload
+@implementation CHIPPowerProfileClusterEnergyPhasesScheduleStateRequestParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -972,7 +819,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPPowerProfileClusterEnergyPhasesScheduleStateResponsePayload
+@implementation CHIPPowerProfileClusterEnergyPhasesScheduleStateResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -987,7 +834,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPPowerProfileClusterGetPowerProfilePriceExtendedResponsePayload
+@implementation CHIPPowerProfileClusterGetPowerProfilePriceExtendedResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -1004,7 +851,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPPowerProfileClusterEnergyPhasesScheduleStateNotificationPayload
+@implementation CHIPPowerProfileClusterEnergyPhasesScheduleStateNotificationParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -1019,7 +866,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPPowerProfileClusterPowerProfileScheduleConstraintsNotificationPayload
+@implementation CHIPPowerProfileClusterPowerProfileScheduleConstraintsNotificationParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -1034,7 +881,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPPowerProfileClusterPowerProfileScheduleConstraintsResponsePayload
+@implementation CHIPPowerProfileClusterPowerProfileScheduleConstraintsResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -1049,7 +896,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPPowerProfileClusterGetPowerProfilePriceExtendedPayload
+@implementation CHIPPowerProfileClusterGetPowerProfilePriceExtendedParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -1064,7 +911,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPApplianceControlClusterExecutionOfACommandPayload
+@implementation CHIPApplianceControlClusterExecutionOfACommandParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -1075,7 +922,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPApplianceControlClusterSignalStateResponsePayload
+@implementation CHIPApplianceControlClusterSignalStateResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -1090,16 +937,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPApplianceControlClusterSignalStatePayload
-- (instancetype)init
-{
-    if (self = [super init]) {
-    }
-    return self;
-}
-@end
-
-@implementation CHIPApplianceControlClusterSignalStateNotificationPayload
+@implementation CHIPApplianceControlClusterSignalStateNotificationParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -1114,7 +952,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPApplianceControlClusterWriteFunctionsPayload
+@implementation CHIPApplianceControlClusterWriteFunctionsParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -1129,25 +967,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPApplianceControlClusterOverloadPauseResumePayload
-- (instancetype)init
-{
-    if (self = [super init]) {
-    }
-    return self;
-}
-@end
-
-@implementation CHIPApplianceControlClusterOverloadPausePayload
-- (instancetype)init
-{
-    if (self = [super init]) {
-    }
-    return self;
-}
-@end
-
-@implementation CHIPApplianceControlClusterOverloadWarningPayload
+@implementation CHIPApplianceControlClusterOverloadWarningParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -1158,16 +978,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPPollControlClusterCheckInPayload
-- (instancetype)init
-{
-    if (self = [super init]) {
-    }
-    return self;
-}
-@end
-
-@implementation CHIPPollControlClusterCheckInResponsePayload
+@implementation CHIPPollControlClusterCheckInResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -1180,16 +991,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPPollControlClusterFastPollStopPayload
-- (instancetype)init
-{
-    if (self = [super init]) {
-    }
-    return self;
-}
-@end
-
-@implementation CHIPPollControlClusterSetLongPollIntervalPayload
+@implementation CHIPPollControlClusterSetLongPollIntervalParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -1200,7 +1002,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPPollControlClusterSetShortPollIntervalPayload
+@implementation CHIPPollControlClusterSetShortPollIntervalParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -1211,7 +1013,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPBridgedActionsClusterInstantActionPayload
+@implementation CHIPBridgedActionsClusterInstantActionParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -1224,7 +1026,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPBridgedActionsClusterInstantActionWithTransitionPayload
+@implementation CHIPBridgedActionsClusterInstantActionWithTransitionParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -1239,7 +1041,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPBridgedActionsClusterStartActionPayload
+@implementation CHIPBridgedActionsClusterStartActionParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -1252,48 +1054,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPBridgedActionsClusterStartActionWithDurationPayload
-- (instancetype)init
-{
-    if (self = [super init]) {
-
-        _actionID = @(0);
-
-        _invokeID = nil;
-
-        _duration = @(0);
-    }
-    return self;
-}
-@end
-
-@implementation CHIPBridgedActionsClusterStopActionPayload
-- (instancetype)init
-{
-    if (self = [super init]) {
-
-        _actionID = @(0);
-
-        _invokeID = nil;
-    }
-    return self;
-}
-@end
-
-@implementation CHIPBridgedActionsClusterPauseActionPayload
-- (instancetype)init
-{
-    if (self = [super init]) {
-
-        _actionID = @(0);
-
-        _invokeID = nil;
-    }
-    return self;
-}
-@end
-
-@implementation CHIPBridgedActionsClusterPauseActionWithDurationPayload
+@implementation CHIPBridgedActionsClusterStartActionWithDurationParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -1308,7 +1069,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPBridgedActionsClusterResumeActionPayload
+@implementation CHIPBridgedActionsClusterStopActionParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -1321,7 +1082,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPBridgedActionsClusterEnableActionPayload
+@implementation CHIPBridgedActionsClusterPauseActionParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -1334,35 +1095,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPBridgedActionsClusterEnableActionWithDurationPayload
-- (instancetype)init
-{
-    if (self = [super init]) {
-
-        _actionID = @(0);
-
-        _invokeID = nil;
-
-        _duration = @(0);
-    }
-    return self;
-}
-@end
-
-@implementation CHIPBridgedActionsClusterDisableActionPayload
-- (instancetype)init
-{
-    if (self = [super init]) {
-
-        _actionID = @(0);
-
-        _invokeID = nil;
-    }
-    return self;
-}
-@end
-
-@implementation CHIPBridgedActionsClusterDisableActionWithDurationPayload
+@implementation CHIPBridgedActionsClusterPauseActionWithDurationParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -1377,43 +1110,76 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPBasicClusterStartUpPayload
+@implementation CHIPBridgedActionsClusterResumeActionParams
 - (instancetype)init
 {
     if (self = [super init]) {
+
+        _actionID = @(0);
+
+        _invokeID = nil;
     }
     return self;
 }
 @end
 
-@implementation CHIPBasicClusterMfgSpecificPingPayload
+@implementation CHIPBridgedActionsClusterEnableActionParams
 - (instancetype)init
 {
     if (self = [super init]) {
+
+        _actionID = @(0);
+
+        _invokeID = nil;
     }
     return self;
 }
 @end
 
-@implementation CHIPBasicClusterShutDownPayload
+@implementation CHIPBridgedActionsClusterEnableActionWithDurationParams
 - (instancetype)init
 {
     if (self = [super init]) {
+
+        _actionID = @(0);
+
+        _invokeID = nil;
+
+        _duration = @(0);
     }
     return self;
 }
 @end
 
-@implementation CHIPBasicClusterLeavePayload
+@implementation CHIPBridgedActionsClusterDisableActionParams
 - (instancetype)init
 {
     if (self = [super init]) {
+
+        _actionID = @(0);
+
+        _invokeID = nil;
     }
     return self;
 }
 @end
 
-@implementation CHIPOtaSoftwareUpdateProviderClusterQueryImagePayload
+@implementation CHIPBridgedActionsClusterDisableActionWithDurationParams
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _actionID = @(0);
+
+        _invokeID = nil;
+
+        _duration = @(0);
+    }
+    return self;
+}
+@end
+
+@implementation CHIPOtaSoftwareUpdateProviderClusterQueryImageParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -1438,7 +1204,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPOtaSoftwareUpdateProviderClusterApplyUpdateRequestPayload
+@implementation CHIPOtaSoftwareUpdateProviderClusterApplyUpdateRequestParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -1451,7 +1217,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPOtaSoftwareUpdateProviderClusterNotifyUpdateAppliedPayload
+@implementation CHIPOtaSoftwareUpdateProviderClusterNotifyUpdateAppliedParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -1464,7 +1230,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPOtaSoftwareUpdateProviderClusterQueryImageResponsePayload
+@implementation CHIPOtaSoftwareUpdateProviderClusterQueryImageResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -1489,7 +1255,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPOtaSoftwareUpdateProviderClusterApplyUpdateResponsePayload
+@implementation CHIPOtaSoftwareUpdateProviderClusterApplyUpdateResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -1502,7 +1268,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPOtaSoftwareUpdateRequestorClusterAnnounceOtaProviderPayload
+@implementation CHIPOtaSoftwareUpdateRequestorClusterAnnounceOtaProviderParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -1519,7 +1285,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPGeneralCommissioningClusterArmFailSafePayload
+@implementation CHIPGeneralCommissioningClusterArmFailSafeParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -1534,7 +1300,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPGeneralCommissioningClusterArmFailSafeResponsePayload
+@implementation CHIPGeneralCommissioningClusterArmFailSafeResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -1547,7 +1313,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPGeneralCommissioningClusterSetRegulatoryConfigPayload
+@implementation CHIPGeneralCommissioningClusterSetRegulatoryConfigParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -1564,7 +1330,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPGeneralCommissioningClusterSetRegulatoryConfigResponsePayload
+@implementation CHIPGeneralCommissioningClusterSetRegulatoryConfigResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -1577,16 +1343,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPGeneralCommissioningClusterCommissioningCompletePayload
-- (instancetype)init
-{
-    if (self = [super init]) {
-    }
-    return self;
-}
-@end
-
-@implementation CHIPGeneralCommissioningClusterCommissioningCompleteResponsePayload
+@implementation CHIPGeneralCommissioningClusterCommissioningCompleteResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -1599,7 +1356,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPNetworkCommissioningClusterScanNetworksPayload
+@implementation CHIPNetworkCommissioningClusterScanNetworksParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -1614,7 +1371,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPNetworkCommissioningClusterScanNetworksResponsePayload
+@implementation CHIPNetworkCommissioningClusterScanNetworksResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -1631,7 +1388,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPNetworkCommissioningClusterAddWiFiNetworkPayload
+@implementation CHIPNetworkCommissioningClusterAddWiFiNetworkParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -1648,7 +1405,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPNetworkCommissioningClusterAddWiFiNetworkResponsePayload
+@implementation CHIPNetworkCommissioningClusterAddWiFiNetworkResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -1661,7 +1418,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPNetworkCommissioningClusterUpdateWiFiNetworkPayload
+@implementation CHIPNetworkCommissioningClusterUpdateWiFiNetworkParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -1678,7 +1435,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPNetworkCommissioningClusterUpdateWiFiNetworkResponsePayload
+@implementation CHIPNetworkCommissioningClusterUpdateWiFiNetworkResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -1691,7 +1448,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPNetworkCommissioningClusterAddThreadNetworkPayload
+@implementation CHIPNetworkCommissioningClusterAddThreadNetworkParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -1706,7 +1463,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPNetworkCommissioningClusterAddThreadNetworkResponsePayload
+@implementation CHIPNetworkCommissioningClusterAddThreadNetworkResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -1719,7 +1476,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPNetworkCommissioningClusterUpdateThreadNetworkPayload
+@implementation CHIPNetworkCommissioningClusterUpdateThreadNetworkParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -1734,7 +1491,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPNetworkCommissioningClusterUpdateThreadNetworkResponsePayload
+@implementation CHIPNetworkCommissioningClusterUpdateThreadNetworkResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -1747,7 +1504,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPNetworkCommissioningClusterRemoveNetworkPayload
+@implementation CHIPNetworkCommissioningClusterRemoveNetworkParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -1762,7 +1519,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPNetworkCommissioningClusterRemoveNetworkResponsePayload
+@implementation CHIPNetworkCommissioningClusterRemoveNetworkResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -1775,7 +1532,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPNetworkCommissioningClusterEnableNetworkPayload
+@implementation CHIPNetworkCommissioningClusterEnableNetworkParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -1790,7 +1547,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPNetworkCommissioningClusterEnableNetworkResponsePayload
+@implementation CHIPNetworkCommissioningClusterEnableNetworkResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -1803,7 +1560,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPNetworkCommissioningClusterDisableNetworkPayload
+@implementation CHIPNetworkCommissioningClusterDisableNetworkParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -1818,7 +1575,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPNetworkCommissioningClusterDisableNetworkResponsePayload
+@implementation CHIPNetworkCommissioningClusterDisableNetworkResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -1831,7 +1588,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPDiagnosticLogsClusterRetrieveLogsRequestPayload
+@implementation CHIPDiagnosticLogsClusterRetrieveLogsRequestParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -1846,7 +1603,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPDiagnosticLogsClusterRetrieveLogsResponsePayload
+@implementation CHIPDiagnosticLogsClusterRetrieveLogsResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -1863,79 +1620,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPSoftwareDiagnosticsClusterResetWatermarksPayload
-- (instancetype)init
-{
-    if (self = [super init]) {
-    }
-    return self;
-}
-@end
-
-@implementation CHIPThreadNetworkDiagnosticsClusterResetCountsPayload
-- (instancetype)init
-{
-    if (self = [super init]) {
-    }
-    return self;
-}
-@end
-
-@implementation CHIPWiFiNetworkDiagnosticsClusterResetCountsPayload
-- (instancetype)init
-{
-    if (self = [super init]) {
-    }
-    return self;
-}
-@end
-
-@implementation CHIPEthernetNetworkDiagnosticsClusterResetCountsPayload
-- (instancetype)init
-{
-    if (self = [super init]) {
-    }
-    return self;
-}
-@end
-
-@implementation CHIPBridgedDeviceBasicClusterStartUpPayload
-- (instancetype)init
-{
-    if (self = [super init]) {
-    }
-    return self;
-}
-@end
-
-@implementation CHIPBridgedDeviceBasicClusterShutDownPayload
-- (instancetype)init
-{
-    if (self = [super init]) {
-    }
-    return self;
-}
-@end
-
-@implementation CHIPBridgedDeviceBasicClusterLeavePayload
-- (instancetype)init
-{
-    if (self = [super init]) {
-    }
-    return self;
-}
-@end
-
-@implementation CHIPBridgedDeviceBasicClusterReachableChangedPayload
-- (instancetype)init
-{
-    if (self = [super init]) {
-    }
-    return self;
-}
-@end
-
-@implementation CHIPAdministratorCommissioningClusterOpenCommissioningWindowPayload
+@implementation CHIPAdministratorCommissioningClusterOpenCommissioningWindowParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -1956,7 +1641,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPAdministratorCommissioningClusterOpenBasicCommissioningWindowPayload
+@implementation CHIPAdministratorCommissioningClusterOpenBasicCommissioningWindowParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -1967,16 +1652,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPAdministratorCommissioningClusterRevokeCommissioningPayload
-- (instancetype)init
-{
-    if (self = [super init]) {
-    }
-    return self;
-}
-@end
-
-@implementation CHIPOperationalCredentialsClusterAttestationRequestPayload
+@implementation CHIPOperationalCredentialsClusterAttestationRequestParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -1987,7 +1663,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPOperationalCredentialsClusterAttestationResponsePayload
+@implementation CHIPOperationalCredentialsClusterAttestationResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -2000,7 +1676,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPOperationalCredentialsClusterCertificateChainRequestPayload
+@implementation CHIPOperationalCredentialsClusterCertificateChainRequestParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -2011,7 +1687,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPOperationalCredentialsClusterCertificateChainResponsePayload
+@implementation CHIPOperationalCredentialsClusterCertificateChainResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -2022,7 +1698,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPOperationalCredentialsClusterOpCSRRequestPayload
+@implementation CHIPOperationalCredentialsClusterOpCSRRequestParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -2033,7 +1709,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPOperationalCredentialsClusterOpCSRResponsePayload
+@implementation CHIPOperationalCredentialsClusterOpCSRResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -2046,7 +1722,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPOperationalCredentialsClusterAddNOCPayload
+@implementation CHIPOperationalCredentialsClusterAddNOCParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -2065,7 +1741,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPOperationalCredentialsClusterUpdateNOCPayload
+@implementation CHIPOperationalCredentialsClusterUpdateNOCParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -2078,7 +1754,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPOperationalCredentialsClusterNOCResponsePayload
+@implementation CHIPOperationalCredentialsClusterNOCResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -2093,7 +1769,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPOperationalCredentialsClusterUpdateFabricLabelPayload
+@implementation CHIPOperationalCredentialsClusterUpdateFabricLabelParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -2104,7 +1780,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPOperationalCredentialsClusterRemoveFabricPayload
+@implementation CHIPOperationalCredentialsClusterRemoveFabricParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -2115,7 +1791,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPOperationalCredentialsClusterAddTrustedRootCertificatePayload
+@implementation CHIPOperationalCredentialsClusterAddTrustedRootCertificateParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -2126,7 +1802,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPOperationalCredentialsClusterRemoveTrustedRootCertificatePayload
+@implementation CHIPOperationalCredentialsClusterRemoveTrustedRootCertificateParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -2137,7 +1813,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPModeSelectClusterChangeToModePayload
+@implementation CHIPModeSelectClusterChangeToModeParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -2148,7 +1824,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPDoorLockClusterLockDoorPayload
+@implementation CHIPDoorLockClusterLockDoorParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -2159,7 +1835,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPDoorLockClusterLockDoorResponsePayload
+@implementation CHIPDoorLockClusterLockDoorResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -2170,7 +1846,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPDoorLockClusterUnlockDoorPayload
+@implementation CHIPDoorLockClusterUnlockDoorParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -2181,7 +1857,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPDoorLockClusterUnlockDoorResponsePayload
+@implementation CHIPDoorLockClusterUnlockDoorResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -2192,7 +1868,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPDoorLockClusterTogglePayload
+@implementation CHIPDoorLockClusterToggleParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -2203,7 +1879,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPDoorLockClusterToggleResponsePayload
+@implementation CHIPDoorLockClusterToggleResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -2214,7 +1890,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPDoorLockClusterUnlockWithTimeoutPayload
+@implementation CHIPDoorLockClusterUnlockWithTimeoutParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -2227,7 +1903,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPDoorLockClusterUnlockWithTimeoutResponsePayload
+@implementation CHIPDoorLockClusterUnlockWithTimeoutResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -2238,7 +1914,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPDoorLockClusterGetLogRecordPayload
+@implementation CHIPDoorLockClusterGetLogRecordParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -2249,7 +1925,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPDoorLockClusterGetLogRecordResponsePayload
+@implementation CHIPDoorLockClusterGetLogRecordResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -2272,7 +1948,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPDoorLockClusterSetPinPayload
+@implementation CHIPDoorLockClusterSetPinParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -2289,7 +1965,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPDoorLockClusterSetPinResponsePayload
+@implementation CHIPDoorLockClusterSetPinResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -2300,7 +1976,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPDoorLockClusterGetPinPayload
+@implementation CHIPDoorLockClusterGetPinParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -2311,7 +1987,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPDoorLockClusterGetPinResponsePayload
+@implementation CHIPDoorLockClusterGetPinResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -2328,7 +2004,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPDoorLockClusterClearPinPayload
+@implementation CHIPDoorLockClusterClearPinParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -2339,7 +2015,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPDoorLockClusterClearPinResponsePayload
+@implementation CHIPDoorLockClusterClearPinResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -2350,16 +2026,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPDoorLockClusterClearAllPinsPayload
-- (instancetype)init
-{
-    if (self = [super init]) {
-    }
-    return self;
-}
-@end
-
-@implementation CHIPDoorLockClusterClearAllPinsResponsePayload
+@implementation CHIPDoorLockClusterClearAllPinsResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -2370,7 +2037,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPDoorLockClusterSetUserStatusPayload
+@implementation CHIPDoorLockClusterSetUserStatusParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -2383,7 +2050,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPDoorLockClusterSetUserStatusResponsePayload
+@implementation CHIPDoorLockClusterSetUserStatusResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -2394,7 +2061,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPDoorLockClusterGetUserStatusPayload
+@implementation CHIPDoorLockClusterGetUserStatusParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -2405,7 +2072,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPDoorLockClusterGetUserStatusResponsePayload
+@implementation CHIPDoorLockClusterGetUserStatusResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -2418,7 +2085,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPDoorLockClusterSetWeekdaySchedulePayload
+@implementation CHIPDoorLockClusterSetWeekdayScheduleParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -2441,7 +2108,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPDoorLockClusterSetWeekdayScheduleResponsePayload
+@implementation CHIPDoorLockClusterSetWeekdayScheduleResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -2452,7 +2119,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPDoorLockClusterGetWeekdaySchedulePayload
+@implementation CHIPDoorLockClusterGetWeekdayScheduleParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -2465,7 +2132,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPDoorLockClusterGetWeekdayScheduleResponsePayload
+@implementation CHIPDoorLockClusterGetWeekdayScheduleResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -2490,7 +2157,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPDoorLockClusterClearWeekdaySchedulePayload
+@implementation CHIPDoorLockClusterClearWeekdayScheduleParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -2503,7 +2170,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPDoorLockClusterClearWeekdayScheduleResponsePayload
+@implementation CHIPDoorLockClusterClearWeekdayScheduleResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -2514,7 +2181,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPDoorLockClusterSetYeardaySchedulePayload
+@implementation CHIPDoorLockClusterSetYeardayScheduleParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -2531,7 +2198,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPDoorLockClusterSetYeardayScheduleResponsePayload
+@implementation CHIPDoorLockClusterSetYeardayScheduleResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -2542,7 +2209,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPDoorLockClusterGetYeardaySchedulePayload
+@implementation CHIPDoorLockClusterGetYeardayScheduleParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -2555,7 +2222,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPDoorLockClusterGetYeardayScheduleResponsePayload
+@implementation CHIPDoorLockClusterGetYeardayScheduleResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -2574,7 +2241,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPDoorLockClusterClearYeardaySchedulePayload
+@implementation CHIPDoorLockClusterClearYeardayScheduleParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -2587,7 +2254,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPDoorLockClusterClearYeardayScheduleResponsePayload
+@implementation CHIPDoorLockClusterClearYeardayScheduleResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -2598,53 +2265,12 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPDoorLockClusterSetHolidaySchedulePayload
+@implementation CHIPDoorLockClusterSetHolidayScheduleParams
 - (instancetype)init
 {
     if (self = [super init]) {
 
         _scheduleId = @(0);
-
-        _localStartTime = @(0);
-
-        _localEndTime = @(0);
-
-        _operatingModeDuringHoliday = @(0);
-    }
-    return self;
-}
-@end
-
-@implementation CHIPDoorLockClusterSetHolidayScheduleResponsePayload
-- (instancetype)init
-{
-    if (self = [super init]) {
-
-        _status = @(0);
-    }
-    return self;
-}
-@end
-
-@implementation CHIPDoorLockClusterGetHolidaySchedulePayload
-- (instancetype)init
-{
-    if (self = [super init]) {
-
-        _scheduleId = @(0);
-    }
-    return self;
-}
-@end
-
-@implementation CHIPDoorLockClusterGetHolidayScheduleResponsePayload
-- (instancetype)init
-{
-    if (self = [super init]) {
-
-        _scheduleId = @(0);
-
-        _status = @(0);
 
         _localStartTime = @(0);
 
@@ -2656,18 +2282,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPDoorLockClusterClearHolidaySchedulePayload
-- (instancetype)init
-{
-    if (self = [super init]) {
-
-        _scheduleId = @(0);
-    }
-    return self;
-}
-@end
-
-@implementation CHIPDoorLockClusterClearHolidayScheduleResponsePayload
+@implementation CHIPDoorLockClusterSetHolidayScheduleResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -2678,7 +2293,59 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPDoorLockClusterSetUserTypePayload
+@implementation CHIPDoorLockClusterGetHolidayScheduleParams
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _scheduleId = @(0);
+    }
+    return self;
+}
+@end
+
+@implementation CHIPDoorLockClusterGetHolidayScheduleResponseParams
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _scheduleId = @(0);
+
+        _status = @(0);
+
+        _localStartTime = @(0);
+
+        _localEndTime = @(0);
+
+        _operatingModeDuringHoliday = @(0);
+    }
+    return self;
+}
+@end
+
+@implementation CHIPDoorLockClusterClearHolidayScheduleParams
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _scheduleId = @(0);
+    }
+    return self;
+}
+@end
+
+@implementation CHIPDoorLockClusterClearHolidayScheduleResponseParams
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _status = @(0);
+    }
+    return self;
+}
+@end
+
+@implementation CHIPDoorLockClusterSetUserTypeParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -2691,7 +2358,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPDoorLockClusterSetUserTypeResponsePayload
+@implementation CHIPDoorLockClusterSetUserTypeResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -2702,7 +2369,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPDoorLockClusterGetUserTypePayload
+@implementation CHIPDoorLockClusterGetUserTypeParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -2713,7 +2380,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPDoorLockClusterGetUserTypeResponsePayload
+@implementation CHIPDoorLockClusterGetUserTypeResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -2726,7 +2393,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPDoorLockClusterSetRfidPayload
+@implementation CHIPDoorLockClusterSetRfidParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -2743,7 +2410,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPDoorLockClusterSetRfidResponsePayload
+@implementation CHIPDoorLockClusterSetRfidResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -2754,7 +2421,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPDoorLockClusterGetRfidPayload
+@implementation CHIPDoorLockClusterGetRfidParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -2765,7 +2432,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPDoorLockClusterGetRfidResponsePayload
+@implementation CHIPDoorLockClusterGetRfidResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -2782,7 +2449,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPDoorLockClusterClearRfidPayload
+@implementation CHIPDoorLockClusterClearRfidParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -2793,7 +2460,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPDoorLockClusterClearRfidResponsePayload
+@implementation CHIPDoorLockClusterClearRfidResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -2804,16 +2471,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPDoorLockClusterClearAllRfidsPayload
-- (instancetype)init
-{
-    if (self = [super init]) {
-    }
-    return self;
-}
-@end
-
-@implementation CHIPDoorLockClusterClearAllRfidsResponsePayload
+@implementation CHIPDoorLockClusterClearAllRfidsResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -2824,7 +2482,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPDoorLockClusterOperationEventNotificationPayload
+@implementation CHIPDoorLockClusterOperationEventNotificationParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -2845,7 +2503,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPDoorLockClusterProgrammingEventNotificationPayload
+@implementation CHIPDoorLockClusterProgrammingEventNotificationParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -2870,34 +2528,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPWindowCoveringClusterUpOrOpenPayload
-- (instancetype)init
-{
-    if (self = [super init]) {
-    }
-    return self;
-}
-@end
-
-@implementation CHIPWindowCoveringClusterDownOrClosePayload
-- (instancetype)init
-{
-    if (self = [super init]) {
-    }
-    return self;
-}
-@end
-
-@implementation CHIPWindowCoveringClusterStopMotionPayload
-- (instancetype)init
-{
-    if (self = [super init]) {
-    }
-    return self;
-}
-@end
-
-@implementation CHIPWindowCoveringClusterGoToLiftValuePayload
+@implementation CHIPWindowCoveringClusterGoToLiftValueParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -2908,7 +2539,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPWindowCoveringClusterGoToLiftPercentagePayload
+@implementation CHIPWindowCoveringClusterGoToLiftPercentageParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -2921,7 +2552,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPWindowCoveringClusterGoToTiltValuePayload
+@implementation CHIPWindowCoveringClusterGoToTiltValueParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -2932,7 +2563,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPWindowCoveringClusterGoToTiltPercentagePayload
+@implementation CHIPWindowCoveringClusterGoToTiltPercentageParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -2945,7 +2576,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPBarrierControlClusterBarrierControlGoToPercentPayload
+@implementation CHIPBarrierControlClusterBarrierControlGoToPercentParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -2956,16 +2587,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPBarrierControlClusterBarrierControlStopPayload
-- (instancetype)init
-{
-    if (self = [super init]) {
-    }
-    return self;
-}
-@end
-
-@implementation CHIPThermostatClusterSetpointRaiseLowerPayload
+@implementation CHIPThermostatClusterSetpointRaiseLowerParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -2978,7 +2600,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPThermostatClusterCurrentWeeklySchedulePayload
+@implementation CHIPThermostatClusterCurrentWeeklyScheduleParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -2995,7 +2617,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPThermostatClusterSetWeeklySchedulePayload
+@implementation CHIPThermostatClusterSetWeeklyScheduleParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -3012,7 +2634,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPThermostatClusterRelayStatusLogPayload
+@implementation CHIPThermostatClusterRelayStatusLogParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -3033,7 +2655,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPThermostatClusterGetWeeklySchedulePayload
+@implementation CHIPThermostatClusterGetWeeklyScheduleParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -3046,25 +2668,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPThermostatClusterClearWeeklySchedulePayload
-- (instancetype)init
-{
-    if (self = [super init]) {
-    }
-    return self;
-}
-@end
-
-@implementation CHIPThermostatClusterGetRelayStatusLogPayload
-- (instancetype)init
-{
-    if (self = [super init]) {
-    }
-    return self;
-}
-@end
-
-@implementation CHIPColorControlClusterMoveToHuePayload
+@implementation CHIPColorControlClusterMoveToHueParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -3083,7 +2687,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPColorControlClusterMoveHuePayload
+@implementation CHIPColorControlClusterMoveHueParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -3100,7 +2704,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPColorControlClusterStepHuePayload
+@implementation CHIPColorControlClusterStepHueParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -3119,7 +2723,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPColorControlClusterMoveToSaturationPayload
+@implementation CHIPColorControlClusterMoveToSaturationParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -3136,7 +2740,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPColorControlClusterMoveSaturationPayload
+@implementation CHIPColorControlClusterMoveSaturationParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -3153,7 +2757,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPColorControlClusterStepSaturationPayload
+@implementation CHIPColorControlClusterStepSaturationParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -3172,7 +2776,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPColorControlClusterMoveToHueAndSaturationPayload
+@implementation CHIPColorControlClusterMoveToHueAndSaturationParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -3191,7 +2795,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPColorControlClusterMoveToColorPayload
+@implementation CHIPColorControlClusterMoveToColorParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -3210,7 +2814,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPColorControlClusterMoveColorPayload
+@implementation CHIPColorControlClusterMoveColorParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -3227,7 +2831,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPColorControlClusterStepColorPayload
+@implementation CHIPColorControlClusterStepColorParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -3246,7 +2850,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPColorControlClusterMoveToColorTemperaturePayload
+@implementation CHIPColorControlClusterMoveToColorTemperatureParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -3263,7 +2867,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPColorControlClusterEnhancedMoveToHuePayload
+@implementation CHIPColorControlClusterEnhancedMoveToHueParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -3282,7 +2886,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPColorControlClusterEnhancedMoveHuePayload
+@implementation CHIPColorControlClusterEnhancedMoveHueParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -3299,7 +2903,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPColorControlClusterEnhancedStepHuePayload
+@implementation CHIPColorControlClusterEnhancedStepHueParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -3318,7 +2922,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPColorControlClusterEnhancedMoveToHueAndSaturationPayload
+@implementation CHIPColorControlClusterEnhancedMoveToHueAndSaturationParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -3337,7 +2941,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPColorControlClusterColorLoopSetPayload
+@implementation CHIPColorControlClusterColorLoopSetParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -3360,7 +2964,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPColorControlClusterStopMoveStepPayload
+@implementation CHIPColorControlClusterStopMoveStepParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -3373,7 +2977,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPColorControlClusterMoveColorTemperaturePayload
+@implementation CHIPColorControlClusterMoveColorTemperatureParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -3394,7 +2998,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPColorControlClusterStepColorTemperaturePayload
+@implementation CHIPColorControlClusterStepColorTemperatureParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -3417,7 +3021,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPIasZoneClusterZoneEnrollResponsePayload
+@implementation CHIPIasZoneClusterZoneEnrollResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -3430,7 +3034,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPIasZoneClusterZoneStatusChangeNotificationPayload
+@implementation CHIPIasZoneClusterZoneStatusChangeNotificationParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -3447,16 +3051,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPIasZoneClusterInitiateNormalOperationModePayload
-- (instancetype)init
-{
-    if (self = [super init]) {
-    }
-    return self;
-}
-@end
-
-@implementation CHIPIasZoneClusterZoneEnrollRequestPayload
+@implementation CHIPIasZoneClusterZoneEnrollRequestParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -3469,7 +3064,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPIasZoneClusterInitiateTestModePayload
+@implementation CHIPIasZoneClusterInitiateTestModeParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -3482,25 +3077,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPIasZoneClusterInitiateNormalOperationModeResponsePayload
-- (instancetype)init
-{
-    if (self = [super init]) {
-    }
-    return self;
-}
-@end
-
-@implementation CHIPIasZoneClusterInitiateTestModeResponsePayload
-- (instancetype)init
-{
-    if (self = [super init]) {
-    }
-    return self;
-}
-@end
-
-@implementation CHIPIasAceClusterArmPayload
+@implementation CHIPIasAceClusterArmParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -3515,7 +3092,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPIasAceClusterArmResponsePayload
+@implementation CHIPIasAceClusterArmResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -3526,7 +3103,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPIasAceClusterBypassPayload
+@implementation CHIPIasAceClusterBypassParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -3541,7 +3118,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPIasAceClusterGetZoneIdMapResponsePayload
+@implementation CHIPIasAceClusterGetZoneIdMapResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -3582,16 +3159,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPIasAceClusterEmergencyPayload
-- (instancetype)init
-{
-    if (self = [super init]) {
-    }
-    return self;
-}
-@end
-
-@implementation CHIPIasAceClusterGetZoneInformationResponsePayload
+@implementation CHIPIasAceClusterGetZoneInformationResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -3608,16 +3176,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPIasAceClusterFirePayload
-- (instancetype)init
-{
-    if (self = [super init]) {
-    }
-    return self;
-}
-@end
-
-@implementation CHIPIasAceClusterZoneStatusChangedPayload
+@implementation CHIPIasAceClusterZoneStatusChangedParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -3634,16 +3193,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPIasAceClusterPanicPayload
-- (instancetype)init
-{
-    if (self = [super init]) {
-    }
-    return self;
-}
-@end
-
-@implementation CHIPIasAceClusterPanelStatusChangedPayload
+@implementation CHIPIasAceClusterPanelStatusChangedParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -3660,16 +3210,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPIasAceClusterGetZoneIdMapPayload
-- (instancetype)init
-{
-    if (self = [super init]) {
-    }
-    return self;
-}
-@end
-
-@implementation CHIPIasAceClusterGetPanelStatusResponsePayload
+@implementation CHIPIasAceClusterGetPanelStatusResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -3686,7 +3227,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPIasAceClusterGetZoneInformationPayload
+@implementation CHIPIasAceClusterGetZoneInformationParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -3697,7 +3238,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPIasAceClusterSetBypassedZoneListPayload
+@implementation CHIPIasAceClusterSetBypassedZoneListParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -3710,16 +3251,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPIasAceClusterGetPanelStatusPayload
-- (instancetype)init
-{
-    if (self = [super init]) {
-    }
-    return self;
-}
-@end
-
-@implementation CHIPIasAceClusterBypassResponsePayload
+@implementation CHIPIasAceClusterBypassResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -3732,16 +3264,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPIasAceClusterGetBypassedZoneListPayload
-- (instancetype)init
-{
-    if (self = [super init]) {
-    }
-    return self;
-}
-@end
-
-@implementation CHIPIasAceClusterGetZoneStatusResponsePayload
+@implementation CHIPIasAceClusterGetZoneStatusResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -3756,7 +3279,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPIasAceClusterGetZoneStatusPayload
+@implementation CHIPIasAceClusterGetZoneStatusParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -3773,7 +3296,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPIasWdClusterStartWarningPayload
+@implementation CHIPIasWdClusterStartWarningParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -3790,7 +3313,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPIasWdClusterSquawkPayload
+@implementation CHIPIasWdClusterSquawkParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -3801,7 +3324,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPTvChannelClusterChangeChannelPayload
+@implementation CHIPTvChannelClusterChangeChannelParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -3812,7 +3335,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPTvChannelClusterChangeChannelResponsePayload
+@implementation CHIPTvChannelClusterChangeChannelResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -3825,7 +3348,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPTvChannelClusterChangeChannelByNumberPayload
+@implementation CHIPTvChannelClusterChangeChannelByNumberParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -3838,7 +3361,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPTvChannelClusterSkipChannelPayload
+@implementation CHIPTvChannelClusterSkipChannelParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -3849,7 +3372,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPTargetNavigatorClusterNavigateTargetPayload
+@implementation CHIPTargetNavigatorClusterNavigateTargetParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -3862,7 +3385,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPTargetNavigatorClusterNavigateTargetResponsePayload
+@implementation CHIPTargetNavigatorClusterNavigateTargetResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -3875,16 +3398,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPMediaPlaybackClusterMediaPlayPayload
-- (instancetype)init
-{
-    if (self = [super init]) {
-    }
-    return self;
-}
-@end
-
-@implementation CHIPMediaPlaybackClusterMediaPlayResponsePayload
+@implementation CHIPMediaPlaybackClusterMediaPlayResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -3895,16 +3409,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPMediaPlaybackClusterMediaPausePayload
-- (instancetype)init
-{
-    if (self = [super init]) {
-    }
-    return self;
-}
-@end
-
-@implementation CHIPMediaPlaybackClusterMediaPauseResponsePayload
+@implementation CHIPMediaPlaybackClusterMediaPauseResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -3915,16 +3420,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPMediaPlaybackClusterMediaStopPayload
-- (instancetype)init
-{
-    if (self = [super init]) {
-    }
-    return self;
-}
-@end
-
-@implementation CHIPMediaPlaybackClusterMediaStopResponsePayload
+@implementation CHIPMediaPlaybackClusterMediaStopResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -3935,16 +3431,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPMediaPlaybackClusterMediaStartOverPayload
-- (instancetype)init
-{
-    if (self = [super init]) {
-    }
-    return self;
-}
-@end
-
-@implementation CHIPMediaPlaybackClusterMediaStartOverResponsePayload
+@implementation CHIPMediaPlaybackClusterMediaStartOverResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -3955,16 +3442,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPMediaPlaybackClusterMediaPreviousPayload
-- (instancetype)init
-{
-    if (self = [super init]) {
-    }
-    return self;
-}
-@end
-
-@implementation CHIPMediaPlaybackClusterMediaPreviousResponsePayload
+@implementation CHIPMediaPlaybackClusterMediaPreviousResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -3975,16 +3453,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPMediaPlaybackClusterMediaNextPayload
-- (instancetype)init
-{
-    if (self = [super init]) {
-    }
-    return self;
-}
-@end
-
-@implementation CHIPMediaPlaybackClusterMediaNextResponsePayload
+@implementation CHIPMediaPlaybackClusterMediaNextResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -3995,16 +3464,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPMediaPlaybackClusterMediaRewindPayload
-- (instancetype)init
-{
-    if (self = [super init]) {
-    }
-    return self;
-}
-@end
-
-@implementation CHIPMediaPlaybackClusterMediaRewindResponsePayload
+@implementation CHIPMediaPlaybackClusterMediaRewindResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -4015,16 +3475,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPMediaPlaybackClusterMediaFastForwardPayload
-- (instancetype)init
-{
-    if (self = [super init]) {
-    }
-    return self;
-}
-@end
-
-@implementation CHIPMediaPlaybackClusterMediaFastForwardResponsePayload
+@implementation CHIPMediaPlaybackClusterMediaFastForwardResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -4035,7 +3486,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPMediaPlaybackClusterMediaSkipForwardPayload
+@implementation CHIPMediaPlaybackClusterMediaSkipForwardParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -4046,7 +3497,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPMediaPlaybackClusterMediaSkipForwardResponsePayload
+@implementation CHIPMediaPlaybackClusterMediaSkipForwardResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -4057,7 +3508,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPMediaPlaybackClusterMediaSkipBackwardPayload
+@implementation CHIPMediaPlaybackClusterMediaSkipBackwardParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -4068,7 +3519,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPMediaPlaybackClusterMediaSkipBackwardResponsePayload
+@implementation CHIPMediaPlaybackClusterMediaSkipBackwardResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -4079,7 +3530,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPMediaPlaybackClusterMediaSeekPayload
+@implementation CHIPMediaPlaybackClusterMediaSeekParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -4090,7 +3541,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPMediaPlaybackClusterMediaSeekResponsePayload
+@implementation CHIPMediaPlaybackClusterMediaSeekResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -4101,7 +3552,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPMediaInputClusterSelectInputPayload
+@implementation CHIPMediaInputClusterSelectInputParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -4112,25 +3563,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPMediaInputClusterShowInputStatusPayload
-- (instancetype)init
-{
-    if (self = [super init]) {
-    }
-    return self;
-}
-@end
-
-@implementation CHIPMediaInputClusterHideInputStatusPayload
-- (instancetype)init
-{
-    if (self = [super init]) {
-    }
-    return self;
-}
-@end
-
-@implementation CHIPMediaInputClusterRenameInputPayload
+@implementation CHIPMediaInputClusterRenameInputParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -4143,16 +3576,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPLowPowerClusterSleepPayload
-- (instancetype)init
-{
-    if (self = [super init]) {
-    }
-    return self;
-}
-@end
-
-@implementation CHIPKeypadInputClusterSendKeyPayload
+@implementation CHIPKeypadInputClusterSendKeyParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -4163,7 +3587,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPKeypadInputClusterSendKeyResponsePayload
+@implementation CHIPKeypadInputClusterSendKeyResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -4174,7 +3598,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPContentLauncherClusterLaunchContentPayload
+@implementation CHIPContentLauncherClusterLaunchContentParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -4187,7 +3611,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPContentLauncherClusterLaunchContentResponsePayload
+@implementation CHIPContentLauncherClusterLaunchContentResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -4200,7 +3624,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPContentLauncherClusterLaunchURLPayload
+@implementation CHIPContentLauncherClusterLaunchURLParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -4213,7 +3637,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPContentLauncherClusterLaunchURLResponsePayload
+@implementation CHIPContentLauncherClusterLaunchURLResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -4226,7 +3650,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPAudioOutputClusterSelectOutputPayload
+@implementation CHIPAudioOutputClusterSelectOutputParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -4237,7 +3661,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPAudioOutputClusterRenameOutputPayload
+@implementation CHIPAudioOutputClusterRenameOutputParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -4250,7 +3674,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPApplicationLauncherClusterLaunchAppPayload
+@implementation CHIPApplicationLauncherClusterLaunchAppParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -4265,7 +3689,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPApplicationLauncherClusterLaunchAppResponsePayload
+@implementation CHIPApplicationLauncherClusterLaunchAppResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -4278,7 +3702,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPApplicationBasicClusterChangeStatusPayload
+@implementation CHIPApplicationBasicClusterChangeStatusParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -4289,7 +3713,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPAccountLoginClusterGetSetupPINPayload
+@implementation CHIPAccountLoginClusterGetSetupPINParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -4300,7 +3724,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPAccountLoginClusterGetSetupPINResponsePayload
+@implementation CHIPAccountLoginClusterGetSetupPINResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -4311,7 +3735,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPAccountLoginClusterLoginPayload
+@implementation CHIPAccountLoginClusterLoginParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -4324,16 +3748,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPTestClusterClusterTestPayload
-- (instancetype)init
-{
-    if (self = [super init]) {
-    }
-    return self;
-}
-@end
-
-@implementation CHIPTestClusterClusterTestSpecificResponsePayload
+@implementation CHIPTestClusterClusterTestSpecificResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -4344,16 +3759,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPTestClusterClusterTestNotHandledPayload
-- (instancetype)init
-{
-    if (self = [super init]) {
-    }
-    return self;
-}
-@end
-
-@implementation CHIPTestClusterClusterTestAddArgumentsResponsePayload
+@implementation CHIPTestClusterClusterTestAddArgumentsResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -4364,16 +3770,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPTestClusterClusterTestSpecificPayload
-- (instancetype)init
-{
-    if (self = [super init]) {
-    }
-    return self;
-}
-@end
-
-@implementation CHIPTestClusterClusterTestSimpleArgumentResponsePayload
+@implementation CHIPTestClusterClusterTestSimpleArgumentResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -4384,16 +3781,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPTestClusterClusterTestUnknownCommandPayload
-- (instancetype)init
-{
-    if (self = [super init]) {
-    }
-    return self;
-}
-@end
-
-@implementation CHIPTestClusterClusterTestStructArrayArgumentResponsePayload
+@implementation CHIPTestClusterClusterTestStructArrayArgumentResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -4414,7 +3802,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPTestClusterClusterTestAddArgumentsPayload
+@implementation CHIPTestClusterClusterTestAddArgumentsParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -4427,7 +3815,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPTestClusterClusterTestListInt8UReverseResponsePayload
+@implementation CHIPTestClusterClusterTestListInt8UReverseResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -4438,7 +3826,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPTestClusterClusterTestSimpleArgumentRequestPayload
+@implementation CHIPTestClusterClusterTestSimpleArgumentRequestParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -4449,7 +3837,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPTestClusterClusterTestEnumsResponsePayload
+@implementation CHIPTestClusterClusterTestEnumsResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -4462,7 +3850,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPTestClusterClusterTestStructArrayArgumentRequestPayload
+@implementation CHIPTestClusterClusterTestStructArrayArgumentRequestParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -4483,7 +3871,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPTestClusterClusterTestNullableOptionalResponsePayload
+@implementation CHIPTestClusterClusterTestNullableOptionalResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -4500,7 +3888,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPTestClusterClusterTestStructArgumentRequestPayload
+@implementation CHIPTestClusterClusterTestStructArgumentRequestParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -4511,7 +3899,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPTestClusterClusterTestComplexNullableOptionalResponsePayload
+@implementation CHIPTestClusterClusterTestComplexNullableOptionalResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -4576,7 +3964,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPTestClusterClusterTestNestedStructArgumentRequestPayload
+@implementation CHIPTestClusterClusterTestNestedStructArgumentRequestParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -4587,7 +3975,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPTestClusterClusterBooleanResponsePayload
+@implementation CHIPTestClusterClusterBooleanResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -4598,7 +3986,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPTestClusterClusterTestListStructArgumentRequestPayload
+@implementation CHIPTestClusterClusterTestListStructArgumentRequestParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -4609,7 +3997,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPTestClusterClusterTestListInt8UArgumentRequestPayload
+@implementation CHIPTestClusterClusterTestListInt8UArgumentRequestParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -4620,7 +4008,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPTestClusterClusterTestNestedStructListArgumentRequestPayload
+@implementation CHIPTestClusterClusterTestNestedStructListArgumentRequestParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -4631,7 +4019,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPTestClusterClusterTestListNestedStructListArgumentRequestPayload
+@implementation CHIPTestClusterClusterTestListNestedStructListArgumentRequestParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -4642,7 +4030,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPTestClusterClusterTestListInt8UReverseRequestPayload
+@implementation CHIPTestClusterClusterTestListInt8UReverseRequestParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -4653,7 +4041,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPTestClusterClusterTestEnumsRequestPayload
+@implementation CHIPTestClusterClusterTestEnumsRequestParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -4666,7 +4054,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPTestClusterClusterTestNullableOptionalRequestPayload
+@implementation CHIPTestClusterClusterTestNullableOptionalRequestParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -4677,7 +4065,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPTestClusterClusterTestComplexNullableOptionalRequestPayload
+@implementation CHIPTestClusterClusterTestComplexNullableOptionalRequestParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -4710,7 +4098,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPMessagingClusterDisplayMessagePayload
+@implementation CHIPMessagingClusterDisplayMessageParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -4731,16 +4119,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPMessagingClusterGetLastMessagePayload
-- (instancetype)init
-{
-    if (self = [super init]) {
-    }
-    return self;
-}
-@end
-
-@implementation CHIPMessagingClusterCancelMessagePayload
+@implementation CHIPMessagingClusterCancelMessageParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -4753,7 +4132,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPMessagingClusterMessageConfirmationPayload
+@implementation CHIPMessagingClusterMessageConfirmationParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -4770,7 +4149,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPMessagingClusterDisplayProtectedMessagePayload
+@implementation CHIPMessagingClusterDisplayProtectedMessageParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -4791,7 +4170,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPMessagingClusterGetMessageCancellationPayload
+@implementation CHIPMessagingClusterGetMessageCancellationParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -4802,7 +4181,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPMessagingClusterCancelAllMessagesPayload
+@implementation CHIPMessagingClusterCancelAllMessagesParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -4813,16 +4192,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPApplianceEventsAndAlertClusterGetAlertsPayload
-- (instancetype)init
-{
-    if (self = [super init]) {
-    }
-    return self;
-}
-@end
-
-@implementation CHIPApplianceEventsAndAlertClusterGetAlertsResponsePayload
+@implementation CHIPApplianceEventsAndAlertClusterGetAlertsResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -4835,7 +4205,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPApplianceEventsAndAlertClusterAlertsNotificationPayload
+@implementation CHIPApplianceEventsAndAlertClusterAlertsNotificationParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -4848,7 +4218,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPApplianceEventsAndAlertClusterEventsNotificationPayload
+@implementation CHIPApplianceEventsAndAlertClusterEventsNotificationParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -4861,7 +4231,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPApplianceStatisticsClusterLogNotificationPayload
+@implementation CHIPApplianceStatisticsClusterLogNotificationParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -4878,7 +4248,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPApplianceStatisticsClusterLogRequestPayload
+@implementation CHIPApplianceStatisticsClusterLogRequestParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -4889,7 +4259,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPApplianceStatisticsClusterLogResponsePayload
+@implementation CHIPApplianceStatisticsClusterLogResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -4906,16 +4276,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPApplianceStatisticsClusterLogQueueRequestPayload
-- (instancetype)init
-{
-    if (self = [super init]) {
-    }
-    return self;
-}
-@end
-
-@implementation CHIPApplianceStatisticsClusterLogQueueResponsePayload
+@implementation CHIPApplianceStatisticsClusterLogQueueResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -4928,7 +4289,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPApplianceStatisticsClusterStatisticsAvailablePayload
+@implementation CHIPApplianceStatisticsClusterStatisticsAvailableParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -4941,7 +4302,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPElectricalMeasurementClusterGetProfileInfoResponseCommandPayload
+@implementation CHIPElectricalMeasurementClusterGetProfileInfoResponseCommandParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -4958,16 +4319,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPElectricalMeasurementClusterGetProfileInfoCommandPayload
-- (instancetype)init
-{
-    if (self = [super init]) {
-    }
-    return self;
-}
-@end
-
-@implementation CHIPElectricalMeasurementClusterGetMeasurementProfileResponseCommandPayload
+@implementation CHIPElectricalMeasurementClusterGetMeasurementProfileResponseCommandParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -4988,7 +4340,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPElectricalMeasurementClusterGetMeasurementProfileCommandPayload
+@implementation CHIPElectricalMeasurementClusterGetMeasurementProfileCommandParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -5003,7 +4355,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPBindingClusterBindPayload
+@implementation CHIPBindingClusterBindParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -5020,7 +4372,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPBindingClusterUnbindPayload
+@implementation CHIPBindingClusterUnbindParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -5037,7 +4389,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPSampleMfgSpecificClusterClusterCommandOnePayload
+@implementation CHIPSampleMfgSpecificClusterClusterCommandOneParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -5048,7 +4400,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@implementation CHIPSampleMfgSpecificCluster2ClusterCommandTwoPayload
+@implementation CHIPSampleMfgSpecificCluster2ClusterCommandTwoParams
 - (instancetype)init
 {
     if (self = [super init]) {

--- a/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
+++ b/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
@@ -157,12 +157,11 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestCluster * cluster = [[CHIPTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    [cluster test:[[CHIPTestClusterClusterTestPayload alloc] init]
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"ReuseCHIPClusterObject test Error: %@", err);
-            XCTAssertEqual(err.code, 0);
-            [expectation fulfill];
-        }];
+    [cluster testWithCompletionHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"ReuseCHIPClusterObject test Error: %@", err);
+        XCTAssertEqual(err.code, 0);
+        [expectation fulfill];
+    }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 
@@ -170,12 +169,11 @@ CHIPDevice * GetConnectedDevice()
 
     // Reuse the CHIPCluster Object for multiple times.
 
-    [cluster test:[[CHIPTestClusterClusterTestPayload alloc] init]
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"ReuseCHIPClusterObject test Error: %@", err);
-            XCTAssertEqual(err.code, 0);
-            [expectation fulfill];
-        }];
+    [cluster testWithCompletionHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"ReuseCHIPClusterObject test Error: %@", err);
+        XCTAssertEqual(err.code, 0);
+        [expectation fulfill];
+    }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -4127,15 +4125,13 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPOnOffClusterOnPayload alloc] init];
-    [cluster on:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Turn on light for color control tests Error: %@", err);
+    [cluster onWithCompletionHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"Turn on light for color control tests Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+        XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+        [expectation fulfill];
+    }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -4172,20 +4168,20 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPColorControlClusterMoveToHuePayload alloc] init];
-    payload.hue = [NSNumber numberWithUnsignedChar:150];
-    payload.direction = [NSNumber numberWithUnsignedChar:0];
-    payload.transitionTime = [NSNumber numberWithUnsignedShort:100U];
-    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
-    [cluster moveToHue:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Move to hue shortest distance command Error: %@", err);
+    __auto_type * params = [[CHIPColorControlClusterMoveToHueParams alloc] init];
+    params.hue = [NSNumber numberWithUnsignedChar:150];
+    params.direction = [NSNumber numberWithUnsignedChar:0];
+    params.transitionTime = [NSNumber numberWithUnsignedShort:100U];
+    params.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    params.optionsOverride = [NSNumber numberWithUnsignedChar:0];
+    [cluster moveToHueWithParams:params
+               completionHandler:^(NSError * err, NSDictionary * values) {
+                   NSLog(@"Move to hue shortest distance command Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+                   XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+                   [expectation fulfill];
+               }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -4198,20 +4194,20 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPColorControlClusterMoveToHuePayload alloc] init];
-    payload.hue = [NSNumber numberWithUnsignedChar:200];
-    payload.direction = [NSNumber numberWithUnsignedChar:1];
-    payload.transitionTime = [NSNumber numberWithUnsignedShort:100U];
-    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
-    [cluster moveToHue:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Move to hue longest distance command Error: %@", err);
+    __auto_type * params = [[CHIPColorControlClusterMoveToHueParams alloc] init];
+    params.hue = [NSNumber numberWithUnsignedChar:200];
+    params.direction = [NSNumber numberWithUnsignedChar:1];
+    params.transitionTime = [NSNumber numberWithUnsignedShort:100U];
+    params.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    params.optionsOverride = [NSNumber numberWithUnsignedChar:0];
+    [cluster moveToHueWithParams:params
+               completionHandler:^(NSError * err, NSDictionary * values) {
+                   NSLog(@"Move to hue longest distance command Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+                   XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+                   [expectation fulfill];
+               }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -4224,20 +4220,20 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPColorControlClusterMoveToHuePayload alloc] init];
-    payload.hue = [NSNumber numberWithUnsignedChar:250];
-    payload.direction = [NSNumber numberWithUnsignedChar:2];
-    payload.transitionTime = [NSNumber numberWithUnsignedShort:100U];
-    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
-    [cluster moveToHue:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Move to hue up command Error: %@", err);
+    __auto_type * params = [[CHIPColorControlClusterMoveToHueParams alloc] init];
+    params.hue = [NSNumber numberWithUnsignedChar:250];
+    params.direction = [NSNumber numberWithUnsignedChar:2];
+    params.transitionTime = [NSNumber numberWithUnsignedShort:100U];
+    params.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    params.optionsOverride = [NSNumber numberWithUnsignedChar:0];
+    [cluster moveToHueWithParams:params
+               completionHandler:^(NSError * err, NSDictionary * values) {
+                   NSLog(@"Move to hue up command Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+                   XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+                   [expectation fulfill];
+               }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -4250,20 +4246,20 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPColorControlClusterMoveToHuePayload alloc] init];
-    payload.hue = [NSNumber numberWithUnsignedChar:225];
-    payload.direction = [NSNumber numberWithUnsignedChar:3];
-    payload.transitionTime = [NSNumber numberWithUnsignedShort:100U];
-    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
-    [cluster moveToHue:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Move to hue down command Error: %@", err);
+    __auto_type * params = [[CHIPColorControlClusterMoveToHueParams alloc] init];
+    params.hue = [NSNumber numberWithUnsignedChar:225];
+    params.direction = [NSNumber numberWithUnsignedChar:3];
+    params.transitionTime = [NSNumber numberWithUnsignedShort:100U];
+    params.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    params.optionsOverride = [NSNumber numberWithUnsignedChar:0];
+    [cluster moveToHueWithParams:params
+               completionHandler:^(NSError * err, NSDictionary * values) {
+                   NSLog(@"Move to hue down command Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+                   XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+                   [expectation fulfill];
+               }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -4276,15 +4272,13 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPOnOffClusterOffPayload alloc] init];
-    [cluster off:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Turn off light that we turned on Error: %@", err);
+    [cluster offWithCompletionHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"Turn off light that we turned on Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+        XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+        [expectation fulfill];
+    }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -4322,15 +4316,13 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPOnOffClusterOnPayload alloc] init];
-    [cluster on:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Turn on light for color control tests Error: %@", err);
+    [cluster onWithCompletionHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"Turn on light for color control tests Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+        XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+        [expectation fulfill];
+    }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -4367,19 +4359,19 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPColorControlClusterMoveHuePayload alloc] init];
-    payload.moveMode = [NSNumber numberWithUnsignedChar:1];
-    payload.rate = [NSNumber numberWithUnsignedChar:50];
-    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
-    [cluster moveHue:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Move hue up command Error: %@", err);
+    __auto_type * params = [[CHIPColorControlClusterMoveHueParams alloc] init];
+    params.moveMode = [NSNumber numberWithUnsignedChar:1];
+    params.rate = [NSNumber numberWithUnsignedChar:50];
+    params.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    params.optionsOverride = [NSNumber numberWithUnsignedChar:0];
+    [cluster moveHueWithParams:params
+             completionHandler:^(NSError * err, NSDictionary * values) {
+                 NSLog(@"Move hue up command Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+                 XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+                 [expectation fulfill];
+             }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -4392,19 +4384,19 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPColorControlClusterMoveHuePayload alloc] init];
-    payload.moveMode = [NSNumber numberWithUnsignedChar:0];
-    payload.rate = [NSNumber numberWithUnsignedChar:50];
-    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
-    [cluster moveHue:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Move hue stop command Error: %@", err);
+    __auto_type * params = [[CHIPColorControlClusterMoveHueParams alloc] init];
+    params.moveMode = [NSNumber numberWithUnsignedChar:0];
+    params.rate = [NSNumber numberWithUnsignedChar:50];
+    params.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    params.optionsOverride = [NSNumber numberWithUnsignedChar:0];
+    [cluster moveHueWithParams:params
+             completionHandler:^(NSError * err, NSDictionary * values) {
+                 NSLog(@"Move hue stop command Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+                 XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+                 [expectation fulfill];
+             }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -4417,19 +4409,19 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPColorControlClusterMoveHuePayload alloc] init];
-    payload.moveMode = [NSNumber numberWithUnsignedChar:3];
-    payload.rate = [NSNumber numberWithUnsignedChar:50];
-    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
-    [cluster moveHue:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Move hue down command Error: %@", err);
+    __auto_type * params = [[CHIPColorControlClusterMoveHueParams alloc] init];
+    params.moveMode = [NSNumber numberWithUnsignedChar:3];
+    params.rate = [NSNumber numberWithUnsignedChar:50];
+    params.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    params.optionsOverride = [NSNumber numberWithUnsignedChar:0];
+    [cluster moveHueWithParams:params
+             completionHandler:^(NSError * err, NSDictionary * values) {
+                 NSLog(@"Move hue down command Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+                 XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+                 [expectation fulfill];
+             }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -4442,19 +4434,19 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPColorControlClusterMoveHuePayload alloc] init];
-    payload.moveMode = [NSNumber numberWithUnsignedChar:0];
-    payload.rate = [NSNumber numberWithUnsignedChar:50];
-    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
-    [cluster moveHue:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Move hue stop command Error: %@", err);
+    __auto_type * params = [[CHIPColorControlClusterMoveHueParams alloc] init];
+    params.moveMode = [NSNumber numberWithUnsignedChar:0];
+    params.rate = [NSNumber numberWithUnsignedChar:50];
+    params.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    params.optionsOverride = [NSNumber numberWithUnsignedChar:0];
+    [cluster moveHueWithParams:params
+             completionHandler:^(NSError * err, NSDictionary * values) {
+                 NSLog(@"Move hue stop command Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+                 XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+                 [expectation fulfill];
+             }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -4467,15 +4459,13 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPOnOffClusterOffPayload alloc] init];
-    [cluster off:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Turn off light that we turned on Error: %@", err);
+    [cluster offWithCompletionHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"Turn off light that we turned on Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+        XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+        [expectation fulfill];
+    }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -4513,15 +4503,13 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPOnOffClusterOnPayload alloc] init];
-    [cluster on:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Turn on light for color control tests Error: %@", err);
+    [cluster onWithCompletionHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"Turn on light for color control tests Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+        XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+        [expectation fulfill];
+    }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -4558,20 +4546,20 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPColorControlClusterStepHuePayload alloc] init];
-    payload.stepMode = [NSNumber numberWithUnsignedChar:1];
-    payload.stepSize = [NSNumber numberWithUnsignedChar:5];
-    payload.transitionTime = [NSNumber numberWithUnsignedChar:25];
-    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
-    [cluster stepHue:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Step hue up command Error: %@", err);
+    __auto_type * params = [[CHIPColorControlClusterStepHueParams alloc] init];
+    params.stepMode = [NSNumber numberWithUnsignedChar:1];
+    params.stepSize = [NSNumber numberWithUnsignedChar:5];
+    params.transitionTime = [NSNumber numberWithUnsignedChar:25];
+    params.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    params.optionsOverride = [NSNumber numberWithUnsignedChar:0];
+    [cluster stepHueWithParams:params
+             completionHandler:^(NSError * err, NSDictionary * values) {
+                 NSLog(@"Step hue up command Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+                 XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+                 [expectation fulfill];
+             }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -4584,20 +4572,20 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPColorControlClusterStepHuePayload alloc] init];
-    payload.stepMode = [NSNumber numberWithUnsignedChar:3];
-    payload.stepSize = [NSNumber numberWithUnsignedChar:5];
-    payload.transitionTime = [NSNumber numberWithUnsignedChar:25];
-    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
-    [cluster stepHue:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Step hue down command Error: %@", err);
+    __auto_type * params = [[CHIPColorControlClusterStepHueParams alloc] init];
+    params.stepMode = [NSNumber numberWithUnsignedChar:3];
+    params.stepSize = [NSNumber numberWithUnsignedChar:5];
+    params.transitionTime = [NSNumber numberWithUnsignedChar:25];
+    params.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    params.optionsOverride = [NSNumber numberWithUnsignedChar:0];
+    [cluster stepHueWithParams:params
+             completionHandler:^(NSError * err, NSDictionary * values) {
+                 NSLog(@"Step hue down command Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+                 XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+                 [expectation fulfill];
+             }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -4610,15 +4598,13 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPOnOffClusterOffPayload alloc] init];
-    [cluster off:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Turn off light that we turned on Error: %@", err);
+    [cluster offWithCompletionHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"Turn off light that we turned on Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+        XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+        [expectation fulfill];
+    }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -4656,15 +4642,13 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPOnOffClusterOnPayload alloc] init];
-    [cluster on:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Turn on light for color control tests Error: %@", err);
+    [cluster onWithCompletionHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"Turn on light for color control tests Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+        XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+        [expectation fulfill];
+    }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -4701,19 +4685,19 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPColorControlClusterMoveToSaturationPayload alloc] init];
-    payload.saturation = [NSNumber numberWithUnsignedChar:90];
-    payload.transitionTime = [NSNumber numberWithUnsignedShort:10U];
-    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
-    [cluster moveToSaturation:payload
-              responseHandler:^(NSError * err, NSDictionary * values) {
-                  NSLog(@"Move to saturation command Error: %@", err);
+    __auto_type * params = [[CHIPColorControlClusterMoveToSaturationParams alloc] init];
+    params.saturation = [NSNumber numberWithUnsignedChar:90];
+    params.transitionTime = [NSNumber numberWithUnsignedShort:10U];
+    params.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    params.optionsOverride = [NSNumber numberWithUnsignedChar:0];
+    [cluster moveToSaturationWithParams:params
+                      completionHandler:^(NSError * err, NSDictionary * values) {
+                          NSLog(@"Move to saturation command Error: %@", err);
 
-                  XCTAssertEqual(err.code, 0);
+                          XCTAssertEqual(err.code, 0);
 
-                  [expectation fulfill];
-              }];
+                          [expectation fulfill];
+                      }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -4726,15 +4710,13 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPOnOffClusterOffPayload alloc] init];
-    [cluster off:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Turn off light that we turned on Error: %@", err);
+    [cluster offWithCompletionHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"Turn off light that we turned on Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+        XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+        [expectation fulfill];
+    }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -4772,15 +4754,13 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPOnOffClusterOnPayload alloc] init];
-    [cluster on:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Turn on light for color control tests Error: %@", err);
+    [cluster onWithCompletionHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"Turn on light for color control tests Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+        XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+        [expectation fulfill];
+    }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -4817,19 +4797,19 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPColorControlClusterMoveSaturationPayload alloc] init];
-    payload.moveMode = [NSNumber numberWithUnsignedChar:1];
-    payload.rate = [NSNumber numberWithUnsignedChar:5];
-    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
-    [cluster moveSaturation:payload
-            responseHandler:^(NSError * err, NSDictionary * values) {
-                NSLog(@"Move saturation up command Error: %@", err);
+    __auto_type * params = [[CHIPColorControlClusterMoveSaturationParams alloc] init];
+    params.moveMode = [NSNumber numberWithUnsignedChar:1];
+    params.rate = [NSNumber numberWithUnsignedChar:5];
+    params.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    params.optionsOverride = [NSNumber numberWithUnsignedChar:0];
+    [cluster moveSaturationWithParams:params
+                    completionHandler:^(NSError * err, NSDictionary * values) {
+                        NSLog(@"Move saturation up command Error: %@", err);
 
-                XCTAssertEqual(err.code, 0);
+                        XCTAssertEqual(err.code, 0);
 
-                [expectation fulfill];
-            }];
+                        [expectation fulfill];
+                    }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -4842,19 +4822,19 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPColorControlClusterMoveSaturationPayload alloc] init];
-    payload.moveMode = [NSNumber numberWithUnsignedChar:3];
-    payload.rate = [NSNumber numberWithUnsignedChar:5];
-    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
-    [cluster moveSaturation:payload
-            responseHandler:^(NSError * err, NSDictionary * values) {
-                NSLog(@"Move saturation down command Error: %@", err);
+    __auto_type * params = [[CHIPColorControlClusterMoveSaturationParams alloc] init];
+    params.moveMode = [NSNumber numberWithUnsignedChar:3];
+    params.rate = [NSNumber numberWithUnsignedChar:5];
+    params.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    params.optionsOverride = [NSNumber numberWithUnsignedChar:0];
+    [cluster moveSaturationWithParams:params
+                    completionHandler:^(NSError * err, NSDictionary * values) {
+                        NSLog(@"Move saturation down command Error: %@", err);
 
-                XCTAssertEqual(err.code, 0);
+                        XCTAssertEqual(err.code, 0);
 
-                [expectation fulfill];
-            }];
+                        [expectation fulfill];
+                    }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -4867,15 +4847,13 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPOnOffClusterOffPayload alloc] init];
-    [cluster off:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Turn off light that we turned on Error: %@", err);
+    [cluster offWithCompletionHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"Turn off light that we turned on Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+        XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+        [expectation fulfill];
+    }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -4913,15 +4891,13 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPOnOffClusterOnPayload alloc] init];
-    [cluster on:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Turn on light for color control tests Error: %@", err);
+    [cluster onWithCompletionHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"Turn on light for color control tests Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+        XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+        [expectation fulfill];
+    }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -4958,20 +4934,20 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPColorControlClusterStepSaturationPayload alloc] init];
-    payload.stepMode = [NSNumber numberWithUnsignedChar:1];
-    payload.stepSize = [NSNumber numberWithUnsignedChar:15];
-    payload.transitionTime = [NSNumber numberWithUnsignedChar:10];
-    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
-    [cluster stepSaturation:payload
-            responseHandler:^(NSError * err, NSDictionary * values) {
-                NSLog(@"Step saturation up command Error: %@", err);
+    __auto_type * params = [[CHIPColorControlClusterStepSaturationParams alloc] init];
+    params.stepMode = [NSNumber numberWithUnsignedChar:1];
+    params.stepSize = [NSNumber numberWithUnsignedChar:15];
+    params.transitionTime = [NSNumber numberWithUnsignedChar:10];
+    params.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    params.optionsOverride = [NSNumber numberWithUnsignedChar:0];
+    [cluster stepSaturationWithParams:params
+                    completionHandler:^(NSError * err, NSDictionary * values) {
+                        NSLog(@"Step saturation up command Error: %@", err);
 
-                XCTAssertEqual(err.code, 0);
+                        XCTAssertEqual(err.code, 0);
 
-                [expectation fulfill];
-            }];
+                        [expectation fulfill];
+                    }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -4984,20 +4960,20 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPColorControlClusterStepSaturationPayload alloc] init];
-    payload.stepMode = [NSNumber numberWithUnsignedChar:3];
-    payload.stepSize = [NSNumber numberWithUnsignedChar:20];
-    payload.transitionTime = [NSNumber numberWithUnsignedChar:10];
-    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
-    [cluster stepSaturation:payload
-            responseHandler:^(NSError * err, NSDictionary * values) {
-                NSLog(@"Step saturation down command Error: %@", err);
+    __auto_type * params = [[CHIPColorControlClusterStepSaturationParams alloc] init];
+    params.stepMode = [NSNumber numberWithUnsignedChar:3];
+    params.stepSize = [NSNumber numberWithUnsignedChar:20];
+    params.transitionTime = [NSNumber numberWithUnsignedChar:10];
+    params.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    params.optionsOverride = [NSNumber numberWithUnsignedChar:0];
+    [cluster stepSaturationWithParams:params
+                    completionHandler:^(NSError * err, NSDictionary * values) {
+                        NSLog(@"Step saturation down command Error: %@", err);
 
-                XCTAssertEqual(err.code, 0);
+                        XCTAssertEqual(err.code, 0);
 
-                [expectation fulfill];
-            }];
+                        [expectation fulfill];
+                    }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -5010,15 +4986,13 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPOnOffClusterOffPayload alloc] init];
-    [cluster off:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Turn off light that we turned on Error: %@", err);
+    [cluster offWithCompletionHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"Turn off light that we turned on Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+        XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+        [expectation fulfill];
+    }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -5056,15 +5030,13 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPOnOffClusterOnPayload alloc] init];
-    [cluster on:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Turn on light for color control tests Error: %@", err);
+    [cluster onWithCompletionHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"Turn on light for color control tests Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+        XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+        [expectation fulfill];
+    }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -5101,20 +5073,20 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPColorControlClusterMoveToHueAndSaturationPayload alloc] init];
-    payload.hue = [NSNumber numberWithUnsignedChar:40];
-    payload.saturation = [NSNumber numberWithUnsignedChar:160];
-    payload.transitionTime = [NSNumber numberWithUnsignedShort:10U];
-    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
-    [cluster moveToHueAndSaturation:payload
-                    responseHandler:^(NSError * err, NSDictionary * values) {
-                        NSLog(@"Move To current hue and saturation command Error: %@", err);
+    __auto_type * params = [[CHIPColorControlClusterMoveToHueAndSaturationParams alloc] init];
+    params.hue = [NSNumber numberWithUnsignedChar:40];
+    params.saturation = [NSNumber numberWithUnsignedChar:160];
+    params.transitionTime = [NSNumber numberWithUnsignedShort:10U];
+    params.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    params.optionsOverride = [NSNumber numberWithUnsignedChar:0];
+    [cluster moveToHueAndSaturationWithParams:params
+                            completionHandler:^(NSError * err, NSDictionary * values) {
+                                NSLog(@"Move To current hue and saturation command Error: %@", err);
 
-                        XCTAssertEqual(err.code, 0);
+                                XCTAssertEqual(err.code, 0);
 
-                        [expectation fulfill];
-                    }];
+                                [expectation fulfill];
+                            }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -5127,15 +5099,13 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPOnOffClusterOffPayload alloc] init];
-    [cluster off:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Turn off light that we turned on Error: %@", err);
+    [cluster offWithCompletionHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"Turn off light that we turned on Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+        XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+        [expectation fulfill];
+    }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -5173,15 +5143,13 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPOnOffClusterOnPayload alloc] init];
-    [cluster on:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Turn on light for color control tests Error: %@", err);
+    [cluster onWithCompletionHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"Turn on light for color control tests Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+        XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+        [expectation fulfill];
+    }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -5218,20 +5186,20 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPColorControlClusterMoveToColorPayload alloc] init];
-    payload.colorX = [NSNumber numberWithUnsignedShort:200U];
-    payload.colorY = [NSNumber numberWithUnsignedShort:300U];
-    payload.transitionTime = [NSNumber numberWithUnsignedShort:20U];
-    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
-    [cluster moveToColor:payload
-         responseHandler:^(NSError * err, NSDictionary * values) {
-             NSLog(@"Move to Color command Error: %@", err);
+    __auto_type * params = [[CHIPColorControlClusterMoveToColorParams alloc] init];
+    params.colorX = [NSNumber numberWithUnsignedShort:200U];
+    params.colorY = [NSNumber numberWithUnsignedShort:300U];
+    params.transitionTime = [NSNumber numberWithUnsignedShort:20U];
+    params.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    params.optionsOverride = [NSNumber numberWithUnsignedChar:0];
+    [cluster moveToColorWithParams:params
+                 completionHandler:^(NSError * err, NSDictionary * values) {
+                     NSLog(@"Move to Color command Error: %@", err);
 
-             XCTAssertEqual(err.code, 0);
+                     XCTAssertEqual(err.code, 0);
 
-             [expectation fulfill];
-         }];
+                     [expectation fulfill];
+                 }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -5244,15 +5212,13 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPOnOffClusterOffPayload alloc] init];
-    [cluster off:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Turn off light that we turned on Error: %@", err);
+    [cluster offWithCompletionHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"Turn off light that we turned on Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+        XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+        [expectation fulfill];
+    }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -5290,15 +5256,13 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPOnOffClusterOnPayload alloc] init];
-    [cluster on:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Turn on light for color control tests Error: %@", err);
+    [cluster onWithCompletionHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"Turn on light for color control tests Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+        XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+        [expectation fulfill];
+    }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -5335,19 +5299,19 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPColorControlClusterMoveColorPayload alloc] init];
-    payload.rateX = [NSNumber numberWithShort:15];
-    payload.rateY = [NSNumber numberWithShort:20];
-    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
-    [cluster moveColor:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Move Color command Error: %@", err);
+    __auto_type * params = [[CHIPColorControlClusterMoveColorParams alloc] init];
+    params.rateX = [NSNumber numberWithShort:15];
+    params.rateY = [NSNumber numberWithShort:20];
+    params.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    params.optionsOverride = [NSNumber numberWithUnsignedChar:0];
+    [cluster moveColorWithParams:params
+               completionHandler:^(NSError * err, NSDictionary * values) {
+                   NSLog(@"Move Color command Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+                   XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+                   [expectation fulfill];
+               }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -5360,17 +5324,17 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPColorControlClusterStopMoveStepPayload alloc] init];
-    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
-    [cluster stopMoveStep:payload
-          responseHandler:^(NSError * err, NSDictionary * values) {
-              NSLog(@"Stop Move Step command Error: %@", err);
+    __auto_type * params = [[CHIPColorControlClusterStopMoveStepParams alloc] init];
+    params.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    params.optionsOverride = [NSNumber numberWithUnsignedChar:0];
+    [cluster stopMoveStepWithParams:params
+                  completionHandler:^(NSError * err, NSDictionary * values) {
+                      NSLog(@"Stop Move Step command Error: %@", err);
 
-              XCTAssertEqual(err.code, 0);
+                      XCTAssertEqual(err.code, 0);
 
-              [expectation fulfill];
-          }];
+                      [expectation fulfill];
+                  }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -5383,15 +5347,13 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPOnOffClusterOffPayload alloc] init];
-    [cluster off:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Turn off light that we turned on Error: %@", err);
+    [cluster offWithCompletionHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"Turn off light that we turned on Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+        XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+        [expectation fulfill];
+    }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -5429,15 +5391,13 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPOnOffClusterOnPayload alloc] init];
-    [cluster on:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Turn on light for color control tests Error: %@", err);
+    [cluster onWithCompletionHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"Turn on light for color control tests Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+        XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+        [expectation fulfill];
+    }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -5474,20 +5434,20 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPColorControlClusterStepColorPayload alloc] init];
-    payload.stepX = [NSNumber numberWithShort:15];
-    payload.stepY = [NSNumber numberWithShort:20];
-    payload.transitionTime = [NSNumber numberWithUnsignedShort:50U];
-    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
-    [cluster stepColor:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Step Color command Error: %@", err);
+    __auto_type * params = [[CHIPColorControlClusterStepColorParams alloc] init];
+    params.stepX = [NSNumber numberWithShort:15];
+    params.stepY = [NSNumber numberWithShort:20];
+    params.transitionTime = [NSNumber numberWithUnsignedShort:50U];
+    params.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    params.optionsOverride = [NSNumber numberWithUnsignedChar:0];
+    [cluster stepColorWithParams:params
+               completionHandler:^(NSError * err, NSDictionary * values) {
+                   NSLog(@"Step Color command Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+                   XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+                   [expectation fulfill];
+               }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -5500,15 +5460,13 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPOnOffClusterOffPayload alloc] init];
-    [cluster off:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Turn off light that we turned on Error: %@", err);
+    [cluster offWithCompletionHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"Turn off light that we turned on Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+        XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+        [expectation fulfill];
+    }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -5546,15 +5504,13 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPOnOffClusterOnPayload alloc] init];
-    [cluster on:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Turn on light for color control tests Error: %@", err);
+    [cluster onWithCompletionHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"Turn on light for color control tests Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+        XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+        [expectation fulfill];
+    }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -5591,19 +5547,19 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPColorControlClusterMoveToColorTemperaturePayload alloc] init];
-    payload.colorTemperature = [NSNumber numberWithUnsignedShort:100U];
-    payload.transitionTime = [NSNumber numberWithUnsignedShort:10U];
-    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
-    [cluster moveToColorTemperature:payload
-                    responseHandler:^(NSError * err, NSDictionary * values) {
-                        NSLog(@"Move To Color Temperature command Error: %@", err);
+    __auto_type * params = [[CHIPColorControlClusterMoveToColorTemperatureParams alloc] init];
+    params.colorTemperature = [NSNumber numberWithUnsignedShort:100U];
+    params.transitionTime = [NSNumber numberWithUnsignedShort:10U];
+    params.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    params.optionsOverride = [NSNumber numberWithUnsignedChar:0];
+    [cluster moveToColorTemperatureWithParams:params
+                            completionHandler:^(NSError * err, NSDictionary * values) {
+                                NSLog(@"Move To Color Temperature command Error: %@", err);
 
-                        XCTAssertEqual(err.code, 0);
+                                XCTAssertEqual(err.code, 0);
 
-                        [expectation fulfill];
-                    }];
+                                [expectation fulfill];
+                            }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -5616,15 +5572,13 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPOnOffClusterOffPayload alloc] init];
-    [cluster off:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Turn off light that we turned on Error: %@", err);
+    [cluster offWithCompletionHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"Turn off light that we turned on Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+        XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+        [expectation fulfill];
+    }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -5662,15 +5616,13 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPOnOffClusterOnPayload alloc] init];
-    [cluster on:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Turn on light for color control tests Error: %@", err);
+    [cluster onWithCompletionHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"Turn on light for color control tests Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+        XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+        [expectation fulfill];
+    }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -5707,21 +5659,21 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPColorControlClusterMoveColorTemperaturePayload alloc] init];
-    payload.moveMode = [NSNumber numberWithUnsignedChar:1];
-    payload.rate = [NSNumber numberWithUnsignedShort:10U];
-    payload.colorTemperatureMinimum = [NSNumber numberWithUnsignedShort:1U];
-    payload.colorTemperatureMaximum = [NSNumber numberWithUnsignedShort:255U];
-    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
-    [cluster moveColorTemperature:payload
-                  responseHandler:^(NSError * err, NSDictionary * values) {
-                      NSLog(@"Move up color temperature command Error: %@", err);
+    __auto_type * params = [[CHIPColorControlClusterMoveColorTemperatureParams alloc] init];
+    params.moveMode = [NSNumber numberWithUnsignedChar:1];
+    params.rate = [NSNumber numberWithUnsignedShort:10U];
+    params.colorTemperatureMinimum = [NSNumber numberWithUnsignedShort:1U];
+    params.colorTemperatureMaximum = [NSNumber numberWithUnsignedShort:255U];
+    params.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    params.optionsOverride = [NSNumber numberWithUnsignedChar:0];
+    [cluster moveColorTemperatureWithParams:params
+                          completionHandler:^(NSError * err, NSDictionary * values) {
+                              NSLog(@"Move up color temperature command Error: %@", err);
 
-                      XCTAssertEqual(err.code, 0);
+                              XCTAssertEqual(err.code, 0);
 
-                      [expectation fulfill];
-                  }];
+                              [expectation fulfill];
+                          }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -5734,21 +5686,21 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPColorControlClusterMoveColorTemperaturePayload alloc] init];
-    payload.moveMode = [NSNumber numberWithUnsignedChar:0];
-    payload.rate = [NSNumber numberWithUnsignedShort:10U];
-    payload.colorTemperatureMinimum = [NSNumber numberWithUnsignedShort:1U];
-    payload.colorTemperatureMaximum = [NSNumber numberWithUnsignedShort:255U];
-    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
-    [cluster moveColorTemperature:payload
-                  responseHandler:^(NSError * err, NSDictionary * values) {
-                      NSLog(@"Stop Color Temperature command Error: %@", err);
+    __auto_type * params = [[CHIPColorControlClusterMoveColorTemperatureParams alloc] init];
+    params.moveMode = [NSNumber numberWithUnsignedChar:0];
+    params.rate = [NSNumber numberWithUnsignedShort:10U];
+    params.colorTemperatureMinimum = [NSNumber numberWithUnsignedShort:1U];
+    params.colorTemperatureMaximum = [NSNumber numberWithUnsignedShort:255U];
+    params.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    params.optionsOverride = [NSNumber numberWithUnsignedChar:0];
+    [cluster moveColorTemperatureWithParams:params
+                          completionHandler:^(NSError * err, NSDictionary * values) {
+                              NSLog(@"Stop Color Temperature command Error: %@", err);
 
-                      XCTAssertEqual(err.code, 0);
+                              XCTAssertEqual(err.code, 0);
 
-                      [expectation fulfill];
-                  }];
+                              [expectation fulfill];
+                          }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -5761,21 +5713,21 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPColorControlClusterMoveColorTemperaturePayload alloc] init];
-    payload.moveMode = [NSNumber numberWithUnsignedChar:3];
-    payload.rate = [NSNumber numberWithUnsignedShort:20U];
-    payload.colorTemperatureMinimum = [NSNumber numberWithUnsignedShort:1U];
-    payload.colorTemperatureMaximum = [NSNumber numberWithUnsignedShort:255U];
-    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
-    [cluster moveColorTemperature:payload
-                  responseHandler:^(NSError * err, NSDictionary * values) {
-                      NSLog(@"Move down color temperature command Error: %@", err);
+    __auto_type * params = [[CHIPColorControlClusterMoveColorTemperatureParams alloc] init];
+    params.moveMode = [NSNumber numberWithUnsignedChar:3];
+    params.rate = [NSNumber numberWithUnsignedShort:20U];
+    params.colorTemperatureMinimum = [NSNumber numberWithUnsignedShort:1U];
+    params.colorTemperatureMaximum = [NSNumber numberWithUnsignedShort:255U];
+    params.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    params.optionsOverride = [NSNumber numberWithUnsignedChar:0];
+    [cluster moveColorTemperatureWithParams:params
+                          completionHandler:^(NSError * err, NSDictionary * values) {
+                              NSLog(@"Move down color temperature command Error: %@", err);
 
-                      XCTAssertEqual(err.code, 0);
+                              XCTAssertEqual(err.code, 0);
 
-                      [expectation fulfill];
-                  }];
+                              [expectation fulfill];
+                          }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -5788,15 +5740,13 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPOnOffClusterOffPayload alloc] init];
-    [cluster off:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Turn off light that we turned on Error: %@", err);
+    [cluster offWithCompletionHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"Turn off light that we turned on Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+        XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+        [expectation fulfill];
+    }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -5834,15 +5784,13 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPOnOffClusterOnPayload alloc] init];
-    [cluster on:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Turn on light for color control tests Error: %@", err);
+    [cluster onWithCompletionHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"Turn on light for color control tests Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+        XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+        [expectation fulfill];
+    }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -5879,22 +5827,22 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPColorControlClusterStepColorTemperaturePayload alloc] init];
-    payload.stepMode = [NSNumber numberWithUnsignedChar:1];
-    payload.stepSize = [NSNumber numberWithUnsignedShort:5U];
-    payload.transitionTime = [NSNumber numberWithUnsignedShort:50U];
-    payload.colorTemperatureMinimum = [NSNumber numberWithUnsignedShort:5U];
-    payload.colorTemperatureMaximum = [NSNumber numberWithUnsignedShort:100U];
-    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
-    [cluster stepColorTemperature:payload
-                  responseHandler:^(NSError * err, NSDictionary * values) {
-                      NSLog(@"Step up color temperature command Error: %@", err);
+    __auto_type * params = [[CHIPColorControlClusterStepColorTemperatureParams alloc] init];
+    params.stepMode = [NSNumber numberWithUnsignedChar:1];
+    params.stepSize = [NSNumber numberWithUnsignedShort:5U];
+    params.transitionTime = [NSNumber numberWithUnsignedShort:50U];
+    params.colorTemperatureMinimum = [NSNumber numberWithUnsignedShort:5U];
+    params.colorTemperatureMaximum = [NSNumber numberWithUnsignedShort:100U];
+    params.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    params.optionsOverride = [NSNumber numberWithUnsignedChar:0];
+    [cluster stepColorTemperatureWithParams:params
+                          completionHandler:^(NSError * err, NSDictionary * values) {
+                              NSLog(@"Step up color temperature command Error: %@", err);
 
-                      XCTAssertEqual(err.code, 0);
+                              XCTAssertEqual(err.code, 0);
 
-                      [expectation fulfill];
-                  }];
+                              [expectation fulfill];
+                          }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -5907,22 +5855,22 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPColorControlClusterStepColorTemperaturePayload alloc] init];
-    payload.stepMode = [NSNumber numberWithUnsignedChar:3];
-    payload.stepSize = [NSNumber numberWithUnsignedShort:5U];
-    payload.transitionTime = [NSNumber numberWithUnsignedShort:50U];
-    payload.colorTemperatureMinimum = [NSNumber numberWithUnsignedShort:5U];
-    payload.colorTemperatureMaximum = [NSNumber numberWithUnsignedShort:100U];
-    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
-    [cluster stepColorTemperature:payload
-                  responseHandler:^(NSError * err, NSDictionary * values) {
-                      NSLog(@"Step down color temperature command Error: %@", err);
+    __auto_type * params = [[CHIPColorControlClusterStepColorTemperatureParams alloc] init];
+    params.stepMode = [NSNumber numberWithUnsignedChar:3];
+    params.stepSize = [NSNumber numberWithUnsignedShort:5U];
+    params.transitionTime = [NSNumber numberWithUnsignedShort:50U];
+    params.colorTemperatureMinimum = [NSNumber numberWithUnsignedShort:5U];
+    params.colorTemperatureMaximum = [NSNumber numberWithUnsignedShort:100U];
+    params.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    params.optionsOverride = [NSNumber numberWithUnsignedChar:0];
+    [cluster stepColorTemperatureWithParams:params
+                          completionHandler:^(NSError * err, NSDictionary * values) {
+                              NSLog(@"Step down color temperature command Error: %@", err);
 
-                      XCTAssertEqual(err.code, 0);
+                              XCTAssertEqual(err.code, 0);
 
-                      [expectation fulfill];
-                  }];
+                              [expectation fulfill];
+                          }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -5935,15 +5883,13 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPOnOffClusterOffPayload alloc] init];
-    [cluster off:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Turn off light that we turned on Error: %@", err);
+    [cluster offWithCompletionHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"Turn off light that we turned on Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+        XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+        [expectation fulfill];
+    }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -5981,15 +5927,13 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPOnOffClusterOnPayload alloc] init];
-    [cluster on:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Turn on light for color control tests Error: %@", err);
+    [cluster onWithCompletionHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"Turn on light for color control tests Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+        XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+        [expectation fulfill];
+    }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -6026,20 +5970,20 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPColorControlClusterEnhancedMoveToHuePayload alloc] init];
-    payload.enhancedHue = [NSNumber numberWithUnsignedShort:1025U];
-    payload.direction = [NSNumber numberWithUnsignedChar:0];
-    payload.transitionTime = [NSNumber numberWithUnsignedShort:1U];
-    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
-    [cluster enhancedMoveToHue:payload
-               responseHandler:^(NSError * err, NSDictionary * values) {
-                   NSLog(@"Enhanced Move To Hue command Error: %@", err);
+    __auto_type * params = [[CHIPColorControlClusterEnhancedMoveToHueParams alloc] init];
+    params.enhancedHue = [NSNumber numberWithUnsignedShort:1025U];
+    params.direction = [NSNumber numberWithUnsignedChar:0];
+    params.transitionTime = [NSNumber numberWithUnsignedShort:1U];
+    params.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    params.optionsOverride = [NSNumber numberWithUnsignedChar:0];
+    [cluster enhancedMoveToHueWithParams:params
+                       completionHandler:^(NSError * err, NSDictionary * values) {
+                           NSLog(@"Enhanced Move To Hue command Error: %@", err);
 
-                   XCTAssertEqual(err.code, 0);
+                           XCTAssertEqual(err.code, 0);
 
-                   [expectation fulfill];
-               }];
+                           [expectation fulfill];
+                       }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -6077,15 +6021,13 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPOnOffClusterOffPayload alloc] init];
-    [cluster off:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Turn off light that we turned on Error: %@", err);
+    [cluster offWithCompletionHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"Turn off light that we turned on Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+        XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+        [expectation fulfill];
+    }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -6123,15 +6065,13 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPOnOffClusterOnPayload alloc] init];
-    [cluster on:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Turn on light for color control tests Error: %@", err);
+    [cluster onWithCompletionHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"Turn on light for color control tests Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+        XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+        [expectation fulfill];
+    }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -6168,19 +6108,19 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPColorControlClusterEnhancedMoveHuePayload alloc] init];
-    payload.moveMode = [NSNumber numberWithUnsignedChar:3];
-    payload.rate = [NSNumber numberWithUnsignedShort:5U];
-    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
-    [cluster enhancedMoveHue:payload
-             responseHandler:^(NSError * err, NSDictionary * values) {
-                 NSLog(@"Enhanced Move Hue Down command  Error: %@", err);
+    __auto_type * params = [[CHIPColorControlClusterEnhancedMoveHueParams alloc] init];
+    params.moveMode = [NSNumber numberWithUnsignedChar:3];
+    params.rate = [NSNumber numberWithUnsignedShort:5U];
+    params.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    params.optionsOverride = [NSNumber numberWithUnsignedChar:0];
+    [cluster enhancedMoveHueWithParams:params
+                     completionHandler:^(NSError * err, NSDictionary * values) {
+                         NSLog(@"Enhanced Move Hue Down command  Error: %@", err);
 
-                 XCTAssertEqual(err.code, 0);
+                         XCTAssertEqual(err.code, 0);
 
-                 [expectation fulfill];
-             }];
+                         [expectation fulfill];
+                     }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -6193,19 +6133,19 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPColorControlClusterEnhancedMoveHuePayload alloc] init];
-    payload.moveMode = [NSNumber numberWithUnsignedChar:0];
-    payload.rate = [NSNumber numberWithUnsignedShort:0U];
-    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
-    [cluster enhancedMoveHue:payload
-             responseHandler:^(NSError * err, NSDictionary * values) {
-                 NSLog(@"Enhanced Move Hue Stop command Error: %@", err);
+    __auto_type * params = [[CHIPColorControlClusterEnhancedMoveHueParams alloc] init];
+    params.moveMode = [NSNumber numberWithUnsignedChar:0];
+    params.rate = [NSNumber numberWithUnsignedShort:0U];
+    params.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    params.optionsOverride = [NSNumber numberWithUnsignedChar:0];
+    [cluster enhancedMoveHueWithParams:params
+                     completionHandler:^(NSError * err, NSDictionary * values) {
+                         NSLog(@"Enhanced Move Hue Stop command Error: %@", err);
 
-                 XCTAssertEqual(err.code, 0);
+                         XCTAssertEqual(err.code, 0);
 
-                 [expectation fulfill];
-             }];
+                         [expectation fulfill];
+                     }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -6218,19 +6158,19 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPColorControlClusterEnhancedMoveHuePayload alloc] init];
-    payload.moveMode = [NSNumber numberWithUnsignedChar:1];
-    payload.rate = [NSNumber numberWithUnsignedShort:50U];
-    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
-    [cluster enhancedMoveHue:payload
-             responseHandler:^(NSError * err, NSDictionary * values) {
-                 NSLog(@"Enhanced Move Hue Up command Error: %@", err);
+    __auto_type * params = [[CHIPColorControlClusterEnhancedMoveHueParams alloc] init];
+    params.moveMode = [NSNumber numberWithUnsignedChar:1];
+    params.rate = [NSNumber numberWithUnsignedShort:50U];
+    params.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    params.optionsOverride = [NSNumber numberWithUnsignedChar:0];
+    [cluster enhancedMoveHueWithParams:params
+                     completionHandler:^(NSError * err, NSDictionary * values) {
+                         NSLog(@"Enhanced Move Hue Up command Error: %@", err);
 
-                 XCTAssertEqual(err.code, 0);
+                         XCTAssertEqual(err.code, 0);
 
-                 [expectation fulfill];
-             }];
+                         [expectation fulfill];
+                     }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -6243,19 +6183,19 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPColorControlClusterEnhancedMoveHuePayload alloc] init];
-    payload.moveMode = [NSNumber numberWithUnsignedChar:0];
-    payload.rate = [NSNumber numberWithUnsignedShort:0U];
-    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
-    [cluster enhancedMoveHue:payload
-             responseHandler:^(NSError * err, NSDictionary * values) {
-                 NSLog(@"Enhanced Move Hue Stop command Error: %@", err);
+    __auto_type * params = [[CHIPColorControlClusterEnhancedMoveHueParams alloc] init];
+    params.moveMode = [NSNumber numberWithUnsignedChar:0];
+    params.rate = [NSNumber numberWithUnsignedShort:0U];
+    params.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    params.optionsOverride = [NSNumber numberWithUnsignedChar:0];
+    [cluster enhancedMoveHueWithParams:params
+                     completionHandler:^(NSError * err, NSDictionary * values) {
+                         NSLog(@"Enhanced Move Hue Stop command Error: %@", err);
 
-                 XCTAssertEqual(err.code, 0);
+                         XCTAssertEqual(err.code, 0);
 
-                 [expectation fulfill];
-             }];
+                         [expectation fulfill];
+                     }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -6268,15 +6208,13 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPOnOffClusterOffPayload alloc] init];
-    [cluster off:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Turn off light that we turned on Error: %@", err);
+    [cluster offWithCompletionHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"Turn off light that we turned on Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+        XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+        [expectation fulfill];
+    }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -6314,15 +6252,13 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPOnOffClusterOnPayload alloc] init];
-    [cluster on:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Turn on light for color control tests Error: %@", err);
+    [cluster onWithCompletionHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"Turn on light for color control tests Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+        XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+        [expectation fulfill];
+    }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -6359,20 +6295,20 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPColorControlClusterEnhancedStepHuePayload alloc] init];
-    payload.stepMode = [NSNumber numberWithUnsignedChar:0];
-    payload.stepSize = [NSNumber numberWithUnsignedShort:50U];
-    payload.transitionTime = [NSNumber numberWithUnsignedShort:1U];
-    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
-    [cluster enhancedStepHue:payload
-             responseHandler:^(NSError * err, NSDictionary * values) {
-                 NSLog(@"Enhanced Step Hue Up command Error: %@", err);
+    __auto_type * params = [[CHIPColorControlClusterEnhancedStepHueParams alloc] init];
+    params.stepMode = [NSNumber numberWithUnsignedChar:0];
+    params.stepSize = [NSNumber numberWithUnsignedShort:50U];
+    params.transitionTime = [NSNumber numberWithUnsignedShort:1U];
+    params.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    params.optionsOverride = [NSNumber numberWithUnsignedChar:0];
+    [cluster enhancedStepHueWithParams:params
+                     completionHandler:^(NSError * err, NSDictionary * values) {
+                         NSLog(@"Enhanced Step Hue Up command Error: %@", err);
 
-                 XCTAssertEqual(err.code, 0);
+                         XCTAssertEqual(err.code, 0);
 
-                 [expectation fulfill];
-             }];
+                         [expectation fulfill];
+                     }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -6385,20 +6321,20 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPColorControlClusterEnhancedStepHuePayload alloc] init];
-    payload.stepMode = [NSNumber numberWithUnsignedChar:1];
-    payload.stepSize = [NSNumber numberWithUnsignedShort:75U];
-    payload.transitionTime = [NSNumber numberWithUnsignedShort:1U];
-    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
-    [cluster enhancedStepHue:payload
-             responseHandler:^(NSError * err, NSDictionary * values) {
-                 NSLog(@"Enhanced Step Hue Down command Error: %@", err);
+    __auto_type * params = [[CHIPColorControlClusterEnhancedStepHueParams alloc] init];
+    params.stepMode = [NSNumber numberWithUnsignedChar:1];
+    params.stepSize = [NSNumber numberWithUnsignedShort:75U];
+    params.transitionTime = [NSNumber numberWithUnsignedShort:1U];
+    params.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    params.optionsOverride = [NSNumber numberWithUnsignedChar:0];
+    [cluster enhancedStepHueWithParams:params
+                     completionHandler:^(NSError * err, NSDictionary * values) {
+                         NSLog(@"Enhanced Step Hue Down command Error: %@", err);
 
-                 XCTAssertEqual(err.code, 0);
+                         XCTAssertEqual(err.code, 0);
 
-                 [expectation fulfill];
-             }];
+                         [expectation fulfill];
+                     }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -6411,15 +6347,13 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPOnOffClusterOffPayload alloc] init];
-    [cluster off:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Turn off light that we turned on Error: %@", err);
+    [cluster offWithCompletionHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"Turn off light that we turned on Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+        XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+        [expectation fulfill];
+    }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -6457,15 +6391,13 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPOnOffClusterOnPayload alloc] init];
-    [cluster on:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Turn on light for color control tests Error: %@", err);
+    [cluster onWithCompletionHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"Turn on light for color control tests Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+        XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+        [expectation fulfill];
+    }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -6502,20 +6434,20 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPColorControlClusterEnhancedMoveToHueAndSaturationPayload alloc] init];
-    payload.enhancedHue = [NSNumber numberWithUnsignedShort:1200U];
-    payload.saturation = [NSNumber numberWithUnsignedChar:90];
-    payload.transitionTime = [NSNumber numberWithUnsignedShort:10U];
-    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
-    [cluster enhancedMoveToHueAndSaturation:payload
-                            responseHandler:^(NSError * err, NSDictionary * values) {
-                                NSLog(@"Enhanced move to hue and saturation command Error: %@", err);
+    __auto_type * params = [[CHIPColorControlClusterEnhancedMoveToHueAndSaturationParams alloc] init];
+    params.enhancedHue = [NSNumber numberWithUnsignedShort:1200U];
+    params.saturation = [NSNumber numberWithUnsignedChar:90];
+    params.transitionTime = [NSNumber numberWithUnsignedShort:10U];
+    params.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    params.optionsOverride = [NSNumber numberWithUnsignedChar:0];
+    [cluster enhancedMoveToHueAndSaturationWithParams:params
+                                    completionHandler:^(NSError * err, NSDictionary * values) {
+                                        NSLog(@"Enhanced move to hue and saturation command Error: %@", err);
 
-                                XCTAssertEqual(err.code, 0);
+                                        XCTAssertEqual(err.code, 0);
 
-                                [expectation fulfill];
-                            }];
+                                        [expectation fulfill];
+                                    }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -6528,15 +6460,13 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPOnOffClusterOffPayload alloc] init];
-    [cluster off:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Turn off light that we turned on Error: %@", err);
+    [cluster offWithCompletionHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"Turn off light that we turned on Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+        XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+        [expectation fulfill];
+    }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -6574,15 +6504,13 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPOnOffClusterOnPayload alloc] init];
-    [cluster on:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Turn on light for color control tests Error: %@", err);
+    [cluster onWithCompletionHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"Turn on light for color control tests Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+        XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+        [expectation fulfill];
+    }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -6619,22 +6547,22 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPColorControlClusterColorLoopSetPayload alloc] init];
-    payload.updateFlags = [NSNumber numberWithUnsignedChar:14];
-    payload.action = [NSNumber numberWithUnsignedChar:0];
-    payload.direction = [NSNumber numberWithUnsignedChar:1];
-    payload.time = [NSNumber numberWithUnsignedShort:100U];
-    payload.startHue = [NSNumber numberWithUnsignedShort:500U];
-    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
-    [cluster colorLoopSet:payload
-          responseHandler:^(NSError * err, NSDictionary * values) {
-              NSLog(@"Color Loop Set Command - Set all Attributs Error: %@", err);
+    __auto_type * params = [[CHIPColorControlClusterColorLoopSetParams alloc] init];
+    params.updateFlags = [NSNumber numberWithUnsignedChar:14];
+    params.action = [NSNumber numberWithUnsignedChar:0];
+    params.direction = [NSNumber numberWithUnsignedChar:1];
+    params.time = [NSNumber numberWithUnsignedShort:100U];
+    params.startHue = [NSNumber numberWithUnsignedShort:500U];
+    params.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    params.optionsOverride = [NSNumber numberWithUnsignedChar:0];
+    [cluster colorLoopSetWithParams:params
+                  completionHandler:^(NSError * err, NSDictionary * values) {
+                      NSLog(@"Color Loop Set Command - Set all Attributs Error: %@", err);
 
-              XCTAssertEqual(err.code, 0);
+                      XCTAssertEqual(err.code, 0);
 
-              [expectation fulfill];
-          }];
+                      [expectation fulfill];
+                  }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -6743,22 +6671,22 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPColorControlClusterColorLoopSetPayload alloc] init];
-    payload.updateFlags = [NSNumber numberWithUnsignedChar:1];
-    payload.action = [NSNumber numberWithUnsignedChar:1];
-    payload.direction = [NSNumber numberWithUnsignedChar:0];
-    payload.time = [NSNumber numberWithUnsignedShort:0U];
-    payload.startHue = [NSNumber numberWithUnsignedShort:0U];
-    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
-    [cluster colorLoopSet:payload
-          responseHandler:^(NSError * err, NSDictionary * values) {
-              NSLog(@"Color Loop Set Command - Start Color Loop Error: %@", err);
+    __auto_type * params = [[CHIPColorControlClusterColorLoopSetParams alloc] init];
+    params.updateFlags = [NSNumber numberWithUnsignedChar:1];
+    params.action = [NSNumber numberWithUnsignedChar:1];
+    params.direction = [NSNumber numberWithUnsignedChar:0];
+    params.time = [NSNumber numberWithUnsignedShort:0U];
+    params.startHue = [NSNumber numberWithUnsignedShort:0U];
+    params.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    params.optionsOverride = [NSNumber numberWithUnsignedChar:0];
+    [cluster colorLoopSetWithParams:params
+                  completionHandler:^(NSError * err, NSDictionary * values) {
+                      NSLog(@"Color Loop Set Command - Start Color Loop Error: %@", err);
 
-              XCTAssertEqual(err.code, 0);
+                      XCTAssertEqual(err.code, 0);
 
-              [expectation fulfill];
-          }];
+                      [expectation fulfill];
+                  }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -6796,22 +6724,22 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPColorControlClusterColorLoopSetPayload alloc] init];
-    payload.updateFlags = [NSNumber numberWithUnsignedChar:6];
-    payload.action = [NSNumber numberWithUnsignedChar:0];
-    payload.direction = [NSNumber numberWithUnsignedChar:0];
-    payload.time = [NSNumber numberWithUnsignedShort:3500U];
-    payload.startHue = [NSNumber numberWithUnsignedShort:0U];
-    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
-    [cluster colorLoopSet:payload
-          responseHandler:^(NSError * err, NSDictionary * values) {
-              NSLog(@"Color Loop Set Command - Set direction and time while running Error: %@", err);
+    __auto_type * params = [[CHIPColorControlClusterColorLoopSetParams alloc] init];
+    params.updateFlags = [NSNumber numberWithUnsignedChar:6];
+    params.action = [NSNumber numberWithUnsignedChar:0];
+    params.direction = [NSNumber numberWithUnsignedChar:0];
+    params.time = [NSNumber numberWithUnsignedShort:3500U];
+    params.startHue = [NSNumber numberWithUnsignedShort:0U];
+    params.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    params.optionsOverride = [NSNumber numberWithUnsignedChar:0];
+    [cluster colorLoopSetWithParams:params
+                  completionHandler:^(NSError * err, NSDictionary * values) {
+                      NSLog(@"Color Loop Set Command - Set direction and time while running Error: %@", err);
 
-              XCTAssertEqual(err.code, 0);
+                      XCTAssertEqual(err.code, 0);
 
-              [expectation fulfill];
-          }];
+                      [expectation fulfill];
+                  }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -6872,22 +6800,22 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPColorControlClusterColorLoopSetPayload alloc] init];
-    payload.updateFlags = [NSNumber numberWithUnsignedChar:2];
-    payload.action = [NSNumber numberWithUnsignedChar:0];
-    payload.direction = [NSNumber numberWithUnsignedChar:1];
-    payload.time = [NSNumber numberWithUnsignedShort:0U];
-    payload.startHue = [NSNumber numberWithUnsignedShort:0U];
-    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
-    [cluster colorLoopSet:payload
-          responseHandler:^(NSError * err, NSDictionary * values) {
-              NSLog(@"Color Loop Set Command - Set direction while running Error: %@", err);
+    __auto_type * params = [[CHIPColorControlClusterColorLoopSetParams alloc] init];
+    params.updateFlags = [NSNumber numberWithUnsignedChar:2];
+    params.action = [NSNumber numberWithUnsignedChar:0];
+    params.direction = [NSNumber numberWithUnsignedChar:1];
+    params.time = [NSNumber numberWithUnsignedShort:0U];
+    params.startHue = [NSNumber numberWithUnsignedShort:0U];
+    params.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    params.optionsOverride = [NSNumber numberWithUnsignedChar:0];
+    [cluster colorLoopSetWithParams:params
+                  completionHandler:^(NSError * err, NSDictionary * values) {
+                      NSLog(@"Color Loop Set Command - Set direction while running Error: %@", err);
 
-              XCTAssertEqual(err.code, 0);
+                      XCTAssertEqual(err.code, 0);
 
-              [expectation fulfill];
-          }];
+                      [expectation fulfill];
+                  }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -6924,15 +6852,13 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPOnOffClusterOffPayload alloc] init];
-    [cluster off:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Turn off light that we turned on Error: %@", err);
+    [cluster offWithCompletionHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"Turn off light that we turned on Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+        XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+        [expectation fulfill];
+    }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -6970,15 +6896,13 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPOnOffClusterOnPayload alloc] init];
-    [cluster on:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Precondition : Turn on light for color control tests Error: %@", err);
+    [cluster onWithCompletionHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"Precondition : Turn on light for color control tests Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+        XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+        [expectation fulfill];
+    }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -7015,22 +6939,22 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPColorControlClusterColorLoopSetPayload alloc] init];
-    payload.updateFlags = [NSNumber numberWithUnsignedChar:1];
-    payload.action = [NSNumber numberWithUnsignedChar:0];
-    payload.direction = [NSNumber numberWithUnsignedChar:0];
-    payload.time = [NSNumber numberWithUnsignedShort:0U];
-    payload.startHue = [NSNumber numberWithUnsignedShort:0U];
-    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
-    [cluster colorLoopSet:payload
-          responseHandler:^(NSError * err, NSDictionary * values) {
-              NSLog(@"Sends ColorLoopSet Command - Set all Attributes Error: %@", err);
+    __auto_type * params = [[CHIPColorControlClusterColorLoopSetParams alloc] init];
+    params.updateFlags = [NSNumber numberWithUnsignedChar:1];
+    params.action = [NSNumber numberWithUnsignedChar:0];
+    params.direction = [NSNumber numberWithUnsignedChar:0];
+    params.time = [NSNumber numberWithUnsignedShort:0U];
+    params.startHue = [NSNumber numberWithUnsignedShort:0U];
+    params.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    params.optionsOverride = [NSNumber numberWithUnsignedChar:0];
+    [cluster colorLoopSetWithParams:params
+                  completionHandler:^(NSError * err, NSDictionary * values) {
+                      NSLog(@"Sends ColorLoopSet Command - Set all Attributes Error: %@", err);
 
-              XCTAssertEqual(err.code, 0);
+                      XCTAssertEqual(err.code, 0);
 
-              [expectation fulfill];
-          }];
+                      [expectation fulfill];
+                  }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -7067,22 +6991,22 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPColorControlClusterColorLoopSetPayload alloc] init];
-    payload.updateFlags = [NSNumber numberWithUnsignedChar:2];
-    payload.action = [NSNumber numberWithUnsignedChar:0];
-    payload.direction = [NSNumber numberWithUnsignedChar:0];
-    payload.time = [NSNumber numberWithUnsignedShort:0U];
-    payload.startHue = [NSNumber numberWithUnsignedShort:0U];
-    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
-    [cluster colorLoopSet:payload
-          responseHandler:^(NSError * err, NSDictionary * values) {
-              NSLog(@"Sends ColorLoopSet Command - Set all Attributes Error: %@", err);
+    __auto_type * params = [[CHIPColorControlClusterColorLoopSetParams alloc] init];
+    params.updateFlags = [NSNumber numberWithUnsignedChar:2];
+    params.action = [NSNumber numberWithUnsignedChar:0];
+    params.direction = [NSNumber numberWithUnsignedChar:0];
+    params.time = [NSNumber numberWithUnsignedShort:0U];
+    params.startHue = [NSNumber numberWithUnsignedShort:0U];
+    params.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    params.optionsOverride = [NSNumber numberWithUnsignedChar:0];
+    [cluster colorLoopSetWithParams:params
+                  completionHandler:^(NSError * err, NSDictionary * values) {
+                      NSLog(@"Sends ColorLoopSet Command - Set all Attributes Error: %@", err);
 
-              XCTAssertEqual(err.code, 0);
+                      XCTAssertEqual(err.code, 0);
 
-              [expectation fulfill];
-          }];
+                      [expectation fulfill];
+                  }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -7119,22 +7043,22 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPColorControlClusterColorLoopSetPayload alloc] init];
-    payload.updateFlags = [NSNumber numberWithUnsignedChar:4];
-    payload.action = [NSNumber numberWithUnsignedChar:0];
-    payload.direction = [NSNumber numberWithUnsignedChar:0];
-    payload.time = [NSNumber numberWithUnsignedShort:30U];
-    payload.startHue = [NSNumber numberWithUnsignedShort:0U];
-    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
-    [cluster colorLoopSet:payload
-          responseHandler:^(NSError * err, NSDictionary * values) {
-              NSLog(@"Sends ColorLoopSet Command - Set all Attributes Error: %@", err);
+    __auto_type * params = [[CHIPColorControlClusterColorLoopSetParams alloc] init];
+    params.updateFlags = [NSNumber numberWithUnsignedChar:4];
+    params.action = [NSNumber numberWithUnsignedChar:0];
+    params.direction = [NSNumber numberWithUnsignedChar:0];
+    params.time = [NSNumber numberWithUnsignedShort:30U];
+    params.startHue = [NSNumber numberWithUnsignedShort:0U];
+    params.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    params.optionsOverride = [NSNumber numberWithUnsignedChar:0];
+    [cluster colorLoopSetWithParams:params
+                  completionHandler:^(NSError * err, NSDictionary * values) {
+                      NSLog(@"Sends ColorLoopSet Command - Set all Attributes Error: %@", err);
 
-              XCTAssertEqual(err.code, 0);
+                      XCTAssertEqual(err.code, 0);
 
-              [expectation fulfill];
-          }];
+                      [expectation fulfill];
+                  }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -7171,22 +7095,22 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPColorControlClusterColorLoopSetPayload alloc] init];
-    payload.updateFlags = [NSNumber numberWithUnsignedChar:8];
-    payload.action = [NSNumber numberWithUnsignedChar:0];
-    payload.direction = [NSNumber numberWithUnsignedChar:0];
-    payload.time = [NSNumber numberWithUnsignedShort:0U];
-    payload.startHue = [NSNumber numberWithUnsignedShort:160U];
-    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
-    [cluster colorLoopSet:payload
-          responseHandler:^(NSError * err, NSDictionary * values) {
-              NSLog(@"Sends ColorLoopSet Command - Set all Attributes Error: %@", err);
+    __auto_type * params = [[CHIPColorControlClusterColorLoopSetParams alloc] init];
+    params.updateFlags = [NSNumber numberWithUnsignedChar:8];
+    params.action = [NSNumber numberWithUnsignedChar:0];
+    params.direction = [NSNumber numberWithUnsignedChar:0];
+    params.time = [NSNumber numberWithUnsignedShort:0U];
+    params.startHue = [NSNumber numberWithUnsignedShort:160U];
+    params.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    params.optionsOverride = [NSNumber numberWithUnsignedChar:0];
+    [cluster colorLoopSetWithParams:params
+                  completionHandler:^(NSError * err, NSDictionary * values) {
+                      NSLog(@"Sends ColorLoopSet Command - Set all Attributes Error: %@", err);
 
-              XCTAssertEqual(err.code, 0);
+                      XCTAssertEqual(err.code, 0);
 
-              [expectation fulfill];
-          }];
+                      [expectation fulfill];
+                  }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -7223,22 +7147,22 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPColorControlClusterColorLoopSetPayload alloc] init];
-    payload.updateFlags = [NSNumber numberWithUnsignedChar:1];
-    payload.action = [NSNumber numberWithUnsignedChar:1];
-    payload.direction = [NSNumber numberWithUnsignedChar:0];
-    payload.time = [NSNumber numberWithUnsignedShort:0U];
-    payload.startHue = [NSNumber numberWithUnsignedShort:0U];
-    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
-    [cluster colorLoopSet:payload
-          responseHandler:^(NSError * err, NSDictionary * values) {
-              NSLog(@"Sends ColorLoopSet Command - Set all Attributes Error: %@", err);
+    __auto_type * params = [[CHIPColorControlClusterColorLoopSetParams alloc] init];
+    params.updateFlags = [NSNumber numberWithUnsignedChar:1];
+    params.action = [NSNumber numberWithUnsignedChar:1];
+    params.direction = [NSNumber numberWithUnsignedChar:0];
+    params.time = [NSNumber numberWithUnsignedShort:0U];
+    params.startHue = [NSNumber numberWithUnsignedShort:0U];
+    params.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    params.optionsOverride = [NSNumber numberWithUnsignedChar:0];
+    [cluster colorLoopSetWithParams:params
+                  completionHandler:^(NSError * err, NSDictionary * values) {
+                      NSLog(@"Sends ColorLoopSet Command - Set all Attributes Error: %@", err);
 
-              XCTAssertEqual(err.code, 0);
+                      XCTAssertEqual(err.code, 0);
 
-              [expectation fulfill];
-          }];
+                      [expectation fulfill];
+                  }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -7275,22 +7199,22 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPColorControlClusterColorLoopSetPayload alloc] init];
-    payload.updateFlags = [NSNumber numberWithUnsignedChar:1];
-    payload.action = [NSNumber numberWithUnsignedChar:0];
-    payload.direction = [NSNumber numberWithUnsignedChar:0];
-    payload.time = [NSNumber numberWithUnsignedShort:0U];
-    payload.startHue = [NSNumber numberWithUnsignedShort:0U];
-    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
-    [cluster colorLoopSet:payload
-          responseHandler:^(NSError * err, NSDictionary * values) {
-              NSLog(@"Sends ColorLoopSet Command - Set all Attributes Error: %@", err);
+    __auto_type * params = [[CHIPColorControlClusterColorLoopSetParams alloc] init];
+    params.updateFlags = [NSNumber numberWithUnsignedChar:1];
+    params.action = [NSNumber numberWithUnsignedChar:0];
+    params.direction = [NSNumber numberWithUnsignedChar:0];
+    params.time = [NSNumber numberWithUnsignedShort:0U];
+    params.startHue = [NSNumber numberWithUnsignedShort:0U];
+    params.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    params.optionsOverride = [NSNumber numberWithUnsignedChar:0];
+    [cluster colorLoopSetWithParams:params
+                  completionHandler:^(NSError * err, NSDictionary * values) {
+                      NSLog(@"Sends ColorLoopSet Command - Set all Attributes Error: %@", err);
 
-              XCTAssertEqual(err.code, 0);
+                      XCTAssertEqual(err.code, 0);
 
-              [expectation fulfill];
-          }];
+                      [expectation fulfill];
+                  }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -7327,22 +7251,22 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPColorControlClusterColorLoopSetPayload alloc] init];
-    payload.updateFlags = [NSNumber numberWithUnsignedChar:2];
-    payload.action = [NSNumber numberWithUnsignedChar:0];
-    payload.direction = [NSNumber numberWithUnsignedChar:1];
-    payload.time = [NSNumber numberWithUnsignedShort:0U];
-    payload.startHue = [NSNumber numberWithUnsignedShort:0U];
-    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
-    [cluster colorLoopSet:payload
-          responseHandler:^(NSError * err, NSDictionary * values) {
-              NSLog(@"Sends ColorLoopSet Command - Set all Attributes Error: %@", err);
+    __auto_type * params = [[CHIPColorControlClusterColorLoopSetParams alloc] init];
+    params.updateFlags = [NSNumber numberWithUnsignedChar:2];
+    params.action = [NSNumber numberWithUnsignedChar:0];
+    params.direction = [NSNumber numberWithUnsignedChar:1];
+    params.time = [NSNumber numberWithUnsignedShort:0U];
+    params.startHue = [NSNumber numberWithUnsignedShort:0U];
+    params.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    params.optionsOverride = [NSNumber numberWithUnsignedChar:0];
+    [cluster colorLoopSetWithParams:params
+                  completionHandler:^(NSError * err, NSDictionary * values) {
+                      NSLog(@"Sends ColorLoopSet Command - Set all Attributes Error: %@", err);
 
-              XCTAssertEqual(err.code, 0);
+                      XCTAssertEqual(err.code, 0);
 
-              [expectation fulfill];
-          }];
+                      [expectation fulfill];
+                  }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -7379,22 +7303,22 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPColorControlClusterColorLoopSetPayload alloc] init];
-    payload.updateFlags = [NSNumber numberWithUnsignedChar:1];
-    payload.action = [NSNumber numberWithUnsignedChar:1];
-    payload.direction = [NSNumber numberWithUnsignedChar:0];
-    payload.time = [NSNumber numberWithUnsignedShort:0U];
-    payload.startHue = [NSNumber numberWithUnsignedShort:0U];
-    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
-    [cluster colorLoopSet:payload
-          responseHandler:^(NSError * err, NSDictionary * values) {
-              NSLog(@"Sends ColorLoopSet Command - Set all Attributes Error: %@", err);
+    __auto_type * params = [[CHIPColorControlClusterColorLoopSetParams alloc] init];
+    params.updateFlags = [NSNumber numberWithUnsignedChar:1];
+    params.action = [NSNumber numberWithUnsignedChar:1];
+    params.direction = [NSNumber numberWithUnsignedChar:0];
+    params.time = [NSNumber numberWithUnsignedShort:0U];
+    params.startHue = [NSNumber numberWithUnsignedShort:0U];
+    params.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    params.optionsOverride = [NSNumber numberWithUnsignedChar:0];
+    [cluster colorLoopSetWithParams:params
+                  completionHandler:^(NSError * err, NSDictionary * values) {
+                      NSLog(@"Sends ColorLoopSet Command - Set all Attributes Error: %@", err);
 
-              XCTAssertEqual(err.code, 0);
+                      XCTAssertEqual(err.code, 0);
 
-              [expectation fulfill];
-          }];
+                      [expectation fulfill];
+                  }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -7431,22 +7355,22 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPColorControlClusterColorLoopSetPayload alloc] init];
-    payload.updateFlags = [NSNumber numberWithUnsignedChar:1];
-    payload.action = [NSNumber numberWithUnsignedChar:0];
-    payload.direction = [NSNumber numberWithUnsignedChar:0];
-    payload.time = [NSNumber numberWithUnsignedShort:0U];
-    payload.startHue = [NSNumber numberWithUnsignedShort:0U];
-    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
-    [cluster colorLoopSet:payload
-          responseHandler:^(NSError * err, NSDictionary * values) {
-              NSLog(@"Sends ColorLoopSet Command - Set all Attributes Error: %@", err);
+    __auto_type * params = [[CHIPColorControlClusterColorLoopSetParams alloc] init];
+    params.updateFlags = [NSNumber numberWithUnsignedChar:1];
+    params.action = [NSNumber numberWithUnsignedChar:0];
+    params.direction = [NSNumber numberWithUnsignedChar:0];
+    params.time = [NSNumber numberWithUnsignedShort:0U];
+    params.startHue = [NSNumber numberWithUnsignedShort:0U];
+    params.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    params.optionsOverride = [NSNumber numberWithUnsignedChar:0];
+    [cluster colorLoopSetWithParams:params
+                  completionHandler:^(NSError * err, NSDictionary * values) {
+                      NSLog(@"Sends ColorLoopSet Command - Set all Attributes Error: %@", err);
 
-              XCTAssertEqual(err.code, 0);
+                      XCTAssertEqual(err.code, 0);
 
-              [expectation fulfill];
-          }];
+                      [expectation fulfill];
+                  }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -7483,20 +7407,20 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPColorControlClusterEnhancedMoveToHuePayload alloc] init];
-    payload.enhancedHue = [NSNumber numberWithUnsignedShort:40960U];
-    payload.direction = [NSNumber numberWithUnsignedChar:0];
-    payload.transitionTime = [NSNumber numberWithUnsignedShort:0U];
-    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
-    [cluster enhancedMoveToHue:payload
-               responseHandler:^(NSError * err, NSDictionary * values) {
-                   NSLog(@"Enhanced Move To Hue command 10 Error: %@", err);
+    __auto_type * params = [[CHIPColorControlClusterEnhancedMoveToHueParams alloc] init];
+    params.enhancedHue = [NSNumber numberWithUnsignedShort:40960U];
+    params.direction = [NSNumber numberWithUnsignedChar:0];
+    params.transitionTime = [NSNumber numberWithUnsignedShort:0U];
+    params.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    params.optionsOverride = [NSNumber numberWithUnsignedChar:0];
+    [cluster enhancedMoveToHueWithParams:params
+                       completionHandler:^(NSError * err, NSDictionary * values) {
+                           NSLog(@"Enhanced Move To Hue command 10 Error: %@", err);
 
-                   XCTAssertEqual(err.code, 0);
+                           XCTAssertEqual(err.code, 0);
 
-                   [expectation fulfill];
-               }];
+                           [expectation fulfill];
+                       }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -7541,22 +7465,22 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPColorControlClusterColorLoopSetPayload alloc] init];
-    payload.updateFlags = [NSNumber numberWithUnsignedChar:2];
-    payload.action = [NSNumber numberWithUnsignedChar:0];
-    payload.direction = [NSNumber numberWithUnsignedChar:0];
-    payload.time = [NSNumber numberWithUnsignedShort:0U];
-    payload.startHue = [NSNumber numberWithUnsignedShort:0U];
-    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
-    [cluster colorLoopSet:payload
-          responseHandler:^(NSError * err, NSDictionary * values) {
-              NSLog(@"Sends ColorLoopSet Command - Set all Attributes Error: %@", err);
+    __auto_type * params = [[CHIPColorControlClusterColorLoopSetParams alloc] init];
+    params.updateFlags = [NSNumber numberWithUnsignedChar:2];
+    params.action = [NSNumber numberWithUnsignedChar:0];
+    params.direction = [NSNumber numberWithUnsignedChar:0];
+    params.time = [NSNumber numberWithUnsignedShort:0U];
+    params.startHue = [NSNumber numberWithUnsignedShort:0U];
+    params.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    params.optionsOverride = [NSNumber numberWithUnsignedChar:0];
+    [cluster colorLoopSetWithParams:params
+                  completionHandler:^(NSError * err, NSDictionary * values) {
+                      NSLog(@"Sends ColorLoopSet Command - Set all Attributes Error: %@", err);
 
-              XCTAssertEqual(err.code, 0);
+                      XCTAssertEqual(err.code, 0);
 
-              [expectation fulfill];
-          }];
+                      [expectation fulfill];
+                  }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -7593,22 +7517,22 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPColorControlClusterColorLoopSetPayload alloc] init];
-    payload.updateFlags = [NSNumber numberWithUnsignedChar:1];
-    payload.action = [NSNumber numberWithUnsignedChar:2];
-    payload.direction = [NSNumber numberWithUnsignedChar:0];
-    payload.time = [NSNumber numberWithUnsignedShort:0U];
-    payload.startHue = [NSNumber numberWithUnsignedShort:0U];
-    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
-    [cluster colorLoopSet:payload
-          responseHandler:^(NSError * err, NSDictionary * values) {
-              NSLog(@"Sends ColorLoopSet Command - Set all Attributes Error: %@", err);
+    __auto_type * params = [[CHIPColorControlClusterColorLoopSetParams alloc] init];
+    params.updateFlags = [NSNumber numberWithUnsignedChar:1];
+    params.action = [NSNumber numberWithUnsignedChar:2];
+    params.direction = [NSNumber numberWithUnsignedChar:0];
+    params.time = [NSNumber numberWithUnsignedShort:0U];
+    params.startHue = [NSNumber numberWithUnsignedShort:0U];
+    params.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    params.optionsOverride = [NSNumber numberWithUnsignedChar:0];
+    [cluster colorLoopSetWithParams:params
+                  completionHandler:^(NSError * err, NSDictionary * values) {
+                      NSLog(@"Sends ColorLoopSet Command - Set all Attributes Error: %@", err);
 
-              XCTAssertEqual(err.code, 0);
+                      XCTAssertEqual(err.code, 0);
 
-              [expectation fulfill];
-          }];
+                      [expectation fulfill];
+                  }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -7645,22 +7569,22 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPColorControlClusterColorLoopSetPayload alloc] init];
-    payload.updateFlags = [NSNumber numberWithUnsignedChar:1];
-    payload.action = [NSNumber numberWithUnsignedChar:0];
-    payload.direction = [NSNumber numberWithUnsignedChar:0];
-    payload.time = [NSNumber numberWithUnsignedShort:0U];
-    payload.startHue = [NSNumber numberWithUnsignedShort:0U];
-    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
-    [cluster colorLoopSet:payload
-          responseHandler:^(NSError * err, NSDictionary * values) {
-              NSLog(@"Sends ColorLoopSet Command - Set all Attributes Error: %@", err);
+    __auto_type * params = [[CHIPColorControlClusterColorLoopSetParams alloc] init];
+    params.updateFlags = [NSNumber numberWithUnsignedChar:1];
+    params.action = [NSNumber numberWithUnsignedChar:0];
+    params.direction = [NSNumber numberWithUnsignedChar:0];
+    params.time = [NSNumber numberWithUnsignedShort:0U];
+    params.startHue = [NSNumber numberWithUnsignedShort:0U];
+    params.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    params.optionsOverride = [NSNumber numberWithUnsignedChar:0];
+    [cluster colorLoopSetWithParams:params
+                  completionHandler:^(NSError * err, NSDictionary * values) {
+                      NSLog(@"Sends ColorLoopSet Command - Set all Attributes Error: %@", err);
 
-              XCTAssertEqual(err.code, 0);
+                      XCTAssertEqual(err.code, 0);
 
-              [expectation fulfill];
-          }];
+                      [expectation fulfill];
+                  }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -7697,22 +7621,22 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPColorControlClusterColorLoopSetPayload alloc] init];
-    payload.updateFlags = [NSNumber numberWithUnsignedChar:2];
-    payload.action = [NSNumber numberWithUnsignedChar:0];
-    payload.direction = [NSNumber numberWithUnsignedChar:1];
-    payload.time = [NSNumber numberWithUnsignedShort:0U];
-    payload.startHue = [NSNumber numberWithUnsignedShort:0U];
-    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
-    [cluster colorLoopSet:payload
-          responseHandler:^(NSError * err, NSDictionary * values) {
-              NSLog(@"Sends ColorLoopSet Command - Set all Attributes Error: %@", err);
+    __auto_type * params = [[CHIPColorControlClusterColorLoopSetParams alloc] init];
+    params.updateFlags = [NSNumber numberWithUnsignedChar:2];
+    params.action = [NSNumber numberWithUnsignedChar:0];
+    params.direction = [NSNumber numberWithUnsignedChar:1];
+    params.time = [NSNumber numberWithUnsignedShort:0U];
+    params.startHue = [NSNumber numberWithUnsignedShort:0U];
+    params.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    params.optionsOverride = [NSNumber numberWithUnsignedChar:0];
+    [cluster colorLoopSetWithParams:params
+                  completionHandler:^(NSError * err, NSDictionary * values) {
+                      NSLog(@"Sends ColorLoopSet Command - Set all Attributes Error: %@", err);
 
-              XCTAssertEqual(err.code, 0);
+                      XCTAssertEqual(err.code, 0);
 
-              [expectation fulfill];
-          }];
+                      [expectation fulfill];
+                  }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -7749,22 +7673,22 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPColorControlClusterColorLoopSetPayload alloc] init];
-    payload.updateFlags = [NSNumber numberWithUnsignedChar:1];
-    payload.action = [NSNumber numberWithUnsignedChar:2];
-    payload.direction = [NSNumber numberWithUnsignedChar:0];
-    payload.time = [NSNumber numberWithUnsignedShort:0U];
-    payload.startHue = [NSNumber numberWithUnsignedShort:0U];
-    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
-    [cluster colorLoopSet:payload
-          responseHandler:^(NSError * err, NSDictionary * values) {
-              NSLog(@"Sends ColorLoopSet Command - Set all Attributes Error: %@", err);
+    __auto_type * params = [[CHIPColorControlClusterColorLoopSetParams alloc] init];
+    params.updateFlags = [NSNumber numberWithUnsignedChar:1];
+    params.action = [NSNumber numberWithUnsignedChar:2];
+    params.direction = [NSNumber numberWithUnsignedChar:0];
+    params.time = [NSNumber numberWithUnsignedShort:0U];
+    params.startHue = [NSNumber numberWithUnsignedShort:0U];
+    params.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    params.optionsOverride = [NSNumber numberWithUnsignedChar:0];
+    [cluster colorLoopSetWithParams:params
+                  completionHandler:^(NSError * err, NSDictionary * values) {
+                      NSLog(@"Sends ColorLoopSet Command - Set all Attributes Error: %@", err);
 
-              XCTAssertEqual(err.code, 0);
+                      XCTAssertEqual(err.code, 0);
 
-              [expectation fulfill];
-          }];
+                      [expectation fulfill];
+                  }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -7801,22 +7725,22 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPColorControlClusterColorLoopSetPayload alloc] init];
-    payload.updateFlags = [NSNumber numberWithUnsignedChar:1];
-    payload.action = [NSNumber numberWithUnsignedChar:0];
-    payload.direction = [NSNumber numberWithUnsignedChar:0];
-    payload.time = [NSNumber numberWithUnsignedShort:0U];
-    payload.startHue = [NSNumber numberWithUnsignedShort:0U];
-    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
-    [cluster colorLoopSet:payload
-          responseHandler:^(NSError * err, NSDictionary * values) {
-              NSLog(@"Sends ColorLoopSet Command - Set all Attributes Error: %@", err);
+    __auto_type * params = [[CHIPColorControlClusterColorLoopSetParams alloc] init];
+    params.updateFlags = [NSNumber numberWithUnsignedChar:1];
+    params.action = [NSNumber numberWithUnsignedChar:0];
+    params.direction = [NSNumber numberWithUnsignedChar:0];
+    params.time = [NSNumber numberWithUnsignedShort:0U];
+    params.startHue = [NSNumber numberWithUnsignedShort:0U];
+    params.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    params.optionsOverride = [NSNumber numberWithUnsignedChar:0];
+    [cluster colorLoopSetWithParams:params
+                  completionHandler:^(NSError * err, NSDictionary * values) {
+                      NSLog(@"Sends ColorLoopSet Command - Set all Attributes Error: %@", err);
 
-              XCTAssertEqual(err.code, 0);
+                      XCTAssertEqual(err.code, 0);
 
-              [expectation fulfill];
-          }];
+                      [expectation fulfill];
+                  }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -7853,15 +7777,13 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPOnOffClusterOffPayload alloc] init];
-    [cluster off:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Turn Off light for color control tests Error: %@", err);
+    [cluster offWithCompletionHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"Turn Off light for color control tests Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+        XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+        [expectation fulfill];
+    }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -7875,15 +7797,13 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPOnOffClusterOnPayload alloc] init];
-    [cluster on:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Precondition: Turn on light for color control tests Error: %@", err);
+    [cluster onWithCompletionHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"Precondition: Turn on light for color control tests Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+        XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+        [expectation fulfill];
+    }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -7921,22 +7841,22 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPColorControlClusterColorLoopSetPayload alloc] init];
-    payload.updateFlags = [NSNumber numberWithUnsignedChar:15];
-    payload.action = [NSNumber numberWithUnsignedChar:0];
-    payload.direction = [NSNumber numberWithUnsignedChar:0];
-    payload.time = [NSNumber numberWithUnsignedShort:30U];
-    payload.startHue = [NSNumber numberWithUnsignedShort:160U];
-    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
-    [cluster colorLoopSet:payload
-          responseHandler:^(NSError * err, NSDictionary * values) {
-              NSLog(@"Sends ColorLoopSet Command - Set all Attributes Error: %@", err);
+    __auto_type * params = [[CHIPColorControlClusterColorLoopSetParams alloc] init];
+    params.updateFlags = [NSNumber numberWithUnsignedChar:15];
+    params.action = [NSNumber numberWithUnsignedChar:0];
+    params.direction = [NSNumber numberWithUnsignedChar:0];
+    params.time = [NSNumber numberWithUnsignedShort:30U];
+    params.startHue = [NSNumber numberWithUnsignedShort:160U];
+    params.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    params.optionsOverride = [NSNumber numberWithUnsignedChar:0];
+    [cluster colorLoopSetWithParams:params
+                  completionHandler:^(NSError * err, NSDictionary * values) {
+                      NSLog(@"Sends ColorLoopSet Command - Set all Attributes Error: %@", err);
 
-              XCTAssertEqual(err.code, 0);
+                      XCTAssertEqual(err.code, 0);
 
-              [expectation fulfill];
-          }];
+                      [expectation fulfill];
+                  }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -8045,22 +7965,22 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPColorControlClusterColorLoopSetPayload alloc] init];
-    payload.updateFlags = [NSNumber numberWithUnsignedChar:1];
-    payload.action = [NSNumber numberWithUnsignedChar:1];
-    payload.direction = [NSNumber numberWithUnsignedChar:0];
-    payload.time = [NSNumber numberWithUnsignedShort:0U];
-    payload.startHue = [NSNumber numberWithUnsignedShort:0U];
-    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
-    [cluster colorLoopSet:payload
-          responseHandler:^(NSError * err, NSDictionary * values) {
-              NSLog(@"Color Loop Set Command - Set all Attributes Error: %@", err);
+    __auto_type * params = [[CHIPColorControlClusterColorLoopSetParams alloc] init];
+    params.updateFlags = [NSNumber numberWithUnsignedChar:1];
+    params.action = [NSNumber numberWithUnsignedChar:1];
+    params.direction = [NSNumber numberWithUnsignedChar:0];
+    params.time = [NSNumber numberWithUnsignedShort:0U];
+    params.startHue = [NSNumber numberWithUnsignedShort:0U];
+    params.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    params.optionsOverride = [NSNumber numberWithUnsignedChar:0];
+    [cluster colorLoopSetWithParams:params
+                  completionHandler:^(NSError * err, NSDictionary * values) {
+                      NSLog(@"Color Loop Set Command - Set all Attributes Error: %@", err);
 
-              XCTAssertEqual(err.code, 0);
+                      XCTAssertEqual(err.code, 0);
 
-              [expectation fulfill];
-          }];
+                      [expectation fulfill];
+                  }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -8097,22 +8017,22 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPColorControlClusterColorLoopSetPayload alloc] init];
-    payload.updateFlags = [NSNumber numberWithUnsignedChar:2];
-    payload.action = [NSNumber numberWithUnsignedChar:0];
-    payload.direction = [NSNumber numberWithUnsignedChar:1];
-    payload.time = [NSNumber numberWithUnsignedShort:0U];
-    payload.startHue = [NSNumber numberWithUnsignedShort:0U];
-    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
-    [cluster colorLoopSet:payload
-          responseHandler:^(NSError * err, NSDictionary * values) {
-              NSLog(@"Color Loop Set Command - Start Color Loop Error: %@", err);
+    __auto_type * params = [[CHIPColorControlClusterColorLoopSetParams alloc] init];
+    params.updateFlags = [NSNumber numberWithUnsignedChar:2];
+    params.action = [NSNumber numberWithUnsignedChar:0];
+    params.direction = [NSNumber numberWithUnsignedChar:1];
+    params.time = [NSNumber numberWithUnsignedShort:0U];
+    params.startHue = [NSNumber numberWithUnsignedShort:0U];
+    params.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    params.optionsOverride = [NSNumber numberWithUnsignedChar:0];
+    [cluster colorLoopSetWithParams:params
+                  completionHandler:^(NSError * err, NSDictionary * values) {
+                      NSLog(@"Color Loop Set Command - Start Color Loop Error: %@", err);
 
-              XCTAssertEqual(err.code, 0);
+                      XCTAssertEqual(err.code, 0);
 
-              [expectation fulfill];
-          }];
+                      [expectation fulfill];
+                  }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -8149,22 +8069,22 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPColorControlClusterColorLoopSetPayload alloc] init];
-    payload.updateFlags = [NSNumber numberWithUnsignedChar:1];
-    payload.action = [NSNumber numberWithUnsignedChar:0];
-    payload.direction = [NSNumber numberWithUnsignedChar:0];
-    payload.time = [NSNumber numberWithUnsignedShort:0U];
-    payload.startHue = [NSNumber numberWithUnsignedShort:0U];
-    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
-    [cluster colorLoopSet:payload
-          responseHandler:^(NSError * err, NSDictionary * values) {
-              NSLog(@"Color Loop Set Command - Start Color Loop Error: %@", err);
+    __auto_type * params = [[CHIPColorControlClusterColorLoopSetParams alloc] init];
+    params.updateFlags = [NSNumber numberWithUnsignedChar:1];
+    params.action = [NSNumber numberWithUnsignedChar:0];
+    params.direction = [NSNumber numberWithUnsignedChar:0];
+    params.time = [NSNumber numberWithUnsignedShort:0U];
+    params.startHue = [NSNumber numberWithUnsignedShort:0U];
+    params.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    params.optionsOverride = [NSNumber numberWithUnsignedChar:0];
+    [cluster colorLoopSetWithParams:params
+                  completionHandler:^(NSError * err, NSDictionary * values) {
+                      NSLog(@"Color Loop Set Command - Start Color Loop Error: %@", err);
 
-              XCTAssertEqual(err.code, 0);
+                      XCTAssertEqual(err.code, 0);
 
-              [expectation fulfill];
-          }];
+                      [expectation fulfill];
+                  }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -8201,15 +8121,13 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPOnOffClusterOffPayload alloc] init];
-    [cluster off:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Turn off light for color control tests Error: %@", err);
+    [cluster offWithCompletionHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"Turn off light for color control tests Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+        XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+        [expectation fulfill];
+    }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -8223,15 +8141,13 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPOnOffClusterOnPayload alloc] init];
-    [cluster on:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Precondition: Turn on light for color control tests Error: %@", err);
+    [cluster onWithCompletionHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"Precondition: Turn on light for color control tests Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+        XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+        [expectation fulfill];
+    }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -8269,22 +8185,22 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPColorControlClusterColorLoopSetPayload alloc] init];
-    payload.updateFlags = [NSNumber numberWithUnsignedChar:15];
-    payload.action = [NSNumber numberWithUnsignedChar:0];
-    payload.direction = [NSNumber numberWithUnsignedChar:0];
-    payload.time = [NSNumber numberWithUnsignedShort:30U];
-    payload.startHue = [NSNumber numberWithUnsignedShort:160U];
-    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
-    [cluster colorLoopSet:payload
-          responseHandler:^(NSError * err, NSDictionary * values) {
-              NSLog(@"Sends ColorLoopSet Command - Set all Attributes Error: %@", err);
+    __auto_type * params = [[CHIPColorControlClusterColorLoopSetParams alloc] init];
+    params.updateFlags = [NSNumber numberWithUnsignedChar:15];
+    params.action = [NSNumber numberWithUnsignedChar:0];
+    params.direction = [NSNumber numberWithUnsignedChar:0];
+    params.time = [NSNumber numberWithUnsignedShort:30U];
+    params.startHue = [NSNumber numberWithUnsignedShort:160U];
+    params.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    params.optionsOverride = [NSNumber numberWithUnsignedChar:0];
+    [cluster colorLoopSetWithParams:params
+                  completionHandler:^(NSError * err, NSDictionary * values) {
+                      NSLog(@"Sends ColorLoopSet Command - Set all Attributes Error: %@", err);
 
-              XCTAssertEqual(err.code, 0);
+                      XCTAssertEqual(err.code, 0);
 
-              [expectation fulfill];
-          }];
+                      [expectation fulfill];
+                  }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -8393,22 +8309,22 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPColorControlClusterColorLoopSetPayload alloc] init];
-    payload.updateFlags = [NSNumber numberWithUnsignedChar:1];
-    payload.action = [NSNumber numberWithUnsignedChar:1];
-    payload.direction = [NSNumber numberWithUnsignedChar:0];
-    payload.time = [NSNumber numberWithUnsignedShort:0U];
-    payload.startHue = [NSNumber numberWithUnsignedShort:0U];
-    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
-    [cluster colorLoopSet:payload
-          responseHandler:^(NSError * err, NSDictionary * values) {
-              NSLog(@"Color Loop Set Command - Set all Attributes Error: %@", err);
+    __auto_type * params = [[CHIPColorControlClusterColorLoopSetParams alloc] init];
+    params.updateFlags = [NSNumber numberWithUnsignedChar:1];
+    params.action = [NSNumber numberWithUnsignedChar:1];
+    params.direction = [NSNumber numberWithUnsignedChar:0];
+    params.time = [NSNumber numberWithUnsignedShort:0U];
+    params.startHue = [NSNumber numberWithUnsignedShort:0U];
+    params.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    params.optionsOverride = [NSNumber numberWithUnsignedChar:0];
+    [cluster colorLoopSetWithParams:params
+                  completionHandler:^(NSError * err, NSDictionary * values) {
+                      NSLog(@"Color Loop Set Command - Set all Attributes Error: %@", err);
 
-              XCTAssertEqual(err.code, 0);
+                      XCTAssertEqual(err.code, 0);
 
-              [expectation fulfill];
-          }];
+                      [expectation fulfill];
+                  }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -8445,22 +8361,22 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPColorControlClusterColorLoopSetPayload alloc] init];
-    payload.updateFlags = [NSNumber numberWithUnsignedChar:4];
-    payload.action = [NSNumber numberWithUnsignedChar:0];
-    payload.direction = [NSNumber numberWithUnsignedChar:0];
-    payload.time = [NSNumber numberWithUnsignedShort:60U];
-    payload.startHue = [NSNumber numberWithUnsignedShort:0U];
-    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
-    [cluster colorLoopSet:payload
-          responseHandler:^(NSError * err, NSDictionary * values) {
-              NSLog(@"Color Loop Set Command - Start Color Loop Error: %@", err);
+    __auto_type * params = [[CHIPColorControlClusterColorLoopSetParams alloc] init];
+    params.updateFlags = [NSNumber numberWithUnsignedChar:4];
+    params.action = [NSNumber numberWithUnsignedChar:0];
+    params.direction = [NSNumber numberWithUnsignedChar:0];
+    params.time = [NSNumber numberWithUnsignedShort:60U];
+    params.startHue = [NSNumber numberWithUnsignedShort:0U];
+    params.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    params.optionsOverride = [NSNumber numberWithUnsignedChar:0];
+    [cluster colorLoopSetWithParams:params
+                  completionHandler:^(NSError * err, NSDictionary * values) {
+                      NSLog(@"Color Loop Set Command - Start Color Loop Error: %@", err);
 
-              XCTAssertEqual(err.code, 0);
+                      XCTAssertEqual(err.code, 0);
 
-              [expectation fulfill];
-          }];
+                      [expectation fulfill];
+                  }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -8497,22 +8413,22 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPColorControlClusterColorLoopSetPayload alloc] init];
-    payload.updateFlags = [NSNumber numberWithUnsignedChar:1];
-    payload.action = [NSNumber numberWithUnsignedChar:0];
-    payload.direction = [NSNumber numberWithUnsignedChar:0];
-    payload.time = [NSNumber numberWithUnsignedShort:0U];
-    payload.startHue = [NSNumber numberWithUnsignedShort:0U];
-    payload.optionsMask = [NSNumber numberWithUnsignedChar:0];
-    payload.optionsOverride = [NSNumber numberWithUnsignedChar:0];
-    [cluster colorLoopSet:payload
-          responseHandler:^(NSError * err, NSDictionary * values) {
-              NSLog(@"Color Loop Set Command - Start Color Loop Error: %@", err);
+    __auto_type * params = [[CHIPColorControlClusterColorLoopSetParams alloc] init];
+    params.updateFlags = [NSNumber numberWithUnsignedChar:1];
+    params.action = [NSNumber numberWithUnsignedChar:0];
+    params.direction = [NSNumber numberWithUnsignedChar:0];
+    params.time = [NSNumber numberWithUnsignedShort:0U];
+    params.startHue = [NSNumber numberWithUnsignedShort:0U];
+    params.optionsMask = [NSNumber numberWithUnsignedChar:0];
+    params.optionsOverride = [NSNumber numberWithUnsignedChar:0];
+    [cluster colorLoopSetWithParams:params
+                  completionHandler:^(NSError * err, NSDictionary * values) {
+                      NSLog(@"Color Loop Set Command - Start Color Loop Error: %@", err);
 
-              XCTAssertEqual(err.code, 0);
+                      XCTAssertEqual(err.code, 0);
 
-              [expectation fulfill];
-          }];
+                      [expectation fulfill];
+                  }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -8549,15 +8465,13 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPOnOffClusterOffPayload alloc] init];
-    [cluster off:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Turn off light for color control tests Error: %@", err);
+    [cluster offWithCompletionHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"Turn off light for color control tests Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+        XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+        [expectation fulfill];
+    }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -9394,19 +9308,19 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestLevelControl * cluster = [[CHIPTestLevelControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPLevelControlClusterMoveToLevelPayload alloc] init];
-    payload.level = [NSNumber numberWithUnsignedChar:64];
-    payload.transitionTime = [NSNumber numberWithUnsignedShort:0U];
-    payload.optionMask = [NSNumber numberWithUnsignedChar:1];
-    payload.optionOverride = [NSNumber numberWithUnsignedChar:1];
-    [cluster moveToLevel:payload
-         responseHandler:^(NSError * err, NSDictionary * values) {
-             NSLog(@"sends a Move to level command Error: %@", err);
+    __auto_type * params = [[CHIPLevelControlClusterMoveToLevelParams alloc] init];
+    params.level = [NSNumber numberWithUnsignedChar:64];
+    params.transitionTime = [NSNumber numberWithUnsignedShort:0U];
+    params.optionMask = [NSNumber numberWithUnsignedChar:1];
+    params.optionOverride = [NSNumber numberWithUnsignedChar:1];
+    [cluster moveToLevelWithParams:params
+                 completionHandler:^(NSError * err, NSDictionary * values) {
+                     NSLog(@"sends a Move to level command Error: %@", err);
 
-             XCTAssertEqual(err.code, 0);
+                     XCTAssertEqual(err.code, 0);
 
-             [expectation fulfill];
-         }];
+                     [expectation fulfill];
+                 }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -9451,19 +9365,19 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestLevelControl * cluster = [[CHIPTestLevelControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPLevelControlClusterMoveToLevelPayload alloc] init];
-    payload.level = [NSNumber numberWithUnsignedChar:128];
-    payload.transitionTime = [NSNumber numberWithUnsignedShort:1U];
-    payload.optionMask = [NSNumber numberWithUnsignedChar:1];
-    payload.optionOverride = [NSNumber numberWithUnsignedChar:1];
-    [cluster moveToLevel:payload
-         responseHandler:^(NSError * err, NSDictionary * values) {
-             NSLog(@"sends a Move to level command Error: %@", err);
+    __auto_type * params = [[CHIPLevelControlClusterMoveToLevelParams alloc] init];
+    params.level = [NSNumber numberWithUnsignedChar:128];
+    params.transitionTime = [NSNumber numberWithUnsignedShort:1U];
+    params.optionMask = [NSNumber numberWithUnsignedChar:1];
+    params.optionOverride = [NSNumber numberWithUnsignedChar:1];
+    [cluster moveToLevelWithParams:params
+                 completionHandler:^(NSError * err, NSDictionary * values) {
+                     NSLog(@"sends a Move to level command Error: %@", err);
 
-             XCTAssertEqual(err.code, 0);
+                     XCTAssertEqual(err.code, 0);
 
-             [expectation fulfill];
-         }];
+                     [expectation fulfill];
+                 }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -9532,19 +9446,19 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestLevelControl * cluster = [[CHIPTestLevelControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPLevelControlClusterMoveToLevelPayload alloc] init];
-    payload.level = [NSNumber numberWithUnsignedChar:254];
-    payload.transitionTime = [NSNumber numberWithUnsignedShort:65535U];
-    payload.optionMask = [NSNumber numberWithUnsignedChar:1];
-    payload.optionOverride = [NSNumber numberWithUnsignedChar:1];
-    [cluster moveToLevel:payload
-         responseHandler:^(NSError * err, NSDictionary * values) {
-             NSLog(@"sends a Move to level command Error: %@", err);
+    __auto_type * params = [[CHIPLevelControlClusterMoveToLevelParams alloc] init];
+    params.level = [NSNumber numberWithUnsignedChar:254];
+    params.transitionTime = [NSNumber numberWithUnsignedShort:65535U];
+    params.optionMask = [NSNumber numberWithUnsignedChar:1];
+    params.optionOverride = [NSNumber numberWithUnsignedChar:1];
+    [cluster moveToLevelWithParams:params
+                 completionHandler:^(NSError * err, NSDictionary * values) {
+                     NSLog(@"sends a Move to level command Error: %@", err);
 
-             XCTAssertEqual(err.code, 0);
+                     XCTAssertEqual(err.code, 0);
 
-             [expectation fulfill];
-         }];
+                     [expectation fulfill];
+                 }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -9589,19 +9503,19 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestLevelControl * cluster = [[CHIPTestLevelControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPLevelControlClusterMoveToLevelPayload alloc] init];
-    payload.level = [NSNumber numberWithUnsignedChar:0];
-    payload.transitionTime = [NSNumber numberWithUnsignedShort:0U];
-    payload.optionMask = [NSNumber numberWithUnsignedChar:1];
-    payload.optionOverride = [NSNumber numberWithUnsignedChar:1];
-    [cluster moveToLevel:payload
-         responseHandler:^(NSError * err, NSDictionary * values) {
-             NSLog(@"Reset level to 0 Error: %@", err);
+    __auto_type * params = [[CHIPLevelControlClusterMoveToLevelParams alloc] init];
+    params.level = [NSNumber numberWithUnsignedChar:0];
+    params.transitionTime = [NSNumber numberWithUnsignedShort:0U];
+    params.optionMask = [NSNumber numberWithUnsignedChar:1];
+    params.optionOverride = [NSNumber numberWithUnsignedChar:1];
+    [cluster moveToLevelWithParams:params
+                 completionHandler:^(NSError * err, NSDictionary * values) {
+                     NSLog(@"Reset level to 0 Error: %@", err);
 
-             XCTAssertEqual(err.code, 0);
+                     XCTAssertEqual(err.code, 0);
 
-             [expectation fulfill];
-         }];
+                     [expectation fulfill];
+                 }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -9671,19 +9585,19 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestLevelControl * cluster = [[CHIPTestLevelControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPLevelControlClusterMovePayload alloc] init];
-    payload.moveMode = [NSNumber numberWithUnsignedChar:0];
-    payload.rate = [NSNumber numberWithUnsignedChar:200];
-    payload.optionMask = [NSNumber numberWithUnsignedChar:1];
-    payload.optionOverride = [NSNumber numberWithUnsignedChar:1];
-    [cluster move:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"sends a Move up command Error: %@", err);
+    __auto_type * params = [[CHIPLevelControlClusterMoveParams alloc] init];
+    params.moveMode = [NSNumber numberWithUnsignedChar:0];
+    params.rate = [NSNumber numberWithUnsignedChar:200];
+    params.optionMask = [NSNumber numberWithUnsignedChar:1];
+    params.optionOverride = [NSNumber numberWithUnsignedChar:1];
+    [cluster moveWithParams:params
+          completionHandler:^(NSError * err, NSDictionary * values) {
+              NSLog(@"sends a Move up command Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+              XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+              [expectation fulfill];
+          }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -9752,19 +9666,19 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestLevelControl * cluster = [[CHIPTestLevelControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPLevelControlClusterMovePayload alloc] init];
-    payload.moveMode = [NSNumber numberWithUnsignedChar:1];
-    payload.rate = [NSNumber numberWithUnsignedChar:250];
-    payload.optionMask = [NSNumber numberWithUnsignedChar:1];
-    payload.optionOverride = [NSNumber numberWithUnsignedChar:1];
-    [cluster move:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"sends a Move down command Error: %@", err);
+    __auto_type * params = [[CHIPLevelControlClusterMoveParams alloc] init];
+    params.moveMode = [NSNumber numberWithUnsignedChar:1];
+    params.rate = [NSNumber numberWithUnsignedChar:250];
+    params.optionMask = [NSNumber numberWithUnsignedChar:1];
+    params.optionOverride = [NSNumber numberWithUnsignedChar:1];
+    [cluster moveWithParams:params
+          completionHandler:^(NSError * err, NSDictionary * values) {
+              NSLog(@"sends a Move down command Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+              XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+              [expectation fulfill];
+          }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -9855,19 +9769,19 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestLevelControl * cluster = [[CHIPTestLevelControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPLevelControlClusterMovePayload alloc] init];
-    payload.moveMode = [NSNumber numberWithUnsignedChar:1];
-    payload.rate = [NSNumber numberWithUnsignedChar:255];
-    payload.optionMask = [NSNumber numberWithUnsignedChar:1];
-    payload.optionOverride = [NSNumber numberWithUnsignedChar:1];
-    [cluster move:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"sends a Move up command at default move rate Error: %@", err);
+    __auto_type * params = [[CHIPLevelControlClusterMoveParams alloc] init];
+    params.moveMode = [NSNumber numberWithUnsignedChar:1];
+    params.rate = [NSNumber numberWithUnsignedChar:255];
+    params.optionMask = [NSNumber numberWithUnsignedChar:1];
+    params.optionOverride = [NSNumber numberWithUnsignedChar:1];
+    [cluster moveWithParams:params
+          completionHandler:^(NSError * err, NSDictionary * values) {
+              NSLog(@"sends a Move up command at default move rate Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+              XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+              [expectation fulfill];
+          }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -9910,15 +9824,13 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPOnOffClusterOnPayload alloc] init];
-    [cluster on:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Sending on command Error: %@", err);
+    [cluster onWithCompletionHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"Sending on command Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+        XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+        [expectation fulfill];
+    }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -9931,20 +9843,20 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestLevelControl * cluster = [[CHIPTestLevelControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPLevelControlClusterStepPayload alloc] init];
-    payload.stepMode = [NSNumber numberWithUnsignedChar:0];
-    payload.stepSize = [NSNumber numberWithUnsignedChar:128];
-    payload.transitionTime = [NSNumber numberWithUnsignedShort:20U];
-    payload.optionMask = [NSNumber numberWithUnsignedChar:0];
-    payload.optionOverride = [NSNumber numberWithUnsignedChar:0];
-    [cluster step:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Precondition: DUT level is set to 0x80 Error: %@", err);
+    __auto_type * params = [[CHIPLevelControlClusterStepParams alloc] init];
+    params.stepMode = [NSNumber numberWithUnsignedChar:0];
+    params.stepSize = [NSNumber numberWithUnsignedChar:128];
+    params.transitionTime = [NSNumber numberWithUnsignedShort:20U];
+    params.optionMask = [NSNumber numberWithUnsignedChar:0];
+    params.optionOverride = [NSNumber numberWithUnsignedChar:0];
+    [cluster stepWithParams:params
+          completionHandler:^(NSError * err, NSDictionary * values) {
+              NSLog(@"Precondition: DUT level is set to 0x80 Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+              XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+              [expectation fulfill];
+          }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -9989,20 +9901,20 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestLevelControl * cluster = [[CHIPTestLevelControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPLevelControlClusterStepPayload alloc] init];
-    payload.stepMode = [NSNumber numberWithUnsignedChar:1];
-    payload.stepSize = [NSNumber numberWithUnsignedChar:64];
-    payload.transitionTime = [NSNumber numberWithUnsignedShort:20U];
-    payload.optionMask = [NSNumber numberWithUnsignedChar:0];
-    payload.optionOverride = [NSNumber numberWithUnsignedChar:0];
-    [cluster step:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Sends step down command to DUT Error: %@", err);
+    __auto_type * params = [[CHIPLevelControlClusterStepParams alloc] init];
+    params.stepMode = [NSNumber numberWithUnsignedChar:1];
+    params.stepSize = [NSNumber numberWithUnsignedChar:64];
+    params.transitionTime = [NSNumber numberWithUnsignedShort:20U];
+    params.optionMask = [NSNumber numberWithUnsignedChar:0];
+    params.optionOverride = [NSNumber numberWithUnsignedChar:0];
+    [cluster stepWithParams:params
+          completionHandler:^(NSError * err, NSDictionary * values) {
+              NSLog(@"Sends step down command to DUT Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+              XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+              [expectation fulfill];
+          }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -10047,20 +9959,20 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestLevelControl * cluster = [[CHIPTestLevelControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPLevelControlClusterStepPayload alloc] init];
-    payload.stepMode = [NSNumber numberWithUnsignedChar:0];
-    payload.stepSize = [NSNumber numberWithUnsignedChar:64];
-    payload.transitionTime = [NSNumber numberWithUnsignedShort:20U];
-    payload.optionMask = [NSNumber numberWithUnsignedChar:0];
-    payload.optionOverride = [NSNumber numberWithUnsignedChar:0];
-    [cluster step:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Sends a Step up command Error: %@", err);
+    __auto_type * params = [[CHIPLevelControlClusterStepParams alloc] init];
+    params.stepMode = [NSNumber numberWithUnsignedChar:0];
+    params.stepSize = [NSNumber numberWithUnsignedChar:64];
+    params.transitionTime = [NSNumber numberWithUnsignedShort:20U];
+    params.optionMask = [NSNumber numberWithUnsignedChar:0];
+    params.optionOverride = [NSNumber numberWithUnsignedChar:0];
+    [cluster stepWithParams:params
+          completionHandler:^(NSError * err, NSDictionary * values) {
+              NSLog(@"Sends a Step up command Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+              XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+              [expectation fulfill];
+          }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -10105,15 +10017,13 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPOnOffClusterOffPayload alloc] init];
-    [cluster off:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Sending off command Error: %@", err);
+    [cluster offWithCompletionHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"Sending off command Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+        XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+        [expectation fulfill];
+    }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -10127,15 +10037,13 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPOnOffClusterOnPayload alloc] init];
-    [cluster on:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Sending on command Error: %@", err);
+    [cluster onWithCompletionHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"Sending on command Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+        XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+        [expectation fulfill];
+    }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -10148,20 +10056,20 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestLevelControl * cluster = [[CHIPTestLevelControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPLevelControlClusterStepPayload alloc] init];
-    payload.stepMode = [NSNumber numberWithUnsignedChar:0];
-    payload.stepSize = [NSNumber numberWithUnsignedChar:128];
-    payload.transitionTime = [NSNumber numberWithUnsignedShort:20U];
-    payload.optionMask = [NSNumber numberWithUnsignedChar:0];
-    payload.optionOverride = [NSNumber numberWithUnsignedChar:0];
-    [cluster step:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Precondition: DUT level is set to 0x80 Error: %@", err);
+    __auto_type * params = [[CHIPLevelControlClusterStepParams alloc] init];
+    params.stepMode = [NSNumber numberWithUnsignedChar:0];
+    params.stepSize = [NSNumber numberWithUnsignedChar:128];
+    params.transitionTime = [NSNumber numberWithUnsignedShort:20U];
+    params.optionMask = [NSNumber numberWithUnsignedChar:0];
+    params.optionOverride = [NSNumber numberWithUnsignedChar:0];
+    [cluster stepWithParams:params
+          completionHandler:^(NSError * err, NSDictionary * values) {
+              NSLog(@"Precondition: DUT level is set to 0x80 Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+              XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+              [expectation fulfill];
+          }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -10182,19 +10090,19 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestLevelControl * cluster = [[CHIPTestLevelControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPLevelControlClusterMovePayload alloc] init];
-    payload.moveMode = [NSNumber numberWithUnsignedChar:0];
-    payload.rate = [NSNumber numberWithUnsignedChar:1];
-    payload.optionMask = [NSNumber numberWithUnsignedChar:1];
-    payload.optionOverride = [NSNumber numberWithUnsignedChar:1];
-    [cluster move:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Sends a move up command to DUT Error: %@", err);
+    __auto_type * params = [[CHIPLevelControlClusterMoveParams alloc] init];
+    params.moveMode = [NSNumber numberWithUnsignedChar:0];
+    params.rate = [NSNumber numberWithUnsignedChar:1];
+    params.optionMask = [NSNumber numberWithUnsignedChar:1];
+    params.optionOverride = [NSNumber numberWithUnsignedChar:1];
+    [cluster moveWithParams:params
+          completionHandler:^(NSError * err, NSDictionary * values) {
+              NSLog(@"Sends a move up command to DUT Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+              XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+              [expectation fulfill];
+          }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -10215,17 +10123,17 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestLevelControl * cluster = [[CHIPTestLevelControl alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPLevelControlClusterStopPayload alloc] init];
-    payload.optionMask = [NSNumber numberWithUnsignedChar:0];
-    payload.optionOverride = [NSNumber numberWithUnsignedChar:0];
-    [cluster stop:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Sends stop command to DUT Error: %@", err);
+    __auto_type * params = [[CHIPLevelControlClusterStopParams alloc] init];
+    params.optionMask = [NSNumber numberWithUnsignedChar:0];
+    params.optionOverride = [NSNumber numberWithUnsignedChar:0];
+    [cluster stopWithParams:params
+          completionHandler:^(NSError * err, NSDictionary * values) {
+              NSLog(@"Sends stop command to DUT Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+              XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+              [expectation fulfill];
+          }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -10238,15 +10146,13 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPOnOffClusterOffPayload alloc] init];
-    [cluster off:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Sending off command Error: %@", err);
+    [cluster offWithCompletionHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"Sending off command Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+        XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+        [expectation fulfill];
+    }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -10286,15 +10192,13 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestLowPower * cluster = [[CHIPTestLowPower alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPLowPowerClusterSleepPayload alloc] init];
-    [cluster sleep:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Put the device into low power mode Error: %@", err);
+    [cluster sleepWithCompletionHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"Put the device into low power mode Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+        XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+        [expectation fulfill];
+    }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -11030,15 +10934,13 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPOnOffClusterOffPayload alloc] init];
-    [cluster off:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Send Off Command Error: %@", err);
+    [cluster offWithCompletionHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"Send Off Command Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+        XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+        [expectation fulfill];
+    }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -11075,15 +10977,13 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPOnOffClusterOnPayload alloc] init];
-    [cluster on:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Send On Command Error: %@", err);
+    [cluster onWithCompletionHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"Send On Command Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+        XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+        [expectation fulfill];
+    }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -11120,15 +11020,13 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPOnOffClusterOffPayload alloc] init];
-    [cluster off:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Send Off Command Error: %@", err);
+    [cluster offWithCompletionHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"Send Off Command Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+        XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+        [expectation fulfill];
+    }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -11165,15 +11063,13 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPOnOffClusterTogglePayload alloc] init];
-    [cluster toggle:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Send Toggle Command Error: %@", err);
+    [cluster toggleWithCompletionHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"Send Toggle Command Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+        XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+        [expectation fulfill];
+    }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -11211,15 +11107,13 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPOnOffClusterTogglePayload alloc] init];
-    [cluster toggle:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Send Toggle Command Error: %@", err);
+    [cluster toggleWithCompletionHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"Send Toggle Command Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+        XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+        [expectation fulfill];
+    }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -11257,15 +11151,13 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPOnOffClusterOnPayload alloc] init];
-    [cluster on:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Send On Command Error: %@", err);
+    [cluster onWithCompletionHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"Send On Command Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+        XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+        [expectation fulfill];
+    }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -11302,15 +11194,13 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPOnOffClusterOffPayload alloc] init];
-    [cluster off:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Send Off Command Error: %@", err);
+    [cluster offWithCompletionHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"Send Off Command Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+        XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+        [expectation fulfill];
+    }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -11348,15 +11238,13 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPOnOffClusterOnPayload alloc] init];
-    [cluster on:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Send On Command Error: %@", err);
+    [cluster onWithCompletionHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"Send On Command Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+        XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+        [expectation fulfill];
+    }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -11425,15 +11313,13 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPOnOffClusterOnPayload alloc] init];
-    [cluster on:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Send On Command Error: %@", err);
+    [cluster onWithCompletionHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"Send On Command Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+        XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+        [expectation fulfill];
+    }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -11502,15 +11388,13 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPOnOffClusterOnPayload alloc] init];
-    [cluster on:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Send On Command Error: %@", err);
+    [cluster onWithCompletionHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"Send On Command Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+        XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+        [expectation fulfill];
+    }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -11627,15 +11511,13 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPOnOffClusterOnPayload alloc] init];
-    [cluster on:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Send On Command Error: %@", err);
+    [cluster onWithCompletionHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"Send On Command Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+        XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+        [expectation fulfill];
+    }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -11720,15 +11602,13 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPOnOffClusterOffPayload alloc] init];
-    [cluster off:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Send Off Command Error: %@", err);
+    [cluster offWithCompletionHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"Send Off Command Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+        XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+        [expectation fulfill];
+    }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -11861,15 +11741,13 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPOnOffClusterOnPayload alloc] init];
-    [cluster on:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Send On Command Error: %@", err);
+    [cluster onWithCompletionHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"Send On Command Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+        XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+        [expectation fulfill];
+    }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -11930,15 +11808,13 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPOnOffClusterOffPayload alloc] init];
-    [cluster off:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Send Off Command Error: %@", err);
+    [cluster offWithCompletionHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"Send Off Command Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+        XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+        [expectation fulfill];
+    }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -12047,15 +11923,13 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPOnOffClusterOnPayload alloc] init];
-    [cluster on:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Send On Command Error: %@", err);
+    [cluster onWithCompletionHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"Send On Command Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+        XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+        [expectation fulfill];
+    }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -12140,15 +12014,13 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPOnOffClusterOffPayload alloc] init];
-    [cluster off:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Send Off Command Error: %@", err);
+    [cluster offWithCompletionHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"Send Off Command Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+        XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+        [expectation fulfill];
+    }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -12353,15 +12225,13 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPOnOffClusterOffPayload alloc] init];
-    [cluster off:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Send Off Command Error: %@", err);
+    [cluster offWithCompletionHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"Send Off Command Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+        XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+        [expectation fulfill];
+    }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -17089,15 +16959,13 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestWindowCovering * cluster = [[CHIPTestWindowCovering alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPWindowCoveringClusterDownOrClosePayload alloc] init];
-    [cluster downOrClose:payload
-         responseHandler:^(NSError * err, NSDictionary * values) {
-             NSLog(@"1a: TH adjusts the the DUT to a non-open position Error: %@", err);
+    [cluster downOrCloseWithCompletionHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"1a: TH adjusts the the DUT to a non-open position Error: %@", err);
 
-             XCTAssertEqual(err.code, 0);
+        XCTAssertEqual(err.code, 0);
 
-             [expectation fulfill];
-         }];
+        [expectation fulfill];
+    }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -17110,15 +16978,13 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestWindowCovering * cluster = [[CHIPTestWindowCovering alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPWindowCoveringClusterUpOrOpenPayload alloc] init];
-    [cluster upOrOpen:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"2a: TH sends UpOrOpen command to DUT Error: %@", err);
+    [cluster upOrOpenWithCompletionHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"2a: TH sends UpOrOpen command to DUT Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+        XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+        [expectation fulfill];
+    }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -17156,15 +17022,13 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestWindowCovering * cluster = [[CHIPTestWindowCovering alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPWindowCoveringClusterUpOrOpenPayload alloc] init];
-    [cluster upOrOpen:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"1a: TH adjusts the the DUT to a non-closed position Error: %@", err);
+    [cluster upOrOpenWithCompletionHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"1a: TH adjusts the the DUT to a non-closed position Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+        XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+        [expectation fulfill];
+    }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -17177,15 +17041,13 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestWindowCovering * cluster = [[CHIPTestWindowCovering alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPWindowCoveringClusterDownOrClosePayload alloc] init];
-    [cluster downOrClose:payload
-         responseHandler:^(NSError * err, NSDictionary * values) {
-             NSLog(@"2a: TH sends DownOrClose command to DUT Error: %@", err);
+    [cluster downOrCloseWithCompletionHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"2a: TH sends DownOrClose command to DUT Error: %@", err);
 
-             XCTAssertEqual(err.code, 0);
+        XCTAssertEqual(err.code, 0);
 
-             [expectation fulfill];
-         }];
+        [expectation fulfill];
+    }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -17223,15 +17085,13 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestWindowCovering * cluster = [[CHIPTestWindowCovering alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPWindowCoveringClusterUpOrOpenPayload alloc] init];
-    [cluster upOrOpen:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"1a: TH adjusts the the DUT to a non-open position Error: %@", err);
+    [cluster upOrOpenWithCompletionHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"1a: TH adjusts the the DUT to a non-open position Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+        XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+        [expectation fulfill];
+    }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -17244,15 +17104,13 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestWindowCovering * cluster = [[CHIPTestWindowCovering alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPWindowCoveringClusterStopMotionPayload alloc] init];
-    [cluster stopMotion:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"2a: TH sends StopMotion command to DUT Error: %@", err);
+    [cluster stopMotionWithCompletionHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"2a: TH sends StopMotion command to DUT Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+        XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+        [expectation fulfill];
+    }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -17290,15 +17148,13 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPTestClusterClusterTestPayload alloc] init];
-    [cluster test:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Send Test Command Error: %@", err);
+    [cluster testWithCompletionHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"Send Test Command Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+        XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+        [expectation fulfill];
+    }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -17311,14 +17167,12 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPTestClusterClusterTestNotHandledPayload alloc] init];
-    [cluster testNotHandled:payload
-            responseHandler:^(NSError * err, NSDictionary * values) {
-                NSLog(@"Send Test Not Handled Command Error: %@", err);
+    [cluster testNotHandledWithCompletionHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"Send Test Not Handled Command Error: %@", err);
 
-                XCTAssertEqual(err.code, 1);
-                [expectation fulfill];
-            }];
+        XCTAssertEqual(err.code, 1);
+        [expectation fulfill];
+    }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -17331,20 +17185,18 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPTestClusterClusterTestSpecificPayload alloc] init];
-    [cluster testSpecific:payload
-          responseHandler:^(NSError * err, NSDictionary * values) {
-              NSLog(@"Send Test Specific Command Error: %@", err);
+    [cluster testSpecificWithCompletionHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"Send Test Specific Command Error: %@", err);
 
-              XCTAssertEqual(err.code, 0);
+        XCTAssertEqual(err.code, 0);
 
-              {
-                  id actualValue = values[@"returnValue"];
-                  XCTAssertEqual([actualValue unsignedCharValue], 7);
-              }
+        {
+            id actualValue = values[@"returnValue"];
+            XCTAssertEqual([actualValue unsignedCharValue], 7);
+        }
 
-              [expectation fulfill];
-          }];
+        [expectation fulfill];
+    }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -17357,22 +17209,22 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPTestClusterClusterTestAddArgumentsPayload alloc] init];
-    payload.arg1 = [NSNumber numberWithUnsignedChar:3];
-    payload.arg2 = [NSNumber numberWithUnsignedChar:17];
-    [cluster testAddArguments:payload
-              responseHandler:^(NSError * err, NSDictionary * values) {
-                  NSLog(@"Send Test Add Arguments Command Error: %@", err);
+    __auto_type * params = [[CHIPTestClusterClusterTestAddArgumentsParams alloc] init];
+    params.arg1 = [NSNumber numberWithUnsignedChar:3];
+    params.arg2 = [NSNumber numberWithUnsignedChar:17];
+    [cluster testAddArgumentsWithParams:params
+                      completionHandler:^(NSError * err, NSDictionary * values) {
+                          NSLog(@"Send Test Add Arguments Command Error: %@", err);
 
-                  XCTAssertEqual(err.code, 0);
+                          XCTAssertEqual(err.code, 0);
 
-                  {
-                      id actualValue = values[@"returnValue"];
-                      XCTAssertEqual([actualValue unsignedCharValue], 20);
-                  }
+                          {
+                              id actualValue = values[@"returnValue"];
+                              XCTAssertEqual([actualValue unsignedCharValue], 20);
+                          }
 
-                  [expectation fulfill];
-              }];
+                          [expectation fulfill];
+                      }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -17385,16 +17237,16 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPTestClusterClusterTestAddArgumentsPayload alloc] init];
-    payload.arg1 = [NSNumber numberWithUnsignedChar:250];
-    payload.arg2 = [NSNumber numberWithUnsignedChar:6];
-    [cluster testAddArguments:payload
-              responseHandler:^(NSError * err, NSDictionary * values) {
-                  NSLog(@"Send failing Test Add Arguments Command Error: %@", err);
+    __auto_type * params = [[CHIPTestClusterClusterTestAddArgumentsParams alloc] init];
+    params.arg1 = [NSNumber numberWithUnsignedChar:250];
+    params.arg2 = [NSNumber numberWithUnsignedChar:6];
+    [cluster testAddArgumentsWithParams:params
+                      completionHandler:^(NSError * err, NSDictionary * values) {
+                          NSLog(@"Send failing Test Add Arguments Command Error: %@", err);
 
-                  XCTAssertEqual(err.code, 1);
-                  [expectation fulfill];
-              }];
+                          XCTAssertEqual(err.code, 1);
+                          [expectation fulfill];
+                      }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -20092,14 +19944,12 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:200 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPTestClusterClusterTestPayload alloc] init];
-    [cluster test:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Send Test Command to unsupported endpoint Error: %@", err);
+    [cluster testWithCompletionHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"Send Test Command to unsupported endpoint Error: %@", err);
 
-            XCTAssertEqual(err.code, 1);
-            [expectation fulfill];
-        }];
+        XCTAssertEqual(err.code, 1);
+        [expectation fulfill];
+    }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -20204,26 +20054,26 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPTestClusterClusterTestEnumsRequestPayload alloc] init];
-    payload.arg1 = [NSNumber numberWithUnsignedShort:20003U];
-    payload.arg2 = [NSNumber numberWithUnsignedChar:101];
-    [cluster testEnumsRequest:payload
-              responseHandler:^(NSError * err, NSDictionary * values) {
-                  NSLog(@"Send a command with a vendor_id and enum Error: %@", err);
+    __auto_type * params = [[CHIPTestClusterClusterTestEnumsRequestParams alloc] init];
+    params.arg1 = [NSNumber numberWithUnsignedShort:20003U];
+    params.arg2 = [NSNumber numberWithUnsignedChar:101];
+    [cluster testEnumsRequestWithParams:params
+                      completionHandler:^(NSError * err, NSDictionary * values) {
+                          NSLog(@"Send a command with a vendor_id and enum Error: %@", err);
 
-                  XCTAssertEqual(err.code, 0);
+                          XCTAssertEqual(err.code, 0);
 
-                  {
-                      id actualValue = values[@"arg1"];
-                      XCTAssertEqual([actualValue unsignedShortValue], 20003U);
-                  }
-                  {
-                      id actualValue = values[@"arg2"];
-                      XCTAssertEqual([actualValue unsignedCharValue], 101);
-                  }
+                          {
+                              id actualValue = values[@"arg1"];
+                              XCTAssertEqual([actualValue unsignedShortValue], 20003U);
+                          }
+                          {
+                              id actualValue = values[@"arg2"];
+                              XCTAssertEqual([actualValue unsignedCharValue], 101);
+                          }
 
-                  [expectation fulfill];
-              }];
+                          [expectation fulfill];
+                      }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -20237,28 +20087,28 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPTestClusterClusterTestStructArgumentRequestPayload alloc] init];
-    payload.arg1 = [[CHIPTestClusterClusterSimpleStruct alloc] init];
-    ((CHIPTestClusterClusterSimpleStruct *) payload.arg1).a = [NSNumber numberWithUnsignedChar:0];
-    ((CHIPTestClusterClusterSimpleStruct *) payload.arg1).b = [NSNumber numberWithBool:true];
-    ((CHIPTestClusterClusterSimpleStruct *) payload.arg1).c = [NSNumber numberWithUnsignedChar:2];
-    ((CHIPTestClusterClusterSimpleStruct *) payload.arg1).d = [[NSData alloc] initWithBytes:"octet_string" length:12];
-    ((CHIPTestClusterClusterSimpleStruct *) payload.arg1).e = @"char_string";
-    ((CHIPTestClusterClusterSimpleStruct *) payload.arg1).f = [NSNumber numberWithUnsignedChar:1];
+    __auto_type * params = [[CHIPTestClusterClusterTestStructArgumentRequestParams alloc] init];
+    params.arg1 = [[CHIPTestClusterClusterSimpleStruct alloc] init];
+    ((CHIPTestClusterClusterSimpleStruct *) params.arg1).a = [NSNumber numberWithUnsignedChar:0];
+    ((CHIPTestClusterClusterSimpleStruct *) params.arg1).b = [NSNumber numberWithBool:true];
+    ((CHIPTestClusterClusterSimpleStruct *) params.arg1).c = [NSNumber numberWithUnsignedChar:2];
+    ((CHIPTestClusterClusterSimpleStruct *) params.arg1).d = [[NSData alloc] initWithBytes:"octet_string" length:12];
+    ((CHIPTestClusterClusterSimpleStruct *) params.arg1).e = @"char_string";
+    ((CHIPTestClusterClusterSimpleStruct *) params.arg1).f = [NSNumber numberWithUnsignedChar:1];
 
-    [cluster testStructArgumentRequest:payload
-                       responseHandler:^(NSError * err, NSDictionary * values) {
-                           NSLog(@"Send Test Command With Struct Argument and arg1.b is true Error: %@", err);
+    [cluster testStructArgumentRequestWithParams:params
+                               completionHandler:^(NSError * err, NSDictionary * values) {
+                                   NSLog(@"Send Test Command With Struct Argument and arg1.b is true Error: %@", err);
 
-                           XCTAssertEqual(err.code, 0);
+                                   XCTAssertEqual(err.code, 0);
 
-                           {
-                               id actualValue = values[@"value"];
-                               XCTAssertEqual([actualValue boolValue], true);
-                           }
+                                   {
+                                       id actualValue = values[@"value"];
+                                       XCTAssertEqual([actualValue boolValue], true);
+                                   }
 
-                           [expectation fulfill];
-                       }];
+                                   [expectation fulfill];
+                               }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -20272,28 +20122,28 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPTestClusterClusterTestStructArgumentRequestPayload alloc] init];
-    payload.arg1 = [[CHIPTestClusterClusterSimpleStruct alloc] init];
-    ((CHIPTestClusterClusterSimpleStruct *) payload.arg1).a = [NSNumber numberWithUnsignedChar:0];
-    ((CHIPTestClusterClusterSimpleStruct *) payload.arg1).b = [NSNumber numberWithBool:false];
-    ((CHIPTestClusterClusterSimpleStruct *) payload.arg1).c = [NSNumber numberWithUnsignedChar:2];
-    ((CHIPTestClusterClusterSimpleStruct *) payload.arg1).d = [[NSData alloc] initWithBytes:"octet_string" length:12];
-    ((CHIPTestClusterClusterSimpleStruct *) payload.arg1).e = @"char_string";
-    ((CHIPTestClusterClusterSimpleStruct *) payload.arg1).f = [NSNumber numberWithUnsignedChar:1];
+    __auto_type * params = [[CHIPTestClusterClusterTestStructArgumentRequestParams alloc] init];
+    params.arg1 = [[CHIPTestClusterClusterSimpleStruct alloc] init];
+    ((CHIPTestClusterClusterSimpleStruct *) params.arg1).a = [NSNumber numberWithUnsignedChar:0];
+    ((CHIPTestClusterClusterSimpleStruct *) params.arg1).b = [NSNumber numberWithBool:false];
+    ((CHIPTestClusterClusterSimpleStruct *) params.arg1).c = [NSNumber numberWithUnsignedChar:2];
+    ((CHIPTestClusterClusterSimpleStruct *) params.arg1).d = [[NSData alloc] initWithBytes:"octet_string" length:12];
+    ((CHIPTestClusterClusterSimpleStruct *) params.arg1).e = @"char_string";
+    ((CHIPTestClusterClusterSimpleStruct *) params.arg1).f = [NSNumber numberWithUnsignedChar:1];
 
-    [cluster testStructArgumentRequest:payload
-                       responseHandler:^(NSError * err, NSDictionary * values) {
-                           NSLog(@"Send Test Command With Struct Argument and arg1.b is false Error: %@", err);
+    [cluster testStructArgumentRequestWithParams:params
+                               completionHandler:^(NSError * err, NSDictionary * values) {
+                                   NSLog(@"Send Test Command With Struct Argument and arg1.b is false Error: %@", err);
 
-                           XCTAssertEqual(err.code, 0);
+                                   XCTAssertEqual(err.code, 0);
 
-                           {
-                               id actualValue = values[@"value"];
-                               XCTAssertEqual([actualValue boolValue], false);
-                           }
+                                   {
+                                       id actualValue = values[@"value"];
+                                       XCTAssertEqual([actualValue boolValue], false);
+                                   }
 
-                           [expectation fulfill];
-                       }];
+                                   [expectation fulfill];
+                               }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -20307,7 +20157,7 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPTestClusterClusterTestListInt8UArgumentRequestPayload alloc] init];
+    __auto_type * params = [[CHIPTestClusterClusterTestListInt8UArgumentRequestParams alloc] init];
     {
         NSMutableArray * temp = [[NSMutableArray alloc] init];
         temp[0] = [NSNumber numberWithUnsignedChar:1];
@@ -20319,21 +20169,21 @@ CHIPDevice * GetConnectedDevice()
         temp[6] = [NSNumber numberWithUnsignedChar:7];
         temp[7] = [NSNumber numberWithUnsignedChar:8];
         temp[8] = [NSNumber numberWithUnsignedChar:9];
-        payload.arg1 = temp;
+        params.arg1 = temp;
     }
-    [cluster testListInt8UArgumentRequest:payload
-                          responseHandler:^(NSError * err, NSDictionary * values) {
-                              NSLog(@"Send Test Command With List of INT8U and none of them is set to 0 Error: %@", err);
+    [cluster testListInt8UArgumentRequestWithParams:params
+                                  completionHandler:^(NSError * err, NSDictionary * values) {
+                                      NSLog(@"Send Test Command With List of INT8U and none of them is set to 0 Error: %@", err);
 
-                              XCTAssertEqual(err.code, 0);
+                                      XCTAssertEqual(err.code, 0);
 
-                              {
-                                  id actualValue = values[@"value"];
-                                  XCTAssertEqual([actualValue boolValue], true);
-                              }
+                                      {
+                                          id actualValue = values[@"value"];
+                                          XCTAssertEqual([actualValue boolValue], true);
+                                      }
 
-                              [expectation fulfill];
-                          }];
+                                      [expectation fulfill];
+                                  }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -20347,7 +20197,7 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPTestClusterClusterTestListInt8UArgumentRequestPayload alloc] init];
+    __auto_type * params = [[CHIPTestClusterClusterTestListInt8UArgumentRequestParams alloc] init];
     {
         NSMutableArray * temp = [[NSMutableArray alloc] init];
         temp[0] = [NSNumber numberWithUnsignedChar:1];
@@ -20360,21 +20210,21 @@ CHIPDevice * GetConnectedDevice()
         temp[7] = [NSNumber numberWithUnsignedChar:8];
         temp[8] = [NSNumber numberWithUnsignedChar:9];
         temp[9] = [NSNumber numberWithUnsignedChar:0];
-        payload.arg1 = temp;
+        params.arg1 = temp;
     }
-    [cluster testListInt8UArgumentRequest:payload
-                          responseHandler:^(NSError * err, NSDictionary * values) {
-                              NSLog(@"Send Test Command With List of INT8U and one of them is set to 0 Error: %@", err);
+    [cluster testListInt8UArgumentRequestWithParams:params
+                                  completionHandler:^(NSError * err, NSDictionary * values) {
+                                      NSLog(@"Send Test Command With List of INT8U and one of them is set to 0 Error: %@", err);
 
-                              XCTAssertEqual(err.code, 0);
+                                      XCTAssertEqual(err.code, 0);
 
-                              {
-                                  id actualValue = values[@"value"];
-                                  XCTAssertEqual([actualValue boolValue], false);
-                              }
+                                      {
+                                          id actualValue = values[@"value"];
+                                          XCTAssertEqual([actualValue boolValue], false);
+                                      }
 
-                              [expectation fulfill];
-                          }];
+                                      [expectation fulfill];
+                                  }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -20387,7 +20237,7 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPTestClusterClusterTestListInt8UReverseRequestPayload alloc] init];
+    __auto_type * params = [[CHIPTestClusterClusterTestListInt8UReverseRequestParams alloc] init];
     {
         NSMutableArray * temp = [[NSMutableArray alloc] init];
         temp[0] = [NSNumber numberWithUnsignedChar:1];
@@ -20399,30 +20249,30 @@ CHIPDevice * GetConnectedDevice()
         temp[6] = [NSNumber numberWithUnsignedChar:7];
         temp[7] = [NSNumber numberWithUnsignedChar:8];
         temp[8] = [NSNumber numberWithUnsignedChar:9];
-        payload.arg1 = temp;
+        params.arg1 = temp;
     }
-    [cluster testListInt8UReverseRequest:payload
-                         responseHandler:^(NSError * err, NSDictionary * values) {
-                             NSLog(@"Send Test Command With List of INT8U and get it reversed Error: %@", err);
+    [cluster testListInt8UReverseRequestWithParams:params
+                                 completionHandler:^(NSError * err, NSDictionary * values) {
+                                     NSLog(@"Send Test Command With List of INT8U and get it reversed Error: %@", err);
 
-                             XCTAssertEqual(err.code, 0);
+                                     XCTAssertEqual(err.code, 0);
 
-                             {
-                                 id actualValue = values[@"arg1"];
-                                 XCTAssertEqual([actualValue count], 9);
-                                 XCTAssertEqual([actualValue[0] unsignedCharValue], 9);
-                                 XCTAssertEqual([actualValue[1] unsignedCharValue], 8);
-                                 XCTAssertEqual([actualValue[2] unsignedCharValue], 7);
-                                 XCTAssertEqual([actualValue[3] unsignedCharValue], 6);
-                                 XCTAssertEqual([actualValue[4] unsignedCharValue], 5);
-                                 XCTAssertEqual([actualValue[5] unsignedCharValue], 4);
-                                 XCTAssertEqual([actualValue[6] unsignedCharValue], 3);
-                                 XCTAssertEqual([actualValue[7] unsignedCharValue], 2);
-                                 XCTAssertEqual([actualValue[8] unsignedCharValue], 1);
-                             }
+                                     {
+                                         id actualValue = values[@"arg1"];
+                                         XCTAssertEqual([actualValue count], 9);
+                                         XCTAssertEqual([actualValue[0] unsignedCharValue], 9);
+                                         XCTAssertEqual([actualValue[1] unsignedCharValue], 8);
+                                         XCTAssertEqual([actualValue[2] unsignedCharValue], 7);
+                                         XCTAssertEqual([actualValue[3] unsignedCharValue], 6);
+                                         XCTAssertEqual([actualValue[4] unsignedCharValue], 5);
+                                         XCTAssertEqual([actualValue[5] unsignedCharValue], 4);
+                                         XCTAssertEqual([actualValue[6] unsignedCharValue], 3);
+                                         XCTAssertEqual([actualValue[7] unsignedCharValue], 2);
+                                         XCTAssertEqual([actualValue[8] unsignedCharValue], 1);
+                                     }
 
-                             [expectation fulfill];
-                         }];
+                                     [expectation fulfill];
+                                 }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -20436,24 +20286,24 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPTestClusterClusterTestListInt8UReverseRequestPayload alloc] init];
+    __auto_type * params = [[CHIPTestClusterClusterTestListInt8UReverseRequestParams alloc] init];
     {
         NSMutableArray * temp = [[NSMutableArray alloc] init];
-        payload.arg1 = temp;
+        params.arg1 = temp;
     }
-    [cluster testListInt8UReverseRequest:payload
-                         responseHandler:^(NSError * err, NSDictionary * values) {
-                             NSLog(@"Send Test Command With empty List of INT8U and get an empty list back Error: %@", err);
+    [cluster testListInt8UReverseRequestWithParams:params
+                                 completionHandler:^(NSError * err, NSDictionary * values) {
+                                     NSLog(@"Send Test Command With empty List of INT8U and get an empty list back Error: %@", err);
 
-                             XCTAssertEqual(err.code, 0);
+                                     XCTAssertEqual(err.code, 0);
 
-                             {
-                                 id actualValue = values[@"arg1"];
-                                 XCTAssertEqual([actualValue count], 0);
-                             }
+                                     {
+                                         id actualValue = values[@"arg1"];
+                                         XCTAssertEqual([actualValue count], 0);
+                                     }
 
-                             [expectation fulfill];
-                         }];
+                                     [expectation fulfill];
+                                 }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -20467,7 +20317,7 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPTestClusterClusterTestListStructArgumentRequestPayload alloc] init];
+    __auto_type * params = [[CHIPTestClusterClusterTestListStructArgumentRequestParams alloc] init];
     {
         NSMutableArray * temp = [[NSMutableArray alloc] init];
         temp[0] = [[CHIPTestClusterClusterSimpleStruct alloc] init];
@@ -20486,22 +20336,24 @@ CHIPDevice * GetConnectedDevice()
         ((CHIPTestClusterClusterSimpleStruct *) temp[1]).e = @"second_char_string";
         ((CHIPTestClusterClusterSimpleStruct *) temp[1]).f = [NSNumber numberWithUnsignedChar:1];
 
-        payload.arg1 = temp;
+        params.arg1 = temp;
     }
     [cluster
-        testListStructArgumentRequest:payload
-                      responseHandler:^(NSError * err, NSDictionary * values) {
-                          NSLog(@"Send Test Command With List of Struct Argument and arg1.b of first item is true Error: %@", err);
+        testListStructArgumentRequestWithParams:params
+                              completionHandler:^(NSError * err, NSDictionary * values) {
+                                  NSLog(
+                                      @"Send Test Command With List of Struct Argument and arg1.b of first item is true Error: %@",
+                                      err);
 
-                          XCTAssertEqual(err.code, 0);
+                                  XCTAssertEqual(err.code, 0);
 
-                          {
-                              id actualValue = values[@"value"];
-                              XCTAssertEqual([actualValue boolValue], true);
-                          }
+                                  {
+                                      id actualValue = values[@"value"];
+                                      XCTAssertEqual([actualValue boolValue], true);
+                                  }
 
-                          [expectation fulfill];
-                      }];
+                                  [expectation fulfill];
+                              }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -20515,7 +20367,7 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPTestClusterClusterTestListStructArgumentRequestPayload alloc] init];
+    __auto_type * params = [[CHIPTestClusterClusterTestListStructArgumentRequestParams alloc] init];
     {
         NSMutableArray * temp = [[NSMutableArray alloc] init];
         temp[0] = [[CHIPTestClusterClusterSimpleStruct alloc] init];
@@ -20534,22 +20386,24 @@ CHIPDevice * GetConnectedDevice()
         ((CHIPTestClusterClusterSimpleStruct *) temp[1]).e = @"first_char_string";
         ((CHIPTestClusterClusterSimpleStruct *) temp[1]).f = [NSNumber numberWithUnsignedChar:1];
 
-        payload.arg1 = temp;
+        params.arg1 = temp;
     }
     [cluster
-        testListStructArgumentRequest:payload
-                      responseHandler:^(NSError * err, NSDictionary * values) {
-                          NSLog(@"Send Test Command With List of Struct Argument and arg1.b of first item is false Error: %@", err);
+        testListStructArgumentRequestWithParams:params
+                              completionHandler:^(NSError * err, NSDictionary * values) {
+                                  NSLog(
+                                      @"Send Test Command With List of Struct Argument and arg1.b of first item is false Error: %@",
+                                      err);
 
-                          XCTAssertEqual(err.code, 0);
+                                  XCTAssertEqual(err.code, 0);
 
-                          {
-                              id actualValue = values[@"value"];
-                              XCTAssertEqual([actualValue boolValue], false);
-                          }
+                                  {
+                                      id actualValue = values[@"value"];
+                                      XCTAssertEqual([actualValue boolValue], false);
+                                  }
 
-                          [expectation fulfill];
-                      }];
+                                  [expectation fulfill];
+                              }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -20562,34 +20416,34 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPTestClusterClusterTestNullableOptionalRequestPayload alloc] init];
-    payload.arg1 = [NSNumber numberWithUnsignedChar:5];
-    [cluster testNullableOptionalRequest:payload
-                         responseHandler:^(NSError * err, NSDictionary * values) {
-                             NSLog(@"Send Test Command with optional arg set. Error: %@", err);
+    __auto_type * params = [[CHIPTestClusterClusterTestNullableOptionalRequestParams alloc] init];
+    params.arg1 = [NSNumber numberWithUnsignedChar:5];
+    [cluster testNullableOptionalRequestWithParams:params
+                                 completionHandler:^(NSError * err, NSDictionary * values) {
+                                     NSLog(@"Send Test Command with optional arg set. Error: %@", err);
 
-                             XCTAssertEqual(err.code, 0);
+                                     XCTAssertEqual(err.code, 0);
 
-                             {
-                                 id actualValue = values[@"wasPresent"];
-                                 XCTAssertEqual([actualValue boolValue], true);
-                             }
-                             {
-                                 id actualValue = values[@"wasNull"];
-                                 XCTAssertEqual([actualValue boolValue], false);
-                             }
-                             {
-                                 id actualValue = values[@"value"];
-                                 XCTAssertEqual([actualValue unsignedCharValue], 5);
-                             }
-                             {
-                                 id actualValue = values[@"originalValue"];
-                                 XCTAssertFalse([actualValue isKindOfClass:[NSNull class]]);
-                                 XCTAssertEqual([actualValue unsignedCharValue], 5);
-                             }
+                                     {
+                                         id actualValue = values[@"wasPresent"];
+                                         XCTAssertEqual([actualValue boolValue], true);
+                                     }
+                                     {
+                                         id actualValue = values[@"wasNull"];
+                                         XCTAssertEqual([actualValue boolValue], false);
+                                     }
+                                     {
+                                         id actualValue = values[@"value"];
+                                         XCTAssertEqual([actualValue unsignedCharValue], 5);
+                                     }
+                                     {
+                                         id actualValue = values[@"originalValue"];
+                                         XCTAssertFalse([actualValue isKindOfClass:[NSNull class]]);
+                                         XCTAssertEqual([actualValue unsignedCharValue], 5);
+                                     }
 
-                             [expectation fulfill];
-                         }];
+                                     [expectation fulfill];
+                                 }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -20602,20 +20456,20 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPTestClusterClusterTestNullableOptionalRequestPayload alloc] init];
-    [cluster testNullableOptionalRequest:payload
-                         responseHandler:^(NSError * err, NSDictionary * values) {
-                             NSLog(@"Send Test Command without its optional arg. Error: %@", err);
+    __auto_type * params = [[CHIPTestClusterClusterTestNullableOptionalRequestParams alloc] init];
+    [cluster testNullableOptionalRequestWithParams:params
+                                 completionHandler:^(NSError * err, NSDictionary * values) {
+                                     NSLog(@"Send Test Command without its optional arg. Error: %@", err);
 
-                             XCTAssertEqual(err.code, 0);
+                                     XCTAssertEqual(err.code, 0);
 
-                             {
-                                 id actualValue = values[@"wasPresent"];
-                                 XCTAssertEqual([actualValue boolValue], false);
-                             }
+                                     {
+                                         id actualValue = values[@"wasPresent"];
+                                         XCTAssertEqual([actualValue boolValue], false);
+                                     }
 
-                             [expectation fulfill];
-                         }];
+                                     [expectation fulfill];
+                                 }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -20944,25 +20798,25 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestGroups * cluster = [[CHIPTestGroups alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPGroupsClusterViewGroupPayload alloc] init];
-    payload.groupId = [NSNumber numberWithUnsignedShort:0U];
-    [cluster viewGroup:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"View Group 0 (invalid) Error: %@", err);
+    __auto_type * params = [[CHIPGroupsClusterViewGroupParams alloc] init];
+    params.groupId = [NSNumber numberWithUnsignedShort:0U];
+    [cluster viewGroupWithParams:params
+               completionHandler:^(NSError * err, NSDictionary * values) {
+                   NSLog(@"View Group 0 (invalid) Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+                   XCTAssertEqual(err.code, 0);
 
-            {
-                id actualValue = values[@"status"];
-                XCTAssertEqual([actualValue unsignedCharValue], 135);
-            }
-            {
-                id actualValue = values[@"groupId"];
-                XCTAssertEqual([actualValue unsignedShortValue], 0U);
-            }
+                   {
+                       id actualValue = values[@"status"];
+                       XCTAssertEqual([actualValue unsignedCharValue], 135);
+                   }
+                   {
+                       id actualValue = values[@"groupId"];
+                       XCTAssertEqual([actualValue unsignedShortValue], 0U);
+                   }
 
-            [expectation fulfill];
-        }];
+                   [expectation fulfill];
+               }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -20975,25 +20829,25 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestGroups * cluster = [[CHIPTestGroups alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPGroupsClusterViewGroupPayload alloc] init];
-    payload.groupId = [NSNumber numberWithUnsignedShort:1U];
-    [cluster viewGroup:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"View Group 1 (not found) Error: %@", err);
+    __auto_type * params = [[CHIPGroupsClusterViewGroupParams alloc] init];
+    params.groupId = [NSNumber numberWithUnsignedShort:1U];
+    [cluster viewGroupWithParams:params
+               completionHandler:^(NSError * err, NSDictionary * values) {
+                   NSLog(@"View Group 1 (not found) Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+                   XCTAssertEqual(err.code, 0);
 
-            {
-                id actualValue = values[@"status"];
-                XCTAssertEqual([actualValue unsignedCharValue], 139);
-            }
-            {
-                id actualValue = values[@"groupId"];
-                XCTAssertEqual([actualValue unsignedShortValue], 1U);
-            }
+                   {
+                       id actualValue = values[@"status"];
+                       XCTAssertEqual([actualValue unsignedCharValue], 139);
+                   }
+                   {
+                       id actualValue = values[@"groupId"];
+                       XCTAssertEqual([actualValue unsignedShortValue], 1U);
+                   }
 
-            [expectation fulfill];
-        }];
+                   [expectation fulfill];
+               }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -21006,26 +20860,26 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestGroups * cluster = [[CHIPTestGroups alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPGroupsClusterAddGroupPayload alloc] init];
-    payload.groupId = [NSNumber numberWithUnsignedShort:1U];
-    payload.groupName = @"Group #1";
-    [cluster addGroup:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Add Group 1 (new) Error: %@", err);
+    __auto_type * params = [[CHIPGroupsClusterAddGroupParams alloc] init];
+    params.groupId = [NSNumber numberWithUnsignedShort:1U];
+    params.groupName = @"Group #1";
+    [cluster addGroupWithParams:params
+              completionHandler:^(NSError * err, NSDictionary * values) {
+                  NSLog(@"Add Group 1 (new) Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+                  XCTAssertEqual(err.code, 0);
 
-            {
-                id actualValue = values[@"status"];
-                XCTAssertEqual([actualValue unsignedCharValue], 0);
-            }
-            {
-                id actualValue = values[@"groupId"];
-                XCTAssertEqual([actualValue unsignedShortValue], 1U);
-            }
+                  {
+                      id actualValue = values[@"status"];
+                      XCTAssertEqual([actualValue unsignedCharValue], 0);
+                  }
+                  {
+                      id actualValue = values[@"groupId"];
+                      XCTAssertEqual([actualValue unsignedShortValue], 1U);
+                  }
 
-            [expectation fulfill];
-        }];
+                  [expectation fulfill];
+              }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -21038,29 +20892,29 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestGroups * cluster = [[CHIPTestGroups alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPGroupsClusterViewGroupPayload alloc] init];
-    payload.groupId = [NSNumber numberWithUnsignedShort:1U];
-    [cluster viewGroup:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"View Group 1 (new) Error: %@", err);
+    __auto_type * params = [[CHIPGroupsClusterViewGroupParams alloc] init];
+    params.groupId = [NSNumber numberWithUnsignedShort:1U];
+    [cluster viewGroupWithParams:params
+               completionHandler:^(NSError * err, NSDictionary * values) {
+                   NSLog(@"View Group 1 (new) Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+                   XCTAssertEqual(err.code, 0);
 
-            {
-                id actualValue = values[@"status"];
-                XCTAssertEqual([actualValue unsignedCharValue], 0);
-            }
-            {
-                id actualValue = values[@"groupId"];
-                XCTAssertEqual([actualValue unsignedShortValue], 1U);
-            }
-            {
-                id actualValue = values[@"groupName"];
-                XCTAssertTrue([actualValue isEqualToString:@"Group #1"]);
-            }
+                   {
+                       id actualValue = values[@"status"];
+                       XCTAssertEqual([actualValue unsignedCharValue], 0);
+                   }
+                   {
+                       id actualValue = values[@"groupId"];
+                       XCTAssertEqual([actualValue unsignedShortValue], 1U);
+                   }
+                   {
+                       id actualValue = values[@"groupName"];
+                       XCTAssertTrue([actualValue isEqualToString:@"Group #1"]);
+                   }
 
-            [expectation fulfill];
-        }];
+                   [expectation fulfill];
+               }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -21073,25 +20927,25 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestGroups * cluster = [[CHIPTestGroups alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPGroupsClusterViewGroupPayload alloc] init];
-    payload.groupId = [NSNumber numberWithUnsignedShort:4369U];
-    [cluster viewGroup:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"View Group 2 (not found) Error: %@", err);
+    __auto_type * params = [[CHIPGroupsClusterViewGroupParams alloc] init];
+    params.groupId = [NSNumber numberWithUnsignedShort:4369U];
+    [cluster viewGroupWithParams:params
+               completionHandler:^(NSError * err, NSDictionary * values) {
+                   NSLog(@"View Group 2 (not found) Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+                   XCTAssertEqual(err.code, 0);
 
-            {
-                id actualValue = values[@"status"];
-                XCTAssertEqual([actualValue unsignedCharValue], 139);
-            }
-            {
-                id actualValue = values[@"groupId"];
-                XCTAssertEqual([actualValue unsignedShortValue], 4369U);
-            }
+                   {
+                       id actualValue = values[@"status"];
+                       XCTAssertEqual([actualValue unsignedCharValue], 139);
+                   }
+                   {
+                       id actualValue = values[@"groupId"];
+                       XCTAssertEqual([actualValue unsignedShortValue], 4369U);
+                   }
 
-            [expectation fulfill];
-        }];
+                   [expectation fulfill];
+               }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -21104,25 +20958,25 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestGroups * cluster = [[CHIPTestGroups alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPGroupsClusterViewGroupPayload alloc] init];
-    payload.groupId = [NSNumber numberWithUnsignedShort:32767U];
-    [cluster viewGroup:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"View Group 3 (not found) Error: %@", err);
+    __auto_type * params = [[CHIPGroupsClusterViewGroupParams alloc] init];
+    params.groupId = [NSNumber numberWithUnsignedShort:32767U];
+    [cluster viewGroupWithParams:params
+               completionHandler:^(NSError * err, NSDictionary * values) {
+                   NSLog(@"View Group 3 (not found) Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+                   XCTAssertEqual(err.code, 0);
 
-            {
-                id actualValue = values[@"status"];
-                XCTAssertEqual([actualValue unsignedCharValue], 139);
-            }
-            {
-                id actualValue = values[@"groupId"];
-                XCTAssertEqual([actualValue unsignedShortValue], 32767U);
-            }
+                   {
+                       id actualValue = values[@"status"];
+                       XCTAssertEqual([actualValue unsignedCharValue], 139);
+                   }
+                   {
+                       id actualValue = values[@"groupId"];
+                       XCTAssertEqual([actualValue unsignedShortValue], 32767U);
+                   }
 
-            [expectation fulfill];
-        }];
+                   [expectation fulfill];
+               }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -21135,29 +20989,29 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestGroups * cluster = [[CHIPTestGroups alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPGroupsClusterViewGroupPayload alloc] init];
-    payload.groupId = [NSNumber numberWithUnsignedShort:1U];
-    [cluster viewGroup:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"View Group 1 (existing) Error: %@", err);
+    __auto_type * params = [[CHIPGroupsClusterViewGroupParams alloc] init];
+    params.groupId = [NSNumber numberWithUnsignedShort:1U];
+    [cluster viewGroupWithParams:params
+               completionHandler:^(NSError * err, NSDictionary * values) {
+                   NSLog(@"View Group 1 (existing) Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+                   XCTAssertEqual(err.code, 0);
 
-            {
-                id actualValue = values[@"status"];
-                XCTAssertEqual([actualValue unsignedCharValue], 0);
-            }
-            {
-                id actualValue = values[@"groupId"];
-                XCTAssertEqual([actualValue unsignedShortValue], 1U);
-            }
-            {
-                id actualValue = values[@"groupName"];
-                XCTAssertTrue([actualValue isEqualToString:@"Group #1"]);
-            }
+                   {
+                       id actualValue = values[@"status"];
+                       XCTAssertEqual([actualValue unsignedCharValue], 0);
+                   }
+                   {
+                       id actualValue = values[@"groupId"];
+                       XCTAssertEqual([actualValue unsignedShortValue], 1U);
+                   }
+                   {
+                       id actualValue = values[@"groupName"];
+                       XCTAssertTrue([actualValue isEqualToString:@"Group #1"]);
+                   }
 
-            [expectation fulfill];
-        }];
+                   [expectation fulfill];
+               }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -21170,25 +21024,25 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestGroups * cluster = [[CHIPTestGroups alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPGroupsClusterRemoveGroupPayload alloc] init];
-    payload.groupId = [NSNumber numberWithUnsignedShort:0U];
-    [cluster removeGroup:payload
-         responseHandler:^(NSError * err, NSDictionary * values) {
-             NSLog(@"Remove Group 0 (invalid) Error: %@", err);
+    __auto_type * params = [[CHIPGroupsClusterRemoveGroupParams alloc] init];
+    params.groupId = [NSNumber numberWithUnsignedShort:0U];
+    [cluster removeGroupWithParams:params
+                 completionHandler:^(NSError * err, NSDictionary * values) {
+                     NSLog(@"Remove Group 0 (invalid) Error: %@", err);
 
-             XCTAssertEqual(err.code, 0);
+                     XCTAssertEqual(err.code, 0);
 
-             {
-                 id actualValue = values[@"status"];
-                 XCTAssertEqual([actualValue unsignedCharValue], 135);
-             }
-             {
-                 id actualValue = values[@"groupId"];
-                 XCTAssertEqual([actualValue unsignedShortValue], 0U);
-             }
+                     {
+                         id actualValue = values[@"status"];
+                         XCTAssertEqual([actualValue unsignedCharValue], 135);
+                     }
+                     {
+                         id actualValue = values[@"groupId"];
+                         XCTAssertEqual([actualValue unsignedShortValue], 0U);
+                     }
 
-             [expectation fulfill];
-         }];
+                     [expectation fulfill];
+                 }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -21201,25 +21055,25 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestGroups * cluster = [[CHIPTestGroups alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPGroupsClusterRemoveGroupPayload alloc] init];
-    payload.groupId = [NSNumber numberWithUnsignedShort:4U];
-    [cluster removeGroup:payload
-         responseHandler:^(NSError * err, NSDictionary * values) {
-             NSLog(@"Remove Group 4 (not found) Error: %@", err);
+    __auto_type * params = [[CHIPGroupsClusterRemoveGroupParams alloc] init];
+    params.groupId = [NSNumber numberWithUnsignedShort:4U];
+    [cluster removeGroupWithParams:params
+                 completionHandler:^(NSError * err, NSDictionary * values) {
+                     NSLog(@"Remove Group 4 (not found) Error: %@", err);
 
-             XCTAssertEqual(err.code, 0);
+                     XCTAssertEqual(err.code, 0);
 
-             {
-                 id actualValue = values[@"status"];
-                 XCTAssertEqual([actualValue unsignedCharValue], 139);
-             }
-             {
-                 id actualValue = values[@"groupId"];
-                 XCTAssertEqual([actualValue unsignedShortValue], 4U);
-             }
+                     {
+                         id actualValue = values[@"status"];
+                         XCTAssertEqual([actualValue unsignedCharValue], 139);
+                     }
+                     {
+                         id actualValue = values[@"groupId"];
+                         XCTAssertEqual([actualValue unsignedShortValue], 4U);
+                     }
 
-             [expectation fulfill];
-         }];
+                     [expectation fulfill];
+                 }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -21232,29 +21086,29 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestGroups * cluster = [[CHIPTestGroups alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPGroupsClusterViewGroupPayload alloc] init];
-    payload.groupId = [NSNumber numberWithUnsignedShort:1U];
-    [cluster viewGroup:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"View Group 1 (not removed) Error: %@", err);
+    __auto_type * params = [[CHIPGroupsClusterViewGroupParams alloc] init];
+    params.groupId = [NSNumber numberWithUnsignedShort:1U];
+    [cluster viewGroupWithParams:params
+               completionHandler:^(NSError * err, NSDictionary * values) {
+                   NSLog(@"View Group 1 (not removed) Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+                   XCTAssertEqual(err.code, 0);
 
-            {
-                id actualValue = values[@"status"];
-                XCTAssertEqual([actualValue unsignedCharValue], 0);
-            }
-            {
-                id actualValue = values[@"groupId"];
-                XCTAssertEqual([actualValue unsignedShortValue], 1U);
-            }
-            {
-                id actualValue = values[@"groupName"];
-                XCTAssertTrue([actualValue isEqualToString:@"Group #1"]);
-            }
+                   {
+                       id actualValue = values[@"status"];
+                       XCTAssertEqual([actualValue unsignedCharValue], 0);
+                   }
+                   {
+                       id actualValue = values[@"groupId"];
+                       XCTAssertEqual([actualValue unsignedShortValue], 1U);
+                   }
+                   {
+                       id actualValue = values[@"groupName"];
+                       XCTAssertTrue([actualValue isEqualToString:@"Group #1"]);
+                   }
 
-            [expectation fulfill];
-        }];
+                   [expectation fulfill];
+               }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -21267,25 +21121,25 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestGroups * cluster = [[CHIPTestGroups alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPGroupsClusterViewGroupPayload alloc] init];
-    payload.groupId = [NSNumber numberWithUnsignedShort:4369U];
-    [cluster viewGroup:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"View Group 2 (removed) Error: %@", err);
+    __auto_type * params = [[CHIPGroupsClusterViewGroupParams alloc] init];
+    params.groupId = [NSNumber numberWithUnsignedShort:4369U];
+    [cluster viewGroupWithParams:params
+               completionHandler:^(NSError * err, NSDictionary * values) {
+                   NSLog(@"View Group 2 (removed) Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+                   XCTAssertEqual(err.code, 0);
 
-            {
-                id actualValue = values[@"status"];
-                XCTAssertEqual([actualValue unsignedCharValue], 139);
-            }
-            {
-                id actualValue = values[@"groupId"];
-                XCTAssertEqual([actualValue unsignedShortValue], 4369U);
-            }
+                   {
+                       id actualValue = values[@"status"];
+                       XCTAssertEqual([actualValue unsignedCharValue], 139);
+                   }
+                   {
+                       id actualValue = values[@"groupId"];
+                       XCTAssertEqual([actualValue unsignedShortValue], 4369U);
+                   }
 
-            [expectation fulfill];
-        }];
+                   [expectation fulfill];
+               }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -21298,15 +21152,13 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestGroups * cluster = [[CHIPTestGroups alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPGroupsClusterRemoveAllGroupsPayload alloc] init];
-    [cluster removeAllGroups:payload
-             responseHandler:^(NSError * err, NSDictionary * values) {
-                 NSLog(@"Remove All Error: %@", err);
+    [cluster removeAllGroupsWithCompletionHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"Remove All Error: %@", err);
 
-                 XCTAssertEqual(err.code, 0);
+        XCTAssertEqual(err.code, 0);
 
-                 [expectation fulfill];
-             }];
+        [expectation fulfill];
+    }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -21319,25 +21171,25 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestGroups * cluster = [[CHIPTestGroups alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPGroupsClusterViewGroupPayload alloc] init];
-    payload.groupId = [NSNumber numberWithUnsignedShort:1U];
-    [cluster viewGroup:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"View Group 1 (removed) Error: %@", err);
+    __auto_type * params = [[CHIPGroupsClusterViewGroupParams alloc] init];
+    params.groupId = [NSNumber numberWithUnsignedShort:1U];
+    [cluster viewGroupWithParams:params
+               completionHandler:^(NSError * err, NSDictionary * values) {
+                   NSLog(@"View Group 1 (removed) Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+                   XCTAssertEqual(err.code, 0);
 
-            {
-                id actualValue = values[@"status"];
-                XCTAssertEqual([actualValue unsignedCharValue], 139);
-            }
-            {
-                id actualValue = values[@"groupId"];
-                XCTAssertEqual([actualValue unsignedShortValue], 1U);
-            }
+                   {
+                       id actualValue = values[@"status"];
+                       XCTAssertEqual([actualValue unsignedCharValue], 139);
+                   }
+                   {
+                       id actualValue = values[@"groupId"];
+                       XCTAssertEqual([actualValue unsignedShortValue], 1U);
+                   }
 
-            [expectation fulfill];
-        }];
+                   [expectation fulfill];
+               }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -21350,25 +21202,25 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestGroups * cluster = [[CHIPTestGroups alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPGroupsClusterViewGroupPayload alloc] init];
-    payload.groupId = [NSNumber numberWithUnsignedShort:4369U];
-    [cluster viewGroup:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"View Group 2 (still removed) Error: %@", err);
+    __auto_type * params = [[CHIPGroupsClusterViewGroupParams alloc] init];
+    params.groupId = [NSNumber numberWithUnsignedShort:4369U];
+    [cluster viewGroupWithParams:params
+               completionHandler:^(NSError * err, NSDictionary * values) {
+                   NSLog(@"View Group 2 (still removed) Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+                   XCTAssertEqual(err.code, 0);
 
-            {
-                id actualValue = values[@"status"];
-                XCTAssertEqual([actualValue unsignedCharValue], 139);
-            }
-            {
-                id actualValue = values[@"groupId"];
-                XCTAssertEqual([actualValue unsignedShortValue], 4369U);
-            }
+                   {
+                       id actualValue = values[@"status"];
+                       XCTAssertEqual([actualValue unsignedCharValue], 139);
+                   }
+                   {
+                       id actualValue = values[@"groupId"];
+                       XCTAssertEqual([actualValue unsignedShortValue], 4369U);
+                   }
 
-            [expectation fulfill];
-        }];
+                   [expectation fulfill];
+               }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -21381,25 +21233,25 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestGroups * cluster = [[CHIPTestGroups alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPGroupsClusterViewGroupPayload alloc] init];
-    payload.groupId = [NSNumber numberWithUnsignedShort:32767U];
-    [cluster viewGroup:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"View Group 3 (removed) Error: %@", err);
+    __auto_type * params = [[CHIPGroupsClusterViewGroupParams alloc] init];
+    params.groupId = [NSNumber numberWithUnsignedShort:32767U];
+    [cluster viewGroupWithParams:params
+               completionHandler:^(NSError * err, NSDictionary * values) {
+                   NSLog(@"View Group 3 (removed) Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+                   XCTAssertEqual(err.code, 0);
 
-            {
-                id actualValue = values[@"status"];
-                XCTAssertEqual([actualValue unsignedCharValue], 139);
-            }
-            {
-                id actualValue = values[@"groupId"];
-                XCTAssertEqual([actualValue unsignedShortValue], 32767U);
-            }
+                   {
+                       id actualValue = values[@"status"];
+                       XCTAssertEqual([actualValue unsignedCharValue], 139);
+                   }
+                   {
+                       id actualValue = values[@"groupId"];
+                       XCTAssertEqual([actualValue unsignedShortValue], 32767U);
+                   }
 
-            [expectation fulfill];
-        }];
+                   [expectation fulfill];
+               }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -21413,16 +21265,16 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestIdentify * cluster = [[CHIPTestIdentify alloc] initWithDevice:device endpoint:0 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPIdentifyClusterIdentifyPayload alloc] init];
-    payload.identifyTime = [NSNumber numberWithUnsignedShort:0U];
-    [cluster identify:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Send Identify command and expect success response Error: %@", err);
+    __auto_type * params = [[CHIPIdentifyClusterIdentifyParams alloc] init];
+    params.identifyTime = [NSNumber numberWithUnsignedShort:0U];
+    [cluster identifyWithParams:params
+              completionHandler:^(NSError * err, NSDictionary * values) {
+                  NSLog(@"Send Identify command and expect success response Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+                  XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+                  [expectation fulfill];
+              }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -21671,16 +21523,16 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestModeSelect * cluster = [[CHIPTestModeSelect alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPModeSelectClusterChangeToModePayload alloc] init];
-    payload.newMode = [NSNumber numberWithUnsignedChar:4];
-    [cluster changeToMode:payload
-          responseHandler:^(NSError * err, NSDictionary * values) {
-              NSLog(@"Change to Supported Mode Error: %@", err);
+    __auto_type * params = [[CHIPModeSelectClusterChangeToModeParams alloc] init];
+    params.newMode = [NSNumber numberWithUnsignedChar:4];
+    [cluster changeToModeWithParams:params
+                  completionHandler:^(NSError * err, NSDictionary * values) {
+                      NSLog(@"Change to Supported Mode Error: %@", err);
 
-              XCTAssertEqual(err.code, 0);
+                      XCTAssertEqual(err.code, 0);
 
-              [expectation fulfill];
-          }];
+                      [expectation fulfill];
+                  }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -21717,15 +21569,15 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestModeSelect * cluster = [[CHIPTestModeSelect alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPModeSelectClusterChangeToModePayload alloc] init];
-    payload.newMode = [NSNumber numberWithUnsignedChar:2];
-    [cluster changeToMode:payload
-          responseHandler:^(NSError * err, NSDictionary * values) {
-              NSLog(@"Change to Unsupported Mode Error: %@", err);
+    __auto_type * params = [[CHIPModeSelectClusterChangeToModeParams alloc] init];
+    params.newMode = [NSNumber numberWithUnsignedChar:2];
+    [cluster changeToModeWithParams:params
+                  completionHandler:^(NSError * err, NSDictionary * values) {
+                      NSLog(@"Change to Unsupported Mode Error: %@", err);
 
-              XCTAssertEqual(err.code, 1);
-              [expectation fulfill];
-          }];
+                      XCTAssertEqual(err.code, 1);
+                      [expectation fulfill];
+                  }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -21838,15 +21690,13 @@ CHIPDevice * GetConnectedDevice()
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPOnOffClusterOffPayload alloc] init];
-    [cluster off:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Set OnOff Attribute to false Error: %@", err);
+    [cluster offWithCompletionHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"Set OnOff Attribute to false Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+        XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+        [expectation fulfill];
+    }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -21904,15 +21754,13 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPOnOffClusterOnPayload alloc] init];
-    [cluster on:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Turn On the light to see attribute change Error: %@", err);
+    [cluster onWithCompletionHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"Turn On the light to see attribute change Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+        XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+        [expectation fulfill];
+    }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -21949,15 +21797,13 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    __auto_type * payload = [[CHIPOnOffClusterOffPayload alloc] init];
-    [cluster off:payload
-        responseHandler:^(NSError * err, NSDictionary * values) {
-            NSLog(@"Turn Off the light to see attribute change Error: %@", err);
+    [cluster offWithCompletionHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"Turn Off the light to see attribute change Error: %@", err);
 
-            XCTAssertEqual(err.code, 0);
+        XCTAssertEqual(err.code, 0);
 
-            [expectation fulfill];
-        }];
+        [expectation fulfill];
+    }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }


### PR DESCRIPTION
Specific changes:

1) Rename Payload structs to Params structs.
2) For commands with no fields, have the name be fooWithCompletionHandler and
   no params struct.
3) For commands with only optional fields, allow the params struct to be nil.
4) Rename "responseHandler" to "completionHandler" so that we get the
   behavior described in
   https://developer.apple.com/documentation/swift/calling_objective-c_apis_asynchronously

#### Problem
See above.

#### Change overview
See above.

#### Testing
No behavior changes intended.