### PR TITLE
Use CASESessionManager to establish CASE sessions from OTA Requestor application

### DIFF
--- a/examples/ota-requestor-app/linux/BUILD.gn
+++ b/examples/ota-requestor-app/linux/BUILD.gn
@@ -23,6 +23,7 @@ executable("chip-ota-requestor-app") {
     "${chip_root}/examples/platform/linux:app-main",
     "${chip_root}/src/app/server",
     "${chip_root}/src/lib",
+    "${chip_root}/src/transport",
   ]
 
   cflags = [ "-Wconversion" ]

--- a/src/app/CASESessionManager.h
+++ b/src/app/CASESessionManager.h
@@ -53,6 +53,9 @@ public:
         VerifyOrReturn(params.sessionInitParams.Validate() == CHIP_NO_ERROR);
 
         mConfig = params;
+
+        // TODO: Revisit who should be set as the resolver delegate
+        Dnssd::Resolver::Instance().SetResolverDelegate(this);
     }
 
     virtual ~CASESessionManager() {}

--- a/src/app/server/Server.h
+++ b/src/app/server/Server.h
@@ -17,7 +17,6 @@
 
 #pragma once
 
-#include <app/OperationalDeviceProxy.h>
 #include <app/server/AppDelegate.h>
 #include <app/server/CommissioningWindowManager.h>
 #include <inet/InetConfig.h>
@@ -71,13 +70,6 @@ public:
     SessionManager & GetSecureSessionManager() { return mSessions; }
 
     TransportMgrBase & GetTransportManager() { return mTransports; }
-
-    chip::OperationalDeviceProxy * GetOperationalDeviceProxy() { return mOperationalDeviceProxy; }
-
-    void SetOperationalDeviceProxy(chip::OperationalDeviceProxy * operationalDeviceProxy)
-    {
-        mOperationalDeviceProxy = operationalDeviceProxy;
-    }
 
 #if CONFIG_NETWORK_LAYER_BLE
     Ble::BleLayer * getBleLayerObject() { return mBleLayer; }
@@ -148,8 +140,6 @@ private:
 
     ServerStorageDelegate mServerStorage;
     CommissioningWindowManager mCommissioningWindowManager;
-
-    chip::OperationalDeviceProxy * mOperationalDeviceProxy = nullptr;
 
     // TODO @ceille: Maybe use OperationalServicePort and CommissionableServicePort
     uint16_t mSecuredServicePort;


### PR DESCRIPTION
#### Problem
Previously, OTA requestor had to pass in the IP address of the peer node it wants to connect to. The IP address should be resolved from a peer node ID.

#### Change overview
- Use the CASESessionManager class to connect to peer nodes to send QueryImage command. IP address will be automatically resolved by this class.
- Update OTA Provider to supply the provider node ID in the BDX ImageURI
- Update OTA requestor to parse the provider node ID from the BDX ImageURI and use CSM to connect to the provider node ID parsed and initiate BDX transfer that way

#### Testing
Manually verified that there are no regression with OTA Requestor/Provider communicating via CASE session and BDX download occurs successfully