### PR TITLE
Fix for multi-fabric for efr32 

### DIFF
--- a/examples/lighting-app/efr32/include/FreeRTOSConfig.h
+++ b/examples/lighting-app/efr32/include/FreeRTOSConfig.h
@@ -237,7 +237,7 @@ See http://www.FreeRTOS.org/RTOS-Cortex-M3-M4.html. */
 #define configENABLE_BACKWARD_COMPATIBILITY (1)
 #define configSUPPORT_STATIC_ALLOCATION (1)
 #define configSUPPORT_DYNAMIC_ALLOCATION (1)
-#define configTOTAL_HEAP_SIZE ((size_t)(16 * 1024))
+#define configTOTAL_HEAP_SIZE ((size_t)(20 * 1024))
 
 /* Optional functions - most linkers will remove unused functions anyway. */
 #define INCLUDE_vTaskPrioritySet (1)

--- a/third_party/efr32_sdk/efr32_sdk.gni
+++ b/third_party/efr32_sdk/efr32_sdk.gni
@@ -132,7 +132,6 @@ template("efr32_sdk") {
       "${efr32_mcu}=1",
       "${efr32_board}=1",
       "SL_SUPRESS_DEPRECATION_WARNINGS_SDK_3_1",
-      "CHIP_KVS_SECTOR_COUNT=4",
       "CHIP_KVS_BASE_SECTOR_INDEX=((FLASH_SIZE/FLASH_PAGE_SIZE)-(CHIP_KVS_SECTOR_COUNT))",
       "CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI=1",
       "__HEAP_SIZE=0",
@@ -164,7 +163,10 @@ template("efr32_sdk") {
         "${efr32_sdk_root}/platform/emdrv/nvm3/lib/libnvm3_CM4_gcc.a",
       ]
 
-      defines += [ "EFR32MG12" ]
+      defines += [
+        "EFR32MG12",
+        "CHIP_KVS_SECTOR_COUNT=6",
+      ]
     } else if (efr32_family == "efr32mg21") {
       _include_dirs += [
         "${efr32_sdk_root}/hardware/driver/memlcd/inc/memlcd_usart",
@@ -187,6 +189,7 @@ template("efr32_sdk") {
       defines += [
         "EFR32MG21",
         "EFR32_SERIES2_CONFIG1_MICRO",
+        "CHIP_KVS_SECTOR_COUNT=4",
       ]
     } else if (efr32_family == "efr32mg24") {
       _include_dirs += [
@@ -210,6 +213,7 @@ template("efr32_sdk") {
       defines += [
         "EFR32MG24",
         "EFR32_SERIES2_CONFIG4_MICRO",
+        "CHIP_KVS_SECTOR_COUNT=4",
       ]
     }
 


### PR DESCRIPTION
#### Problem
* When connecting fourth admin, the device runs out of heap
* On MG12, KVS runs out of space for fourth admin

#### Change overview
* Increase heap to 20k
* Move sector count for KVS to per board config
* Increase KVS count for MG12 to 5

#### Testing
* Tested MG12 to verify fix
* Tested MG24 to confirm no regressions
