### PR TITLE
Add event definitions for OTA Software Update Requestor cluster

### DIFF
--- a/src/app/zap-templates/zcl/data-model/chip/chip-ota.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/chip-ota.xml
@@ -87,6 +87,26 @@ limitations under the License.
         <item name="UpdateAvailable" value="0x1"/>
         <item name="UrgentUpdateAvailable" value="0x2"/>
     </enum>
+    <enum name="UpdateStateEnum" type="ENUM8">
+        <cluster code="0x002a"/>
+        <item name="Unknown" value="0x0"/>
+        <item name="Idle" value="0x1"/>
+        <item name="Querying" value="0x2"/>
+        <item name="DelayedOnQuery" value="0x3"/>
+        <item name="Downloading" value="0x4"/>
+        <item name="Applying" value="0x5"/>       
+        <item name="DelayedOnApply" value="0x6"/>
+        <item name="RollingBack" value="0x7"/>
+        <item name="DelayedOnUserConsent" value="0x8"/>            
+    </enum>
+    <enum name="ChangeReasonEnum" type="ENUM8">
+        <cluster code="0x002a"/>
+        <item name="Unknown" value="0x0"/>
+        <item name="Success" value="0x1"/>
+        <item name="Failure" value="0x2"/>
+        <item name="TimeOut" value="0x3"/>
+        <item name="DelayByProvider" value="0x4"/>
+    </enum>         
     <cluster>
         <name>OTA Software Update Requestor</name>
         <domain>CHIP</domain>
@@ -104,5 +124,24 @@ limitations under the License.
             <arg name="announcementReason" type="OTAAnnouncementReason"/>
             <arg name="metadataForNode" type="OCTET_STRING" length="512" optional="true"/>
         </command>
+        <event side="server" code="0x00" name="StateTransition" priority="info" optional="false">
+          <description>This event SHALL be generated when a change of the UpdateState attribute occurs due to an OTA Requestor moving through the states necessary to query for updates.</description>
+          <field id="0" name="PreviousState" type="UpdateStateEnum"/>
+          <field id="1" name="NewState" type="UpdateStateEnum"/>
+          <field id="2" name="Reason" type="ChangeReasonEnum"/>
+          <field id="3" name="TargetSoftwareVersion" type="INT32U"/>                 
+        </event> 
+        <event side="server" code="0x01" name="VersionApplied" priority="critical" optional="false">
+          <description>This event SHALL be generated whenever a new version starts executing after being applied due to a software update.</description>
+          <field id="0" name="SoftwareVersion" type="INT32U"/> 
+          <field id="1" name="ProductID" type="INT16U"/> 
+        </event>
+        <event side="server" code="0x02" name="DownloadError" priority="info" optional="false">
+          <description>This event SHALL be generated whenever an error occurs during OTA Requestor download operation.</description>
+          <field id="0" name="SoftwareVersion" type="INT32U"/> 
+          <field id="1" name="BytesDownloaded" type="INT64U"/>
+          <field id="2" name="ProgressPercent" type="INT8U"/> 
+          <field id="3" name="PlatformCode" type="INT64S"/>         
+        </event>                     
     </cluster>
 </configurator>

--- a/src/controller/python/chip/clusters/Objects.py
+++ b/src/controller/python/chip/clusters/Objects.py
@@ -5794,10 +5794,28 @@ class OtaSoftwareUpdateRequestor(Cluster):
     id: typing.ClassVar[int] = 0x002A
 
     class Enums:
+        class ChangeReasonEnum(IntEnum):
+            kUnknown = 0x00
+            kSuccess = 0x01
+            kFailure = 0x02
+            kTimeOut = 0x03
+            kDelayByProvider = 0x04
+
         class OTAAnnouncementReason(IntEnum):
             kSimpleAnnouncement = 0x00
             kUpdateAvailable = 0x01
             kUrgentUpdateAvailable = 0x02
