### PR TITLE
Implement init methods for Darwin structs

### DIFF
--- a/src/darwin/Framework/CHIP/templates/CHIPCommandPayloadsObjc-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/CHIPCommandPayloadsObjc-src.zapt
@@ -2,10 +2,23 @@
 
 #import "CHIPCommandPayloadsObjc.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 {{#zcl_clusters}}
 {{#zcl_commands}}
 @implementation CHIP{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}Payload
+- (instancetype)init
+{
+  if (self = [super init]) {
+    {{#zcl_command_arguments}}
+    {{>init_struct_member label=label type=type cluster=parent.parent.name}}
+    {{/zcl_command_arguments}}
+  }
+  return self;
+}
 @end
 
 {{/zcl_commands}}
 {{/zcl_clusters}}
+
+NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/templates/CHIPCommandPayloadsObjc.zapt
+++ b/src/darwin/Framework/CHIP/templates/CHIPCommandPayloadsObjc.zapt
@@ -6,6 +6,8 @@
 #import <Foundation/Foundation.h>
 #import <CHIP/CHIPStructsObjc.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 {{#zcl_clusters}}
 {{#zcl_commands}}
 @interface CHIP{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}Payload : NSObject
@@ -14,8 +16,12 @@
 {{#zcl_command_arguments}}
 @property (strong, nonatomic{{#unless (isStrEqual (asGetterName label) (asStructPropertyName label))}}, getter={{asGetterName label}}{{/unless}}) {{asObjectiveCType type parent.parent.name}} {{asStructPropertyName label}};
 {{/zcl_command_arguments}}
-@end
+ - (instancetype)init;
+ @end
 
 {{/zcl_commands}}
 {{/zcl_clusters}}
+
+NS_ASSUME_NONNULL_END
+
 #endif /* CHIP_COMMAND_PAYLOADS_H */

--- a/src/darwin/Framework/CHIP/templates/CHIPStructsObjc-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/CHIPStructsObjc-src.zapt
@@ -2,10 +2,23 @@
 
 #import "CHIPStructsObjc.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 {{#zcl_clusters}}
 {{#zcl_structs}}
 @implementation CHIP{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}
+- (instancetype)init
+{
+  if (self = [super init]) {
+    {{#zcl_struct_items}}
+    {{>init_struct_member label=label type=type cluster=parent.parent.name}}
+    {{/zcl_struct_items}}
+  }
+  return self;
+}
 @end
 
 {{/zcl_structs}}
 {{/zcl_clusters}}
+
+NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/templates/CHIPStructsObjc.zapt
+++ b/src/darwin/Framework/CHIP/templates/CHIPStructsObjc.zapt
@@ -5,6 +5,8 @@
 
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 {{#zcl_clusters}}
 {{#zcl_structs}}
 @interface CHIP{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}} : NSObject
@@ -13,9 +15,12 @@
 {{#zcl_struct_items}}
 @property (strong, nonatomic{{#unless (isStrEqual (asGetterName label) (asStructPropertyName label))}}, getter={{asGetterName label}}{{/unless}}) {{asObjectiveCType type parent.parent.name}} {{asStructPropertyName label}};
 {{/zcl_struct_items}}
+- (instancetype)init;
 @end
 
 {{/zcl_structs}}
 {{/zcl_clusters}}
+
+NS_ASSUME_NONNULL_END
 
 #endif /* CHIP_STRUCTS_H */

--- a/src/darwin/Framework/CHIP/templates/partials/init_struct_member.zapt
+++ b/src/darwin/Framework/CHIP/templates/partials/init_struct_member.zapt
@@ -1,0 +1,19 @@
+{{#*inline "memberName"}}_{{asStructPropertyName label}}{{/inline}}
+{{#if isOptional}}
+{{>memberName}} = nil;
+{{else if isNullable}}
+{{>memberName}} = nil;
+{{else if isArray}}
+  {{>memberName}} = [NSArray array];
+{{else if (isOctetString type)}}
+  {{>memberName}} = [NSData data];
+{{else if (isCharString type)}}
+  {{>memberName}} = @"";
+{{else}}
+  {{! Our memberName inline partial won't work inside the async if_is_struct }}
+  {{#if_is_struct type}}
+    _{{asStructPropertyName label}} = [{{asObjectiveCClass type cluster}} new];
+  {{else}}
+    _{{asStructPropertyName label}} = @(0);
+  {{/if_is_struct}}
+{{/if}}

--- a/src/darwin/Framework/CHIP/templates/templates.json
+++ b/src/darwin/Framework/CHIP/templates/templates.json
@@ -39,6 +39,10 @@
         {
             "name": "check_test_value",
             "path": "partials/check_test_value.zapt"
+        },
+        {
+            "name": "init_struct_member",
+            "path": "partials/init_struct_member.zapt"
         }
     ],
     "templates": [

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPCommandPayloadsObjc.h
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPCommandPayloadsObjc.h
@@ -23,66 +23,82 @@
 #import <CHIP/CHIPStructsObjc.h>
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface CHIPIdentifyClusterIdentifyPayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull identifyTime;
+- (instancetype)init;
 @end
 
 @interface CHIPIdentifyClusterIdentifyQueryResponsePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull timeout;
+- (instancetype)init;
 @end
 
 @interface CHIPIdentifyClusterIdentifyQueryPayload : NSObject
+- (instancetype)init;
 @end
 
 @interface CHIPIdentifyClusterTriggerEffectPayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull effectIdentifier;
 @property (strong, nonatomic) NSNumber * _Nonnull effectVariant;
+- (instancetype)init;
 @end
 
 @interface CHIPGroupsClusterAddGroupPayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull groupId;
 @property (strong, nonatomic) NSString * _Nonnull groupName;
+- (instancetype)init;
 @end
 
 @interface CHIPGroupsClusterAddGroupResponsePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull status;
 @property (strong, nonatomic) NSNumber * _Nonnull groupId;
+- (instancetype)init;
 @end
 
 @interface CHIPGroupsClusterViewGroupPayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull groupId;
+- (instancetype)init;
 @end
 
 @interface CHIPGroupsClusterViewGroupResponsePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull status;
 @property (strong, nonatomic) NSNumber * _Nonnull groupId;
 @property (strong, nonatomic) NSString * _Nonnull groupName;
+- (instancetype)init;
 @end
 
 @interface CHIPGroupsClusterGetGroupMembershipPayload : NSObject
 @property (strong, nonatomic) NSArray * _Nonnull groupList;
+- (instancetype)init;
 @end
 
 @interface CHIPGroupsClusterGetGroupMembershipResponsePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull capacity;
 @property (strong, nonatomic) NSArray * _Nonnull groupList;
+- (instancetype)init;
 @end
 
 @interface CHIPGroupsClusterRemoveGroupPayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull groupId;
+- (instancetype)init;
 @end
 
 @interface CHIPGroupsClusterRemoveGroupResponsePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull status;
 @property (strong, nonatomic) NSNumber * _Nonnull groupId;
+- (instancetype)init;
 @end
 
 @interface CHIPGroupsClusterRemoveAllGroupsPayload : NSObject
+- (instancetype)init;
 @end
 
 @interface CHIPGroupsClusterAddGroupIfIdentifyingPayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull groupId;
 @property (strong, nonatomic) NSString * _Nonnull groupName;
+- (instancetype)init;
 @end
 
 @interface CHIPScenesClusterAddScenePayload : NSObject
@@ -91,17 +107,20 @@
 @property (strong, nonatomic) NSNumber * _Nonnull transitionTime;
 @property (strong, nonatomic) NSString * _Nonnull sceneName;
 @property (strong, nonatomic) NSArray * _Nonnull extensionFieldSets;
+- (instancetype)init;
 @end
 
 @interface CHIPScenesClusterAddSceneResponsePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull status;
 @property (strong, nonatomic) NSNumber * _Nonnull groupId;
 @property (strong, nonatomic) NSNumber * _Nonnull sceneId;
+- (instancetype)init;
 @end
 
 @interface CHIPScenesClusterViewScenePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull groupId;
 @property (strong, nonatomic) NSNumber * _Nonnull sceneId;
+- (instancetype)init;
 @end
 
 @interface CHIPScenesClusterViewSceneResponsePayload : NSObject
@@ -111,47 +130,56 @@
 @property (strong, nonatomic) NSNumber * _Nonnull transitionTime;
 @property (strong, nonatomic) NSString * _Nonnull sceneName;
 @property (strong, nonatomic) NSArray * _Nonnull extensionFieldSets;
+- (instancetype)init;
 @end
 
 @interface CHIPScenesClusterRemoveScenePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull groupId;
 @property (strong, nonatomic) NSNumber * _Nonnull sceneId;
+- (instancetype)init;
 @end
 
 @interface CHIPScenesClusterRemoveSceneResponsePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull status;
 @property (strong, nonatomic) NSNumber * _Nonnull groupId;
 @property (strong, nonatomic) NSNumber * _Nonnull sceneId;
+- (instancetype)init;
 @end
 
 @interface CHIPScenesClusterRemoveAllScenesPayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull groupId;
+- (instancetype)init;
 @end
 
 @interface CHIPScenesClusterRemoveAllScenesResponsePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull status;
 @property (strong, nonatomic) NSNumber * _Nonnull groupId;
+- (instancetype)init;
 @end
 
 @interface CHIPScenesClusterStoreScenePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull groupId;
 @property (strong, nonatomic) NSNumber * _Nonnull sceneId;
+- (instancetype)init;
 @end
 
 @interface CHIPScenesClusterStoreSceneResponsePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull status;
 @property (strong, nonatomic) NSNumber * _Nonnull groupId;
 @property (strong, nonatomic) NSNumber * _Nonnull sceneId;
+- (instancetype)init;
 @end
 
 @interface CHIPScenesClusterRecallScenePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull groupId;
 @property (strong, nonatomic) NSNumber * _Nonnull sceneId;
 @property (strong, nonatomic) NSNumber * _Nonnull transitionTime;
+- (instancetype)init;
 @end
 
 @interface CHIPScenesClusterGetSceneMembershipPayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull groupId;
+- (instancetype)init;
 @end
 
 @interface CHIPScenesClusterGetSceneMembershipResponsePayload : NSObject
@@ -160,6 +188,7 @@
 @property (strong, nonatomic) NSNumber * _Nonnull groupId;
 @property (strong, nonatomic) NSNumber * _Nonnull sceneCount;
 @property (strong, nonatomic) NSArray * _Nonnull sceneList;
+- (instancetype)init;
 @end
 
 @interface CHIPScenesClusterEnhancedAddScenePayload : NSObject
@@ -168,17 +197,20 @@
 @property (strong, nonatomic) NSNumber * _Nonnull transitionTime;
 @property (strong, nonatomic) NSString * _Nonnull sceneName;
 @property (strong, nonatomic) NSArray * _Nonnull extensionFieldSets;
+- (instancetype)init;
 @end
 
 @interface CHIPScenesClusterEnhancedAddSceneResponsePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull status;
 @property (strong, nonatomic) NSNumber * _Nonnull groupId;
 @property (strong, nonatomic) NSNumber * _Nonnull sceneId;
+- (instancetype)init;
 @end
 
 @interface CHIPScenesClusterEnhancedViewScenePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull groupId;
 @property (strong, nonatomic) NSNumber * _Nonnull sceneId;
+- (instancetype)init;
 @end
 
 @interface CHIPScenesClusterEnhancedViewSceneResponsePayload : NSObject
@@ -188,6 +220,7 @@
 @property (strong, nonatomic) NSNumber * _Nonnull transitionTime;
 @property (strong, nonatomic) NSString * _Nonnull sceneName;
 @property (strong, nonatomic) NSArray * _Nonnull extensionFieldSets;
+- (instancetype)init;
 @end
 
 @interface CHIPScenesClusterCopyScenePayload : NSObject
@@ -196,50 +229,63 @@
 @property (strong, nonatomic) NSNumber * _Nonnull sceneIdFrom;
 @property (strong, nonatomic) NSNumber * _Nonnull groupIdTo;
 @property (strong, nonatomic) NSNumber * _Nonnull sceneIdTo;
+- (instancetype)init;
 @end
 
 @interface CHIPScenesClusterCopySceneResponsePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull status;
 @property (strong, nonatomic) NSNumber * _Nonnull groupIdFrom;
 @property (strong, nonatomic) NSNumber * _Nonnull sceneIdFrom;
+- (instancetype)init;
 @end
 
 @interface CHIPOnOffClusterOffPayload : NSObject
+- (instancetype)init;
 @end
 
 @interface CHIPOnOffClusterSampleMfgSpecificOffWithTransitionPayload : NSObject
+- (instancetype)init;
 @end
 
 @interface CHIPOnOffClusterOnPayload : NSObject
+- (instancetype)init;
 @end
 
 @interface CHIPOnOffClusterSampleMfgSpecificOnWithTransitionPayload : NSObject
+- (instancetype)init;
 @end
 
 @interface CHIPOnOffClusterSampleMfgSpecificOnWithTransition2Payload : NSObject
+- (instancetype)init;
 @end
 
 @interface CHIPOnOffClusterTogglePayload : NSObject
+- (instancetype)init;
 @end
 
 @interface CHIPOnOffClusterSampleMfgSpecificToggleWithTransitionPayload : NSObject
+- (instancetype)init;
 @end
 
 @interface CHIPOnOffClusterSampleMfgSpecificToggleWithTransition2Payload : NSObject
+- (instancetype)init;
 @end
 
 @interface CHIPOnOffClusterOffWithEffectPayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull effectId;
 @property (strong, nonatomic) NSNumber * _Nonnull effectVariant;
+- (instancetype)init;
 @end
 
 @interface CHIPOnOffClusterOnWithRecallGlobalScenePayload : NSObject
+- (instancetype)init;
 @end
 
 @interface CHIPOnOffClusterOnWithTimedOffPayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull onOffControl;
 @property (strong, nonatomic) NSNumber * _Nonnull onTime;
 @property (strong, nonatomic) NSNumber * _Nonnull offWaitTime;
+- (instancetype)init;
 @end
 
 @interface CHIPLevelControlClusterMoveToLevelPayload : NSObject
@@ -247,6 +293,7 @@
 @property (strong, nonatomic) NSNumber * _Nonnull transitionTime;
 @property (strong, nonatomic) NSNumber * _Nonnull optionMask;
 @property (strong, nonatomic) NSNumber * _Nonnull optionOverride;
+- (instancetype)init;
 @end
 
 @interface CHIPLevelControlClusterMovePayload : NSObject
@@ -254,6 +301,7 @@
 @property (strong, nonatomic) NSNumber * _Nonnull rate;
 @property (strong, nonatomic) NSNumber * _Nonnull optionMask;
 @property (strong, nonatomic) NSNumber * _Nonnull optionOverride;
+- (instancetype)init;
 @end
 
 @interface CHIPLevelControlClusterStepPayload : NSObject
@@ -262,43 +310,52 @@
 @property (strong, nonatomic) NSNumber * _Nonnull transitionTime;
 @property (strong, nonatomic) NSNumber * _Nonnull optionMask;
 @property (strong, nonatomic) NSNumber * _Nonnull optionOverride;
+- (instancetype)init;
 @end
 
 @interface CHIPLevelControlClusterStopPayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull optionMask;
 @property (strong, nonatomic) NSNumber * _Nonnull optionOverride;
+- (instancetype)init;
 @end
 
 @interface CHIPLevelControlClusterMoveToLevelWithOnOffPayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull level;
 @property (strong, nonatomic) NSNumber * _Nonnull transitionTime;
+- (instancetype)init;
 @end
 
 @interface CHIPLevelControlClusterMoveWithOnOffPayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull moveMode;
 @property (strong, nonatomic) NSNumber * _Nonnull rate;
+- (instancetype)init;
 @end
 
 @interface CHIPLevelControlClusterStepWithOnOffPayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull stepMode;
 @property (strong, nonatomic) NSNumber * _Nonnull stepSize;
 @property (strong, nonatomic) NSNumber * _Nonnull transitionTime;
+- (instancetype)init;
 @end
 
 @interface CHIPLevelControlClusterStopWithOnOffPayload : NSObject
+- (instancetype)init;
 @end
 
 @interface CHIPAlarmsClusterResetAlarmPayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull alarmCode;
 @property (strong, nonatomic) NSNumber * _Nonnull clusterId;
+- (instancetype)init;
 @end
 
 @interface CHIPAlarmsClusterAlarmPayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull alarmCode;
 @property (strong, nonatomic) NSNumber * _Nonnull clusterId;
+- (instancetype)init;
 @end
 
 @interface CHIPAlarmsClusterResetAllAlarmsPayload : NSObject
+- (instancetype)init;
 @end
 
 @interface CHIPAlarmsClusterGetAlarmResponsePayload : NSObject
@@ -306,16 +363,20 @@
 @property (strong, nonatomic) NSNumber * _Nonnull alarmCode;
 @property (strong, nonatomic) NSNumber * _Nonnull clusterId;
 @property (strong, nonatomic) NSNumber * _Nonnull timeStamp;
+- (instancetype)init;
 @end
 
 @interface CHIPAlarmsClusterGetAlarmPayload : NSObject
+- (instancetype)init;
 @end
 
 @interface CHIPAlarmsClusterResetAlarmLogPayload : NSObject
+- (instancetype)init;
 @end
 
 @interface CHIPPowerProfileClusterPowerProfileRequestPayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull powerProfileId;
+- (instancetype)init;
 @end
 
 @interface CHIPPowerProfileClusterPowerProfileNotificationPayload : NSObject
@@ -323,9 +384,11 @@
 @property (strong, nonatomic) NSNumber * _Nonnull powerProfileId;
 @property (strong, nonatomic) NSNumber * _Nonnull numOfTransferredPhases;
 @property (strong, nonatomic) NSArray * _Nonnull transferredPhases;
+- (instancetype)init;
 @end
 
 @interface CHIPPowerProfileClusterPowerProfileStateRequestPayload : NSObject
+- (instancetype)init;
 @end
 
 @interface CHIPPowerProfileClusterPowerProfileResponsePayload : NSObject
@@ -333,6 +396,7 @@
 @property (strong, nonatomic) NSNumber * _Nonnull powerProfileId;
 @property (strong, nonatomic) NSNumber * _Nonnull numOfTransferredPhases;
 @property (strong, nonatomic) NSArray * _Nonnull transferredPhases;
+- (instancetype)init;
 @end
 
 @interface CHIPPowerProfileClusterGetPowerProfilePriceResponsePayload : NSObject
@@ -340,59 +404,71 @@
 @property (strong, nonatomic) NSNumber * _Nonnull currency;
 @property (strong, nonatomic) NSNumber * _Nonnull price;
 @property (strong, nonatomic) NSNumber * _Nonnull priceTrailingDigit;
+- (instancetype)init;
 @end
 
 @interface CHIPPowerProfileClusterPowerProfileStateResponsePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull powerProfileCount;
 @property (strong, nonatomic) NSArray * _Nonnull powerProfileRecords;
+- (instancetype)init;
 @end
 
 @interface CHIPPowerProfileClusterGetOverallSchedulePriceResponsePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull currency;
 @property (strong, nonatomic) NSNumber * _Nonnull price;
 @property (strong, nonatomic) NSNumber * _Nonnull priceTrailingDigit;
+- (instancetype)init;
 @end
 
 @interface CHIPPowerProfileClusterGetPowerProfilePricePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull powerProfileId;
+- (instancetype)init;
 @end
 
 @interface CHIPPowerProfileClusterEnergyPhasesScheduleNotificationPayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull powerProfileId;
 @property (strong, nonatomic) NSNumber * _Nonnull numOfScheduledPhases;
 @property (strong, nonatomic) NSArray * _Nonnull scheduledPhases;
+- (instancetype)init;
 @end
 
 @interface CHIPPowerProfileClusterPowerProfilesStateNotificationPayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull powerProfileCount;
 @property (strong, nonatomic) NSArray * _Nonnull powerProfileRecords;
+- (instancetype)init;
 @end
 
 @interface CHIPPowerProfileClusterEnergyPhasesScheduleResponsePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull powerProfileId;
 @property (strong, nonatomic) NSNumber * _Nonnull numOfScheduledPhases;
 @property (strong, nonatomic) NSArray * _Nonnull scheduledPhases;
+- (instancetype)init;
 @end
 
 @interface CHIPPowerProfileClusterGetOverallSchedulePricePayload : NSObject
+- (instancetype)init;
 @end
 
 @interface CHIPPowerProfileClusterPowerProfileScheduleConstraintsRequestPayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull powerProfileId;
+- (instancetype)init;
 @end
 
 @interface CHIPPowerProfileClusterEnergyPhasesScheduleRequestPayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull powerProfileId;
+- (instancetype)init;
 @end
 
 @interface CHIPPowerProfileClusterEnergyPhasesScheduleStateRequestPayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull powerProfileId;
+- (instancetype)init;
 @end
 
 @interface CHIPPowerProfileClusterEnergyPhasesScheduleStateResponsePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull powerProfileId;
 @property (strong, nonatomic) NSNumber * _Nonnull numOfScheduledPhases;
 @property (strong, nonatomic) NSArray * _Nonnull scheduledPhases;
+- (instancetype)init;
 @end
 
 @interface CHIPPowerProfileClusterGetPowerProfilePriceExtendedResponsePayload : NSObject
@@ -400,161 +476,195 @@
 @property (strong, nonatomic) NSNumber * _Nonnull currency;
 @property (strong, nonatomic) NSNumber * _Nonnull price;
 @property (strong, nonatomic) NSNumber * _Nonnull priceTrailingDigit;
+- (instancetype)init;
 @end
 
 @interface CHIPPowerProfileClusterEnergyPhasesScheduleStateNotificationPayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull powerProfileId;
 @property (strong, nonatomic) NSNumber * _Nonnull numOfScheduledPhases;
 @property (strong, nonatomic) NSArray * _Nonnull scheduledPhases;
+- (instancetype)init;
 @end
 
 @interface CHIPPowerProfileClusterPowerProfileScheduleConstraintsNotificationPayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull powerProfileId;
 @property (strong, nonatomic) NSNumber * _Nonnull startAfter;
 @property (strong, nonatomic) NSNumber * _Nonnull stopBefore;
+- (instancetype)init;
 @end
 
 @interface CHIPPowerProfileClusterPowerProfileScheduleConstraintsResponsePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull powerProfileId;
 @property (strong, nonatomic) NSNumber * _Nonnull startAfter;
 @property (strong, nonatomic) NSNumber * _Nonnull stopBefore;
+- (instancetype)init;
 @end
 
 @interface CHIPPowerProfileClusterGetPowerProfilePriceExtendedPayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull options;
 @property (strong, nonatomic) NSNumber * _Nonnull powerProfileId;
 @property (strong, nonatomic) NSNumber * _Nonnull powerProfileStartTime;
+- (instancetype)init;
 @end
 
 @interface CHIPApplianceControlClusterExecutionOfACommandPayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull commandId;
+- (instancetype)init;
 @end
 
 @interface CHIPApplianceControlClusterSignalStateResponsePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull applianceStatus;
 @property (strong, nonatomic) NSNumber * _Nonnull remoteEnableFlagsAndDeviceStatus2;
 @property (strong, nonatomic) NSNumber * _Nonnull applianceStatus2;
+- (instancetype)init;
 @end
 
 @interface CHIPApplianceControlClusterSignalStatePayload : NSObject
+- (instancetype)init;
 @end
 
 @interface CHIPApplianceControlClusterSignalStateNotificationPayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull applianceStatus;
 @property (strong, nonatomic) NSNumber * _Nonnull remoteEnableFlagsAndDeviceStatus2;
 @property (strong, nonatomic) NSNumber * _Nonnull applianceStatus2;
+- (instancetype)init;
 @end
 
 @interface CHIPApplianceControlClusterWriteFunctionsPayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull functionId;
 @property (strong, nonatomic) NSNumber * _Nonnull functionDataType;
 @property (strong, nonatomic) NSArray * _Nonnull functionData;
+- (instancetype)init;
 @end
 
 @interface CHIPApplianceControlClusterOverloadPauseResumePayload : NSObject
+- (instancetype)init;
 @end
 
 @interface CHIPApplianceControlClusterOverloadPausePayload : NSObject
+- (instancetype)init;
 @end
 
 @interface CHIPApplianceControlClusterOverloadWarningPayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull warningEvent;
+- (instancetype)init;
 @end
 
 @interface CHIPPollControlClusterCheckInPayload : NSObject
+- (instancetype)init;
 @end
 
 @interface CHIPPollControlClusterCheckInResponsePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull startFastPolling;
 @property (strong, nonatomic) NSNumber * _Nonnull fastPollTimeout;
+- (instancetype)init;
 @end
 
 @interface CHIPPollControlClusterFastPollStopPayload : NSObject
+- (instancetype)init;
 @end
 
 @interface CHIPPollControlClusterSetLongPollIntervalPayload : NSObject
 @property (strong, nonatomic, getter=getNewLongPollInterval) NSNumber * _Nonnull newLongPollInterval;
+- (instancetype)init;
 @end
 
 @interface CHIPPollControlClusterSetShortPollIntervalPayload : NSObject
 @property (strong, nonatomic, getter=getNewShortPollInterval) NSNumber * _Nonnull newShortPollInterval;
+- (instancetype)init;
 @end
 
 @interface CHIPBridgedActionsClusterInstantActionPayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull actionID;
 @property (strong, nonatomic) NSNumber * _Nullable invokeID;
+- (instancetype)init;
 @end
 
 @interface CHIPBridgedActionsClusterInstantActionWithTransitionPayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull actionID;
 @property (strong, nonatomic) NSNumber * _Nullable invokeID;
 @property (strong, nonatomic) NSNumber * _Nonnull transitionTime;
+- (instancetype)init;
 @end
 
 @interface CHIPBridgedActionsClusterStartActionPayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull actionID;
 @property (strong, nonatomic) NSNumber * _Nullable invokeID;
+- (instancetype)init;
 @end
 
 @interface CHIPBridgedActionsClusterStartActionWithDurationPayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull actionID;
 @property (strong, nonatomic) NSNumber * _Nullable invokeID;
 @property (strong, nonatomic) NSNumber * _Nonnull duration;
+- (instancetype)init;
 @end
 
 @interface CHIPBridgedActionsClusterStopActionPayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull actionID;
 @property (strong, nonatomic) NSNumber * _Nullable invokeID;
+- (instancetype)init;
 @end
 
 @interface CHIPBridgedActionsClusterPauseActionPayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull actionID;
 @property (strong, nonatomic) NSNumber * _Nullable invokeID;
+- (instancetype)init;
 @end
 
 @interface CHIPBridgedActionsClusterPauseActionWithDurationPayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull actionID;
 @property (strong, nonatomic) NSNumber * _Nullable invokeID;
 @property (strong, nonatomic) NSNumber * _Nonnull duration;
+- (instancetype)init;
 @end
 
 @interface CHIPBridgedActionsClusterResumeActionPayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull actionID;
 @property (strong, nonatomic) NSNumber * _Nullable invokeID;
+- (instancetype)init;
 @end
 
 @interface CHIPBridgedActionsClusterEnableActionPayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull actionID;
 @property (strong, nonatomic) NSNumber * _Nullable invokeID;
+- (instancetype)init;
 @end
 
 @interface CHIPBridgedActionsClusterEnableActionWithDurationPayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull actionID;
 @property (strong, nonatomic) NSNumber * _Nullable invokeID;
 @property (strong, nonatomic) NSNumber * _Nonnull duration;
+- (instancetype)init;
 @end
 
 @interface CHIPBridgedActionsClusterDisableActionPayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull actionID;
 @property (strong, nonatomic) NSNumber * _Nullable invokeID;
+- (instancetype)init;
 @end
 
 @interface CHIPBridgedActionsClusterDisableActionWithDurationPayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull actionID;
 @property (strong, nonatomic) NSNumber * _Nullable invokeID;
 @property (strong, nonatomic) NSNumber * _Nonnull duration;
+- (instancetype)init;
 @end
 
 @interface CHIPBasicClusterStartUpPayload : NSObject
+- (instancetype)init;
 @end
 
 @interface CHIPBasicClusterMfgSpecificPingPayload : NSObject
+- (instancetype)init;
 @end
 
 @interface CHIPBasicClusterShutDownPayload : NSObject
+- (instancetype)init;
 @end
 
 @interface CHIPBasicClusterLeavePayload : NSObject
+- (instancetype)init;
 @end
 
 @interface CHIPOtaSoftwareUpdateProviderClusterQueryImagePayload : NSObject
@@ -566,16 +676,19 @@
 @property (strong, nonatomic) NSString * _Nullable location;
 @property (strong, nonatomic) NSNumber * _Nullable requestorCanConsent;
 @property (strong, nonatomic) NSData * _Nullable metadataForProvider;
+- (instancetype)init;
 @end
 
 @interface CHIPOtaSoftwareUpdateProviderClusterApplyUpdateRequestPayload : NSObject
 @property (strong, nonatomic) NSData * _Nonnull updateToken;
 @property (strong, nonatomic, getter=getNewVersion) NSNumber * _Nonnull newVersion;
+- (instancetype)init;
 @end
 
 @interface CHIPOtaSoftwareUpdateProviderClusterNotifyUpdateAppliedPayload : NSObject
 @property (strong, nonatomic) NSData * _Nonnull updateToken;
 @property (strong, nonatomic) NSNumber * _Nonnull softwareVersion;
+- (instancetype)init;
 @end
 
 @interface CHIPOtaSoftwareUpdateProviderClusterQueryImageResponsePayload : NSObject
@@ -587,11 +700,13 @@
 @property (strong, nonatomic) NSData * _Nullable updateToken;
 @property (strong, nonatomic) NSNumber * _Nullable userConsentNeeded;
 @property (strong, nonatomic) NSData * _Nullable metadataForRequestor;
+- (instancetype)init;
 @end
 
 @interface CHIPOtaSoftwareUpdateProviderClusterApplyUpdateResponsePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull action;
 @property (strong, nonatomic) NSNumber * _Nonnull delayedActionTime;
+- (instancetype)init;
 @end
 
 @interface CHIPOtaSoftwareUpdateRequestorClusterAnnounceOtaProviderPayload : NSObject
@@ -599,17 +714,20 @@
 @property (strong, nonatomic) NSNumber * _Nonnull vendorId;
 @property (strong, nonatomic) NSNumber * _Nonnull announcementReason;
 @property (strong, nonatomic) NSData * _Nullable metadataForNode;
+- (instancetype)init;
 @end
 
 @interface CHIPGeneralCommissioningClusterArmFailSafePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull expiryLengthSeconds;
 @property (strong, nonatomic) NSNumber * _Nonnull breadcrumb;
 @property (strong, nonatomic) NSNumber * _Nonnull timeoutMs;
+- (instancetype)init;
 @end
 
 @interface CHIPGeneralCommissioningClusterArmFailSafeResponsePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull errorCode;
 @property (strong, nonatomic) NSString * _Nonnull debugText;
+- (instancetype)init;
 @end
 
 @interface CHIPGeneralCommissioningClusterSetRegulatoryConfigPayload : NSObject
@@ -617,25 +735,30 @@
 @property (strong, nonatomic) NSString * _Nonnull countryCode;
 @property (strong, nonatomic) NSNumber * _Nonnull breadcrumb;
 @property (strong, nonatomic) NSNumber * _Nonnull timeoutMs;
+- (instancetype)init;
 @end
 
 @interface CHIPGeneralCommissioningClusterSetRegulatoryConfigResponsePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull errorCode;
 @property (strong, nonatomic) NSString * _Nonnull debugText;
+- (instancetype)init;
 @end
 
 @interface CHIPGeneralCommissioningClusterCommissioningCompletePayload : NSObject
+- (instancetype)init;
 @end
 
 @interface CHIPGeneralCommissioningClusterCommissioningCompleteResponsePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull errorCode;
 @property (strong, nonatomic) NSString * _Nonnull debugText;
+- (instancetype)init;
 @end
 
 @interface CHIPNetworkCommissioningClusterScanNetworksPayload : NSObject
 @property (strong, nonatomic) NSData * _Nonnull ssid;
 @property (strong, nonatomic) NSNumber * _Nonnull breadcrumb;
 @property (strong, nonatomic) NSNumber * _Nonnull timeoutMs;
+- (instancetype)init;
 @end
 
 @interface CHIPNetworkCommissioningClusterScanNetworksResponsePayload : NSObject
@@ -643,6 +766,7 @@
 @property (strong, nonatomic) NSString * _Nonnull debugText;
 @property (strong, nonatomic) NSArray * _Nonnull wifiScanResults;
 @property (strong, nonatomic) NSArray * _Nonnull threadScanResults;
+- (instancetype)init;
 @end
 
 @interface CHIPNetworkCommissioningClusterAddWiFiNetworkPayload : NSObject
@@ -650,11 +774,13 @@
 @property (strong, nonatomic) NSData * _Nonnull credentials;
 @property (strong, nonatomic) NSNumber * _Nonnull breadcrumb;
 @property (strong, nonatomic) NSNumber * _Nonnull timeoutMs;
+- (instancetype)init;
 @end
 
 @interface CHIPNetworkCommissioningClusterAddWiFiNetworkResponsePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull errorCode;
 @property (strong, nonatomic) NSString * _Nonnull debugText;
+- (instancetype)init;
 @end
 
 @interface CHIPNetworkCommissioningClusterUpdateWiFiNetworkPayload : NSObject
@@ -662,72 +788,85 @@
 @property (strong, nonatomic) NSData * _Nonnull credentials;
 @property (strong, nonatomic) NSNumber * _Nonnull breadcrumb;
 @property (strong, nonatomic) NSNumber * _Nonnull timeoutMs;
+- (instancetype)init;
 @end
 
 @interface CHIPNetworkCommissioningClusterUpdateWiFiNetworkResponsePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull errorCode;
 @property (strong, nonatomic) NSString * _Nonnull debugText;
+- (instancetype)init;
 @end
 
 @interface CHIPNetworkCommissioningClusterAddThreadNetworkPayload : NSObject
 @property (strong, nonatomic) NSData * _Nonnull operationalDataset;
 @property (strong, nonatomic) NSNumber * _Nonnull breadcrumb;
 @property (strong, nonatomic) NSNumber * _Nonnull timeoutMs;
+- (instancetype)init;
 @end
 
 @interface CHIPNetworkCommissioningClusterAddThreadNetworkResponsePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull errorCode;
 @property (strong, nonatomic) NSString * _Nonnull debugText;
+- (instancetype)init;
 @end
 
 @interface CHIPNetworkCommissioningClusterUpdateThreadNetworkPayload : NSObject
 @property (strong, nonatomic) NSData * _Nonnull operationalDataset;
 @property (strong, nonatomic) NSNumber * _Nonnull breadcrumb;
 @property (strong, nonatomic) NSNumber * _Nonnull timeoutMs;
+- (instancetype)init;
 @end
 
 @interface CHIPNetworkCommissioningClusterUpdateThreadNetworkResponsePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull errorCode;
 @property (strong, nonatomic) NSString * _Nonnull debugText;
+- (instancetype)init;
 @end
 
 @interface CHIPNetworkCommissioningClusterRemoveNetworkPayload : NSObject
 @property (strong, nonatomic) NSData * _Nonnull networkID;
 @property (strong, nonatomic) NSNumber * _Nonnull breadcrumb;
 @property (strong, nonatomic) NSNumber * _Nonnull timeoutMs;
+- (instancetype)init;
 @end
 
 @interface CHIPNetworkCommissioningClusterRemoveNetworkResponsePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull errorCode;
 @property (strong, nonatomic) NSString * _Nonnull debugText;
+- (instancetype)init;
 @end
 
 @interface CHIPNetworkCommissioningClusterEnableNetworkPayload : NSObject
 @property (strong, nonatomic) NSData * _Nonnull networkID;
 @property (strong, nonatomic) NSNumber * _Nonnull breadcrumb;
 @property (strong, nonatomic) NSNumber * _Nonnull timeoutMs;
+- (instancetype)init;
 @end
 
 @interface CHIPNetworkCommissioningClusterEnableNetworkResponsePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull errorCode;
 @property (strong, nonatomic) NSString * _Nonnull debugText;
+- (instancetype)init;
 @end
 
 @interface CHIPNetworkCommissioningClusterDisableNetworkPayload : NSObject
 @property (strong, nonatomic) NSData * _Nonnull networkID;
 @property (strong, nonatomic) NSNumber * _Nonnull breadcrumb;
 @property (strong, nonatomic) NSNumber * _Nonnull timeoutMs;
+- (instancetype)init;
 @end
 
 @interface CHIPNetworkCommissioningClusterDisableNetworkResponsePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull errorCode;
 @property (strong, nonatomic) NSString * _Nonnull debugText;
+- (instancetype)init;
 @end
 
 @interface CHIPDiagnosticLogsClusterRetrieveLogsRequestPayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull intent;
 @property (strong, nonatomic) NSNumber * _Nonnull requestedProtocol;
 @property (strong, nonatomic) NSData * _Nonnull transferFileDesignator;
+- (instancetype)init;
 @end
 
 @interface CHIPDiagnosticLogsClusterRetrieveLogsResponsePayload : NSObject
@@ -735,30 +874,39 @@
 @property (strong, nonatomic) NSData * _Nonnull content;
 @property (strong, nonatomic) NSNumber * _Nonnull timeStamp;
 @property (strong, nonatomic) NSNumber * _Nonnull timeSinceBoot;
+- (instancetype)init;
 @end
 
 @interface CHIPSoftwareDiagnosticsClusterResetWatermarksPayload : NSObject
+- (instancetype)init;
 @end
 
 @interface CHIPThreadNetworkDiagnosticsClusterResetCountsPayload : NSObject
+- (instancetype)init;
 @end
 
 @interface CHIPWiFiNetworkDiagnosticsClusterResetCountsPayload : NSObject
+- (instancetype)init;
 @end
 
 @interface CHIPEthernetNetworkDiagnosticsClusterResetCountsPayload : NSObject
+- (instancetype)init;
 @end
 
 @interface CHIPBridgedDeviceBasicClusterStartUpPayload : NSObject
+- (instancetype)init;
 @end
 
 @interface CHIPBridgedDeviceBasicClusterShutDownPayload : NSObject
+- (instancetype)init;
 @end
 
 @interface CHIPBridgedDeviceBasicClusterLeavePayload : NSObject
+- (instancetype)init;
 @end
 
 @interface CHIPBridgedDeviceBasicClusterReachableChangedPayload : NSObject
+- (instancetype)init;
 @end
 
 @interface CHIPAdministratorCommissioningClusterOpenCommissioningWindowPayload : NSObject
@@ -768,39 +916,48 @@
 @property (strong, nonatomic) NSNumber * _Nonnull iterations;
 @property (strong, nonatomic) NSData * _Nonnull salt;
 @property (strong, nonatomic) NSNumber * _Nonnull passcodeID;
+- (instancetype)init;
 @end
 
 @interface CHIPAdministratorCommissioningClusterOpenBasicCommissioningWindowPayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull commissioningTimeout;
+- (instancetype)init;
 @end
 
 @interface CHIPAdministratorCommissioningClusterRevokeCommissioningPayload : NSObject
+- (instancetype)init;
 @end
 
 @interface CHIPOperationalCredentialsClusterAttestationRequestPayload : NSObject
 @property (strong, nonatomic) NSData * _Nonnull attestationNonce;
+- (instancetype)init;
 @end
 
 @interface CHIPOperationalCredentialsClusterAttestationResponsePayload : NSObject
 @property (strong, nonatomic) NSData * _Nonnull attestationElements;
 @property (strong, nonatomic) NSData * _Nonnull signature;
+- (instancetype)init;
 @end
 
 @interface CHIPOperationalCredentialsClusterCertificateChainRequestPayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull certificateType;
+- (instancetype)init;
 @end
 
 @interface CHIPOperationalCredentialsClusterCertificateChainResponsePayload : NSObject
 @property (strong, nonatomic) NSData * _Nonnull certificate;
+- (instancetype)init;
 @end
 
 @interface CHIPOperationalCredentialsClusterOpCSRRequestPayload : NSObject
 @property (strong, nonatomic) NSData * _Nonnull csrNonce;
+- (instancetype)init;
 @end
 
 @interface CHIPOperationalCredentialsClusterOpCSRResponsePayload : NSObject
 @property (strong, nonatomic) NSData * _Nonnull nocsrElements;
 @property (strong, nonatomic) NSData * _Nonnull attestationSignature;
+- (instancetype)init;
 @end
 
 @interface CHIPOperationalCredentialsClusterAddNOCPayload : NSObject
@@ -809,74 +966,91 @@
 @property (strong, nonatomic) NSData * _Nonnull ipkValue;
 @property (strong, nonatomic) NSNumber * _Nonnull caseAdminNode;
 @property (strong, nonatomic) NSNumber * _Nonnull adminVendorId;
+- (instancetype)init;
 @end
 
 @interface CHIPOperationalCredentialsClusterUpdateNOCPayload : NSObject
 @property (strong, nonatomic) NSData * _Nonnull nocValue;
 @property (strong, nonatomic) NSData * _Nullable icacValue;
+- (instancetype)init;
 @end
 
 @interface CHIPOperationalCredentialsClusterNOCResponsePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull statusCode;
 @property (strong, nonatomic) NSNumber * _Nonnull fabricIndex;
 @property (strong, nonatomic) NSString * _Nonnull debugText;
+- (instancetype)init;
 @end
 
 @interface CHIPOperationalCredentialsClusterUpdateFabricLabelPayload : NSObject
 @property (strong, nonatomic) NSString * _Nonnull label;
+- (instancetype)init;
 @end
 
 @interface CHIPOperationalCredentialsClusterRemoveFabricPayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull fabricIndex;
+- (instancetype)init;
 @end
 
 @interface CHIPOperationalCredentialsClusterAddTrustedRootCertificatePayload : NSObject
 @property (strong, nonatomic) NSData * _Nonnull rootCertificate;
+- (instancetype)init;
 @end
 
 @interface CHIPOperationalCredentialsClusterRemoveTrustedRootCertificatePayload : NSObject
 @property (strong, nonatomic) NSData * _Nonnull trustedRootIdentifier;
+- (instancetype)init;
 @end
 
 @interface CHIPModeSelectClusterChangeToModePayload : NSObject
 @property (strong, nonatomic, getter=getNewMode) NSNumber * _Nonnull newMode;
+- (instancetype)init;
 @end
 
 @interface CHIPDoorLockClusterLockDoorPayload : NSObject
 @property (strong, nonatomic) NSData * _Nonnull pin;
+- (instancetype)init;
 @end
 
 @interface CHIPDoorLockClusterLockDoorResponsePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull status;
+- (instancetype)init;
 @end
 
 @interface CHIPDoorLockClusterUnlockDoorPayload : NSObject
 @property (strong, nonatomic) NSData * _Nonnull pin;
+- (instancetype)init;
 @end
 
 @interface CHIPDoorLockClusterUnlockDoorResponsePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull status;
+- (instancetype)init;
 @end
 
 @interface CHIPDoorLockClusterTogglePayload : NSObject
 @property (strong, nonatomic) NSString * _Nonnull pin;
+- (instancetype)init;
 @end
 
 @interface CHIPDoorLockClusterToggleResponsePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull status;
+- (instancetype)init;
 @end
 
 @interface CHIPDoorLockClusterUnlockWithTimeoutPayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull timeoutInSeconds;
 @property (strong, nonatomic) NSData * _Nonnull pin;
+- (instancetype)init;
 @end
 
 @interface CHIPDoorLockClusterUnlockWithTimeoutResponsePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull status;
+- (instancetype)init;
 @end
 
 @interface CHIPDoorLockClusterGetLogRecordPayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull logIndex;
+- (instancetype)init;
 @end
 
 @interface CHIPDoorLockClusterGetLogRecordResponsePayload : NSObject
@@ -887,6 +1061,7 @@
 @property (strong, nonatomic) NSNumber * _Nonnull eventIdOrAlarmCode;
 @property (strong, nonatomic) NSNumber * _Nonnull userId;
 @property (strong, nonatomic) NSData * _Nonnull pin;
+- (instancetype)init;
 @end
 
 @interface CHIPDoorLockClusterSetPinPayload : NSObject
@@ -894,14 +1069,17 @@
 @property (strong, nonatomic) NSNumber * _Nonnull userStatus;
 @property (strong, nonatomic) NSNumber * _Nonnull userType;
 @property (strong, nonatomic) NSData * _Nonnull pin;
+- (instancetype)init;
 @end
 
 @interface CHIPDoorLockClusterSetPinResponsePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull status;
+- (instancetype)init;
 @end
 
 @interface CHIPDoorLockClusterGetPinPayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull userId;
+- (instancetype)init;
 @end
 
 @interface CHIPDoorLockClusterGetPinResponsePayload : NSObject
@@ -909,39 +1087,48 @@
 @property (strong, nonatomic) NSNumber * _Nonnull userStatus;
 @property (strong, nonatomic) NSNumber * _Nonnull userType;
 @property (strong, nonatomic) NSData * _Nonnull pin;
+- (instancetype)init;
 @end
 
 @interface CHIPDoorLockClusterClearPinPayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull userId;
+- (instancetype)init;
 @end
 
 @interface CHIPDoorLockClusterClearPinResponsePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull status;
+- (instancetype)init;
 @end
 
 @interface CHIPDoorLockClusterClearAllPinsPayload : NSObject
+- (instancetype)init;
 @end
 
 @interface CHIPDoorLockClusterClearAllPinsResponsePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull status;
+- (instancetype)init;
 @end
 
 @interface CHIPDoorLockClusterSetUserStatusPayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull userId;
 @property (strong, nonatomic) NSNumber * _Nonnull userStatus;
+- (instancetype)init;
 @end
 
 @interface CHIPDoorLockClusterSetUserStatusResponsePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull status;
+- (instancetype)init;
 @end
 
 @interface CHIPDoorLockClusterGetUserStatusPayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull userId;
+- (instancetype)init;
 @end
 
 @interface CHIPDoorLockClusterGetUserStatusResponsePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull userId;
 @property (strong, nonatomic) NSNumber * _Nonnull status;
+- (instancetype)init;
 @end
 
 @interface CHIPDoorLockClusterSetWeekdaySchedulePayload : NSObject
@@ -952,15 +1139,18 @@
 @property (strong, nonatomic) NSNumber * _Nonnull startMinute;
 @property (strong, nonatomic) NSNumber * _Nonnull endHour;
 @property (strong, nonatomic) NSNumber * _Nonnull endMinute;
+- (instancetype)init;
 @end
 
 @interface CHIPDoorLockClusterSetWeekdayScheduleResponsePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull status;
+- (instancetype)init;
 @end
 
 @interface CHIPDoorLockClusterGetWeekdaySchedulePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull scheduleId;
 @property (strong, nonatomic) NSNumber * _Nonnull userId;
+- (instancetype)init;
 @end
 
 @interface CHIPDoorLockClusterGetWeekdayScheduleResponsePayload : NSObject
@@ -972,15 +1162,18 @@
 @property (strong, nonatomic) NSNumber * _Nonnull startMinute;
 @property (strong, nonatomic) NSNumber * _Nonnull endHour;
 @property (strong, nonatomic) NSNumber * _Nonnull endMinute;
+- (instancetype)init;
 @end
 
 @interface CHIPDoorLockClusterClearWeekdaySchedulePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull scheduleId;
 @property (strong, nonatomic) NSNumber * _Nonnull userId;
+- (instancetype)init;
 @end
 
 @interface CHIPDoorLockClusterClearWeekdayScheduleResponsePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull status;
+- (instancetype)init;
 @end
 
 @interface CHIPDoorLockClusterSetYeardaySchedulePayload : NSObject
@@ -988,15 +1181,18 @@
 @property (strong, nonatomic) NSNumber * _Nonnull userId;
 @property (strong, nonatomic) NSNumber * _Nonnull localStartTime;
 @property (strong, nonatomic) NSNumber * _Nonnull localEndTime;
+- (instancetype)init;
 @end
 
 @interface CHIPDoorLockClusterSetYeardayScheduleResponsePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull status;
+- (instancetype)init;
 @end
 
 @interface CHIPDoorLockClusterGetYeardaySchedulePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull scheduleId;
 @property (strong, nonatomic) NSNumber * _Nonnull userId;
+- (instancetype)init;
 @end
 
 @interface CHIPDoorLockClusterGetYeardayScheduleResponsePayload : NSObject
@@ -1005,15 +1201,18 @@
 @property (strong, nonatomic) NSNumber * _Nonnull status;
 @property (strong, nonatomic) NSNumber * _Nonnull localStartTime;
 @property (strong, nonatomic) NSNumber * _Nonnull localEndTime;
+- (instancetype)init;
 @end
 
 @interface CHIPDoorLockClusterClearYeardaySchedulePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull scheduleId;
 @property (strong, nonatomic) NSNumber * _Nonnull userId;
+- (instancetype)init;
 @end
 
 @interface CHIPDoorLockClusterClearYeardayScheduleResponsePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull status;
+- (instancetype)init;
 @end
 
 @interface CHIPDoorLockClusterSetHolidaySchedulePayload : NSObject
@@ -1021,14 +1220,17 @@
 @property (strong, nonatomic) NSNumber * _Nonnull localStartTime;
 @property (strong, nonatomic) NSNumber * _Nonnull localEndTime;
 @property (strong, nonatomic) NSNumber * _Nonnull operatingModeDuringHoliday;
+- (instancetype)init;
 @end
 
 @interface CHIPDoorLockClusterSetHolidayScheduleResponsePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull status;
+- (instancetype)init;
 @end
 
 @interface CHIPDoorLockClusterGetHolidaySchedulePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull scheduleId;
+- (instancetype)init;
 @end
 
 @interface CHIPDoorLockClusterGetHolidayScheduleResponsePayload : NSObject
@@ -1037,32 +1239,39 @@
 @property (strong, nonatomic) NSNumber * _Nonnull localStartTime;
 @property (strong, nonatomic) NSNumber * _Nonnull localEndTime;
 @property (strong, nonatomic) NSNumber * _Nonnull operatingModeDuringHoliday;
+- (instancetype)init;
 @end
 
 @interface CHIPDoorLockClusterClearHolidaySchedulePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull scheduleId;
+- (instancetype)init;
 @end
 
 @interface CHIPDoorLockClusterClearHolidayScheduleResponsePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull status;
+- (instancetype)init;
 @end
 
 @interface CHIPDoorLockClusterSetUserTypePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull userId;
 @property (strong, nonatomic) NSNumber * _Nonnull userType;
+- (instancetype)init;
 @end
 
 @interface CHIPDoorLockClusterSetUserTypeResponsePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull status;
+- (instancetype)init;
 @end
 
 @interface CHIPDoorLockClusterGetUserTypePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull userId;
+- (instancetype)init;
 @end
 
 @interface CHIPDoorLockClusterGetUserTypeResponsePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull userId;
 @property (strong, nonatomic) NSNumber * _Nonnull userType;
+- (instancetype)init;
 @end
 
 @interface CHIPDoorLockClusterSetRfidPayload : NSObject
@@ -1070,14 +1279,17 @@
 @property (strong, nonatomic) NSNumber * _Nonnull userStatus;
 @property (strong, nonatomic) NSNumber * _Nonnull userType;
 @property (strong, nonatomic) NSData * _Nonnull id;
+- (instancetype)init;
 @end
 
 @interface CHIPDoorLockClusterSetRfidResponsePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull status;
+- (instancetype)init;
 @end
 
 @interface CHIPDoorLockClusterGetRfidPayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull userId;
+- (instancetype)init;
 @end
 
 @interface CHIPDoorLockClusterGetRfidResponsePayload : NSObject
@@ -1085,21 +1297,26 @@
 @property (strong, nonatomic) NSNumber * _Nonnull userStatus;
 @property (strong, nonatomic) NSNumber * _Nonnull userType;
 @property (strong, nonatomic) NSData * _Nonnull rfid;
+- (instancetype)init;
 @end
 
 @interface CHIPDoorLockClusterClearRfidPayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull userId;
+- (instancetype)init;
 @end
 
 @interface CHIPDoorLockClusterClearRfidResponsePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull status;
+- (instancetype)init;
 @end
 
 @interface CHIPDoorLockClusterClearAllRfidsPayload : NSObject
+- (instancetype)init;
 @end
 
 @interface CHIPDoorLockClusterClearAllRfidsResponsePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull status;
+- (instancetype)init;
 @end
 
 @interface CHIPDoorLockClusterOperationEventNotificationPayload : NSObject
@@ -1109,6 +1326,7 @@
 @property (strong, nonatomic) NSData * _Nonnull pin;
 @property (strong, nonatomic) NSNumber * _Nonnull timeStamp;
 @property (strong, nonatomic) NSString * _Nonnull data;
+- (instancetype)init;
 @end
 
 @interface CHIPDoorLockClusterProgrammingEventNotificationPayload : NSObject
@@ -1120,45 +1338,56 @@
 @property (strong, nonatomic) NSNumber * _Nonnull userStatus;
 @property (strong, nonatomic) NSNumber * _Nonnull timeStamp;
 @property (strong, nonatomic) NSString * _Nonnull data;
+- (instancetype)init;
 @end
 
 @interface CHIPWindowCoveringClusterUpOrOpenPayload : NSObject
+- (instancetype)init;
 @end
 
 @interface CHIPWindowCoveringClusterDownOrClosePayload : NSObject
+- (instancetype)init;
 @end
 
 @interface CHIPWindowCoveringClusterStopMotionPayload : NSObject
+- (instancetype)init;
 @end
 
 @interface CHIPWindowCoveringClusterGoToLiftValuePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull liftValue;
+- (instancetype)init;
 @end
 
 @interface CHIPWindowCoveringClusterGoToLiftPercentagePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull liftPercentageValue;
 @property (strong, nonatomic) NSNumber * _Nonnull liftPercent100thsValue;
+- (instancetype)init;
 @end
 
 @interface CHIPWindowCoveringClusterGoToTiltValuePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull tiltValue;
+- (instancetype)init;
 @end
 
 @interface CHIPWindowCoveringClusterGoToTiltPercentagePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull tiltPercentageValue;
 @property (strong, nonatomic) NSNumber * _Nonnull tiltPercent100thsValue;
+- (instancetype)init;
 @end
 
 @interface CHIPBarrierControlClusterBarrierControlGoToPercentPayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull percentOpen;
+- (instancetype)init;
 @end
 
 @interface CHIPBarrierControlClusterBarrierControlStopPayload : NSObject
+- (instancetype)init;
 @end
 
 @interface CHIPThermostatClusterSetpointRaiseLowerPayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull mode;
 @property (strong, nonatomic) NSNumber * _Nonnull amount;
+- (instancetype)init;
 @end
 
 @interface CHIPThermostatClusterCurrentWeeklySchedulePayload : NSObject
@@ -1166,6 +1395,7 @@
 @property (strong, nonatomic) NSNumber * _Nonnull dayOfWeekForSequence;
 @property (strong, nonatomic) NSNumber * _Nonnull modeForSequence;
 @property (strong, nonatomic) NSArray * _Nonnull payload;
+- (instancetype)init;
 @end
 
 @interface CHIPThermostatClusterSetWeeklySchedulePayload : NSObject
@@ -1173,6 +1403,7 @@
 @property (strong, nonatomic) NSNumber * _Nonnull dayOfWeekForSequence;
 @property (strong, nonatomic) NSNumber * _Nonnull modeForSequence;
 @property (strong, nonatomic) NSArray * _Nonnull payload;
+- (instancetype)init;
 @end
 
 @interface CHIPThermostatClusterRelayStatusLogPayload : NSObject
@@ -1182,17 +1413,21 @@
 @property (strong, nonatomic) NSNumber * _Nonnull humidityInPercentage;
 @property (strong, nonatomic) NSNumber * _Nonnull setpoint;
 @property (strong, nonatomic) NSNumber * _Nonnull unreadEntries;
+- (instancetype)init;
 @end
 
 @interface CHIPThermostatClusterGetWeeklySchedulePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull daysToReturn;
 @property (strong, nonatomic) NSNumber * _Nonnull modeToReturn;
+- (instancetype)init;
 @end
 
 @interface CHIPThermostatClusterClearWeeklySchedulePayload : NSObject
+- (instancetype)init;
 @end
 
 @interface CHIPThermostatClusterGetRelayStatusLogPayload : NSObject
+- (instancetype)init;
 @end
 
 @interface CHIPColorControlClusterMoveToHuePayload : NSObject
@@ -1201,6 +1436,7 @@
 @property (strong, nonatomic) NSNumber * _Nonnull transitionTime;
 @property (strong, nonatomic) NSNumber * _Nonnull optionsMask;
 @property (strong, nonatomic) NSNumber * _Nonnull optionsOverride;
+- (instancetype)init;
 @end
 
 @interface CHIPColorControlClusterMoveHuePayload : NSObject
@@ -1208,6 +1444,7 @@
 @property (strong, nonatomic) NSNumber * _Nonnull rate;
 @property (strong, nonatomic) NSNumber * _Nonnull optionsMask;
 @property (strong, nonatomic) NSNumber * _Nonnull optionsOverride;
+- (instancetype)init;
 @end
 
 @interface CHIPColorControlClusterStepHuePayload : NSObject
@@ -1216,6 +1453,7 @@
 @property (strong, nonatomic) NSNumber * _Nonnull transitionTime;
 @property (strong, nonatomic) NSNumber * _Nonnull optionsMask;
 @property (strong, nonatomic) NSNumber * _Nonnull optionsOverride;
+- (instancetype)init;
 @end
 
 @interface CHIPColorControlClusterMoveToSaturationPayload : NSObject
@@ -1223,6 +1461,7 @@
 @property (strong, nonatomic) NSNumber * _Nonnull transitionTime;
 @property (strong, nonatomic) NSNumber * _Nonnull optionsMask;
 @property (strong, nonatomic) NSNumber * _Nonnull optionsOverride;
+- (instancetype)init;
 @end
 
 @interface CHIPColorControlClusterMoveSaturationPayload : NSObject
@@ -1230,6 +1469,7 @@
 @property (strong, nonatomic) NSNumber * _Nonnull rate;
 @property (strong, nonatomic) NSNumber * _Nonnull optionsMask;
 @property (strong, nonatomic) NSNumber * _Nonnull optionsOverride;
+- (instancetype)init;
 @end
 
 @interface CHIPColorControlClusterStepSaturationPayload : NSObject
@@ -1238,6 +1478,7 @@
 @property (strong, nonatomic) NSNumber * _Nonnull transitionTime;
 @property (strong, nonatomic) NSNumber * _Nonnull optionsMask;
 @property (strong, nonatomic) NSNumber * _Nonnull optionsOverride;
+- (instancetype)init;
 @end
 
 @interface CHIPColorControlClusterMoveToHueAndSaturationPayload : NSObject
@@ -1246,6 +1487,7 @@
 @property (strong, nonatomic) NSNumber * _Nonnull transitionTime;
 @property (strong, nonatomic) NSNumber * _Nonnull optionsMask;
 @property (strong, nonatomic) NSNumber * _Nonnull optionsOverride;
+- (instancetype)init;
 @end
 
 @interface CHIPColorControlClusterMoveToColorPayload : NSObject
@@ -1254,6 +1496,7 @@
 @property (strong, nonatomic) NSNumber * _Nonnull transitionTime;
 @property (strong, nonatomic) NSNumber * _Nonnull optionsMask;
 @property (strong, nonatomic) NSNumber * _Nonnull optionsOverride;
+- (instancetype)init;
 @end
 
 @interface CHIPColorControlClusterMoveColorPayload : NSObject
@@ -1261,6 +1504,7 @@
 @property (strong, nonatomic) NSNumber * _Nonnull rateY;
 @property (strong, nonatomic) NSNumber * _Nonnull optionsMask;
 @property (strong, nonatomic) NSNumber * _Nonnull optionsOverride;
+- (instancetype)init;
 @end
 
 @interface CHIPColorControlClusterStepColorPayload : NSObject
@@ -1269,6 +1513,7 @@
 @property (strong, nonatomic) NSNumber * _Nonnull transitionTime;
 @property (strong, nonatomic) NSNumber * _Nonnull optionsMask;
 @property (strong, nonatomic) NSNumber * _Nonnull optionsOverride;
+- (instancetype)init;
 @end
 
 @interface CHIPColorControlClusterMoveToColorTemperaturePayload : NSObject
@@ -1276,6 +1521,7 @@
 @property (strong, nonatomic) NSNumber * _Nonnull transitionTime;
 @property (strong, nonatomic) NSNumber * _Nonnull optionsMask;
 @property (strong, nonatomic) NSNumber * _Nonnull optionsOverride;
+- (instancetype)init;
 @end
 
 @interface CHIPColorControlClusterEnhancedMoveToHuePayload : NSObject
@@ -1284,6 +1530,7 @@
 @property (strong, nonatomic) NSNumber * _Nonnull transitionTime;
 @property (strong, nonatomic) NSNumber * _Nonnull optionsMask;
 @property (strong, nonatomic) NSNumber * _Nonnull optionsOverride;
+- (instancetype)init;
 @end
 
 @interface CHIPColorControlClusterEnhancedMoveHuePayload : NSObject
@@ -1291,6 +1538,7 @@
 @property (strong, nonatomic) NSNumber * _Nonnull rate;
 @property (strong, nonatomic) NSNumber * _Nonnull optionsMask;
 @property (strong, nonatomic) NSNumber * _Nonnull optionsOverride;
+- (instancetype)init;
 @end
 
 @interface CHIPColorControlClusterEnhancedStepHuePayload : NSObject
@@ -1299,6 +1547,7 @@
 @property (strong, nonatomic) NSNumber * _Nonnull transitionTime;
 @property (strong, nonatomic) NSNumber * _Nonnull optionsMask;
 @property (strong, nonatomic) NSNumber * _Nonnull optionsOverride;
+- (instancetype)init;
 @end
 
 @interface CHIPColorControlClusterEnhancedMoveToHueAndSaturationPayload : NSObject
@@ -1307,6 +1556,7 @@
 @property (strong, nonatomic) NSNumber * _Nonnull transitionTime;
 @property (strong, nonatomic) NSNumber * _Nonnull optionsMask;
 @property (strong, nonatomic) NSNumber * _Nonnull optionsOverride;
+- (instancetype)init;
 @end
 
 @interface CHIPColorControlClusterColorLoopSetPayload : NSObject
@@ -1317,11 +1567,13 @@
 @property (strong, nonatomic) NSNumber * _Nonnull startHue;
 @property (strong, nonatomic) NSNumber * _Nonnull optionsMask;
 @property (strong, nonatomic) NSNumber * _Nonnull optionsOverride;
+- (instancetype)init;
 @end
 
 @interface CHIPColorControlClusterStopMoveStepPayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull optionsMask;
 @property (strong, nonatomic) NSNumber * _Nonnull optionsOverride;
+- (instancetype)init;
 @end
 
 @interface CHIPColorControlClusterMoveColorTemperaturePayload : NSObject
@@ -1331,6 +1583,7 @@
 @property (strong, nonatomic) NSNumber * _Nonnull colorTemperatureMaximum;
 @property (strong, nonatomic) NSNumber * _Nonnull optionsMask;
 @property (strong, nonatomic) NSNumber * _Nonnull optionsOverride;
+- (instancetype)init;
 @end
 
 @interface CHIPColorControlClusterStepColorTemperaturePayload : NSObject
@@ -1341,11 +1594,13 @@
 @property (strong, nonatomic) NSNumber * _Nonnull colorTemperatureMaximum;
 @property (strong, nonatomic) NSNumber * _Nonnull optionsMask;
 @property (strong, nonatomic) NSNumber * _Nonnull optionsOverride;
+- (instancetype)init;
 @end
 
 @interface CHIPIasZoneClusterZoneEnrollResponsePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull enrollResponseCode;
 @property (strong, nonatomic) NSNumber * _Nonnull zoneId;
+- (instancetype)init;
 @end
 
 @interface CHIPIasZoneClusterZoneStatusChangeNotificationPayload : NSObject
@@ -1353,41 +1608,50 @@
 @property (strong, nonatomic) NSNumber * _Nonnull extendedStatus;
 @property (strong, nonatomic) NSNumber * _Nonnull zoneId;
 @property (strong, nonatomic) NSNumber * _Nonnull delay;
+- (instancetype)init;
 @end
 
 @interface CHIPIasZoneClusterInitiateNormalOperationModePayload : NSObject
+- (instancetype)init;
 @end
 
 @interface CHIPIasZoneClusterZoneEnrollRequestPayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull zoneType;
 @property (strong, nonatomic) NSNumber * _Nonnull manufacturerCode;
+- (instancetype)init;
 @end
 
 @interface CHIPIasZoneClusterInitiateTestModePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull testModeDuration;
 @property (strong, nonatomic) NSNumber * _Nonnull currentZoneSensitivityLevel;
+- (instancetype)init;
 @end
 
 @interface CHIPIasZoneClusterInitiateNormalOperationModeResponsePayload : NSObject
+- (instancetype)init;
 @end
 
 @interface CHIPIasZoneClusterInitiateTestModeResponsePayload : NSObject
+- (instancetype)init;
 @end
 
 @interface CHIPIasAceClusterArmPayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull armMode;
 @property (strong, nonatomic) NSString * _Nonnull armDisarmCode;
 @property (strong, nonatomic) NSNumber * _Nonnull zoneId;
+- (instancetype)init;
 @end
 
 @interface CHIPIasAceClusterArmResponsePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull armNotification;
+- (instancetype)init;
 @end
 
 @interface CHIPIasAceClusterBypassPayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull numberOfZones;
 @property (strong, nonatomic) NSArray * _Nonnull zoneIds;
 @property (strong, nonatomic) NSString * _Nonnull armDisarmCode;
+- (instancetype)init;
 @end
 
 @interface CHIPIasAceClusterGetZoneIdMapResponsePayload : NSObject
@@ -1407,9 +1671,11 @@
 @property (strong, nonatomic) NSNumber * _Nonnull section13;
 @property (strong, nonatomic) NSNumber * _Nonnull section14;
 @property (strong, nonatomic) NSNumber * _Nonnull section15;
+- (instancetype)init;
 @end
 
 @interface CHIPIasAceClusterEmergencyPayload : NSObject
+- (instancetype)init;
 @end
 
 @interface CHIPIasAceClusterGetZoneInformationResponsePayload : NSObject
@@ -1417,9 +1683,11 @@
 @property (strong, nonatomic) NSNumber * _Nonnull zoneType;
 @property (strong, nonatomic) NSNumber * _Nonnull ieeeAddress;
 @property (strong, nonatomic) NSString * _Nonnull zoneLabel;
+- (instancetype)init;
 @end
 
 @interface CHIPIasAceClusterFirePayload : NSObject
+- (instancetype)init;
 @end
 
 @interface CHIPIasAceClusterZoneStatusChangedPayload : NSObject
@@ -1427,9 +1695,11 @@
 @property (strong, nonatomic) NSNumber * _Nonnull zoneStatus;
 @property (strong, nonatomic) NSNumber * _Nonnull audibleNotification;
 @property (strong, nonatomic) NSString * _Nonnull zoneLabel;
+- (instancetype)init;
 @end
 
 @interface CHIPIasAceClusterPanicPayload : NSObject
+- (instancetype)init;
 @end
 
 @interface CHIPIasAceClusterPanelStatusChangedPayload : NSObject
@@ -1437,9 +1707,11 @@
 @property (strong, nonatomic) NSNumber * _Nonnull secondsRemaining;
 @property (strong, nonatomic) NSNumber * _Nonnull audibleNotification;
 @property (strong, nonatomic) NSNumber * _Nonnull alarmStatus;
+- (instancetype)init;
 @end
 
 @interface CHIPIasAceClusterGetZoneIdMapPayload : NSObject
+- (instancetype)init;
 @end
 
 @interface CHIPIasAceClusterGetPanelStatusResponsePayload : NSObject
@@ -1447,32 +1719,39 @@
 @property (strong, nonatomic) NSNumber * _Nonnull secondsRemaining;
 @property (strong, nonatomic) NSNumber * _Nonnull audibleNotification;
 @property (strong, nonatomic) NSNumber * _Nonnull alarmStatus;
+- (instancetype)init;
 @end
 
 @interface CHIPIasAceClusterGetZoneInformationPayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull zoneId;
+- (instancetype)init;
 @end
 
 @interface CHIPIasAceClusterSetBypassedZoneListPayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull numberOfZones;
 @property (strong, nonatomic) NSArray * _Nonnull zoneIds;
+- (instancetype)init;
 @end
 
 @interface CHIPIasAceClusterGetPanelStatusPayload : NSObject
+- (instancetype)init;
 @end
 
 @interface CHIPIasAceClusterBypassResponsePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull numberOfZones;
 @property (strong, nonatomic) NSArray * _Nonnull bypassResult;
+- (instancetype)init;
 @end
 
 @interface CHIPIasAceClusterGetBypassedZoneListPayload : NSObject
+- (instancetype)init;
 @end
 
 @interface CHIPIasAceClusterGetZoneStatusResponsePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull zoneStatusComplete;
 @property (strong, nonatomic) NSNumber * _Nonnull numberOfZones;
 @property (strong, nonatomic) NSArray * _Nonnull zoneStatusResult;
+- (instancetype)init;
 @end
 
 @interface CHIPIasAceClusterGetZoneStatusPayload : NSObject
@@ -1480,6 +1759,7 @@
 @property (strong, nonatomic) NSNumber * _Nonnull maxNumberOfZoneIds;
 @property (strong, nonatomic) NSNumber * _Nonnull zoneStatusMaskFlag;
 @property (strong, nonatomic) NSNumber * _Nonnull zoneStatusMask;
+- (instancetype)init;
 @end
 
 @interface CHIPIasWdClusterStartWarningPayload : NSObject
@@ -1487,225 +1767,281 @@
 @property (strong, nonatomic) NSNumber * _Nonnull warningDuration;
 @property (strong, nonatomic) NSNumber * _Nonnull strobeDutyCycle;
 @property (strong, nonatomic) NSNumber * _Nonnull strobeLevel;
+- (instancetype)init;
 @end
 
 @interface CHIPIasWdClusterSquawkPayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull squawkInfo;
+- (instancetype)init;
 @end
 
 @interface CHIPTvChannelClusterChangeChannelPayload : NSObject
 @property (strong, nonatomic) NSString * _Nonnull match;
+- (instancetype)init;
 @end
 
 @interface CHIPTvChannelClusterChangeChannelResponsePayload : NSObject
 @property (strong, nonatomic) NSArray * _Nonnull channelMatch;
 @property (strong, nonatomic) NSNumber * _Nonnull errorType;
+- (instancetype)init;
 @end
 
 @interface CHIPTvChannelClusterChangeChannelByNumberPayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull majorNumber;
 @property (strong, nonatomic) NSNumber * _Nonnull minorNumber;
+- (instancetype)init;
 @end
 
 @interface CHIPTvChannelClusterSkipChannelPayload : NSObject
 @property (strong, nonatomic, getter=getCount) NSNumber * _Nonnull count;
+- (instancetype)init;
 @end
 
 @interface CHIPTargetNavigatorClusterNavigateTargetPayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull target;
 @property (strong, nonatomic) NSString * _Nonnull data;
+- (instancetype)init;
 @end
 
 @interface CHIPTargetNavigatorClusterNavigateTargetResponsePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull status;
 @property (strong, nonatomic) NSString * _Nonnull data;
+- (instancetype)init;
 @end
 
 @interface CHIPMediaPlaybackClusterMediaPlayPayload : NSObject
+- (instancetype)init;
 @end
 
 @interface CHIPMediaPlaybackClusterMediaPlayResponsePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull mediaPlaybackStatus;
+- (instancetype)init;
 @end
 
 @interface CHIPMediaPlaybackClusterMediaPausePayload : NSObject
+- (instancetype)init;
 @end
 
 @interface CHIPMediaPlaybackClusterMediaPauseResponsePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull mediaPlaybackStatus;
+- (instancetype)init;
 @end
 
 @interface CHIPMediaPlaybackClusterMediaStopPayload : NSObject
+- (instancetype)init;
 @end
 
 @interface CHIPMediaPlaybackClusterMediaStopResponsePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull mediaPlaybackStatus;
+- (instancetype)init;
 @end
 
 @interface CHIPMediaPlaybackClusterMediaStartOverPayload : NSObject
+- (instancetype)init;
 @end
 
 @interface CHIPMediaPlaybackClusterMediaStartOverResponsePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull mediaPlaybackStatus;
+- (instancetype)init;
 @end
 
 @interface CHIPMediaPlaybackClusterMediaPreviousPayload : NSObject
+- (instancetype)init;
 @end
 
 @interface CHIPMediaPlaybackClusterMediaPreviousResponsePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull mediaPlaybackStatus;
+- (instancetype)init;
 @end
 
 @interface CHIPMediaPlaybackClusterMediaNextPayload : NSObject
+- (instancetype)init;
 @end
 
 @interface CHIPMediaPlaybackClusterMediaNextResponsePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull mediaPlaybackStatus;
+- (instancetype)init;
 @end
 
 @interface CHIPMediaPlaybackClusterMediaRewindPayload : NSObject
+- (instancetype)init;
 @end
 
 @interface CHIPMediaPlaybackClusterMediaRewindResponsePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull mediaPlaybackStatus;
+- (instancetype)init;
 @end
 
 @interface CHIPMediaPlaybackClusterMediaFastForwardPayload : NSObject
+- (instancetype)init;
 @end
 
 @interface CHIPMediaPlaybackClusterMediaFastForwardResponsePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull mediaPlaybackStatus;
+- (instancetype)init;
 @end
 
 @interface CHIPMediaPlaybackClusterMediaSkipForwardPayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull deltaPositionMilliseconds;
+- (instancetype)init;
 @end
 
 @interface CHIPMediaPlaybackClusterMediaSkipForwardResponsePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull mediaPlaybackStatus;
+- (instancetype)init;
 @end
 
 @interface CHIPMediaPlaybackClusterMediaSkipBackwardPayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull deltaPositionMilliseconds;
+- (instancetype)init;
 @end
 
 @interface CHIPMediaPlaybackClusterMediaSkipBackwardResponsePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull mediaPlaybackStatus;
+- (instancetype)init;
 @end
 
 @interface CHIPMediaPlaybackClusterMediaSeekPayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull position;
+- (instancetype)init;
 @end
 
 @interface CHIPMediaPlaybackClusterMediaSeekResponsePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull mediaPlaybackStatus;
+- (instancetype)init;
 @end
 
 @interface CHIPMediaInputClusterSelectInputPayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull index;
+- (instancetype)init;
 @end
 
 @interface CHIPMediaInputClusterShowInputStatusPayload : NSObject
+- (instancetype)init;
 @end
 
 @interface CHIPMediaInputClusterHideInputStatusPayload : NSObject
+- (instancetype)init;
 @end
 
 @interface CHIPMediaInputClusterRenameInputPayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull index;
 @property (strong, nonatomic) NSString * _Nonnull name;
+- (instancetype)init;
 @end
 
 @interface CHIPLowPowerClusterSleepPayload : NSObject
+- (instancetype)init;
 @end
 
 @interface CHIPKeypadInputClusterSendKeyPayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull keyCode;
+- (instancetype)init;
 @end
 
 @interface CHIPKeypadInputClusterSendKeyResponsePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull status;
+- (instancetype)init;
 @end
 
 @interface CHIPContentLauncherClusterLaunchContentPayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull autoPlay;
 @property (strong, nonatomic) NSString * _Nonnull data;
+- (instancetype)init;
 @end
 
 @interface CHIPContentLauncherClusterLaunchContentResponsePayload : NSObject
 @property (strong, nonatomic) NSString * _Nonnull data;
 @property (strong, nonatomic) NSNumber * _Nonnull contentLaunchStatus;
+- (instancetype)init;
 @end
 
 @interface CHIPContentLauncherClusterLaunchURLPayload : NSObject
 @property (strong, nonatomic) NSString * _Nonnull contentURL;
 @property (strong, nonatomic) NSString * _Nonnull displayString;
+- (instancetype)init;
 @end
 
 @interface CHIPContentLauncherClusterLaunchURLResponsePayload : NSObject
 @property (strong, nonatomic) NSString * _Nonnull data;
 @property (strong, nonatomic) NSNumber * _Nonnull contentLaunchStatus;
+- (instancetype)init;
 @end
 
 @interface CHIPAudioOutputClusterSelectOutputPayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull index;
+- (instancetype)init;
 @end
 
 @interface CHIPAudioOutputClusterRenameOutputPayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull index;
 @property (strong, nonatomic) NSString * _Nonnull name;
+- (instancetype)init;
 @end
 
 @interface CHIPApplicationLauncherClusterLaunchAppPayload : NSObject
 @property (strong, nonatomic) NSString * _Nonnull data;
 @property (strong, nonatomic) NSNumber * _Nonnull catalogVendorId;
 @property (strong, nonatomic) NSString * _Nonnull applicationId;
+- (instancetype)init;
 @end
 
 @interface CHIPApplicationLauncherClusterLaunchAppResponsePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull status;
 @property (strong, nonatomic) NSString * _Nonnull data;
+- (instancetype)init;
 @end
 
 @interface CHIPApplicationBasicClusterChangeStatusPayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull status;
+- (instancetype)init;
 @end
 
 @interface CHIPAccountLoginClusterGetSetupPINPayload : NSObject
 @property (strong, nonatomic) NSString * _Nonnull tempAccountIdentifier;
+- (instancetype)init;
 @end
 
 @interface CHIPAccountLoginClusterGetSetupPINResponsePayload : NSObject
 @property (strong, nonatomic) NSString * _Nonnull setupPIN;
+- (instancetype)init;
 @end
 
 @interface CHIPAccountLoginClusterLoginPayload : NSObject
 @property (strong, nonatomic) NSString * _Nonnull tempAccountIdentifier;
 @property (strong, nonatomic) NSString * _Nonnull setupPIN;
+- (instancetype)init;
 @end
 
 @interface CHIPTestClusterClusterTestPayload : NSObject
+- (instancetype)init;
 @end
 
 @interface CHIPTestClusterClusterTestSpecificResponsePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull returnValue;
+- (instancetype)init;
 @end
 
 @interface CHIPTestClusterClusterTestNotHandledPayload : NSObject
+- (instancetype)init;
 @end
 
 @interface CHIPTestClusterClusterTestAddArgumentsResponsePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull returnValue;
+- (instancetype)init;
 @end
 
 @interface CHIPTestClusterClusterTestSpecificPayload : NSObject
+- (instancetype)init;
 @end
 
 @interface CHIPTestClusterClusterTestSimpleArgumentResponsePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull returnValue;
+- (instancetype)init;
 @end
 
 @interface CHIPTestClusterClusterTestUnknownCommandPayload : NSObject
+- (instancetype)init;
 @end
 
 @interface CHIPTestClusterClusterTestStructArrayArgumentResponsePayload : NSObject
@@ -1715,24 +2051,29 @@
 @property (strong, nonatomic) NSArray * _Nonnull arg4;
 @property (strong, nonatomic) NSNumber * _Nonnull arg5;
 @property (strong, nonatomic) NSNumber * _Nonnull arg6;
+- (instancetype)init;
 @end
 
 @interface CHIPTestClusterClusterTestAddArgumentsPayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull arg1;
 @property (strong, nonatomic) NSNumber * _Nonnull arg2;
+- (instancetype)init;
 @end
 
 @interface CHIPTestClusterClusterTestListInt8UReverseResponsePayload : NSObject
 @property (strong, nonatomic) NSArray * _Nonnull arg1;
+- (instancetype)init;
 @end
 
 @interface CHIPTestClusterClusterTestSimpleArgumentRequestPayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull arg1;
+- (instancetype)init;
 @end
 
 @interface CHIPTestClusterClusterTestEnumsResponsePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull arg1;
 @property (strong, nonatomic) NSNumber * _Nonnull arg2;
+- (instancetype)init;
 @end
 
 @interface CHIPTestClusterClusterTestStructArrayArgumentRequestPayload : NSObject
@@ -1742,6 +2083,7 @@
 @property (strong, nonatomic) NSArray * _Nonnull arg4;
 @property (strong, nonatomic) NSNumber * _Nonnull arg5;
 @property (strong, nonatomic) NSNumber * _Nonnull arg6;
+- (instancetype)init;
 @end
 
 @interface CHIPTestClusterClusterTestNullableOptionalResponsePayload : NSObject
@@ -1749,10 +2091,12 @@
 @property (strong, nonatomic) NSNumber * _Nullable wasNull;
 @property (strong, nonatomic) NSNumber * _Nullable value;
 @property (strong, nonatomic) NSNumber * _Nullable originalValue;
+- (instancetype)init;
 @end
 
 @interface CHIPTestClusterClusterTestStructArgumentRequestPayload : NSObject
 @property (strong, nonatomic) CHIPTestClusterClusterSimpleStruct * _Nonnull arg1;
+- (instancetype)init;
 @end
 
 @interface CHIPTestClusterClusterTestComplexNullableOptionalResponsePayload : NSObject
@@ -1784,43 +2128,53 @@
 @property (strong, nonatomic) NSNumber * _Nonnull nullableOptionalListWasPresent;
 @property (strong, nonatomic) NSNumber * _Nullable nullableOptionalListWasNull;
 @property (strong, nonatomic) NSArray * _Nullable nullableOptionalListValue;
+- (instancetype)init;
 @end
 
 @interface CHIPTestClusterClusterTestNestedStructArgumentRequestPayload : NSObject
 @property (strong, nonatomic) CHIPTestClusterClusterNestedStruct * _Nonnull arg1;
+- (instancetype)init;
 @end
 
 @interface CHIPTestClusterClusterBooleanResponsePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull value;
+- (instancetype)init;
 @end
 
 @interface CHIPTestClusterClusterTestListStructArgumentRequestPayload : NSObject
 @property (strong, nonatomic) NSArray * _Nonnull arg1;
+- (instancetype)init;
 @end
 
 @interface CHIPTestClusterClusterTestListInt8UArgumentRequestPayload : NSObject
 @property (strong, nonatomic) NSArray * _Nonnull arg1;
+- (instancetype)init;
 @end
 
 @interface CHIPTestClusterClusterTestNestedStructListArgumentRequestPayload : NSObject
 @property (strong, nonatomic) CHIPTestClusterClusterNestedStructList * _Nonnull arg1;
+- (instancetype)init;
 @end
 
 @interface CHIPTestClusterClusterTestListNestedStructListArgumentRequestPayload : NSObject
 @property (strong, nonatomic) NSArray * _Nonnull arg1;
+- (instancetype)init;
 @end
 
 @interface CHIPTestClusterClusterTestListInt8UReverseRequestPayload : NSObject
 @property (strong, nonatomic) NSArray * _Nonnull arg1;
+- (instancetype)init;
 @end
 
 @interface CHIPTestClusterClusterTestEnumsRequestPayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull arg1;
 @property (strong, nonatomic) NSNumber * _Nonnull arg2;
+- (instancetype)init;
 @end
 
 @interface CHIPTestClusterClusterTestNullableOptionalRequestPayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nullable arg1;
+- (instancetype)init;
 @end
 
 @interface CHIPTestClusterClusterTestComplexNullableOptionalRequestPayload : NSObject
@@ -1836,6 +2190,7 @@
 @property (strong, nonatomic) NSArray * _Nullable nullableList;
 @property (strong, nonatomic) NSArray * _Nullable optionalList;
 @property (strong, nonatomic) NSArray * _Nullable nullableOptionalList;
+- (instancetype)init;
 @end
 
 @interface CHIPMessagingClusterDisplayMessagePayload : NSObject
@@ -1845,14 +2200,17 @@
 @property (strong, nonatomic) NSNumber * _Nonnull durationInMinutes;
 @property (strong, nonatomic) NSString * _Nonnull message;
 @property (strong, nonatomic) NSNumber * _Nonnull optionalExtendedMessageControl;
+- (instancetype)init;
 @end
 
 @interface CHIPMessagingClusterGetLastMessagePayload : NSObject
+- (instancetype)init;
 @end
 
 @interface CHIPMessagingClusterCancelMessagePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull messageId;
 @property (strong, nonatomic) NSNumber * _Nonnull messageControl;
+- (instancetype)init;
 @end
 
 @interface CHIPMessagingClusterMessageConfirmationPayload : NSObject
@@ -1860,6 +2218,7 @@
 @property (strong, nonatomic) NSNumber * _Nonnull confirmationTime;
 @property (strong, nonatomic) NSNumber * _Nonnull messageConfirmationControl;
 @property (strong, nonatomic) NSData * _Nonnull messageResponse;
+- (instancetype)init;
 @end
 
 @interface CHIPMessagingClusterDisplayProtectedMessagePayload : NSObject
@@ -1869,32 +2228,39 @@
 @property (strong, nonatomic) NSNumber * _Nonnull durationInMinutes;
 @property (strong, nonatomic) NSString * _Nonnull message;
 @property (strong, nonatomic) NSNumber * _Nonnull optionalExtendedMessageControl;
+- (instancetype)init;
 @end
 
 @interface CHIPMessagingClusterGetMessageCancellationPayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull earliestImplementationTime;
+- (instancetype)init;
 @end
 
 @interface CHIPMessagingClusterCancelAllMessagesPayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull implementationDateTime;
+- (instancetype)init;
 @end
 
 @interface CHIPApplianceEventsAndAlertClusterGetAlertsPayload : NSObject
+- (instancetype)init;
 @end
 
 @interface CHIPApplianceEventsAndAlertClusterGetAlertsResponsePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull alertsCount;
 @property (strong, nonatomic) NSArray * _Nonnull alertStructures;
+- (instancetype)init;
 @end
 
 @interface CHIPApplianceEventsAndAlertClusterAlertsNotificationPayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull alertsCount;
 @property (strong, nonatomic) NSArray * _Nonnull alertStructures;
+- (instancetype)init;
 @end
 
 @interface CHIPApplianceEventsAndAlertClusterEventsNotificationPayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull eventHeader;
 @property (strong, nonatomic) NSNumber * _Nonnull eventId;
+- (instancetype)init;
 @end
 
 @interface CHIPApplianceStatisticsClusterLogNotificationPayload : NSObject
@@ -1902,10 +2268,12 @@
 @property (strong, nonatomic) NSNumber * _Nonnull logId;
 @property (strong, nonatomic) NSNumber * _Nonnull logLength;
 @property (strong, nonatomic) NSArray * _Nonnull logPayload;
+- (instancetype)init;
 @end
 
 @interface CHIPApplianceStatisticsClusterLogRequestPayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull logId;
+- (instancetype)init;
 @end
 
 @interface CHIPApplianceStatisticsClusterLogResponsePayload : NSObject
@@ -1913,19 +2281,23 @@
 @property (strong, nonatomic) NSNumber * _Nonnull logId;
 @property (strong, nonatomic) NSNumber * _Nonnull logLength;
 @property (strong, nonatomic) NSArray * _Nonnull logPayload;
+- (instancetype)init;
 @end
 
 @interface CHIPApplianceStatisticsClusterLogQueueRequestPayload : NSObject
+- (instancetype)init;
 @end
 
 @interface CHIPApplianceStatisticsClusterLogQueueResponsePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull logQueueSize;
 @property (strong, nonatomic) NSArray * _Nonnull logIds;
+- (instancetype)init;
 @end
 
 @interface CHIPApplianceStatisticsClusterStatisticsAvailablePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull logQueueSize;
 @property (strong, nonatomic) NSArray * _Nonnull logIds;
+- (instancetype)init;
 @end
 
 @interface CHIPElectricalMeasurementClusterGetProfileInfoResponseCommandPayload : NSObject
@@ -1933,9 +2305,11 @@
 @property (strong, nonatomic) NSNumber * _Nonnull profileIntervalPeriod;
 @property (strong, nonatomic) NSNumber * _Nonnull maxNumberOfIntervals;
 @property (strong, nonatomic) NSArray * _Nonnull listOfAttributes;
+- (instancetype)init;
 @end
 
 @interface CHIPElectricalMeasurementClusterGetProfileInfoCommandPayload : NSObject
+- (instancetype)init;
 @end
 
 @interface CHIPElectricalMeasurementClusterGetMeasurementProfileResponseCommandPayload : NSObject
@@ -1945,12 +2319,14 @@
 @property (strong, nonatomic) NSNumber * _Nonnull numberOfIntervalsDelivered;
 @property (strong, nonatomic) NSNumber * _Nonnull attributeId;
 @property (strong, nonatomic) NSArray * _Nonnull intervals;
+- (instancetype)init;
 @end
 
 @interface CHIPElectricalMeasurementClusterGetMeasurementProfileCommandPayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull attributeId;
 @property (strong, nonatomic) NSNumber * _Nonnull startTime;
 @property (strong, nonatomic) NSNumber * _Nonnull numberOfIntervals;
+- (instancetype)init;
 @end
 
 @interface CHIPBindingClusterBindPayload : NSObject
@@ -1958,6 +2334,7 @@
 @property (strong, nonatomic) NSNumber * _Nonnull groupId;
 @property (strong, nonatomic) NSNumber * _Nonnull endpointId;
 @property (strong, nonatomic) NSNumber * _Nonnull clusterId;
+- (instancetype)init;
 @end
 
 @interface CHIPBindingClusterUnbindPayload : NSObject
@@ -1965,14 +2342,19 @@
 @property (strong, nonatomic) NSNumber * _Nonnull groupId;
 @property (strong, nonatomic) NSNumber * _Nonnull endpointId;
 @property (strong, nonatomic) NSNumber * _Nonnull clusterId;
+- (instancetype)init;
 @end
 
 @interface CHIPSampleMfgSpecificClusterClusterCommandOnePayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull argOne;
+- (instancetype)init;
 @end
 
 @interface CHIPSampleMfgSpecificCluster2ClusterCommandTwoPayload : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull argOne;
+- (instancetype)init;
 @end
+
+NS_ASSUME_NONNULL_END
 
 #endif /* CHIP_COMMAND_PAYLOADS_H */

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPCommandPayloadsObjc.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPCommandPayloadsObjc.mm
@@ -19,1136 +19,5044 @@
 
 #import "CHIPCommandPayloadsObjc.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @implementation CHIPIdentifyClusterIdentifyPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _identifyTime = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPIdentifyClusterIdentifyQueryResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _timeout = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPIdentifyClusterIdentifyQueryPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+    }
+    return self;
+}
 @end
 
 @implementation CHIPIdentifyClusterTriggerEffectPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _effectIdentifier = @(0);
+
+        _effectVariant = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPGroupsClusterAddGroupPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _groupId = @(0);
+
+        _groupName = @"";
+    }
+    return self;
+}
 @end
 
 @implementation CHIPGroupsClusterAddGroupResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _status = @(0);
+
+        _groupId = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPGroupsClusterViewGroupPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _groupId = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPGroupsClusterViewGroupResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _status = @(0);
+
+        _groupId = @(0);
+
+        _groupName = @"";
+    }
+    return self;
+}
 @end
 
 @implementation CHIPGroupsClusterGetGroupMembershipPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _groupList = [NSArray array];
+    }
+    return self;
+}
 @end
 
 @implementation CHIPGroupsClusterGetGroupMembershipResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _capacity = @(0);
+
+        _groupList = [NSArray array];
+    }
+    return self;
+}
 @end
 
 @implementation CHIPGroupsClusterRemoveGroupPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _groupId = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPGroupsClusterRemoveGroupResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _status = @(0);
+
+        _groupId = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPGroupsClusterRemoveAllGroupsPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+    }
+    return self;
+}
 @end
 
 @implementation CHIPGroupsClusterAddGroupIfIdentifyingPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _groupId = @(0);
+
+        _groupName = @"";
+    }
+    return self;
+}
 @end
 
 @implementation CHIPScenesClusterAddScenePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _groupId = @(0);
+
+        _sceneId = @(0);
+
+        _transitionTime = @(0);
+
+        _sceneName = @"";
+
+        _extensionFieldSets = [NSArray array];
+    }
+    return self;
+}
 @end
 
 @implementation CHIPScenesClusterAddSceneResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _status = @(0);
+
+        _groupId = @(0);
+
+        _sceneId = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPScenesClusterViewScenePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _groupId = @(0);
+
+        _sceneId = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPScenesClusterViewSceneResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _status = @(0);
+
+        _groupId = @(0);
+
+        _sceneId = @(0);
+
+        _transitionTime = @(0);
+
+        _sceneName = @"";
+
+        _extensionFieldSets = [NSArray array];
+    }
+    return self;
+}
 @end
 
 @implementation CHIPScenesClusterRemoveScenePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _groupId = @(0);
+
+        _sceneId = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPScenesClusterRemoveSceneResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _status = @(0);
+
+        _groupId = @(0);
+
+        _sceneId = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPScenesClusterRemoveAllScenesPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _groupId = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPScenesClusterRemoveAllScenesResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _status = @(0);
+
+        _groupId = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPScenesClusterStoreScenePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _groupId = @(0);
+
+        _sceneId = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPScenesClusterStoreSceneResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _status = @(0);
+
+        _groupId = @(0);
+
+        _sceneId = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPScenesClusterRecallScenePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _groupId = @(0);
+
+        _sceneId = @(0);
+
+        _transitionTime = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPScenesClusterGetSceneMembershipPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _groupId = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPScenesClusterGetSceneMembershipResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _status = @(0);
+
+        _capacity = @(0);
+
+        _groupId = @(0);
+
+        _sceneCount = @(0);
+
+        _sceneList = [NSArray array];
+    }
+    return self;
+}
 @end
 
 @implementation CHIPScenesClusterEnhancedAddScenePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _groupId = @(0);
+
+        _sceneId = @(0);
+
+        _transitionTime = @(0);
+
+        _sceneName = @"";
+
+        _extensionFieldSets = [NSArray array];
+    }
+    return self;
+}
 @end
 
 @implementation CHIPScenesClusterEnhancedAddSceneResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _status = @(0);
+
+        _groupId = @(0);
+
+        _sceneId = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPScenesClusterEnhancedViewScenePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _groupId = @(0);
+
+        _sceneId = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPScenesClusterEnhancedViewSceneResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _status = @(0);
+
+        _groupId = @(0);
+
+        _sceneId = @(0);
+
+        _transitionTime = @(0);
+
+        _sceneName = @"";
+
+        _extensionFieldSets = [NSArray array];
+    }
+    return self;
+}
 @end
 
 @implementation CHIPScenesClusterCopyScenePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _mode = @(0);
+
+        _groupIdFrom = @(0);
+
+        _sceneIdFrom = @(0);
+
+        _groupIdTo = @(0);
+
+        _sceneIdTo = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPScenesClusterCopySceneResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _status = @(0);
+
+        _groupIdFrom = @(0);
+
+        _sceneIdFrom = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPOnOffClusterOffPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+    }
+    return self;
+}
 @end
 
 @implementation CHIPOnOffClusterSampleMfgSpecificOffWithTransitionPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+    }
+    return self;
+}
 @end
 
 @implementation CHIPOnOffClusterOnPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+    }
+    return self;
+}
 @end
 
 @implementation CHIPOnOffClusterSampleMfgSpecificOnWithTransitionPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+    }
+    return self;
+}
 @end
 
 @implementation CHIPOnOffClusterSampleMfgSpecificOnWithTransition2Payload
