### PR TITLE
[Mbed] Fix WiFi provisioning

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -105,7 +105,7 @@ using namespace chip::Encoding;
 using namespace chip::Protocols::UserDirectedCommissioning;
 #endif // CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY
 
-constexpr uint32_t kSessionEstablishmentTimeout = 30 * kMillisecondsPerSecond;
+constexpr uint32_t kSessionEstablishmentTimeout = 40 * kMillisecondsPerSecond;
 
 DeviceController::DeviceController() :
     mOpenPairingSuccessCallback(OnOpenPairingWindowSuccessResponse, this),

--- a/src/platform/mbed/ConfigurationManagerImpl.cpp
+++ b/src/platform/mbed/ConfigurationManagerImpl.cpp
@@ -36,6 +36,7 @@
 
 // mbed-os headers
 #include "platform/mbed_power_mgmt.h"
+#include <net_common.h>
 
 namespace chip {
 namespace DeviceLayer {
@@ -55,35 +56,33 @@ CHIP_ERROR ConfigurationManagerImpl::Init()
 
 CHIP_ERROR ConfigurationManagerImpl::GetPrimaryWiFiMACAddress(uint8_t * buf)
 {
-    auto interface = WiFiInterface::get_default_instance();
-    if (interface)
+    auto net_if = get_mbed_net_if();
+    if (net_if == nullptr && net_if->wifiInterface() == nullptr)
     {
-        auto * mac_address = interface->get_mac_address();
-        if (mac_address)
+        ChipLogError(DeviceLayer, "Failed to extract the MAC address: WiFi interface not available");
+        return CHIP_ERROR_INTERNAL;
+    }
+
+    auto * mac_address = net_if->wifiInterface()->get_mac_address();
+    if (mac_address)
+    {
+        int last = -1;
+        int rc =
+            sscanf(mac_address, "%hhx:%hhx:%hhx:%hhx:%hhx:%hhx%n", buf + 5, buf + 4, buf + 3, buf + 2, buf + 1, buf + 0, &last);
+        if (rc != NSAPI_MAC_BYTES || last != (NSAPI_MAC_SIZE - 1))
         {
-            int last = -1;
-            int rc =
-                sscanf(mac_address, "%hhx:%hhx:%hhx:%hhx:%hhx:%hhx%n", buf + 5, buf + 4, buf + 3, buf + 2, buf + 1, buf + 0, &last);
-            if (rc != NSAPI_MAC_BYTES || last != (NSAPI_MAC_SIZE - 1))
-            {
-                ChipLogError(DeviceLayer, "Failed to extract the MAC address: %s, rc = %d, last = %d", mac_address, rc, last);
-                return CHIP_ERROR_INTERNAL;
-            }
-            else
-            {
-                ChipLogError(DeviceLayer, "Extract the MAC address: %s", mac_address);
-                return CHIP_NO_ERROR;
-            }
+            ChipLogError(DeviceLayer, "Failed to extract the MAC address: %s, rc = %d, last = %d", mac_address, rc, last);
+            return CHIP_ERROR_INTERNAL;
         }
         else
         {
-            ChipLogError(DeviceLayer, "Failed to extract the MAC address: nothing returned by the interface");
-            return CHIP_ERROR_INTERNAL;
+            ChipLogError(DeviceLayer, "Extract the MAC address: %s", mac_address);
+            return CHIP_NO_ERROR;
         }
     }
     else
     {
-        ChipLogError(DeviceLayer, "Failed to extract the MAC address: interface not available");
+        ChipLogError(DeviceLayer, "Failed to extract the MAC address: nothing returned by the interface");
         return CHIP_ERROR_INTERNAL;
     }
 }

--- a/src/platform/mbed/ConfigurationManagerImpl.cpp
+++ b/src/platform/mbed/ConfigurationManagerImpl.cpp
@@ -57,7 +57,7 @@ CHIP_ERROR ConfigurationManagerImpl::Init()
 CHIP_ERROR ConfigurationManagerImpl::GetPrimaryWiFiMACAddress(uint8_t * buf)
 {
     auto net_if = get_mbed_net_if();
-    if (net_if == nullptr && net_if->wifiInterface() == nullptr)
+    if (net_if == nullptr || net_if->wifiInterface() == nullptr)
     {
         ChipLogError(DeviceLayer, "Failed to extract the MAC address: WiFi interface not available");
         return CHIP_ERROR_INTERNAL;

--- a/src/platform/mbed/ConnectivityManagerImpl.cpp
+++ b/src/platform/mbed/ConnectivityManagerImpl.cpp
@@ -18,7 +18,7 @@
  */
 /* this file behaves like a config.h, comes first */
 
-#include "netsocket/WiFiInterface.h"
+#include <net_common.h>
 #include <platform/internal/CHIPDeviceLayerInternal.h>
 
 #include <platform/ConnectivityManager.h>
@@ -123,7 +123,7 @@ CHIP_ERROR ConnectivityManagerImpl::_Init()
     mWiFiAPIdleTimeout            = System::Clock::Milliseconds32(CHIP_DEVICE_CONFIG_WIFI_AP_IDLE_TIMEOUT);
     mSecurityType                 = NSAPI_SECURITY_WPA_WPA2;
 
-    ::NetworkInterface * net_if = ::NetworkInterface::get_default_instance();
+    auto net_if = get_mbed_net_if();
     if (net_if == nullptr)
     {
         ChipLogError(DeviceLayer, "No network interface available");


### PR DESCRIPTION
#### Problem
The WiFi provisioning with the device controller stops working for Mbed examples. After checking some internal improvements were needed. 

#### Change overview
Update mbed-os-posix-socket lib 
Improve get default network interface in ConfigurationManagerImpl and ConnectivityManagerImpl
Increase session establishment timeout in CHIPDeviceController to 40s - for Mbed examples it takes more time to establish a new session. 

#### Testing
Build and run lock-app and lighting-app examples manually. Provisioning WiFi using Python device controller app
