### PR TITLE
[Python] Use Generated Cluster Objects instead of functions for ZCLSend / ZCLWriteAttribute

### DIFF
--- a/src/controller/python/chip/clusters/CHIPClusters.cpp
+++ b/src/controller/python/chip/clusters/CHIPClusters.cpp
@@ -1963,33 +1963,6 @@ void chip_ime_SetFailureResponseDelegate(FailureResponseDelegate delegate)
 
 // Cluster AccountLogin
 
-chip::ChipError::StorageType chip_ime_AppendCommand_AccountLogin_GetSetupPIN(chip::DeviceProxy * device,
-                                                                             chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                             const uint8_t * tempAccountIdentifier,
-                                                                             uint32_t tempAccountIdentifier_Len)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::AccountLoginCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster
-        .GetSetupPIN(nullptr, nullptr,
-                     chip::CharSpan(reinterpret_cast<const char *>(tempAccountIdentifier), tempAccountIdentifier_Len))
-        .AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_AccountLogin_Login(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
-                                                                       chip::GroupId, const uint8_t * tempAccountIdentifier,
-                                                                       uint32_t tempAccountIdentifier_Len, const uint8_t * setupPIN,
-                                                                       uint32_t setupPIN_Len)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::AccountLoginCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster
-        .Login(nullptr, nullptr, chip::CharSpan(reinterpret_cast<const char *>(tempAccountIdentifier), tempAccountIdentifier_Len),
-               chip::CharSpan(reinterpret_cast<const char *>(setupPIN), setupPIN_Len))
-        .AsInteger();
-}
-
 chip::ChipError::StorageType chip_ime_ReadAttribute_AccountLogin_ClusterRevision(chip::DeviceProxy * device,
                                                                                  chip::EndpointId ZCLendpointId,
                                                                                  chip::GroupId /* ZCLgroupId */)
@@ -2003,37 +1976,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_AccountLogin_ClusterRevision
 // End of Cluster AccountLogin
 // Cluster AdministratorCommissioning
 
-chip::ChipError::StorageType chip_ime_AppendCommand_AdministratorCommissioning_OpenBasicCommissioningWindow(
-    chip::DeviceProxy * device, chip::EndpointId ZCLendpointId, chip::GroupId, uint16_t commissioningTimeout)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::AdministratorCommissioningCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.OpenBasicCommissioningWindow(nullptr, nullptr, commissioningTimeout).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_AdministratorCommissioning_OpenCommissioningWindow(
-    chip::DeviceProxy * device, chip::EndpointId ZCLendpointId, chip::GroupId, uint16_t commissioningTimeout,
-    const uint8_t * PAKEVerifier, uint32_t PAKEVerifier_Len, uint16_t discriminator, uint32_t iterations, const uint8_t * salt,
-    uint32_t salt_Len, uint16_t passcodeID)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::AdministratorCommissioningCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster
-        .OpenCommissioningWindow(nullptr, nullptr, commissioningTimeout, chip::ByteSpan(PAKEVerifier, PAKEVerifier_Len),
-                                 discriminator, iterations, chip::ByteSpan(salt, salt_Len), passcodeID)
-        .AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_AdministratorCommissioning_RevokeCommissioning(chip::DeviceProxy * device,
-                                                                                                   chip::EndpointId ZCLendpointId,
-                                                                                                   chip::GroupId)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::AdministratorCommissioningCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.RevokeCommissioning(nullptr, nullptr).AsInteger();
-}
-
 chip::ChipError::StorageType chip_ime_ReadAttribute_AdministratorCommissioning_ClusterRevision(chip::DeviceProxy * device,
                                                                                                chip::EndpointId ZCLendpointId,
                                                                                                chip::GroupId /* ZCLgroupId */)
@@ -2046,16 +1988,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_AdministratorCommissioning_C
 
 // End of Cluster AdministratorCommissioning
 // Cluster ApplicationBasic
-
-chip::ChipError::StorageType chip_ime_AppendCommand_ApplicationBasic_ChangeStatus(chip::DeviceProxy * device,
-                                                                                  chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                                  uint8_t status)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::ApplicationBasicCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.ChangeStatus(nullptr, nullptr, status).AsInteger();
-}
 
 chip::ChipError::StorageType chip_ime_ReadAttribute_ApplicationBasic_VendorName(chip::DeviceProxy * device,
                                                                                 chip::EndpointId ZCLendpointId,
@@ -2141,20 +2073,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_ApplicationBasic_ClusterRevi
 // End of Cluster ApplicationBasic
 // Cluster ApplicationLauncher
 
-chip::ChipError::StorageType
-chip_ime_AppendCommand_ApplicationLauncher_LaunchApp(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                     const uint8_t * data, uint32_t data_Len, uint16_t catalogVendorId,
-                                                     const uint8_t * applicationId, uint32_t applicationId_Len)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::ApplicationLauncherCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster
-        .LaunchApp(nullptr, nullptr, chip::CharSpan(reinterpret_cast<const char *>(data), data_Len), catalogVendorId,
-                   chip::CharSpan(reinterpret_cast<const char *>(applicationId), applicationId_Len))
-        .AsInteger();
-}
-
 chip::ChipError::StorageType chip_ime_ReadAttribute_ApplicationLauncher_ApplicationLauncherList(chip::DeviceProxy * device,
                                                                                                 chip::EndpointId ZCLendpointId,
                                                                                                 chip::GroupId /* ZCLgroupId */)
@@ -2201,26 +2119,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_ApplicationLauncher_ClusterR
 // End of Cluster ApplicationLauncher
 // Cluster AudioOutput
 
-chip::ChipError::StorageType chip_ime_AppendCommand_AudioOutput_RenameOutput(chip::DeviceProxy * device,
-                                                                             chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                             uint8_t index, const uint8_t * name, uint32_t name_Len)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::AudioOutputCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.RenameOutput(nullptr, nullptr, index, chip::CharSpan(reinterpret_cast<const char *>(name), name_Len))
-        .AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_AudioOutput_SelectOutput(chip::DeviceProxy * device,
-                                                                             chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                             uint8_t index)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::AudioOutputCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.SelectOutput(nullptr, nullptr, index).AsInteger();
-}
-
 chip::ChipError::StorageType chip_ime_ReadAttribute_AudioOutput_AudioOutputList(chip::DeviceProxy * device,
                                                                                 chip::EndpointId ZCLendpointId,
                                                                                 chip::GroupId /* ZCLgroupId */)
@@ -2255,24 +2153,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_AudioOutput_ClusterRevision(
 
 // End of Cluster AudioOutput
 // Cluster BarrierControl
-
-chip::ChipError::StorageType chip_ime_AppendCommand_BarrierControl_BarrierControlGoToPercent(chip::DeviceProxy * device,
-                                                                                             chip::EndpointId ZCLendpointId,
-                                                                                             chip::GroupId, uint8_t percentOpen)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::BarrierControlCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.BarrierControlGoToPercent(nullptr, nullptr, percentOpen).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_BarrierControl_BarrierControlStop(chip::DeviceProxy * device,
-                                                                                      chip::EndpointId ZCLendpointId, chip::GroupId)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::BarrierControlCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.BarrierControlStop(nullptr, nullptr).AsInteger();
-}
 
 chip::ChipError::StorageType chip_ime_ReadAttribute_BarrierControl_BarrierMovingState(chip::DeviceProxy * device,
                                                                                       chip::EndpointId ZCLendpointId,
@@ -2327,15 +2207,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_BarrierControl_ClusterRevisi
 
 // End of Cluster BarrierControl
 // Cluster Basic
-
-chip::ChipError::StorageType chip_ime_AppendCommand_Basic_MfgSpecificPing(chip::DeviceProxy * device,
-                                                                          chip::EndpointId ZCLendpointId, chip::GroupId)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::BasicCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.MfgSpecificPing(nullptr, nullptr).AsInteger();
-}
 
 chip::ChipError::StorageType chip_ime_ReadAttribute_Basic_InteractionModelVersion(chip::DeviceProxy * device,
                                                                                   chip::EndpointId ZCLendpointId,
@@ -2393,17 +2264,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_Basic_UserLabel(chip::Device
     return cluster.ReadAttributeUserLabel(gCharStringAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_Basic_UserLabel(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
-                                                                     chip::GroupId, uint8_t * value, size_t len)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::BasicCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster
-        .WriteAttributeUserLabel(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(),
-                                 chip::CharSpan(reinterpret_cast<const char *>(value), len))
-        .AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_Basic_Location(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
                                                                    chip::GroupId /* ZCLgroupId */)
 {
@@ -2413,17 +2273,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_Basic_Location(chip::DeviceP
     return cluster.ReadAttributeLocation(gCharStringAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_Basic_Location(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
-                                                                    chip::GroupId, uint8_t * value, size_t len)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::BasicCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster
-        .WriteAttributeLocation(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(),
-                                chip::CharSpan(reinterpret_cast<const char *>(value), len))
-        .AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_Basic_HardwareVersion(chip::DeviceProxy * device,
                                                                           chip::EndpointId ZCLendpointId,
                                                                           chip::GroupId /* ZCLgroupId */)
@@ -2524,16 +2373,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_Basic_LocalConfigDisabled(ch
         .AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_Basic_LocalConfigDisabled(chip::DeviceProxy * device,
-                                                                               chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                               bool value)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::BasicCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.WriteAttributeLocalConfigDisabled(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), value)
-        .AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_Basic_Reachable(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
                                                                     chip::GroupId /* ZCLgroupId */)
 {
@@ -2566,16 +2405,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_BinaryInputBasic_OutOfServic
     return cluster.ReadAttributeOutOfService(gBooleanAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_BinaryInputBasic_OutOfService(chip::DeviceProxy * device,
-                                                                                   chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                                   bool value)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::BinaryInputBasicCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.WriteAttributeOutOfService(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), value)
-        .AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_BinaryInputBasic_PresentValue(chip::DeviceProxy * device,
                                                                                   chip::EndpointId ZCLendpointId,
                                                                                   chip::GroupId /* ZCLgroupId */)
@@ -2599,16 +2428,6 @@ chip::ChipError::StorageType chip_ime_SubscribeAttribute_BinaryInputBasic_Presen
         .AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_BinaryInputBasic_PresentValue(chip::DeviceProxy * device,
-                                                                                   chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                                   bool value)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::BinaryInputBasicCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.WriteAttributePresentValue(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), value)
-        .AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_BinaryInputBasic_StatusFlags(chip::DeviceProxy * device,
                                                                                  chip::EndpointId ZCLendpointId,
                                                                                  chip::GroupId /* ZCLgroupId */)
@@ -2643,25 +2462,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_BinaryInputBasic_ClusterRevi
 
 // End of Cluster BinaryInputBasic
 // Cluster Binding
-
-chip::ChipError::StorageType chip_ime_AppendCommand_Binding_Bind(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
-                                                                 chip::GroupId, chip::NodeId nodeId, chip::GroupId groupId,
-                                                                 chip::EndpointId endpointId, chip::ClusterId clusterId)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::BindingCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.Bind(nullptr, nullptr, nodeId, groupId, endpointId, clusterId).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_Binding_Unbind(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
-                                                                   chip::GroupId, chip::NodeId nodeId, chip::GroupId groupId,
-                                                                   chip::EndpointId endpointId, chip::ClusterId clusterId)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::BindingCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.Unbind(nullptr, nullptr, nodeId, groupId, endpointId, clusterId).AsInteger();
-}
 
 chip::ChipError::StorageType chip_ime_ReadAttribute_Binding_ClusterRevision(chip::DeviceProxy * device,
                                                                             chip::EndpointId ZCLendpointId,
@@ -2711,121 +2511,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_BooleanState_ClusterRevision
 
 // End of Cluster BooleanState
 // Cluster BridgedActions
-
-chip::ChipError::StorageType chip_ime_AppendCommand_BridgedActions_DisableAction(chip::DeviceProxy * device,
-                                                                                 chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                                 uint16_t actionID, uint32_t invokeID)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::BridgedActionsCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.DisableAction(nullptr, nullptr, actionID, invokeID).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_BridgedActions_DisableActionWithDuration(chip::DeviceProxy * device,
-                                                                                             chip::EndpointId ZCLendpointId,
-                                                                                             chip::GroupId, uint16_t actionID,
-                                                                                             uint32_t invokeID, uint32_t duration)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::BridgedActionsCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.DisableActionWithDuration(nullptr, nullptr, actionID, invokeID, duration).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_BridgedActions_EnableAction(chip::DeviceProxy * device,
-                                                                                chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                                uint16_t actionID, uint32_t invokeID)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::BridgedActionsCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.EnableAction(nullptr, nullptr, actionID, invokeID).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_BridgedActions_EnableActionWithDuration(chip::DeviceProxy * device,
-                                                                                            chip::EndpointId ZCLendpointId,
-                                                                                            chip::GroupId, uint16_t actionID,
-                                                                                            uint32_t invokeID, uint32_t duration)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::BridgedActionsCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.EnableActionWithDuration(nullptr, nullptr, actionID, invokeID, duration).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_BridgedActions_InstantAction(chip::DeviceProxy * device,
-                                                                                 chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                                 uint16_t actionID, uint32_t invokeID)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::BridgedActionsCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.InstantAction(nullptr, nullptr, actionID, invokeID).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_BridgedActions_InstantActionWithTransition(chip::DeviceProxy * device,
-                                                                                               chip::EndpointId ZCLendpointId,
-                                                                                               chip::GroupId, uint16_t actionID,
-                                                                                               uint32_t invokeID,
-                                                                                               uint16_t transitionTime)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::BridgedActionsCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.InstantActionWithTransition(nullptr, nullptr, actionID, invokeID, transitionTime).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_BridgedActions_PauseAction(chip::DeviceProxy * device,
-                                                                               chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                               uint16_t actionID, uint32_t invokeID)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::BridgedActionsCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.PauseAction(nullptr, nullptr, actionID, invokeID).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_BridgedActions_PauseActionWithDuration(chip::DeviceProxy * device,
-                                                                                           chip::EndpointId ZCLendpointId,
-                                                                                           chip::GroupId, uint16_t actionID,
-                                                                                           uint32_t invokeID, uint32_t duration)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::BridgedActionsCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.PauseActionWithDuration(nullptr, nullptr, actionID, invokeID, duration).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_BridgedActions_ResumeAction(chip::DeviceProxy * device,
-                                                                                chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                                uint16_t actionID, uint32_t invokeID)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::BridgedActionsCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.ResumeAction(nullptr, nullptr, actionID, invokeID).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_BridgedActions_StartAction(chip::DeviceProxy * device,
-                                                                               chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                               uint16_t actionID, uint32_t invokeID)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::BridgedActionsCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.StartAction(nullptr, nullptr, actionID, invokeID).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_BridgedActions_StartActionWithDuration(chip::DeviceProxy * device,
-                                                                                           chip::EndpointId ZCLendpointId,
-                                                                                           chip::GroupId, uint16_t actionID,
-                                                                                           uint32_t invokeID, uint32_t duration)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::BridgedActionsCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.StartActionWithDuration(nullptr, nullptr, actionID, invokeID, duration).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_BridgedActions_StopAction(chip::DeviceProxy * device,
-                                                                              chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                              uint16_t actionID, uint32_t invokeID)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::BridgedActionsCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.StopAction(nullptr, nullptr, actionID, invokeID).AsInteger();
-}
 
 chip::ChipError::StorageType chip_ime_ReadAttribute_BridgedActions_ActionList(chip::DeviceProxy * device,
                                                                               chip::EndpointId ZCLendpointId,
@@ -2914,18 +2599,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_BridgedDeviceBasic_UserLabel
     return cluster.ReadAttributeUserLabel(gCharStringAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_BridgedDeviceBasic_UserLabel(chip::DeviceProxy * device,
-                                                                                  chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                                  uint8_t * value, size_t len)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::BridgedDeviceBasicCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster
-        .WriteAttributeUserLabel(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(),
-                                 chip::CharSpan(reinterpret_cast<const char *>(value), len))
-        .AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_BridgedDeviceBasic_HardwareVersion(chip::DeviceProxy * device,
                                                                                        chip::EndpointId ZCLendpointId,
                                                                                        chip::GroupId /* ZCLgroupId */)
@@ -3041,211 +2714,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_BridgedDeviceBasic_ClusterRe
 
 // End of Cluster BridgedDeviceBasic
 // Cluster ColorControl
-
-chip::ChipError::StorageType chip_ime_AppendCommand_ColorControl_ColorLoopSet(chip::DeviceProxy * device,
-                                                                              chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                              uint8_t updateFlags, uint8_t action,
-                                                                              uint8_t direction, uint16_t time, uint16_t startHue,
-                                                                              uint8_t optionsMask, uint8_t optionsOverride)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::ColorControlCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.ColorLoopSet(nullptr, nullptr, updateFlags, action, direction, time, startHue, optionsMask, optionsOverride)
-        .AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_ColorControl_EnhancedMoveHue(chip::DeviceProxy * device,
-                                                                                 chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                                 uint8_t moveMode, uint16_t rate,
-                                                                                 uint8_t optionsMask, uint8_t optionsOverride)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::ColorControlCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.EnhancedMoveHue(nullptr, nullptr, moveMode, rate, optionsMask, optionsOverride).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_ColorControl_EnhancedMoveToHue(chip::DeviceProxy * device,
-                                                                                   chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                                   uint16_t enhancedHue, uint8_t direction,
-                                                                                   uint16_t transitionTime, uint8_t optionsMask,
-                                                                                   uint8_t optionsOverride)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::ColorControlCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.EnhancedMoveToHue(nullptr, nullptr, enhancedHue, direction, transitionTime, optionsMask, optionsOverride)
-        .AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_ColorControl_EnhancedMoveToHueAndSaturation(
-    chip::DeviceProxy * device, chip::EndpointId ZCLendpointId, chip::GroupId, uint16_t enhancedHue, uint8_t saturation,
-    uint16_t transitionTime, uint8_t optionsMask, uint8_t optionsOverride)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::ColorControlCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster
-        .EnhancedMoveToHueAndSaturation(nullptr, nullptr, enhancedHue, saturation, transitionTime, optionsMask, optionsOverride)
-        .AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_ColorControl_EnhancedStepHue(chip::DeviceProxy * device,
-                                                                                 chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                                 uint8_t stepMode, uint16_t stepSize,
-                                                                                 uint16_t transitionTime, uint8_t optionsMask,
-                                                                                 uint8_t optionsOverride)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::ColorControlCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.EnhancedStepHue(nullptr, nullptr, stepMode, stepSize, transitionTime, optionsMask, optionsOverride).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_ColorControl_MoveColor(chip::DeviceProxy * device,
-                                                                           chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                           int16_t rateX, int16_t rateY, uint8_t optionsMask,
-                                                                           uint8_t optionsOverride)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::ColorControlCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.MoveColor(nullptr, nullptr, rateX, rateY, optionsMask, optionsOverride).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_ColorControl_MoveColorTemperature(
-    chip::DeviceProxy * device, chip::EndpointId ZCLendpointId, chip::GroupId, uint8_t moveMode, uint16_t rate,
-    uint16_t colorTemperatureMinimum, uint16_t colorTemperatureMaximum, uint8_t optionsMask, uint8_t optionsOverride)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::ColorControlCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster
-        .MoveColorTemperature(nullptr, nullptr, moveMode, rate, colorTemperatureMinimum, colorTemperatureMaximum, optionsMask,
-                              optionsOverride)
-        .AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_ColorControl_MoveHue(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
-                                                                         chip::GroupId, uint8_t moveMode, uint8_t rate,
-                                                                         uint8_t optionsMask, uint8_t optionsOverride)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::ColorControlCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.MoveHue(nullptr, nullptr, moveMode, rate, optionsMask, optionsOverride).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_ColorControl_MoveSaturation(chip::DeviceProxy * device,
-                                                                                chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                                uint8_t moveMode, uint8_t rate, uint8_t optionsMask,
-                                                                                uint8_t optionsOverride)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::ColorControlCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.MoveSaturation(nullptr, nullptr, moveMode, rate, optionsMask, optionsOverride).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_ColorControl_MoveToColor(chip::DeviceProxy * device,
-                                                                             chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                             uint16_t colorX, uint16_t colorY,
-                                                                             uint16_t transitionTime, uint8_t optionsMask,
-                                                                             uint8_t optionsOverride)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::ColorControlCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.MoveToColor(nullptr, nullptr, colorX, colorY, transitionTime, optionsMask, optionsOverride).AsInteger();
-}
-chip::ChipError::StorageType
-chip_ime_AppendCommand_ColorControl_MoveToColorTemperature(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
-                                                           chip::GroupId, uint16_t colorTemperature, uint16_t transitionTime,
-                                                           uint8_t optionsMask, uint8_t optionsOverride)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::ColorControlCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.MoveToColorTemperature(nullptr, nullptr, colorTemperature, transitionTime, optionsMask, optionsOverride)
-        .AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_ColorControl_MoveToHue(chip::DeviceProxy * device,
-                                                                           chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                           uint8_t hue, uint8_t direction, uint16_t transitionTime,
-                                                                           uint8_t optionsMask, uint8_t optionsOverride)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::ColorControlCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.MoveToHue(nullptr, nullptr, hue, direction, transitionTime, optionsMask, optionsOverride).AsInteger();
-}
-chip::ChipError::StorageType
-chip_ime_AppendCommand_ColorControl_MoveToHueAndSaturation(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
-                                                           chip::GroupId, uint8_t hue, uint8_t saturation, uint16_t transitionTime,
-                                                           uint8_t optionsMask, uint8_t optionsOverride)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::ColorControlCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.MoveToHueAndSaturation(nullptr, nullptr, hue, saturation, transitionTime, optionsMask, optionsOverride)
-        .AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_ColorControl_MoveToSaturation(chip::DeviceProxy * device,
-                                                                                  chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                                  uint8_t saturation, uint16_t transitionTime,
-                                                                                  uint8_t optionsMask, uint8_t optionsOverride)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::ColorControlCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.MoveToSaturation(nullptr, nullptr, saturation, transitionTime, optionsMask, optionsOverride).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_ColorControl_StepColor(chip::DeviceProxy * device,
-                                                                           chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                           int16_t stepX, int16_t stepY, uint16_t transitionTime,
-                                                                           uint8_t optionsMask, uint8_t optionsOverride)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::ColorControlCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.StepColor(nullptr, nullptr, stepX, stepY, transitionTime, optionsMask, optionsOverride).AsInteger();
-}
-chip::ChipError::StorageType
-chip_ime_AppendCommand_ColorControl_StepColorTemperature(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                         uint8_t stepMode, uint16_t stepSize, uint16_t transitionTime,
-                                                         uint16_t colorTemperatureMinimum, uint16_t colorTemperatureMaximum,
-                                                         uint8_t optionsMask, uint8_t optionsOverride)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::ColorControlCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster
-        .StepColorTemperature(nullptr, nullptr, stepMode, stepSize, transitionTime, colorTemperatureMinimum,
-                              colorTemperatureMaximum, optionsMask, optionsOverride)
-        .AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_ColorControl_StepHue(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
-                                                                         chip::GroupId, uint8_t stepMode, uint8_t stepSize,
-                                                                         uint8_t transitionTime, uint8_t optionsMask,
-                                                                         uint8_t optionsOverride)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::ColorControlCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.StepHue(nullptr, nullptr, stepMode, stepSize, transitionTime, optionsMask, optionsOverride).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_ColorControl_StepSaturation(chip::DeviceProxy * device,
-                                                                                chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                                uint8_t stepMode, uint8_t stepSize,
-                                                                                uint8_t transitionTime, uint8_t optionsMask,
-                                                                                uint8_t optionsOverride)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::ColorControlCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.StepSaturation(nullptr, nullptr, stepMode, stepSize, transitionTime, optionsMask, optionsOverride).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_ColorControl_StopMoveStep(chip::DeviceProxy * device,
-                                                                              chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                              uint8_t optionsMask, uint8_t optionsOverride)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::ColorControlCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.StopMoveStep(nullptr, nullptr, optionsMask, optionsOverride).AsInteger();
-}
 
 chip::ChipError::StorageType chip_ime_ReadAttribute_ColorControl_CurrentHue(chip::DeviceProxy * device,
                                                                             chip::EndpointId ZCLendpointId,
@@ -3410,16 +2878,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_ColorControl_ColorControlOpt
     return cluster.ReadAttributeColorControlOptions(gInt8uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_ColorControl_ColorControlOptions(chip::DeviceProxy * device,
-                                                                                      chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                                      uint8_t value)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::ColorControlCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.WriteAttributeColorControlOptions(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), value)
-        .AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_ColorControl_NumberOfPrimaries(chip::DeviceProxy * device,
                                                                                    chip::EndpointId ZCLendpointId,
                                                                                    chip::GroupId /* ZCLgroupId */)
@@ -3620,15 +3078,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_ColorControl_WhitePointX(chi
     return cluster.ReadAttributeWhitePointX(gInt16uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_ColorControl_WhitePointX(chip::DeviceProxy * device,
-                                                                              chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                              uint16_t value)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::ColorControlCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.WriteAttributeWhitePointX(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), value).AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_ColorControl_WhitePointY(chip::DeviceProxy * device,
                                                                              chip::EndpointId ZCLendpointId,
                                                                              chip::GroupId /* ZCLgroupId */)
@@ -3639,15 +3088,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_ColorControl_WhitePointY(chi
     return cluster.ReadAttributeWhitePointY(gInt16uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_ColorControl_WhitePointY(chip::DeviceProxy * device,
-                                                                              chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                              uint16_t value)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::ColorControlCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.WriteAttributeWhitePointY(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), value).AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_ColorControl_ColorPointRX(chip::DeviceProxy * device,
                                                                               chip::EndpointId ZCLendpointId,
                                                                               chip::GroupId /* ZCLgroupId */)
@@ -3658,16 +3098,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_ColorControl_ColorPointRX(ch
     return cluster.ReadAttributeColorPointRX(gInt16uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_ColorControl_ColorPointRX(chip::DeviceProxy * device,
-                                                                               chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                               uint16_t value)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::ColorControlCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.WriteAttributeColorPointRX(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), value)
-        .AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_ColorControl_ColorPointRY(chip::DeviceProxy * device,
                                                                               chip::EndpointId ZCLendpointId,
                                                                               chip::GroupId /* ZCLgroupId */)
@@ -3678,16 +3108,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_ColorControl_ColorPointRY(ch
     return cluster.ReadAttributeColorPointRY(gInt16uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_ColorControl_ColorPointRY(chip::DeviceProxy * device,
-                                                                               chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                               uint16_t value)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::ColorControlCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.WriteAttributeColorPointRY(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), value)
-        .AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_ColorControl_ColorPointRIntensity(chip::DeviceProxy * device,
                                                                                       chip::EndpointId ZCLendpointId,
                                                                                       chip::GroupId /* ZCLgroupId */)
@@ -3699,16 +3119,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_ColorControl_ColorPointRInte
         .AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_ColorControl_ColorPointRIntensity(chip::DeviceProxy * device,
-                                                                                       chip::EndpointId ZCLendpointId,
-                                                                                       chip::GroupId, uint8_t value)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::ColorControlCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.WriteAttributeColorPointRIntensity(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), value)
-        .AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_ColorControl_ColorPointGX(chip::DeviceProxy * device,
                                                                               chip::EndpointId ZCLendpointId,
                                                                               chip::GroupId /* ZCLgroupId */)
@@ -3719,16 +3129,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_ColorControl_ColorPointGX(ch
     return cluster.ReadAttributeColorPointGX(gInt16uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_ColorControl_ColorPointGX(chip::DeviceProxy * device,
-                                                                               chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                               uint16_t value)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::ColorControlCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.WriteAttributeColorPointGX(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), value)
-        .AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_ColorControl_ColorPointGY(chip::DeviceProxy * device,
                                                                               chip::EndpointId ZCLendpointId,
                                                                               chip::GroupId /* ZCLgroupId */)
@@ -3739,16 +3139,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_ColorControl_ColorPointGY(ch
     return cluster.ReadAttributeColorPointGY(gInt16uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_ColorControl_ColorPointGY(chip::DeviceProxy * device,
-                                                                               chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                               uint16_t value)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::ColorControlCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.WriteAttributeColorPointGY(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), value)
-        .AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_ColorControl_ColorPointGIntensity(chip::DeviceProxy * device,
                                                                                       chip::EndpointId ZCLendpointId,
                                                                                       chip::GroupId /* ZCLgroupId */)
@@ -3760,16 +3150,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_ColorControl_ColorPointGInte
         .AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_ColorControl_ColorPointGIntensity(chip::DeviceProxy * device,
-                                                                                       chip::EndpointId ZCLendpointId,
-                                                                                       chip::GroupId, uint8_t value)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::ColorControlCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.WriteAttributeColorPointGIntensity(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), value)
-        .AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_ColorControl_ColorPointBX(chip::DeviceProxy * device,
                                                                               chip::EndpointId ZCLendpointId,
                                                                               chip::GroupId /* ZCLgroupId */)
@@ -3780,16 +3160,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_ColorControl_ColorPointBX(ch
     return cluster.ReadAttributeColorPointBX(gInt16uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_ColorControl_ColorPointBX(chip::DeviceProxy * device,
-                                                                               chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                               uint16_t value)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::ColorControlCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.WriteAttributeColorPointBX(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), value)
-        .AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_ColorControl_ColorPointBY(chip::DeviceProxy * device,
                                                                               chip::EndpointId ZCLendpointId,
                                                                               chip::GroupId /* ZCLgroupId */)
@@ -3800,16 +3170,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_ColorControl_ColorPointBY(ch
     return cluster.ReadAttributeColorPointBY(gInt16uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_ColorControl_ColorPointBY(chip::DeviceProxy * device,
-                                                                               chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                               uint16_t value)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::ColorControlCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.WriteAttributeColorPointBY(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), value)
-        .AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_ColorControl_ColorPointBIntensity(chip::DeviceProxy * device,
                                                                                       chip::EndpointId ZCLendpointId,
                                                                                       chip::GroupId /* ZCLgroupId */)
@@ -3821,16 +3181,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_ColorControl_ColorPointBInte
         .AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_ColorControl_ColorPointBIntensity(chip::DeviceProxy * device,
-                                                                                       chip::EndpointId ZCLendpointId,
-                                                                                       chip::GroupId, uint8_t value)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::ColorControlCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.WriteAttributeColorPointBIntensity(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), value)
-        .AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_ColorControl_EnhancedCurrentHue(chip::DeviceProxy * device,
                                                                                     chip::EndpointId ZCLendpointId,
                                                                                     chip::GroupId /* ZCLgroupId */)
@@ -3957,17 +3307,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_ColorControl_StartUpColorTem
         .AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_ColorControl_StartUpColorTemperatureMireds(chip::DeviceProxy * device,
-                                                                                                chip::EndpointId ZCLendpointId,
-                                                                                                chip::GroupId, uint16_t value)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::ColorControlCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster
-        .WriteAttributeStartUpColorTemperatureMireds(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), value)
-        .AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_ColorControl_ClusterRevision(chip::DeviceProxy * device,
                                                                                  chip::EndpointId ZCLendpointId,
                                                                                  chip::GroupId /* ZCLgroupId */)
@@ -3980,32 +3319,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_ColorControl_ClusterRevision
 
 // End of Cluster ColorControl
 // Cluster ContentLauncher
-
-chip::ChipError::StorageType chip_ime_AppendCommand_ContentLauncher_LaunchContent(chip::DeviceProxy * device,
-                                                                                  chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                                  bool autoPlay, const uint8_t * data,
-                                                                                  uint32_t data_Len)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::ContentLauncherCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.LaunchContent(nullptr, nullptr, autoPlay, chip::CharSpan(reinterpret_cast<const char *>(data), data_Len))
-        .AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_ContentLauncher_LaunchURL(chip::DeviceProxy * device,
-                                                                              chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                              const uint8_t * contentURL, uint32_t contentURL_Len,
-                                                                              const uint8_t * displayString,
-                                                                              uint32_t displayString_Len)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::ContentLauncherCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster
-        .LaunchURL(nullptr, nullptr, chip::CharSpan(reinterpret_cast<const char *>(contentURL), contentURL_Len),
-                   chip::CharSpan(reinterpret_cast<const char *>(displayString), displayString_Len))
-        .AsInteger();
-}
 
 chip::ChipError::StorageType chip_ime_ReadAttribute_ContentLauncher_AcceptsHeaderList(chip::DeviceProxy * device,
                                                                                       chip::EndpointId ZCLendpointId,
@@ -4102,226 +3415,8 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_Descriptor_ClusterRevision(c
 // End of Cluster Descriptor
 // Cluster DiagnosticLogs
 
-chip::ChipError::StorageType chip_ime_AppendCommand_DiagnosticLogs_RetrieveLogsRequest(
-    chip::DeviceProxy * device, chip::EndpointId ZCLendpointId, chip::GroupId, uint8_t intent, uint8_t requestedProtocol,
-    const uint8_t * transferFileDesignator, uint32_t transferFileDesignator_Len)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::DiagnosticLogsCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster
-        .RetrieveLogsRequest(nullptr, nullptr, intent, requestedProtocol,
-                             chip::ByteSpan(transferFileDesignator, transferFileDesignator_Len))
-        .AsInteger();
-}
-
 // End of Cluster DiagnosticLogs
 // Cluster DoorLock
-
-chip::ChipError::StorageType chip_ime_AppendCommand_DoorLock_ClearAllPins(chip::DeviceProxy * device,
-                                                                          chip::EndpointId ZCLendpointId, chip::GroupId)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::DoorLockCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.ClearAllPins(nullptr, nullptr).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_DoorLock_ClearAllRfids(chip::DeviceProxy * device,
-                                                                           chip::EndpointId ZCLendpointId, chip::GroupId)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::DoorLockCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.ClearAllRfids(nullptr, nullptr).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_DoorLock_ClearHolidaySchedule(chip::DeviceProxy * device,
-                                                                                  chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                                  uint8_t scheduleId)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::DoorLockCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.ClearHolidaySchedule(nullptr, nullptr, scheduleId).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_DoorLock_ClearPin(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
-                                                                      chip::GroupId, uint16_t userId)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::DoorLockCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.ClearPin(nullptr, nullptr, userId).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_DoorLock_ClearRfid(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
-                                                                       chip::GroupId, uint16_t userId)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::DoorLockCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.ClearRfid(nullptr, nullptr, userId).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_DoorLock_ClearWeekdaySchedule(chip::DeviceProxy * device,
-                                                                                  chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                                  uint8_t scheduleId, uint16_t userId)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::DoorLockCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.ClearWeekdaySchedule(nullptr, nullptr, scheduleId, userId).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_DoorLock_ClearYeardaySchedule(chip::DeviceProxy * device,
-                                                                                  chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                                  uint8_t scheduleId, uint16_t userId)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::DoorLockCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.ClearYeardaySchedule(nullptr, nullptr, scheduleId, userId).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_DoorLock_GetHolidaySchedule(chip::DeviceProxy * device,
-                                                                                chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                                uint8_t scheduleId)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::DoorLockCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.GetHolidaySchedule(nullptr, nullptr, scheduleId).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_DoorLock_GetLogRecord(chip::DeviceProxy * device,
-                                                                          chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                          uint16_t logIndex)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::DoorLockCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.GetLogRecord(nullptr, nullptr, logIndex).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_DoorLock_GetPin(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
-                                                                    chip::GroupId, uint16_t userId)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::DoorLockCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.GetPin(nullptr, nullptr, userId).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_DoorLock_GetRfid(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
-                                                                     chip::GroupId, uint16_t userId)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::DoorLockCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.GetRfid(nullptr, nullptr, userId).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_DoorLock_GetUserType(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
-                                                                         chip::GroupId, uint16_t userId)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::DoorLockCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.GetUserType(nullptr, nullptr, userId).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_DoorLock_GetWeekdaySchedule(chip::DeviceProxy * device,
-                                                                                chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                                uint8_t scheduleId, uint16_t userId)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::DoorLockCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.GetWeekdaySchedule(nullptr, nullptr, scheduleId, userId).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_DoorLock_GetYeardaySchedule(chip::DeviceProxy * device,
-                                                                                chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                                uint8_t scheduleId, uint16_t userId)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::DoorLockCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.GetYeardaySchedule(nullptr, nullptr, scheduleId, userId).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_DoorLock_LockDoor(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
-                                                                      chip::GroupId, const uint8_t * pin, uint32_t pin_Len)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::DoorLockCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.LockDoor(nullptr, nullptr, chip::ByteSpan(pin, pin_Len)).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_DoorLock_SetHolidaySchedule(chip::DeviceProxy * device,
-                                                                                chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                                uint8_t scheduleId, uint32_t localStartTime,
-                                                                                uint32_t localEndTime,
-                                                                                uint8_t operatingModeDuringHoliday)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::DoorLockCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.SetHolidaySchedule(nullptr, nullptr, scheduleId, localStartTime, localEndTime, operatingModeDuringHoliday)
-        .AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_DoorLock_SetPin(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
-                                                                    chip::GroupId, uint16_t userId, uint8_t userStatus,
-                                                                    uint8_t userType, const uint8_t * pin, uint32_t pin_Len)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::DoorLockCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.SetPin(nullptr, nullptr, userId, userStatus, userType, chip::ByteSpan(pin, pin_Len)).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_DoorLock_SetRfid(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
-                                                                     chip::GroupId, uint16_t userId, uint8_t userStatus,
-                                                                     uint8_t userType, const uint8_t * id, uint32_t id_Len)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::DoorLockCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.SetRfid(nullptr, nullptr, userId, userStatus, userType, chip::ByteSpan(id, id_Len)).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_DoorLock_SetUserType(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
-                                                                         chip::GroupId, uint16_t userId, uint8_t userType)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::DoorLockCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.SetUserType(nullptr, nullptr, userId, userType).AsInteger();
-}
-chip::ChipError::StorageType
-chip_ime_AppendCommand_DoorLock_SetWeekdaySchedule(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                   uint8_t scheduleId, uint16_t userId, uint8_t daysMask, uint8_t startHour,
-                                                   uint8_t startMinute, uint8_t endHour, uint8_t endMinute)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::DoorLockCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.SetWeekdaySchedule(nullptr, nullptr, scheduleId, userId, daysMask, startHour, startMinute, endHour, endMinute)
-        .AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_DoorLock_SetYeardaySchedule(chip::DeviceProxy * device,
-                                                                                chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                                uint8_t scheduleId, uint16_t userId,
-                                                                                uint32_t localStartTime, uint32_t localEndTime)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::DoorLockCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.SetYeardaySchedule(nullptr, nullptr, scheduleId, userId, localStartTime, localEndTime).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_DoorLock_UnlockDoor(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
-                                                                        chip::GroupId, const uint8_t * pin, uint32_t pin_Len)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::DoorLockCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.UnlockDoor(nullptr, nullptr, chip::ByteSpan(pin, pin_Len)).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_DoorLock_UnlockWithTimeout(chip::DeviceProxy * device,
-                                                                               chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                               uint16_t timeoutInSeconds, const uint8_t * pin,
-                                                                               uint32_t pin_Len)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::DoorLockCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.UnlockWithTimeout(nullptr, nullptr, timeoutInSeconds, chip::ByteSpan(pin, pin_Len)).AsInteger();
-}
 
 chip::ChipError::StorageType chip_ime_ReadAttribute_DoorLock_LockState(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
                                                                        chip::GroupId /* ZCLgroupId */)
@@ -4498,16 +3593,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_ElectricalMeasurement_Cluste
 
 // End of Cluster ElectricalMeasurement
 // Cluster EthernetNetworkDiagnostics
-
-chip::ChipError::StorageType chip_ime_AppendCommand_EthernetNetworkDiagnostics_ResetCounts(chip::DeviceProxy * device,
-                                                                                           chip::EndpointId ZCLendpointId,
-                                                                                           chip::GroupId)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::EthernetNetworkDiagnosticsCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.ResetCounts(nullptr, nullptr).AsInteger();
-}
 
 chip::ChipError::StorageType chip_ime_ReadAttribute_EthernetNetworkDiagnostics_PHYRate(chip::DeviceProxy * device,
                                                                                        chip::EndpointId ZCLendpointId,
@@ -4688,39 +3773,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_FlowMeasurement_ClusterRevis
 // End of Cluster FlowMeasurement
 // Cluster GeneralCommissioning
 
-chip::ChipError::StorageType chip_ime_AppendCommand_GeneralCommissioning_ArmFailSafe(chip::DeviceProxy * device,
-                                                                                     chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                                     uint16_t expiryLengthSeconds,
-                                                                                     uint64_t breadcrumb, uint32_t timeoutMs)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::GeneralCommissioningCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.ArmFailSafe(nullptr, nullptr, expiryLengthSeconds, breadcrumb, timeoutMs).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_GeneralCommissioning_CommissioningComplete(chip::DeviceProxy * device,
-                                                                                               chip::EndpointId ZCLendpointId,
-                                                                                               chip::GroupId)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::GeneralCommissioningCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.CommissioningComplete(nullptr, nullptr).AsInteger();
-}
-chip::ChipError::StorageType
-chip_ime_AppendCommand_GeneralCommissioning_SetRegulatoryConfig(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
-                                                                chip::GroupId, uint8_t location, const uint8_t * countryCode,
-                                                                uint32_t countryCode_Len, uint64_t breadcrumb, uint32_t timeoutMs)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::GeneralCommissioningCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster
-        .SetRegulatoryConfig(nullptr, nullptr, location,
-                             chip::CharSpan(reinterpret_cast<const char *>(countryCode), countryCode_Len), breadcrumb, timeoutMs)
-        .AsInteger();
-}
-
 chip::ChipError::StorageType chip_ime_ReadAttribute_GeneralCommissioning_Breadcrumb(chip::DeviceProxy * device,
                                                                                     chip::EndpointId ZCLendpointId,
                                                                                     chip::GroupId /* ZCLgroupId */)
@@ -4731,15 +3783,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_GeneralCommissioning_Breadcr
     return cluster.ReadAttributeBreadcrumb(gInt64uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_GeneralCommissioning_Breadcrumb(chip::DeviceProxy * device,
-                                                                                     chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                                     uint64_t value)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::GeneralCommissioningCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.WriteAttributeBreadcrumb(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), value).AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_GeneralCommissioning_BasicCommissioningInfoList(chip::DeviceProxy * device,
                                                                                                     chip::EndpointId ZCLendpointId,
                                                                                                     chip::GroupId /* ZCLgroupId */)
@@ -4908,62 +3951,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_GroupKeyManagement_ClusterRe
 // End of Cluster GroupKeyManagement
 // Cluster Groups
 
-chip::ChipError::StorageType chip_ime_AppendCommand_Groups_AddGroup(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
-                                                                    chip::GroupId, uint16_t groupId, const uint8_t * groupName,
-                                                                    uint32_t groupName_Len)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::GroupsCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.AddGroup(nullptr, nullptr, groupId, chip::CharSpan(reinterpret_cast<const char *>(groupName), groupName_Len))
-        .AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_Groups_AddGroupIfIdentifying(chip::DeviceProxy * device,
-                                                                                 chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                                 uint16_t groupId, const uint8_t * groupName,
-                                                                                 uint32_t groupName_Len)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::GroupsCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster
-        .AddGroupIfIdentifying(nullptr, nullptr, groupId, chip::CharSpan(reinterpret_cast<const char *>(groupName), groupName_Len))
-        .AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_Groups_GetGroupMembership(chip::DeviceProxy * device,
-                                                                              chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                              uint8_t groupCount, uint16_t groupList)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::GroupsCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.GetGroupMembership(nullptr, nullptr, groupCount, groupList).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_Groups_RemoveAllGroups(chip::DeviceProxy * device,
-                                                                           chip::EndpointId ZCLendpointId, chip::GroupId)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::GroupsCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.RemoveAllGroups(nullptr, nullptr).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_Groups_RemoveGroup(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
-                                                                       chip::GroupId, uint16_t groupId)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::GroupsCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.RemoveGroup(nullptr, nullptr, groupId).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_Groups_ViewGroup(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
-                                                                     chip::GroupId, uint16_t groupId)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::GroupsCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.ViewGroup(nullptr, nullptr, groupId).AsInteger();
-}
-
 chip::ChipError::StorageType chip_ime_ReadAttribute_Groups_NameSupport(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
                                                                        chip::GroupId /* ZCLgroupId */)
 {
@@ -4986,32 +3973,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_Groups_ClusterRevision(chip:
 // End of Cluster Groups
 // Cluster Identify
 
-chip::ChipError::StorageType chip_ime_AppendCommand_Identify_Identify(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
-                                                                      chip::GroupId, uint16_t identifyTime)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::IdentifyCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.Identify(nullptr, nullptr, identifyTime).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_Identify_IdentifyQuery(chip::DeviceProxy * device,
-                                                                           chip::EndpointId ZCLendpointId, chip::GroupId)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::IdentifyCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.IdentifyQuery(nullptr, nullptr).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_Identify_TriggerEffect(chip::DeviceProxy * device,
-                                                                           chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                           uint8_t effectIdentifier, uint8_t effectVariant)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::IdentifyCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.TriggerEffect(nullptr, nullptr, effectIdentifier, effectVariant).AsInteger();
-}
-
 chip::ChipError::StorageType chip_ime_ReadAttribute_Identify_IdentifyTime(chip::DeviceProxy * device,
                                                                           chip::EndpointId ZCLendpointId,
                                                                           chip::GroupId /* ZCLgroupId */)
@@ -5022,16 +3983,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_Identify_IdentifyTime(chip::
     return cluster.ReadAttributeIdentifyTime(gInt16uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_Identify_IdentifyTime(chip::DeviceProxy * device,
-                                                                           chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                           uint16_t value)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::IdentifyCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.WriteAttributeIdentifyTime(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), value)
-        .AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_Identify_IdentifyType(chip::DeviceProxy * device,
                                                                           chip::EndpointId ZCLendpointId,
                                                                           chip::GroupId /* ZCLgroupId */)
@@ -5132,15 +4083,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_IlluminanceMeasurement_Clust
 // End of Cluster IlluminanceMeasurement
 // Cluster KeypadInput
 
-chip::ChipError::StorageType chip_ime_AppendCommand_KeypadInput_SendKey(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
-                                                                        chip::GroupId, uint8_t keyCode)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::KeypadInputCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.SendKey(nullptr, nullptr, keyCode).AsInteger();
-}
-
 chip::ChipError::StorageType chip_ime_ReadAttribute_KeypadInput_ClusterRevision(chip::DeviceProxy * device,
                                                                                 chip::EndpointId ZCLendpointId,
                                                                                 chip::GroupId /* ZCLgroupId */)
@@ -5153,80 +4095,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_KeypadInput_ClusterRevision(
 
 // End of Cluster KeypadInput
 // Cluster LevelControl
-
-chip::ChipError::StorageType chip_ime_AppendCommand_LevelControl_Move(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
-                                                                      chip::GroupId, uint8_t moveMode, uint8_t rate,
-                                                                      uint8_t optionMask, uint8_t optionOverride)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::LevelControlCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.Move(nullptr, nullptr, moveMode, rate, optionMask, optionOverride).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_LevelControl_MoveToLevel(chip::DeviceProxy * device,
-                                                                             chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                             uint8_t level, uint16_t transitionTime,
-                                                                             uint8_t optionMask, uint8_t optionOverride)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::LevelControlCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.MoveToLevel(nullptr, nullptr, level, transitionTime, optionMask, optionOverride).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_LevelControl_MoveToLevelWithOnOff(chip::DeviceProxy * device,
-                                                                                      chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                                      uint8_t level, uint16_t transitionTime)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::LevelControlCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.MoveToLevelWithOnOff(nullptr, nullptr, level, transitionTime).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_LevelControl_MoveWithOnOff(chip::DeviceProxy * device,
-                                                                               chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                               uint8_t moveMode, uint8_t rate)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::LevelControlCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.MoveWithOnOff(nullptr, nullptr, moveMode, rate).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_LevelControl_Step(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
-                                                                      chip::GroupId, uint8_t stepMode, uint8_t stepSize,
-                                                                      uint16_t transitionTime, uint8_t optionMask,
-                                                                      uint8_t optionOverride)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::LevelControlCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.Step(nullptr, nullptr, stepMode, stepSize, transitionTime, optionMask, optionOverride).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_LevelControl_StepWithOnOff(chip::DeviceProxy * device,
-                                                                               chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                               uint8_t stepMode, uint8_t stepSize,
-                                                                               uint16_t transitionTime)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::LevelControlCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.StepWithOnOff(nullptr, nullptr, stepMode, stepSize, transitionTime).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_LevelControl_Stop(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
-                                                                      chip::GroupId, uint8_t optionMask, uint8_t optionOverride)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::LevelControlCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.Stop(nullptr, nullptr, optionMask, optionOverride).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_LevelControl_StopWithOnOff(chip::DeviceProxy * device,
-                                                                               chip::EndpointId ZCLendpointId, chip::GroupId)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::LevelControlCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.StopWithOnOff(nullptr, nullptr).AsInteger();
-}
 
 chip::ChipError::StorageType chip_ime_ReadAttribute_LevelControl_CurrentLevel(chip::DeviceProxy * device,
                                                                               chip::EndpointId ZCLendpointId,
@@ -5320,15 +4188,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_LevelControl_Options(chip::D
     return cluster.ReadAttributeOptions(gInt8uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_LevelControl_Options(chip::DeviceProxy * device,
-                                                                          chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                          uint8_t value)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::LevelControlCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.WriteAttributeOptions(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), value).AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_LevelControl_OnOffTransitionTime(chip::DeviceProxy * device,
                                                                                      chip::EndpointId ZCLendpointId,
                                                                                      chip::GroupId /* ZCLgroupId */)
@@ -5340,16 +4199,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_LevelControl_OnOffTransition
         .AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_LevelControl_OnOffTransitionTime(chip::DeviceProxy * device,
-                                                                                      chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                                      uint16_t value)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::LevelControlCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.WriteAttributeOnOffTransitionTime(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), value)
-        .AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_LevelControl_OnLevel(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
                                                                          chip::GroupId /* ZCLgroupId */)
 {
@@ -5359,15 +4208,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_LevelControl_OnLevel(chip::D
     return cluster.ReadAttributeOnLevel(gInt8uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_LevelControl_OnLevel(chip::DeviceProxy * device,
-                                                                          chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                          uint8_t value)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::LevelControlCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.WriteAttributeOnLevel(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), value).AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_LevelControl_OnTransitionTime(chip::DeviceProxy * device,
                                                                                   chip::EndpointId ZCLendpointId,
                                                                                   chip::GroupId /* ZCLgroupId */)
@@ -5378,16 +4218,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_LevelControl_OnTransitionTim
     return cluster.ReadAttributeOnTransitionTime(gInt16uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_LevelControl_OnTransitionTime(chip::DeviceProxy * device,
-                                                                                   chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                                   uint16_t value)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::LevelControlCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.WriteAttributeOnTransitionTime(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), value)
-        .AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_LevelControl_OffTransitionTime(chip::DeviceProxy * device,
                                                                                    chip::EndpointId ZCLendpointId,
                                                                                    chip::GroupId /* ZCLgroupId */)
@@ -5398,16 +4228,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_LevelControl_OffTransitionTi
     return cluster.ReadAttributeOffTransitionTime(gInt16uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_LevelControl_OffTransitionTime(chip::DeviceProxy * device,
-                                                                                    chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                                    uint16_t value)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::LevelControlCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.WriteAttributeOffTransitionTime(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), value)
-        .AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_LevelControl_DefaultMoveRate(chip::DeviceProxy * device,
                                                                                  chip::EndpointId ZCLendpointId,
                                                                                  chip::GroupId /* ZCLgroupId */)
@@ -5418,16 +4238,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_LevelControl_DefaultMoveRate
     return cluster.ReadAttributeDefaultMoveRate(gInt8uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_LevelControl_DefaultMoveRate(chip::DeviceProxy * device,
-                                                                                  chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                                  uint8_t value)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::LevelControlCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.WriteAttributeDefaultMoveRate(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), value)
-        .AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_LevelControl_StartUpCurrentLevel(chip::DeviceProxy * device,
                                                                                      chip::EndpointId ZCLendpointId,
                                                                                      chip::GroupId /* ZCLgroupId */)
@@ -5438,16 +4248,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_LevelControl_StartUpCurrentL
     return cluster.ReadAttributeStartUpCurrentLevel(gInt8uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_LevelControl_StartUpCurrentLevel(chip::DeviceProxy * device,
-                                                                                      chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                                      uint8_t value)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::LevelControlCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.WriteAttributeStartUpCurrentLevel(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), value)
-        .AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_LevelControl_ClusterRevision(chip::DeviceProxy * device,
                                                                                  chip::EndpointId ZCLendpointId,
                                                                                  chip::GroupId /* ZCLgroupId */)
@@ -5461,15 +4261,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_LevelControl_ClusterRevision
 // End of Cluster LevelControl
 // Cluster LowPower
 
-chip::ChipError::StorageType chip_ime_AppendCommand_LowPower_Sleep(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
-                                                                   chip::GroupId)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::LowPowerCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.Sleep(nullptr, nullptr).AsInteger();
-}
-
 chip::ChipError::StorageType chip_ime_ReadAttribute_LowPower_ClusterRevision(chip::DeviceProxy * device,
                                                                              chip::EndpointId ZCLendpointId,
                                                                              chip::GroupId /* ZCLgroupId */)
@@ -5482,41 +4273,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_LowPower_ClusterRevision(chi
 
 // End of Cluster LowPower
 // Cluster MediaInput
-
-chip::ChipError::StorageType chip_ime_AppendCommand_MediaInput_HideInputStatus(chip::DeviceProxy * device,
-                                                                               chip::EndpointId ZCLendpointId, chip::GroupId)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::MediaInputCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.HideInputStatus(nullptr, nullptr).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_MediaInput_RenameInput(chip::DeviceProxy * device,
-                                                                           chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                           uint8_t index, const uint8_t * name, uint32_t name_Len)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::MediaInputCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.RenameInput(nullptr, nullptr, index, chip::CharSpan(reinterpret_cast<const char *>(name), name_Len)).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_MediaInput_SelectInput(chip::DeviceProxy * device,
-                                                                           chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                           uint8_t index)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::MediaInputCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.SelectInput(nullptr, nullptr, index).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_MediaInput_ShowInputStatus(chip::DeviceProxy * device,
-                                                                               chip::EndpointId ZCLendpointId, chip::GroupId)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::MediaInputCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.ShowInputStatus(nullptr, nullptr).AsInteger();
-}
 
 chip::ChipError::StorageType chip_ime_ReadAttribute_MediaInput_MediaInputList(chip::DeviceProxy * device,
                                                                               chip::EndpointId ZCLendpointId,
@@ -5552,98 +4308,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_MediaInput_ClusterRevision(c
 
 // End of Cluster MediaInput
 // Cluster MediaPlayback
-
-chip::ChipError::StorageType chip_ime_AppendCommand_MediaPlayback_MediaFastForward(chip::DeviceProxy * device,
-                                                                                   chip::EndpointId ZCLendpointId, chip::GroupId)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::MediaPlaybackCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.MediaFastForward(nullptr, nullptr).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_MediaPlayback_MediaNext(chip::DeviceProxy * device,
-                                                                            chip::EndpointId ZCLendpointId, chip::GroupId)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::MediaPlaybackCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.MediaNext(nullptr, nullptr).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_MediaPlayback_MediaPause(chip::DeviceProxy * device,
-                                                                             chip::EndpointId ZCLendpointId, chip::GroupId)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::MediaPlaybackCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.MediaPause(nullptr, nullptr).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_MediaPlayback_MediaPlay(chip::DeviceProxy * device,
-                                                                            chip::EndpointId ZCLendpointId, chip::GroupId)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::MediaPlaybackCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.MediaPlay(nullptr, nullptr).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_MediaPlayback_MediaPrevious(chip::DeviceProxy * device,
-                                                                                chip::EndpointId ZCLendpointId, chip::GroupId)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::MediaPlaybackCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.MediaPrevious(nullptr, nullptr).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_MediaPlayback_MediaRewind(chip::DeviceProxy * device,
-                                                                              chip::EndpointId ZCLendpointId, chip::GroupId)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::MediaPlaybackCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.MediaRewind(nullptr, nullptr).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_MediaPlayback_MediaSeek(chip::DeviceProxy * device,
-                                                                            chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                            uint64_t position)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::MediaPlaybackCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.MediaSeek(nullptr, nullptr, position).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_MediaPlayback_MediaSkipBackward(chip::DeviceProxy * device,
-                                                                                    chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                                    uint64_t deltaPositionMilliseconds)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::MediaPlaybackCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.MediaSkipBackward(nullptr, nullptr, deltaPositionMilliseconds).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_MediaPlayback_MediaSkipForward(chip::DeviceProxy * device,
-                                                                                   chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                                   uint64_t deltaPositionMilliseconds)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::MediaPlaybackCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.MediaSkipForward(nullptr, nullptr, deltaPositionMilliseconds).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_MediaPlayback_MediaStartOver(chip::DeviceProxy * device,
-                                                                                 chip::EndpointId ZCLendpointId, chip::GroupId)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::MediaPlaybackCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.MediaStartOver(nullptr, nullptr).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_MediaPlayback_MediaStop(chip::DeviceProxy * device,
-                                                                            chip::EndpointId ZCLendpointId, chip::GroupId)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::MediaPlaybackCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.MediaStop(nullptr, nullptr).AsInteger();
-}
 
 chip::ChipError::StorageType chip_ime_ReadAttribute_MediaPlayback_PlaybackState(chip::DeviceProxy * device,
                                                                                 chip::EndpointId ZCLendpointId,
@@ -5738,16 +4402,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_MediaPlayback_ClusterRevisio
 // End of Cluster MediaPlayback
 // Cluster ModeSelect
 
-chip::ChipError::StorageType chip_ime_AppendCommand_ModeSelect_ChangeToMode(chip::DeviceProxy * device,
-                                                                            chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                            uint8_t newMode)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::ModeSelectCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.ChangeToMode(nullptr, nullptr, newMode).AsInteger();
-}
-
 chip::ChipError::StorageType chip_ime_ReadAttribute_ModeSelect_CurrentMode(chip::DeviceProxy * device,
                                                                            chip::EndpointId ZCLendpointId,
                                                                            chip::GroupId /* ZCLgroupId */)
@@ -5791,14 +4445,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_ModeSelect_OnMode(chip::Devi
     return cluster.ReadAttributeOnMode(gInt8uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_ModeSelect_OnMode(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
-                                                                       chip::GroupId, uint8_t value)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::ModeSelectCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.WriteAttributeOnMode(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), value).AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_ModeSelect_StartUpMode(chip::DeviceProxy * device,
                                                                            chip::EndpointId ZCLendpointId,
                                                                            chip::GroupId /* ZCLgroupId */)
@@ -5832,96 +4478,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_ModeSelect_ClusterRevision(c
 // End of Cluster ModeSelect
 // Cluster NetworkCommissioning
 
-chip::ChipError::StorageType chip_ime_AppendCommand_NetworkCommissioning_AddThreadNetwork(
-    chip::DeviceProxy * device, chip::EndpointId ZCLendpointId, chip::GroupId, const uint8_t * operationalDataset,
-    uint32_t operationalDataset_Len, uint64_t breadcrumb, uint32_t timeoutMs)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::NetworkCommissioningCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster
-        .AddThreadNetwork(nullptr, nullptr, chip::ByteSpan(operationalDataset, operationalDataset_Len), breadcrumb, timeoutMs)
-        .AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_NetworkCommissioning_AddWiFiNetwork(
-    chip::DeviceProxy * device, chip::EndpointId ZCLendpointId, chip::GroupId, const uint8_t * ssid, uint32_t ssid_Len,
-    const uint8_t * credentials, uint32_t credentials_Len, uint64_t breadcrumb, uint32_t timeoutMs)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::NetworkCommissioningCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster
-        .AddWiFiNetwork(nullptr, nullptr, chip::ByteSpan(ssid, ssid_Len), chip::ByteSpan(credentials, credentials_Len), breadcrumb,
-                        timeoutMs)
-        .AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_NetworkCommissioning_DisableNetwork(chip::DeviceProxy * device,
-                                                                                        chip::EndpointId ZCLendpointId,
-                                                                                        chip::GroupId, const uint8_t * networkID,
-                                                                                        uint32_t networkID_Len, uint64_t breadcrumb,
-                                                                                        uint32_t timeoutMs)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::NetworkCommissioningCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.DisableNetwork(nullptr, nullptr, chip::ByteSpan(networkID, networkID_Len), breadcrumb, timeoutMs).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_NetworkCommissioning_EnableNetwork(chip::DeviceProxy * device,
-                                                                                       chip::EndpointId ZCLendpointId,
-                                                                                       chip::GroupId, const uint8_t * networkID,
-                                                                                       uint32_t networkID_Len, uint64_t breadcrumb,
-                                                                                       uint32_t timeoutMs)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::NetworkCommissioningCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.EnableNetwork(nullptr, nullptr, chip::ByteSpan(networkID, networkID_Len), breadcrumb, timeoutMs).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_NetworkCommissioning_RemoveNetwork(chip::DeviceProxy * device,
-                                                                                       chip::EndpointId ZCLendpointId,
-                                                                                       chip::GroupId, const uint8_t * networkID,
-                                                                                       uint32_t networkID_Len, uint64_t breadcrumb,
-                                                                                       uint32_t timeoutMs)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::NetworkCommissioningCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.RemoveNetwork(nullptr, nullptr, chip::ByteSpan(networkID, networkID_Len), breadcrumb, timeoutMs).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_NetworkCommissioning_ScanNetworks(chip::DeviceProxy * device,
-                                                                                      chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                                      const uint8_t * ssid, uint32_t ssid_Len,
-                                                                                      uint64_t breadcrumb, uint32_t timeoutMs)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::NetworkCommissioningCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.ScanNetworks(nullptr, nullptr, chip::ByteSpan(ssid, ssid_Len), breadcrumb, timeoutMs).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_NetworkCommissioning_UpdateThreadNetwork(
-    chip::DeviceProxy * device, chip::EndpointId ZCLendpointId, chip::GroupId, const uint8_t * operationalDataset,
-    uint32_t operationalDataset_Len, uint64_t breadcrumb, uint32_t timeoutMs)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::NetworkCommissioningCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster
-        .UpdateThreadNetwork(nullptr, nullptr, chip::ByteSpan(operationalDataset, operationalDataset_Len), breadcrumb, timeoutMs)
-        .AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_NetworkCommissioning_UpdateWiFiNetwork(
-    chip::DeviceProxy * device, chip::EndpointId ZCLendpointId, chip::GroupId, const uint8_t * ssid, uint32_t ssid_Len,
-    const uint8_t * credentials, uint32_t credentials_Len, uint64_t breadcrumb, uint32_t timeoutMs)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::NetworkCommissioningCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster
-        .UpdateWiFiNetwork(nullptr, nullptr, chip::ByteSpan(ssid, ssid_Len), chip::ByteSpan(credentials, credentials_Len),
-                           breadcrumb, timeoutMs)
-        .AsInteger();
-}
-
 chip::ChipError::StorageType chip_ime_ReadAttribute_NetworkCommissioning_FeatureMap(chip::DeviceProxy * device,
                                                                                     chip::EndpointId ZCLendpointId,
                                                                                     chip::GroupId /* ZCLgroupId */)
@@ -5945,41 +4501,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_NetworkCommissioning_Cluster
 // End of Cluster NetworkCommissioning
 // Cluster OtaSoftwareUpdateProvider
 
-chip::ChipError::StorageType
-chip_ime_AppendCommand_OtaSoftwareUpdateProvider_ApplyUpdateRequest(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
-                                                                    chip::GroupId, const uint8_t * updateToken,
-                                                                    uint32_t updateToken_Len, uint32_t newVersion)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::OtaSoftwareUpdateProviderCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.ApplyUpdateRequest(nullptr, nullptr, chip::ByteSpan(updateToken, updateToken_Len), newVersion).AsInteger();
-}
-chip::ChipError::StorageType
-chip_ime_AppendCommand_OtaSoftwareUpdateProvider_NotifyUpdateApplied(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
-                                                                     chip::GroupId, const uint8_t * updateToken,
-                                                                     uint32_t updateToken_Len, uint32_t softwareVersion)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::OtaSoftwareUpdateProviderCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.NotifyUpdateApplied(nullptr, nullptr, chip::ByteSpan(updateToken, updateToken_Len), softwareVersion).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_OtaSoftwareUpdateProvider_QueryImage(
-    chip::DeviceProxy * device, chip::EndpointId ZCLendpointId, chip::GroupId, chip::VendorId vendorId, uint16_t productId,
-    uint32_t softwareVersion, uint8_t protocolsSupported, uint16_t hardwareVersion, const uint8_t * location, uint32_t location_Len,
-    bool requestorCanConsent, const uint8_t * metadataForProvider, uint32_t metadataForProvider_Len)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::OtaSoftwareUpdateProviderCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster
-        .QueryImage(nullptr, nullptr, vendorId, productId, softwareVersion, protocolsSupported, hardwareVersion,
-                    chip::CharSpan(reinterpret_cast<const char *>(location), location_Len), requestorCanConsent,
-                    chip::ByteSpan(metadataForProvider, metadataForProvider_Len))
-        .AsInteger();
-}
-
 chip::ChipError::StorageType chip_ime_ReadAttribute_OtaSoftwareUpdateProvider_ClusterRevision(chip::DeviceProxy * device,
                                                                                               chip::EndpointId ZCLendpointId,
                                                                                               chip::GroupId /* ZCLgroupId */)
@@ -5993,19 +4514,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_OtaSoftwareUpdateProvider_Cl
 // End of Cluster OtaSoftwareUpdateProvider
 // Cluster OtaSoftwareUpdateRequestor
 
-chip::ChipError::StorageType chip_ime_AppendCommand_OtaSoftwareUpdateRequestor_AnnounceOtaProvider(
-    chip::DeviceProxy * device, chip::EndpointId ZCLendpointId, chip::GroupId, chip::NodeId providerLocation,
-    chip::VendorId vendorId, uint8_t announcementReason, const uint8_t * metadataForNode, uint32_t metadataForNode_Len)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::OtaSoftwareUpdateRequestorCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster
-        .AnnounceOtaProvider(nullptr, nullptr, providerLocation, vendorId, announcementReason,
-                             chip::ByteSpan(metadataForNode, metadataForNode_Len))
-        .AsInteger();
-}
-
 chip::ChipError::StorageType chip_ime_ReadAttribute_OtaSoftwareUpdateRequestor_DefaultOtaProvider(chip::DeviceProxy * device,
                                                                                                   chip::EndpointId ZCLendpointId,
                                                                                                   chip::GroupId /* ZCLgroupId */)
@@ -6017,19 +4525,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_OtaSoftwareUpdateRequestor_D
         .AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_OtaSoftwareUpdateRequestor_DefaultOtaProvider(chip::DeviceProxy * device,
-                                                                                                   chip::EndpointId ZCLendpointId,
-                                                                                                   chip::GroupId, uint8_t * value,
-                                                                                                   size_t len)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::OtaSoftwareUpdateRequestorCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster
-        .WriteAttributeDefaultOtaProvider(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(),
-                                          chip::ByteSpan(value, len))
-        .AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_OtaSoftwareUpdateRequestor_UpdatePossible(chip::DeviceProxy * device,
                                                                                               chip::EndpointId ZCLendpointId,
                                                                                               chip::GroupId /* ZCLgroupId */)
@@ -6109,56 +4604,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_OccupancySensing_ClusterRevi
 // End of Cluster OccupancySensing
 // Cluster OnOff
 
-chip::ChipError::StorageType chip_ime_AppendCommand_OnOff_Off(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
-                                                              chip::GroupId)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::OnOffCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.Off(nullptr, nullptr).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_OnOff_OffWithEffect(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
-                                                                        chip::GroupId, uint8_t effectId, uint8_t effectVariant)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::OnOffCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.OffWithEffect(nullptr, nullptr, effectId, effectVariant).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_OnOff_On(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
-                                                             chip::GroupId)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::OnOffCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.On(nullptr, nullptr).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_OnOff_OnWithRecallGlobalScene(chip::DeviceProxy * device,
-                                                                                  chip::EndpointId ZCLendpointId, chip::GroupId)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::OnOffCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.OnWithRecallGlobalScene(nullptr, nullptr).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_OnOff_OnWithTimedOff(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
-                                                                         chip::GroupId, uint8_t onOffControl, uint16_t onTime,
-                                                                         uint16_t offWaitTime)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::OnOffCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.OnWithTimedOff(nullptr, nullptr, onOffControl, onTime, offWaitTime).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_OnOff_Toggle(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
-                                                                 chip::GroupId)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::OnOffCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.Toggle(nullptr, nullptr).AsInteger();
-}
-
 chip::ChipError::StorageType chip_ime_ReadAttribute_OnOff_OnOff(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
                                                                 chip::GroupId /* ZCLgroupId */)
 {
@@ -6199,14 +4644,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_OnOff_OnTime(chip::DevicePro
     return cluster.ReadAttributeOnTime(gInt16uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_OnOff_OnTime(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
-                                                                  chip::GroupId, uint16_t value)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::OnOffCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.WriteAttributeOnTime(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), value).AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_OnOff_OffWaitTime(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
                                                                       chip::GroupId /* ZCLgroupId */)
 {
@@ -6216,14 +4653,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_OnOff_OffWaitTime(chip::Devi
     return cluster.ReadAttributeOffWaitTime(gInt16uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_OnOff_OffWaitTime(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
-                                                                       chip::GroupId, uint16_t value)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::OnOffCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.WriteAttributeOffWaitTime(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), value).AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_OnOff_StartUpOnOff(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
                                                                        chip::GroupId /* ZCLgroupId */)
 {
@@ -6233,15 +4662,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_OnOff_StartUpOnOff(chip::Dev
     return cluster.ReadAttributeStartUpOnOff(gInt8uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_OnOff_StartUpOnOff(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
-                                                                        chip::GroupId, uint8_t value)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::OnOffCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.WriteAttributeStartUpOnOff(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), value)
-        .AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_OnOff_FeatureMap(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
                                                                      chip::GroupId /* ZCLgroupId */)
 {
@@ -6284,16 +4704,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_OnOffSwitchConfiguration_Swi
     return cluster.ReadAttributeSwitchActions(gInt8uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_OnOffSwitchConfiguration_SwitchActions(chip::DeviceProxy * device,
-                                                                                            chip::EndpointId ZCLendpointId,
-                                                                                            chip::GroupId, uint8_t value)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::OnOffSwitchConfigurationCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.WriteAttributeSwitchActions(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), value)
-        .AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_OnOffSwitchConfiguration_ClusterRevision(chip::DeviceProxy * device,
                                                                                              chip::EndpointId ZCLendpointId,
                                                                                              chip::GroupId /* ZCLgroupId */)
@@ -6306,103 +4716,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_OnOffSwitchConfiguration_Clu
 
 // End of Cluster OnOffSwitchConfiguration
 // Cluster OperationalCredentials
-
-chip::ChipError::StorageType
-chip_ime_AppendCommand_OperationalCredentials_AddNOC(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                     const uint8_t * NOCValue, uint32_t NOCValue_Len, const uint8_t * ICACValue,
-                                                     uint32_t ICACValue_Len, const uint8_t * IPKValue, uint32_t IPKValue_Len,
-                                                     chip::NodeId caseAdminNode, uint16_t adminVendorId)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::OperationalCredentialsCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster
-        .AddNOC(nullptr, nullptr, chip::ByteSpan(NOCValue, NOCValue_Len), chip::ByteSpan(ICACValue, ICACValue_Len),
-                chip::ByteSpan(IPKValue, IPKValue_Len), caseAdminNode, adminVendorId)
-        .AsInteger();
-}
-chip::ChipError::StorageType
-chip_ime_AppendCommand_OperationalCredentials_AddTrustedRootCertificate(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
-                                                                        chip::GroupId, const uint8_t * rootCertificate,
-                                                                        uint32_t rootCertificate_Len)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::OperationalCredentialsCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.AddTrustedRootCertificate(nullptr, nullptr, chip::ByteSpan(rootCertificate, rootCertificate_Len)).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_OperationalCredentials_AttestationRequest(chip::DeviceProxy * device,
-                                                                                              chip::EndpointId ZCLendpointId,
-                                                                                              chip::GroupId,
-                                                                                              const uint8_t * attestationNonce,
-                                                                                              uint32_t attestationNonce_Len)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::OperationalCredentialsCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.AttestationRequest(nullptr, nullptr, chip::ByteSpan(attestationNonce, attestationNonce_Len)).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_OperationalCredentials_CertificateChainRequest(chip::DeviceProxy * device,
-                                                                                                   chip::EndpointId ZCLendpointId,
-                                                                                                   chip::GroupId,
-                                                                                                   uint8_t certificateType)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::OperationalCredentialsCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.CertificateChainRequest(nullptr, nullptr, certificateType).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_OperationalCredentials_OpCSRRequest(chip::DeviceProxy * device,
-                                                                                        chip::EndpointId ZCLendpointId,
-                                                                                        chip::GroupId, const uint8_t * CSRNonce,
-                                                                                        uint32_t CSRNonce_Len)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::OperationalCredentialsCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.OpCSRRequest(nullptr, nullptr, chip::ByteSpan(CSRNonce, CSRNonce_Len)).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_OperationalCredentials_RemoveFabric(chip::DeviceProxy * device,
-                                                                                        chip::EndpointId ZCLendpointId,
-                                                                                        chip::GroupId, uint8_t fabricIndex)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::OperationalCredentialsCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.RemoveFabric(nullptr, nullptr, fabricIndex).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_OperationalCredentials_RemoveTrustedRootCertificate(
-    chip::DeviceProxy * device, chip::EndpointId ZCLendpointId, chip::GroupId, const uint8_t * trustedRootIdentifier,
-    uint32_t trustedRootIdentifier_Len)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::OperationalCredentialsCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.RemoveTrustedRootCertificate(nullptr, nullptr, chip::ByteSpan(trustedRootIdentifier, trustedRootIdentifier_Len))
-        .AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_OperationalCredentials_UpdateFabricLabel(chip::DeviceProxy * device,
-                                                                                             chip::EndpointId ZCLendpointId,
-                                                                                             chip::GroupId, const uint8_t * label,
-                                                                                             uint32_t label_Len)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::OperationalCredentialsCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.UpdateFabricLabel(nullptr, nullptr, chip::CharSpan(reinterpret_cast<const char *>(label), label_Len))
-        .AsInteger();
-}
-chip::ChipError::StorageType
-chip_ime_AppendCommand_OperationalCredentials_UpdateNOC(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                        const uint8_t * NOCValue, uint32_t NOCValue_Len, const uint8_t * ICACValue,
-                                                        uint32_t ICACValue_Len)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::OperationalCredentialsCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.UpdateNOC(nullptr, nullptr, chip::ByteSpan(NOCValue, NOCValue_Len), chip::ByteSpan(ICACValue, ICACValue_Len))
-        .AsInteger();
-}
 
 chip::ChipError::StorageType chip_ime_ReadAttribute_OperationalCredentials_FabricsList(chip::DeviceProxy * device,
                                                                                        chip::EndpointId ZCLendpointId,
@@ -6873,16 +5186,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_PumpConfigurationAndControl_
     return cluster.ReadAttributeOperationMode(gInt8uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_PumpConfigurationAndControl_OperationMode(chip::DeviceProxy * device,
-                                                                                               chip::EndpointId ZCLendpointId,
-                                                                                               chip::GroupId, uint8_t value)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::PumpConfigurationAndControlCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.WriteAttributeOperationMode(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), value)
-        .AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_PumpConfigurationAndControl_ControlMode(chip::DeviceProxy * device,
                                                                                             chip::EndpointId ZCLendpointId,
                                                                                             chip::GroupId /* ZCLgroupId */)
@@ -6893,15 +5196,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_PumpConfigurationAndControl_
     return cluster.ReadAttributeControlMode(gInt8uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_PumpConfigurationAndControl_ControlMode(chip::DeviceProxy * device,
-                                                                                             chip::EndpointId ZCLendpointId,
-                                                                                             chip::GroupId, uint8_t value)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::PumpConfigurationAndControlCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.WriteAttributeControlMode(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), value).AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_PumpConfigurationAndControl_AlarmMask(chip::DeviceProxy * device,
                                                                                           chip::EndpointId ZCLendpointId,
                                                                                           chip::GroupId /* ZCLgroupId */)
@@ -7015,72 +5309,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_RelativeHumidityMeasurement_
 // End of Cluster RelativeHumidityMeasurement
 // Cluster Scenes
 
-chip::ChipError::StorageType chip_ime_AppendCommand_Scenes_AddScene(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
-                                                                    chip::GroupId, uint16_t groupId, uint8_t sceneId,
-                                                                    uint16_t transitionTime, const uint8_t * sceneName,
-                                                                    uint32_t sceneName_Len, chip::ClusterId clusterId,
-                                                                    uint8_t length, uint8_t value)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::ScenesCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster
-        .AddScene(nullptr, nullptr, groupId, sceneId, transitionTime,
-                  chip::CharSpan(reinterpret_cast<const char *>(sceneName), sceneName_Len), clusterId, length, value)
-        .AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_Scenes_GetSceneMembership(chip::DeviceProxy * device,
-                                                                              chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                              uint16_t groupId)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::ScenesCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.GetSceneMembership(nullptr, nullptr, groupId).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_Scenes_RecallScene(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
-                                                                       chip::GroupId, uint16_t groupId, uint8_t sceneId,
-                                                                       uint16_t transitionTime)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::ScenesCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.RecallScene(nullptr, nullptr, groupId, sceneId, transitionTime).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_Scenes_RemoveAllScenes(chip::DeviceProxy * device,
-                                                                           chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                           uint16_t groupId)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::ScenesCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.RemoveAllScenes(nullptr, nullptr, groupId).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_Scenes_RemoveScene(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
-                                                                       chip::GroupId, uint16_t groupId, uint8_t sceneId)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::ScenesCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.RemoveScene(nullptr, nullptr, groupId, sceneId).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_Scenes_StoreScene(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
-                                                                      chip::GroupId, uint16_t groupId, uint8_t sceneId)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::ScenesCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.StoreScene(nullptr, nullptr, groupId, sceneId).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_Scenes_ViewScene(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
-                                                                     chip::GroupId, uint16_t groupId, uint8_t sceneId)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::ScenesCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.ViewScene(nullptr, nullptr, groupId, sceneId).AsInteger();
-}
-
 chip::ChipError::StorageType chip_ime_ReadAttribute_Scenes_SceneCount(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
                                                                       chip::GroupId /* ZCLgroupId */)
 {
@@ -7138,16 +5366,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_Scenes_ClusterRevision(chip:
 
 // End of Cluster Scenes
 // Cluster SoftwareDiagnostics
-
-chip::ChipError::StorageType chip_ime_AppendCommand_SoftwareDiagnostics_ResetWatermarks(chip::DeviceProxy * device,
-                                                                                        chip::EndpointId ZCLendpointId,
-                                                                                        chip::GroupId)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::SoftwareDiagnosticsCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.ResetWatermarks(nullptr, nullptr).AsInteger();
-}
 
 chip::ChipError::StorageType chip_ime_ReadAttribute_SoftwareDiagnostics_ThreadMetrics(chip::DeviceProxy * device,
                                                                                       chip::EndpointId ZCLendpointId,
@@ -7270,34 +5488,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_Switch_ClusterRevision(chip:
 // End of Cluster Switch
 // Cluster TvChannel
 
-chip::ChipError::StorageType chip_ime_AppendCommand_TvChannel_ChangeChannel(chip::DeviceProxy * device,
-                                                                            chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                            const uint8_t * match, uint32_t match_Len)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::TvChannelCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.ChangeChannel(nullptr, nullptr, chip::CharSpan(reinterpret_cast<const char *>(match), match_Len)).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_TvChannel_ChangeChannelByNumber(chip::DeviceProxy * device,
-                                                                                    chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                                    uint16_t majorNumber, uint16_t minorNumber)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::TvChannelCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.ChangeChannelByNumber(nullptr, nullptr, majorNumber, minorNumber).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_TvChannel_SkipChannel(chip::DeviceProxy * device,
-                                                                          chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                          uint16_t count)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::TvChannelCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.SkipChannel(nullptr, nullptr, count).AsInteger();
-}
-
 chip::ChipError::StorageType chip_ime_ReadAttribute_TvChannel_TvChannelList(chip::DeviceProxy * device,
                                                                             chip::EndpointId ZCLendpointId,
                                                                             chip::GroupId /* ZCLgroupId */)
@@ -7344,18 +5534,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_TvChannel_ClusterRevision(ch
 
 // End of Cluster TvChannel
 // Cluster TargetNavigator
-
-chip::ChipError::StorageType chip_ime_AppendCommand_TargetNavigator_NavigateTarget(chip::DeviceProxy * device,
-                                                                                   chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                                   uint8_t target, const uint8_t * data,
-                                                                                   uint32_t data_Len)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::TargetNavigatorCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.NavigateTarget(nullptr, nullptr, target, chip::CharSpan(reinterpret_cast<const char *>(data), data_Len))
-        .AsInteger();
-}
 
 chip::ChipError::StorageType chip_ime_ReadAttribute_TargetNavigator_TargetNavigatorList(chip::DeviceProxy * device,
                                                                                         chip::EndpointId ZCLendpointId,
@@ -7463,110 +5641,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_TemperatureMeasurement_Clust
 // End of Cluster TemperatureMeasurement
 // Cluster TestCluster
 
-chip::ChipError::StorageType chip_ime_AppendCommand_TestCluster_Test(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
-                                                                     chip::GroupId)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::TestClusterCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.Test(nullptr, nullptr).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_TestCluster_TestAddArguments(chip::DeviceProxy * device,
-                                                                                 chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                                 uint8_t arg1, uint8_t arg2)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::TestClusterCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.TestAddArguments(nullptr, nullptr, arg1, arg2).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_TestCluster_TestEnumsRequest(chip::DeviceProxy * device,
-                                                                                 chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                                 chip::VendorId arg1, uint8_t arg2)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::TestClusterCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.TestEnumsRequest(nullptr, nullptr, arg1, arg2).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_TestCluster_TestListInt8UArgumentRequest(chip::DeviceProxy * device,
-                                                                                             chip::EndpointId ZCLendpointId,
-                                                                                             chip::GroupId, uint8_t arg1)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::TestClusterCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.TestListInt8UArgumentRequest(nullptr, nullptr, arg1).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_TestCluster_TestListInt8UReverseRequest(chip::DeviceProxy * device,
-                                                                                            chip::EndpointId ZCLendpointId,
-                                                                                            chip::GroupId, uint8_t arg1)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::TestClusterCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.TestListInt8UReverseRequest(nullptr, nullptr, arg1).AsInteger();
-}
-chip::ChipError::StorageType
-chip_ime_AppendCommand_TestCluster_TestListStructArgumentRequest(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
-                                                                 chip::GroupId, uint8_t a, bool b, uint8_t c, const uint8_t * d,
-                                                                 uint32_t d_Len, const uint8_t * e, uint32_t e_Len, uint8_t f)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::TestClusterCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster
-        .TestListStructArgumentRequest(nullptr, nullptr, a, b, c, chip::ByteSpan(d, d_Len),
-                                       chip::CharSpan(reinterpret_cast<const char *>(e), e_Len), f)
-        .AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_TestCluster_TestNotHandled(chip::DeviceProxy * device,
-                                                                               chip::EndpointId ZCLendpointId, chip::GroupId)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::TestClusterCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.TestNotHandled(nullptr, nullptr).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_TestCluster_TestNullableOptionalRequest(chip::DeviceProxy * device,
-                                                                                            chip::EndpointId ZCLendpointId,
-                                                                                            chip::GroupId, uint8_t arg1)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::TestClusterCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.TestNullableOptionalRequest(nullptr, nullptr, arg1).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_TestCluster_TestSpecific(chip::DeviceProxy * device,
-                                                                             chip::EndpointId ZCLendpointId, chip::GroupId)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::TestClusterCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.TestSpecific(nullptr, nullptr).AsInteger();
-}
-chip::ChipError::StorageType
-chip_ime_AppendCommand_TestCluster_TestStructArgumentRequest(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
-                                                             chip::GroupId, uint8_t a, bool b, uint8_t c, const uint8_t * d,
-                                                             uint32_t d_Len, const uint8_t * e, uint32_t e_Len, uint8_t f)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::TestClusterCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster
-        .TestStructArgumentRequest(nullptr, nullptr, a, b, c, chip::ByteSpan(d, d_Len),
-                                   chip::CharSpan(reinterpret_cast<const char *>(e), e_Len), f)
-        .AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_TestCluster_TestUnknownCommand(chip::DeviceProxy * device,
-                                                                                   chip::EndpointId ZCLendpointId, chip::GroupId)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::TestClusterCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.TestUnknownCommand(nullptr, nullptr).AsInteger();
-}
-
 chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_Boolean(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
                                                                         chip::GroupId /* ZCLgroupId */)
 {
@@ -7576,14 +5650,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_Boolean(chip::De
     return cluster.ReadAttributeBoolean(gBooleanAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_TestCluster_Boolean(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
-                                                                         chip::GroupId, bool value)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::TestClusterCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.WriteAttributeBoolean(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), value).AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_Bitmap8(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
                                                                         chip::GroupId /* ZCLgroupId */)
 {
@@ -7593,14 +5659,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_Bitmap8(chip::De
     return cluster.ReadAttributeBitmap8(gInt8uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_TestCluster_Bitmap8(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
-                                                                         chip::GroupId, uint8_t value)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::TestClusterCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.WriteAttributeBitmap8(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), value).AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_Bitmap16(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
                                                                          chip::GroupId /* ZCLgroupId */)
 {
@@ -7610,15 +5668,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_Bitmap16(chip::D
     return cluster.ReadAttributeBitmap16(gInt16uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_TestCluster_Bitmap16(chip::DeviceProxy * device,
-                                                                          chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                          uint16_t value)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::TestClusterCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.WriteAttributeBitmap16(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), value).AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_Bitmap32(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
                                                                          chip::GroupId /* ZCLgroupId */)
 {
@@ -7628,15 +5677,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_Bitmap32(chip::D
     return cluster.ReadAttributeBitmap32(gInt32uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_TestCluster_Bitmap32(chip::DeviceProxy * device,
-                                                                          chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                          uint32_t value)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::TestClusterCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.WriteAttributeBitmap32(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), value).AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_Bitmap64(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
                                                                          chip::GroupId /* ZCLgroupId */)
 {
@@ -7646,15 +5686,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_Bitmap64(chip::D
     return cluster.ReadAttributeBitmap64(gInt64uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_TestCluster_Bitmap64(chip::DeviceProxy * device,
-                                                                          chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                          uint64_t value)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::TestClusterCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.WriteAttributeBitmap64(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), value).AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_Int8u(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
                                                                       chip::GroupId /* ZCLgroupId */)
 {
@@ -7664,14 +5695,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_Int8u(chip::Devi
     return cluster.ReadAttributeInt8u(gInt8uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_TestCluster_Int8u(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
-                                                                       chip::GroupId, uint8_t value)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::TestClusterCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.WriteAttributeInt8u(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), value).AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_Int16u(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
                                                                        chip::GroupId /* ZCLgroupId */)
 {
@@ -7681,14 +5704,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_Int16u(chip::Dev
     return cluster.ReadAttributeInt16u(gInt16uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_TestCluster_Int16u(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
-                                                                        chip::GroupId, uint16_t value)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::TestClusterCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.WriteAttributeInt16u(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), value).AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_Int32u(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
                                                                        chip::GroupId /* ZCLgroupId */)
 {
@@ -7698,14 +5713,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_Int32u(chip::Dev
     return cluster.ReadAttributeInt32u(gInt32uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_TestCluster_Int32u(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
-                                                                        chip::GroupId, uint32_t value)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::TestClusterCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.WriteAttributeInt32u(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), value).AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_Int64u(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
                                                                        chip::GroupId /* ZCLgroupId */)
 {
@@ -7715,14 +5722,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_Int64u(chip::Dev
     return cluster.ReadAttributeInt64u(gInt64uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_TestCluster_Int64u(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
-                                                                        chip::GroupId, uint64_t value)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::TestClusterCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.WriteAttributeInt64u(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), value).AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_Int8s(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
                                                                       chip::GroupId /* ZCLgroupId */)
 {
@@ -7732,14 +5731,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_Int8s(chip::Devi
     return cluster.ReadAttributeInt8s(gInt8sAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_TestCluster_Int8s(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
-                                                                       chip::GroupId, int8_t value)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::TestClusterCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.WriteAttributeInt8s(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), value).AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_Int16s(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
                                                                        chip::GroupId /* ZCLgroupId */)
 {
@@ -7749,14 +5740,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_Int16s(chip::Dev
     return cluster.ReadAttributeInt16s(gInt16sAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_TestCluster_Int16s(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
-                                                                        chip::GroupId, int16_t value)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::TestClusterCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.WriteAttributeInt16s(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), value).AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_Int32s(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
                                                                        chip::GroupId /* ZCLgroupId */)
 {
@@ -7766,14 +5749,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_Int32s(chip::Dev
     return cluster.ReadAttributeInt32s(gInt32sAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_TestCluster_Int32s(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
-                                                                        chip::GroupId, int32_t value)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::TestClusterCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.WriteAttributeInt32s(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), value).AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_Int64s(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
                                                                        chip::GroupId /* ZCLgroupId */)
 {
@@ -7783,14 +5758,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_Int64s(chip::Dev
     return cluster.ReadAttributeInt64s(gInt64sAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_TestCluster_Int64s(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
-                                                                        chip::GroupId, int64_t value)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::TestClusterCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.WriteAttributeInt64s(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), value).AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_Enum8(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
                                                                       chip::GroupId /* ZCLgroupId */)
 {
@@ -7800,14 +5767,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_Enum8(chip::Devi
     return cluster.ReadAttributeEnum8(gInt8uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_TestCluster_Enum8(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
-                                                                       chip::GroupId, uint8_t value)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::TestClusterCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.WriteAttributeEnum8(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), value).AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_Enum16(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
                                                                        chip::GroupId /* ZCLgroupId */)
 {
@@ -7817,14 +5776,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_Enum16(chip::Dev
     return cluster.ReadAttributeEnum16(gInt16uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_TestCluster_Enum16(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
-                                                                        chip::GroupId, uint16_t value)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::TestClusterCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.WriteAttributeEnum16(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), value).AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_OctetString(chip::DeviceProxy * device,
                                                                             chip::EndpointId ZCLendpointId,
                                                                             chip::GroupId /* ZCLgroupId */)
@@ -7835,17 +5786,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_OctetString(chip
     return cluster.ReadAttributeOctetString(gOctetStringAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_TestCluster_OctetString(chip::DeviceProxy * device,
-                                                                             chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                             uint8_t * value, size_t len)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::TestClusterCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster
-        .WriteAttributeOctetString(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), chip::ByteSpan(value, len))
-        .AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_ListInt8u(chip::DeviceProxy * device,
                                                                           chip::EndpointId ZCLendpointId,
                                                                           chip::GroupId /* ZCLgroupId */)
@@ -7893,18 +5833,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_LongOctetString(
         .AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_TestCluster_LongOctetString(chip::DeviceProxy * device,
-                                                                                 chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                                 uint8_t * value, size_t len)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::TestClusterCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster
-        .WriteAttributeLongOctetString(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(),
-                                       chip::ByteSpan(value, len))
-        .AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_CharString(chip::DeviceProxy * device,
                                                                            chip::EndpointId ZCLendpointId,
                                                                            chip::GroupId /* ZCLgroupId */)
@@ -7915,18 +5843,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_CharString(chip:
     return cluster.ReadAttributeCharString(gCharStringAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_TestCluster_CharString(chip::DeviceProxy * device,
-                                                                            chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                            uint8_t * value, size_t len)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::TestClusterCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster
-        .WriteAttributeCharString(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(),
-                                  chip::CharSpan(reinterpret_cast<const char *>(value), len))
-        .AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_LongCharString(chip::DeviceProxy * device,
                                                                                chip::EndpointId ZCLendpointId,
                                                                                chip::GroupId /* ZCLgroupId */)
@@ -7937,18 +5853,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_LongCharString(c
     return cluster.ReadAttributeLongCharString(gCharStringAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_TestCluster_LongCharString(chip::DeviceProxy * device,
-                                                                                chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                                uint8_t * value, size_t len)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::TestClusterCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster
-        .WriteAttributeLongCharString(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(),
-                                      chip::CharSpan(reinterpret_cast<const char *>(value), len))
-        .AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_EpochUs(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
                                                                         chip::GroupId /* ZCLgroupId */)
 {
@@ -7958,14 +5862,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_EpochUs(chip::De
     return cluster.ReadAttributeEpochUs(gInt64uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_TestCluster_EpochUs(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
-                                                                         chip::GroupId, uint64_t value)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::TestClusterCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.WriteAttributeEpochUs(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), value).AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_EpochS(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
                                                                        chip::GroupId /* ZCLgroupId */)
 {
@@ -7975,14 +5871,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_EpochS(chip::Dev
     return cluster.ReadAttributeEpochS(gInt32uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_TestCluster_EpochS(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
-                                                                        chip::GroupId, uint32_t value)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::TestClusterCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.WriteAttributeEpochS(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), value).AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_VendorId(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
                                                                          chip::GroupId /* ZCLgroupId */)
 {
@@ -7992,15 +5880,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_VendorId(chip::D
     return cluster.ReadAttributeVendorId(gInt16uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_TestCluster_VendorId(chip::DeviceProxy * device,
-                                                                          chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                          chip::VendorId value)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::TestClusterCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.WriteAttributeVendorId(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), value).AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_ListNullablesAndOptionalsStruct(chip::DeviceProxy * device,
                                                                                                 chip::EndpointId ZCLendpointId,
                                                                                                 chip::GroupId /* ZCLgroupId */)
@@ -8024,15 +5903,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_Unsupported(chip
     return cluster.ReadAttributeUnsupported(gBooleanAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_TestCluster_Unsupported(chip::DeviceProxy * device,
-                                                                             chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                             bool value)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::TestClusterCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.WriteAttributeUnsupported(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), value).AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_NullableBoolean(chip::DeviceProxy * device,
                                                                                 chip::EndpointId ZCLendpointId,
                                                                                 chip::GroupId /* ZCLgroupId */)
@@ -8043,16 +5913,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_NullableBoolean(
     return cluster.ReadAttributeNullableBoolean(gBooleanAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_TestCluster_NullableBoolean(chip::DeviceProxy * device,
-                                                                                 chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                                 bool value)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::TestClusterCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.WriteAttributeNullableBoolean(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), value)
-        .AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_NullableBitmap8(chip::DeviceProxy * device,
                                                                                 chip::EndpointId ZCLendpointId,
                                                                                 chip::GroupId /* ZCLgroupId */)
@@ -8063,16 +5923,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_NullableBitmap8(
     return cluster.ReadAttributeNullableBitmap8(gInt8uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_TestCluster_NullableBitmap8(chip::DeviceProxy * device,
-                                                                                 chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                                 uint8_t value)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::TestClusterCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.WriteAttributeNullableBitmap8(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), value)
-        .AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_NullableBitmap16(chip::DeviceProxy * device,
                                                                                  chip::EndpointId ZCLendpointId,
                                                                                  chip::GroupId /* ZCLgroupId */)
@@ -8083,16 +5933,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_NullableBitmap16
     return cluster.ReadAttributeNullableBitmap16(gInt16uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_TestCluster_NullableBitmap16(chip::DeviceProxy * device,
-                                                                                  chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                                  uint16_t value)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::TestClusterCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.WriteAttributeNullableBitmap16(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), value)
-        .AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_NullableBitmap32(chip::DeviceProxy * device,
                                                                                  chip::EndpointId ZCLendpointId,
                                                                                  chip::GroupId /* ZCLgroupId */)
@@ -8103,16 +5943,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_NullableBitmap32
     return cluster.ReadAttributeNullableBitmap32(gInt32uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_TestCluster_NullableBitmap32(chip::DeviceProxy * device,
-                                                                                  chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                                  uint32_t value)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::TestClusterCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.WriteAttributeNullableBitmap32(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), value)
-        .AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_NullableBitmap64(chip::DeviceProxy * device,
                                                                                  chip::EndpointId ZCLendpointId,
                                                                                  chip::GroupId /* ZCLgroupId */)
@@ -8123,16 +5953,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_NullableBitmap64
     return cluster.ReadAttributeNullableBitmap64(gInt64uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_TestCluster_NullableBitmap64(chip::DeviceProxy * device,
-                                                                                  chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                                  uint64_t value)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::TestClusterCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.WriteAttributeNullableBitmap64(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), value)
-        .AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_NullableInt8u(chip::DeviceProxy * device,
                                                                               chip::EndpointId ZCLendpointId,
                                                                               chip::GroupId /* ZCLgroupId */)
@@ -8143,16 +5963,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_NullableInt8u(ch
     return cluster.ReadAttributeNullableInt8u(gInt8uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_TestCluster_NullableInt8u(chip::DeviceProxy * device,
-                                                                               chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                               uint8_t value)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::TestClusterCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.WriteAttributeNullableInt8u(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), value)
-        .AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_NullableInt16u(chip::DeviceProxy * device,
                                                                                chip::EndpointId ZCLendpointId,
                                                                                chip::GroupId /* ZCLgroupId */)
@@ -8163,16 +5973,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_NullableInt16u(c
     return cluster.ReadAttributeNullableInt16u(gInt16uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_TestCluster_NullableInt16u(chip::DeviceProxy * device,
-                                                                                chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                                uint16_t value)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::TestClusterCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.WriteAttributeNullableInt16u(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), value)
-        .AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_NullableInt32u(chip::DeviceProxy * device,
                                                                                chip::EndpointId ZCLendpointId,
                                                                                chip::GroupId /* ZCLgroupId */)
@@ -8183,16 +5983,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_NullableInt32u(c
     return cluster.ReadAttributeNullableInt32u(gInt32uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_TestCluster_NullableInt32u(chip::DeviceProxy * device,
-                                                                                chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                                uint32_t value)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::TestClusterCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.WriteAttributeNullableInt32u(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), value)
-        .AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_NullableInt64u(chip::DeviceProxy * device,
                                                                                chip::EndpointId ZCLendpointId,
                                                                                chip::GroupId /* ZCLgroupId */)
@@ -8203,16 +5993,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_NullableInt64u(c
     return cluster.ReadAttributeNullableInt64u(gInt64uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_TestCluster_NullableInt64u(chip::DeviceProxy * device,
-                                                                                chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                                uint64_t value)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::TestClusterCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.WriteAttributeNullableInt64u(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), value)
-        .AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_NullableInt8s(chip::DeviceProxy * device,
                                                                               chip::EndpointId ZCLendpointId,
                                                                               chip::GroupId /* ZCLgroupId */)
@@ -8223,16 +6003,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_NullableInt8s(ch
     return cluster.ReadAttributeNullableInt8s(gInt8sAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_TestCluster_NullableInt8s(chip::DeviceProxy * device,
-                                                                               chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                               int8_t value)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::TestClusterCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.WriteAttributeNullableInt8s(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), value)
-        .AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_NullableInt16s(chip::DeviceProxy * device,
                                                                                chip::EndpointId ZCLendpointId,
                                                                                chip::GroupId /* ZCLgroupId */)
@@ -8243,16 +6013,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_NullableInt16s(c
     return cluster.ReadAttributeNullableInt16s(gInt16sAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_TestCluster_NullableInt16s(chip::DeviceProxy * device,
-                                                                                chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                                int16_t value)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::TestClusterCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.WriteAttributeNullableInt16s(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), value)
-        .AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_NullableInt32s(chip::DeviceProxy * device,
                                                                                chip::EndpointId ZCLendpointId,
                                                                                chip::GroupId /* ZCLgroupId */)
@@ -8263,16 +6023,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_NullableInt32s(c
     return cluster.ReadAttributeNullableInt32s(gInt32sAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_TestCluster_NullableInt32s(chip::DeviceProxy * device,
-                                                                                chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                                int32_t value)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::TestClusterCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.WriteAttributeNullableInt32s(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), value)
-        .AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_NullableInt64s(chip::DeviceProxy * device,
                                                                                chip::EndpointId ZCLendpointId,
                                                                                chip::GroupId /* ZCLgroupId */)
@@ -8283,16 +6033,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_NullableInt64s(c
     return cluster.ReadAttributeNullableInt64s(gInt64sAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_TestCluster_NullableInt64s(chip::DeviceProxy * device,
-                                                                                chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                                int64_t value)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::TestClusterCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.WriteAttributeNullableInt64s(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), value)
-        .AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_NullableEnum8(chip::DeviceProxy * device,
                                                                               chip::EndpointId ZCLendpointId,
                                                                               chip::GroupId /* ZCLgroupId */)
@@ -8303,16 +6043,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_NullableEnum8(ch
     return cluster.ReadAttributeNullableEnum8(gInt8uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_TestCluster_NullableEnum8(chip::DeviceProxy * device,
-                                                                               chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                               uint8_t value)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::TestClusterCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.WriteAttributeNullableEnum8(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), value)
-        .AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_NullableEnum16(chip::DeviceProxy * device,
                                                                                chip::EndpointId ZCLendpointId,
                                                                                chip::GroupId /* ZCLgroupId */)
@@ -8323,16 +6053,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_NullableEnum16(c
     return cluster.ReadAttributeNullableEnum16(gInt16uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_TestCluster_NullableEnum16(chip::DeviceProxy * device,
-                                                                                chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                                uint16_t value)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::TestClusterCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.WriteAttributeNullableEnum16(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), value)
-        .AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_NullableOctetString(chip::DeviceProxy * device,
                                                                                     chip::EndpointId ZCLendpointId,
                                                                                     chip::GroupId /* ZCLgroupId */)
@@ -8344,18 +6064,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_NullableOctetStr
         .AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_TestCluster_NullableOctetString(chip::DeviceProxy * device,
-                                                                                     chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                                     uint8_t * value, size_t len)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::TestClusterCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster
-        .WriteAttributeNullableOctetString(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(),
-                                           chip::ByteSpan(value, len))
-        .AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_NullableCharString(chip::DeviceProxy * device,
                                                                                    chip::EndpointId ZCLendpointId,
                                                                                    chip::GroupId /* ZCLgroupId */)
@@ -8367,18 +6075,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_NullableCharStri
         .AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_TestCluster_NullableCharString(chip::DeviceProxy * device,
-                                                                                    chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                                    uint8_t * value, size_t len)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::TestClusterCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster
-        .WriteAttributeNullableCharString(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(),
-                                          chip::CharSpan(reinterpret_cast<const char *>(value), len))
-        .AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_ClusterRevision(chip::DeviceProxy * device,
                                                                                 chip::EndpointId ZCLendpointId,
                                                                                 chip::GroupId /* ZCLgroupId */)
@@ -8391,54 +6087,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_ClusterRevision(
 
 // End of Cluster TestCluster
 // Cluster Thermostat
-
-chip::ChipError::StorageType chip_ime_AppendCommand_Thermostat_ClearWeeklySchedule(chip::DeviceProxy * device,
-                                                                                   chip::EndpointId ZCLendpointId, chip::GroupId)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::ThermostatCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.ClearWeeklySchedule(nullptr, nullptr).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_Thermostat_GetRelayStatusLog(chip::DeviceProxy * device,
-                                                                                 chip::EndpointId ZCLendpointId, chip::GroupId)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::ThermostatCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.GetRelayStatusLog(nullptr, nullptr).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_Thermostat_GetWeeklySchedule(chip::DeviceProxy * device,
-                                                                                 chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                                 uint8_t daysToReturn, uint8_t modeToReturn)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::ThermostatCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.GetWeeklySchedule(nullptr, nullptr, daysToReturn, modeToReturn).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_Thermostat_SetWeeklySchedule(chip::DeviceProxy * device,
-                                                                                 chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                                 uint8_t numberOfTransitionsForSequence,
-                                                                                 uint8_t dayOfWeekForSequence,
-                                                                                 uint8_t modeForSequence, uint8_t payload)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::ThermostatCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster
-        .SetWeeklySchedule(nullptr, nullptr, numberOfTransitionsForSequence, dayOfWeekForSequence, modeForSequence, payload)
-        .AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_Thermostat_SetpointRaiseLower(chip::DeviceProxy * device,
-                                                                                  chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                                  uint8_t mode, int8_t amount)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::ThermostatCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.SetpointRaiseLower(nullptr, nullptr, mode, amount).AsInteger();
-}
 
 chip::ChipError::StorageType chip_ime_ReadAttribute_Thermostat_LocalTemperature(chip::DeviceProxy * device,
                                                                                 chip::EndpointId ZCLendpointId,
@@ -8518,16 +6166,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_Thermostat_OccupiedCoolingSe
         .AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_Thermostat_OccupiedCoolingSetpoint(chip::DeviceProxy * device,
-                                                                                        chip::EndpointId ZCLendpointId,
-                                                                                        chip::GroupId, int16_t value)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::ThermostatCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.WriteAttributeOccupiedCoolingSetpoint(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), value)
-        .AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_Thermostat_OccupiedHeatingSetpoint(chip::DeviceProxy * device,
                                                                                        chip::EndpointId ZCLendpointId,
                                                                                        chip::GroupId /* ZCLgroupId */)
@@ -8539,16 +6177,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_Thermostat_OccupiedHeatingSe
         .AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_Thermostat_OccupiedHeatingSetpoint(chip::DeviceProxy * device,
-                                                                                        chip::EndpointId ZCLendpointId,
-                                                                                        chip::GroupId, int16_t value)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::ThermostatCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.WriteAttributeOccupiedHeatingSetpoint(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), value)
-        .AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_Thermostat_MinHeatSetpointLimit(chip::DeviceProxy * device,
                                                                                     chip::EndpointId ZCLendpointId,
                                                                                     chip::GroupId /* ZCLgroupId */)
@@ -8560,16 +6188,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_Thermostat_MinHeatSetpointLi
         .AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_Thermostat_MinHeatSetpointLimit(chip::DeviceProxy * device,
-                                                                                     chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                                     int16_t value)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::ThermostatCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.WriteAttributeMinHeatSetpointLimit(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), value)
-        .AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_Thermostat_MaxHeatSetpointLimit(chip::DeviceProxy * device,
                                                                                     chip::EndpointId ZCLendpointId,
                                                                                     chip::GroupId /* ZCLgroupId */)
@@ -8581,16 +6199,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_Thermostat_MaxHeatSetpointLi
         .AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_Thermostat_MaxHeatSetpointLimit(chip::DeviceProxy * device,
-                                                                                     chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                                     int16_t value)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::ThermostatCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.WriteAttributeMaxHeatSetpointLimit(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), value)
-        .AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_Thermostat_MinCoolSetpointLimit(chip::DeviceProxy * device,
                                                                                     chip::EndpointId ZCLendpointId,
                                                                                     chip::GroupId /* ZCLgroupId */)
@@ -8602,16 +6210,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_Thermostat_MinCoolSetpointLi
         .AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_Thermostat_MinCoolSetpointLimit(chip::DeviceProxy * device,
-                                                                                     chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                                     int16_t value)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::ThermostatCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.WriteAttributeMinCoolSetpointLimit(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), value)
-        .AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_Thermostat_MaxCoolSetpointLimit(chip::DeviceProxy * device,
                                                                                     chip::EndpointId ZCLendpointId,
                                                                                     chip::GroupId /* ZCLgroupId */)
@@ -8623,16 +6221,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_Thermostat_MaxCoolSetpointLi
         .AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_Thermostat_MaxCoolSetpointLimit(chip::DeviceProxy * device,
-                                                                                     chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                                     int16_t value)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::ThermostatCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.WriteAttributeMaxCoolSetpointLimit(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), value)
-        .AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_Thermostat_MinSetpointDeadBand(chip::DeviceProxy * device,
                                                                                    chip::EndpointId ZCLendpointId,
                                                                                    chip::GroupId /* ZCLgroupId */)
@@ -8643,16 +6231,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_Thermostat_MinSetpointDeadBa
     return cluster.ReadAttributeMinSetpointDeadBand(gInt8sAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_Thermostat_MinSetpointDeadBand(chip::DeviceProxy * device,
-                                                                                    chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                                    int8_t value)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::ThermostatCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.WriteAttributeMinSetpointDeadBand(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), value)
-        .AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_Thermostat_ControlSequenceOfOperation(chip::DeviceProxy * device,
                                                                                           chip::EndpointId ZCLendpointId,
                                                                                           chip::GroupId /* ZCLgroupId */)
@@ -8664,17 +6242,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_Thermostat_ControlSequenceOf
         .AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_Thermostat_ControlSequenceOfOperation(chip::DeviceProxy * device,
-                                                                                           chip::EndpointId ZCLendpointId,
-                                                                                           chip::GroupId, uint8_t value)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::ThermostatCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster
-        .WriteAttributeControlSequenceOfOperation(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), value)
-        .AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_Thermostat_SystemMode(chip::DeviceProxy * device,
                                                                           chip::EndpointId ZCLendpointId,
                                                                           chip::GroupId /* ZCLgroupId */)
@@ -8685,15 +6252,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_Thermostat_SystemMode(chip::
     return cluster.ReadAttributeSystemMode(gInt8uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_Thermostat_SystemMode(chip::DeviceProxy * device,
-                                                                           chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                           uint8_t value)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::ThermostatCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.WriteAttributeSystemMode(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), value).AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_Thermostat_StartOfWeek(chip::DeviceProxy * device,
                                                                            chip::EndpointId ZCLendpointId,
                                                                            chip::GroupId /* ZCLgroupId */)
@@ -8759,15 +6317,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_ThermostatUserInterfaceConfi
         .AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_ThermostatUserInterfaceConfiguration_TemperatureDisplayMode(
-    chip::DeviceProxy * device, chip::EndpointId ZCLendpointId, chip::GroupId, uint8_t value)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::ThermostatUserInterfaceConfigurationCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.WriteAttributeTemperatureDisplayMode(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), value)
-        .AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_ThermostatUserInterfaceConfiguration_KeypadLockout(
     chip::DeviceProxy * device, chip::EndpointId ZCLendpointId, chip::GroupId /* ZCLgroupId */)
 {
@@ -8777,15 +6326,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_ThermostatUserInterfaceConfi
     return cluster.ReadAttributeKeypadLockout(gInt8uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_ThermostatUserInterfaceConfiguration_KeypadLockout(
-    chip::DeviceProxy * device, chip::EndpointId ZCLendpointId, chip::GroupId, uint8_t value)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::ThermostatUserInterfaceConfigurationCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.WriteAttributeKeypadLockout(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), value)
-        .AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_ThermostatUserInterfaceConfiguration_ScheduleProgrammingVisibility(
     chip::DeviceProxy * device, chip::EndpointId ZCLendpointId, chip::GroupId /* ZCLgroupId */)
 {
@@ -8796,16 +6336,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_ThermostatUserInterfaceConfi
         .AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_ThermostatUserInterfaceConfiguration_ScheduleProgrammingVisibility(
-    chip::DeviceProxy * device, chip::EndpointId ZCLendpointId, chip::GroupId, uint8_t value)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::ThermostatUserInterfaceConfigurationCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster
-        .WriteAttributeScheduleProgrammingVisibility(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), value)
-        .AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_ThermostatUserInterfaceConfiguration_ClusterRevision(
     chip::DeviceProxy * device, chip::EndpointId ZCLendpointId, chip::GroupId /* ZCLgroupId */)
 {
@@ -8817,16 +6347,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_ThermostatUserInterfaceConfi
 
 // End of Cluster ThermostatUserInterfaceConfiguration
 // Cluster ThreadNetworkDiagnostics
-
-chip::ChipError::StorageType chip_ime_AppendCommand_ThreadNetworkDiagnostics_ResetCounts(chip::DeviceProxy * device,
-                                                                                         chip::EndpointId ZCLendpointId,
-                                                                                         chip::GroupId)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::ThreadNetworkDiagnosticsCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.ResetCounts(nullptr, nullptr).AsInteger();
-}
 
 chip::ChipError::StorageType chip_ime_ReadAttribute_ThreadNetworkDiagnostics_Channel(chip::DeviceProxy * device,
                                                                                      chip::EndpointId ZCLendpointId,
@@ -9520,15 +7040,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_WakeOnLan_ClusterRevision(ch
 // End of Cluster WakeOnLan
 // Cluster WiFiNetworkDiagnostics
 
-chip::ChipError::StorageType
-chip_ime_AppendCommand_WiFiNetworkDiagnostics_ResetCounts(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId, chip::GroupId)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::WiFiNetworkDiagnosticsCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.ResetCounts(nullptr, nullptr).AsInteger();
-}
-
 chip::ChipError::StorageType chip_ime_ReadAttribute_WiFiNetworkDiagnostics_Bssid(chip::DeviceProxy * device,
                                                                                  chip::EndpointId ZCLendpointId,
                                                                                  chip::GroupId /* ZCLgroupId */)
@@ -9675,69 +7186,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_WiFiNetworkDiagnostics_Clust
 
 // End of Cluster WiFiNetworkDiagnostics
 // Cluster WindowCovering
-
-chip::ChipError::StorageType chip_ime_AppendCommand_WindowCovering_DownOrClose(chip::DeviceProxy * device,
-                                                                               chip::EndpointId ZCLendpointId, chip::GroupId)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::WindowCoveringCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.DownOrClose(nullptr, nullptr).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_WindowCovering_GoToLiftPercentage(chip::DeviceProxy * device,
-                                                                                      chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                                      uint8_t liftPercentageValue,
-                                                                                      uint16_t liftPercent100thsValue)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::WindowCoveringCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.GoToLiftPercentage(nullptr, nullptr, liftPercentageValue, liftPercent100thsValue).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_WindowCovering_GoToLiftValue(chip::DeviceProxy * device,
-                                                                                 chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                                 uint16_t liftValue)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::WindowCoveringCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.GoToLiftValue(nullptr, nullptr, liftValue).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_WindowCovering_GoToTiltPercentage(chip::DeviceProxy * device,
-                                                                                      chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                                      uint8_t tiltPercentageValue,
-                                                                                      uint16_t tiltPercent100thsValue)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::WindowCoveringCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.GoToTiltPercentage(nullptr, nullptr, tiltPercentageValue, tiltPercent100thsValue).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_WindowCovering_GoToTiltValue(chip::DeviceProxy * device,
-                                                                                 chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                                 uint16_t tiltValue)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::WindowCoveringCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.GoToTiltValue(nullptr, nullptr, tiltValue).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_WindowCovering_StopMotion(chip::DeviceProxy * device,
-                                                                              chip::EndpointId ZCLendpointId, chip::GroupId)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::WindowCoveringCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.StopMotion(nullptr, nullptr).AsInteger();
-}
-chip::ChipError::StorageType chip_ime_AppendCommand_WindowCovering_UpOrOpen(chip::DeviceProxy * device,
-                                                                            chip::EndpointId ZCLendpointId, chip::GroupId)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::WindowCoveringCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.UpOrOpen(nullptr, nullptr).AsInteger();
-}
 
 chip::ChipError::StorageType chip_ime_ReadAttribute_WindowCovering_Type(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
                                                                         chip::GroupId /* ZCLgroupId */)
@@ -10009,14 +7457,6 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_WindowCovering_Mode(chip::De
     return cluster.ReadAttributeMode(gInt8uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_WriteAttribute_WindowCovering_Mode(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId,
-                                                                         chip::GroupId, uint8_t value)
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::WindowCoveringCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.WriteAttributeMode(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), value).AsInteger();
-}
 chip::ChipError::StorageType chip_ime_ReadAttribute_WindowCovering_SafetyStatus(chip::DeviceProxy * device,
                                                                                 chip::EndpointId ZCLendpointId,
                                                                                 chip::GroupId /* ZCLgroupId */)

--- a/src/controller/python/chip/clusters/CHIPClusters.py
+++ b/src/controller/python/chip/clusters/CHIPClusters.py
@@ -4630,925 +4630,6 @@ class ChipClusters:
         if res != 0:
             raise self._ChipStack.ErrorToException(res)
 
-    # Cluster commands
-
-    def ClusterAccountLogin_CommandGetSetupPIN(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, tempAccountIdentifier: str):
-        tempAccountIdentifier = tempAccountIdentifier.encode("utf-8") + b'\x00'
-        return self._chipLib.chip_ime_AppendCommand_AccountLogin_GetSetupPIN(
-            device, ZCLendpoint, ZCLgroupid, tempAccountIdentifier, len(
-                tempAccountIdentifier)
-        )
-
-    def ClusterAccountLogin_CommandLogin(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, tempAccountIdentifier: str, setupPIN: str):
-        tempAccountIdentifier = tempAccountIdentifier.encode("utf-8") + b'\x00'
-        setupPIN = setupPIN.encode("utf-8") + b'\x00'
-        return self._chipLib.chip_ime_AppendCommand_AccountLogin_Login(
-            device, ZCLendpoint, ZCLgroupid, tempAccountIdentifier, len(
-                tempAccountIdentifier), setupPIN, len(setupPIN)
-        )
-
-    def ClusterAdministratorCommissioning_CommandOpenBasicCommissioningWindow(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, commissioningTimeout: int):
-        return self._chipLib.chip_ime_AppendCommand_AdministratorCommissioning_OpenBasicCommissioningWindow(
-            device, ZCLendpoint, ZCLgroupid, commissioningTimeout
-        )
-
-    def ClusterAdministratorCommissioning_CommandOpenCommissioningWindow(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, commissioningTimeout: int, PAKEVerifier: bytes, discriminator: int, iterations: int, salt: bytes, passcodeID: int):
-        return self._chipLib.chip_ime_AppendCommand_AdministratorCommissioning_OpenCommissioningWindow(
-            device, ZCLendpoint, ZCLgroupid, commissioningTimeout, PAKEVerifier, len(
-                PAKEVerifier), discriminator, iterations, salt, len(salt), passcodeID
-        )
-
-    def ClusterAdministratorCommissioning_CommandRevokeCommissioning(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
-        return self._chipLib.chip_ime_AppendCommand_AdministratorCommissioning_RevokeCommissioning(
-            device, ZCLendpoint, ZCLgroupid
-        )
-
-    def ClusterApplicationBasic_CommandChangeStatus(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, status: int):
-        return self._chipLib.chip_ime_AppendCommand_ApplicationBasic_ChangeStatus(
-            device, ZCLendpoint, ZCLgroupid, status
-        )
-
-    def ClusterApplicationLauncher_CommandLaunchApp(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, data: str, catalogVendorId: int, applicationId: str):
-        data = data.encode("utf-8") + b'\x00'
-        applicationId = applicationId.encode("utf-8") + b'\x00'
-        return self._chipLib.chip_ime_AppendCommand_ApplicationLauncher_LaunchApp(
-            device, ZCLendpoint, ZCLgroupid, data, len(
-                data), catalogVendorId, applicationId, len(applicationId)
-        )
-
-    def ClusterAudioOutput_CommandRenameOutput(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, index: int, name: str):
-        name = name.encode("utf-8") + b'\x00'
-        return self._chipLib.chip_ime_AppendCommand_AudioOutput_RenameOutput(
-            device, ZCLendpoint, ZCLgroupid, index, name, len(name)
-        )
-
-    def ClusterAudioOutput_CommandSelectOutput(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, index: int):
-        return self._chipLib.chip_ime_AppendCommand_AudioOutput_SelectOutput(
-            device, ZCLendpoint, ZCLgroupid, index
-        )
-
-    def ClusterBarrierControl_CommandBarrierControlGoToPercent(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, percentOpen: int):
-        return self._chipLib.chip_ime_AppendCommand_BarrierControl_BarrierControlGoToPercent(
-            device, ZCLendpoint, ZCLgroupid, percentOpen
-        )
-
-    def ClusterBarrierControl_CommandBarrierControlStop(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
-        return self._chipLib.chip_ime_AppendCommand_BarrierControl_BarrierControlStop(
-            device, ZCLendpoint, ZCLgroupid
-        )
-
-    def ClusterBasic_CommandMfgSpecificPing(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
-        return self._chipLib.chip_ime_AppendCommand_Basic_MfgSpecificPing(
-            device, ZCLendpoint, ZCLgroupid
-        )
-
-    def ClusterBinding_CommandBind(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, nodeId: int, groupId: int, endpointId: int, clusterId: int):
-        return self._chipLib.chip_ime_AppendCommand_Binding_Bind(
-            device, ZCLendpoint, ZCLgroupid, nodeId, groupId, endpointId, clusterId
-        )
-
-    def ClusterBinding_CommandUnbind(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, nodeId: int, groupId: int, endpointId: int, clusterId: int):
-        return self._chipLib.chip_ime_AppendCommand_Binding_Unbind(
-            device, ZCLendpoint, ZCLgroupid, nodeId, groupId, endpointId, clusterId
-        )
-
-    def ClusterBridgedActions_CommandDisableAction(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, actionID: int, invokeID: int):
-        return self._chipLib.chip_ime_AppendCommand_BridgedActions_DisableAction(
-            device, ZCLendpoint, ZCLgroupid, actionID, invokeID
-        )
-
-    def ClusterBridgedActions_CommandDisableActionWithDuration(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, actionID: int, invokeID: int, duration: int):
-        return self._chipLib.chip_ime_AppendCommand_BridgedActions_DisableActionWithDuration(
-            device, ZCLendpoint, ZCLgroupid, actionID, invokeID, duration
-        )
-
-    def ClusterBridgedActions_CommandEnableAction(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, actionID: int, invokeID: int):
-        return self._chipLib.chip_ime_AppendCommand_BridgedActions_EnableAction(
-            device, ZCLendpoint, ZCLgroupid, actionID, invokeID
-        )
-
-    def ClusterBridgedActions_CommandEnableActionWithDuration(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, actionID: int, invokeID: int, duration: int):
-        return self._chipLib.chip_ime_AppendCommand_BridgedActions_EnableActionWithDuration(
-            device, ZCLendpoint, ZCLgroupid, actionID, invokeID, duration
-        )
-
-    def ClusterBridgedActions_CommandInstantAction(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, actionID: int, invokeID: int):
-        return self._chipLib.chip_ime_AppendCommand_BridgedActions_InstantAction(
-            device, ZCLendpoint, ZCLgroupid, actionID, invokeID
-        )
-
-    def ClusterBridgedActions_CommandInstantActionWithTransition(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, actionID: int, invokeID: int, transitionTime: int):
-        return self._chipLib.chip_ime_AppendCommand_BridgedActions_InstantActionWithTransition(
-            device, ZCLendpoint, ZCLgroupid, actionID, invokeID, transitionTime
-        )
-
-    def ClusterBridgedActions_CommandPauseAction(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, actionID: int, invokeID: int):
-        return self._chipLib.chip_ime_AppendCommand_BridgedActions_PauseAction(
-            device, ZCLendpoint, ZCLgroupid, actionID, invokeID
-        )
-
-    def ClusterBridgedActions_CommandPauseActionWithDuration(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, actionID: int, invokeID: int, duration: int):
-        return self._chipLib.chip_ime_AppendCommand_BridgedActions_PauseActionWithDuration(
-            device, ZCLendpoint, ZCLgroupid, actionID, invokeID, duration
-        )
-
-    def ClusterBridgedActions_CommandResumeAction(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, actionID: int, invokeID: int):
-        return self._chipLib.chip_ime_AppendCommand_BridgedActions_ResumeAction(
-            device, ZCLendpoint, ZCLgroupid, actionID, invokeID
-        )
-
-    def ClusterBridgedActions_CommandStartAction(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, actionID: int, invokeID: int):
-        return self._chipLib.chip_ime_AppendCommand_BridgedActions_StartAction(
-            device, ZCLendpoint, ZCLgroupid, actionID, invokeID
-        )
-
-    def ClusterBridgedActions_CommandStartActionWithDuration(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, actionID: int, invokeID: int, duration: int):
-        return self._chipLib.chip_ime_AppendCommand_BridgedActions_StartActionWithDuration(
-            device, ZCLendpoint, ZCLgroupid, actionID, invokeID, duration
-        )
-
-    def ClusterBridgedActions_CommandStopAction(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, actionID: int, invokeID: int):
-        return self._chipLib.chip_ime_AppendCommand_BridgedActions_StopAction(
-            device, ZCLendpoint, ZCLgroupid, actionID, invokeID
-        )
-
-    def ClusterColorControl_CommandColorLoopSet(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, updateFlags: int, action: int, direction: int, time: int, startHue: int, optionsMask: int, optionsOverride: int):
-        return self._chipLib.chip_ime_AppendCommand_ColorControl_ColorLoopSet(
-            device, ZCLendpoint, ZCLgroupid, updateFlags, action, direction, time, startHue, optionsMask, optionsOverride
-        )
-
-    def ClusterColorControl_CommandEnhancedMoveHue(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, moveMode: int, rate: int, optionsMask: int, optionsOverride: int):
-        return self._chipLib.chip_ime_AppendCommand_ColorControl_EnhancedMoveHue(
-            device, ZCLendpoint, ZCLgroupid, moveMode, rate, optionsMask, optionsOverride
-        )
-
-    def ClusterColorControl_CommandEnhancedMoveToHue(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, enhancedHue: int, direction: int, transitionTime: int, optionsMask: int, optionsOverride: int):
-        return self._chipLib.chip_ime_AppendCommand_ColorControl_EnhancedMoveToHue(
-            device, ZCLendpoint, ZCLgroupid, enhancedHue, direction, transitionTime, optionsMask, optionsOverride
-        )
-
-    def ClusterColorControl_CommandEnhancedMoveToHueAndSaturation(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, enhancedHue: int, saturation: int, transitionTime: int, optionsMask: int, optionsOverride: int):
-        return self._chipLib.chip_ime_AppendCommand_ColorControl_EnhancedMoveToHueAndSaturation(
-            device, ZCLendpoint, ZCLgroupid, enhancedHue, saturation, transitionTime, optionsMask, optionsOverride
-        )
-
-    def ClusterColorControl_CommandEnhancedStepHue(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, stepMode: int, stepSize: int, transitionTime: int, optionsMask: int, optionsOverride: int):
-        return self._chipLib.chip_ime_AppendCommand_ColorControl_EnhancedStepHue(
-            device, ZCLendpoint, ZCLgroupid, stepMode, stepSize, transitionTime, optionsMask, optionsOverride
-        )
-
-    def ClusterColorControl_CommandMoveColor(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, rateX: int, rateY: int, optionsMask: int, optionsOverride: int):
-        return self._chipLib.chip_ime_AppendCommand_ColorControl_MoveColor(
-            device, ZCLendpoint, ZCLgroupid, rateX, rateY, optionsMask, optionsOverride
-        )
-
-    def ClusterColorControl_CommandMoveColorTemperature(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, moveMode: int, rate: int, colorTemperatureMinimum: int, colorTemperatureMaximum: int, optionsMask: int, optionsOverride: int):
-        return self._chipLib.chip_ime_AppendCommand_ColorControl_MoveColorTemperature(
-            device, ZCLendpoint, ZCLgroupid, moveMode, rate, colorTemperatureMinimum, colorTemperatureMaximum, optionsMask, optionsOverride
-        )
-
-    def ClusterColorControl_CommandMoveHue(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, moveMode: int, rate: int, optionsMask: int, optionsOverride: int):
-        return self._chipLib.chip_ime_AppendCommand_ColorControl_MoveHue(
-            device, ZCLendpoint, ZCLgroupid, moveMode, rate, optionsMask, optionsOverride
-        )
-
-    def ClusterColorControl_CommandMoveSaturation(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, moveMode: int, rate: int, optionsMask: int, optionsOverride: int):
-        return self._chipLib.chip_ime_AppendCommand_ColorControl_MoveSaturation(
-            device, ZCLendpoint, ZCLgroupid, moveMode, rate, optionsMask, optionsOverride
-        )
-
-    def ClusterColorControl_CommandMoveToColor(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, colorX: int, colorY: int, transitionTime: int, optionsMask: int, optionsOverride: int):
-        return self._chipLib.chip_ime_AppendCommand_ColorControl_MoveToColor(
-            device, ZCLendpoint, ZCLgroupid, colorX, colorY, transitionTime, optionsMask, optionsOverride
-        )
-
-    def ClusterColorControl_CommandMoveToColorTemperature(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, colorTemperature: int, transitionTime: int, optionsMask: int, optionsOverride: int):
-        return self._chipLib.chip_ime_AppendCommand_ColorControl_MoveToColorTemperature(
-            device, ZCLendpoint, ZCLgroupid, colorTemperature, transitionTime, optionsMask, optionsOverride
-        )
-
-    def ClusterColorControl_CommandMoveToHue(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, hue: int, direction: int, transitionTime: int, optionsMask: int, optionsOverride: int):
-        return self._chipLib.chip_ime_AppendCommand_ColorControl_MoveToHue(
-            device, ZCLendpoint, ZCLgroupid, hue, direction, transitionTime, optionsMask, optionsOverride
-        )
-
-    def ClusterColorControl_CommandMoveToHueAndSaturation(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, hue: int, saturation: int, transitionTime: int, optionsMask: int, optionsOverride: int):
-        return self._chipLib.chip_ime_AppendCommand_ColorControl_MoveToHueAndSaturation(
-            device, ZCLendpoint, ZCLgroupid, hue, saturation, transitionTime, optionsMask, optionsOverride
-        )
-
-    def ClusterColorControl_CommandMoveToSaturation(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, saturation: int, transitionTime: int, optionsMask: int, optionsOverride: int):
-        return self._chipLib.chip_ime_AppendCommand_ColorControl_MoveToSaturation(
-            device, ZCLendpoint, ZCLgroupid, saturation, transitionTime, optionsMask, optionsOverride
-        )
-
-    def ClusterColorControl_CommandStepColor(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, stepX: int, stepY: int, transitionTime: int, optionsMask: int, optionsOverride: int):
-        return self._chipLib.chip_ime_AppendCommand_ColorControl_StepColor(
-            device, ZCLendpoint, ZCLgroupid, stepX, stepY, transitionTime, optionsMask, optionsOverride
-        )
-
-    def ClusterColorControl_CommandStepColorTemperature(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, stepMode: int, stepSize: int, transitionTime: int, colorTemperatureMinimum: int, colorTemperatureMaximum: int, optionsMask: int, optionsOverride: int):
-        return self._chipLib.chip_ime_AppendCommand_ColorControl_StepColorTemperature(
-            device, ZCLendpoint, ZCLgroupid, stepMode, stepSize, transitionTime, colorTemperatureMinimum, colorTemperatureMaximum, optionsMask, optionsOverride
-        )
-
-    def ClusterColorControl_CommandStepHue(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, stepMode: int, stepSize: int, transitionTime: int, optionsMask: int, optionsOverride: int):
-        return self._chipLib.chip_ime_AppendCommand_ColorControl_StepHue(
-            device, ZCLendpoint, ZCLgroupid, stepMode, stepSize, transitionTime, optionsMask, optionsOverride
-        )
-
-    def ClusterColorControl_CommandStepSaturation(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, stepMode: int, stepSize: int, transitionTime: int, optionsMask: int, optionsOverride: int):
-        return self._chipLib.chip_ime_AppendCommand_ColorControl_StepSaturation(
-            device, ZCLendpoint, ZCLgroupid, stepMode, stepSize, transitionTime, optionsMask, optionsOverride
-        )
-
-    def ClusterColorControl_CommandStopMoveStep(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, optionsMask: int, optionsOverride: int):
-        return self._chipLib.chip_ime_AppendCommand_ColorControl_StopMoveStep(
-            device, ZCLendpoint, ZCLgroupid, optionsMask, optionsOverride
-        )
-
-    def ClusterContentLauncher_CommandLaunchContent(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, autoPlay: bool, data: str):
-        data = data.encode("utf-8") + b'\x00'
-        return self._chipLib.chip_ime_AppendCommand_ContentLauncher_LaunchContent(
-            device, ZCLendpoint, ZCLgroupid, autoPlay, data, len(data)
-        )
-
-    def ClusterContentLauncher_CommandLaunchURL(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, contentURL: str, displayString: str):
-        contentURL = contentURL.encode("utf-8") + b'\x00'
-        displayString = displayString.encode("utf-8") + b'\x00'
-        return self._chipLib.chip_ime_AppendCommand_ContentLauncher_LaunchURL(
-            device, ZCLendpoint, ZCLgroupid, contentURL, len(
-                contentURL), displayString, len(displayString)
-        )
-
-    def ClusterDiagnosticLogs_CommandRetrieveLogsRequest(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, intent: int, requestedProtocol: int, transferFileDesignator: bytes):
-        return self._chipLib.chip_ime_AppendCommand_DiagnosticLogs_RetrieveLogsRequest(
-            device, ZCLendpoint, ZCLgroupid, intent, requestedProtocol, transferFileDesignator, len(
-                transferFileDesignator)
-        )
-
-    def ClusterDoorLock_CommandClearAllPins(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
-        return self._chipLib.chip_ime_AppendCommand_DoorLock_ClearAllPins(
-            device, ZCLendpoint, ZCLgroupid
-        )
-
-    def ClusterDoorLock_CommandClearAllRfids(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
-        return self._chipLib.chip_ime_AppendCommand_DoorLock_ClearAllRfids(
-            device, ZCLendpoint, ZCLgroupid
-        )
-
-    def ClusterDoorLock_CommandClearHolidaySchedule(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, scheduleId: int):
-        return self._chipLib.chip_ime_AppendCommand_DoorLock_ClearHolidaySchedule(
-            device, ZCLendpoint, ZCLgroupid, scheduleId
-        )
-
-    def ClusterDoorLock_CommandClearPin(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, userId: int):
-        return self._chipLib.chip_ime_AppendCommand_DoorLock_ClearPin(
-            device, ZCLendpoint, ZCLgroupid, userId
-        )
-
-    def ClusterDoorLock_CommandClearRfid(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, userId: int):
-        return self._chipLib.chip_ime_AppendCommand_DoorLock_ClearRfid(
-            device, ZCLendpoint, ZCLgroupid, userId
-        )
-
-    def ClusterDoorLock_CommandClearWeekdaySchedule(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, scheduleId: int, userId: int):
-        return self._chipLib.chip_ime_AppendCommand_DoorLock_ClearWeekdaySchedule(
-            device, ZCLendpoint, ZCLgroupid, scheduleId, userId
-        )
-
-    def ClusterDoorLock_CommandClearYeardaySchedule(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, scheduleId: int, userId: int):
-        return self._chipLib.chip_ime_AppendCommand_DoorLock_ClearYeardaySchedule(
-            device, ZCLendpoint, ZCLgroupid, scheduleId, userId
-        )
-
-    def ClusterDoorLock_CommandGetHolidaySchedule(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, scheduleId: int):
-        return self._chipLib.chip_ime_AppendCommand_DoorLock_GetHolidaySchedule(
-            device, ZCLendpoint, ZCLgroupid, scheduleId
-        )
-
-    def ClusterDoorLock_CommandGetLogRecord(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, logIndex: int):
-        return self._chipLib.chip_ime_AppendCommand_DoorLock_GetLogRecord(
-            device, ZCLendpoint, ZCLgroupid, logIndex
-        )
-
-    def ClusterDoorLock_CommandGetPin(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, userId: int):
-        return self._chipLib.chip_ime_AppendCommand_DoorLock_GetPin(
-            device, ZCLendpoint, ZCLgroupid, userId
-        )
-
-    def ClusterDoorLock_CommandGetRfid(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, userId: int):
-        return self._chipLib.chip_ime_AppendCommand_DoorLock_GetRfid(
-            device, ZCLendpoint, ZCLgroupid, userId
-        )
-
-    def ClusterDoorLock_CommandGetUserType(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, userId: int):
-        return self._chipLib.chip_ime_AppendCommand_DoorLock_GetUserType(
-            device, ZCLendpoint, ZCLgroupid, userId
-        )
-
-    def ClusterDoorLock_CommandGetWeekdaySchedule(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, scheduleId: int, userId: int):
-        return self._chipLib.chip_ime_AppendCommand_DoorLock_GetWeekdaySchedule(
-            device, ZCLendpoint, ZCLgroupid, scheduleId, userId
-        )
-
-    def ClusterDoorLock_CommandGetYeardaySchedule(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, scheduleId: int, userId: int):
-        return self._chipLib.chip_ime_AppendCommand_DoorLock_GetYeardaySchedule(
-            device, ZCLendpoint, ZCLgroupid, scheduleId, userId
-        )
-
-    def ClusterDoorLock_CommandLockDoor(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, pin: bytes):
-        return self._chipLib.chip_ime_AppendCommand_DoorLock_LockDoor(
-            device, ZCLendpoint, ZCLgroupid, pin, len(pin)
-        )
-
-    def ClusterDoorLock_CommandSetHolidaySchedule(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, scheduleId: int, localStartTime: int, localEndTime: int, operatingModeDuringHoliday: int):
-        return self._chipLib.chip_ime_AppendCommand_DoorLock_SetHolidaySchedule(
-            device, ZCLendpoint, ZCLgroupid, scheduleId, localStartTime, localEndTime, operatingModeDuringHoliday
-        )
-
-    def ClusterDoorLock_CommandSetPin(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, userId: int, userStatus: int, userType: int, pin: bytes):
-        return self._chipLib.chip_ime_AppendCommand_DoorLock_SetPin(
-            device, ZCLendpoint, ZCLgroupid, userId, userStatus, userType, pin, len(
-                pin)
-        )
-
-    def ClusterDoorLock_CommandSetRfid(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, userId: int, userStatus: int, userType: int, id: bytes):
-        return self._chipLib.chip_ime_AppendCommand_DoorLock_SetRfid(
-            device, ZCLendpoint, ZCLgroupid, userId, userStatus, userType, id, len(
-                id)
-        )
-
-    def ClusterDoorLock_CommandSetUserType(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, userId: int, userType: int):
-        return self._chipLib.chip_ime_AppendCommand_DoorLock_SetUserType(
-            device, ZCLendpoint, ZCLgroupid, userId, userType
-        )
-
-    def ClusterDoorLock_CommandSetWeekdaySchedule(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, scheduleId: int, userId: int, daysMask: int, startHour: int, startMinute: int, endHour: int, endMinute: int):
-        return self._chipLib.chip_ime_AppendCommand_DoorLock_SetWeekdaySchedule(
-            device, ZCLendpoint, ZCLgroupid, scheduleId, userId, daysMask, startHour, startMinute, endHour, endMinute
-        )
-
-    def ClusterDoorLock_CommandSetYeardaySchedule(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, scheduleId: int, userId: int, localStartTime: int, localEndTime: int):
-        return self._chipLib.chip_ime_AppendCommand_DoorLock_SetYeardaySchedule(
-            device, ZCLendpoint, ZCLgroupid, scheduleId, userId, localStartTime, localEndTime
-        )
-
-    def ClusterDoorLock_CommandUnlockDoor(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, pin: bytes):
-        return self._chipLib.chip_ime_AppendCommand_DoorLock_UnlockDoor(
-            device, ZCLendpoint, ZCLgroupid, pin, len(pin)
-        )
-
-    def ClusterDoorLock_CommandUnlockWithTimeout(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, timeoutInSeconds: int, pin: bytes):
-        return self._chipLib.chip_ime_AppendCommand_DoorLock_UnlockWithTimeout(
-            device, ZCLendpoint, ZCLgroupid, timeoutInSeconds, pin, len(pin)
-        )
-
-    def ClusterEthernetNetworkDiagnostics_CommandResetCounts(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
-        return self._chipLib.chip_ime_AppendCommand_EthernetNetworkDiagnostics_ResetCounts(
-            device, ZCLendpoint, ZCLgroupid
-        )
-
-    def ClusterGeneralCommissioning_CommandArmFailSafe(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, expiryLengthSeconds: int, breadcrumb: int, timeoutMs: int):
-        return self._chipLib.chip_ime_AppendCommand_GeneralCommissioning_ArmFailSafe(
-            device, ZCLendpoint, ZCLgroupid, expiryLengthSeconds, breadcrumb, timeoutMs
-        )
-
-    def ClusterGeneralCommissioning_CommandCommissioningComplete(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
-        return self._chipLib.chip_ime_AppendCommand_GeneralCommissioning_CommissioningComplete(
-            device, ZCLendpoint, ZCLgroupid
-        )
-
-    def ClusterGeneralCommissioning_CommandSetRegulatoryConfig(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, location: int, countryCode: str, breadcrumb: int, timeoutMs: int):
-        countryCode = countryCode.encode("utf-8") + b'\x00'
-        return self._chipLib.chip_ime_AppendCommand_GeneralCommissioning_SetRegulatoryConfig(
-            device, ZCLendpoint, ZCLgroupid, location, countryCode, len(
-                countryCode), breadcrumb, timeoutMs
-        )
-
-    def ClusterGroups_CommandAddGroup(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, groupId: int, groupName: str):
-        groupName = groupName.encode("utf-8") + b'\x00'
-        return self._chipLib.chip_ime_AppendCommand_Groups_AddGroup(
-            device, ZCLendpoint, ZCLgroupid, groupId, groupName, len(groupName)
-        )
-
-    def ClusterGroups_CommandAddGroupIfIdentifying(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, groupId: int, groupName: str):
-        groupName = groupName.encode("utf-8") + b'\x00'
-        return self._chipLib.chip_ime_AppendCommand_Groups_AddGroupIfIdentifying(
-            device, ZCLendpoint, ZCLgroupid, groupId, groupName, len(groupName)
-        )
-
-    def ClusterGroups_CommandGetGroupMembership(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, groupCount: int, groupList: int):
-        return self._chipLib.chip_ime_AppendCommand_Groups_GetGroupMembership(
-            device, ZCLendpoint, ZCLgroupid, groupCount, groupList
-        )
-
-    def ClusterGroups_CommandRemoveAllGroups(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
-        return self._chipLib.chip_ime_AppendCommand_Groups_RemoveAllGroups(
-            device, ZCLendpoint, ZCLgroupid
-        )
-
-    def ClusterGroups_CommandRemoveGroup(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, groupId: int):
-        return self._chipLib.chip_ime_AppendCommand_Groups_RemoveGroup(
-            device, ZCLendpoint, ZCLgroupid, groupId
-        )
-
-    def ClusterGroups_CommandViewGroup(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, groupId: int):
-        return self._chipLib.chip_ime_AppendCommand_Groups_ViewGroup(
-            device, ZCLendpoint, ZCLgroupid, groupId
-        )
-
-    def ClusterIdentify_CommandIdentify(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, identifyTime: int):
-        return self._chipLib.chip_ime_AppendCommand_Identify_Identify(
-            device, ZCLendpoint, ZCLgroupid, identifyTime
-        )
-
-    def ClusterIdentify_CommandIdentifyQuery(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
-        return self._chipLib.chip_ime_AppendCommand_Identify_IdentifyQuery(
-            device, ZCLendpoint, ZCLgroupid
-        )
-
-    def ClusterIdentify_CommandTriggerEffect(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, effectIdentifier: int, effectVariant: int):
-        return self._chipLib.chip_ime_AppendCommand_Identify_TriggerEffect(
-            device, ZCLendpoint, ZCLgroupid, effectIdentifier, effectVariant
-        )
-
-    def ClusterKeypadInput_CommandSendKey(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, keyCode: int):
-        return self._chipLib.chip_ime_AppendCommand_KeypadInput_SendKey(
-            device, ZCLendpoint, ZCLgroupid, keyCode
-        )
-
-    def ClusterLevelControl_CommandMove(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, moveMode: int, rate: int, optionMask: int, optionOverride: int):
-        return self._chipLib.chip_ime_AppendCommand_LevelControl_Move(
-            device, ZCLendpoint, ZCLgroupid, moveMode, rate, optionMask, optionOverride
-        )
-
-    def ClusterLevelControl_CommandMoveToLevel(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, level: int, transitionTime: int, optionMask: int, optionOverride: int):
-        return self._chipLib.chip_ime_AppendCommand_LevelControl_MoveToLevel(
-            device, ZCLendpoint, ZCLgroupid, level, transitionTime, optionMask, optionOverride
-        )
-
-    def ClusterLevelControl_CommandMoveToLevelWithOnOff(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, level: int, transitionTime: int):
-        return self._chipLib.chip_ime_AppendCommand_LevelControl_MoveToLevelWithOnOff(
-            device, ZCLendpoint, ZCLgroupid, level, transitionTime
-        )
-
-    def ClusterLevelControl_CommandMoveWithOnOff(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, moveMode: int, rate: int):
-        return self._chipLib.chip_ime_AppendCommand_LevelControl_MoveWithOnOff(
-            device, ZCLendpoint, ZCLgroupid, moveMode, rate
-        )
-
-    def ClusterLevelControl_CommandStep(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, stepMode: int, stepSize: int, transitionTime: int, optionMask: int, optionOverride: int):
-        return self._chipLib.chip_ime_AppendCommand_LevelControl_Step(
-            device, ZCLendpoint, ZCLgroupid, stepMode, stepSize, transitionTime, optionMask, optionOverride
-        )
-
-    def ClusterLevelControl_CommandStepWithOnOff(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, stepMode: int, stepSize: int, transitionTime: int):
-        return self._chipLib.chip_ime_AppendCommand_LevelControl_StepWithOnOff(
-            device, ZCLendpoint, ZCLgroupid, stepMode, stepSize, transitionTime
-        )
-
-    def ClusterLevelControl_CommandStop(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, optionMask: int, optionOverride: int):
-        return self._chipLib.chip_ime_AppendCommand_LevelControl_Stop(
-            device, ZCLendpoint, ZCLgroupid, optionMask, optionOverride
-        )
-
-    def ClusterLevelControl_CommandStopWithOnOff(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
-        return self._chipLib.chip_ime_AppendCommand_LevelControl_StopWithOnOff(
-            device, ZCLendpoint, ZCLgroupid
-        )
-
-    def ClusterLowPower_CommandSleep(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
-        return self._chipLib.chip_ime_AppendCommand_LowPower_Sleep(
-            device, ZCLendpoint, ZCLgroupid
-        )
-
-    def ClusterMediaInput_CommandHideInputStatus(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
-        return self._chipLib.chip_ime_AppendCommand_MediaInput_HideInputStatus(
-            device, ZCLendpoint, ZCLgroupid
-        )
-
-    def ClusterMediaInput_CommandRenameInput(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, index: int, name: str):
-        name = name.encode("utf-8") + b'\x00'
-        return self._chipLib.chip_ime_AppendCommand_MediaInput_RenameInput(
-            device, ZCLendpoint, ZCLgroupid, index, name, len(name)
-        )
-
-    def ClusterMediaInput_CommandSelectInput(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, index: int):
-        return self._chipLib.chip_ime_AppendCommand_MediaInput_SelectInput(
-            device, ZCLendpoint, ZCLgroupid, index
-        )
-
-    def ClusterMediaInput_CommandShowInputStatus(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
-        return self._chipLib.chip_ime_AppendCommand_MediaInput_ShowInputStatus(
-            device, ZCLendpoint, ZCLgroupid
-        )
-
-    def ClusterMediaPlayback_CommandMediaFastForward(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
-        return self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaFastForward(
-            device, ZCLendpoint, ZCLgroupid
-        )
-
-    def ClusterMediaPlayback_CommandMediaNext(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
-        return self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaNext(
-            device, ZCLendpoint, ZCLgroupid
-        )
-
-    def ClusterMediaPlayback_CommandMediaPause(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
-        return self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaPause(
-            device, ZCLendpoint, ZCLgroupid
-        )
-
-    def ClusterMediaPlayback_CommandMediaPlay(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
-        return self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaPlay(
-            device, ZCLendpoint, ZCLgroupid
-        )
-
-    def ClusterMediaPlayback_CommandMediaPrevious(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
-        return self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaPrevious(
-            device, ZCLendpoint, ZCLgroupid
-        )
-
-    def ClusterMediaPlayback_CommandMediaRewind(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
-        return self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaRewind(
-            device, ZCLendpoint, ZCLgroupid
-        )
-
-    def ClusterMediaPlayback_CommandMediaSeek(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, position: int):
-        return self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaSeek(
-            device, ZCLendpoint, ZCLgroupid, position
-        )
-
-    def ClusterMediaPlayback_CommandMediaSkipBackward(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, deltaPositionMilliseconds: int):
-        return self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaSkipBackward(
-            device, ZCLendpoint, ZCLgroupid, deltaPositionMilliseconds
-        )
-
-    def ClusterMediaPlayback_CommandMediaSkipForward(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, deltaPositionMilliseconds: int):
-        return self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaSkipForward(
-            device, ZCLendpoint, ZCLgroupid, deltaPositionMilliseconds
-        )
-
-    def ClusterMediaPlayback_CommandMediaStartOver(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
-        return self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaStartOver(
-            device, ZCLendpoint, ZCLgroupid
-        )
-
-    def ClusterMediaPlayback_CommandMediaStop(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
-        return self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaStop(
-            device, ZCLendpoint, ZCLgroupid
-        )
-
-    def ClusterModeSelect_CommandChangeToMode(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, newMode: int):
-        return self._chipLib.chip_ime_AppendCommand_ModeSelect_ChangeToMode(
-            device, ZCLendpoint, ZCLgroupid, newMode
-        )
-
-    def ClusterNetworkCommissioning_CommandAddThreadNetwork(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, operationalDataset: bytes, breadcrumb: int, timeoutMs: int):
-        return self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_AddThreadNetwork(
-            device, ZCLendpoint, ZCLgroupid, operationalDataset, len(
-                operationalDataset), breadcrumb, timeoutMs
-        )
-
-    def ClusterNetworkCommissioning_CommandAddWiFiNetwork(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, ssid: bytes, credentials: bytes, breadcrumb: int, timeoutMs: int):
-        return self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_AddWiFiNetwork(
-            device, ZCLendpoint, ZCLgroupid, ssid, len(
-                ssid), credentials, len(credentials), breadcrumb, timeoutMs
-        )
-
-    def ClusterNetworkCommissioning_CommandDisableNetwork(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, networkID: bytes, breadcrumb: int, timeoutMs: int):
-        return self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_DisableNetwork(
-            device, ZCLendpoint, ZCLgroupid, networkID, len(
-                networkID), breadcrumb, timeoutMs
-        )
-
-    def ClusterNetworkCommissioning_CommandEnableNetwork(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, networkID: bytes, breadcrumb: int, timeoutMs: int):
-        return self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_EnableNetwork(
-            device, ZCLendpoint, ZCLgroupid, networkID, len(
-                networkID), breadcrumb, timeoutMs
-        )
-
-    def ClusterNetworkCommissioning_CommandRemoveNetwork(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, networkID: bytes, breadcrumb: int, timeoutMs: int):
-        return self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_RemoveNetwork(
-            device, ZCLendpoint, ZCLgroupid, networkID, len(
-                networkID), breadcrumb, timeoutMs
-        )
-
-    def ClusterNetworkCommissioning_CommandScanNetworks(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, ssid: bytes, breadcrumb: int, timeoutMs: int):
-        return self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_ScanNetworks(
-            device, ZCLendpoint, ZCLgroupid, ssid, len(
-                ssid), breadcrumb, timeoutMs
-        )
-
-    def ClusterNetworkCommissioning_CommandUpdateThreadNetwork(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, operationalDataset: bytes, breadcrumb: int, timeoutMs: int):
-        return self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_UpdateThreadNetwork(
-            device, ZCLendpoint, ZCLgroupid, operationalDataset, len(
-                operationalDataset), breadcrumb, timeoutMs
-        )
-
-    def ClusterNetworkCommissioning_CommandUpdateWiFiNetwork(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, ssid: bytes, credentials: bytes, breadcrumb: int, timeoutMs: int):
-        return self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_UpdateWiFiNetwork(
-            device, ZCLendpoint, ZCLgroupid, ssid, len(
-                ssid), credentials, len(credentials), breadcrumb, timeoutMs
-        )
-
-    def ClusterOtaSoftwareUpdateProvider_CommandApplyUpdateRequest(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, updateToken: bytes, newVersion: int):
-        return self._chipLib.chip_ime_AppendCommand_OtaSoftwareUpdateProvider_ApplyUpdateRequest(
-            device, ZCLendpoint, ZCLgroupid, updateToken, len(
-                updateToken), newVersion
-        )
-
-    def ClusterOtaSoftwareUpdateProvider_CommandNotifyUpdateApplied(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, updateToken: bytes, softwareVersion: int):
-        return self._chipLib.chip_ime_AppendCommand_OtaSoftwareUpdateProvider_NotifyUpdateApplied(
-            device, ZCLendpoint, ZCLgroupid, updateToken, len(
-                updateToken), softwareVersion
-        )
-
-    def ClusterOtaSoftwareUpdateProvider_CommandQueryImage(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, vendorId: int, productId: int, softwareVersion: int, protocolsSupported: int, hardwareVersion: int, location: str, requestorCanConsent: bool, metadataForProvider: bytes):
-        location = location.encode("utf-8") + b'\x00'
-        return self._chipLib.chip_ime_AppendCommand_OtaSoftwareUpdateProvider_QueryImage(
-            device, ZCLendpoint, ZCLgroupid, vendorId, productId, softwareVersion, protocolsSupported, hardwareVersion, location, len(
-                location), requestorCanConsent, metadataForProvider, len(metadataForProvider)
-        )
-
-    def ClusterOtaSoftwareUpdateRequestor_CommandAnnounceOtaProvider(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, providerLocation: int, vendorId: int, announcementReason: int, metadataForNode: bytes):
-        return self._chipLib.chip_ime_AppendCommand_OtaSoftwareUpdateRequestor_AnnounceOtaProvider(
-            device, ZCLendpoint, ZCLgroupid, providerLocation, vendorId, announcementReason, metadataForNode, len(
-                metadataForNode)
-        )
-
-    def ClusterOnOff_CommandOff(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
-        return self._chipLib.chip_ime_AppendCommand_OnOff_Off(
-            device, ZCLendpoint, ZCLgroupid
-        )
-
-    def ClusterOnOff_CommandOffWithEffect(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, effectId: int, effectVariant: int):
-        return self._chipLib.chip_ime_AppendCommand_OnOff_OffWithEffect(
-            device, ZCLendpoint, ZCLgroupid, effectId, effectVariant
-        )
-
-    def ClusterOnOff_CommandOn(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
-        return self._chipLib.chip_ime_AppendCommand_OnOff_On(
-            device, ZCLendpoint, ZCLgroupid
-        )
-
-    def ClusterOnOff_CommandOnWithRecallGlobalScene(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
-        return self._chipLib.chip_ime_AppendCommand_OnOff_OnWithRecallGlobalScene(
-            device, ZCLendpoint, ZCLgroupid
-        )
-
-    def ClusterOnOff_CommandOnWithTimedOff(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, onOffControl: int, onTime: int, offWaitTime: int):
-        return self._chipLib.chip_ime_AppendCommand_OnOff_OnWithTimedOff(
-            device, ZCLendpoint, ZCLgroupid, onOffControl, onTime, offWaitTime
-        )
-
-    def ClusterOnOff_CommandToggle(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
-        return self._chipLib.chip_ime_AppendCommand_OnOff_Toggle(
-            device, ZCLendpoint, ZCLgroupid
-        )
-
-    def ClusterOperationalCredentials_CommandAddNOC(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, NOCValue: bytes, ICACValue: bytes, IPKValue: bytes, caseAdminNode: int, adminVendorId: int):
-        return self._chipLib.chip_ime_AppendCommand_OperationalCredentials_AddNOC(
-            device, ZCLendpoint, ZCLgroupid, NOCValue, len(NOCValue), ICACValue, len(
-                ICACValue), IPKValue, len(IPKValue), caseAdminNode, adminVendorId
-        )
-
-    def ClusterOperationalCredentials_CommandAddTrustedRootCertificate(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, rootCertificate: bytes):
-        return self._chipLib.chip_ime_AppendCommand_OperationalCredentials_AddTrustedRootCertificate(
-            device, ZCLendpoint, ZCLgroupid, rootCertificate, len(
-                rootCertificate)
-        )
-
-    def ClusterOperationalCredentials_CommandAttestationRequest(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, attestationNonce: bytes):
-        return self._chipLib.chip_ime_AppendCommand_OperationalCredentials_AttestationRequest(
-            device, ZCLendpoint, ZCLgroupid, attestationNonce, len(
-                attestationNonce)
-        )
-
-    def ClusterOperationalCredentials_CommandCertificateChainRequest(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, certificateType: int):
-        return self._chipLib.chip_ime_AppendCommand_OperationalCredentials_CertificateChainRequest(
-            device, ZCLendpoint, ZCLgroupid, certificateType
-        )
-
-    def ClusterOperationalCredentials_CommandOpCSRRequest(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, CSRNonce: bytes):
-        return self._chipLib.chip_ime_AppendCommand_OperationalCredentials_OpCSRRequest(
-            device, ZCLendpoint, ZCLgroupid, CSRNonce, len(CSRNonce)
-        )
-
-    def ClusterOperationalCredentials_CommandRemoveFabric(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, fabricIndex: int):
-        return self._chipLib.chip_ime_AppendCommand_OperationalCredentials_RemoveFabric(
-            device, ZCLendpoint, ZCLgroupid, fabricIndex
-        )
-
-    def ClusterOperationalCredentials_CommandRemoveTrustedRootCertificate(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, trustedRootIdentifier: bytes):
-        return self._chipLib.chip_ime_AppendCommand_OperationalCredentials_RemoveTrustedRootCertificate(
-            device, ZCLendpoint, ZCLgroupid, trustedRootIdentifier, len(
-                trustedRootIdentifier)
-        )
-
-    def ClusterOperationalCredentials_CommandUpdateFabricLabel(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, label: str):
-        label = label.encode("utf-8") + b'\x00'
-        return self._chipLib.chip_ime_AppendCommand_OperationalCredentials_UpdateFabricLabel(
-            device, ZCLendpoint, ZCLgroupid, label, len(label)
-        )
-
-    def ClusterOperationalCredentials_CommandUpdateNOC(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, NOCValue: bytes, ICACValue: bytes):
-        return self._chipLib.chip_ime_AppendCommand_OperationalCredentials_UpdateNOC(
-            device, ZCLendpoint, ZCLgroupid, NOCValue, len(
-                NOCValue), ICACValue, len(ICACValue)
-        )
-
-    def ClusterScenes_CommandAddScene(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, groupId: int, sceneId: int, transitionTime: int, sceneName: str, clusterId: int, length: int, value: int):
-        sceneName = sceneName.encode("utf-8") + b'\x00'
-        return self._chipLib.chip_ime_AppendCommand_Scenes_AddScene(
-            device, ZCLendpoint, ZCLgroupid, groupId, sceneId, transitionTime, sceneName, len(
-                sceneName), clusterId, length, value
-        )
-
-    def ClusterScenes_CommandGetSceneMembership(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, groupId: int):
-        return self._chipLib.chip_ime_AppendCommand_Scenes_GetSceneMembership(
-            device, ZCLendpoint, ZCLgroupid, groupId
-        )
-
-    def ClusterScenes_CommandRecallScene(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, groupId: int, sceneId: int, transitionTime: int):
-        return self._chipLib.chip_ime_AppendCommand_Scenes_RecallScene(
-            device, ZCLendpoint, ZCLgroupid, groupId, sceneId, transitionTime
-        )
-
-    def ClusterScenes_CommandRemoveAllScenes(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, groupId: int):
-        return self._chipLib.chip_ime_AppendCommand_Scenes_RemoveAllScenes(
-            device, ZCLendpoint, ZCLgroupid, groupId
-        )
-
-    def ClusterScenes_CommandRemoveScene(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, groupId: int, sceneId: int):
-        return self._chipLib.chip_ime_AppendCommand_Scenes_RemoveScene(
-            device, ZCLendpoint, ZCLgroupid, groupId, sceneId
-        )
-
-    def ClusterScenes_CommandStoreScene(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, groupId: int, sceneId: int):
-        return self._chipLib.chip_ime_AppendCommand_Scenes_StoreScene(
-            device, ZCLendpoint, ZCLgroupid, groupId, sceneId
-        )
-
-    def ClusterScenes_CommandViewScene(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, groupId: int, sceneId: int):
-        return self._chipLib.chip_ime_AppendCommand_Scenes_ViewScene(
-            device, ZCLendpoint, ZCLgroupid, groupId, sceneId
-        )
-
-    def ClusterSoftwareDiagnostics_CommandResetWatermarks(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
-        return self._chipLib.chip_ime_AppendCommand_SoftwareDiagnostics_ResetWatermarks(
-            device, ZCLendpoint, ZCLgroupid
-        )
-
-    def ClusterTvChannel_CommandChangeChannel(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, match: str):
-        match = match.encode("utf-8") + b'\x00'
-        return self._chipLib.chip_ime_AppendCommand_TvChannel_ChangeChannel(
-            device, ZCLendpoint, ZCLgroupid, match, len(match)
-        )
-
-    def ClusterTvChannel_CommandChangeChannelByNumber(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, majorNumber: int, minorNumber: int):
-        return self._chipLib.chip_ime_AppendCommand_TvChannel_ChangeChannelByNumber(
-            device, ZCLendpoint, ZCLgroupid, majorNumber, minorNumber
-        )
-
-    def ClusterTvChannel_CommandSkipChannel(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, count: int):
-        return self._chipLib.chip_ime_AppendCommand_TvChannel_SkipChannel(
-            device, ZCLendpoint, ZCLgroupid, count
-        )
-
-    def ClusterTargetNavigator_CommandNavigateTarget(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, target: int, data: str):
-        data = data.encode("utf-8") + b'\x00'
-        return self._chipLib.chip_ime_AppendCommand_TargetNavigator_NavigateTarget(
-            device, ZCLendpoint, ZCLgroupid, target, data, len(data)
-        )
-
-    def ClusterTestCluster_CommandTest(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
-        return self._chipLib.chip_ime_AppendCommand_TestCluster_Test(
-            device, ZCLendpoint, ZCLgroupid
-        )
-
-    def ClusterTestCluster_CommandTestAddArguments(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, arg1: int, arg2: int):
-        return self._chipLib.chip_ime_AppendCommand_TestCluster_TestAddArguments(
-            device, ZCLendpoint, ZCLgroupid, arg1, arg2
-        )
-
-    def ClusterTestCluster_CommandTestEnumsRequest(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, arg1: int, arg2: int):
-        return self._chipLib.chip_ime_AppendCommand_TestCluster_TestEnumsRequest(
-            device, ZCLendpoint, ZCLgroupid, arg1, arg2
-        )
-
-    def ClusterTestCluster_CommandTestListInt8UArgumentRequest(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, arg1: int):
-        return self._chipLib.chip_ime_AppendCommand_TestCluster_TestListInt8UArgumentRequest(
-            device, ZCLendpoint, ZCLgroupid, arg1
-        )
-
-    def ClusterTestCluster_CommandTestListInt8UReverseRequest(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, arg1: int):
-        return self._chipLib.chip_ime_AppendCommand_TestCluster_TestListInt8UReverseRequest(
-            device, ZCLendpoint, ZCLgroupid, arg1
-        )
-
-    def ClusterTestCluster_CommandTestListStructArgumentRequest(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, a: int, b: bool, c: int, d: bytes, e: str, f: int):
-        e = e.encode("utf-8") + b'\x00'
-        return self._chipLib.chip_ime_AppendCommand_TestCluster_TestListStructArgumentRequest(
-            device, ZCLendpoint, ZCLgroupid, a, b, c, d, len(d), e, len(e), f
-        )
-
-    def ClusterTestCluster_CommandTestNotHandled(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
-        return self._chipLib.chip_ime_AppendCommand_TestCluster_TestNotHandled(
-            device, ZCLendpoint, ZCLgroupid
-        )
-
-    def ClusterTestCluster_CommandTestNullableOptionalRequest(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, arg1: int):
-        return self._chipLib.chip_ime_AppendCommand_TestCluster_TestNullableOptionalRequest(
-            device, ZCLendpoint, ZCLgroupid, arg1
-        )
-
-    def ClusterTestCluster_CommandTestSpecific(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
-        return self._chipLib.chip_ime_AppendCommand_TestCluster_TestSpecific(
-            device, ZCLendpoint, ZCLgroupid
-        )
-
-    def ClusterTestCluster_CommandTestStructArgumentRequest(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, a: int, b: bool, c: int, d: bytes, e: str, f: int):
-        e = e.encode("utf-8") + b'\x00'
-        return self._chipLib.chip_ime_AppendCommand_TestCluster_TestStructArgumentRequest(
-            device, ZCLendpoint, ZCLgroupid, a, b, c, d, len(d), e, len(e), f
-        )
-
-    def ClusterTestCluster_CommandTestUnknownCommand(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
-        return self._chipLib.chip_ime_AppendCommand_TestCluster_TestUnknownCommand(
-            device, ZCLendpoint, ZCLgroupid
-        )
-
-    def ClusterThermostat_CommandClearWeeklySchedule(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
-        return self._chipLib.chip_ime_AppendCommand_Thermostat_ClearWeeklySchedule(
-            device, ZCLendpoint, ZCLgroupid
-        )
-
-    def ClusterThermostat_CommandGetRelayStatusLog(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
-        return self._chipLib.chip_ime_AppendCommand_Thermostat_GetRelayStatusLog(
-            device, ZCLendpoint, ZCLgroupid
-        )
-
-    def ClusterThermostat_CommandGetWeeklySchedule(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, daysToReturn: int, modeToReturn: int):
-        return self._chipLib.chip_ime_AppendCommand_Thermostat_GetWeeklySchedule(
-            device, ZCLendpoint, ZCLgroupid, daysToReturn, modeToReturn
-        )
-
-    def ClusterThermostat_CommandSetWeeklySchedule(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, numberOfTransitionsForSequence: int, dayOfWeekForSequence: int, modeForSequence: int, payload: int):
-        return self._chipLib.chip_ime_AppendCommand_Thermostat_SetWeeklySchedule(
-            device, ZCLendpoint, ZCLgroupid, numberOfTransitionsForSequence, dayOfWeekForSequence, modeForSequence, payload
-        )
-
-    def ClusterThermostat_CommandSetpointRaiseLower(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, mode: int, amount: int):
-        return self._chipLib.chip_ime_AppendCommand_Thermostat_SetpointRaiseLower(
-            device, ZCLendpoint, ZCLgroupid, mode, amount
-        )
-
-    def ClusterThreadNetworkDiagnostics_CommandResetCounts(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
-        return self._chipLib.chip_ime_AppendCommand_ThreadNetworkDiagnostics_ResetCounts(
-            device, ZCLendpoint, ZCLgroupid
-        )
-
-    def ClusterWiFiNetworkDiagnostics_CommandResetCounts(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
-        return self._chipLib.chip_ime_AppendCommand_WiFiNetworkDiagnostics_ResetCounts(
-            device, ZCLendpoint, ZCLgroupid
-        )
-
-    def ClusterWindowCovering_CommandDownOrClose(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
-        return self._chipLib.chip_ime_AppendCommand_WindowCovering_DownOrClose(
-            device, ZCLendpoint, ZCLgroupid
-        )
-
-    def ClusterWindowCovering_CommandGoToLiftPercentage(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, liftPercentageValue: int, liftPercent100thsValue: int):
-        return self._chipLib.chip_ime_AppendCommand_WindowCovering_GoToLiftPercentage(
-            device, ZCLendpoint, ZCLgroupid, liftPercentageValue, liftPercent100thsValue
-        )
-
-    def ClusterWindowCovering_CommandGoToLiftValue(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, liftValue: int):
-        return self._chipLib.chip_ime_AppendCommand_WindowCovering_GoToLiftValue(
-            device, ZCLendpoint, ZCLgroupid, liftValue
-        )
-
-    def ClusterWindowCovering_CommandGoToTiltPercentage(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, tiltPercentageValue: int, tiltPercent100thsValue: int):
-        return self._chipLib.chip_ime_AppendCommand_WindowCovering_GoToTiltPercentage(
-            device, ZCLendpoint, ZCLgroupid, tiltPercentageValue, tiltPercent100thsValue
-        )
-
-    def ClusterWindowCovering_CommandGoToTiltValue(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, tiltValue: int):
-        return self._chipLib.chip_ime_AppendCommand_WindowCovering_GoToTiltValue(
-            device, ZCLendpoint, ZCLgroupid, tiltValue
-        )
-
-    def ClusterWindowCovering_CommandStopMotion(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
-        return self._chipLib.chip_ime_AppendCommand_WindowCovering_StopMotion(
-            device, ZCLendpoint, ZCLgroupid
-        )
-
-    def ClusterWindowCovering_CommandUpOrOpen(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
-        return self._chipLib.chip_ime_AppendCommand_WindowCovering_UpOrOpen(
-            device, ZCLendpoint, ZCLgroupid
-        )
-
     # Cluster attributes
 
     def ClusterAccountLogin_ReadAttributeClusterRevision(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
@@ -5635,16 +4716,8 @@ class ChipClusters:
     def ClusterBasic_ReadAttributeUserLabel(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Basic_UserLabel(device, ZCLendpoint, ZCLgroupid)
 
-    def ClusterBasic_WriteAttributeUserLabel(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: str):
-        value = value.encode("utf-8")
-        return self._chipLib.chip_ime_WriteAttribute_Basic_UserLabel(device, ZCLendpoint, ZCLgroupid, value, len(value))
-
     def ClusterBasic_ReadAttributeLocation(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Basic_Location(device, ZCLendpoint, ZCLgroupid)
-
-    def ClusterBasic_WriteAttributeLocation(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: str):
-        value = value.encode("utf-8")
-        return self._chipLib.chip_ime_WriteAttribute_Basic_Location(device, ZCLendpoint, ZCLgroupid, value, len(value))
 
     def ClusterBasic_ReadAttributeHardwareVersion(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Basic_HardwareVersion(device, ZCLendpoint, ZCLgroupid)
@@ -5676,9 +4749,6 @@ class ChipClusters:
     def ClusterBasic_ReadAttributeLocalConfigDisabled(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Basic_LocalConfigDisabled(device, ZCLendpoint, ZCLgroupid)
 
-    def ClusterBasic_WriteAttributeLocalConfigDisabled(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: bool):
-        return self._chipLib.chip_ime_WriteAttribute_Basic_LocalConfigDisabled(device, ZCLendpoint, ZCLgroupid, value)
-
     def ClusterBasic_ReadAttributeReachable(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Basic_Reachable(device, ZCLendpoint, ZCLgroupid)
 
@@ -5688,17 +4758,11 @@ class ChipClusters:
     def ClusterBinaryInputBasic_ReadAttributeOutOfService(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_BinaryInputBasic_OutOfService(device, ZCLendpoint, ZCLgroupid)
 
-    def ClusterBinaryInputBasic_WriteAttributeOutOfService(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: bool):
-        return self._chipLib.chip_ime_WriteAttribute_BinaryInputBasic_OutOfService(device, ZCLendpoint, ZCLgroupid, value)
-
     def ClusterBinaryInputBasic_ReadAttributePresentValue(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_BinaryInputBasic_PresentValue(device, ZCLendpoint, ZCLgroupid)
 
     def ClusterBinaryInputBasic_SubscribeAttributePresentValue(self, device: ctypes.c_void_p, ZCLendpoint: int, minInterval: int, maxInterval: int):
         return self._chipLib.chip_ime_SubscribeAttribute_BinaryInputBasic_PresentValue(device, ZCLendpoint, minInterval, maxInterval)
-
-    def ClusterBinaryInputBasic_WriteAttributePresentValue(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: bool):
-        return self._chipLib.chip_ime_WriteAttribute_BinaryInputBasic_PresentValue(device, ZCLendpoint, ZCLgroupid, value)
 
     def ClusterBinaryInputBasic_ReadAttributeStatusFlags(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_BinaryInputBasic_StatusFlags(device, ZCLendpoint, ZCLgroupid)
@@ -5744,10 +4808,6 @@ class ChipClusters:
 
     def ClusterBridgedDeviceBasic_ReadAttributeUserLabel(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_BridgedDeviceBasic_UserLabel(device, ZCLendpoint, ZCLgroupid)
-
-    def ClusterBridgedDeviceBasic_WriteAttributeUserLabel(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: str):
-        value = value.encode("utf-8")
-        return self._chipLib.chip_ime_WriteAttribute_BridgedDeviceBasic_UserLabel(device, ZCLendpoint, ZCLgroupid, value, len(value))
 
     def ClusterBridgedDeviceBasic_ReadAttributeHardwareVersion(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_BridgedDeviceBasic_HardwareVersion(device, ZCLendpoint, ZCLgroupid)
@@ -5827,9 +4887,6 @@ class ChipClusters:
     def ClusterColorControl_ReadAttributeColorControlOptions(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorControlOptions(device, ZCLendpoint, ZCLgroupid)
 
-    def ClusterColorControl_WriteAttributeColorControlOptions(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
-        return self._chipLib.chip_ime_WriteAttribute_ColorControl_ColorControlOptions(device, ZCLendpoint, ZCLgroupid, value)
-
     def ClusterColorControl_ReadAttributeNumberOfPrimaries(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ColorControl_NumberOfPrimaries(device, ZCLendpoint, ZCLgroupid)
 
@@ -5890,68 +4947,35 @@ class ChipClusters:
     def ClusterColorControl_ReadAttributeWhitePointX(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ColorControl_WhitePointX(device, ZCLendpoint, ZCLgroupid)
 
-    def ClusterColorControl_WriteAttributeWhitePointX(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
-        return self._chipLib.chip_ime_WriteAttribute_ColorControl_WhitePointX(device, ZCLendpoint, ZCLgroupid, value)
-
     def ClusterColorControl_ReadAttributeWhitePointY(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ColorControl_WhitePointY(device, ZCLendpoint, ZCLgroupid)
-
-    def ClusterColorControl_WriteAttributeWhitePointY(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
-        return self._chipLib.chip_ime_WriteAttribute_ColorControl_WhitePointY(device, ZCLendpoint, ZCLgroupid, value)
 
     def ClusterColorControl_ReadAttributeColorPointRX(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorPointRX(device, ZCLendpoint, ZCLgroupid)
 
-    def ClusterColorControl_WriteAttributeColorPointRX(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
-        return self._chipLib.chip_ime_WriteAttribute_ColorControl_ColorPointRX(device, ZCLendpoint, ZCLgroupid, value)
-
     def ClusterColorControl_ReadAttributeColorPointRY(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorPointRY(device, ZCLendpoint, ZCLgroupid)
-
-    def ClusterColorControl_WriteAttributeColorPointRY(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
-        return self._chipLib.chip_ime_WriteAttribute_ColorControl_ColorPointRY(device, ZCLendpoint, ZCLgroupid, value)
 
     def ClusterColorControl_ReadAttributeColorPointRIntensity(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorPointRIntensity(device, ZCLendpoint, ZCLgroupid)
 
-    def ClusterColorControl_WriteAttributeColorPointRIntensity(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
-        return self._chipLib.chip_ime_WriteAttribute_ColorControl_ColorPointRIntensity(device, ZCLendpoint, ZCLgroupid, value)
-
     def ClusterColorControl_ReadAttributeColorPointGX(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorPointGX(device, ZCLendpoint, ZCLgroupid)
-
-    def ClusterColorControl_WriteAttributeColorPointGX(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
-        return self._chipLib.chip_ime_WriteAttribute_ColorControl_ColorPointGX(device, ZCLendpoint, ZCLgroupid, value)
 
     def ClusterColorControl_ReadAttributeColorPointGY(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorPointGY(device, ZCLendpoint, ZCLgroupid)
 
-    def ClusterColorControl_WriteAttributeColorPointGY(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
-        return self._chipLib.chip_ime_WriteAttribute_ColorControl_ColorPointGY(device, ZCLendpoint, ZCLgroupid, value)
-
     def ClusterColorControl_ReadAttributeColorPointGIntensity(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorPointGIntensity(device, ZCLendpoint, ZCLgroupid)
-
-    def ClusterColorControl_WriteAttributeColorPointGIntensity(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
-        return self._chipLib.chip_ime_WriteAttribute_ColorControl_ColorPointGIntensity(device, ZCLendpoint, ZCLgroupid, value)
 
     def ClusterColorControl_ReadAttributeColorPointBX(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorPointBX(device, ZCLendpoint, ZCLgroupid)
 
-    def ClusterColorControl_WriteAttributeColorPointBX(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
-        return self._chipLib.chip_ime_WriteAttribute_ColorControl_ColorPointBX(device, ZCLendpoint, ZCLgroupid, value)
-
     def ClusterColorControl_ReadAttributeColorPointBY(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorPointBY(device, ZCLendpoint, ZCLgroupid)
 
-    def ClusterColorControl_WriteAttributeColorPointBY(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
-        return self._chipLib.chip_ime_WriteAttribute_ColorControl_ColorPointBY(device, ZCLendpoint, ZCLgroupid, value)
-
     def ClusterColorControl_ReadAttributeColorPointBIntensity(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorPointBIntensity(device, ZCLendpoint, ZCLgroupid)
-
-    def ClusterColorControl_WriteAttributeColorPointBIntensity(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
-        return self._chipLib.chip_ime_WriteAttribute_ColorControl_ColorPointBIntensity(device, ZCLendpoint, ZCLgroupid, value)
 
     def ClusterColorControl_ReadAttributeEnhancedCurrentHue(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ColorControl_EnhancedCurrentHue(device, ZCLendpoint, ZCLgroupid)
@@ -5988,9 +5012,6 @@ class ChipClusters:
 
     def ClusterColorControl_ReadAttributeStartUpColorTemperatureMireds(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ColorControl_StartUpColorTemperatureMireds(device, ZCLendpoint, ZCLgroupid)
-
-    def ClusterColorControl_WriteAttributeStartUpColorTemperatureMireds(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
-        return self._chipLib.chip_ime_WriteAttribute_ColorControl_StartUpColorTemperatureMireds(device, ZCLendpoint, ZCLgroupid, value)
 
     def ClusterColorControl_ReadAttributeClusterRevision(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ColorControl_ClusterRevision(device, ZCLendpoint, ZCLgroupid)
@@ -6124,9 +5145,6 @@ class ChipClusters:
     def ClusterGeneralCommissioning_ReadAttributeBreadcrumb(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_GeneralCommissioning_Breadcrumb(device, ZCLendpoint, ZCLgroupid)
 
-    def ClusterGeneralCommissioning_WriteAttributeBreadcrumb(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
-        return self._chipLib.chip_ime_WriteAttribute_GeneralCommissioning_Breadcrumb(device, ZCLendpoint, ZCLgroupid, value)
-
     def ClusterGeneralCommissioning_ReadAttributeBasicCommissioningInfoList(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_GeneralCommissioning_BasicCommissioningInfoList(device, ZCLendpoint, ZCLgroupid)
 
@@ -6177,9 +5195,6 @@ class ChipClusters:
 
     def ClusterIdentify_ReadAttributeIdentifyTime(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Identify_IdentifyTime(device, ZCLendpoint, ZCLgroupid)
-
-    def ClusterIdentify_WriteAttributeIdentifyTime(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
-        return self._chipLib.chip_ime_WriteAttribute_Identify_IdentifyTime(device, ZCLendpoint, ZCLgroupid, value)
 
     def ClusterIdentify_ReadAttributeIdentifyType(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Identify_IdentifyType(device, ZCLendpoint, ZCLgroupid)
@@ -6238,44 +5253,23 @@ class ChipClusters:
     def ClusterLevelControl_ReadAttributeOptions(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_LevelControl_Options(device, ZCLendpoint, ZCLgroupid)
 
-    def ClusterLevelControl_WriteAttributeOptions(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
-        return self._chipLib.chip_ime_WriteAttribute_LevelControl_Options(device, ZCLendpoint, ZCLgroupid, value)
-
     def ClusterLevelControl_ReadAttributeOnOffTransitionTime(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_LevelControl_OnOffTransitionTime(device, ZCLendpoint, ZCLgroupid)
-
-    def ClusterLevelControl_WriteAttributeOnOffTransitionTime(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
-        return self._chipLib.chip_ime_WriteAttribute_LevelControl_OnOffTransitionTime(device, ZCLendpoint, ZCLgroupid, value)
 
     def ClusterLevelControl_ReadAttributeOnLevel(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_LevelControl_OnLevel(device, ZCLendpoint, ZCLgroupid)
 
-    def ClusterLevelControl_WriteAttributeOnLevel(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
-        return self._chipLib.chip_ime_WriteAttribute_LevelControl_OnLevel(device, ZCLendpoint, ZCLgroupid, value)
-
     def ClusterLevelControl_ReadAttributeOnTransitionTime(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_LevelControl_OnTransitionTime(device, ZCLendpoint, ZCLgroupid)
-
-    def ClusterLevelControl_WriteAttributeOnTransitionTime(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
-        return self._chipLib.chip_ime_WriteAttribute_LevelControl_OnTransitionTime(device, ZCLendpoint, ZCLgroupid, value)
 
     def ClusterLevelControl_ReadAttributeOffTransitionTime(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_LevelControl_OffTransitionTime(device, ZCLendpoint, ZCLgroupid)
 
-    def ClusterLevelControl_WriteAttributeOffTransitionTime(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
-        return self._chipLib.chip_ime_WriteAttribute_LevelControl_OffTransitionTime(device, ZCLendpoint, ZCLgroupid, value)
-
     def ClusterLevelControl_ReadAttributeDefaultMoveRate(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_LevelControl_DefaultMoveRate(device, ZCLendpoint, ZCLgroupid)
 
-    def ClusterLevelControl_WriteAttributeDefaultMoveRate(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
-        return self._chipLib.chip_ime_WriteAttribute_LevelControl_DefaultMoveRate(device, ZCLendpoint, ZCLgroupid, value)
-
     def ClusterLevelControl_ReadAttributeStartUpCurrentLevel(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_LevelControl_StartUpCurrentLevel(device, ZCLendpoint, ZCLgroupid)
-
-    def ClusterLevelControl_WriteAttributeStartUpCurrentLevel(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
-        return self._chipLib.chip_ime_WriteAttribute_LevelControl_StartUpCurrentLevel(device, ZCLendpoint, ZCLgroupid, value)
 
     def ClusterLevelControl_ReadAttributeClusterRevision(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_LevelControl_ClusterRevision(device, ZCLendpoint, ZCLgroupid)
@@ -6331,9 +5325,6 @@ class ChipClusters:
     def ClusterModeSelect_ReadAttributeOnMode(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ModeSelect_OnMode(device, ZCLendpoint, ZCLgroupid)
 
-    def ClusterModeSelect_WriteAttributeOnMode(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
-        return self._chipLib.chip_ime_WriteAttribute_ModeSelect_OnMode(device, ZCLendpoint, ZCLgroupid, value)
-
     def ClusterModeSelect_ReadAttributeStartUpMode(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ModeSelect_StartUpMode(device, ZCLendpoint, ZCLgroupid)
 
@@ -6354,9 +5345,6 @@ class ChipClusters:
 
     def ClusterOtaSoftwareUpdateRequestor_ReadAttributeDefaultOtaProvider(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_OtaSoftwareUpdateRequestor_DefaultOtaProvider(device, ZCLendpoint, ZCLgroupid)
-
-    def ClusterOtaSoftwareUpdateRequestor_WriteAttributeDefaultOtaProvider(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: bytes):
-        return self._chipLib.chip_ime_WriteAttribute_OtaSoftwareUpdateRequestor_DefaultOtaProvider(device, ZCLendpoint, ZCLgroupid, value, len(value))
 
     def ClusterOtaSoftwareUpdateRequestor_ReadAttributeUpdatePossible(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_OtaSoftwareUpdateRequestor_UpdatePossible(device, ZCLendpoint, ZCLgroupid)
@@ -6391,20 +5379,11 @@ class ChipClusters:
     def ClusterOnOff_ReadAttributeOnTime(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_OnOff_OnTime(device, ZCLendpoint, ZCLgroupid)
 
-    def ClusterOnOff_WriteAttributeOnTime(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
-        return self._chipLib.chip_ime_WriteAttribute_OnOff_OnTime(device, ZCLendpoint, ZCLgroupid, value)
-
     def ClusterOnOff_ReadAttributeOffWaitTime(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_OnOff_OffWaitTime(device, ZCLendpoint, ZCLgroupid)
 
-    def ClusterOnOff_WriteAttributeOffWaitTime(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
-        return self._chipLib.chip_ime_WriteAttribute_OnOff_OffWaitTime(device, ZCLendpoint, ZCLgroupid, value)
-
     def ClusterOnOff_ReadAttributeStartUpOnOff(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_OnOff_StartUpOnOff(device, ZCLendpoint, ZCLgroupid)
-
-    def ClusterOnOff_WriteAttributeStartUpOnOff(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
-        return self._chipLib.chip_ime_WriteAttribute_OnOff_StartUpOnOff(device, ZCLendpoint, ZCLgroupid, value)
 
     def ClusterOnOff_ReadAttributeFeatureMap(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_OnOff_FeatureMap(device, ZCLendpoint, ZCLgroupid)
@@ -6417,9 +5396,6 @@ class ChipClusters:
 
     def ClusterOnOffSwitchConfiguration_ReadAttributeSwitchActions(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_OnOffSwitchConfiguration_SwitchActions(device, ZCLendpoint, ZCLgroupid)
-
-    def ClusterOnOffSwitchConfiguration_WriteAttributeSwitchActions(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
-        return self._chipLib.chip_ime_WriteAttribute_OnOffSwitchConfiguration_SwitchActions(device, ZCLendpoint, ZCLgroupid, value)
 
     def ClusterOnOffSwitchConfiguration_ReadAttributeClusterRevision(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_OnOffSwitchConfiguration_ClusterRevision(device, ZCLendpoint, ZCLgroupid)
@@ -6556,14 +5532,8 @@ class ChipClusters:
     def ClusterPumpConfigurationAndControl_ReadAttributeOperationMode(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_OperationMode(device, ZCLendpoint, ZCLgroupid)
 
-    def ClusterPumpConfigurationAndControl_WriteAttributeOperationMode(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
-        return self._chipLib.chip_ime_WriteAttribute_PumpConfigurationAndControl_OperationMode(device, ZCLendpoint, ZCLgroupid, value)
-
     def ClusterPumpConfigurationAndControl_ReadAttributeControlMode(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_ControlMode(device, ZCLendpoint, ZCLgroupid)
-
-    def ClusterPumpConfigurationAndControl_WriteAttributeControlMode(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
-        return self._chipLib.chip_ime_WriteAttribute_PumpConfigurationAndControl_ControlMode(device, ZCLendpoint, ZCLgroupid, value)
 
     def ClusterPumpConfigurationAndControl_ReadAttributeAlarmMask(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_AlarmMask(device, ZCLendpoint, ZCLgroupid)
@@ -6688,98 +5658,50 @@ class ChipClusters:
     def ClusterTestCluster_ReadAttributeBoolean(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TestCluster_Boolean(device, ZCLendpoint, ZCLgroupid)
 
-    def ClusterTestCluster_WriteAttributeBoolean(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: bool):
-        return self._chipLib.chip_ime_WriteAttribute_TestCluster_Boolean(device, ZCLendpoint, ZCLgroupid, value)
-
     def ClusterTestCluster_ReadAttributeBitmap8(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TestCluster_Bitmap8(device, ZCLendpoint, ZCLgroupid)
-
-    def ClusterTestCluster_WriteAttributeBitmap8(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
-        return self._chipLib.chip_ime_WriteAttribute_TestCluster_Bitmap8(device, ZCLendpoint, ZCLgroupid, value)
 
     def ClusterTestCluster_ReadAttributeBitmap16(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TestCluster_Bitmap16(device, ZCLendpoint, ZCLgroupid)
 
-    def ClusterTestCluster_WriteAttributeBitmap16(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
-        return self._chipLib.chip_ime_WriteAttribute_TestCluster_Bitmap16(device, ZCLendpoint, ZCLgroupid, value)
-
     def ClusterTestCluster_ReadAttributeBitmap32(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TestCluster_Bitmap32(device, ZCLendpoint, ZCLgroupid)
-
-    def ClusterTestCluster_WriteAttributeBitmap32(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
-        return self._chipLib.chip_ime_WriteAttribute_TestCluster_Bitmap32(device, ZCLendpoint, ZCLgroupid, value)
 
     def ClusterTestCluster_ReadAttributeBitmap64(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TestCluster_Bitmap64(device, ZCLendpoint, ZCLgroupid)
 
-    def ClusterTestCluster_WriteAttributeBitmap64(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
-        return self._chipLib.chip_ime_WriteAttribute_TestCluster_Bitmap64(device, ZCLendpoint, ZCLgroupid, value)
-
     def ClusterTestCluster_ReadAttributeInt8u(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TestCluster_Int8u(device, ZCLendpoint, ZCLgroupid)
-
-    def ClusterTestCluster_WriteAttributeInt8u(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
-        return self._chipLib.chip_ime_WriteAttribute_TestCluster_Int8u(device, ZCLendpoint, ZCLgroupid, value)
 
     def ClusterTestCluster_ReadAttributeInt16u(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TestCluster_Int16u(device, ZCLendpoint, ZCLgroupid)
 
-    def ClusterTestCluster_WriteAttributeInt16u(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
-        return self._chipLib.chip_ime_WriteAttribute_TestCluster_Int16u(device, ZCLendpoint, ZCLgroupid, value)
-
     def ClusterTestCluster_ReadAttributeInt32u(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TestCluster_Int32u(device, ZCLendpoint, ZCLgroupid)
-
-    def ClusterTestCluster_WriteAttributeInt32u(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
-        return self._chipLib.chip_ime_WriteAttribute_TestCluster_Int32u(device, ZCLendpoint, ZCLgroupid, value)
 
     def ClusterTestCluster_ReadAttributeInt64u(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TestCluster_Int64u(device, ZCLendpoint, ZCLgroupid)
 
-    def ClusterTestCluster_WriteAttributeInt64u(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
-        return self._chipLib.chip_ime_WriteAttribute_TestCluster_Int64u(device, ZCLendpoint, ZCLgroupid, value)
-
     def ClusterTestCluster_ReadAttributeInt8s(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TestCluster_Int8s(device, ZCLendpoint, ZCLgroupid)
-
-    def ClusterTestCluster_WriteAttributeInt8s(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
-        return self._chipLib.chip_ime_WriteAttribute_TestCluster_Int8s(device, ZCLendpoint, ZCLgroupid, value)
 
     def ClusterTestCluster_ReadAttributeInt16s(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TestCluster_Int16s(device, ZCLendpoint, ZCLgroupid)
 
-    def ClusterTestCluster_WriteAttributeInt16s(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
-        return self._chipLib.chip_ime_WriteAttribute_TestCluster_Int16s(device, ZCLendpoint, ZCLgroupid, value)
-
     def ClusterTestCluster_ReadAttributeInt32s(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TestCluster_Int32s(device, ZCLendpoint, ZCLgroupid)
-
-    def ClusterTestCluster_WriteAttributeInt32s(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
-        return self._chipLib.chip_ime_WriteAttribute_TestCluster_Int32s(device, ZCLendpoint, ZCLgroupid, value)
 
     def ClusterTestCluster_ReadAttributeInt64s(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TestCluster_Int64s(device, ZCLendpoint, ZCLgroupid)
 
-    def ClusterTestCluster_WriteAttributeInt64s(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
-        return self._chipLib.chip_ime_WriteAttribute_TestCluster_Int64s(device, ZCLendpoint, ZCLgroupid, value)
-
     def ClusterTestCluster_ReadAttributeEnum8(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TestCluster_Enum8(device, ZCLendpoint, ZCLgroupid)
-
-    def ClusterTestCluster_WriteAttributeEnum8(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
-        return self._chipLib.chip_ime_WriteAttribute_TestCluster_Enum8(device, ZCLendpoint, ZCLgroupid, value)
 
     def ClusterTestCluster_ReadAttributeEnum16(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TestCluster_Enum16(device, ZCLendpoint, ZCLgroupid)
 
-    def ClusterTestCluster_WriteAttributeEnum16(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
-        return self._chipLib.chip_ime_WriteAttribute_TestCluster_Enum16(device, ZCLendpoint, ZCLgroupid, value)
-
     def ClusterTestCluster_ReadAttributeOctetString(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TestCluster_OctetString(device, ZCLendpoint, ZCLgroupid)
-
-    def ClusterTestCluster_WriteAttributeOctetString(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: bytes):
-        return self._chipLib.chip_ime_WriteAttribute_TestCluster_OctetString(device, ZCLendpoint, ZCLgroupid, value, len(value))
 
     def ClusterTestCluster_ReadAttributeListInt8u(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TestCluster_ListInt8u(device, ZCLendpoint, ZCLgroupid)
@@ -6793,40 +5715,20 @@ class ChipClusters:
     def ClusterTestCluster_ReadAttributeLongOctetString(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TestCluster_LongOctetString(device, ZCLendpoint, ZCLgroupid)
 
-    def ClusterTestCluster_WriteAttributeLongOctetString(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: bytes):
-        return self._chipLib.chip_ime_WriteAttribute_TestCluster_LongOctetString(device, ZCLendpoint, ZCLgroupid, value, len(value))
-
     def ClusterTestCluster_ReadAttributeCharString(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TestCluster_CharString(device, ZCLendpoint, ZCLgroupid)
-
-    def ClusterTestCluster_WriteAttributeCharString(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: str):
-        value = value.encode("utf-8")
-        return self._chipLib.chip_ime_WriteAttribute_TestCluster_CharString(device, ZCLendpoint, ZCLgroupid, value, len(value))
 
     def ClusterTestCluster_ReadAttributeLongCharString(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TestCluster_LongCharString(device, ZCLendpoint, ZCLgroupid)
 
-    def ClusterTestCluster_WriteAttributeLongCharString(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: str):
-        value = value.encode("utf-8")
-        return self._chipLib.chip_ime_WriteAttribute_TestCluster_LongCharString(device, ZCLendpoint, ZCLgroupid, value, len(value))
-
     def ClusterTestCluster_ReadAttributeEpochUs(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TestCluster_EpochUs(device, ZCLendpoint, ZCLgroupid)
-
-    def ClusterTestCluster_WriteAttributeEpochUs(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
-        return self._chipLib.chip_ime_WriteAttribute_TestCluster_EpochUs(device, ZCLendpoint, ZCLgroupid, value)
 
     def ClusterTestCluster_ReadAttributeEpochS(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TestCluster_EpochS(device, ZCLendpoint, ZCLgroupid)
 
-    def ClusterTestCluster_WriteAttributeEpochS(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
-        return self._chipLib.chip_ime_WriteAttribute_TestCluster_EpochS(device, ZCLendpoint, ZCLgroupid, value)
-
     def ClusterTestCluster_ReadAttributeVendorId(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TestCluster_VendorId(device, ZCLendpoint, ZCLgroupid)
-
-    def ClusterTestCluster_WriteAttributeVendorId(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
-        return self._chipLib.chip_ime_WriteAttribute_TestCluster_VendorId(device, ZCLendpoint, ZCLgroupid, value)
 
     def ClusterTestCluster_ReadAttributeListNullablesAndOptionalsStruct(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TestCluster_ListNullablesAndOptionalsStruct(device, ZCLendpoint, ZCLgroupid)
@@ -6834,111 +5736,56 @@ class ChipClusters:
     def ClusterTestCluster_ReadAttributeUnsupported(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TestCluster_Unsupported(device, ZCLendpoint, ZCLgroupid)
 
-    def ClusterTestCluster_WriteAttributeUnsupported(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: bool):
-        return self._chipLib.chip_ime_WriteAttribute_TestCluster_Unsupported(device, ZCLendpoint, ZCLgroupid, value)
-
     def ClusterTestCluster_ReadAttributeNullableBoolean(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TestCluster_NullableBoolean(device, ZCLendpoint, ZCLgroupid)
-
-    def ClusterTestCluster_WriteAttributeNullableBoolean(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: bool):
-        return self._chipLib.chip_ime_WriteAttribute_TestCluster_NullableBoolean(device, ZCLendpoint, ZCLgroupid, value)
 
     def ClusterTestCluster_ReadAttributeNullableBitmap8(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TestCluster_NullableBitmap8(device, ZCLendpoint, ZCLgroupid)
 
-    def ClusterTestCluster_WriteAttributeNullableBitmap8(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
-        return self._chipLib.chip_ime_WriteAttribute_TestCluster_NullableBitmap8(device, ZCLendpoint, ZCLgroupid, value)
-
     def ClusterTestCluster_ReadAttributeNullableBitmap16(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TestCluster_NullableBitmap16(device, ZCLendpoint, ZCLgroupid)
-
-    def ClusterTestCluster_WriteAttributeNullableBitmap16(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
-        return self._chipLib.chip_ime_WriteAttribute_TestCluster_NullableBitmap16(device, ZCLendpoint, ZCLgroupid, value)
 
     def ClusterTestCluster_ReadAttributeNullableBitmap32(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TestCluster_NullableBitmap32(device, ZCLendpoint, ZCLgroupid)
 
-    def ClusterTestCluster_WriteAttributeNullableBitmap32(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
-        return self._chipLib.chip_ime_WriteAttribute_TestCluster_NullableBitmap32(device, ZCLendpoint, ZCLgroupid, value)
-
     def ClusterTestCluster_ReadAttributeNullableBitmap64(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TestCluster_NullableBitmap64(device, ZCLendpoint, ZCLgroupid)
-
-    def ClusterTestCluster_WriteAttributeNullableBitmap64(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
-        return self._chipLib.chip_ime_WriteAttribute_TestCluster_NullableBitmap64(device, ZCLendpoint, ZCLgroupid, value)
 
     def ClusterTestCluster_ReadAttributeNullableInt8u(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TestCluster_NullableInt8u(device, ZCLendpoint, ZCLgroupid)
 
-    def ClusterTestCluster_WriteAttributeNullableInt8u(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
-        return self._chipLib.chip_ime_WriteAttribute_TestCluster_NullableInt8u(device, ZCLendpoint, ZCLgroupid, value)
-
     def ClusterTestCluster_ReadAttributeNullableInt16u(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TestCluster_NullableInt16u(device, ZCLendpoint, ZCLgroupid)
-
-    def ClusterTestCluster_WriteAttributeNullableInt16u(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
-        return self._chipLib.chip_ime_WriteAttribute_TestCluster_NullableInt16u(device, ZCLendpoint, ZCLgroupid, value)
 
     def ClusterTestCluster_ReadAttributeNullableInt32u(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TestCluster_NullableInt32u(device, ZCLendpoint, ZCLgroupid)
 
-    def ClusterTestCluster_WriteAttributeNullableInt32u(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
-        return self._chipLib.chip_ime_WriteAttribute_TestCluster_NullableInt32u(device, ZCLendpoint, ZCLgroupid, value)
-
     def ClusterTestCluster_ReadAttributeNullableInt64u(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TestCluster_NullableInt64u(device, ZCLendpoint, ZCLgroupid)
-
-    def ClusterTestCluster_WriteAttributeNullableInt64u(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
-        return self._chipLib.chip_ime_WriteAttribute_TestCluster_NullableInt64u(device, ZCLendpoint, ZCLgroupid, value)
 
     def ClusterTestCluster_ReadAttributeNullableInt8s(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TestCluster_NullableInt8s(device, ZCLendpoint, ZCLgroupid)
 
-    def ClusterTestCluster_WriteAttributeNullableInt8s(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
-        return self._chipLib.chip_ime_WriteAttribute_TestCluster_NullableInt8s(device, ZCLendpoint, ZCLgroupid, value)
-
     def ClusterTestCluster_ReadAttributeNullableInt16s(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TestCluster_NullableInt16s(device, ZCLendpoint, ZCLgroupid)
-
-    def ClusterTestCluster_WriteAttributeNullableInt16s(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
-        return self._chipLib.chip_ime_WriteAttribute_TestCluster_NullableInt16s(device, ZCLendpoint, ZCLgroupid, value)
 
     def ClusterTestCluster_ReadAttributeNullableInt32s(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TestCluster_NullableInt32s(device, ZCLendpoint, ZCLgroupid)
 
-    def ClusterTestCluster_WriteAttributeNullableInt32s(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
-        return self._chipLib.chip_ime_WriteAttribute_TestCluster_NullableInt32s(device, ZCLendpoint, ZCLgroupid, value)
-
     def ClusterTestCluster_ReadAttributeNullableInt64s(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TestCluster_NullableInt64s(device, ZCLendpoint, ZCLgroupid)
-
-    def ClusterTestCluster_WriteAttributeNullableInt64s(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
-        return self._chipLib.chip_ime_WriteAttribute_TestCluster_NullableInt64s(device, ZCLendpoint, ZCLgroupid, value)
 
     def ClusterTestCluster_ReadAttributeNullableEnum8(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TestCluster_NullableEnum8(device, ZCLendpoint, ZCLgroupid)
 
-    def ClusterTestCluster_WriteAttributeNullableEnum8(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
-        return self._chipLib.chip_ime_WriteAttribute_TestCluster_NullableEnum8(device, ZCLendpoint, ZCLgroupid, value)
-
     def ClusterTestCluster_ReadAttributeNullableEnum16(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TestCluster_NullableEnum16(device, ZCLendpoint, ZCLgroupid)
-
-    def ClusterTestCluster_WriteAttributeNullableEnum16(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
-        return self._chipLib.chip_ime_WriteAttribute_TestCluster_NullableEnum16(device, ZCLendpoint, ZCLgroupid, value)
 
     def ClusterTestCluster_ReadAttributeNullableOctetString(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TestCluster_NullableOctetString(device, ZCLendpoint, ZCLgroupid)
 
-    def ClusterTestCluster_WriteAttributeNullableOctetString(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: bytes):
-        return self._chipLib.chip_ime_WriteAttribute_TestCluster_NullableOctetString(device, ZCLendpoint, ZCLgroupid, value, len(value))
-
     def ClusterTestCluster_ReadAttributeNullableCharString(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TestCluster_NullableCharString(device, ZCLendpoint, ZCLgroupid)
-
-    def ClusterTestCluster_WriteAttributeNullableCharString(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: str):
-        value = value.encode("utf-8")
-        return self._chipLib.chip_ime_WriteAttribute_TestCluster_NullableCharString(device, ZCLendpoint, ZCLgroupid, value, len(value))
 
     def ClusterTestCluster_ReadAttributeClusterRevision(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TestCluster_ClusterRevision(device, ZCLendpoint, ZCLgroupid)
@@ -6964,56 +5811,29 @@ class ChipClusters:
     def ClusterThermostat_ReadAttributeOccupiedCoolingSetpoint(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Thermostat_OccupiedCoolingSetpoint(device, ZCLendpoint, ZCLgroupid)
 
-    def ClusterThermostat_WriteAttributeOccupiedCoolingSetpoint(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
-        return self._chipLib.chip_ime_WriteAttribute_Thermostat_OccupiedCoolingSetpoint(device, ZCLendpoint, ZCLgroupid, value)
-
     def ClusterThermostat_ReadAttributeOccupiedHeatingSetpoint(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Thermostat_OccupiedHeatingSetpoint(device, ZCLendpoint, ZCLgroupid)
-
-    def ClusterThermostat_WriteAttributeOccupiedHeatingSetpoint(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
-        return self._chipLib.chip_ime_WriteAttribute_Thermostat_OccupiedHeatingSetpoint(device, ZCLendpoint, ZCLgroupid, value)
 
     def ClusterThermostat_ReadAttributeMinHeatSetpointLimit(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Thermostat_MinHeatSetpointLimit(device, ZCLendpoint, ZCLgroupid)
 
-    def ClusterThermostat_WriteAttributeMinHeatSetpointLimit(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
-        return self._chipLib.chip_ime_WriteAttribute_Thermostat_MinHeatSetpointLimit(device, ZCLendpoint, ZCLgroupid, value)
-
     def ClusterThermostat_ReadAttributeMaxHeatSetpointLimit(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Thermostat_MaxHeatSetpointLimit(device, ZCLendpoint, ZCLgroupid)
-
-    def ClusterThermostat_WriteAttributeMaxHeatSetpointLimit(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
-        return self._chipLib.chip_ime_WriteAttribute_Thermostat_MaxHeatSetpointLimit(device, ZCLendpoint, ZCLgroupid, value)
 
     def ClusterThermostat_ReadAttributeMinCoolSetpointLimit(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Thermostat_MinCoolSetpointLimit(device, ZCLendpoint, ZCLgroupid)
 
-    def ClusterThermostat_WriteAttributeMinCoolSetpointLimit(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
-        return self._chipLib.chip_ime_WriteAttribute_Thermostat_MinCoolSetpointLimit(device, ZCLendpoint, ZCLgroupid, value)
-
     def ClusterThermostat_ReadAttributeMaxCoolSetpointLimit(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Thermostat_MaxCoolSetpointLimit(device, ZCLendpoint, ZCLgroupid)
-
-    def ClusterThermostat_WriteAttributeMaxCoolSetpointLimit(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
-        return self._chipLib.chip_ime_WriteAttribute_Thermostat_MaxCoolSetpointLimit(device, ZCLendpoint, ZCLgroupid, value)
 
     def ClusterThermostat_ReadAttributeMinSetpointDeadBand(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Thermostat_MinSetpointDeadBand(device, ZCLendpoint, ZCLgroupid)
 
-    def ClusterThermostat_WriteAttributeMinSetpointDeadBand(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
-        return self._chipLib.chip_ime_WriteAttribute_Thermostat_MinSetpointDeadBand(device, ZCLendpoint, ZCLgroupid, value)
-
     def ClusterThermostat_ReadAttributeControlSequenceOfOperation(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Thermostat_ControlSequenceOfOperation(device, ZCLendpoint, ZCLgroupid)
 
-    def ClusterThermostat_WriteAttributeControlSequenceOfOperation(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
-        return self._chipLib.chip_ime_WriteAttribute_Thermostat_ControlSequenceOfOperation(device, ZCLendpoint, ZCLgroupid, value)
-
     def ClusterThermostat_ReadAttributeSystemMode(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Thermostat_SystemMode(device, ZCLendpoint, ZCLgroupid)
-
-    def ClusterThermostat_WriteAttributeSystemMode(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
-        return self._chipLib.chip_ime_WriteAttribute_Thermostat_SystemMode(device, ZCLendpoint, ZCLgroupid, value)
 
     def ClusterThermostat_ReadAttributeStartOfWeek(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Thermostat_StartOfWeek(device, ZCLendpoint, ZCLgroupid)
@@ -7033,20 +5853,11 @@ class ChipClusters:
     def ClusterThermostatUserInterfaceConfiguration_ReadAttributeTemperatureDisplayMode(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ThermostatUserInterfaceConfiguration_TemperatureDisplayMode(device, ZCLendpoint, ZCLgroupid)
 
-    def ClusterThermostatUserInterfaceConfiguration_WriteAttributeTemperatureDisplayMode(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
-        return self._chipLib.chip_ime_WriteAttribute_ThermostatUserInterfaceConfiguration_TemperatureDisplayMode(device, ZCLendpoint, ZCLgroupid, value)
-
     def ClusterThermostatUserInterfaceConfiguration_ReadAttributeKeypadLockout(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ThermostatUserInterfaceConfiguration_KeypadLockout(device, ZCLendpoint, ZCLgroupid)
 
-    def ClusterThermostatUserInterfaceConfiguration_WriteAttributeKeypadLockout(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
-        return self._chipLib.chip_ime_WriteAttribute_ThermostatUserInterfaceConfiguration_KeypadLockout(device, ZCLendpoint, ZCLgroupid, value)
-
     def ClusterThermostatUserInterfaceConfiguration_ReadAttributeScheduleProgrammingVisibility(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ThermostatUserInterfaceConfiguration_ScheduleProgrammingVisibility(device, ZCLendpoint, ZCLgroupid)
-
-    def ClusterThermostatUserInterfaceConfiguration_WriteAttributeScheduleProgrammingVisibility(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
-        return self._chipLib.chip_ime_WriteAttribute_ThermostatUserInterfaceConfiguration_ScheduleProgrammingVisibility(device, ZCLendpoint, ZCLgroupid, value)
 
     def ClusterThermostatUserInterfaceConfiguration_ReadAttributeClusterRevision(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ThermostatUserInterfaceConfiguration_ClusterRevision(device, ZCLendpoint, ZCLgroupid)
@@ -7363,9 +6174,6 @@ class ChipClusters:
     def ClusterWindowCovering_ReadAttributeMode(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_WindowCovering_Mode(device, ZCLendpoint, ZCLgroupid)
 
-    def ClusterWindowCovering_WriteAttributeMode(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
-        return self._chipLib.chip_ime_WriteAttribute_WindowCovering_Mode(device, ZCLendpoint, ZCLgroupid, value)
-
     def ClusterWindowCovering_ReadAttributeSafetyStatus(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_WindowCovering_SafetyStatus(device, ZCLendpoint, ZCLgroupid)
 
@@ -7390,40 +6198,16 @@ class ChipClusters:
             ChipClusters.FAILURE_DELEGATE]
         self._chipLib.chip_ime_SetFailureResponseDelegate.res = None
         # Cluster AccountLogin
-        # Cluster AccountLogin Command GetSetupPIN
-        self._chipLib.chip_ime_AppendCommand_AccountLogin_GetSetupPIN.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
-        self._chipLib.chip_ime_AppendCommand_AccountLogin_GetSetupPIN.restype = ctypes.c_uint32
-        # Cluster AccountLogin Command Login
-        self._chipLib.chip_ime_AppendCommand_AccountLogin_Login.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_char_p, ctypes.c_uint32]
-        self._chipLib.chip_ime_AppendCommand_AccountLogin_Login.restype = ctypes.c_uint32
         # Cluster AccountLogin ReadAttribute ClusterRevision
         self._chipLib.chip_ime_ReadAttribute_AccountLogin_ClusterRevision.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_AccountLogin_ClusterRevision.restype = ctypes.c_uint32
         # Cluster AdministratorCommissioning
-        # Cluster AdministratorCommissioning Command OpenBasicCommissioningWindow
-        self._chipLib.chip_ime_AppendCommand_AdministratorCommissioning_OpenBasicCommissioningWindow.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
-        self._chipLib.chip_ime_AppendCommand_AdministratorCommissioning_OpenBasicCommissioningWindow.restype = ctypes.c_uint32
-        # Cluster AdministratorCommissioning Command OpenCommissioningWindow
-        self._chipLib.chip_ime_AppendCommand_AdministratorCommissioning_OpenCommissioningWindow.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint16, ctypes.c_uint32, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint16]
-        self._chipLib.chip_ime_AppendCommand_AdministratorCommissioning_OpenCommissioningWindow.restype = ctypes.c_uint32
-        # Cluster AdministratorCommissioning Command RevokeCommissioning
-        self._chipLib.chip_ime_AppendCommand_AdministratorCommissioning_RevokeCommissioning.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
-        self._chipLib.chip_ime_AppendCommand_AdministratorCommissioning_RevokeCommissioning.restype = ctypes.c_uint32
         # Cluster AdministratorCommissioning ReadAttribute ClusterRevision
         self._chipLib.chip_ime_ReadAttribute_AdministratorCommissioning_ClusterRevision.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_AdministratorCommissioning_ClusterRevision.restype = ctypes.c_uint32
         # Cluster ApplicationBasic
-        # Cluster ApplicationBasic Command ChangeStatus
-        self._chipLib.chip_ime_AppendCommand_ApplicationBasic_ChangeStatus.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
-        self._chipLib.chip_ime_AppendCommand_ApplicationBasic_ChangeStatus.restype = ctypes.c_uint32
         # Cluster ApplicationBasic ReadAttribute VendorName
         self._chipLib.chip_ime_ReadAttribute_ApplicationBasic_VendorName.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -7457,10 +6241,6 @@ class ChipClusters:
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ApplicationBasic_ClusterRevision.restype = ctypes.c_uint32
         # Cluster ApplicationLauncher
-        # Cluster ApplicationLauncher Command LaunchApp
-        self._chipLib.chip_ime_AppendCommand_ApplicationLauncher_LaunchApp.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
-        self._chipLib.chip_ime_AppendCommand_ApplicationLauncher_LaunchApp.restype = ctypes.c_uint32
         # Cluster ApplicationLauncher ReadAttribute ApplicationLauncherList
         self._chipLib.chip_ime_ReadAttribute_ApplicationLauncher_ApplicationLauncherList.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -7478,14 +6258,6 @@ class ChipClusters:
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ApplicationLauncher_ClusterRevision.restype = ctypes.c_uint32
         # Cluster AudioOutput
-        # Cluster AudioOutput Command RenameOutput
-        self._chipLib.chip_ime_AppendCommand_AudioOutput_RenameOutput.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_char_p, ctypes.c_uint32]
-        self._chipLib.chip_ime_AppendCommand_AudioOutput_RenameOutput.restype = ctypes.c_uint32
-        # Cluster AudioOutput Command SelectOutput
-        self._chipLib.chip_ime_AppendCommand_AudioOutput_SelectOutput.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
-        self._chipLib.chip_ime_AppendCommand_AudioOutput_SelectOutput.restype = ctypes.c_uint32
         # Cluster AudioOutput ReadAttribute AudioOutputList
         self._chipLib.chip_ime_ReadAttribute_AudioOutput_AudioOutputList.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -7499,14 +6271,6 @@ class ChipClusters:
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_AudioOutput_ClusterRevision.restype = ctypes.c_uint32
         # Cluster BarrierControl
-        # Cluster BarrierControl Command BarrierControlGoToPercent
-        self._chipLib.chip_ime_AppendCommand_BarrierControl_BarrierControlGoToPercent.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
-        self._chipLib.chip_ime_AppendCommand_BarrierControl_BarrierControlGoToPercent.restype = ctypes.c_uint32
-        # Cluster BarrierControl Command BarrierControlStop
-        self._chipLib.chip_ime_AppendCommand_BarrierControl_BarrierControlStop.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
-        self._chipLib.chip_ime_AppendCommand_BarrierControl_BarrierControlStop.restype = ctypes.c_uint32
         # Cluster BarrierControl ReadAttribute BarrierMovingState
         self._chipLib.chip_ime_ReadAttribute_BarrierControl_BarrierMovingState.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -7528,10 +6292,6 @@ class ChipClusters:
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_BarrierControl_ClusterRevision.restype = ctypes.c_uint32
         # Cluster Basic
-        # Cluster Basic Command MfgSpecificPing
-        self._chipLib.chip_ime_AppendCommand_Basic_MfgSpecificPing.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
-        self._chipLib.chip_ime_AppendCommand_Basic_MfgSpecificPing.restype = ctypes.c_uint32
         # Cluster Basic ReadAttribute InteractionModelVersion
         self._chipLib.chip_ime_ReadAttribute_Basic_InteractionModelVersion.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -7556,18 +6316,10 @@ class ChipClusters:
         self._chipLib.chip_ime_ReadAttribute_Basic_UserLabel.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_Basic_UserLabel.restype = ctypes.c_uint32
-        # Cluster Basic WriteAttribute UserLabel
-        self._chipLib.chip_ime_WriteAttribute_Basic_UserLabel.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
-        self._chipLib.chip_ime_WriteAttribute_Basic_UserLabel.restype = ctypes.c_uint32
         # Cluster Basic ReadAttribute Location
         self._chipLib.chip_ime_ReadAttribute_Basic_Location.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_Basic_Location.restype = ctypes.c_uint32
-        # Cluster Basic WriteAttribute Location
-        self._chipLib.chip_ime_WriteAttribute_Basic_Location.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
-        self._chipLib.chip_ime_WriteAttribute_Basic_Location.restype = ctypes.c_uint32
         # Cluster Basic ReadAttribute HardwareVersion
         self._chipLib.chip_ime_ReadAttribute_Basic_HardwareVersion.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -7608,10 +6360,6 @@ class ChipClusters:
         self._chipLib.chip_ime_ReadAttribute_Basic_LocalConfigDisabled.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_Basic_LocalConfigDisabled.restype = ctypes.c_uint32
-        # Cluster Basic WriteAttribute LocalConfigDisabled
-        self._chipLib.chip_ime_WriteAttribute_Basic_LocalConfigDisabled.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_bool]
-        self._chipLib.chip_ime_WriteAttribute_Basic_LocalConfigDisabled.restype = ctypes.c_uint32
         # Cluster Basic ReadAttribute Reachable
         self._chipLib.chip_ime_ReadAttribute_Basic_Reachable.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -7625,10 +6373,6 @@ class ChipClusters:
         self._chipLib.chip_ime_ReadAttribute_BinaryInputBasic_OutOfService.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_BinaryInputBasic_OutOfService.restype = ctypes.c_uint32
-        # Cluster BinaryInputBasic WriteAttribute OutOfService
-        self._chipLib.chip_ime_WriteAttribute_BinaryInputBasic_OutOfService.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_bool]
-        self._chipLib.chip_ime_WriteAttribute_BinaryInputBasic_OutOfService.restype = ctypes.c_uint32
         # Cluster BinaryInputBasic ReadAttribute PresentValue
         self._chipLib.chip_ime_ReadAttribute_BinaryInputBasic_PresentValue.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -7637,10 +6381,6 @@ class ChipClusters:
         self._chipLib.chip_ime_SubscribeAttribute_BinaryInputBasic_PresentValue.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_SubscribeAttribute_BinaryInputBasic_PresentValue.restype = ctypes.c_uint32
-        # Cluster BinaryInputBasic WriteAttribute PresentValue
-        self._chipLib.chip_ime_WriteAttribute_BinaryInputBasic_PresentValue.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_bool]
-        self._chipLib.chip_ime_WriteAttribute_BinaryInputBasic_PresentValue.restype = ctypes.c_uint32
         # Cluster BinaryInputBasic ReadAttribute StatusFlags
         self._chipLib.chip_ime_ReadAttribute_BinaryInputBasic_StatusFlags.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -7654,14 +6394,6 @@ class ChipClusters:
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_BinaryInputBasic_ClusterRevision.restype = ctypes.c_uint32
         # Cluster Binding
-        # Cluster Binding Command Bind
-        self._chipLib.chip_ime_AppendCommand_Binding_Bind.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint64, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint32]
-        self._chipLib.chip_ime_AppendCommand_Binding_Bind.restype = ctypes.c_uint32
-        # Cluster Binding Command Unbind
-        self._chipLib.chip_ime_AppendCommand_Binding_Unbind.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint64, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint32]
-        self._chipLib.chip_ime_AppendCommand_Binding_Unbind.restype = ctypes.c_uint32
         # Cluster Binding ReadAttribute ClusterRevision
         self._chipLib.chip_ime_ReadAttribute_Binding_ClusterRevision.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -7680,54 +6412,6 @@ class ChipClusters:
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_BooleanState_ClusterRevision.restype = ctypes.c_uint32
         # Cluster BridgedActions
-        # Cluster BridgedActions Command DisableAction
-        self._chipLib.chip_ime_AppendCommand_BridgedActions_DisableAction.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint32]
-        self._chipLib.chip_ime_AppendCommand_BridgedActions_DisableAction.restype = ctypes.c_uint32
-        # Cluster BridgedActions Command DisableActionWithDuration
-        self._chipLib.chip_ime_AppendCommand_BridgedActions_DisableActionWithDuration.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint32, ctypes.c_uint32]
-        self._chipLib.chip_ime_AppendCommand_BridgedActions_DisableActionWithDuration.restype = ctypes.c_uint32
-        # Cluster BridgedActions Command EnableAction
-        self._chipLib.chip_ime_AppendCommand_BridgedActions_EnableAction.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint32]
-        self._chipLib.chip_ime_AppendCommand_BridgedActions_EnableAction.restype = ctypes.c_uint32
-        # Cluster BridgedActions Command EnableActionWithDuration
-        self._chipLib.chip_ime_AppendCommand_BridgedActions_EnableActionWithDuration.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint32, ctypes.c_uint32]
-        self._chipLib.chip_ime_AppendCommand_BridgedActions_EnableActionWithDuration.restype = ctypes.c_uint32
-        # Cluster BridgedActions Command InstantAction
-        self._chipLib.chip_ime_AppendCommand_BridgedActions_InstantAction.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint32]
-        self._chipLib.chip_ime_AppendCommand_BridgedActions_InstantAction.restype = ctypes.c_uint32
-        # Cluster BridgedActions Command InstantActionWithTransition
-        self._chipLib.chip_ime_AppendCommand_BridgedActions_InstantActionWithTransition.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint32, ctypes.c_uint16]
-        self._chipLib.chip_ime_AppendCommand_BridgedActions_InstantActionWithTransition.restype = ctypes.c_uint32
-        # Cluster BridgedActions Command PauseAction
-        self._chipLib.chip_ime_AppendCommand_BridgedActions_PauseAction.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint32]
-        self._chipLib.chip_ime_AppendCommand_BridgedActions_PauseAction.restype = ctypes.c_uint32
-        # Cluster BridgedActions Command PauseActionWithDuration
-        self._chipLib.chip_ime_AppendCommand_BridgedActions_PauseActionWithDuration.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint32, ctypes.c_uint32]
-        self._chipLib.chip_ime_AppendCommand_BridgedActions_PauseActionWithDuration.restype = ctypes.c_uint32
-        # Cluster BridgedActions Command ResumeAction
-        self._chipLib.chip_ime_AppendCommand_BridgedActions_ResumeAction.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint32]
-        self._chipLib.chip_ime_AppendCommand_BridgedActions_ResumeAction.restype = ctypes.c_uint32
-        # Cluster BridgedActions Command StartAction
-        self._chipLib.chip_ime_AppendCommand_BridgedActions_StartAction.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint32]
-        self._chipLib.chip_ime_AppendCommand_BridgedActions_StartAction.restype = ctypes.c_uint32
-        # Cluster BridgedActions Command StartActionWithDuration
-        self._chipLib.chip_ime_AppendCommand_BridgedActions_StartActionWithDuration.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint32, ctypes.c_uint32]
-        self._chipLib.chip_ime_AppendCommand_BridgedActions_StartActionWithDuration.restype = ctypes.c_uint32
-        # Cluster BridgedActions Command StopAction
-        self._chipLib.chip_ime_AppendCommand_BridgedActions_StopAction.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint32]
-        self._chipLib.chip_ime_AppendCommand_BridgedActions_StopAction.restype = ctypes.c_uint32
         # Cluster BridgedActions ReadAttribute ActionList
         self._chipLib.chip_ime_ReadAttribute_BridgedActions_ActionList.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -7761,10 +6445,6 @@ class ChipClusters:
         self._chipLib.chip_ime_ReadAttribute_BridgedDeviceBasic_UserLabel.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_BridgedDeviceBasic_UserLabel.restype = ctypes.c_uint32
-        # Cluster BridgedDeviceBasic WriteAttribute UserLabel
-        self._chipLib.chip_ime_WriteAttribute_BridgedDeviceBasic_UserLabel.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
-        self._chipLib.chip_ime_WriteAttribute_BridgedDeviceBasic_UserLabel.restype = ctypes.c_uint32
         # Cluster BridgedDeviceBasic ReadAttribute HardwareVersion
         self._chipLib.chip_ime_ReadAttribute_BridgedDeviceBasic_HardwareVersion.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -7810,82 +6490,6 @@ class ChipClusters:
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_BridgedDeviceBasic_ClusterRevision.restype = ctypes.c_uint32
         # Cluster ColorControl
-        # Cluster ColorControl Command ColorLoopSet
-        self._chipLib.chip_ime_AppendCommand_ColorControl_ColorLoopSet.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
-        self._chipLib.chip_ime_AppendCommand_ColorControl_ColorLoopSet.restype = ctypes.c_uint32
-        # Cluster ColorControl Command EnhancedMoveHue
-        self._chipLib.chip_ime_AppendCommand_ColorControl_EnhancedMoveHue.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
-        self._chipLib.chip_ime_AppendCommand_ColorControl_EnhancedMoveHue.restype = ctypes.c_uint32
-        # Cluster ColorControl Command EnhancedMoveToHue
-        self._chipLib.chip_ime_AppendCommand_ColorControl_EnhancedMoveToHue.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
-        self._chipLib.chip_ime_AppendCommand_ColorControl_EnhancedMoveToHue.restype = ctypes.c_uint32
-        # Cluster ColorControl Command EnhancedMoveToHueAndSaturation
-        self._chipLib.chip_ime_AppendCommand_ColorControl_EnhancedMoveToHueAndSaturation.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
-        self._chipLib.chip_ime_AppendCommand_ColorControl_EnhancedMoveToHueAndSaturation.restype = ctypes.c_uint32
-        # Cluster ColorControl Command EnhancedStepHue
-        self._chipLib.chip_ime_AppendCommand_ColorControl_EnhancedStepHue.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
-        self._chipLib.chip_ime_AppendCommand_ColorControl_EnhancedStepHue.restype = ctypes.c_uint32
-        # Cluster ColorControl Command MoveColor
-        self._chipLib.chip_ime_AppendCommand_ColorControl_MoveColor.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_int16, ctypes.c_int16, ctypes.c_uint8, ctypes.c_uint8]
-        self._chipLib.chip_ime_AppendCommand_ColorControl_MoveColor.restype = ctypes.c_uint32
-        # Cluster ColorControl Command MoveColorTemperature
-        self._chipLib.chip_ime_AppendCommand_ColorControl_MoveColorTemperature.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
-        self._chipLib.chip_ime_AppendCommand_ColorControl_MoveColorTemperature.restype = ctypes.c_uint32
-        # Cluster ColorControl Command MoveHue
-        self._chipLib.chip_ime_AppendCommand_ColorControl_MoveHue.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8]
-        self._chipLib.chip_ime_AppendCommand_ColorControl_MoveHue.restype = ctypes.c_uint32
-        # Cluster ColorControl Command MoveSaturation
-        self._chipLib.chip_ime_AppendCommand_ColorControl_MoveSaturation.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8]
-        self._chipLib.chip_ime_AppendCommand_ColorControl_MoveSaturation.restype = ctypes.c_uint32
-        # Cluster ColorControl Command MoveToColor
-        self._chipLib.chip_ime_AppendCommand_ColorControl_MoveToColor.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
-        self._chipLib.chip_ime_AppendCommand_ColorControl_MoveToColor.restype = ctypes.c_uint32
-        # Cluster ColorControl Command MoveToColorTemperature
-        self._chipLib.chip_ime_AppendCommand_ColorControl_MoveToColorTemperature.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
-        self._chipLib.chip_ime_AppendCommand_ColorControl_MoveToColorTemperature.restype = ctypes.c_uint32
-        # Cluster ColorControl Command MoveToHue
-        self._chipLib.chip_ime_AppendCommand_ColorControl_MoveToHue.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
-        self._chipLib.chip_ime_AppendCommand_ColorControl_MoveToHue.restype = ctypes.c_uint32
-        # Cluster ColorControl Command MoveToHueAndSaturation
-        self._chipLib.chip_ime_AppendCommand_ColorControl_MoveToHueAndSaturation.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
-        self._chipLib.chip_ime_AppendCommand_ColorControl_MoveToHueAndSaturation.restype = ctypes.c_uint32
-        # Cluster ColorControl Command MoveToSaturation
-        self._chipLib.chip_ime_AppendCommand_ColorControl_MoveToSaturation.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
-        self._chipLib.chip_ime_AppendCommand_ColorControl_MoveToSaturation.restype = ctypes.c_uint32
-        # Cluster ColorControl Command StepColor
-        self._chipLib.chip_ime_AppendCommand_ColorControl_StepColor.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_int16, ctypes.c_int16, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
-        self._chipLib.chip_ime_AppendCommand_ColorControl_StepColor.restype = ctypes.c_uint32
-        # Cluster ColorControl Command StepColorTemperature
-        self._chipLib.chip_ime_AppendCommand_ColorControl_StepColorTemperature.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
-        self._chipLib.chip_ime_AppendCommand_ColorControl_StepColorTemperature.restype = ctypes.c_uint32
-        # Cluster ColorControl Command StepHue
-        self._chipLib.chip_ime_AppendCommand_ColorControl_StepHue.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8]
-        self._chipLib.chip_ime_AppendCommand_ColorControl_StepHue.restype = ctypes.c_uint32
-        # Cluster ColorControl Command StepSaturation
-        self._chipLib.chip_ime_AppendCommand_ColorControl_StepSaturation.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8]
-        self._chipLib.chip_ime_AppendCommand_ColorControl_StepSaturation.restype = ctypes.c_uint32
-        # Cluster ColorControl Command StopMoveStep
-        self._chipLib.chip_ime_AppendCommand_ColorControl_StopMoveStep.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
-        self._chipLib.chip_ime_AppendCommand_ColorControl_StopMoveStep.restype = ctypes.c_uint32
         # Cluster ColorControl ReadAttribute CurrentHue
         self._chipLib.chip_ime_ReadAttribute_ColorControl_CurrentHue.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -7946,10 +6550,6 @@ class ChipClusters:
         self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorControlOptions.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorControlOptions.restype = ctypes.c_uint32
-        # Cluster ColorControl WriteAttribute ColorControlOptions
-        self._chipLib.chip_ime_WriteAttribute_ColorControl_ColorControlOptions.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
-        self._chipLib.chip_ime_WriteAttribute_ColorControl_ColorControlOptions.restype = ctypes.c_uint32
         # Cluster ColorControl ReadAttribute NumberOfPrimaries
         self._chipLib.chip_ime_ReadAttribute_ColorControl_NumberOfPrimaries.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -8030,90 +6630,46 @@ class ChipClusters:
         self._chipLib.chip_ime_ReadAttribute_ColorControl_WhitePointX.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ColorControl_WhitePointX.restype = ctypes.c_uint32
-        # Cluster ColorControl WriteAttribute WhitePointX
-        self._chipLib.chip_ime_WriteAttribute_ColorControl_WhitePointX.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
-        self._chipLib.chip_ime_WriteAttribute_ColorControl_WhitePointX.restype = ctypes.c_uint32
         # Cluster ColorControl ReadAttribute WhitePointY
         self._chipLib.chip_ime_ReadAttribute_ColorControl_WhitePointY.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ColorControl_WhitePointY.restype = ctypes.c_uint32
-        # Cluster ColorControl WriteAttribute WhitePointY
-        self._chipLib.chip_ime_WriteAttribute_ColorControl_WhitePointY.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
-        self._chipLib.chip_ime_WriteAttribute_ColorControl_WhitePointY.restype = ctypes.c_uint32
         # Cluster ColorControl ReadAttribute ColorPointRX
         self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorPointRX.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorPointRX.restype = ctypes.c_uint32
-        # Cluster ColorControl WriteAttribute ColorPointRX
-        self._chipLib.chip_ime_WriteAttribute_ColorControl_ColorPointRX.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
-        self._chipLib.chip_ime_WriteAttribute_ColorControl_ColorPointRX.restype = ctypes.c_uint32
         # Cluster ColorControl ReadAttribute ColorPointRY
         self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorPointRY.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorPointRY.restype = ctypes.c_uint32
-        # Cluster ColorControl WriteAttribute ColorPointRY
-        self._chipLib.chip_ime_WriteAttribute_ColorControl_ColorPointRY.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
-        self._chipLib.chip_ime_WriteAttribute_ColorControl_ColorPointRY.restype = ctypes.c_uint32
         # Cluster ColorControl ReadAttribute ColorPointRIntensity
         self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorPointRIntensity.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorPointRIntensity.restype = ctypes.c_uint32
-        # Cluster ColorControl WriteAttribute ColorPointRIntensity
-        self._chipLib.chip_ime_WriteAttribute_ColorControl_ColorPointRIntensity.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
-        self._chipLib.chip_ime_WriteAttribute_ColorControl_ColorPointRIntensity.restype = ctypes.c_uint32
         # Cluster ColorControl ReadAttribute ColorPointGX
         self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorPointGX.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorPointGX.restype = ctypes.c_uint32
-        # Cluster ColorControl WriteAttribute ColorPointGX
-        self._chipLib.chip_ime_WriteAttribute_ColorControl_ColorPointGX.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
-        self._chipLib.chip_ime_WriteAttribute_ColorControl_ColorPointGX.restype = ctypes.c_uint32
         # Cluster ColorControl ReadAttribute ColorPointGY
         self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorPointGY.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorPointGY.restype = ctypes.c_uint32
-        # Cluster ColorControl WriteAttribute ColorPointGY
-        self._chipLib.chip_ime_WriteAttribute_ColorControl_ColorPointGY.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
-        self._chipLib.chip_ime_WriteAttribute_ColorControl_ColorPointGY.restype = ctypes.c_uint32
         # Cluster ColorControl ReadAttribute ColorPointGIntensity
         self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorPointGIntensity.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorPointGIntensity.restype = ctypes.c_uint32
-        # Cluster ColorControl WriteAttribute ColorPointGIntensity
-        self._chipLib.chip_ime_WriteAttribute_ColorControl_ColorPointGIntensity.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
-        self._chipLib.chip_ime_WriteAttribute_ColorControl_ColorPointGIntensity.restype = ctypes.c_uint32
         # Cluster ColorControl ReadAttribute ColorPointBX
         self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorPointBX.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorPointBX.restype = ctypes.c_uint32
-        # Cluster ColorControl WriteAttribute ColorPointBX
-        self._chipLib.chip_ime_WriteAttribute_ColorControl_ColorPointBX.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
-        self._chipLib.chip_ime_WriteAttribute_ColorControl_ColorPointBX.restype = ctypes.c_uint32
         # Cluster ColorControl ReadAttribute ColorPointBY
         self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorPointBY.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorPointBY.restype = ctypes.c_uint32
-        # Cluster ColorControl WriteAttribute ColorPointBY
-        self._chipLib.chip_ime_WriteAttribute_ColorControl_ColorPointBY.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
-        self._chipLib.chip_ime_WriteAttribute_ColorControl_ColorPointBY.restype = ctypes.c_uint32
         # Cluster ColorControl ReadAttribute ColorPointBIntensity
         self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorPointBIntensity.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorPointBIntensity.restype = ctypes.c_uint32
-        # Cluster ColorControl WriteAttribute ColorPointBIntensity
-        self._chipLib.chip_ime_WriteAttribute_ColorControl_ColorPointBIntensity.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
-        self._chipLib.chip_ime_WriteAttribute_ColorControl_ColorPointBIntensity.restype = ctypes.c_uint32
         # Cluster ColorControl ReadAttribute EnhancedCurrentHue
         self._chipLib.chip_ime_ReadAttribute_ColorControl_EnhancedCurrentHue.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -8162,23 +6718,11 @@ class ChipClusters:
         self._chipLib.chip_ime_ReadAttribute_ColorControl_StartUpColorTemperatureMireds.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ColorControl_StartUpColorTemperatureMireds.restype = ctypes.c_uint32
-        # Cluster ColorControl WriteAttribute StartUpColorTemperatureMireds
-        self._chipLib.chip_ime_WriteAttribute_ColorControl_StartUpColorTemperatureMireds.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
-        self._chipLib.chip_ime_WriteAttribute_ColorControl_StartUpColorTemperatureMireds.restype = ctypes.c_uint32
         # Cluster ColorControl ReadAttribute ClusterRevision
         self._chipLib.chip_ime_ReadAttribute_ColorControl_ClusterRevision.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ColorControl_ClusterRevision.restype = ctypes.c_uint32
         # Cluster ContentLauncher
-        # Cluster ContentLauncher Command LaunchContent
-        self._chipLib.chip_ime_AppendCommand_ContentLauncher_LaunchContent.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_bool, ctypes.c_char_p, ctypes.c_uint32]
-        self._chipLib.chip_ime_AppendCommand_ContentLauncher_LaunchContent.restype = ctypes.c_uint32
-        # Cluster ContentLauncher Command LaunchURL
-        self._chipLib.chip_ime_AppendCommand_ContentLauncher_LaunchURL.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_char_p, ctypes.c_uint32]
-        self._chipLib.chip_ime_AppendCommand_ContentLauncher_LaunchURL.restype = ctypes.c_uint32
         # Cluster ContentLauncher ReadAttribute AcceptsHeaderList
         self._chipLib.chip_ime_ReadAttribute_ContentLauncher_AcceptsHeaderList.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -8213,103 +6757,7 @@ class ChipClusters:
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_Descriptor_ClusterRevision.restype = ctypes.c_uint32
         # Cluster DiagnosticLogs
-        # Cluster DiagnosticLogs Command RetrieveLogsRequest
-        self._chipLib.chip_ime_AppendCommand_DiagnosticLogs_RetrieveLogsRequest.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_char_p, ctypes.c_uint32]
-        self._chipLib.chip_ime_AppendCommand_DiagnosticLogs_RetrieveLogsRequest.restype = ctypes.c_uint32
         # Cluster DoorLock
-        # Cluster DoorLock Command ClearAllPins
-        self._chipLib.chip_ime_AppendCommand_DoorLock_ClearAllPins.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
-        self._chipLib.chip_ime_AppendCommand_DoorLock_ClearAllPins.restype = ctypes.c_uint32
-        # Cluster DoorLock Command ClearAllRfids
-        self._chipLib.chip_ime_AppendCommand_DoorLock_ClearAllRfids.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
-        self._chipLib.chip_ime_AppendCommand_DoorLock_ClearAllRfids.restype = ctypes.c_uint32
-        # Cluster DoorLock Command ClearHolidaySchedule
-        self._chipLib.chip_ime_AppendCommand_DoorLock_ClearHolidaySchedule.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
-        self._chipLib.chip_ime_AppendCommand_DoorLock_ClearHolidaySchedule.restype = ctypes.c_uint32
-        # Cluster DoorLock Command ClearPin
-        self._chipLib.chip_ime_AppendCommand_DoorLock_ClearPin.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
-        self._chipLib.chip_ime_AppendCommand_DoorLock_ClearPin.restype = ctypes.c_uint32
-        # Cluster DoorLock Command ClearRfid
-        self._chipLib.chip_ime_AppendCommand_DoorLock_ClearRfid.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
-        self._chipLib.chip_ime_AppendCommand_DoorLock_ClearRfid.restype = ctypes.c_uint32
-        # Cluster DoorLock Command ClearWeekdaySchedule
-        self._chipLib.chip_ime_AppendCommand_DoorLock_ClearWeekdaySchedule.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16]
-        self._chipLib.chip_ime_AppendCommand_DoorLock_ClearWeekdaySchedule.restype = ctypes.c_uint32
-        # Cluster DoorLock Command ClearYeardaySchedule
-        self._chipLib.chip_ime_AppendCommand_DoorLock_ClearYeardaySchedule.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16]
-        self._chipLib.chip_ime_AppendCommand_DoorLock_ClearYeardaySchedule.restype = ctypes.c_uint32
-        # Cluster DoorLock Command GetHolidaySchedule
-        self._chipLib.chip_ime_AppendCommand_DoorLock_GetHolidaySchedule.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
-        self._chipLib.chip_ime_AppendCommand_DoorLock_GetHolidaySchedule.restype = ctypes.c_uint32
-        # Cluster DoorLock Command GetLogRecord
-        self._chipLib.chip_ime_AppendCommand_DoorLock_GetLogRecord.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
-        self._chipLib.chip_ime_AppendCommand_DoorLock_GetLogRecord.restype = ctypes.c_uint32
-        # Cluster DoorLock Command GetPin
-        self._chipLib.chip_ime_AppendCommand_DoorLock_GetPin.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
-        self._chipLib.chip_ime_AppendCommand_DoorLock_GetPin.restype = ctypes.c_uint32
-        # Cluster DoorLock Command GetRfid
-        self._chipLib.chip_ime_AppendCommand_DoorLock_GetRfid.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
-        self._chipLib.chip_ime_AppendCommand_DoorLock_GetRfid.restype = ctypes.c_uint32
-        # Cluster DoorLock Command GetUserType
-        self._chipLib.chip_ime_AppendCommand_DoorLock_GetUserType.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
-        self._chipLib.chip_ime_AppendCommand_DoorLock_GetUserType.restype = ctypes.c_uint32
-        # Cluster DoorLock Command GetWeekdaySchedule
-        self._chipLib.chip_ime_AppendCommand_DoorLock_GetWeekdaySchedule.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16]
-        self._chipLib.chip_ime_AppendCommand_DoorLock_GetWeekdaySchedule.restype = ctypes.c_uint32
-        # Cluster DoorLock Command GetYeardaySchedule
-        self._chipLib.chip_ime_AppendCommand_DoorLock_GetYeardaySchedule.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16]
-        self._chipLib.chip_ime_AppendCommand_DoorLock_GetYeardaySchedule.restype = ctypes.c_uint32
-        # Cluster DoorLock Command LockDoor
-        self._chipLib.chip_ime_AppendCommand_DoorLock_LockDoor.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
-        self._chipLib.chip_ime_AppendCommand_DoorLock_LockDoor.restype = ctypes.c_uint32
-        # Cluster DoorLock Command SetHolidaySchedule
-        self._chipLib.chip_ime_AppendCommand_DoorLock_SetHolidaySchedule.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint32, ctypes.c_uint32, ctypes.c_uint8]
-        self._chipLib.chip_ime_AppendCommand_DoorLock_SetHolidaySchedule.restype = ctypes.c_uint32
-        # Cluster DoorLock Command SetPin
-        self._chipLib.chip_ime_AppendCommand_DoorLock_SetPin.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_char_p, ctypes.c_uint32]
-        self._chipLib.chip_ime_AppendCommand_DoorLock_SetPin.restype = ctypes.c_uint32
-        # Cluster DoorLock Command SetRfid
-        self._chipLib.chip_ime_AppendCommand_DoorLock_SetRfid.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_char_p, ctypes.c_uint32]
-        self._chipLib.chip_ime_AppendCommand_DoorLock_SetRfid.restype = ctypes.c_uint32
-        # Cluster DoorLock Command SetUserType
-        self._chipLib.chip_ime_AppendCommand_DoorLock_SetUserType.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint8]
-        self._chipLib.chip_ime_AppendCommand_DoorLock_SetUserType.restype = ctypes.c_uint32
-        # Cluster DoorLock Command SetWeekdaySchedule
-        self._chipLib.chip_ime_AppendCommand_DoorLock_SetWeekdaySchedule.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8]
-        self._chipLib.chip_ime_AppendCommand_DoorLock_SetWeekdaySchedule.restype = ctypes.c_uint32
-        # Cluster DoorLock Command SetYeardaySchedule
-        self._chipLib.chip_ime_AppendCommand_DoorLock_SetYeardaySchedule.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint32, ctypes.c_uint32]
-        self._chipLib.chip_ime_AppendCommand_DoorLock_SetYeardaySchedule.restype = ctypes.c_uint32
-        # Cluster DoorLock Command UnlockDoor
-        self._chipLib.chip_ime_AppendCommand_DoorLock_UnlockDoor.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
-        self._chipLib.chip_ime_AppendCommand_DoorLock_UnlockDoor.restype = ctypes.c_uint32
-        # Cluster DoorLock Command UnlockWithTimeout
-        self._chipLib.chip_ime_AppendCommand_DoorLock_UnlockWithTimeout.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
-        self._chipLib.chip_ime_AppendCommand_DoorLock_UnlockWithTimeout.restype = ctypes.c_uint32
         # Cluster DoorLock ReadAttribute LockState
         self._chipLib.chip_ime_ReadAttribute_DoorLock_LockState.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -8380,10 +6828,6 @@ class ChipClusters:
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ElectricalMeasurement_ClusterRevision.restype = ctypes.c_uint32
         # Cluster EthernetNetworkDiagnostics
-        # Cluster EthernetNetworkDiagnostics Command ResetCounts
-        self._chipLib.chip_ime_AppendCommand_EthernetNetworkDiagnostics_ResetCounts.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
-        self._chipLib.chip_ime_AppendCommand_EthernetNetworkDiagnostics_ResetCounts.restype = ctypes.c_uint32
         # Cluster EthernetNetworkDiagnostics ReadAttribute PHYRate
         self._chipLib.chip_ime_ReadAttribute_EthernetNetworkDiagnostics_PHYRate.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -8455,26 +6899,10 @@ class ChipClusters:
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_FlowMeasurement_ClusterRevision.restype = ctypes.c_uint32
         # Cluster GeneralCommissioning
-        # Cluster GeneralCommissioning Command ArmFailSafe
-        self._chipLib.chip_ime_AppendCommand_GeneralCommissioning_ArmFailSafe.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint64, ctypes.c_uint32]
-        self._chipLib.chip_ime_AppendCommand_GeneralCommissioning_ArmFailSafe.restype = ctypes.c_uint32
-        # Cluster GeneralCommissioning Command CommissioningComplete
-        self._chipLib.chip_ime_AppendCommand_GeneralCommissioning_CommissioningComplete.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
-        self._chipLib.chip_ime_AppendCommand_GeneralCommissioning_CommissioningComplete.restype = ctypes.c_uint32
-        # Cluster GeneralCommissioning Command SetRegulatoryConfig
-        self._chipLib.chip_ime_AppendCommand_GeneralCommissioning_SetRegulatoryConfig.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint64, ctypes.c_uint32]
-        self._chipLib.chip_ime_AppendCommand_GeneralCommissioning_SetRegulatoryConfig.restype = ctypes.c_uint32
         # Cluster GeneralCommissioning ReadAttribute Breadcrumb
         self._chipLib.chip_ime_ReadAttribute_GeneralCommissioning_Breadcrumb.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_GeneralCommissioning_Breadcrumb.restype = ctypes.c_uint32
-        # Cluster GeneralCommissioning WriteAttribute Breadcrumb
-        self._chipLib.chip_ime_WriteAttribute_GeneralCommissioning_Breadcrumb.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint64]
-        self._chipLib.chip_ime_WriteAttribute_GeneralCommissioning_Breadcrumb.restype = ctypes.c_uint32
         # Cluster GeneralCommissioning ReadAttribute BasicCommissioningInfoList
         self._chipLib.chip_ime_ReadAttribute_GeneralCommissioning_BasicCommissioningInfoList.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -8534,30 +6962,6 @@ class ChipClusters:
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_GroupKeyManagement_ClusterRevision.restype = ctypes.c_uint32
         # Cluster Groups
-        # Cluster Groups Command AddGroup
-        self._chipLib.chip_ime_AppendCommand_Groups_AddGroup.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
-        self._chipLib.chip_ime_AppendCommand_Groups_AddGroup.restype = ctypes.c_uint32
-        # Cluster Groups Command AddGroupIfIdentifying
-        self._chipLib.chip_ime_AppendCommand_Groups_AddGroupIfIdentifying.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
-        self._chipLib.chip_ime_AppendCommand_Groups_AddGroupIfIdentifying.restype = ctypes.c_uint32
-        # Cluster Groups Command GetGroupMembership
-        self._chipLib.chip_ime_AppendCommand_Groups_GetGroupMembership.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16]
-        self._chipLib.chip_ime_AppendCommand_Groups_GetGroupMembership.restype = ctypes.c_uint32
-        # Cluster Groups Command RemoveAllGroups
-        self._chipLib.chip_ime_AppendCommand_Groups_RemoveAllGroups.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
-        self._chipLib.chip_ime_AppendCommand_Groups_RemoveAllGroups.restype = ctypes.c_uint32
-        # Cluster Groups Command RemoveGroup
-        self._chipLib.chip_ime_AppendCommand_Groups_RemoveGroup.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
-        self._chipLib.chip_ime_AppendCommand_Groups_RemoveGroup.restype = ctypes.c_uint32
-        # Cluster Groups Command ViewGroup
-        self._chipLib.chip_ime_AppendCommand_Groups_ViewGroup.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
-        self._chipLib.chip_ime_AppendCommand_Groups_ViewGroup.restype = ctypes.c_uint32
         # Cluster Groups ReadAttribute NameSupport
         self._chipLib.chip_ime_ReadAttribute_Groups_NameSupport.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -8567,26 +6971,10 @@ class ChipClusters:
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_Groups_ClusterRevision.restype = ctypes.c_uint32
         # Cluster Identify
-        # Cluster Identify Command Identify
-        self._chipLib.chip_ime_AppendCommand_Identify_Identify.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
-        self._chipLib.chip_ime_AppendCommand_Identify_Identify.restype = ctypes.c_uint32
-        # Cluster Identify Command IdentifyQuery
-        self._chipLib.chip_ime_AppendCommand_Identify_IdentifyQuery.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
-        self._chipLib.chip_ime_AppendCommand_Identify_IdentifyQuery.restype = ctypes.c_uint32
-        # Cluster Identify Command TriggerEffect
-        self._chipLib.chip_ime_AppendCommand_Identify_TriggerEffect.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
-        self._chipLib.chip_ime_AppendCommand_Identify_TriggerEffect.restype = ctypes.c_uint32
         # Cluster Identify ReadAttribute IdentifyTime
         self._chipLib.chip_ime_ReadAttribute_Identify_IdentifyTime.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_Identify_IdentifyTime.restype = ctypes.c_uint32
-        # Cluster Identify WriteAttribute IdentifyTime
-        self._chipLib.chip_ime_WriteAttribute_Identify_IdentifyTime.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
-        self._chipLib.chip_ime_WriteAttribute_Identify_IdentifyTime.restype = ctypes.c_uint32
         # Cluster Identify ReadAttribute IdentifyType
         self._chipLib.chip_ime_ReadAttribute_Identify_IdentifyType.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -8625,47 +7013,11 @@ class ChipClusters:
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_IlluminanceMeasurement_ClusterRevision.restype = ctypes.c_uint32
         # Cluster KeypadInput
-        # Cluster KeypadInput Command SendKey
-        self._chipLib.chip_ime_AppendCommand_KeypadInput_SendKey.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
-        self._chipLib.chip_ime_AppendCommand_KeypadInput_SendKey.restype = ctypes.c_uint32
         # Cluster KeypadInput ReadAttribute ClusterRevision
         self._chipLib.chip_ime_ReadAttribute_KeypadInput_ClusterRevision.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_KeypadInput_ClusterRevision.restype = ctypes.c_uint32
         # Cluster LevelControl
-        # Cluster LevelControl Command Move
-        self._chipLib.chip_ime_AppendCommand_LevelControl_Move.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8]
-        self._chipLib.chip_ime_AppendCommand_LevelControl_Move.restype = ctypes.c_uint32
-        # Cluster LevelControl Command MoveToLevel
-        self._chipLib.chip_ime_AppendCommand_LevelControl_MoveToLevel.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
-        self._chipLib.chip_ime_AppendCommand_LevelControl_MoveToLevel.restype = ctypes.c_uint32
-        # Cluster LevelControl Command MoveToLevelWithOnOff
-        self._chipLib.chip_ime_AppendCommand_LevelControl_MoveToLevelWithOnOff.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16]
-        self._chipLib.chip_ime_AppendCommand_LevelControl_MoveToLevelWithOnOff.restype = ctypes.c_uint32
-        # Cluster LevelControl Command MoveWithOnOff
-        self._chipLib.chip_ime_AppendCommand_LevelControl_MoveWithOnOff.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
-        self._chipLib.chip_ime_AppendCommand_LevelControl_MoveWithOnOff.restype = ctypes.c_uint32
-        # Cluster LevelControl Command Step
-        self._chipLib.chip_ime_AppendCommand_LevelControl_Step.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
-        self._chipLib.chip_ime_AppendCommand_LevelControl_Step.restype = ctypes.c_uint32
-        # Cluster LevelControl Command StepWithOnOff
-        self._chipLib.chip_ime_AppendCommand_LevelControl_StepWithOnOff.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint16]
-        self._chipLib.chip_ime_AppendCommand_LevelControl_StepWithOnOff.restype = ctypes.c_uint32
-        # Cluster LevelControl Command Stop
-        self._chipLib.chip_ime_AppendCommand_LevelControl_Stop.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
-        self._chipLib.chip_ime_AppendCommand_LevelControl_Stop.restype = ctypes.c_uint32
-        # Cluster LevelControl Command StopWithOnOff
-        self._chipLib.chip_ime_AppendCommand_LevelControl_StopWithOnOff.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
-        self._chipLib.chip_ime_AppendCommand_LevelControl_StopWithOnOff.restype = ctypes.c_uint32
         # Cluster LevelControl ReadAttribute CurrentLevel
         self._chipLib.chip_ime_ReadAttribute_LevelControl_CurrentLevel.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -8702,88 +7054,40 @@ class ChipClusters:
         self._chipLib.chip_ime_ReadAttribute_LevelControl_Options.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_LevelControl_Options.restype = ctypes.c_uint32
-        # Cluster LevelControl WriteAttribute Options
-        self._chipLib.chip_ime_WriteAttribute_LevelControl_Options.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
-        self._chipLib.chip_ime_WriteAttribute_LevelControl_Options.restype = ctypes.c_uint32
         # Cluster LevelControl ReadAttribute OnOffTransitionTime
         self._chipLib.chip_ime_ReadAttribute_LevelControl_OnOffTransitionTime.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_LevelControl_OnOffTransitionTime.restype = ctypes.c_uint32
-        # Cluster LevelControl WriteAttribute OnOffTransitionTime
-        self._chipLib.chip_ime_WriteAttribute_LevelControl_OnOffTransitionTime.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
-        self._chipLib.chip_ime_WriteAttribute_LevelControl_OnOffTransitionTime.restype = ctypes.c_uint32
         # Cluster LevelControl ReadAttribute OnLevel
         self._chipLib.chip_ime_ReadAttribute_LevelControl_OnLevel.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_LevelControl_OnLevel.restype = ctypes.c_uint32
-        # Cluster LevelControl WriteAttribute OnLevel
-        self._chipLib.chip_ime_WriteAttribute_LevelControl_OnLevel.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
-        self._chipLib.chip_ime_WriteAttribute_LevelControl_OnLevel.restype = ctypes.c_uint32
         # Cluster LevelControl ReadAttribute OnTransitionTime
         self._chipLib.chip_ime_ReadAttribute_LevelControl_OnTransitionTime.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_LevelControl_OnTransitionTime.restype = ctypes.c_uint32
-        # Cluster LevelControl WriteAttribute OnTransitionTime
-        self._chipLib.chip_ime_WriteAttribute_LevelControl_OnTransitionTime.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
-        self._chipLib.chip_ime_WriteAttribute_LevelControl_OnTransitionTime.restype = ctypes.c_uint32
         # Cluster LevelControl ReadAttribute OffTransitionTime
         self._chipLib.chip_ime_ReadAttribute_LevelControl_OffTransitionTime.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_LevelControl_OffTransitionTime.restype = ctypes.c_uint32
-        # Cluster LevelControl WriteAttribute OffTransitionTime
-        self._chipLib.chip_ime_WriteAttribute_LevelControl_OffTransitionTime.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
-        self._chipLib.chip_ime_WriteAttribute_LevelControl_OffTransitionTime.restype = ctypes.c_uint32
         # Cluster LevelControl ReadAttribute DefaultMoveRate
         self._chipLib.chip_ime_ReadAttribute_LevelControl_DefaultMoveRate.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_LevelControl_DefaultMoveRate.restype = ctypes.c_uint32
-        # Cluster LevelControl WriteAttribute DefaultMoveRate
-        self._chipLib.chip_ime_WriteAttribute_LevelControl_DefaultMoveRate.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
-        self._chipLib.chip_ime_WriteAttribute_LevelControl_DefaultMoveRate.restype = ctypes.c_uint32
         # Cluster LevelControl ReadAttribute StartUpCurrentLevel
         self._chipLib.chip_ime_ReadAttribute_LevelControl_StartUpCurrentLevel.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_LevelControl_StartUpCurrentLevel.restype = ctypes.c_uint32
-        # Cluster LevelControl WriteAttribute StartUpCurrentLevel
-        self._chipLib.chip_ime_WriteAttribute_LevelControl_StartUpCurrentLevel.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
-        self._chipLib.chip_ime_WriteAttribute_LevelControl_StartUpCurrentLevel.restype = ctypes.c_uint32
         # Cluster LevelControl ReadAttribute ClusterRevision
         self._chipLib.chip_ime_ReadAttribute_LevelControl_ClusterRevision.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_LevelControl_ClusterRevision.restype = ctypes.c_uint32
         # Cluster LowPower
-        # Cluster LowPower Command Sleep
-        self._chipLib.chip_ime_AppendCommand_LowPower_Sleep.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
-        self._chipLib.chip_ime_AppendCommand_LowPower_Sleep.restype = ctypes.c_uint32
         # Cluster LowPower ReadAttribute ClusterRevision
         self._chipLib.chip_ime_ReadAttribute_LowPower_ClusterRevision.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_LowPower_ClusterRevision.restype = ctypes.c_uint32
         # Cluster MediaInput
-        # Cluster MediaInput Command HideInputStatus
-        self._chipLib.chip_ime_AppendCommand_MediaInput_HideInputStatus.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
-        self._chipLib.chip_ime_AppendCommand_MediaInput_HideInputStatus.restype = ctypes.c_uint32
-        # Cluster MediaInput Command RenameInput
-        self._chipLib.chip_ime_AppendCommand_MediaInput_RenameInput.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_char_p, ctypes.c_uint32]
-        self._chipLib.chip_ime_AppendCommand_MediaInput_RenameInput.restype = ctypes.c_uint32
-        # Cluster MediaInput Command SelectInput
-        self._chipLib.chip_ime_AppendCommand_MediaInput_SelectInput.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
-        self._chipLib.chip_ime_AppendCommand_MediaInput_SelectInput.restype = ctypes.c_uint32
-        # Cluster MediaInput Command ShowInputStatus
-        self._chipLib.chip_ime_AppendCommand_MediaInput_ShowInputStatus.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
-        self._chipLib.chip_ime_AppendCommand_MediaInput_ShowInputStatus.restype = ctypes.c_uint32
         # Cluster MediaInput ReadAttribute MediaInputList
         self._chipLib.chip_ime_ReadAttribute_MediaInput_MediaInputList.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -8797,50 +7101,6 @@ class ChipClusters:
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_MediaInput_ClusterRevision.restype = ctypes.c_uint32
         # Cluster MediaPlayback
-        # Cluster MediaPlayback Command MediaFastForward
-        self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaFastForward.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
-        self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaFastForward.restype = ctypes.c_uint32
-        # Cluster MediaPlayback Command MediaNext
-        self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaNext.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
-        self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaNext.restype = ctypes.c_uint32
-        # Cluster MediaPlayback Command MediaPause
-        self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaPause.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
-        self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaPause.restype = ctypes.c_uint32
-        # Cluster MediaPlayback Command MediaPlay
-        self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaPlay.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
-        self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaPlay.restype = ctypes.c_uint32
-        # Cluster MediaPlayback Command MediaPrevious
-        self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaPrevious.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
-        self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaPrevious.restype = ctypes.c_uint32
-        # Cluster MediaPlayback Command MediaRewind
-        self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaRewind.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
-        self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaRewind.restype = ctypes.c_uint32
-        # Cluster MediaPlayback Command MediaSeek
-        self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaSeek.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint64]
-        self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaSeek.restype = ctypes.c_uint32
-        # Cluster MediaPlayback Command MediaSkipBackward
-        self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaSkipBackward.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint64]
-        self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaSkipBackward.restype = ctypes.c_uint32
-        # Cluster MediaPlayback Command MediaSkipForward
-        self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaSkipForward.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint64]
-        self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaSkipForward.restype = ctypes.c_uint32
-        # Cluster MediaPlayback Command MediaStartOver
-        self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaStartOver.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
-        self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaStartOver.restype = ctypes.c_uint32
-        # Cluster MediaPlayback Command MediaStop
-        self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaStop.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
-        self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaStop.restype = ctypes.c_uint32
         # Cluster MediaPlayback ReadAttribute PlaybackState
         self._chipLib.chip_ime_ReadAttribute_MediaPlayback_PlaybackState.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -8878,10 +7138,6 @@ class ChipClusters:
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_MediaPlayback_ClusterRevision.restype = ctypes.c_uint32
         # Cluster ModeSelect
-        # Cluster ModeSelect Command ChangeToMode
-        self._chipLib.chip_ime_AppendCommand_ModeSelect_ChangeToMode.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
-        self._chipLib.chip_ime_AppendCommand_ModeSelect_ChangeToMode.restype = ctypes.c_uint32
         # Cluster ModeSelect ReadAttribute CurrentMode
         self._chipLib.chip_ime_ReadAttribute_ModeSelect_CurrentMode.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -8898,10 +7154,6 @@ class ChipClusters:
         self._chipLib.chip_ime_ReadAttribute_ModeSelect_OnMode.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ModeSelect_OnMode.restype = ctypes.c_uint32
-        # Cluster ModeSelect WriteAttribute OnMode
-        self._chipLib.chip_ime_WriteAttribute_ModeSelect_OnMode.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
-        self._chipLib.chip_ime_WriteAttribute_ModeSelect_OnMode.restype = ctypes.c_uint32
         # Cluster ModeSelect ReadAttribute StartUpMode
         self._chipLib.chip_ime_ReadAttribute_ModeSelect_StartUpMode.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -8915,38 +7167,6 @@ class ChipClusters:
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ModeSelect_ClusterRevision.restype = ctypes.c_uint32
         # Cluster NetworkCommissioning
-        # Cluster NetworkCommissioning Command AddThreadNetwork
-        self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_AddThreadNetwork.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint64, ctypes.c_uint32]
-        self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_AddThreadNetwork.restype = ctypes.c_uint32
-        # Cluster NetworkCommissioning Command AddWiFiNetwork
-        self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_AddWiFiNetwork.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint64, ctypes.c_uint32]
-        self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_AddWiFiNetwork.restype = ctypes.c_uint32
-        # Cluster NetworkCommissioning Command DisableNetwork
-        self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_DisableNetwork.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint64, ctypes.c_uint32]
-        self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_DisableNetwork.restype = ctypes.c_uint32
-        # Cluster NetworkCommissioning Command EnableNetwork
-        self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_EnableNetwork.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint64, ctypes.c_uint32]
-        self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_EnableNetwork.restype = ctypes.c_uint32
-        # Cluster NetworkCommissioning Command RemoveNetwork
-        self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_RemoveNetwork.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint64, ctypes.c_uint32]
-        self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_RemoveNetwork.restype = ctypes.c_uint32
-        # Cluster NetworkCommissioning Command ScanNetworks
-        self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_ScanNetworks.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint64, ctypes.c_uint32]
-        self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_ScanNetworks.restype = ctypes.c_uint32
-        # Cluster NetworkCommissioning Command UpdateThreadNetwork
-        self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_UpdateThreadNetwork.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint64, ctypes.c_uint32]
-        self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_UpdateThreadNetwork.restype = ctypes.c_uint32
-        # Cluster NetworkCommissioning Command UpdateWiFiNetwork
-        self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_UpdateWiFiNetwork.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint64, ctypes.c_uint32]
-        self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_UpdateWiFiNetwork.restype = ctypes.c_uint32
         # Cluster NetworkCommissioning ReadAttribute FeatureMap
         self._chipLib.chip_ime_ReadAttribute_NetworkCommissioning_FeatureMap.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -8956,35 +7176,15 @@ class ChipClusters:
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_NetworkCommissioning_ClusterRevision.restype = ctypes.c_uint32
         # Cluster OtaSoftwareUpdateProvider
-        # Cluster OtaSoftwareUpdateProvider Command ApplyUpdateRequest
-        self._chipLib.chip_ime_AppendCommand_OtaSoftwareUpdateProvider_ApplyUpdateRequest.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint32]
-        self._chipLib.chip_ime_AppendCommand_OtaSoftwareUpdateProvider_ApplyUpdateRequest.restype = ctypes.c_uint32
-        # Cluster OtaSoftwareUpdateProvider Command NotifyUpdateApplied
-        self._chipLib.chip_ime_AppendCommand_OtaSoftwareUpdateProvider_NotifyUpdateApplied.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint32]
-        self._chipLib.chip_ime_AppendCommand_OtaSoftwareUpdateProvider_NotifyUpdateApplied.restype = ctypes.c_uint32
-        # Cluster OtaSoftwareUpdateProvider Command QueryImage
-        self._chipLib.chip_ime_AppendCommand_OtaSoftwareUpdateProvider_QueryImage.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint32, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_bool, ctypes.c_char_p, ctypes.c_uint32]
-        self._chipLib.chip_ime_AppendCommand_OtaSoftwareUpdateProvider_QueryImage.restype = ctypes.c_uint32
         # Cluster OtaSoftwareUpdateProvider ReadAttribute ClusterRevision
         self._chipLib.chip_ime_ReadAttribute_OtaSoftwareUpdateProvider_ClusterRevision.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_OtaSoftwareUpdateProvider_ClusterRevision.restype = ctypes.c_uint32
         # Cluster OtaSoftwareUpdateRequestor
-        # Cluster OtaSoftwareUpdateRequestor Command AnnounceOtaProvider
-        self._chipLib.chip_ime_AppendCommand_OtaSoftwareUpdateRequestor_AnnounceOtaProvider.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint64, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_char_p, ctypes.c_uint32]
-        self._chipLib.chip_ime_AppendCommand_OtaSoftwareUpdateRequestor_AnnounceOtaProvider.restype = ctypes.c_uint32
         # Cluster OtaSoftwareUpdateRequestor ReadAttribute DefaultOtaProvider
         self._chipLib.chip_ime_ReadAttribute_OtaSoftwareUpdateRequestor_DefaultOtaProvider.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_OtaSoftwareUpdateRequestor_DefaultOtaProvider.restype = ctypes.c_uint32
-        # Cluster OtaSoftwareUpdateRequestor WriteAttribute DefaultOtaProvider
-        self._chipLib.chip_ime_WriteAttribute_OtaSoftwareUpdateRequestor_DefaultOtaProvider.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
-        self._chipLib.chip_ime_WriteAttribute_OtaSoftwareUpdateRequestor_DefaultOtaProvider.restype = ctypes.c_uint32
         # Cluster OtaSoftwareUpdateRequestor ReadAttribute UpdatePossible
         self._chipLib.chip_ime_ReadAttribute_OtaSoftwareUpdateRequestor_UpdatePossible.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -9015,30 +7215,6 @@ class ChipClusters:
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_OccupancySensing_ClusterRevision.restype = ctypes.c_uint32
         # Cluster OnOff
-        # Cluster OnOff Command Off
-        self._chipLib.chip_ime_AppendCommand_OnOff_Off.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
-        self._chipLib.chip_ime_AppendCommand_OnOff_Off.restype = ctypes.c_uint32
-        # Cluster OnOff Command OffWithEffect
-        self._chipLib.chip_ime_AppendCommand_OnOff_OffWithEffect.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
-        self._chipLib.chip_ime_AppendCommand_OnOff_OffWithEffect.restype = ctypes.c_uint32
-        # Cluster OnOff Command On
-        self._chipLib.chip_ime_AppendCommand_OnOff_On.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
-        self._chipLib.chip_ime_AppendCommand_OnOff_On.restype = ctypes.c_uint32
-        # Cluster OnOff Command OnWithRecallGlobalScene
-        self._chipLib.chip_ime_AppendCommand_OnOff_OnWithRecallGlobalScene.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
-        self._chipLib.chip_ime_AppendCommand_OnOff_OnWithRecallGlobalScene.restype = ctypes.c_uint32
-        # Cluster OnOff Command OnWithTimedOff
-        self._chipLib.chip_ime_AppendCommand_OnOff_OnWithTimedOff.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
-        self._chipLib.chip_ime_AppendCommand_OnOff_OnWithTimedOff.restype = ctypes.c_uint32
-        # Cluster OnOff Command Toggle
-        self._chipLib.chip_ime_AppendCommand_OnOff_Toggle.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
-        self._chipLib.chip_ime_AppendCommand_OnOff_Toggle.restype = ctypes.c_uint32
         # Cluster OnOff ReadAttribute OnOff
         self._chipLib.chip_ime_ReadAttribute_OnOff_OnOff.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -9055,26 +7231,14 @@ class ChipClusters:
         self._chipLib.chip_ime_ReadAttribute_OnOff_OnTime.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_OnOff_OnTime.restype = ctypes.c_uint32
-        # Cluster OnOff WriteAttribute OnTime
-        self._chipLib.chip_ime_WriteAttribute_OnOff_OnTime.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
-        self._chipLib.chip_ime_WriteAttribute_OnOff_OnTime.restype = ctypes.c_uint32
         # Cluster OnOff ReadAttribute OffWaitTime
         self._chipLib.chip_ime_ReadAttribute_OnOff_OffWaitTime.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_OnOff_OffWaitTime.restype = ctypes.c_uint32
-        # Cluster OnOff WriteAttribute OffWaitTime
-        self._chipLib.chip_ime_WriteAttribute_OnOff_OffWaitTime.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
-        self._chipLib.chip_ime_WriteAttribute_OnOff_OffWaitTime.restype = ctypes.c_uint32
         # Cluster OnOff ReadAttribute StartUpOnOff
         self._chipLib.chip_ime_ReadAttribute_OnOff_StartUpOnOff.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_OnOff_StartUpOnOff.restype = ctypes.c_uint32
-        # Cluster OnOff WriteAttribute StartUpOnOff
-        self._chipLib.chip_ime_WriteAttribute_OnOff_StartUpOnOff.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
-        self._chipLib.chip_ime_WriteAttribute_OnOff_StartUpOnOff.restype = ctypes.c_uint32
         # Cluster OnOff ReadAttribute FeatureMap
         self._chipLib.chip_ime_ReadAttribute_OnOff_FeatureMap.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -9092,51 +7256,11 @@ class ChipClusters:
         self._chipLib.chip_ime_ReadAttribute_OnOffSwitchConfiguration_SwitchActions.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_OnOffSwitchConfiguration_SwitchActions.restype = ctypes.c_uint32
-        # Cluster OnOffSwitchConfiguration WriteAttribute SwitchActions
-        self._chipLib.chip_ime_WriteAttribute_OnOffSwitchConfiguration_SwitchActions.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
-        self._chipLib.chip_ime_WriteAttribute_OnOffSwitchConfiguration_SwitchActions.restype = ctypes.c_uint32
         # Cluster OnOffSwitchConfiguration ReadAttribute ClusterRevision
         self._chipLib.chip_ime_ReadAttribute_OnOffSwitchConfiguration_ClusterRevision.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_OnOffSwitchConfiguration_ClusterRevision.restype = ctypes.c_uint32
         # Cluster OperationalCredentials
-        # Cluster OperationalCredentials Command AddNOC
-        self._chipLib.chip_ime_AppendCommand_OperationalCredentials_AddNOC.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint64, ctypes.c_uint16]
-        self._chipLib.chip_ime_AppendCommand_OperationalCredentials_AddNOC.restype = ctypes.c_uint32
-        # Cluster OperationalCredentials Command AddTrustedRootCertificate
-        self._chipLib.chip_ime_AppendCommand_OperationalCredentials_AddTrustedRootCertificate.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
-        self._chipLib.chip_ime_AppendCommand_OperationalCredentials_AddTrustedRootCertificate.restype = ctypes.c_uint32
-        # Cluster OperationalCredentials Command AttestationRequest
-        self._chipLib.chip_ime_AppendCommand_OperationalCredentials_AttestationRequest.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
-        self._chipLib.chip_ime_AppendCommand_OperationalCredentials_AttestationRequest.restype = ctypes.c_uint32
-        # Cluster OperationalCredentials Command CertificateChainRequest
-        self._chipLib.chip_ime_AppendCommand_OperationalCredentials_CertificateChainRequest.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
-        self._chipLib.chip_ime_AppendCommand_OperationalCredentials_CertificateChainRequest.restype = ctypes.c_uint32
-        # Cluster OperationalCredentials Command OpCSRRequest
-        self._chipLib.chip_ime_AppendCommand_OperationalCredentials_OpCSRRequest.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
-        self._chipLib.chip_ime_AppendCommand_OperationalCredentials_OpCSRRequest.restype = ctypes.c_uint32
-        # Cluster OperationalCredentials Command RemoveFabric
-        self._chipLib.chip_ime_AppendCommand_OperationalCredentials_RemoveFabric.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
-        self._chipLib.chip_ime_AppendCommand_OperationalCredentials_RemoveFabric.restype = ctypes.c_uint32
-        # Cluster OperationalCredentials Command RemoveTrustedRootCertificate
-        self._chipLib.chip_ime_AppendCommand_OperationalCredentials_RemoveTrustedRootCertificate.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
-        self._chipLib.chip_ime_AppendCommand_OperationalCredentials_RemoveTrustedRootCertificate.restype = ctypes.c_uint32
-        # Cluster OperationalCredentials Command UpdateFabricLabel
-        self._chipLib.chip_ime_AppendCommand_OperationalCredentials_UpdateFabricLabel.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
-        self._chipLib.chip_ime_AppendCommand_OperationalCredentials_UpdateFabricLabel.restype = ctypes.c_uint32
-        # Cluster OperationalCredentials Command UpdateNOC
-        self._chipLib.chip_ime_AppendCommand_OperationalCredentials_UpdateNOC.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_char_p, ctypes.c_uint32]
-        self._chipLib.chip_ime_AppendCommand_OperationalCredentials_UpdateNOC.restype = ctypes.c_uint32
         # Cluster OperationalCredentials ReadAttribute FabricsList
         self._chipLib.chip_ime_ReadAttribute_OperationalCredentials_FabricsList.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -9316,18 +7440,10 @@ class ChipClusters:
         self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_OperationMode.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_OperationMode.restype = ctypes.c_uint32
-        # Cluster PumpConfigurationAndControl WriteAttribute OperationMode
-        self._chipLib.chip_ime_WriteAttribute_PumpConfigurationAndControl_OperationMode.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
-        self._chipLib.chip_ime_WriteAttribute_PumpConfigurationAndControl_OperationMode.restype = ctypes.c_uint32
         # Cluster PumpConfigurationAndControl ReadAttribute ControlMode
         self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_ControlMode.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_ControlMode.restype = ctypes.c_uint32
-        # Cluster PumpConfigurationAndControl WriteAttribute ControlMode
-        self._chipLib.chip_ime_WriteAttribute_PumpConfigurationAndControl_ControlMode.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
-        self._chipLib.chip_ime_WriteAttribute_PumpConfigurationAndControl_ControlMode.restype = ctypes.c_uint32
         # Cluster PumpConfigurationAndControl ReadAttribute AlarmMask
         self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_AlarmMask.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -9370,34 +7486,6 @@ class ChipClusters:
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_RelativeHumidityMeasurement_ClusterRevision.restype = ctypes.c_uint32
         # Cluster Scenes
-        # Cluster Scenes Command AddScene
-        self._chipLib.chip_ime_AppendCommand_Scenes_AddScene.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16,
-                                                                         ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint32, ctypes.c_uint8, ctypes.c_uint8]
-        self._chipLib.chip_ime_AppendCommand_Scenes_AddScene.restype = ctypes.c_uint32
-        # Cluster Scenes Command GetSceneMembership
-        self._chipLib.chip_ime_AppendCommand_Scenes_GetSceneMembership.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
-        self._chipLib.chip_ime_AppendCommand_Scenes_GetSceneMembership.restype = ctypes.c_uint32
-        # Cluster Scenes Command RecallScene
-        self._chipLib.chip_ime_AppendCommand_Scenes_RecallScene.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16]
-        self._chipLib.chip_ime_AppendCommand_Scenes_RecallScene.restype = ctypes.c_uint32
-        # Cluster Scenes Command RemoveAllScenes
-        self._chipLib.chip_ime_AppendCommand_Scenes_RemoveAllScenes.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
-        self._chipLib.chip_ime_AppendCommand_Scenes_RemoveAllScenes.restype = ctypes.c_uint32
-        # Cluster Scenes Command RemoveScene
-        self._chipLib.chip_ime_AppendCommand_Scenes_RemoveScene.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint8]
-        self._chipLib.chip_ime_AppendCommand_Scenes_RemoveScene.restype = ctypes.c_uint32
-        # Cluster Scenes Command StoreScene
-        self._chipLib.chip_ime_AppendCommand_Scenes_StoreScene.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint8]
-        self._chipLib.chip_ime_AppendCommand_Scenes_StoreScene.restype = ctypes.c_uint32
-        # Cluster Scenes Command ViewScene
-        self._chipLib.chip_ime_AppendCommand_Scenes_ViewScene.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint8]
-        self._chipLib.chip_ime_AppendCommand_Scenes_ViewScene.restype = ctypes.c_uint32
         # Cluster Scenes ReadAttribute SceneCount
         self._chipLib.chip_ime_ReadAttribute_Scenes_SceneCount.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -9423,10 +7511,6 @@ class ChipClusters:
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_Scenes_ClusterRevision.restype = ctypes.c_uint32
         # Cluster SoftwareDiagnostics
-        # Cluster SoftwareDiagnostics Command ResetWatermarks
-        self._chipLib.chip_ime_AppendCommand_SoftwareDiagnostics_ResetWatermarks.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
-        self._chipLib.chip_ime_AppendCommand_SoftwareDiagnostics_ResetWatermarks.restype = ctypes.c_uint32
         # Cluster SoftwareDiagnostics ReadAttribute ThreadMetrics
         self._chipLib.chip_ime_ReadAttribute_SoftwareDiagnostics_ThreadMetrics.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -9473,18 +7557,6 @@ class ChipClusters:
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_Switch_ClusterRevision.restype = ctypes.c_uint32
         # Cluster TvChannel
-        # Cluster TvChannel Command ChangeChannel
-        self._chipLib.chip_ime_AppendCommand_TvChannel_ChangeChannel.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
-        self._chipLib.chip_ime_AppendCommand_TvChannel_ChangeChannel.restype = ctypes.c_uint32
-        # Cluster TvChannel Command ChangeChannelByNumber
-        self._chipLib.chip_ime_AppendCommand_TvChannel_ChangeChannelByNumber.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint16]
-        self._chipLib.chip_ime_AppendCommand_TvChannel_ChangeChannelByNumber.restype = ctypes.c_uint32
-        # Cluster TvChannel Command SkipChannel
-        self._chipLib.chip_ime_AppendCommand_TvChannel_SkipChannel.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
-        self._chipLib.chip_ime_AppendCommand_TvChannel_SkipChannel.restype = ctypes.c_uint32
         # Cluster TvChannel ReadAttribute TvChannelList
         self._chipLib.chip_ime_ReadAttribute_TvChannel_TvChannelList.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -9502,10 +7574,6 @@ class ChipClusters:
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_TvChannel_ClusterRevision.restype = ctypes.c_uint32
         # Cluster TargetNavigator
-        # Cluster TargetNavigator Command NavigateTarget
-        self._chipLib.chip_ime_AppendCommand_TargetNavigator_NavigateTarget.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_char_p, ctypes.c_uint32]
-        self._chipLib.chip_ime_AppendCommand_TargetNavigator_NavigateTarget.restype = ctypes.c_uint32
         # Cluster TargetNavigator ReadAttribute TargetNavigatorList
         self._chipLib.chip_ime_ReadAttribute_TargetNavigator_TargetNavigatorList.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -9544,178 +7612,70 @@ class ChipClusters:
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_TemperatureMeasurement_ClusterRevision.restype = ctypes.c_uint32
         # Cluster TestCluster
-        # Cluster TestCluster Command Test
-        self._chipLib.chip_ime_AppendCommand_TestCluster_Test.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
-        self._chipLib.chip_ime_AppendCommand_TestCluster_Test.restype = ctypes.c_uint32
-        # Cluster TestCluster Command TestAddArguments
-        self._chipLib.chip_ime_AppendCommand_TestCluster_TestAddArguments.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
-        self._chipLib.chip_ime_AppendCommand_TestCluster_TestAddArguments.restype = ctypes.c_uint32
-        # Cluster TestCluster Command TestEnumsRequest
-        self._chipLib.chip_ime_AppendCommand_TestCluster_TestEnumsRequest.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint8]
-        self._chipLib.chip_ime_AppendCommand_TestCluster_TestEnumsRequest.restype = ctypes.c_uint32
-        # Cluster TestCluster Command TestListInt8UArgumentRequest
-        self._chipLib.chip_ime_AppendCommand_TestCluster_TestListInt8UArgumentRequest.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
-        self._chipLib.chip_ime_AppendCommand_TestCluster_TestListInt8UArgumentRequest.restype = ctypes.c_uint32
-        # Cluster TestCluster Command TestListInt8UReverseRequest
-        self._chipLib.chip_ime_AppendCommand_TestCluster_TestListInt8UReverseRequest.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
-        self._chipLib.chip_ime_AppendCommand_TestCluster_TestListInt8UReverseRequest.restype = ctypes.c_uint32
-        # Cluster TestCluster Command TestListStructArgumentRequest
-        self._chipLib.chip_ime_AppendCommand_TestCluster_TestListStructArgumentRequest.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_bool, ctypes.c_uint8, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint8]
-        self._chipLib.chip_ime_AppendCommand_TestCluster_TestListStructArgumentRequest.restype = ctypes.c_uint32
-        # Cluster TestCluster Command TestNotHandled
-        self._chipLib.chip_ime_AppendCommand_TestCluster_TestNotHandled.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
-        self._chipLib.chip_ime_AppendCommand_TestCluster_TestNotHandled.restype = ctypes.c_uint32
-        # Cluster TestCluster Command TestNullableOptionalRequest
-        self._chipLib.chip_ime_AppendCommand_TestCluster_TestNullableOptionalRequest.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
-        self._chipLib.chip_ime_AppendCommand_TestCluster_TestNullableOptionalRequest.restype = ctypes.c_uint32
-        # Cluster TestCluster Command TestSpecific
-        self._chipLib.chip_ime_AppendCommand_TestCluster_TestSpecific.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
-        self._chipLib.chip_ime_AppendCommand_TestCluster_TestSpecific.restype = ctypes.c_uint32
-        # Cluster TestCluster Command TestStructArgumentRequest
-        self._chipLib.chip_ime_AppendCommand_TestCluster_TestStructArgumentRequest.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_bool, ctypes.c_uint8, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint8]
-        self._chipLib.chip_ime_AppendCommand_TestCluster_TestStructArgumentRequest.restype = ctypes.c_uint32
-        # Cluster TestCluster Command TestUnknownCommand
-        self._chipLib.chip_ime_AppendCommand_TestCluster_TestUnknownCommand.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
-        self._chipLib.chip_ime_AppendCommand_TestCluster_TestUnknownCommand.restype = ctypes.c_uint32
         # Cluster TestCluster ReadAttribute Boolean
         self._chipLib.chip_ime_ReadAttribute_TestCluster_Boolean.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_TestCluster_Boolean.restype = ctypes.c_uint32
-        # Cluster TestCluster WriteAttribute Boolean
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_Boolean.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_bool]
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_Boolean.restype = ctypes.c_uint32
         # Cluster TestCluster ReadAttribute Bitmap8
         self._chipLib.chip_ime_ReadAttribute_TestCluster_Bitmap8.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_TestCluster_Bitmap8.restype = ctypes.c_uint32
-        # Cluster TestCluster WriteAttribute Bitmap8
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_Bitmap8.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_Bitmap8.restype = ctypes.c_uint32
         # Cluster TestCluster ReadAttribute Bitmap16
         self._chipLib.chip_ime_ReadAttribute_TestCluster_Bitmap16.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_TestCluster_Bitmap16.restype = ctypes.c_uint32
-        # Cluster TestCluster WriteAttribute Bitmap16
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_Bitmap16.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_Bitmap16.restype = ctypes.c_uint32
         # Cluster TestCluster ReadAttribute Bitmap32
         self._chipLib.chip_ime_ReadAttribute_TestCluster_Bitmap32.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_TestCluster_Bitmap32.restype = ctypes.c_uint32
-        # Cluster TestCluster WriteAttribute Bitmap32
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_Bitmap32.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint32]
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_Bitmap32.restype = ctypes.c_uint32
         # Cluster TestCluster ReadAttribute Bitmap64
         self._chipLib.chip_ime_ReadAttribute_TestCluster_Bitmap64.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_TestCluster_Bitmap64.restype = ctypes.c_uint32
-        # Cluster TestCluster WriteAttribute Bitmap64
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_Bitmap64.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint64]
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_Bitmap64.restype = ctypes.c_uint32
         # Cluster TestCluster ReadAttribute Int8u
         self._chipLib.chip_ime_ReadAttribute_TestCluster_Int8u.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_TestCluster_Int8u.restype = ctypes.c_uint32
-        # Cluster TestCluster WriteAttribute Int8u
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_Int8u.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_Int8u.restype = ctypes.c_uint32
         # Cluster TestCluster ReadAttribute Int16u
         self._chipLib.chip_ime_ReadAttribute_TestCluster_Int16u.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_TestCluster_Int16u.restype = ctypes.c_uint32
-        # Cluster TestCluster WriteAttribute Int16u
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_Int16u.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_Int16u.restype = ctypes.c_uint32
         # Cluster TestCluster ReadAttribute Int32u
         self._chipLib.chip_ime_ReadAttribute_TestCluster_Int32u.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_TestCluster_Int32u.restype = ctypes.c_uint32
-        # Cluster TestCluster WriteAttribute Int32u
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_Int32u.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint32]
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_Int32u.restype = ctypes.c_uint32
         # Cluster TestCluster ReadAttribute Int64u
         self._chipLib.chip_ime_ReadAttribute_TestCluster_Int64u.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_TestCluster_Int64u.restype = ctypes.c_uint32
-        # Cluster TestCluster WriteAttribute Int64u
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_Int64u.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint64]
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_Int64u.restype = ctypes.c_uint32
         # Cluster TestCluster ReadAttribute Int8s
         self._chipLib.chip_ime_ReadAttribute_TestCluster_Int8s.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_TestCluster_Int8s.restype = ctypes.c_uint32
-        # Cluster TestCluster WriteAttribute Int8s
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_Int8s.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_int8]
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_Int8s.restype = ctypes.c_uint32
         # Cluster TestCluster ReadAttribute Int16s
         self._chipLib.chip_ime_ReadAttribute_TestCluster_Int16s.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_TestCluster_Int16s.restype = ctypes.c_uint32
-        # Cluster TestCluster WriteAttribute Int16s
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_Int16s.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_int16]
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_Int16s.restype = ctypes.c_uint32
         # Cluster TestCluster ReadAttribute Int32s
         self._chipLib.chip_ime_ReadAttribute_TestCluster_Int32s.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_TestCluster_Int32s.restype = ctypes.c_uint32
-        # Cluster TestCluster WriteAttribute Int32s
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_Int32s.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_int32]
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_Int32s.restype = ctypes.c_uint32
         # Cluster TestCluster ReadAttribute Int64s
         self._chipLib.chip_ime_ReadAttribute_TestCluster_Int64s.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_TestCluster_Int64s.restype = ctypes.c_uint32
-        # Cluster TestCluster WriteAttribute Int64s
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_Int64s.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_int64]
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_Int64s.restype = ctypes.c_uint32
         # Cluster TestCluster ReadAttribute Enum8
         self._chipLib.chip_ime_ReadAttribute_TestCluster_Enum8.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_TestCluster_Enum8.restype = ctypes.c_uint32
-        # Cluster TestCluster WriteAttribute Enum8
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_Enum8.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_Enum8.restype = ctypes.c_uint32
         # Cluster TestCluster ReadAttribute Enum16
         self._chipLib.chip_ime_ReadAttribute_TestCluster_Enum16.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_TestCluster_Enum16.restype = ctypes.c_uint32
-        # Cluster TestCluster WriteAttribute Enum16
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_Enum16.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_Enum16.restype = ctypes.c_uint32
         # Cluster TestCluster ReadAttribute OctetString
         self._chipLib.chip_ime_ReadAttribute_TestCluster_OctetString.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_TestCluster_OctetString.restype = ctypes.c_uint32
-        # Cluster TestCluster WriteAttribute OctetString
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_OctetString.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_OctetString.restype = ctypes.c_uint32
         # Cluster TestCluster ReadAttribute ListInt8u
         self._chipLib.chip_ime_ReadAttribute_TestCluster_ListInt8u.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -9732,50 +7692,26 @@ class ChipClusters:
         self._chipLib.chip_ime_ReadAttribute_TestCluster_LongOctetString.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_TestCluster_LongOctetString.restype = ctypes.c_uint32
-        # Cluster TestCluster WriteAttribute LongOctetString
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_LongOctetString.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_LongOctetString.restype = ctypes.c_uint32
         # Cluster TestCluster ReadAttribute CharString
         self._chipLib.chip_ime_ReadAttribute_TestCluster_CharString.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_TestCluster_CharString.restype = ctypes.c_uint32
-        # Cluster TestCluster WriteAttribute CharString
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_CharString.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_CharString.restype = ctypes.c_uint32
         # Cluster TestCluster ReadAttribute LongCharString
         self._chipLib.chip_ime_ReadAttribute_TestCluster_LongCharString.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_TestCluster_LongCharString.restype = ctypes.c_uint32
-        # Cluster TestCluster WriteAttribute LongCharString
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_LongCharString.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_LongCharString.restype = ctypes.c_uint32
         # Cluster TestCluster ReadAttribute EpochUs
         self._chipLib.chip_ime_ReadAttribute_TestCluster_EpochUs.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_TestCluster_EpochUs.restype = ctypes.c_uint32
-        # Cluster TestCluster WriteAttribute EpochUs
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_EpochUs.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint64]
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_EpochUs.restype = ctypes.c_uint32
         # Cluster TestCluster ReadAttribute EpochS
         self._chipLib.chip_ime_ReadAttribute_TestCluster_EpochS.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_TestCluster_EpochS.restype = ctypes.c_uint32
-        # Cluster TestCluster WriteAttribute EpochS
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_EpochS.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint32]
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_EpochS.restype = ctypes.c_uint32
         # Cluster TestCluster ReadAttribute VendorId
         self._chipLib.chip_ime_ReadAttribute_TestCluster_VendorId.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_TestCluster_VendorId.restype = ctypes.c_uint32
-        # Cluster TestCluster WriteAttribute VendorId
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_VendorId.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_VendorId.restype = ctypes.c_uint32
         # Cluster TestCluster ReadAttribute ListNullablesAndOptionalsStruct
         self._chipLib.chip_ime_ReadAttribute_TestCluster_ListNullablesAndOptionalsStruct.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -9784,171 +7720,79 @@ class ChipClusters:
         self._chipLib.chip_ime_ReadAttribute_TestCluster_Unsupported.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_TestCluster_Unsupported.restype = ctypes.c_uint32
-        # Cluster TestCluster WriteAttribute Unsupported
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_Unsupported.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_bool]
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_Unsupported.restype = ctypes.c_uint32
         # Cluster TestCluster ReadAttribute NullableBoolean
         self._chipLib.chip_ime_ReadAttribute_TestCluster_NullableBoolean.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_TestCluster_NullableBoolean.restype = ctypes.c_uint32
-        # Cluster TestCluster WriteAttribute NullableBoolean
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_NullableBoolean.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_bool]
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_NullableBoolean.restype = ctypes.c_uint32
         # Cluster TestCluster ReadAttribute NullableBitmap8
         self._chipLib.chip_ime_ReadAttribute_TestCluster_NullableBitmap8.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_TestCluster_NullableBitmap8.restype = ctypes.c_uint32
-        # Cluster TestCluster WriteAttribute NullableBitmap8
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_NullableBitmap8.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_NullableBitmap8.restype = ctypes.c_uint32
         # Cluster TestCluster ReadAttribute NullableBitmap16
         self._chipLib.chip_ime_ReadAttribute_TestCluster_NullableBitmap16.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_TestCluster_NullableBitmap16.restype = ctypes.c_uint32
-        # Cluster TestCluster WriteAttribute NullableBitmap16
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_NullableBitmap16.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_NullableBitmap16.restype = ctypes.c_uint32
         # Cluster TestCluster ReadAttribute NullableBitmap32
         self._chipLib.chip_ime_ReadAttribute_TestCluster_NullableBitmap32.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_TestCluster_NullableBitmap32.restype = ctypes.c_uint32
-        # Cluster TestCluster WriteAttribute NullableBitmap32
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_NullableBitmap32.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint32]
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_NullableBitmap32.restype = ctypes.c_uint32
         # Cluster TestCluster ReadAttribute NullableBitmap64
         self._chipLib.chip_ime_ReadAttribute_TestCluster_NullableBitmap64.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_TestCluster_NullableBitmap64.restype = ctypes.c_uint32
-        # Cluster TestCluster WriteAttribute NullableBitmap64
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_NullableBitmap64.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint64]
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_NullableBitmap64.restype = ctypes.c_uint32
         # Cluster TestCluster ReadAttribute NullableInt8u
         self._chipLib.chip_ime_ReadAttribute_TestCluster_NullableInt8u.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_TestCluster_NullableInt8u.restype = ctypes.c_uint32
-        # Cluster TestCluster WriteAttribute NullableInt8u
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_NullableInt8u.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_NullableInt8u.restype = ctypes.c_uint32
         # Cluster TestCluster ReadAttribute NullableInt16u
         self._chipLib.chip_ime_ReadAttribute_TestCluster_NullableInt16u.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_TestCluster_NullableInt16u.restype = ctypes.c_uint32
-        # Cluster TestCluster WriteAttribute NullableInt16u
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_NullableInt16u.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_NullableInt16u.restype = ctypes.c_uint32
         # Cluster TestCluster ReadAttribute NullableInt32u
         self._chipLib.chip_ime_ReadAttribute_TestCluster_NullableInt32u.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_TestCluster_NullableInt32u.restype = ctypes.c_uint32
-        # Cluster TestCluster WriteAttribute NullableInt32u
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_NullableInt32u.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint32]
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_NullableInt32u.restype = ctypes.c_uint32
         # Cluster TestCluster ReadAttribute NullableInt64u
         self._chipLib.chip_ime_ReadAttribute_TestCluster_NullableInt64u.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_TestCluster_NullableInt64u.restype = ctypes.c_uint32
-        # Cluster TestCluster WriteAttribute NullableInt64u
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_NullableInt64u.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint64]
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_NullableInt64u.restype = ctypes.c_uint32
         # Cluster TestCluster ReadAttribute NullableInt8s
         self._chipLib.chip_ime_ReadAttribute_TestCluster_NullableInt8s.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_TestCluster_NullableInt8s.restype = ctypes.c_uint32
-        # Cluster TestCluster WriteAttribute NullableInt8s
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_NullableInt8s.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_int8]
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_NullableInt8s.restype = ctypes.c_uint32
         # Cluster TestCluster ReadAttribute NullableInt16s
         self._chipLib.chip_ime_ReadAttribute_TestCluster_NullableInt16s.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_TestCluster_NullableInt16s.restype = ctypes.c_uint32
-        # Cluster TestCluster WriteAttribute NullableInt16s
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_NullableInt16s.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_int16]
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_NullableInt16s.restype = ctypes.c_uint32
         # Cluster TestCluster ReadAttribute NullableInt32s
         self._chipLib.chip_ime_ReadAttribute_TestCluster_NullableInt32s.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_TestCluster_NullableInt32s.restype = ctypes.c_uint32
-        # Cluster TestCluster WriteAttribute NullableInt32s
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_NullableInt32s.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_int32]
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_NullableInt32s.restype = ctypes.c_uint32
         # Cluster TestCluster ReadAttribute NullableInt64s
         self._chipLib.chip_ime_ReadAttribute_TestCluster_NullableInt64s.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_TestCluster_NullableInt64s.restype = ctypes.c_uint32
-        # Cluster TestCluster WriteAttribute NullableInt64s
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_NullableInt64s.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_int64]
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_NullableInt64s.restype = ctypes.c_uint32
         # Cluster TestCluster ReadAttribute NullableEnum8
         self._chipLib.chip_ime_ReadAttribute_TestCluster_NullableEnum8.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_TestCluster_NullableEnum8.restype = ctypes.c_uint32
-        # Cluster TestCluster WriteAttribute NullableEnum8
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_NullableEnum8.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_NullableEnum8.restype = ctypes.c_uint32
         # Cluster TestCluster ReadAttribute NullableEnum16
         self._chipLib.chip_ime_ReadAttribute_TestCluster_NullableEnum16.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_TestCluster_NullableEnum16.restype = ctypes.c_uint32
-        # Cluster TestCluster WriteAttribute NullableEnum16
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_NullableEnum16.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_NullableEnum16.restype = ctypes.c_uint32
         # Cluster TestCluster ReadAttribute NullableOctetString
         self._chipLib.chip_ime_ReadAttribute_TestCluster_NullableOctetString.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_TestCluster_NullableOctetString.restype = ctypes.c_uint32
-        # Cluster TestCluster WriteAttribute NullableOctetString
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_NullableOctetString.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_NullableOctetString.restype = ctypes.c_uint32
         # Cluster TestCluster ReadAttribute NullableCharString
         self._chipLib.chip_ime_ReadAttribute_TestCluster_NullableCharString.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_TestCluster_NullableCharString.restype = ctypes.c_uint32
-        # Cluster TestCluster WriteAttribute NullableCharString
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_NullableCharString.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_NullableCharString.restype = ctypes.c_uint32
         # Cluster TestCluster ReadAttribute ClusterRevision
         self._chipLib.chip_ime_ReadAttribute_TestCluster_ClusterRevision.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_TestCluster_ClusterRevision.restype = ctypes.c_uint32
         # Cluster Thermostat
-        # Cluster Thermostat Command ClearWeeklySchedule
-        self._chipLib.chip_ime_AppendCommand_Thermostat_ClearWeeklySchedule.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
-        self._chipLib.chip_ime_AppendCommand_Thermostat_ClearWeeklySchedule.restype = ctypes.c_uint32
-        # Cluster Thermostat Command GetRelayStatusLog
-        self._chipLib.chip_ime_AppendCommand_Thermostat_GetRelayStatusLog.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
-        self._chipLib.chip_ime_AppendCommand_Thermostat_GetRelayStatusLog.restype = ctypes.c_uint32
-        # Cluster Thermostat Command GetWeeklySchedule
-        self._chipLib.chip_ime_AppendCommand_Thermostat_GetWeeklySchedule.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
-        self._chipLib.chip_ime_AppendCommand_Thermostat_GetWeeklySchedule.restype = ctypes.c_uint32
-        # Cluster Thermostat Command SetWeeklySchedule
-        self._chipLib.chip_ime_AppendCommand_Thermostat_SetWeeklySchedule.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8]
-        self._chipLib.chip_ime_AppendCommand_Thermostat_SetWeeklySchedule.restype = ctypes.c_uint32
-        # Cluster Thermostat Command SetpointRaiseLower
-        self._chipLib.chip_ime_AppendCommand_Thermostat_SetpointRaiseLower.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_int8]
-        self._chipLib.chip_ime_AppendCommand_Thermostat_SetpointRaiseLower.restype = ctypes.c_uint32
         # Cluster Thermostat ReadAttribute LocalTemperature
         self._chipLib.chip_ime_ReadAttribute_Thermostat_LocalTemperature.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -9977,74 +7821,38 @@ class ChipClusters:
         self._chipLib.chip_ime_ReadAttribute_Thermostat_OccupiedCoolingSetpoint.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_Thermostat_OccupiedCoolingSetpoint.restype = ctypes.c_uint32
-        # Cluster Thermostat WriteAttribute OccupiedCoolingSetpoint
-        self._chipLib.chip_ime_WriteAttribute_Thermostat_OccupiedCoolingSetpoint.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_int16]
-        self._chipLib.chip_ime_WriteAttribute_Thermostat_OccupiedCoolingSetpoint.restype = ctypes.c_uint32
         # Cluster Thermostat ReadAttribute OccupiedHeatingSetpoint
         self._chipLib.chip_ime_ReadAttribute_Thermostat_OccupiedHeatingSetpoint.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_Thermostat_OccupiedHeatingSetpoint.restype = ctypes.c_uint32
-        # Cluster Thermostat WriteAttribute OccupiedHeatingSetpoint
-        self._chipLib.chip_ime_WriteAttribute_Thermostat_OccupiedHeatingSetpoint.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_int16]
-        self._chipLib.chip_ime_WriteAttribute_Thermostat_OccupiedHeatingSetpoint.restype = ctypes.c_uint32
         # Cluster Thermostat ReadAttribute MinHeatSetpointLimit
         self._chipLib.chip_ime_ReadAttribute_Thermostat_MinHeatSetpointLimit.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_Thermostat_MinHeatSetpointLimit.restype = ctypes.c_uint32
-        # Cluster Thermostat WriteAttribute MinHeatSetpointLimit
-        self._chipLib.chip_ime_WriteAttribute_Thermostat_MinHeatSetpointLimit.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_int16]
-        self._chipLib.chip_ime_WriteAttribute_Thermostat_MinHeatSetpointLimit.restype = ctypes.c_uint32
         # Cluster Thermostat ReadAttribute MaxHeatSetpointLimit
         self._chipLib.chip_ime_ReadAttribute_Thermostat_MaxHeatSetpointLimit.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_Thermostat_MaxHeatSetpointLimit.restype = ctypes.c_uint32
-        # Cluster Thermostat WriteAttribute MaxHeatSetpointLimit
-        self._chipLib.chip_ime_WriteAttribute_Thermostat_MaxHeatSetpointLimit.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_int16]
-        self._chipLib.chip_ime_WriteAttribute_Thermostat_MaxHeatSetpointLimit.restype = ctypes.c_uint32
         # Cluster Thermostat ReadAttribute MinCoolSetpointLimit
         self._chipLib.chip_ime_ReadAttribute_Thermostat_MinCoolSetpointLimit.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_Thermostat_MinCoolSetpointLimit.restype = ctypes.c_uint32
-        # Cluster Thermostat WriteAttribute MinCoolSetpointLimit
-        self._chipLib.chip_ime_WriteAttribute_Thermostat_MinCoolSetpointLimit.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_int16]
-        self._chipLib.chip_ime_WriteAttribute_Thermostat_MinCoolSetpointLimit.restype = ctypes.c_uint32
         # Cluster Thermostat ReadAttribute MaxCoolSetpointLimit
         self._chipLib.chip_ime_ReadAttribute_Thermostat_MaxCoolSetpointLimit.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_Thermostat_MaxCoolSetpointLimit.restype = ctypes.c_uint32
-        # Cluster Thermostat WriteAttribute MaxCoolSetpointLimit
-        self._chipLib.chip_ime_WriteAttribute_Thermostat_MaxCoolSetpointLimit.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_int16]
-        self._chipLib.chip_ime_WriteAttribute_Thermostat_MaxCoolSetpointLimit.restype = ctypes.c_uint32
         # Cluster Thermostat ReadAttribute MinSetpointDeadBand
         self._chipLib.chip_ime_ReadAttribute_Thermostat_MinSetpointDeadBand.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_Thermostat_MinSetpointDeadBand.restype = ctypes.c_uint32
-        # Cluster Thermostat WriteAttribute MinSetpointDeadBand
-        self._chipLib.chip_ime_WriteAttribute_Thermostat_MinSetpointDeadBand.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_int8]
-        self._chipLib.chip_ime_WriteAttribute_Thermostat_MinSetpointDeadBand.restype = ctypes.c_uint32
         # Cluster Thermostat ReadAttribute ControlSequenceOfOperation
         self._chipLib.chip_ime_ReadAttribute_Thermostat_ControlSequenceOfOperation.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_Thermostat_ControlSequenceOfOperation.restype = ctypes.c_uint32
-        # Cluster Thermostat WriteAttribute ControlSequenceOfOperation
-        self._chipLib.chip_ime_WriteAttribute_Thermostat_ControlSequenceOfOperation.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
-        self._chipLib.chip_ime_WriteAttribute_Thermostat_ControlSequenceOfOperation.restype = ctypes.c_uint32
         # Cluster Thermostat ReadAttribute SystemMode
         self._chipLib.chip_ime_ReadAttribute_Thermostat_SystemMode.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_Thermostat_SystemMode.restype = ctypes.c_uint32
-        # Cluster Thermostat WriteAttribute SystemMode
-        self._chipLib.chip_ime_WriteAttribute_Thermostat_SystemMode.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
-        self._chipLib.chip_ime_WriteAttribute_Thermostat_SystemMode.restype = ctypes.c_uint32
         # Cluster Thermostat ReadAttribute StartOfWeek
         self._chipLib.chip_ime_ReadAttribute_Thermostat_StartOfWeek.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -10070,35 +7878,19 @@ class ChipClusters:
         self._chipLib.chip_ime_ReadAttribute_ThermostatUserInterfaceConfiguration_TemperatureDisplayMode.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ThermostatUserInterfaceConfiguration_TemperatureDisplayMode.restype = ctypes.c_uint32
-        # Cluster ThermostatUserInterfaceConfiguration WriteAttribute TemperatureDisplayMode
-        self._chipLib.chip_ime_WriteAttribute_ThermostatUserInterfaceConfiguration_TemperatureDisplayMode.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
-        self._chipLib.chip_ime_WriteAttribute_ThermostatUserInterfaceConfiguration_TemperatureDisplayMode.restype = ctypes.c_uint32
         # Cluster ThermostatUserInterfaceConfiguration ReadAttribute KeypadLockout
         self._chipLib.chip_ime_ReadAttribute_ThermostatUserInterfaceConfiguration_KeypadLockout.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ThermostatUserInterfaceConfiguration_KeypadLockout.restype = ctypes.c_uint32
-        # Cluster ThermostatUserInterfaceConfiguration WriteAttribute KeypadLockout
-        self._chipLib.chip_ime_WriteAttribute_ThermostatUserInterfaceConfiguration_KeypadLockout.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
-        self._chipLib.chip_ime_WriteAttribute_ThermostatUserInterfaceConfiguration_KeypadLockout.restype = ctypes.c_uint32
         # Cluster ThermostatUserInterfaceConfiguration ReadAttribute ScheduleProgrammingVisibility
         self._chipLib.chip_ime_ReadAttribute_ThermostatUserInterfaceConfiguration_ScheduleProgrammingVisibility.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ThermostatUserInterfaceConfiguration_ScheduleProgrammingVisibility.restype = ctypes.c_uint32
-        # Cluster ThermostatUserInterfaceConfiguration WriteAttribute ScheduleProgrammingVisibility
-        self._chipLib.chip_ime_WriteAttribute_ThermostatUserInterfaceConfiguration_ScheduleProgrammingVisibility.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
-        self._chipLib.chip_ime_WriteAttribute_ThermostatUserInterfaceConfiguration_ScheduleProgrammingVisibility.restype = ctypes.c_uint32
         # Cluster ThermostatUserInterfaceConfiguration ReadAttribute ClusterRevision
         self._chipLib.chip_ime_ReadAttribute_ThermostatUserInterfaceConfiguration_ClusterRevision.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ThermostatUserInterfaceConfiguration_ClusterRevision.restype = ctypes.c_uint32
         # Cluster ThreadNetworkDiagnostics
-        # Cluster ThreadNetworkDiagnostics Command ResetCounts
-        self._chipLib.chip_ime_AppendCommand_ThreadNetworkDiagnostics_ResetCounts.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
-        self._chipLib.chip_ime_AppendCommand_ThreadNetworkDiagnostics_ResetCounts.restype = ctypes.c_uint32
         # Cluster ThreadNetworkDiagnostics ReadAttribute Channel
         self._chipLib.chip_ime_ReadAttribute_ThreadNetworkDiagnostics_Channel.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -10365,10 +8157,6 @@ class ChipClusters:
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_WakeOnLan_ClusterRevision.restype = ctypes.c_uint32
         # Cluster WiFiNetworkDiagnostics
-        # Cluster WiFiNetworkDiagnostics Command ResetCounts
-        self._chipLib.chip_ime_AppendCommand_WiFiNetworkDiagnostics_ResetCounts.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
-        self._chipLib.chip_ime_AppendCommand_WiFiNetworkDiagnostics_ResetCounts.restype = ctypes.c_uint32
         # Cluster WiFiNetworkDiagnostics ReadAttribute Bssid
         self._chipLib.chip_ime_ReadAttribute_WiFiNetworkDiagnostics_Bssid.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -10426,34 +8214,6 @@ class ChipClusters:
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_WiFiNetworkDiagnostics_ClusterRevision.restype = ctypes.c_uint32
         # Cluster WindowCovering
-        # Cluster WindowCovering Command DownOrClose
-        self._chipLib.chip_ime_AppendCommand_WindowCovering_DownOrClose.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
-        self._chipLib.chip_ime_AppendCommand_WindowCovering_DownOrClose.restype = ctypes.c_uint32
-        # Cluster WindowCovering Command GoToLiftPercentage
-        self._chipLib.chip_ime_AppendCommand_WindowCovering_GoToLiftPercentage.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16]
-        self._chipLib.chip_ime_AppendCommand_WindowCovering_GoToLiftPercentage.restype = ctypes.c_uint32
-        # Cluster WindowCovering Command GoToLiftValue
-        self._chipLib.chip_ime_AppendCommand_WindowCovering_GoToLiftValue.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
-        self._chipLib.chip_ime_AppendCommand_WindowCovering_GoToLiftValue.restype = ctypes.c_uint32
-        # Cluster WindowCovering Command GoToTiltPercentage
-        self._chipLib.chip_ime_AppendCommand_WindowCovering_GoToTiltPercentage.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16]
-        self._chipLib.chip_ime_AppendCommand_WindowCovering_GoToTiltPercentage.restype = ctypes.c_uint32
-        # Cluster WindowCovering Command GoToTiltValue
-        self._chipLib.chip_ime_AppendCommand_WindowCovering_GoToTiltValue.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
-        self._chipLib.chip_ime_AppendCommand_WindowCovering_GoToTiltValue.restype = ctypes.c_uint32
-        # Cluster WindowCovering Command StopMotion
-        self._chipLib.chip_ime_AppendCommand_WindowCovering_StopMotion.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
-        self._chipLib.chip_ime_AppendCommand_WindowCovering_StopMotion.restype = ctypes.c_uint32
-        # Cluster WindowCovering Command UpOrOpen
-        self._chipLib.chip_ime_AppendCommand_WindowCovering_UpOrOpen.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
-        self._chipLib.chip_ime_AppendCommand_WindowCovering_UpOrOpen.restype = ctypes.c_uint32
         # Cluster WindowCovering ReadAttribute Type
         self._chipLib.chip_ime_ReadAttribute_WindowCovering_Type.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -10550,10 +8310,6 @@ class ChipClusters:
         self._chipLib.chip_ime_ReadAttribute_WindowCovering_Mode.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_WindowCovering_Mode.restype = ctypes.c_uint32
-        # Cluster WindowCovering WriteAttribute Mode
-        self._chipLib.chip_ime_WriteAttribute_WindowCovering_Mode.argtypes = [
-            ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
-        self._chipLib.chip_ime_WriteAttribute_WindowCovering_Mode.restype = ctypes.c_uint32
         # Cluster WindowCovering ReadAttribute SafetyStatus
         self._chipLib.chip_ime_ReadAttribute_WindowCovering_SafetyStatus.argtypes = [
             ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]

--- a/src/controller/python/templates/python-CHIPClusters-cpp.zapt
+++ b/src/controller/python/templates/python-CHIPClusters-cpp.zapt
@@ -210,16 +210,6 @@ void chip_ime_SetFailureResponseDelegate(FailureResponseDelegate delegate)
 {{#chip_client_clusters}}
 // Cluster {{asUpperCamelCase name}}
 
-{{#chip_cluster_commands}}
-chip::ChipError::StorageType chip_ime_AppendCommand_{{asUpperCamelCase clusterName}}_{{asUpperCamelCase name}}(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId, chip::GroupId{{#chip_cluster_command_arguments_with_structs_expanded}}, {{#if (isString type)}}const uint8_t * {{asLowerCamelCase label}}, uint32_t {{asLowerCamelCase label}}_Len{{else}}{{chipType}} {{asLowerCamelCase label}}{{/if}}{{/chip_cluster_command_arguments_with_structs_expanded}})
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::{{asUpperCamelCase clusterName}}Cluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.{{asUpperCamelCase name}}(nullptr, nullptr{{#chip_cluster_command_arguments_with_structs_expanded}}, {{#if (isOctetString type)}}chip::ByteSpan({{asLowerCamelCase label}}, {{asLowerCamelCase label}}_Len){{else if (isCharString type)}}chip::CharSpan(reinterpret_cast<const char*>({{asLowerCamelCase label}}), {{asLowerCamelCase label}}_Len){{else}}{{asLowerCamelCase label}}{{/if}}{{/chip_cluster_command_arguments_with_structs_expanded}}).AsInteger();
-}
-{{/chip_cluster_commands}}
-
 {{#chip_server_cluster_attributes}}
 chip::ChipError::StorageType chip_ime_ReadAttribute_{{asUpperCamelCase parent.name}}_{{asUpperCamelCase name}}(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId, chip::GroupId /* ZCLgroupId */)
 {
@@ -248,15 +238,6 @@ chip::ChipError::StorageType chip_ime_SubscribeAttribute_{{asUpperCamelCase pare
 }
 {{/if}}
 
-{{#if isWritableAttribute}}
-chip::ChipError::StorageType chip_ime_WriteAttribute_{{asUpperCamelCase parent.name}}_{{asUpperCamelCase name}}(chip::DeviceProxy * device, chip::EndpointId ZCLendpointId, chip::GroupId, {{#if (isString type)}} uint8_t * value, size_t len{{else}}{{chipType}} value{{/if}})
-{
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::{{asUpperCamelCase parent.name}}Cluster cluster;
-    cluster.Associate(device, ZCLendpointId);
-    return cluster.WriteAttribute{{asUpperCamelCase name}}(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), {{#if (isOctetString type)}} chip::ByteSpan(value, len){{else if (isCharString type)}} chip::CharSpan(reinterpret_cast<const char*>(value), len){{else}}value{{/if}}).AsInteger();
-}
-{{/if}}
 {{/chip_server_cluster_attributes}}
 
 // End of Cluster {{asUpperCamelCase name}}

--- a/src/controller/python/templates/python-CHIPClusters-py.zapt
+++ b/src/controller/python/templates/python-CHIPClusters-py.zapt
@@ -115,22 +115,6 @@ class ChipClusters:
         if res != 0:
             raise self._ChipStack.ErrorToException(res)
 
-    # Cluster commands
-
-{{#chip_client_clusters}}
-{{#chip_cluster_commands}}
-    def Cluster{{asUpperCamelCase clusterName}}_Command{{asUpperCamelCase name}}(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int{{#chip_cluster_command_arguments_with_structs_expanded}}, {{asLowerCamelCase label}}: {{asPythonType chipType}}{{/chip_cluster_command_arguments_with_structs_expanded}}):
-{{#chip_cluster_command_arguments_with_structs_expanded}}
-{{#if (isCharString type)}}
-        {{asLowerCamelCase label}} = {{asLowerCamelCase label}}.encode("utf-8") + b'\x00'
-{{/if}}
-{{/chip_cluster_command_arguments_with_structs_expanded}}
-        return self._chipLib.chip_ime_AppendCommand_{{asUpperCamelCase clusterName}}_{{asUpperCamelCase name}}(
-                device, ZCLendpoint, ZCLgroupid{{#chip_cluster_command_arguments_with_structs_expanded}}, {{asLowerCamelCase label}}{{#if (isString type)}}, len({{asLowerCamelCase label}}){{/if}}{{/chip_cluster_command_arguments_with_structs_expanded}}
-        )
-{{/chip_cluster_commands}}
-{{/chip_client_clusters}}
-
     # Cluster attributes
 
 {{#chip_client_clusters}}
@@ -140,13 +124,6 @@ class ChipClusters:
 {{#if isReportableAttribute}}
     def Cluster{{asUpperCamelCase parent.name}}_SubscribeAttribute{{asUpperCamelCase name}}(self, device: ctypes.c_void_p, ZCLendpoint: int, minInterval: int, maxInterval: int):
         return self._chipLib.chip_ime_SubscribeAttribute_{{asUpperCamelCase parent.name}}_{{asUpperCamelCase name}}(device, ZCLendpoint, minInterval, maxInterval)
-{{/if}}
-{{#if isWritableAttribute}}
-    def Cluster{{asUpperCamelCase parent.name}}_WriteAttribute{{asUpperCamelCase name}}(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: {{ asPythonType chipType }}):
-{{#if (isCharString type)}}
-        value = value.encode("utf-8")
-{{/if}}
-        return self._chipLib.chip_ime_WriteAttribute_{{asUpperCamelCase parent.name}}_{{asUpperCamelCase name}}(device, ZCLendpoint, ZCLgroupid, value{{#if (isString type)}}, len(value){{/if}})
 {{/if}}
 {{/chip_server_cluster_attributes}}
 {{/chip_client_clusters}}
@@ -162,11 +139,6 @@ class ChipClusters:
         self._chipLib.chip_ime_SetFailureResponseDelegate.res = None
 {{#chip_client_clusters}}
         # Cluster {{asUpperCamelCase name}}
-{{#chip_cluster_commands}}
-        # Cluster {{asUpperCamelCase clusterName}} Command {{asUpperCamelCase name}}
-        self._chipLib.chip_ime_AppendCommand_{{asUpperCamelCase clusterName}}_{{asUpperCamelCase name}}.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16{{#chip_cluster_command_arguments_with_structs_expanded}}{{#if (isString type)}}, ctypes.c_char_p, ctypes.c_uint32{{else}}, ctypes.{{asPythonCType chipType}}{{/if}}{{/chip_cluster_command_arguments_with_structs_expanded}}]
-        self._chipLib.chip_ime_AppendCommand_{{asUpperCamelCase clusterName}}_{{asUpperCamelCase name}}.restype = ctypes.c_uint32
-{{/chip_cluster_commands}}
 {{#chip_server_cluster_attributes}}
         # Cluster {{asUpperCamelCase parent.name}} ReadAttribute {{asUpperCamelCase name}}
         self._chipLib.chip_ime_ReadAttribute_{{asUpperCamelCase parent.name}}_{{asUpperCamelCase name}}.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -175,11 +147,6 @@ class ChipClusters:
         # Cluster {{asUpperCamelCase parent.name}} SubscribeAttribute {{asUpperCamelCase name}}
         self._chipLib.chip_ime_SubscribeAttribute_{{asUpperCamelCase parent.name}}_{{asUpperCamelCase name}}.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_SubscribeAttribute_{{asUpperCamelCase parent.name}}_{{asUpperCamelCase name}}.restype = ctypes.c_uint32
-{{/if}}
-{{#if isWritableAttribute}}
-        # Cluster {{asUpperCamelCase parent.name}} WriteAttribute {{asUpperCamelCase name}}
-        self._chipLib.chip_ime_WriteAttribute_{{asUpperCamelCase parent.name}}_{{asUpperCamelCase name}}.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, {{#if (isString type)}}ctypes.c_char_p, ctypes.c_uint32{{else}}ctypes.{{asPythonCType chipType}}{{/if}}]
-        self._chipLib.chip_ime_WriteAttribute_{{asUpperCamelCase parent.name}}_{{asUpperCamelCase name}}.restype = ctypes.c_uint32
 {{/if}}
 {{/chip_server_cluster_attributes}}
 {{/chip_client_clusters}}

--- a/src/controller/python/test/test_scripts/base.py
+++ b/src/controller/python/test/test_scripts/base.py
@@ -175,30 +175,13 @@ class BaseTestHelper:
             "Sending On/Off commands to device {} endpoint {}".format(nodeid, endpoint))
         err, resp = self.devCtrl.ZCLSend("OnOff", "On", nodeid,
                                          endpoint, group, {}, blocking=True)
-        if err != 0 or resp is None or resp.Status != 0:
+        if err != 0:
             self.logger.error(
                 "failed to send OnOff.On: error is {} with im response{}".format(err, resp))
             return False
         err, resp = self.devCtrl.ZCLSend("OnOff", "Off", nodeid,
                                          endpoint, group, {}, blocking=True)
-        if err != 0 or resp is None or resp.Status != 0:
-            self.logger.error(
-                "failed to send OnOff.Off: error is {} with im response {}".format(err, resp))
-            return False
-        return True
-
-    def TestOnOffCluster(self, nodeid: int, endpoint: int, group: int):
-        self.logger.info(
-            "Sending On/Off commands to device {} endpoint {}".format(nodeid, endpoint))
-        err, resp = self.devCtrl.ZCLSend("OnOff", "On", nodeid,
-                                         endpoint, group, {}, blocking=True)
-        if err != 0 or resp is None or resp.Status != 0:
-            self.logger.error(
-                "failed to send OnOff.On: error is {} with im response{}".format(err, resp))
-            return False
-        err, resp = self.devCtrl.ZCLSend("OnOff", "Off", nodeid,
-                                         endpoint, group, {}, blocking=True)
-        if err != 0 or resp is None or resp.Status != 0:
+        if err != 0:
             self.logger.error(
                 "failed to send OnOff.Off: error is {} with im response {}".format(err, resp))
             return False


### PR DESCRIPTION
#### Problem
Current ZCLSend and ZCLWriteAttribute cannot fit our need for more complex types, and is blocking us adding support

#### Change overview
Remove the generated functions for ZCLCommands and ZCLWriteAttribute in Python, change ZCLSend and ZCLWriteAttribute to use Python's Cluster Object implementation

#### Testing
- CI Passed