+- (instancetype)init
+{
+    if (self = [super init]) {
+    }
+    return self;
+}
 @end
 
 @implementation CHIPOnOffClusterTogglePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+    }
+    return self;
+}
 @end
 
 @implementation CHIPOnOffClusterSampleMfgSpecificToggleWithTransitionPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+    }
+    return self;
+}
 @end
 
 @implementation CHIPOnOffClusterSampleMfgSpecificToggleWithTransition2Payload
+- (instancetype)init
+{
+    if (self = [super init]) {
+    }
+    return self;
+}
 @end
 
 @implementation CHIPOnOffClusterOffWithEffectPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _effectId = @(0);
+
+        _effectVariant = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPOnOffClusterOnWithRecallGlobalScenePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+    }
+    return self;
+}
 @end
 
 @implementation CHIPOnOffClusterOnWithTimedOffPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _onOffControl = @(0);
+
+        _onTime = @(0);
+
+        _offWaitTime = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPLevelControlClusterMoveToLevelPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _level = @(0);
+
+        _transitionTime = @(0);
+
+        _optionMask = @(0);
+
+        _optionOverride = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPLevelControlClusterMovePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _moveMode = @(0);
+
+        _rate = @(0);
+
+        _optionMask = @(0);
+
+        _optionOverride = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPLevelControlClusterStepPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _stepMode = @(0);
+
+        _stepSize = @(0);
+
+        _transitionTime = @(0);
+
+        _optionMask = @(0);
+
+        _optionOverride = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPLevelControlClusterStopPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _optionMask = @(0);
+
+        _optionOverride = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPLevelControlClusterMoveToLevelWithOnOffPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _level = @(0);
+
+        _transitionTime = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPLevelControlClusterMoveWithOnOffPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _moveMode = @(0);
+
+        _rate = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPLevelControlClusterStepWithOnOffPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _stepMode = @(0);
+
+        _stepSize = @(0);
+
+        _transitionTime = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPLevelControlClusterStopWithOnOffPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+    }
+    return self;
+}
 @end
 
 @implementation CHIPAlarmsClusterResetAlarmPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _alarmCode = @(0);
