### PR TITLE
Fix broken eps-idf links in ESP32 example READMEs

### DIFF
--- a/examples/all-clusters-app/esp32/README.md
+++ b/examples/all-clusters-app/esp32/README.md
@@ -40,8 +40,8 @@ the riscv-esp32-elf toolchain for ESP32C3 modules.
 The VSCode devcontainer has these components pre-installed, so you can skip this
 step. To install these components manually, follow these steps:
 
--   Clone the Espressif ESP-IDF and checkout
-    [v4.4 tag](https://github.com/espressif/esp-idf/releases/v4.4)
+-   Clone the Espressif ESP-IDF and checkout branch
+    [release/v4.4](https://github.com/espressif/esp-idf/tree/release/v4.4)
 
           $ mkdir ${HOME}/tools
           $ cd ${HOME}/tools

--- a/examples/bridge-app/esp32/README.md
+++ b/examples/bridge-app/esp32/README.md
@@ -83,8 +83,8 @@ Development Framework and the xtensa-esp32-elf toolchain.
 The VSCode devcontainer has these components pre-installed, so you can skip this
 step. To install these components manually, follow these steps:
 
--   Clone the Espressif ESP-IDF and checkout
-    [v4.4 tag](https://github.com/espressif/esp-idf/releases/v4.4)
+-   Clone the Espressif ESP-IDF and checkout branch
+    [release/v4.4](https://github.com/espressif/esp-idf/tree/release/v4.4)
 
           $ mkdir ${HOME}/tools
           $ cd ${HOME}/tools

--- a/examples/ipv6only-app/esp32/README.md
+++ b/examples/ipv6only-app/esp32/README.md
@@ -20,7 +20,8 @@ Development Framework and the xtensa-esp32-elf toolchain.
 The VSCode devcontainer has these components pre-installed, so you can skip this
 step. To install these components manually, follow these steps:
 
--   Clone the Espressif ESP-IDF and checkout release/v4.1 branch
+-   Clone the Espressif ESP-IDF and checkout branch
+    [release/v4.4](https://github.com/espressif/esp-idf/tree/release/v4.4)
 
           $ mkdir ${HOME}/tools
           $ cd ${HOME}/tools

--- a/examples/lock-app/esp32/README.md
+++ b/examples/lock-app/esp32/README.md
@@ -23,8 +23,8 @@ Development Framework and the xtensa-esp32-elf toolchain.
 The VSCode devcontainer has these components pre-installed, so you can skip this
 step. To install these components manually, follow these steps:
 
--   Clone the Espressif ESP-IDF and checkout
-    [v4.4 tag](https://github.com/espressif/esp-idf/releases/v4.4)
+-   Clone the Espressif ESP-IDF and checkout branch
+    [release/v4.4](https://github.com/espressif/esp-idf/tree/release/v4.4)
 
           $ mkdir ${HOME}/tools
           $ cd ${HOME}/tools

--- a/examples/persistent-storage/esp32/README.md
+++ b/examples/persistent-storage/esp32/README.md
@@ -42,8 +42,8 @@ Development Framework and the xtensa-esp32-elf toolchain.
 The VSCode devcontainer has these components pre-installed, so you can skip this
 step. To install these components manually, follow these steps:
 
--   Clone the Espressif ESP-IDF and checkout
-    [v4.4 tag](https://github.com/espressif/esp-idf/releases/v4.4)
+-   Clone the Espressif ESP-IDF and checkout branch
+    [release/v4.4](https://github.com/espressif/esp-idf/tree/release/v4.4)
 
           $ mkdir ${HOME}/tools
           $ cd ${HOME}/tools

--- a/examples/pigweed-app/esp32/README.md
+++ b/examples/pigweed-app/esp32/README.md
@@ -35,8 +35,8 @@ Development Framework and the xtensa-esp32-elf toolchain.
 The VSCode devcontainer has these components pre-installed, so you can skip this
 step. To install these components manually, follow these steps:
 
--   Clone the Espressif ESP-IDF and checkout
-    [v4.4 tag](https://github.com/espressif/esp-idf/releases/v4.4)
+-   Clone the Espressif ESP-IDF and checkout branch
+    [release/v4.4](https://github.com/espressif/esp-idf/tree/release/v4.4)
 
           $ mkdir ${HOME}/tools
           $ cd ${HOME}/tools

--- a/examples/temperature-measurement-app/esp32/README.md
+++ b/examples/temperature-measurement-app/esp32/README.md
@@ -23,8 +23,8 @@ Development Framework and the xtensa-esp32-elf toolchain.
 The VSCode devcontainer has these components pre-installed, so you can skip this
 step. To install these components manually, follow these steps:
 
--   Clone the Espressif ESP-IDF and checkout
-    [v4.4 tag](https://github.com/espressif/esp-idf/releases/v4.4)
+-   Clone the Espressif ESP-IDF and checkout branch
+    [release/v4.4](https://github.com/espressif/esp-idf/tree/release/v4.4)
 
           $ mkdir ${HOME}/tools
           $ cd ${HOME}/tools


### PR DESCRIPTION
#### Problem
* Link for esp-idf release/v4.4 is broken

#### Change overview
* Using the valid link for release/v4.4

#### Testing
* Manually tested by clicking on the link.