### PR TITLE
[dnssd] fix minimal mDNS resolver issues

### DIFF
--- a/src/lib/dnssd/Resolver_ImplMinimalMdns.cpp
+++ b/src/lib/dnssd/Resolver_ImplMinimalMdns.cpp
@@ -176,9 +176,9 @@ void PacketDataReporter::OnOperationalIPAddress(const chip::Inet::IPAddress & ad
     // This code assumes that all entries in the mDNS packet relate to the
     // same entity. This may not be correct if multiple servers are reported
     // (if multi-admin decides to use unique ports for every ecosystem).
-    mNodeData.mAddress[mDiscoveredNodeData.numIPs++] = addr;
-    mNodeData.mInterfaceId                           = mInterfaceId;
-    mHasIP                                           = true;
+    mNodeData.mAddress[mNodeData.mNumIPs++] = addr;
+    mNodeData.mInterfaceId                  = mInterfaceId;
+    mHasIP                                  = true;
 }
 
 void PacketDataReporter::OnDiscoveredNodeIPAddress(const chip::Inet::IPAddress & addr)
@@ -402,12 +402,12 @@ CHIP_ERROR MinMdnsResolver::Init(chip::Inet::InetLayer * inetLayer)
 {
     /// Note: we do not double-check the port as we assume the APP will always use
     /// the same inetLayer and port for mDNS.
+    mSystemLayer = inetLayer->SystemLayer();
+
     if (GlobalMinimalMdnsServer::Server().IsListening())
     {
         return CHIP_NO_ERROR;
     }
-
-    mSystemLayer = inetLayer->SystemLayer();
 
     return GlobalMinimalMdnsServer::Instance().StartServer(inetLayer, kMdnsPort);
 }


### PR DESCRIPTION
#### Problem

* When intializing both resolver and advertiser with minimal mDNS, the resolver will report `INCORRECT_STATE` when resolving.
* The `mNumIPs` returned by resovler is always zero.


#### Change overview

Fix these issues.


#### Testing

The minimal mDNS resolver can give correct results when testing the switch app and binding.