+
+        _clusterId = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPAlarmsClusterAlarmPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _alarmCode = @(0);
+
+        _clusterId = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPAlarmsClusterResetAllAlarmsPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+    }
+    return self;
+}
 @end
 
 @implementation CHIPAlarmsClusterGetAlarmResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _status = @(0);
+
+        _alarmCode = @(0);
+
+        _clusterId = @(0);
+
+        _timeStamp = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPAlarmsClusterGetAlarmPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+    }
+    return self;
+}
 @end
 
 @implementation CHIPAlarmsClusterResetAlarmLogPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+    }
+    return self;
+}
 @end
 
 @implementation CHIPPowerProfileClusterPowerProfileRequestPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _powerProfileId = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPPowerProfileClusterPowerProfileNotificationPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _totalProfileNum = @(0);
+
+        _powerProfileId = @(0);
+
+        _numOfTransferredPhases = @(0);
+
+        _transferredPhases = [NSArray array];
+    }
+    return self;
+}
 @end
 
 @implementation CHIPPowerProfileClusterPowerProfileStateRequestPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+    }
+    return self;
+}
 @end
 
 @implementation CHIPPowerProfileClusterPowerProfileResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _totalProfileNum = @(0);
+
+        _powerProfileId = @(0);
+
+        _numOfTransferredPhases = @(0);
+
+        _transferredPhases = [NSArray array];
+    }
+    return self;
+}
 @end
 
 @implementation CHIPPowerProfileClusterGetPowerProfilePriceResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _powerProfileId = @(0);
