### PR TITLE
Fix echo_requester TCP leak

### DIFF
--- a/src/messaging/tests/echo/echo_requester.cpp
+++ b/src/messaging/tests/echo/echo_requester.cpp
@@ -269,6 +269,7 @@ int main(int argc, char * argv[])
     chip::DeviceLayer::PlatformMgr().RunEventLoop();
 
     gUDPManager.Close();
+    gTCPManager.Close();
 
     Shutdown();
 


### PR DESCRIPTION
#### Problem

`echo_requester.cpp` leaks TCP endpoints.

Instance of #11880 _Possible use of destroyed pool objects_

#### Change overview

Shut down `TCPManager`.

#### Testing

If `ObjectPool` checks that objects do not outlive it
(originally part of PR #11698 but deferred due to current leaks),
then Cirque CI fails without this change.
