### PR TITLE
Fix CommissioningWindowManager DNS UDP leak

### DIFF
--- a/src/app/server/CommissioningWindowManager.cpp
+++ b/src/app/server/CommissioningWindowManager.cpp
@@ -71,7 +71,7 @@ void CommissioningWindowManager::OnPlatformEvent(const DeviceLayer::ChipDeviceEv
     }
 }
 
-void CommissioningWindowManager::Cleanup()
+void CommissioningWindowManager::Shutdown()
 {
     StopAdvertisement();
 
@@ -84,6 +84,11 @@ void CommissioningWindowManager::Cleanup()
 
     memset(&mECMPASEVerifier, 0, sizeof(mECMPASEVerifier));
     memset(mECMSalt, 0, sizeof(mECMSalt));
+}
+
+void CommissioningWindowManager::Cleanup()
+{
+    Shutdown();
 
     // reset all advertising
     app::DnssdServer::Instance().StartServer(Dnssd::CommissioningMode::kDisabled);

--- a/src/app/server/CommissioningWindowManager.h
+++ b/src/app/server/CommissioningWindowManager.h
@@ -65,6 +65,7 @@ public:
     void OnSessionEstablishmentStarted() override;
     void OnSessionEstablished() override;
 
+    void Shutdown();
     void Cleanup();
 
     void OnPlatformEvent(const DeviceLayer::ChipDeviceEvent * event);

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -184,7 +184,7 @@ void Server::Shutdown()
     mExchangeMgr.Shutdown();
     mSessions.Shutdown();
     mTransports.Close();
-    mCommissioningWindowManager.Cleanup();
+    mCommissioningWindowManager.Shutdown();
     chip::Platform::MemoryShutdown();
 }
 

--- a/src/app/tests/TestCommissionManager.cpp
+++ b/src/app/tests/TestCommissionManager.cpp
@@ -138,7 +138,6 @@ void CheckCommissioningWindowManagerEnhancedWindow(nlTestSuite * suite, void *)
 void TearDownTask(intptr_t context)
 {
     chip::Server::GetInstance().Shutdown();
-    chip::DeviceLayer::PlatformMgr().Shutdown();
 }
 
 const nlTest sTests[] = {
@@ -167,6 +166,8 @@ int TestCommissioningWindowManager()
     // TODO: The platform memory was intentionally left not deinitialized so that minimal mdns can destruct
     chip::DeviceLayer::PlatformMgr().ScheduleWork(TearDownTask, 0);
     sleep(kTestTaskWaitSeconds);
+    chip::DeviceLayer::PlatformMgr().StopEventLoopTask();
+    chip::DeviceLayer::PlatformMgr().Shutdown();
 
     return (nlTestRunnerStats(&theSuite));
 }


### PR DESCRIPTION
#### Problem

`chip::Server::Shutdown()` contains

```
chip::Dnssd::ServiceAdvertiser::Instance().Shutdown();
    ⋮
mCommissioningWindowManager.Cleanup();
```

but the latter restarts `Dnssd::ServiceAdvertiser`.

Instance of #11880 _Possible use of destroyed pool objects_

#### Change overview

Add `CommissioningWindowManager::Shutdown()` which does not restart DNS.

#### Testing

If `ObjectPool` checks that objects do not outlive it
(originally part of PR #11698 but deferred due to current leaks),
then `TestCommissionManager` fails without this change.