+
+        _currency = @(0);
+
+        _price = @(0);
+
+        _priceTrailingDigit = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPPowerProfileClusterPowerProfileStateResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _powerProfileCount = @(0);
+
+        _powerProfileRecords = [NSArray array];
+    }
+    return self;
+}
 @end
 
 @implementation CHIPPowerProfileClusterGetOverallSchedulePriceResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _currency = @(0);
+
+        _price = @(0);
+
+        _priceTrailingDigit = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPPowerProfileClusterGetPowerProfilePricePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _powerProfileId = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPPowerProfileClusterEnergyPhasesScheduleNotificationPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _powerProfileId = @(0);
+
+        _numOfScheduledPhases = @(0);
+
+        _scheduledPhases = [NSArray array];
+    }
+    return self;
+}
 @end
 
 @implementation CHIPPowerProfileClusterPowerProfilesStateNotificationPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _powerProfileCount = @(0);
+
+        _powerProfileRecords = [NSArray array];
+    }
+    return self;
+}
 @end
 
 @implementation CHIPPowerProfileClusterEnergyPhasesScheduleResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _powerProfileId = @(0);
+
+        _numOfScheduledPhases = @(0);
+
+        _scheduledPhases = [NSArray array];
+    }
+    return self;
+}
 @end
 
 @implementation CHIPPowerProfileClusterGetOverallSchedulePricePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+    }
