### PR TITLE
ESP32: Remove unnecessary while(1) from examples

### DIFF
--- a/examples/all-clusters-app/esp32/main/main.cpp
+++ b/examples/all-clusters-app/esp32/main/main.cpp
@@ -682,10 +682,10 @@ extern "C" void app_main()
 
 #endif // CONFIG_HAVE_DISPLAY
 
+#if CONFIG_DEVICE_TYPE_M5STACK
     // Run the UI Loop
     while (true)
     {
-#if CONFIG_DEVICE_TYPE_M5STACK
         // TODO consider refactoring this example to use FreeRTOS tasks
 
         bool woken = false;
@@ -710,10 +710,9 @@ extern "C" void app_main()
             }
         }
 
-#endif // CONFIG_DEVICE_TYPE_M5STACK
-
         vTaskDelay(50 / portTICK_PERIOD_MS);
     }
+#endif // CONFIG_DEVICE_TYPE_M5STACK
 }
 
 bool lowPowerClusterSleep()

--- a/examples/ota-provider-app/esp32/main/main.cpp
+++ b/examples/ota-provider-app/esp32/main/main.cpp
@@ -225,10 +225,4 @@ extern "C" void app_main()
         ChipLogError(BDX, "Failed to init BDX server: %s", chip::ErrorStr(error));
         return;
     }
-
-    // Run the UI Loop
-    while (true)
-    {
-        vTaskDelay(50 / portTICK_PERIOD_MS);
-    }
 }

--- a/examples/ota-requestor-app/esp32/main/main.cpp
+++ b/examples/ota-requestor-app/esp32/main/main.cpp
@@ -179,10 +179,4 @@ extern "C" void app_main()
     SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
 
     ESPInitConsole();
-
-    // Run the UI Loop
-    while (true)
-    {
-        vTaskDelay(50 / portTICK_PERIOD_MS);
-    }
 }

--- a/examples/pigweed-app/esp32/main/main.cpp
+++ b/examples/pigweed-app/esp32/main/main.cpp
@@ -64,9 +64,4 @@ extern "C" void app_main()
     ESP_LOGI(TAG, "----------- chip-esp32-pigweed-example starting -----------");
 
     xTaskCreate(RunRpcService, "RPC", kRpcStackSizeBytes / sizeof(StackType_t), nullptr, kRpcTaskPriority, &rpcTaskHandle);
-
-    while (1)
-    {
-        vTaskDelay(50 / portTICK_PERIOD_MS);
-    }
 }

--- a/examples/temperature-measurement-app/esp32/main/main.cpp
+++ b/examples/temperature-measurement-app/esp32/main/main.cpp
@@ -84,10 +84,4 @@ extern "C" void app_main()
 
     // Initialize device attestation config
     SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
-
-    // Run the UI Loop
-    while (true)
-    {
-        vTaskDelay(50 / portTICK_PERIOD_MS);
-    }
 }


### PR DESCRIPTION
#### Problem
The ESP32 all-clusters-app main has an infinite while loop. This is ideally required to handle UI events (for M5Stack). It is not required for other boards and the memory for main stack can be reclaimed as heap (around 3.5KB)

This has been copied across a few examples for ESP32

#### Change overview
Remove the unnecessary while or keep it under M5Stack config option (wherever supported) so that the main task returns and is deleted

#### Testing
1. Boot up of all-clusters-app, followed by commissioning on ESP32. Also, verified that the free heap has increased around 3.5KB (size of main task)
2. Boot up of all-clusters-app, followed by commissioning on M5Stack. Verified that the M5Stack UI works fine as well