### PR TITLE
[NetworkCommissioning] Send Response Command instead of status code for network commissioning cluster

### DIFF
--- a/src/app/clusters/network-commissioning/network-commissioning-ember.cpp
+++ b/src/app/clusters/network-commissioning/network-commissioning-ember.cpp
@@ -43,10 +43,8 @@ bool emberAfNetworkCommissioningClusterAddThreadNetworkCallback(app::CommandHand
     auto & breadcrumb         = commandData.breadcrumb;
     auto & timeoutMs          = commandData.timeoutMs;
 
-    EmberAfNetworkCommissioningError err = app::Clusters::NetworkCommissioning::OnAddThreadNetworkCommandCallbackInternal(
-        nullptr, emberAfCurrentEndpoint(), operationalDataset, breadcrumb, timeoutMs);
-    emberAfSendImmediateDefaultResponse(err == EMBER_ZCL_NETWORK_COMMISSIONING_ERROR_SUCCESS ? EMBER_ZCL_STATUS_SUCCESS
-                                                                                             : EMBER_ZCL_STATUS_FAILURE);
+    app::Clusters::NetworkCommissioning::OnAddThreadNetworkCommandCallbackInternal(commandObj, commandPath, operationalDataset,
+                                                                                   breadcrumb, timeoutMs);
     return true;
 }
 
@@ -59,10 +57,8 @@ bool emberAfNetworkCommissioningClusterAddWiFiNetworkCallback(app::CommandHandle
     auto & breadcrumb  = commandData.breadcrumb;
     auto & timeoutMs   = commandData.timeoutMs;
 
-    EmberAfNetworkCommissioningError err = app::Clusters::NetworkCommissioning::OnAddWiFiNetworkCommandCallbackInternal(
-        nullptr, emberAfCurrentEndpoint(), ssid, credentials, breadcrumb, timeoutMs);
-    emberAfSendImmediateDefaultResponse(err == EMBER_ZCL_NETWORK_COMMISSIONING_ERROR_SUCCESS ? EMBER_ZCL_STATUS_SUCCESS
-                                                                                             : EMBER_ZCL_STATUS_FAILURE);
+    app::Clusters::NetworkCommissioning::OnAddWiFiNetworkCommandCallbackInternal(commandObj, commandPath, ssid, credentials,
+                                                                                 breadcrumb, timeoutMs);
     return true;
 }
 
@@ -74,10 +70,8 @@ bool emberAfNetworkCommissioningClusterEnableNetworkCallback(app::CommandHandler
     auto & breadcrumb = commandData.breadcrumb;
     auto & timeoutMs  = commandData.timeoutMs;
 
-    EmberAfNetworkCommissioningError err = app::Clusters::NetworkCommissioning::OnEnableNetworkCommandCallbackInternal(
-        nullptr, emberAfCurrentEndpoint(), networkID, breadcrumb, timeoutMs);
-    emberAfSendImmediateDefaultResponse(err == EMBER_ZCL_NETWORK_COMMISSIONING_ERROR_SUCCESS ? EMBER_ZCL_STATUS_SUCCESS
-                                                                                             : EMBER_ZCL_STATUS_FAILURE);
+    app::Clusters::NetworkCommissioning::OnEnableNetworkCommandCallbackInternal(commandObj, commandPath, networkID, breadcrumb,
+                                                                                timeoutMs);
     return true;
 }
 

--- a/src/app/clusters/network-commissioning/network-commissioning.h
+++ b/src/app/clusters/network-commissioning/network-commissioning.h
@@ -27,14 +27,12 @@ namespace chip {
 namespace app {
 namespace Clusters {
 namespace NetworkCommissioning {
-EmberAfNetworkCommissioningError OnAddThreadNetworkCommandCallbackInternal(app::CommandHandler *, EndpointId,
-                                                                           ByteSpan operationalDataset, uint64_t breadcrumb,
-                                                                           uint32_t timeoutMs);
-EmberAfNetworkCommissioningError OnAddWiFiNetworkCommandCallbackInternal(app::CommandHandler *, EndpointId, ByteSpan ssid,
-                                                                         ByteSpan credentials, uint64_t breadcrumb,
-                                                                         uint32_t timeoutMs);
-EmberAfNetworkCommissioningError OnEnableNetworkCommandCallbackInternal(app::CommandHandler *, EndpointId, ByteSpan networkID,
-                                                                        uint64_t breadcrumb, uint32_t timeoutMs);
+void OnAddThreadNetworkCommandCallbackInternal(app::CommandHandler *, const app::ConcreteCommandPath & commandPath,
+                                               ByteSpan operationalDataset, uint64_t breadcrumb, uint32_t timeoutMs);
+void OnAddWiFiNetworkCommandCallbackInternal(app::CommandHandler *, const app::ConcreteCommandPath & commandPath, ByteSpan ssid,
+                                             ByteSpan credentials, uint64_t breadcrumb, uint32_t timeoutMs);
+void OnEnableNetworkCommandCallbackInternal(app::CommandHandler *, const app::ConcreteCommandPath & commandPath, ByteSpan networkID,
+                                            uint64_t breadcrumb, uint32_t timeoutMs);
 } // namespace NetworkCommissioning
 
 } // namespace Clusters

--- a/src/controller/python/test/test_scripts/base.py
+++ b/src/controller/python/test/test_scripts/base.py
@@ -151,10 +151,14 @@ class BaseTestHelper:
     def TestNetworkCommissioning(self, nodeid: int, endpoint: int, group: int, dataset: str, network_id: str):
         self.logger.info("Commissioning network to device {}".format(nodeid))
         try:
-            self.devCtrl.ZCLSend("NetworkCommissioning", "AddThreadNetwork", nodeid, endpoint, group, {
+            (err, resp) = self.devCtrl.ZCLSend("NetworkCommissioning", "AddThreadNetwork", nodeid, endpoint, group, {
                 "operationalDataset": bytes.fromhex(dataset),
                 "breadcrumb": 0,
                 "timeoutMs": 1000}, blocking=True)
+            self.logger.info(f"Received response: {resp}")
+            if resp.errorCode != 0:
+                self.logger.exception("Failed to add Thread network.")
+                return False
         except Exception as ex:
             self.logger.exception("Failed to send AddThreadNetwork command")
             return False
@@ -165,6 +169,10 @@ class BaseTestHelper:
                 "networkID": bytes.fromhex(network_id),
                 "breadcrumb": 0,
                 "timeoutMs": 1000}, blocking=True)
+            self.logger.info(f"Received response: {resp}")
+            if resp.errorCode != 0:
+                self.logger.exception("Failed to enable Thread network.")
+                return False
         except Exception as ex:
             self.logger.exception("Failed to send EnableNetwork command")
             return False


### PR DESCRIPTION
#### Problem

Network Commissioning cluster commands are sending status codes instead of cluster commands, this should be fixed

Fixes #12006

#### Change overview

- Use cluster object to encode command response

#### Testing
- Updated Cirque test case to verify the response.