+    return self;
+}
 @end
 
 @implementation CHIPPowerProfileClusterPowerProfileScheduleConstraintsRequestPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _powerProfileId = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPPowerProfileClusterEnergyPhasesScheduleRequestPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _powerProfileId = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPPowerProfileClusterEnergyPhasesScheduleStateRequestPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _powerProfileId = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPPowerProfileClusterEnergyPhasesScheduleStateResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _powerProfileId = @(0);
+
+        _numOfScheduledPhases = @(0);
+
+        _scheduledPhases = [NSArray array];
+    }
+    return self;
+}
 @end
 
 @implementation CHIPPowerProfileClusterGetPowerProfilePriceExtendedResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _powerProfileId = @(0);
+
+        _currency = @(0);
+
+        _price = @(0);
+
+        _priceTrailingDigit = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPPowerProfileClusterEnergyPhasesScheduleStateNotificationPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _powerProfileId = @(0);
+
+        _numOfScheduledPhases = @(0);
+
+        _scheduledPhases = [NSArray array];
+    }
+    return self;
+}
 @end
 
 @implementation CHIPPowerProfileClusterPowerProfileScheduleConstraintsNotificationPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _powerProfileId = @(0);
+
+        _startAfter = @(0);
+
+        _stopBefore = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPPowerProfileClusterPowerProfileScheduleConstraintsResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _powerProfileId = @(0);
+
+        _startAfter = @(0);
+
+        _stopBefore = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPPowerProfileClusterGetPowerProfilePriceExtendedPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _options = @(0);
+
+        _powerProfileId = @(0);
+
+        _powerProfileStartTime = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPApplianceControlClusterExecutionOfACommandPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _commandId = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPApplianceControlClusterSignalStateResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _applianceStatus = @(0);
+
+        _remoteEnableFlagsAndDeviceStatus2 = @(0);
+
+        _applianceStatus2 = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPApplianceControlClusterSignalStatePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+    }
+    return self;
+}
 @end
 
 @implementation CHIPApplianceControlClusterSignalStateNotificationPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _applianceStatus = @(0);
+
+        _remoteEnableFlagsAndDeviceStatus2 = @(0);
+
+        _applianceStatus2 = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPApplianceControlClusterWriteFunctionsPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _functionId = @(0);
+
+        _functionDataType = @(0);
+
+        _functionData = [NSArray array];
+    }
+    return self;
+}
 @end
 
 @implementation CHIPApplianceControlClusterOverloadPauseResumePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+    }
+    return self;
+}
 @end
 
 @implementation CHIPApplianceControlClusterOverloadPausePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+    }
+    return self;
+}
 @end
 
 @implementation CHIPApplianceControlClusterOverloadWarningPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _warningEvent = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPPollControlClusterCheckInPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+    }
+    return self;
+}
 @end
 
 @implementation CHIPPollControlClusterCheckInResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _startFastPolling = @(0);
+
+        _fastPollTimeout = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPPollControlClusterFastPollStopPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+    }
+    return self;
+}
 @end
 
 @implementation CHIPPollControlClusterSetLongPollIntervalPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _newLongPollInterval = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPPollControlClusterSetShortPollIntervalPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _newShortPollInterval = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPBridgedActionsClusterInstantActionPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _actionID = @(0);
+
+        _invokeID = nil;
+    }
+    return self;
+}
 @end
 
 @implementation CHIPBridgedActionsClusterInstantActionWithTransitionPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _actionID = @(0);
+
+        _invokeID = nil;
+
+        _transitionTime = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPBridgedActionsClusterStartActionPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _actionID = @(0);
+
+        _invokeID = nil;
+    }
+    return self;
+}
 @end
 
 @implementation CHIPBridgedActionsClusterStartActionWithDurationPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _actionID = @(0);
+
+        _invokeID = nil;
+
+        _duration = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPBridgedActionsClusterStopActionPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _actionID = @(0);
+
+        _invokeID = nil;
+    }
+    return self;
+}
 @end
 
 @implementation CHIPBridgedActionsClusterPauseActionPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _actionID = @(0);
+
+        _invokeID = nil;
+    }
+    return self;
+}
 @end
 
 @implementation CHIPBridgedActionsClusterPauseActionWithDurationPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _actionID = @(0);
+
+        _invokeID = nil;
+
+        _duration = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPBridgedActionsClusterResumeActionPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _actionID = @(0);
+
+        _invokeID = nil;
+    }
+    return self;
+}
 @end
 
 @implementation CHIPBridgedActionsClusterEnableActionPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _actionID = @(0);
+
+        _invokeID = nil;
+    }
+    return self;
+}
 @end
 
 @implementation CHIPBridgedActionsClusterEnableActionWithDurationPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _actionID = @(0);
+
+        _invokeID = nil;
+
+        _duration = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPBridgedActionsClusterDisableActionPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _actionID = @(0);
+
+        _invokeID = nil;
+    }
+    return self;
+}
 @end
 
 @implementation CHIPBridgedActionsClusterDisableActionWithDurationPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _actionID = @(0);
+
+        _invokeID = nil;
+
+        _duration = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPBasicClusterStartUpPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+    }
+    return self;
+}
 @end
 
 @implementation CHIPBasicClusterMfgSpecificPingPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+    }
+    return self;
+}
 @end
 
 @implementation CHIPBasicClusterShutDownPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+    }
+    return self;
+}
 @end
 
 @implementation CHIPBasicClusterLeavePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+    }
+    return self;
+}
 @end
 
 @implementation CHIPOtaSoftwareUpdateProviderClusterQueryImagePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _vendorId = @(0);
+
+        _productId = @(0);
+
+        _softwareVersion = @(0);
+
+        _protocolsSupported = [NSArray array];
+
+        _hardwareVersion = nil;
+
+        _location = nil;
+
+        _requestorCanConsent = nil;
+
+        _metadataForProvider = nil;
+    }
+    return self;
+}
 @end
 
 @implementation CHIPOtaSoftwareUpdateProviderClusterApplyUpdateRequestPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _updateToken = [NSData data];
+
+        _newVersion = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPOtaSoftwareUpdateProviderClusterNotifyUpdateAppliedPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _updateToken = [NSData data];
+
+        _softwareVersion = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPOtaSoftwareUpdateProviderClusterQueryImageResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _status = @(0);
+
+        _delayedActionTime = nil;
+
+        _imageURI = nil;
+
+        _softwareVersion = nil;
+
+        _softwareVersionString = nil;
+
+        _updateToken = nil;
+
+        _userConsentNeeded = nil;
+
+        _metadataForRequestor = nil;
+    }
+    return self;
+}
 @end
 
 @implementation CHIPOtaSoftwareUpdateProviderClusterApplyUpdateResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _action = @(0);
