### PR TITLE
[ESP32C3] remove unused external component

### DIFF
--- a/examples/all-clusters-app/esp32/CMakeLists.txt
+++ b/examples/all-clusters-app/esp32/CMakeLists.txt
@@ -29,8 +29,6 @@ if(${IDF_TARGET} STREQUAL "esp32")
     list(APPEND EXTRA_COMPONENT_DIRS "${CMAKE_CURRENT_LIST_DIR}/../../common/m5stack-tft/repo/components/tft"
                                      "${CMAKE_CURRENT_LIST_DIR}/../../common/m5stack-tft/repo/components/spidriver"
                                      "${CMAKE_CURRENT_LIST_DIR}/../../common/screen-framework")
-elseif(${IDF_TARGET} STREQUAL "esp32c3")
-    list(APPEND EXTRA_COMPONENT_DIRS "$ENV{IDF_PATH}/examples/peripherals/rmt/led_strip/components")
 endif()
 
 project(chip-all-clusters-app)


### PR DESCRIPTION
#### Problem
* Remove unused external component

with the tag `release/v4.4` of the ESP-IDF, there is a commit (cccdb3e) which has already moved `examples/peripherals/rmt/led_strip/component/led_strip` to the `examples/common_components`. In the commit `05cdfbfa3c` we have already added the new dirs `${IDF_PATH}/examples/common_components`, but did not removed this unused external component.