+
+        class UpdateStateEnum(IntEnum):
+            kUnknown = 0x00
+            kIdle = 0x01
+            kQuerying = 0x02
+            kDelayedOnQuery = 0x03
+            kDownloading = 0x04
+            kApplying = 0x05
+            kDelayedOnApply = 0x06
+            kRollingBack = 0x07
+            kDelayedOnUserConsent = 0x08
 
     class Commands:
         @dataclass
@@ -5889,6 +5907,73 @@ class OtaSoftwareUpdateRequestor(Cluster):
                 return ClusterObjectFieldDescriptor(Type=uint)
 
             value: 'uint' = None
+
+    class Events:
+        @dataclass
+        class StateTransition(ClusterEventDescriptor):
+            cluster_id: typing.ClassVar[int] = 0x002A
+            event_id: typing.ClassVar[int] = 0x00000000
+
+            @ChipUtility.classproperty
+            def descriptor(cls) -> ClusterObjectDescriptor:
+                return ClusterObjectDescriptor(
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="previousState", Tag=0, Type=OtaSoftwareUpdateRequestor.Enums.UpdateStateEnum),
+                        ClusterObjectFieldDescriptor(
+                            Label="newState", Tag=1, Type=OtaSoftwareUpdateRequestor.Enums.UpdateStateEnum),
+                        ClusterObjectFieldDescriptor(
+                            Label="reason", Tag=2, Type=OtaSoftwareUpdateRequestor.Enums.ChangeReasonEnum),
+                        ClusterObjectFieldDescriptor(
+                            Label="targetSoftwareVersion", Tag=3, Type=uint),
+                    ])
+
+            previousState: 'OtaSoftwareUpdateRequestor.Enums.UpdateStateEnum' = None
+            newState: 'OtaSoftwareUpdateRequestor.Enums.UpdateStateEnum' = None
+            reason: 'OtaSoftwareUpdateRequestor.Enums.ChangeReasonEnum' = None
+            targetSoftwareVersion: 'uint' = None
+
+        @dataclass
+        class VersionApplied(ClusterEventDescriptor):
+            cluster_id: typing.ClassVar[int] = 0x002A
+            event_id: typing.ClassVar[int] = 0x00000001
+
+            @ChipUtility.classproperty
+            def descriptor(cls) -> ClusterObjectDescriptor:
+                return ClusterObjectDescriptor(
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="softwareVersion", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="productID", Tag=1, Type=uint),
+                    ])
+
+            softwareVersion: 'uint' = None
+            productID: 'uint' = None
+
+        @dataclass
+        class DownloadError(ClusterEventDescriptor):
+            cluster_id: typing.ClassVar[int] = 0x002A
+            event_id: typing.ClassVar[int] = 0x00000002
+
+            @ChipUtility.classproperty
+            def descriptor(cls) -> ClusterObjectDescriptor:
+                return ClusterObjectDescriptor(
+                    Fields=[
+                        ClusterObjectFieldDescriptor(
+                            Label="softwareVersion", Tag=0, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="bytesDownloaded", Tag=1, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="progressPercent", Tag=2, Type=uint),
+                        ClusterObjectFieldDescriptor(
+                            Label="platformCode", Tag=3, Type=int),
+                    ])
+
+            softwareVersion: 'uint' = None
+            bytesDownloaded: 'uint' = None
+            progressPercent: 'uint' = None
+            platformCode: 'int' = None
 
 
 @dataclass

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.cpp
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.cpp
@@ -5059,6 +5059,137 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 } // namespace Commands
 
 namespace Events {
+namespace StateTransition {
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
+{
+    TLV::TLVType outer;
+    ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kPreviousState)), previousState));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kNewState)), newState));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kReason)), reason));
+    ReturnErrorOnFailure(
+        DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kTargetSoftwareVersion)), targetSoftwareVersion));
+    ReturnErrorOnFailure(writer.EndContainer(outer));
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    TLV::TLVType outer;
+    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
+    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    while ((err = reader.Next()) == CHIP_NO_ERROR)
+    {
+        VerifyOrReturnError(TLV::IsContextTag(reader.GetTag()), CHIP_ERROR_INVALID_TLV_TAG);
+        switch (TLV::TagNumFromTag(reader.GetTag()))
+        {
+        case to_underlying(Fields::kPreviousState):
+            ReturnErrorOnFailure(DataModel::Decode(reader, previousState));
+            break;
+        case to_underlying(Fields::kNewState):
+            ReturnErrorOnFailure(DataModel::Decode(reader, newState));
+            break;
+        case to_underlying(Fields::kReason):
+            ReturnErrorOnFailure(DataModel::Decode(reader, reason));
+            break;
+        case to_underlying(Fields::kTargetSoftwareVersion):
+            ReturnErrorOnFailure(DataModel::Decode(reader, targetSoftwareVersion));
+            break;
+        default:
+            break;
+        }
+    }
+
+    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
+    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    return CHIP_NO_ERROR;
+}
+} // namespace StateTransition.
+namespace VersionApplied {
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
+{
+    TLV::TLVType outer;
+    ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kSoftwareVersion)), softwareVersion));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kProductID)), productID));
+    ReturnErrorOnFailure(writer.EndContainer(outer));
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    TLV::TLVType outer;
+    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
+    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    while ((err = reader.Next()) == CHIP_NO_ERROR)
+    {
+        VerifyOrReturnError(TLV::IsContextTag(reader.GetTag()), CHIP_ERROR_INVALID_TLV_TAG);
+        switch (TLV::TagNumFromTag(reader.GetTag()))
+        {
+        case to_underlying(Fields::kSoftwareVersion):
+            ReturnErrorOnFailure(DataModel::Decode(reader, softwareVersion));
+            break;
+        case to_underlying(Fields::kProductID):
+            ReturnErrorOnFailure(DataModel::Decode(reader, productID));
+            break;
+        default:
+            break;
+        }
+    }
+
+    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
+    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    return CHIP_NO_ERROR;
+}
+} // namespace VersionApplied.
+namespace DownloadError {
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
+{
+    TLV::TLVType outer;
+    ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kSoftwareVersion)), softwareVersion));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kBytesDownloaded)), bytesDownloaded));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kProgressPercent)), progressPercent));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kPlatformCode)), platformCode));
+    ReturnErrorOnFailure(writer.EndContainer(outer));
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    TLV::TLVType outer;
+    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
+    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    while ((err = reader.Next()) == CHIP_NO_ERROR)
+    {
+        VerifyOrReturnError(TLV::IsContextTag(reader.GetTag()), CHIP_ERROR_INVALID_TLV_TAG);
+        switch (TLV::TagNumFromTag(reader.GetTag()))
+        {
+        case to_underlying(Fields::kSoftwareVersion):
+            ReturnErrorOnFailure(DataModel::Decode(reader, softwareVersion));
+            break;
+        case to_underlying(Fields::kBytesDownloaded):
+            ReturnErrorOnFailure(DataModel::Decode(reader, bytesDownloaded));
+            break;
+        case to_underlying(Fields::kProgressPercent):
+            ReturnErrorOnFailure(DataModel::Decode(reader, progressPercent));
+            break;
+        case to_underlying(Fields::kPlatformCode):
+            ReturnErrorOnFailure(DataModel::Decode(reader, platformCode));
+            break;
+        default:
+            break;
+        }
+    }
+
+    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
+    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    return CHIP_NO_ERROR;
+}
+} // namespace DownloadError.
 } // namespace Events
 
 } // namespace OtaSoftwareUpdateRequestor

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
@@ -7294,6 +7294,21 @@ namespace OtaSoftwareUpdateRequestor {
 // Need to convert consumers to using the new enum classes, so we
 // don't just have casts all over.
 #ifdef CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
+// Enum for ChangeReasonEnum
+enum class ChangeReasonEnum : uint8_t
+{
+    kUnknown         = 0x00,
+    kSuccess         = 0x01,
+    kFailure         = 0x02,
+    kTimeOut         = 0x03,
+    kDelayByProvider = 0x04,
+};
+#else // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
+using ChangeReasonEnum                     = EmberAfChangeReasonEnum;
+#endif
+// Need to convert consumers to using the new enum classes, so we
+// don't just have casts all over.
+#ifdef CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
 // Enum for OTAAnnouncementReason
 enum class OTAAnnouncementReason : uint8_t
 {
@@ -7303,6 +7318,25 @@ enum class OTAAnnouncementReason : uint8_t
 };
 #else // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
 using OTAAnnouncementReason                = EmberAfOTAAnnouncementReason;
+#endif
+// Need to convert consumers to using the new enum classes, so we
+// don't just have casts all over.
+#ifdef CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
+// Enum for UpdateStateEnum
+enum class UpdateStateEnum : uint8_t
+{
+    kUnknown              = 0x00,
+    kIdle                 = 0x01,
+    kQuerying             = 0x02,
+    kDelayedOnQuery       = 0x03,
+    kDownloading          = 0x04,
+    kApplying             = 0x05,
+    kDelayedOnApply       = 0x06,
+    kRollingBack          = 0x07,
+    kDelayedOnUserConsent = 0x08,
+};
+#else // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
+using UpdateStateEnum                      = EmberAfUpdateStateEnum;
 #endif
 
 namespace Commands {
@@ -7403,6 +7437,128 @@ struct TypeInfo
 };
 } // namespace ClusterRevision
 } // namespace Attributes