+
+        _delayedActionTime = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPOtaSoftwareUpdateRequestorClusterAnnounceOtaProviderPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _providerLocation = @(0);
+
+        _vendorId = @(0);
+
+        _announcementReason = @(0);
+
+        _metadataForNode = nil;
+    }
+    return self;
+}
 @end
 
 @implementation CHIPGeneralCommissioningClusterArmFailSafePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _expiryLengthSeconds = @(0);
+
+        _breadcrumb = @(0);
+
+        _timeoutMs = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPGeneralCommissioningClusterArmFailSafeResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _errorCode = @(0);
+
+        _debugText = @"";
+    }
+    return self;
+}
 @end
 
 @implementation CHIPGeneralCommissioningClusterSetRegulatoryConfigPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _location = @(0);
+
+        _countryCode = @"";
+
+        _breadcrumb = @(0);
+
+        _timeoutMs = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPGeneralCommissioningClusterSetRegulatoryConfigResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _errorCode = @(0);
+
+        _debugText = @"";
+    }
+    return self;
+}
 @end
 
 @implementation CHIPGeneralCommissioningClusterCommissioningCompletePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+    }
+    return self;
+}
 @end
 
 @implementation CHIPGeneralCommissioningClusterCommissioningCompleteResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _errorCode = @(0);
+
+        _debugText = @"";
+    }
+    return self;
+}
 @end
 
 @implementation CHIPNetworkCommissioningClusterScanNetworksPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _ssid = [NSData data];
+
+        _breadcrumb = @(0);
+
+        _timeoutMs = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPNetworkCommissioningClusterScanNetworksResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _errorCode = @(0);
+
+        _debugText = @"";
+
+        _wifiScanResults = [NSArray array];
+
+        _threadScanResults = [NSArray array];
+    }
+    return self;
+}
 @end
 
 @implementation CHIPNetworkCommissioningClusterAddWiFiNetworkPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _ssid = [NSData data];
+
+        _credentials = [NSData data];
+
+        _breadcrumb = @(0);
+
+        _timeoutMs = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPNetworkCommissioningClusterAddWiFiNetworkResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _errorCode = @(0);
+
+        _debugText = @"";
+    }
+    return self;
+}
 @end
 
 @implementation CHIPNetworkCommissioningClusterUpdateWiFiNetworkPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _ssid = [NSData data];
+
+        _credentials = [NSData data];
+
+        _breadcrumb = @(0);
+
+        _timeoutMs = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPNetworkCommissioningClusterUpdateWiFiNetworkResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _errorCode = @(0);
+
+        _debugText = @"";
+    }
+    return self;
+}
 @end
 
 @implementation CHIPNetworkCommissioningClusterAddThreadNetworkPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _operationalDataset = [NSData data];
+
+        _breadcrumb = @(0);
+
+        _timeoutMs = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPNetworkCommissioningClusterAddThreadNetworkResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _errorCode = @(0);
+
+        _debugText = @"";
+    }
+    return self;
+}
 @end
 
 @implementation CHIPNetworkCommissioningClusterUpdateThreadNetworkPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _operationalDataset = [NSData data];
+
+        _breadcrumb = @(0);
+
+        _timeoutMs = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPNetworkCommissioningClusterUpdateThreadNetworkResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _errorCode = @(0);
+
+        _debugText = @"";
+    }
+    return self;
+}
 @end
 
 @implementation CHIPNetworkCommissioningClusterRemoveNetworkPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _networkID = [NSData data];
+
+        _breadcrumb = @(0);
+
+        _timeoutMs = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPNetworkCommissioningClusterRemoveNetworkResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _errorCode = @(0);
+
+        _debugText = @"";
+    }
+    return self;
+}
 @end
 
 @implementation CHIPNetworkCommissioningClusterEnableNetworkPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _networkID = [NSData data];
+
+        _breadcrumb = @(0);
+
+        _timeoutMs = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPNetworkCommissioningClusterEnableNetworkResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _errorCode = @(0);
+
+        _debugText = @"";
+    }
+    return self;
+}
 @end
 
 @implementation CHIPNetworkCommissioningClusterDisableNetworkPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _networkID = [NSData data];
+
+        _breadcrumb = @(0);
+
+        _timeoutMs = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPNetworkCommissioningClusterDisableNetworkResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _errorCode = @(0);
+
+        _debugText = @"";
+    }
+    return self;
+}
 @end
 
 @implementation CHIPDiagnosticLogsClusterRetrieveLogsRequestPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _intent = @(0);
+
+        _requestedProtocol = @(0);
+
+        _transferFileDesignator = [NSData data];
+    }
+    return self;
+}
 @end
 
 @implementation CHIPDiagnosticLogsClusterRetrieveLogsResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _status = @(0);
+
+        _content = [NSData data];
+
+        _timeStamp = @(0);
+
+        _timeSinceBoot = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPSoftwareDiagnosticsClusterResetWatermarksPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+    }
+    return self;
+}
 @end
 
 @implementation CHIPThreadNetworkDiagnosticsClusterResetCountsPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+    }
+    return self;
+}
 @end
 
 @implementation CHIPWiFiNetworkDiagnosticsClusterResetCountsPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+    }
+    return self;
+}
 @end
 
 @implementation CHIPEthernetNetworkDiagnosticsClusterResetCountsPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+    }
+    return self;
+}
 @end
 
 @implementation CHIPBridgedDeviceBasicClusterStartUpPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+    }
+    return self;
+}
 @end
 
 @implementation CHIPBridgedDeviceBasicClusterShutDownPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+    }
+    return self;
+}
 @end
 
 @implementation CHIPBridgedDeviceBasicClusterLeavePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+    }
+    return self;
+}
 @end
 
 @implementation CHIPBridgedDeviceBasicClusterReachableChangedPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+    }
+    return self;
+}
 @end
 
 @implementation CHIPAdministratorCommissioningClusterOpenCommissioningWindowPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _commissioningTimeout = @(0);
+
+        _pakeVerifier = [NSData data];
+
+        _discriminator = @(0);
+
+        _iterations = @(0);
+
+        _salt = [NSData data];
+
+        _passcodeID = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPAdministratorCommissioningClusterOpenBasicCommissioningWindowPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _commissioningTimeout = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPAdministratorCommissioningClusterRevokeCommissioningPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+    }
+    return self;
+}
 @end
 
 @implementation CHIPOperationalCredentialsClusterAttestationRequestPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _attestationNonce = [NSData data];
+    }
+    return self;
+}
 @end
 
 @implementation CHIPOperationalCredentialsClusterAttestationResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _attestationElements = [NSData data];
+
+        _signature = [NSData data];
+    }
+    return self;
+}
 @end
 
 @implementation CHIPOperationalCredentialsClusterCertificateChainRequestPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _certificateType = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPOperationalCredentialsClusterCertificateChainResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _certificate = [NSData data];
+    }
+    return self;
+}
 @end
 
 @implementation CHIPOperationalCredentialsClusterOpCSRRequestPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _csrNonce = [NSData data];
+    }
+    return self;
+}
 @end
 
 @implementation CHIPOperationalCredentialsClusterOpCSRResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _nocsrElements = [NSData data];
+
+        _attestationSignature = [NSData data];
+    }
+    return self;
+}
 @end
 
 @implementation CHIPOperationalCredentialsClusterAddNOCPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _nocValue = [NSData data];
+
+        _icacValue = nil;
+
+        _ipkValue = [NSData data];
+
+        _caseAdminNode = @(0);
+
+        _adminVendorId = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPOperationalCredentialsClusterUpdateNOCPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _nocValue = [NSData data];
+
+        _icacValue = nil;
+    }
+    return self;
+}
 @end
 
 @implementation CHIPOperationalCredentialsClusterNOCResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _statusCode = @(0);
+
+        _fabricIndex = @(0);
+
+        _debugText = @"";
+    }
+    return self;
+}
 @end
 
 @implementation CHIPOperationalCredentialsClusterUpdateFabricLabelPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _label = @"";
+    }
+    return self;
+}
 @end
 
 @implementation CHIPOperationalCredentialsClusterRemoveFabricPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _fabricIndex = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPOperationalCredentialsClusterAddTrustedRootCertificatePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _rootCertificate = [NSData data];
+    }
+    return self;
+}
 @end
 
 @implementation CHIPOperationalCredentialsClusterRemoveTrustedRootCertificatePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _trustedRootIdentifier = [NSData data];
+    }
+    return self;
+}
 @end
 
 @implementation CHIPModeSelectClusterChangeToModePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _newMode = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPDoorLockClusterLockDoorPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _pin = [NSData data];
+    }
+    return self;
+}
 @end
 
 @implementation CHIPDoorLockClusterLockDoorResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _status = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPDoorLockClusterUnlockDoorPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _pin = [NSData data];
+    }
+    return self;
+}
 @end
 
 @implementation CHIPDoorLockClusterUnlockDoorResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _status = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPDoorLockClusterTogglePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _pin = @"";
+    }
+    return self;
+}
 @end
 
 @implementation CHIPDoorLockClusterToggleResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _status = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPDoorLockClusterUnlockWithTimeoutPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _timeoutInSeconds = @(0);
+
+        _pin = [NSData data];
+    }
+    return self;
+}
 @end
 
 @implementation CHIPDoorLockClusterUnlockWithTimeoutResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _status = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPDoorLockClusterGetLogRecordPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _logIndex = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPDoorLockClusterGetLogRecordResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _logEntryId = @(0);
+
+        _timestamp = @(0);
+
+        _eventType = @(0);
+
+        _source = @(0);
+
+        _eventIdOrAlarmCode = @(0);
+
+        _userId = @(0);
+
+        _pin = [NSData data];
+    }
+    return self;
+}
 @end
 
 @implementation CHIPDoorLockClusterSetPinPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _userId = @(0);
+
+        _userStatus = @(0);
+
+        _userType = @(0);
+
+        _pin = [NSData data];
+    }
+    return self;
+}
 @end
 
 @implementation CHIPDoorLockClusterSetPinResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _status = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPDoorLockClusterGetPinPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _userId = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPDoorLockClusterGetPinResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _userId = @(0);
+
+        _userStatus = @(0);
+
+        _userType = @(0);
+
+        _pin = [NSData data];
+    }
+    return self;
+}
 @end
 
 @implementation CHIPDoorLockClusterClearPinPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _userId = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPDoorLockClusterClearPinResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _status = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPDoorLockClusterClearAllPinsPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+    }
+    return self;
+}
 @end
 
 @implementation CHIPDoorLockClusterClearAllPinsResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _status = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPDoorLockClusterSetUserStatusPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _userId = @(0);
+
+        _userStatus = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPDoorLockClusterSetUserStatusResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _status = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPDoorLockClusterGetUserStatusPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _userId = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPDoorLockClusterGetUserStatusResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _userId = @(0);
+
+        _status = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPDoorLockClusterSetWeekdaySchedulePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _scheduleId = @(0);
+
+        _userId = @(0);
+
+        _daysMask = @(0);
+
+        _startHour = @(0);
+
+        _startMinute = @(0);
+
+        _endHour = @(0);
+
+        _endMinute = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPDoorLockClusterSetWeekdayScheduleResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _status = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPDoorLockClusterGetWeekdaySchedulePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _scheduleId = @(0);
+
+        _userId = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPDoorLockClusterGetWeekdayScheduleResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _scheduleId = @(0);
+
+        _userId = @(0);
+
+        _status = @(0);
+
+        _daysMask = @(0);
+
+        _startHour = @(0);
+
+        _startMinute = @(0);
+
+        _endHour = @(0);
+
+        _endMinute = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPDoorLockClusterClearWeekdaySchedulePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _scheduleId = @(0);
+
+        _userId = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPDoorLockClusterClearWeekdayScheduleResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _status = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPDoorLockClusterSetYeardaySchedulePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _scheduleId = @(0);
+
+        _userId = @(0);
+
+        _localStartTime = @(0);
+
+        _localEndTime = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPDoorLockClusterSetYeardayScheduleResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _status = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPDoorLockClusterGetYeardaySchedulePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _scheduleId = @(0);
+
+        _userId = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPDoorLockClusterGetYeardayScheduleResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _scheduleId = @(0);
+
+        _userId = @(0);
+
+        _status = @(0);
+
+        _localStartTime = @(0);
+
+        _localEndTime = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPDoorLockClusterClearYeardaySchedulePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _scheduleId = @(0);
+
+        _userId = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPDoorLockClusterClearYeardayScheduleResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _status = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPDoorLockClusterSetHolidaySchedulePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _scheduleId = @(0);
+
+        _localStartTime = @(0);
+
+        _localEndTime = @(0);
+
+        _operatingModeDuringHoliday = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPDoorLockClusterSetHolidayScheduleResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _status = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPDoorLockClusterGetHolidaySchedulePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _scheduleId = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPDoorLockClusterGetHolidayScheduleResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _scheduleId = @(0);
+
+        _status = @(0);
+
+        _localStartTime = @(0);
+
+        _localEndTime = @(0);
+
+        _operatingModeDuringHoliday = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPDoorLockClusterClearHolidaySchedulePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _scheduleId = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPDoorLockClusterClearHolidayScheduleResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _status = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPDoorLockClusterSetUserTypePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _userId = @(0);
+
+        _userType = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPDoorLockClusterSetUserTypeResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _status = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPDoorLockClusterGetUserTypePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _userId = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPDoorLockClusterGetUserTypeResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _userId = @(0);
+
+        _userType = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPDoorLockClusterSetRfidPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _userId = @(0);
+
+        _userStatus = @(0);
+
+        _userType = @(0);
+
+        _id = [NSData data];
+    }
+    return self;
+}
 @end
 
 @implementation CHIPDoorLockClusterSetRfidResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _status = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPDoorLockClusterGetRfidPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _userId = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPDoorLockClusterGetRfidResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _userId = @(0);
+
+        _userStatus = @(0);
+
+        _userType = @(0);
+
+        _rfid = [NSData data];
+    }
+    return self;
+}
 @end
 
 @implementation CHIPDoorLockClusterClearRfidPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _userId = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPDoorLockClusterClearRfidResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _status = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPDoorLockClusterClearAllRfidsPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+    }
+    return self;
+}
 @end
 
 @implementation CHIPDoorLockClusterClearAllRfidsResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _status = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPDoorLockClusterOperationEventNotificationPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _source = @(0);
+
+        _eventCode = @(0);
+
+        _userId = @(0);
+
+        _pin = [NSData data];
+
+        _timeStamp = @(0);
+
+        _data = @"";
+    }
+    return self;
+}
 @end
 
 @implementation CHIPDoorLockClusterProgrammingEventNotificationPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _source = @(0);
+
+        _eventCode = @(0);
+
+        _userId = @(0);
+
+        _pin = [NSData data];
+
+        _userType = @(0);
+
+        _userStatus = @(0);
+
+        _timeStamp = @(0);
+
+        _data = @"";
+    }
+    return self;
+}
 @end
 
 @implementation CHIPWindowCoveringClusterUpOrOpenPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+    }
+    return self;
+}
 @end
 
 @implementation CHIPWindowCoveringClusterDownOrClosePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+    }
+    return self;
+}
 @end
 
 @implementation CHIPWindowCoveringClusterStopMotionPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+    }
+    return self;
+}
 @end
 
 @implementation CHIPWindowCoveringClusterGoToLiftValuePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _liftValue = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPWindowCoveringClusterGoToLiftPercentagePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _liftPercentageValue = @(0);
+
+        _liftPercent100thsValue = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPWindowCoveringClusterGoToTiltValuePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _tiltValue = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPWindowCoveringClusterGoToTiltPercentagePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _tiltPercentageValue = @(0);
+
+        _tiltPercent100thsValue = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPBarrierControlClusterBarrierControlGoToPercentPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _percentOpen = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPBarrierControlClusterBarrierControlStopPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+    }
+    return self;
+}
 @end
 
 @implementation CHIPThermostatClusterSetpointRaiseLowerPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _mode = @(0);
+
+        _amount = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPThermostatClusterCurrentWeeklySchedulePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _numberOfTransitionsForSequence = @(0);
+
+        _dayOfWeekForSequence = @(0);
+
+        _modeForSequence = @(0);
+
+        _payload = [NSArray array];
+    }
+    return self;
+}
 @end
 
 @implementation CHIPThermostatClusterSetWeeklySchedulePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _numberOfTransitionsForSequence = @(0);
+
+        _dayOfWeekForSequence = @(0);
+
+        _modeForSequence = @(0);
+
+        _payload = [NSArray array];
+    }
+    return self;
+}
 @end
 
 @implementation CHIPThermostatClusterRelayStatusLogPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _timeOfDay = @(0);
+
+        _relayStatus = @(0);
+
+        _localTemperature = @(0);
+
+        _humidityInPercentage = @(0);
+
+        _setpoint = @(0);
+
+        _unreadEntries = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPThermostatClusterGetWeeklySchedulePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _daysToReturn = @(0);
+
+        _modeToReturn = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPThermostatClusterClearWeeklySchedulePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+    }
+    return self;
+}
 @end
 
 @implementation CHIPThermostatClusterGetRelayStatusLogPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+    }
+    return self;
+}
 @end
 
 @implementation CHIPColorControlClusterMoveToHuePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _hue = @(0);
+
+        _direction = @(0);
+
+        _transitionTime = @(0);
+
+        _optionsMask = @(0);
+
+        _optionsOverride = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPColorControlClusterMoveHuePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _moveMode = @(0);
+
+        _rate = @(0);
+
+        _optionsMask = @(0);
+
+        _optionsOverride = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPColorControlClusterStepHuePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _stepMode = @(0);
+
+        _stepSize = @(0);
+
+        _transitionTime = @(0);
+
+        _optionsMask = @(0);
+
+        _optionsOverride = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPColorControlClusterMoveToSaturationPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _saturation = @(0);
+
+        _transitionTime = @(0);
+
+        _optionsMask = @(0);
+
+        _optionsOverride = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPColorControlClusterMoveSaturationPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _moveMode = @(0);
+
+        _rate = @(0);
+
+        _optionsMask = @(0);
+
+        _optionsOverride = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPColorControlClusterStepSaturationPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _stepMode = @(0);
+
+        _stepSize = @(0);
+
+        _transitionTime = @(0);
+
+        _optionsMask = @(0);
+
+        _optionsOverride = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPColorControlClusterMoveToHueAndSaturationPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _hue = @(0);
+
+        _saturation = @(0);
+
+        _transitionTime = @(0);
+
+        _optionsMask = @(0);
+
+        _optionsOverride = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPColorControlClusterMoveToColorPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _colorX = @(0);
+
+        _colorY = @(0);
+
+        _transitionTime = @(0);
+
+        _optionsMask = @(0);
+
+        _optionsOverride = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPColorControlClusterMoveColorPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _rateX = @(0);
+
+        _rateY = @(0);
+
+        _optionsMask = @(0);
+
+        _optionsOverride = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPColorControlClusterStepColorPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _stepX = @(0);
+
+        _stepY = @(0);
+
+        _transitionTime = @(0);
+
+        _optionsMask = @(0);
+
+        _optionsOverride = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPColorControlClusterMoveToColorTemperaturePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _colorTemperature = @(0);
+
+        _transitionTime = @(0);
+
+        _optionsMask = @(0);
+
+        _optionsOverride = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPColorControlClusterEnhancedMoveToHuePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _enhancedHue = @(0);
+
+        _direction = @(0);
+
+        _transitionTime = @(0);
+
+        _optionsMask = @(0);
+
+        _optionsOverride = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPColorControlClusterEnhancedMoveHuePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _moveMode = @(0);
+
+        _rate = @(0);
+
+        _optionsMask = @(0);
+
+        _optionsOverride = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPColorControlClusterEnhancedStepHuePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _stepMode = @(0);
+
+        _stepSize = @(0);
+
+        _transitionTime = @(0);
+
+        _optionsMask = @(0);
+
+        _optionsOverride = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPColorControlClusterEnhancedMoveToHueAndSaturationPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _enhancedHue = @(0);
+
+        _saturation = @(0);
+
+        _transitionTime = @(0);
+
+        _optionsMask = @(0);
+
+        _optionsOverride = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPColorControlClusterColorLoopSetPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _updateFlags = @(0);
+
+        _action = @(0);
+
+        _direction = @(0);
+
+        _time = @(0);
+
+        _startHue = @(0);
+
+        _optionsMask = @(0);
+
+        _optionsOverride = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPColorControlClusterStopMoveStepPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _optionsMask = @(0);
+
+        _optionsOverride = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPColorControlClusterMoveColorTemperaturePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _moveMode = @(0);
+
+        _rate = @(0);
+
+        _colorTemperatureMinimum = @(0);
+
+        _colorTemperatureMaximum = @(0);
+
+        _optionsMask = @(0);
+
+        _optionsOverride = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPColorControlClusterStepColorTemperaturePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _stepMode = @(0);
+
+        _stepSize = @(0);
+
+        _transitionTime = @(0);
+
+        _colorTemperatureMinimum = @(0);
+
+        _colorTemperatureMaximum = @(0);
+
+        _optionsMask = @(0);
+
+        _optionsOverride = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPIasZoneClusterZoneEnrollResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _enrollResponseCode = @(0);
+
+        _zoneId = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPIasZoneClusterZoneStatusChangeNotificationPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _zoneStatus = @(0);
+
+        _extendedStatus = @(0);
+
+        _zoneId = @(0);
+
+        _delay = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPIasZoneClusterInitiateNormalOperationModePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+    }
+    return self;
+}
 @end
 
 @implementation CHIPIasZoneClusterZoneEnrollRequestPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _zoneType = @(0);
