### PR TITLE
Add an accessing fabric index to AttributeAccessInterface writes.

### DIFF
--- a/src/app/AttributeAccessInterface.h
+++ b/src/app/AttributeAccessInterface.h
@@ -105,7 +105,9 @@ private:
 class AttributeValueDecoder
 {
 public:
-    AttributeValueDecoder(TLV::TLVReader & aReader) : mReader(aReader) {}
+    AttributeValueDecoder(TLV::TLVReader & aReader, FabricIndex aAccessingFabricIndex) :
+        mReader(aReader), mAccessingFabricIndex(aAccessingFabricIndex)
+    {}
 
     template <typename T>
     CHIP_ERROR Decode(T & aArg)
@@ -116,9 +118,15 @@ public:
 
     bool TriedDecode() const { return mTriedDecode; }
 
+    /**
+     * The accessing fabric index for this write interaction.
+     */
+    FabricIndex AccessingFabricIndex() const { return mAccessingFabricIndex; }
+
 private:
     TLV::TLVReader & mReader;
     bool mTriedDecode = false;
+    const FabricIndex mAccessingFabricIndex;
 };
 
 class AttributeAccessInterface

--- a/src/app/WriteHandler.cpp
+++ b/src/app/WriteHandler.cpp
@@ -252,6 +252,11 @@ exit:
     return err;
 }
 
+FabricIndex WriteHandler::GetAccessingFabricIndex() const
+{
+    return mpExchangeCtx->GetSessionHandle().GetFabricIndex();
+}
+
 const char * WriteHandler::GetStateStr() const
 {
 #if CHIP_DETAIL_LOGGING

--- a/src/app/WriteHandler.h
+++ b/src/app/WriteHandler.h
@@ -84,6 +84,8 @@ public:
         return CHIP_ERROR_NOT_IMPLEMENTED;
     }
 
+    FabricIndex GetAccessingFabricIndex() const;
+
 private:
     enum class State
     {

--- a/src/app/util/ember-compatibility-functions.cpp
+++ b/src/app/util/ember-compatibility-functions.cpp
@@ -592,7 +592,7 @@ CHIP_ERROR WriteSingleClusterData(ClusterInfo & aClusterInfo, TLV::TLVReader & a
     AttributeAccessInterface * attrOverride = findAttributeAccessOverride(aClusterInfo.mEndpointId, aClusterInfo.mClusterId);
     if (attrOverride != nullptr)
     {
-        AttributeValueDecoder valueDecoder(aReader);
+        AttributeValueDecoder valueDecoder(aReader, apWriteHandler->GetAccessingFabricIndex());
         ReturnErrorOnFailure(attrOverride->Write(aPath, valueDecoder));
 
         if (valueDecoder.TriedDecode())


### PR DESCRIPTION
We will need this for bindings.

#### Problem
No way to get fabric info in an AttributeAccessInterface write.

#### Change overview
Add GetAccessingFabricIndex on `AttributeValueDecoder` like we have for `AttributeValueEncoder`

#### Testing
Compiles.  No consumers yet.