+namespace Events {
+namespace StateTransition {
+static constexpr PriorityLevel kPriorityLevel = PriorityLevel::Info;
+static constexpr EventId kEventId             = 0x00000000;
+
+enum class Fields
+{
+    kPreviousState         = 0,
+    kNewState              = 1,
+    kReason                = 2,
+    kTargetSoftwareVersion = 3,
+};
+
+struct Type
+{
+public:
+    static constexpr PriorityLevel GetPriorityLevel() { return kPriorityLevel; }
+    static constexpr EventId GetEventId() { return kEventId; }
+    static constexpr ClusterId GetClusterId() { return Clusters::OtaSoftwareUpdateRequestor::Id; }
+
+    UpdateStateEnum previousState;
+    UpdateStateEnum newState;
+    ChangeReasonEnum reason;
+    uint32_t targetSoftwareVersion;
+
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+};
+
+struct DecodableType
+{
+public:
+    static constexpr PriorityLevel GetPriorityLevel() { return kPriorityLevel; }
+    static constexpr EventId GetEventId() { return kEventId; }
+    static constexpr ClusterId GetClusterId() { return Clusters::OtaSoftwareUpdateRequestor::Id; }
+
+    UpdateStateEnum previousState;
+    UpdateStateEnum newState;
+    ChangeReasonEnum reason;
+    uint32_t targetSoftwareVersion;
+
+    CHIP_ERROR Decode(TLV::TLVReader & reader);
+};
+} // namespace StateTransition
+namespace VersionApplied {
+static constexpr PriorityLevel kPriorityLevel = PriorityLevel::Critical;
+static constexpr EventId kEventId             = 0x00000001;
+
+enum class Fields
+{
+    kSoftwareVersion = 0,
+    kProductID       = 1,
+};
+
+struct Type
+{
+public:
+    static constexpr PriorityLevel GetPriorityLevel() { return kPriorityLevel; }
+    static constexpr EventId GetEventId() { return kEventId; }
+    static constexpr ClusterId GetClusterId() { return Clusters::OtaSoftwareUpdateRequestor::Id; }
+
+    uint32_t softwareVersion;
+    uint16_t productID;
+
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+};
+
+struct DecodableType
+{
+public:
+    static constexpr PriorityLevel GetPriorityLevel() { return kPriorityLevel; }
+    static constexpr EventId GetEventId() { return kEventId; }
+    static constexpr ClusterId GetClusterId() { return Clusters::OtaSoftwareUpdateRequestor::Id; }
+
+    uint32_t softwareVersion;
+    uint16_t productID;
+
+    CHIP_ERROR Decode(TLV::TLVReader & reader);
+};
+} // namespace VersionApplied
+namespace DownloadError {
+static constexpr PriorityLevel kPriorityLevel = PriorityLevel::Info;
+static constexpr EventId kEventId             = 0x00000002;
+
+enum class Fields
+{
+    kSoftwareVersion = 0,
+    kBytesDownloaded = 1,
+    kProgressPercent = 2,
+    kPlatformCode    = 3,
+};
+
+struct Type
+{
+public:
+    static constexpr PriorityLevel GetPriorityLevel() { return kPriorityLevel; }
+    static constexpr EventId GetEventId() { return kEventId; }
+    static constexpr ClusterId GetClusterId() { return Clusters::OtaSoftwareUpdateRequestor::Id; }
+
+    uint32_t softwareVersion;
+    uint64_t bytesDownloaded;
+    uint8_t progressPercent;
+    int64_t platformCode;
+
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+};
+
+struct DecodableType
+{
+public:
+    static constexpr PriorityLevel GetPriorityLevel() { return kPriorityLevel; }
+    static constexpr EventId GetEventId() { return kEventId; }
+    static constexpr ClusterId GetClusterId() { return Clusters::OtaSoftwareUpdateRequestor::Id; }
+
+    uint32_t softwareVersion;
+    uint64_t bytesDownloaded;
+    uint8_t progressPercent;
+    int64_t platformCode;
+
+    CHIP_ERROR Decode(TLV::TLVReader & reader);
+};
+} // namespace DownloadError
+} // namespace Events
 } // namespace OtaSoftwareUpdateRequestor
 namespace LocalizationConfiguration {
 

--- a/zzz_generated/app-common/app-common/zap-generated/enums.h
+++ b/zzz_generated/app-common/app-common/zap-generated/enums.h
@@ -259,6 +259,16 @@ enum EmberAfCecedSpecificationVersion : uint8_t
     EMBER_ZCL_CECED_SPECIFICATION_VERSION_COMPLIANT_WITH_V10_CERTIFIED     = 26,
 };
 