+
+        _manufacturerCode = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPIasZoneClusterInitiateTestModePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _testModeDuration = @(0);
+
+        _currentZoneSensitivityLevel = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPIasZoneClusterInitiateNormalOperationModeResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+    }
+    return self;
+}
 @end
 
 @implementation CHIPIasZoneClusterInitiateTestModeResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+    }
+    return self;
+}
 @end
 
 @implementation CHIPIasAceClusterArmPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _armMode = @(0);
+
+        _armDisarmCode = @"";
+
+        _zoneId = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPIasAceClusterArmResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _armNotification = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPIasAceClusterBypassPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _numberOfZones = @(0);
+
+        _zoneIds = [NSArray array];
+
+        _armDisarmCode = @"";
+    }
+    return self;
+}
 @end
 
 @implementation CHIPIasAceClusterGetZoneIdMapResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _section0 = @(0);
+
+        _section1 = @(0);
+
+        _section2 = @(0);
+
+        _section3 = @(0);
+
+        _section4 = @(0);
+
+        _section5 = @(0);
+
+        _section6 = @(0);
+
+        _section7 = @(0);
+
+        _section8 = @(0);
+
+        _section9 = @(0);
+
+        _section10 = @(0);
+
+        _section11 = @(0);
+
+        _section12 = @(0);
+
+        _section13 = @(0);
+
+        _section14 = @(0);
+
+        _section15 = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPIasAceClusterEmergencyPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+    }
+    return self;
+}
 @end
 
 @implementation CHIPIasAceClusterGetZoneInformationResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _zoneId = @(0);
+
+        _zoneType = @(0);
+
+        _ieeeAddress = @(0);
+
+        _zoneLabel = @"";
+    }
+    return self;
+}
 @end
 
 @implementation CHIPIasAceClusterFirePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+    }
+    return self;
+}
 @end
 
 @implementation CHIPIasAceClusterZoneStatusChangedPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _zoneId = @(0);
+
+        _zoneStatus = @(0);
+
+        _audibleNotification = @(0);
+
+        _zoneLabel = @"";
+    }
+    return self;
+}
 @end
 
 @implementation CHIPIasAceClusterPanicPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+    }
+    return self;
+}
 @end
 
 @implementation CHIPIasAceClusterPanelStatusChangedPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _panelStatus = @(0);
+
+        _secondsRemaining = @(0);
+
+        _audibleNotification = @(0);
+
+        _alarmStatus = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPIasAceClusterGetZoneIdMapPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+    }
+    return self;
+}
 @end
 
 @implementation CHIPIasAceClusterGetPanelStatusResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _panelStatus = @(0);
+
+        _secondsRemaining = @(0);
+
+        _audibleNotification = @(0);
+
+        _alarmStatus = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPIasAceClusterGetZoneInformationPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _zoneId = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPIasAceClusterSetBypassedZoneListPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _numberOfZones = @(0);
+
+        _zoneIds = [NSArray array];
+    }
+    return self;
+}
 @end
 
 @implementation CHIPIasAceClusterGetPanelStatusPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+    }
+    return self;
+}
 @end
 
 @implementation CHIPIasAceClusterBypassResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _numberOfZones = @(0);
+
+        _bypassResult = [NSArray array];
+    }
+    return self;
+}
 @end
 
 @implementation CHIPIasAceClusterGetBypassedZoneListPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+    }
+    return self;
+}
 @end
 
 @implementation CHIPIasAceClusterGetZoneStatusResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _zoneStatusComplete = @(0);
+
+        _numberOfZones = @(0);
+
+        _zoneStatusResult = [NSArray array];
+    }
+    return self;
+}
 @end
 
 @implementation CHIPIasAceClusterGetZoneStatusPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _startingZoneId = @(0);
+
+        _maxNumberOfZoneIds = @(0);
+
+        _zoneStatusMaskFlag = @(0);
+
+        _zoneStatusMask = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPIasWdClusterStartWarningPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _warningInfo = @(0);
+
+        _warningDuration = @(0);
+
+        _strobeDutyCycle = @(0);
+
+        _strobeLevel = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPIasWdClusterSquawkPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _squawkInfo = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPTvChannelClusterChangeChannelPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _match = @"";
+    }
+    return self;
+}
 @end
 
 @implementation CHIPTvChannelClusterChangeChannelResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _channelMatch = [NSArray array];
+
+        _errorType = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPTvChannelClusterChangeChannelByNumberPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _majorNumber = @(0);
+
+        _minorNumber = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPTvChannelClusterSkipChannelPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _count = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPTargetNavigatorClusterNavigateTargetPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _target = @(0);
+
+        _data = @"";
+    }
+    return self;
+}
 @end
 
 @implementation CHIPTargetNavigatorClusterNavigateTargetResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _status = @(0);
+
+        _data = @"";
+    }
+    return self;
+}
 @end
 
 @implementation CHIPMediaPlaybackClusterMediaPlayPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+    }
+    return self;
+}
 @end
 
 @implementation CHIPMediaPlaybackClusterMediaPlayResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _mediaPlaybackStatus = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPMediaPlaybackClusterMediaPausePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+    }
+    return self;
+}
 @end
 
 @implementation CHIPMediaPlaybackClusterMediaPauseResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _mediaPlaybackStatus = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPMediaPlaybackClusterMediaStopPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+    }
+    return self;
+}
 @end
 
 @implementation CHIPMediaPlaybackClusterMediaStopResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _mediaPlaybackStatus = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPMediaPlaybackClusterMediaStartOverPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+    }
+    return self;
+}
 @end
 
 @implementation CHIPMediaPlaybackClusterMediaStartOverResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _mediaPlaybackStatus = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPMediaPlaybackClusterMediaPreviousPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+    }
+    return self;
+}
 @end
 
 @implementation CHIPMediaPlaybackClusterMediaPreviousResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _mediaPlaybackStatus = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPMediaPlaybackClusterMediaNextPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+    }
+    return self;
+}
 @end
 
 @implementation CHIPMediaPlaybackClusterMediaNextResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _mediaPlaybackStatus = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPMediaPlaybackClusterMediaRewindPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+    }
+    return self;
+}
 @end
 
 @implementation CHIPMediaPlaybackClusterMediaRewindResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _mediaPlaybackStatus = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPMediaPlaybackClusterMediaFastForwardPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+    }
+    return self;
+}
 @end
 
 @implementation CHIPMediaPlaybackClusterMediaFastForwardResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _mediaPlaybackStatus = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPMediaPlaybackClusterMediaSkipForwardPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _deltaPositionMilliseconds = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPMediaPlaybackClusterMediaSkipForwardResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _mediaPlaybackStatus = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPMediaPlaybackClusterMediaSkipBackwardPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _deltaPositionMilliseconds = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPMediaPlaybackClusterMediaSkipBackwardResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _mediaPlaybackStatus = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPMediaPlaybackClusterMediaSeekPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _position = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPMediaPlaybackClusterMediaSeekResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _mediaPlaybackStatus = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPMediaInputClusterSelectInputPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _index = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPMediaInputClusterShowInputStatusPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+    }
+    return self;
+}
 @end
 
 @implementation CHIPMediaInputClusterHideInputStatusPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+    }
+    return self;
+}
 @end
 
 @implementation CHIPMediaInputClusterRenameInputPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _index = @(0);
+
+        _name = @"";
+    }
+    return self;
+}
 @end
 
 @implementation CHIPLowPowerClusterSleepPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+    }
+    return self;
+}
 @end
 
 @implementation CHIPKeypadInputClusterSendKeyPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _keyCode = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPKeypadInputClusterSendKeyResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _status = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPContentLauncherClusterLaunchContentPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _autoPlay = @(0);
+
+        _data = @"";
+    }
+    return self;
+}
 @end
 
 @implementation CHIPContentLauncherClusterLaunchContentResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _data = @"";
+
+        _contentLaunchStatus = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPContentLauncherClusterLaunchURLPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _contentURL = @"";
+
+        _displayString = @"";
+    }
+    return self;
+}
 @end
 
 @implementation CHIPContentLauncherClusterLaunchURLResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _data = @"";
+
+        _contentLaunchStatus = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPAudioOutputClusterSelectOutputPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _index = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPAudioOutputClusterRenameOutputPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _index = @(0);
+
+        _name = @"";
+    }
+    return self;
+}
 @end
 
 @implementation CHIPApplicationLauncherClusterLaunchAppPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _data = @"";
+
+        _catalogVendorId = @(0);
+
+        _applicationId = @"";
+    }
+    return self;
+}
 @end
 
 @implementation CHIPApplicationLauncherClusterLaunchAppResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _status = @(0);
+
+        _data = @"";
+    }
+    return self;
+}
 @end
 
 @implementation CHIPApplicationBasicClusterChangeStatusPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _status = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPAccountLoginClusterGetSetupPINPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _tempAccountIdentifier = @"";
+    }
+    return self;
+}
 @end
 
 @implementation CHIPAccountLoginClusterGetSetupPINResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _setupPIN = @"";
+    }
+    return self;
+}
 @end
 
 @implementation CHIPAccountLoginClusterLoginPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _tempAccountIdentifier = @"";
+
+        _setupPIN = @"";
+    }
+    return self;
+}
 @end
 
 @implementation CHIPTestClusterClusterTestPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+    }
+    return self;
+}
 @end
 
 @implementation CHIPTestClusterClusterTestSpecificResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _returnValue = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPTestClusterClusterTestNotHandledPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+    }
+    return self;
+}
 @end
 
 @implementation CHIPTestClusterClusterTestAddArgumentsResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _returnValue = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPTestClusterClusterTestSpecificPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+    }
+    return self;
+}
 @end
 
 @implementation CHIPTestClusterClusterTestSimpleArgumentResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _returnValue = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPTestClusterClusterTestUnknownCommandPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+    }
+    return self;
+}
 @end
 
 @implementation CHIPTestClusterClusterTestStructArrayArgumentResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _arg1 = [NSArray array];
+
+        _arg2 = [NSArray array];
+
+        _arg3 = [NSArray array];
+
+        _arg4 = [NSArray array];
+
+        _arg5 = @(0);
+
+        _arg6 = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPTestClusterClusterTestAddArgumentsPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _arg1 = @(0);
+
+        _arg2 = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPTestClusterClusterTestListInt8UReverseResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _arg1 = [NSArray array];
+    }
+    return self;
+}
 @end
 
 @implementation CHIPTestClusterClusterTestSimpleArgumentRequestPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _arg1 = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPTestClusterClusterTestEnumsResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _arg1 = @(0);
+
+        _arg2 = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPTestClusterClusterTestStructArrayArgumentRequestPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _arg1 = [NSArray array];
+
+        _arg2 = [NSArray array];
+
+        _arg3 = [NSArray array];
+
+        _arg4 = [NSArray array];
+
+        _arg5 = @(0);
+
+        _arg6 = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPTestClusterClusterTestNullableOptionalResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _wasPresent = @(0);
+
+        _wasNull = nil;
+
+        _value = nil;
+
+        _originalValue = nil;
+    }
+    return self;
+}
 @end
 
 @implementation CHIPTestClusterClusterTestStructArgumentRequestPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _arg1 = [CHIPTestClusterClusterSimpleStruct new];
+    }
+    return self;
+}
 @end
 
 @implementation CHIPTestClusterClusterTestComplexNullableOptionalResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _nullableIntWasNull = @(0);
+
+        _nullableIntValue = nil;
+
+        _optionalIntWasPresent = @(0);
+
+        _optionalIntValue = nil;
+
+        _nullableOptionalIntWasPresent = @(0);
+
+        _nullableOptionalIntWasNull = nil;
+
+        _nullableOptionalIntValue = nil;
+
+        _nullableStringWasNull = @(0);
+
+        _nullableStringValue = nil;
+
+        _optionalStringWasPresent = @(0);
+
+        _optionalStringValue = nil;
+
+        _nullableOptionalStringWasPresent = @(0);
+
+        _nullableOptionalStringWasNull = nil;
+
+        _nullableOptionalStringValue = nil;
+
+        _nullableStructWasNull = @(0);
+
+        _nullableStructValue = nil;
+
+        _optionalStructWasPresent = @(0);
+
+        _optionalStructValue = nil;
+
+        _nullableOptionalStructWasPresent = @(0);
+
+        _nullableOptionalStructWasNull = nil;
+
+        _nullableOptionalStructValue = nil;
+
+        _nullableListWasNull = @(0);
+
+        _nullableListValue = nil;
+
+        _optionalListWasPresent = @(0);
+
+        _optionalListValue = nil;
+
+        _nullableOptionalListWasPresent = @(0);
+
+        _nullableOptionalListWasNull = nil;
+
+        _nullableOptionalListValue = nil;
+    }
+    return self;
+}
 @end
 
 @implementation CHIPTestClusterClusterTestNestedStructArgumentRequestPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _arg1 = [CHIPTestClusterClusterNestedStruct new];
+    }
+    return self;
+}
 @end
 
 @implementation CHIPTestClusterClusterBooleanResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _value = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPTestClusterClusterTestListStructArgumentRequestPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _arg1 = [NSArray array];
+    }
+    return self;
+}
 @end
 
 @implementation CHIPTestClusterClusterTestListInt8UArgumentRequestPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _arg1 = [NSArray array];
+    }
+    return self;
+}
 @end
 
 @implementation CHIPTestClusterClusterTestNestedStructListArgumentRequestPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _arg1 = [CHIPTestClusterClusterNestedStructList new];
+    }
+    return self;
+}
 @end
 
 @implementation CHIPTestClusterClusterTestListNestedStructListArgumentRequestPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _arg1 = [NSArray array];
+    }
+    return self;
+}
 @end
 
 @implementation CHIPTestClusterClusterTestListInt8UReverseRequestPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _arg1 = [NSArray array];
+    }
+    return self;
+}
 @end
 
 @implementation CHIPTestClusterClusterTestEnumsRequestPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _arg1 = @(0);
+
+        _arg2 = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPTestClusterClusterTestNullableOptionalRequestPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _arg1 = nil;
+    }
+    return self;
+}
 @end
 
 @implementation CHIPTestClusterClusterTestComplexNullableOptionalRequestPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _nullableInt = nil;
+
+        _optionalInt = nil;
+
+        _nullableOptionalInt = nil;
+
+        _nullableString = nil;
+
+        _optionalString = nil;
+
+        _nullableOptionalString = nil;
+
+        _nullableStruct = nil;
+
+        _optionalStruct = nil;
+
+        _nullableOptionalStruct = nil;
+
+        _nullableList = nil;
+
+        _optionalList = nil;
+
+        _nullableOptionalList = nil;
+    }
+    return self;
+}
 @end
 
 @implementation CHIPMessagingClusterDisplayMessagePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _messageId = @(0);
+
+        _messageControl = @(0);
+
+        _startTime = @(0);
+
+        _durationInMinutes = @(0);
+
+        _message = @"";
+
+        _optionalExtendedMessageControl = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPMessagingClusterGetLastMessagePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+    }
+    return self;
+}
 @end
 
 @implementation CHIPMessagingClusterCancelMessagePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _messageId = @(0);
+
+        _messageControl = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPMessagingClusterMessageConfirmationPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _messageId = @(0);
+
+        _confirmationTime = @(0);
+
+        _messageConfirmationControl = @(0);
+
+        _messageResponse = [NSData data];
+    }
+    return self;
+}
 @end
 
 @implementation CHIPMessagingClusterDisplayProtectedMessagePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _messageId = @(0);
+
+        _messageControl = @(0);
+
+        _startTime = @(0);
+
+        _durationInMinutes = @(0);
+
+        _message = @"";
+
+        _optionalExtendedMessageControl = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPMessagingClusterGetMessageCancellationPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _earliestImplementationTime = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPMessagingClusterCancelAllMessagesPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _implementationDateTime = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPApplianceEventsAndAlertClusterGetAlertsPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+    }
+    return self;
+}
 @end
 
 @implementation CHIPApplianceEventsAndAlertClusterGetAlertsResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _alertsCount = @(0);
+
+        _alertStructures = [NSArray array];
+    }
+    return self;
+}
 @end
 
 @implementation CHIPApplianceEventsAndAlertClusterAlertsNotificationPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _alertsCount = @(0);
+
+        _alertStructures = [NSArray array];
+    }
+    return self;
+}
 @end
 
 @implementation CHIPApplianceEventsAndAlertClusterEventsNotificationPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _eventHeader = @(0);
+
+        _eventId = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPApplianceStatisticsClusterLogNotificationPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _timeStamp = @(0);
+
+        _logId = @(0);
+
+        _logLength = @(0);
+
+        _logPayload = [NSArray array];
+    }
+    return self;
+}
 @end
 
 @implementation CHIPApplianceStatisticsClusterLogRequestPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _logId = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPApplianceStatisticsClusterLogResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _timeStamp = @(0);
+
+        _logId = @(0);
+
+        _logLength = @(0);
+
+        _logPayload = [NSArray array];
+    }
+    return self;
+}
 @end
 
 @implementation CHIPApplianceStatisticsClusterLogQueueRequestPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+    }
+    return self;
+}
 @end
 
 @implementation CHIPApplianceStatisticsClusterLogQueueResponsePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _logQueueSize = @(0);
+
+        _logIds = [NSArray array];
+    }
+    return self;
+}
 @end
 
 @implementation CHIPApplianceStatisticsClusterStatisticsAvailablePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _logQueueSize = @(0);
+
+        _logIds = [NSArray array];
+    }
+    return self;
+}
 @end
 
 @implementation CHIPElectricalMeasurementClusterGetProfileInfoResponseCommandPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _profileCount = @(0);
+
+        _profileIntervalPeriod = @(0);
+
+        _maxNumberOfIntervals = @(0);
+
+        _listOfAttributes = [NSArray array];
+    }
+    return self;
+}
 @end
 
 @implementation CHIPElectricalMeasurementClusterGetProfileInfoCommandPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+    }
+    return self;
+}
 @end
 
 @implementation CHIPElectricalMeasurementClusterGetMeasurementProfileResponseCommandPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _startTime = @(0);
+
+        _status = @(0);
+
+        _profileIntervalPeriod = @(0);
+
+        _numberOfIntervalsDelivered = @(0);
+
+        _attributeId = @(0);
+
+        _intervals = [NSArray array];
+    }
+    return self;
+}
 @end
 
 @implementation CHIPElectricalMeasurementClusterGetMeasurementProfileCommandPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _attributeId = @(0);
+
+        _startTime = @(0);
+
+        _numberOfIntervals = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPBindingClusterBindPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _nodeId = @(0);
+
+        _groupId = @(0);
+
+        _endpointId = @(0);
+
+        _clusterId = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPBindingClusterUnbindPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _nodeId = @(0);
+
+        _groupId = @(0);
+
+        _endpointId = @(0);
+
+        _clusterId = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPSampleMfgSpecificClusterClusterCommandOnePayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _argOne = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPSampleMfgSpecificCluster2ClusterCommandTwoPayload
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _argOne = @(0);
+    }
+    return self;
+}
 @end
+
+NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPStructsObjc.h
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPStructsObjc.h
@@ -22,10 +22,13 @@
 
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface CHIPScenesClusterSceneExtensionFieldSet : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull clusterId;
 @property (strong, nonatomic) NSNumber * _Nonnull length;
 @property (strong, nonatomic) NSNumber * _Nonnull value;
+- (instancetype)init;
 @end
 
 @interface CHIPPowerProfileClusterPowerProfileRecord : NSObject
@@ -33,11 +36,13 @@
 @property (strong, nonatomic) NSNumber * _Nonnull energyPhaseId;
 @property (strong, nonatomic) NSNumber * _Nonnull powerProfileRemoteControl;
 @property (strong, nonatomic) NSNumber * _Nonnull powerProfileState;
+- (instancetype)init;
 @end
 
 @interface CHIPPowerProfileClusterScheduledPhase : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull energyPhaseId;
 @property (strong, nonatomic) NSNumber * _Nonnull scheduledTime;
+- (instancetype)init;
 @end
 
 @interface CHIPPowerProfileClusterTransferredPhase : NSObject
@@ -47,11 +52,13 @@
 @property (strong, nonatomic) NSNumber * _Nonnull peakPower;
 @property (strong, nonatomic) NSNumber * _Nonnull energy;
 @property (strong, nonatomic) NSNumber * _Nonnull maxActivationDelay;
+- (instancetype)init;
 @end
 
 @interface CHIPDescriptorClusterDeviceType : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull type;
 @property (strong, nonatomic) NSNumber * _Nonnull revision;
+- (instancetype)init;
 @end
 
 @interface CHIPBridgedActionsClusterActionStruct : NSObject
@@ -61,6 +68,7 @@
 @property (strong, nonatomic) NSNumber * _Nonnull endpointListID;
 @property (strong, nonatomic) NSNumber * _Nonnull supportedCommands;
 @property (strong, nonatomic) NSNumber * _Nonnull status;
+- (instancetype)init;
 @end
 
 @interface CHIPBridgedActionsClusterEndpointListStruct : NSObject
@@ -68,14 +76,17 @@
 @property (strong, nonatomic) NSString * _Nonnull name;
 @property (strong, nonatomic) NSNumber * _Nonnull type;
 @property (strong, nonatomic) NSData * _Nonnull endpoints;