+// Enum for ChangeReasonEnum
+enum EmberAfChangeReasonEnum : uint8_t
+{
+    EMBER_ZCL_CHANGE_REASON_ENUM_UNKNOWN           = 0,
+    EMBER_ZCL_CHANGE_REASON_ENUM_SUCCESS           = 1,
+    EMBER_ZCL_CHANGE_REASON_ENUM_FAILURE           = 2,
+    EMBER_ZCL_CHANGE_REASON_ENUM_TIME_OUT          = 3,
+    EMBER_ZCL_CHANGE_REASON_ENUM_DELAY_BY_PROVIDER = 4,
+};
+
 // Enum for ColorControlOptions
 enum EmberAfColorControlOptions : uint8_t
 {
@@ -1595,6 +1605,20 @@ enum EmberAfTvChannelErrorType : uint8_t
 enum EmberAfTvChannelLineupInfoType : uint8_t
 {
     EMBER_ZCL_TV_CHANNEL_LINEUP_INFO_TYPE_MSO = 0,
+};
+
+// Enum for UpdateStateEnum
+enum EmberAfUpdateStateEnum : uint8_t
+{
+    EMBER_ZCL_UPDATE_STATE_ENUM_UNKNOWN                 = 0,
+    EMBER_ZCL_UPDATE_STATE_ENUM_IDLE                    = 1,
+    EMBER_ZCL_UPDATE_STATE_ENUM_QUERYING                = 2,
+    EMBER_ZCL_UPDATE_STATE_ENUM_DELAYED_ON_QUERY        = 3,
+    EMBER_ZCL_UPDATE_STATE_ENUM_DOWNLOADING             = 4,
+    EMBER_ZCL_UPDATE_STATE_ENUM_APPLYING                = 5,
+    EMBER_ZCL_UPDATE_STATE_ENUM_DELAYED_ON_APPLY        = 6,
+    EMBER_ZCL_UPDATE_STATE_ENUM_ROLLING_BACK            = 7,
+    EMBER_ZCL_UPDATE_STATE_ENUM_DELAYED_ON_USER_CONSENT = 8,
 };
 
 // Enum for WarningEvent


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* The  event definitions for OTA Software Update Requestor cluster are missing.

#### Change overview
Add event definitions for OTA Software Update Requestor cluster

#### Testing
How was this tested? (at least one bullet point required)
* Only xml definitions, no logic change, covered by CI