+- (instancetype)init;
 @end
 
 @interface CHIPGeneralCommissioningClusterBasicCommissioningInfoType : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull failSafeExpiryLengthMs;
+- (instancetype)init;
 @end
 
 @interface CHIPNetworkCommissioningClusterThreadInterfaceScanResult : NSObject
 @property (strong, nonatomic) NSData * _Nonnull discoveryResponse;
+- (instancetype)init;
 @end
 
 @interface CHIPNetworkCommissioningClusterWiFiInterfaceScanResult : NSObject
@@ -84,6 +95,7 @@
 @property (strong, nonatomic) NSData * _Nonnull bssid;
 @property (strong, nonatomic) NSNumber * _Nonnull channel;
 @property (strong, nonatomic) NSNumber * _Nonnull frequencyBand;
+- (instancetype)init;
 @end
 
 @interface CHIPGeneralDiagnosticsClusterNetworkInterfaceType : NSObject
@@ -93,12 +105,14 @@
 @property (strong, nonatomic) NSNumber * _Nonnull offPremiseServicesReachableIPv6;
 @property (strong, nonatomic) NSData * _Nonnull hardwareAddress;
 @property (strong, nonatomic) NSNumber * _Nonnull type;
+- (instancetype)init;
 @end
 
 @interface CHIPSoftwareDiagnosticsClusterSoftwareFault : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull id;
 @property (strong, nonatomic) NSString * _Nonnull name;
 @property (strong, nonatomic) NSData * _Nonnull faultRecording;
+- (instancetype)init;
 @end
 
 @interface CHIPSoftwareDiagnosticsClusterThreadMetrics : NSObject
@@ -107,6 +121,7 @@
 @property (strong, nonatomic) NSNumber * _Nonnull stackFreeCurrent;
 @property (strong, nonatomic) NSNumber * _Nonnull stackFreeMinimum;
 @property (strong, nonatomic) NSNumber * _Nonnull stackSize;
+- (instancetype)init;
 @end
 
 @interface CHIPThreadNetworkDiagnosticsClusterNeighborTable : NSObject
@@ -124,6 +139,7 @@
 @property (strong, nonatomic) NSNumber * _Nonnull fullThreadDevice;
 @property (strong, nonatomic) NSNumber * _Nonnull fullNetworkData;
 @property (strong, nonatomic) NSNumber * _Nonnull isChild;
+- (instancetype)init;
 @end
 
 @interface CHIPThreadNetworkDiagnosticsClusterOperationalDatasetComponents : NSObject
@@ -139,6 +155,7 @@
 @property (strong, nonatomic) NSNumber * _Nonnull pskcPresent;
 @property (strong, nonatomic) NSNumber * _Nonnull securityPolicyPresent;
 @property (strong, nonatomic) NSNumber * _Nonnull channelMaskPresent;
+- (instancetype)init;
 @end
 
 @interface CHIPThreadNetworkDiagnosticsClusterRouteTable : NSObject
@@ -152,11 +169,13 @@
 @property (strong, nonatomic) NSNumber * _Nonnull age;
 @property (strong, nonatomic) NSNumber * _Nonnull allocated;
 @property (strong, nonatomic) NSNumber * _Nonnull linkEstablished;
+- (instancetype)init;
 @end
 
 @interface CHIPThreadNetworkDiagnosticsClusterSecurityPolicy : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull rotationTime;
 @property (strong, nonatomic) NSNumber * _Nonnull flags;
+- (instancetype)init;
 @end
 
 @interface CHIPOperationalCredentialsClusterFabricDescriptor : NSObject
@@ -166,32 +185,38 @@
 @property (strong, nonatomic) NSNumber * _Nonnull fabricId;
 @property (strong, nonatomic) NSNumber * _Nonnull nodeId;
 @property (strong, nonatomic) NSString * _Nonnull label;
+- (instancetype)init;
 @end
 
 @interface CHIPOperationalCredentialsClusterNOCStruct : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull fabricIndex;
 @property (strong, nonatomic) NSData * _Nonnull noc;
+- (instancetype)init;
 @end
 
 @interface CHIPFixedLabelClusterLabelStruct : NSObject
 @property (strong, nonatomic) NSString * _Nonnull label;
 @property (strong, nonatomic) NSString * _Nonnull value;
+- (instancetype)init;
 @end
 
 @interface CHIPModeSelectClusterModeOptionStruct : NSObject
 @property (strong, nonatomic) NSString * _Nonnull label;
 @property (strong, nonatomic) NSNumber * _Nonnull mode;
 @property (strong, nonatomic) NSNumber * _Nonnull semanticTag;
+- (instancetype)init;
 @end
 
 @interface CHIPModeSelectClusterSemanticTag : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull mfgCode;
 @property (strong, nonatomic) NSNumber * _Nonnull value;
+- (instancetype)init;
 @end
 
 @interface CHIPIasAceClusterIasAceZoneStatusResult : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull zoneId;
 @property (strong, nonatomic) NSNumber * _Nonnull zoneStatus;
+- (instancetype)init;
 @end
 
 @interface CHIPTvChannelClusterTvChannelInfo : NSObject
@@ -200,6 +225,7 @@
 @property (strong, nonatomic) NSString * _Nonnull name;
 @property (strong, nonatomic) NSString * _Nonnull callSign;
 @property (strong, nonatomic) NSString * _Nonnull affiliateCallSign;
+- (instancetype)init;
 @end
 
 @interface CHIPTvChannelClusterTvChannelLineupInfo : NSObject
@@ -207,16 +233,19 @@
 @property (strong, nonatomic) NSString * _Nonnull lineupName;
 @property (strong, nonatomic) NSString * _Nonnull postalCode;
 @property (strong, nonatomic) NSNumber * _Nonnull lineupInfoType;
+- (instancetype)init;
 @end
 
 @interface CHIPTargetNavigatorClusterNavigateTargetTargetInfo : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull identifier;
 @property (strong, nonatomic) NSString * _Nonnull name;
+- (instancetype)init;
 @end
 
 @interface CHIPMediaPlaybackClusterMediaPlaybackPosition : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull updatedAt;
 @property (strong, nonatomic) NSNumber * _Nonnull position;
+- (instancetype)init;
 @end
 
 @interface CHIPMediaInputClusterMediaInputInfo : NSObject
@@ -224,17 +253,20 @@
 @property (strong, nonatomic) NSNumber * _Nonnull inputType;
 @property (strong, nonatomic) NSString * _Nonnull name;
 @property (strong, nonatomic) NSString * _Nonnull descriptionString;
+- (instancetype)init;
 @end
 
 @interface CHIPContentLauncherClusterContentLaunchAdditionalInfo : NSObject
 @property (strong, nonatomic) NSString * _Nonnull name;
 @property (strong, nonatomic) NSString * _Nonnull value;
+- (instancetype)init;
 @end
 
 @interface CHIPContentLauncherClusterContentLaunchParamater : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull type;
 @property (strong, nonatomic) NSString * _Nonnull value;
 @property (strong, nonatomic) NSArray * _Nonnull externalIDList;
+- (instancetype)init;
 @end
 
 @interface CHIPContentLauncherClusterContentLaunchBrandingInformation : NSObject
@@ -244,29 +276,34 @@
 @property (strong, nonatomic) NSNumber * _Nonnull progressBar;
 @property (strong, nonatomic) NSNumber * _Nonnull splash;
 @property (strong, nonatomic) NSNumber * _Nonnull waterMark;
+- (instancetype)init;
 @end
 
 @interface CHIPContentLauncherClusterContentLaunchDimension : NSObject
 @property (strong, nonatomic) NSString * _Nonnull width;
 @property (strong, nonatomic) NSString * _Nonnull height;
 @property (strong, nonatomic) NSNumber * _Nonnull metric;
+- (instancetype)init;
 @end
 
 @interface CHIPContentLauncherClusterContentLaunchStyleInformation : NSObject
 @property (strong, nonatomic) NSString * _Nonnull imageUrl;
 @property (strong, nonatomic) NSString * _Nonnull color;
 @property (strong, nonatomic) NSNumber * _Nonnull size;
+- (instancetype)init;
 @end
 
 @interface CHIPAudioOutputClusterAudioOutputInfo : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull index;
 @property (strong, nonatomic) NSNumber * _Nonnull outputType;
 @property (strong, nonatomic) NSString * _Nonnull name;
+- (instancetype)init;
 @end
 
 @interface CHIPApplicationLauncherClusterApplicationLauncherApp : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull catalogVendorId;
 @property (strong, nonatomic) NSString * _Nonnull applicationId;
+- (instancetype)init;
 @end
 
 @interface CHIPTestClusterClusterSimpleStruct : NSObject
@@ -276,6 +313,7 @@
 @property (strong, nonatomic) NSData * _Nonnull d;
 @property (strong, nonatomic) NSString * _Nonnull e;
 @property (strong, nonatomic) NSNumber * _Nonnull f;
+- (instancetype)init;
 @end
 
 @interface CHIPTestClusterClusterNullablesAndOptionalsStruct : NSObject
@@ -291,12 +329,14 @@
 @property (strong, nonatomic) NSArray * _Nullable nullableList;
 @property (strong, nonatomic) NSArray * _Nullable optionalList;
 @property (strong, nonatomic) NSArray * _Nullable nullableOptionalList;
+- (instancetype)init;
 @end
 
 @interface CHIPTestClusterClusterNestedStruct : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull a;
 @property (strong, nonatomic) NSNumber * _Nonnull b;
 @property (strong, nonatomic) CHIPTestClusterClusterSimpleStruct * _Nonnull c;
+- (instancetype)init;
 @end
 
 @interface CHIPTestClusterClusterNestedStructList : NSObject
@@ -307,15 +347,18 @@
 @property (strong, nonatomic) NSArray * _Nonnull e;
 @property (strong, nonatomic) NSArray * _Nonnull f;
 @property (strong, nonatomic) NSArray * _Nonnull g;
+- (instancetype)init;
 @end
 
 @interface CHIPTestClusterClusterDoubleNestedStructList : NSObject
 @property (strong, nonatomic) NSArray * _Nonnull a;
+- (instancetype)init;
 @end
 
 @interface CHIPTestClusterClusterTestListStructOctet : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull fabricIndex;
 @property (strong, nonatomic) NSData * _Nonnull operationalCert;
+- (instancetype)init;
 @end
 
 @interface CHIPGroupKeyManagementClusterGroupKey : NSObject
@@ -324,12 +367,16 @@
 @property (strong, nonatomic) NSData * _Nonnull groupKeyRoot;
 @property (strong, nonatomic) NSNumber * _Nonnull groupKeyEpochStartTime;
 @property (strong, nonatomic) NSNumber * _Nonnull groupKeySecurityPolicy;
+- (instancetype)init;
 @end
 
 @interface CHIPGroupKeyManagementClusterGroupState : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull vendorId;
 @property (strong, nonatomic) NSNumber * _Nonnull vendorGroupId;
 @property (strong, nonatomic) NSNumber * _Nonnull groupKeySetIndex;
+- (instancetype)init;
 @end
+
+NS_ASSUME_NONNULL_END
 
 #endif /* CHIP_STRUCTS_H */

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPStructsObjc.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPStructsObjc.mm
@@ -19,131 +19,755 @@
 
 #import "CHIPStructsObjc.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @implementation CHIPScenesClusterSceneExtensionFieldSet
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _clusterId = @(0);
+
+        _length = @(0);
+
+        _value = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPPowerProfileClusterPowerProfileRecord
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _powerProfileId = @(0);
+
+        _energyPhaseId = @(0);
+
+        _powerProfileRemoteControl = @(0);
+
+        _powerProfileState = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPPowerProfileClusterScheduledPhase
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _energyPhaseId = @(0);
+
+        _scheduledTime = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPPowerProfileClusterTransferredPhase
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _energyPhaseId = @(0);
+
+        _macroPhaseId = @(0);
+
+        _expectedDuration = @(0);
+
+        _peakPower = @(0);
+
+        _energy = @(0);
+
+        _maxActivationDelay = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPDescriptorClusterDeviceType
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _type = @(0);
+
+        _revision = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPBridgedActionsClusterActionStruct
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _actionID = @(0);
+
+        _name = @"";
+
+        _type = @(0);
+
+        _endpointListID = @(0);
+
+        _supportedCommands = @(0);
+
+        _status = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPBridgedActionsClusterEndpointListStruct
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _endpointListID = @(0);
+
+        _name = @"";
+
+        _type = @(0);
+
+        _endpoints = [NSData data];
+    }
+    return self;
+}
 @end
 
 @implementation CHIPGeneralCommissioningClusterBasicCommissioningInfoType
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _failSafeExpiryLengthMs = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPNetworkCommissioningClusterThreadInterfaceScanResult
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _discoveryResponse = [NSData data];
+    }
+    return self;
+}
 @end
 
 @implementation CHIPNetworkCommissioningClusterWiFiInterfaceScanResult
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _security = @(0);
+
+        _ssid = [NSData data];
+
+        _bssid = [NSData data];
+
+        _channel = @(0);
+
+        _frequencyBand = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPGeneralDiagnosticsClusterNetworkInterfaceType
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _name = @"";
+
+        _fabricConnected = @(0);
+
+        _offPremiseServicesReachableIPv4 = @(0);
+
+        _offPremiseServicesReachableIPv6 = @(0);
+
+        _hardwareAddress = [NSData data];
+
+        _type = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPSoftwareDiagnosticsClusterSoftwareFault
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _id = @(0);
+
+        _name = @"";
+
+        _faultRecording = [NSData data];
+    }
+    return self;
+}
 @end
 
 @implementation CHIPSoftwareDiagnosticsClusterThreadMetrics
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _id = @(0);
+
+        _name = @"";
+
+        _stackFreeCurrent = @(0);
+
+        _stackFreeMinimum = @(0);
+
+        _stackSize = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPThreadNetworkDiagnosticsClusterNeighborTable
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _extAddress = @(0);
+
+        _age = @(0);
+
+        _rloc16 = @(0);
+
+        _linkFrameCounter = @(0);
+
+        _mleFrameCounter = @(0);
+
+        _lqi = @(0);
+
+        _averageRssi = @(0);
+
+        _lastRssi = @(0);
+
+        _frameErrorRate = @(0);
+
+        _messageErrorRate = @(0);
+
+        _rxOnWhenIdle = @(0);
+
+        _fullThreadDevice = @(0);
+
+        _fullNetworkData = @(0);
+
+        _isChild = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPThreadNetworkDiagnosticsClusterOperationalDatasetComponents
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _activeTimestampPresent = @(0);
+
+        _pendingTimestampPresent = @(0);
+
+        _masterKeyPresent = @(0);
+
+        _networkNamePresent = @(0);
+
+        _extendedPanIdPresent = @(0);
+
+        _meshLocalPrefixPresent = @(0);
+
+        _delayPresent = @(0);
+
+        _panIdPresent = @(0);
+
+        _channelPresent = @(0);
+
+        _pskcPresent = @(0);
+
+        _securityPolicyPresent = @(0);
+
+        _channelMaskPresent = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPThreadNetworkDiagnosticsClusterRouteTable
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _extAddress = @(0);
+
+        _rloc16 = @(0);
+
+        _routerId = @(0);
+
+        _nextHop = @(0);
+
+        _pathCost = @(0);
+
+        _lqiIn = @(0);
+
+        _lqiOut = @(0);
+
+        _age = @(0);
+
+        _allocated = @(0);
+
+        _linkEstablished = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPThreadNetworkDiagnosticsClusterSecurityPolicy
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _rotationTime = @(0);
+
+        _flags = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPOperationalCredentialsClusterFabricDescriptor
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _fabricIndex = @(0);
+
+        _rootPublicKey = [NSData data];
+
+        _vendorId = @(0);
+
+        _fabricId = @(0);
+
+        _nodeId = @(0);
+
+        _label = @"";
+    }
+    return self;
+}
 @end
 
 @implementation CHIPOperationalCredentialsClusterNOCStruct
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _fabricIndex = @(0);
+
+        _noc = [NSData data];
+    }
+    return self;
+}
 @end
 
 @implementation CHIPFixedLabelClusterLabelStruct
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _label = @"";
+
+        _value = @"";
+    }
+    return self;
+}
 @end
 
 @implementation CHIPModeSelectClusterModeOptionStruct
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _label = @"";
+
+        _mode = @(0);
+
+        _semanticTag = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPModeSelectClusterSemanticTag
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _mfgCode = @(0);
+
+        _value = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPIasAceClusterIasAceZoneStatusResult
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _zoneId = @(0);
+
+        _zoneStatus = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPTvChannelClusterTvChannelInfo
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _majorNumber = @(0);
+
+        _minorNumber = @(0);
+
+        _name = @"";
+
+        _callSign = @"";
+
+        _affiliateCallSign = @"";
+    }
+    return self;
+}
 @end
 
 @implementation CHIPTvChannelClusterTvChannelLineupInfo
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _operatorName = @"";
+
+        _lineupName = @"";
+
+        _postalCode = @"";
+
+        _lineupInfoType = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPTargetNavigatorClusterNavigateTargetTargetInfo
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _identifier = @(0);
+
+        _name = @"";
+    }
+    return self;
+}
 @end
 
 @implementation CHIPMediaPlaybackClusterMediaPlaybackPosition
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _updatedAt = @(0);
+
+        _position = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPMediaInputClusterMediaInputInfo
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _index = @(0);
+
+        _inputType = @(0);
+
+        _name = @"";
+
+        _descriptionString = @"";
+    }
+    return self;
+}
 @end
 
 @implementation CHIPContentLauncherClusterContentLaunchAdditionalInfo
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _name = @"";
+
+        _value = @"";
+    }
+    return self;
+}
 @end
 
 @implementation CHIPContentLauncherClusterContentLaunchParamater
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _type = @(0);
+
+        _value = @"";
+
+        _externalIDList = [NSArray array];
+    }
+    return self;
+}
 @end
 
 @implementation CHIPContentLauncherClusterContentLaunchBrandingInformation
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _providerName = @"";
+
+        _background = @(0);
+
+        _logo = @(0);
+
+        _progressBar = @(0);
+
+        _splash = @(0);
+
+        _waterMark = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPContentLauncherClusterContentLaunchDimension
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _width = @"";
+
+        _height = @"";
+
+        _metric = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPContentLauncherClusterContentLaunchStyleInformation
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _imageUrl = @"";
+
+        _color = @"";
+
+        _size = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPAudioOutputClusterAudioOutputInfo
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _index = @(0);
+
+        _outputType = @(0);
+
+        _name = @"";
+    }
+    return self;
+}
 @end
 
 @implementation CHIPApplicationLauncherClusterApplicationLauncherApp
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _catalogVendorId = @(0);
+
+        _applicationId = @"";
+    }
+    return self;
+}
 @end
 
 @implementation CHIPTestClusterClusterSimpleStruct
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _a = @(0);
+
+        _b = @(0);
+
+        _c = @(0);
+
+        _d = [NSData data];
+
+        _e = @"";
+
+        _f = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPTestClusterClusterNullablesAndOptionalsStruct
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _nullableInt = nil;
+
+        _optionalInt = nil;
+
+        _nullableOptionalInt = nil;
+
+        _nullableString = nil;
+
+        _optionalString = nil;
+
+        _nullableOptionalString = nil;
+
+        _nullableStruct = nil;
+
+        _optionalStruct = nil;
+
+        _nullableOptionalStruct = nil;
+
+        _nullableList = nil;
+
+        _optionalList = nil;
+
+        _nullableOptionalList = nil;
+    }
+    return self;
+}
 @end
 
 @implementation CHIPTestClusterClusterNestedStruct
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _a = @(0);
+
+        _b = @(0);
+
+        _c = [CHIPTestClusterClusterSimpleStruct new];
+    }
+    return self;
+}
 @end
 
 @implementation CHIPTestClusterClusterNestedStructList
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _a = @(0);
+
+        _b = @(0);
+
+        _c = [CHIPTestClusterClusterSimpleStruct new];
+
+        _d = [NSArray array];
+
+        _e = [NSArray array];
+
+        _f = [NSArray array];
+
+        _g = [NSArray array];
+    }
+    return self;
+}
 @end
 
 @implementation CHIPTestClusterClusterDoubleNestedStructList
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _a = [NSArray array];
+    }
+    return self;
+}
 @end
 
 @implementation CHIPTestClusterClusterTestListStructOctet
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _fabricIndex = @(0);
+
+        _operationalCert = [NSData data];
+    }
+    return self;
+}
 @end
 
 @implementation CHIPGroupKeyManagementClusterGroupKey
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _vendorId = @(0);
+
+        _groupKeyIndex = @(0);
+
+        _groupKeyRoot = [NSData data];
+
+        _groupKeyEpochStartTime = @(0);
+
+        _groupKeySecurityPolicy = @(0);
+    }
+    return self;
+}
 @end
 
 @implementation CHIPGroupKeyManagementClusterGroupState
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _vendorId = @(0);
+
+        _vendorGroupId = @(0);
+
+        _groupKeySetIndex = @(0);
+    }
+    return self;
+}
 @end
+
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
#### Problem
Darwin API structs (command payloads and struct types) do not initialize their members.

#### Change overview
Initialize the members as follows:
* Nullable/optional: `nil`
* List: `[NSArray array]`
* String: `@""`
* Octet string: `[NSData data]`
* Struct: `[StructType new]` (which will of course init its members).
* Numeric: `@(0)`

#### Testing
Code inspection to make sure that we are in fact outputting the initializers and the right things are happening around nil.  Everything else the compiler checks.