### PR TITLE
Group MRP parameters

### DIFF
--- a/examples/ota-requestor-app/esp32/main/OTARequesterImpl.cpp
+++ b/examples/ota-requestor-app/esp32/main/OTARequesterImpl.cpp
@@ -302,10 +302,7 @@ void ConnectToProvider(const char * ipAddress, uint32_t nodeId)
         IPAddress ipAddr;
         IPAddress::FromString(ipAddress, ipAddr);
         PeerAddress addr = PeerAddress::UDP(ipAddr, CHIP_PORT);
-        uint32_t idleInterval;
-        uint32_t activeInterval;
-        operationalDeviceProxy->GetMRPIntervals(idleInterval, activeInterval);
-        operationalDeviceProxy->UpdateDeviceData(addr, idleInterval, activeInterval);
+        operationalDeviceProxy->UpdateDeviceData(addr, operationalDeviceProxy->GetMRPConfig());
     }
 
     CHIP_ERROR err = operationalDeviceProxy->Connect(&onConnectedCallback, &onConnectionFailureCallback);

--- a/examples/ota-requestor-app/linux/main.cpp
+++ b/examples/ota-requestor-app/linux/main.cpp
@@ -286,10 +286,7 @@ void SendQueryImageCommand(chip::NodeId peerNodeId = providerNodeId, chip::Fabri
     IPAddress ipAddr;
     IPAddress::FromString(ipAddress, ipAddr);
     PeerAddress addr = PeerAddress::UDP(ipAddr, CHIP_PORT);
-    uint32_t idleInterval;
-    uint32_t activeInterval;
-    operationalDeviceProxy->GetMRPIntervals(idleInterval, activeInterval);
-    operationalDeviceProxy->UpdateDeviceData(addr, idleInterval, activeInterval);
+    operationalDeviceProxy->UpdateDeviceData(addr, operationalDeviceProxy->GetMRPConfig());
 
     CHIP_ERROR err = operationalDeviceProxy->Connect(&mOnConnectedCallback, &mOnConnectionFailureCallback);
     if (err != CHIP_NO_ERROR)

--- a/src/app/CASESessionManager.cpp
+++ b/src/app/CASESessionManager.cpp
@@ -85,9 +85,7 @@ void CASESessionManager::OnNodeIdResolved(const Dnssd::ResolvedNodeData & nodeDa
     VerifyOrReturn(session != nullptr,
                    ChipLogDetail(Controller, "OnNodeIdResolved was called for a device with no active sessions, ignoring it."));
 
-    LogErrorOnFailure(session->UpdateDeviceData(
-        session->ToPeerAddress(nodeData), nodeData.GetMrpRetryIntervalIdle().ValueOr(CHIP_CONFIG_MRP_DEFAULT_IDLE_RETRY_INTERVAL),
-        nodeData.GetMrpRetryIntervalActive().ValueOr(CHIP_CONFIG_MRP_DEFAULT_ACTIVE_RETRY_INTERVAL)));
+    LogErrorOnFailure(session->UpdateDeviceData(session->ToPeerAddress(nodeData), nodeData.GetMRPConfig()));
 }
 
 void CASESessionManager::OnNodeIdResolutionFailed(const PeerId & peer, CHIP_ERROR error)

--- a/src/app/DeviceProxy.h
+++ b/src/app/DeviceProxy.h
@@ -81,13 +81,7 @@ public:
 
     virtual bool IsActive() const { return true; }
 
-    uint32_t GetMRPIdleInterval() const { return mMrpIdleInterval; }
-    uint32_t GetMRPActiveInterval() const { return mMrpActiveInterval; }
-    void GetMRPIntervals(uint32_t & idleInterval, uint32_t & activeInterval) const
-    {
-        idleInterval   = mMrpIdleInterval;
-        activeInterval = mMrpActiveInterval;
-    }
+    const ReliableMessageProtocolConfig & GetMRPConfig() const { return mMRPConfig; }
 
 protected:
     virtual bool IsSecureConnected() const = 0;
@@ -96,8 +90,7 @@ protected:
 
     app::CHIPDeviceCallbacksMgr & mCallbacksMgr = app::CHIPDeviceCallbacksMgr::GetInstance();
 
-    uint32_t mMrpIdleInterval   = CHIP_CONFIG_MRP_DEFAULT_IDLE_RETRY_INTERVAL;
-    uint32_t mMrpActiveInterval = CHIP_CONFIG_MRP_DEFAULT_ACTIVE_RETRY_INTERVAL;
+    ReliableMessageProtocolConfig mMRPConfig = gDefaultMRPConfig;
 };
 
 } // namespace chip

--- a/src/app/OperationalDeviceProxy.h
+++ b/src/app/OperationalDeviceProxy.h
@@ -119,8 +119,7 @@ public:
     {
         mDeviceAddress = ToPeerAddress(nodeResolutionData);
 
-        mMrpIdleInterval   = nodeResolutionData.GetMrpRetryIntervalIdle().ValueOr(CHIP_CONFIG_MRP_DEFAULT_IDLE_RETRY_INTERVAL);
-        mMrpActiveInterval = nodeResolutionData.GetMrpRetryIntervalActive().ValueOr(CHIP_CONFIG_MRP_DEFAULT_ACTIVE_RETRY_INTERVAL);
+        mMRPConfig = nodeResolutionData.GetMRPConfig();
 
         if (mState == State::NeedsAddress)
         {
@@ -141,7 +140,7 @@ public:
      *   Since the device settings might have been moved from RAM to the persistent storage, the function
      *   will load the device settings first, before making the changes.
      */
-    CHIP_ERROR UpdateDeviceData(const Transport::PeerAddress & addr, uint32_t mrpIdleInterval, uint32_t mrpActiveInterval);
+    CHIP_ERROR UpdateDeviceData(const Transport::PeerAddress & addr, const ReliableMessageProtocolConfig & config);
 
     PeerId GetPeerId() const { return mPeerId; }
 

--- a/src/app/server/Dnssd.cpp
+++ b/src/app/server/Dnssd.cpp
@@ -258,15 +258,13 @@ CHIP_ERROR DnssdServer::AdvertiseOperational()
             MutableByteSpan mac(macBuffer);
             chip::DeviceLayer::ConfigurationMgr().GetPrimaryMACAddress(mac);
 
-            const auto advertiseParameters =
-                chip::Dnssd::OperationalAdvertisingParameters()
-                    .SetPeerId(fabricInfo.GetPeerId())
-                    .SetMac(mac)
-                    .SetPort(GetSecuredPort())
-                    .SetMRPRetryIntervals(Optional<uint32_t>(CHIP_CONFIG_MRP_DEFAULT_IDLE_RETRY_INTERVAL),
-                                          Optional<uint32_t>(CHIP_CONFIG_MRP_DEFAULT_ACTIVE_RETRY_INTERVAL))
-                    .SetTcpSupported(Optional<bool>(INET_CONFIG_ENABLE_TCP_ENDPOINT))
-                    .EnableIpV4(true);
+            const auto advertiseParameters = chip::Dnssd::OperationalAdvertisingParameters()
+                                                 .SetPeerId(fabricInfo.GetPeerId())
+                                                 .SetMac(mac)
+                                                 .SetPort(GetSecuredPort())
+                                                 .SetMRPConfig(gDefaultMRPConfig)
+                                                 .SetTcpSupported(Optional<bool>(INET_CONFIG_ENABLE_TCP_ENDPOINT))
+                                                 .EnableIpV4(true);
 
             auto & mdnsAdvertiser = chip::Dnssd::ServiceAdvertiser::Instance();
 
@@ -343,10 +341,7 @@ CHIP_ERROR DnssdServer::Advertise(bool commissionableNode, chip::Dnssd::Commissi
     advertiseParameters.SetRotatingId(chip::Optional<const char *>::Value(rotatingDeviceIdHexBuffer));
 #endif
 
-    advertiseParameters
-        .SetMRPRetryIntervals(Optional<uint32_t>(CHIP_CONFIG_MRP_DEFAULT_IDLE_RETRY_INTERVAL),
-                              Optional<uint32_t>(CHIP_CONFIG_MRP_DEFAULT_ACTIVE_RETRY_INTERVAL))
-        .SetTcpSupported(Optional<bool>(INET_CONFIG_ENABLE_TCP_ENDPOINT));
+    advertiseParameters.SetMRPConfig(gDefaultMRPConfig).SetTcpSupported(Optional<bool>(INET_CONFIG_ENABLE_TCP_ENDPOINT));
 
     if (mode != chip::Dnssd::CommissioningMode::kEnabledEnhanced)
     {

--- a/src/channel/ChannelContext.cpp
+++ b/src/channel/ChannelContext.cpp
@@ -263,7 +263,7 @@ void ChannelContext::EnterCasePairingState()
     Transport::PeerAddress addr;
     addr.SetTransportType(Transport::Type::kUdp).SetIPAddress(prepare.mAddress);
 
-    auto session = mExchangeManager->GetSessionManager()->CreateUnauthenticatedSession(addr);
+    auto session = mExchangeManager->GetSessionManager()->CreateUnauthenticatedSession(addr, gDefaultMRPConfig);
     if (!session.HasValue())
     {
         ExitCasePairingState();
@@ -271,8 +271,6 @@ void ChannelContext::EnterCasePairingState()
         EnterFailedState(CHIP_ERROR_NO_MEMORY);
         return;
     }
-    session.Value().GetUnauthenticatedSession()->SetMRPIntervals(CHIP_CONFIG_MRP_DEFAULT_IDLE_RETRY_INTERVAL,
-                                                                 CHIP_CONFIG_MRP_DEFAULT_ACTIVE_RETRY_INTERVAL);
 
     ExchangeContext * ctxt = mExchangeManager->NewContext(session.Value(), prepare.mCasePairingSession);
     VerifyOrReturn(ctxt != nullptr);

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -694,7 +694,6 @@ CHIP_ERROR DeviceCommissioner::PairDevice(NodeId remoteDeviceId, RendezvousParam
     CHIP_ERROR err                     = CHIP_NO_ERROR;
     CommissioneeDeviceProxy * device   = nullptr;
     Transport::PeerAddress peerAddress = Transport::PeerAddress::UDP(Inet::IPAddress::Any);
-    uint32_t mrpIdleInterval, mrpActiveInterval;
 
     Messaging::ExchangeContext * exchangeCtxt = nullptr;
     Optional<SessionHandle> session;
@@ -789,12 +788,9 @@ CHIP_ERROR DeviceCommissioner::PairDevice(NodeId remoteDeviceId, RendezvousParam
         }
     }
 #endif
-    session = mSystemState->SessionMgr()->CreateUnauthenticatedSession(params.GetPeerAddress());
-    VerifyOrExit(session.HasValue(), err = CHIP_ERROR_NO_MEMORY);
-
     // TODO: In some cases like PASE over IP, CRA and CRI values from commissionable node service should be used
-    device->GetMRPIntervals(mrpIdleInterval, mrpActiveInterval);
-    session.Value().GetUnauthenticatedSession()->SetMRPIntervals(mrpIdleInterval, mrpActiveInterval);
+    session = mSystemState->SessionMgr()->CreateUnauthenticatedSession(params.GetPeerAddress(), device->GetMRPConfig());
+    VerifyOrExit(session.HasValue(), err = CHIP_ERROR_NO_MEMORY);
 
     exchangeCtxt = mSystemState->ExchangeMgr()->NewContext(session.Value(), &device->GetPairing());
     VerifyOrExit(exchangeCtxt != nullptr, err = CHIP_ERROR_INTERNAL);

--- a/src/controller/CommissioneeDeviceProxy.cpp
+++ b/src/controller/CommissioneeDeviceProxy.cpp
@@ -112,15 +112,14 @@ CHIP_ERROR CommissioneeDeviceProxy::CloseSession()
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR CommissioneeDeviceProxy::UpdateDeviceData(const Transport::PeerAddress & addr, uint32_t mrpIdleInterval,
-                                                     uint32_t mrpActiveInterval)
+CHIP_ERROR CommissioneeDeviceProxy::UpdateDeviceData(const Transport::PeerAddress & addr,
+                                                     const ReliableMessageProtocolConfig & config)
 {
     bool didLoad;
 
     mDeviceAddress = addr;
 
-    mMrpIdleInterval   = mrpIdleInterval;
-    mMrpActiveInterval = mrpActiveInterval;
+    mMRPConfig = config;
 
     ReturnErrorOnFailure(LoadSecureSessionParametersIfNeeded(didLoad));
 
@@ -135,7 +134,7 @@ CHIP_ERROR CommissioneeDeviceProxy::UpdateDeviceData(const Transport::PeerAddres
 
     Transport::SecureSession * secureSession = mSessionManager->GetSecureSession(mSecureSession.Value());
     secureSession->SetPeerAddress(addr);
-    secureSession->SetMRPIntervals(mrpIdleInterval, mrpActiveInterval);
+    secureSession->SetMRPConfig(config);
 
     return CHIP_NO_ERROR;
 }

--- a/src/controller/CommissioneeDeviceProxy.h
+++ b/src/controller/CommissioneeDeviceProxy.h
@@ -188,13 +188,12 @@ public:
      *   Since the device settings might have been moved from RAM to the persistent storage, the function
      *   will load the device settings first, before making the changes.
      *
-     * @param[in] addr                Address of the device to be set.
-     * @param[in] mrpIdleInterval     MRP idle retransmission interval of the device to be set.
-     * @param[in] mrpActiveInterval   MRP active retransmision interval of the device to be set.
+     * @param[in] addr   Address of the device to be set.
+     * @param[in] config MRP parameters
      *
      * @return CHIP_NO_ERROR if the data has been updated, an error code otherwise.
      */
-    CHIP_ERROR UpdateDeviceData(const Transport::PeerAddress & addr, uint32_t mrpIdleInterval, uint32_t mrpActiveInterval);
+    CHIP_ERROR UpdateDeviceData(const Transport::PeerAddress & addr, const ReliableMessageProtocolConfig & config);
     /**
      * @brief
      *   Return whether the current device object is actively associated with a paired CHIP

--- a/src/lib/core/Optional.h
+++ b/src/lib/core/Optional.h
@@ -157,7 +157,14 @@ public:
     }
 
     /** Gets the current value of the optional. Valid IFF `HasValue`. */
-    const T & Value() const
+    T & Value() &
+    {
+        VerifyOrDie(HasValue());
+        return mValue.mData;
+    }
+
+    /** Gets the current value of the optional. Valid IFF `HasValue`. */
+    const T & Value() const &
     {
         VerifyOrDie(HasValue());
         return mValue.mData;
@@ -195,6 +202,12 @@ private:
         T mData;
     } mValue;
 };
+
+template <class T>
+constexpr Optional<std::decay_t<T>> MakeOptional(T && value)
+{
+    return Optional<std::decay_t<T>>(InPlace, std::forward<T>(value));
+}
 
 template <class T, class... Args>
 constexpr Optional<T> MakeOptional(Args &&... args)

--- a/src/lib/dnssd/Advertiser.h
+++ b/src/lib/dnssd/Advertiser.h
@@ -81,17 +81,12 @@ public:
     const chip::ByteSpan GetMac() const { return chip::ByteSpan(mMacStorage, mMacLength); }
 
     // Common Flags
-    Derived & SetMRPRetryIntervals(Optional<uint32_t> intervalIdle, Optional<uint32_t> intervalActive)
+    Derived & SetMRPConfig(const ReliableMessageProtocolConfig & config)
     {
-        mMrpRetryIntervalIdle   = intervalIdle;
-        mMrpRetryIntervalActive = intervalActive;
+        mMRPConfig.SetValue(config);
         return *reinterpret_cast<Derived *>(this);
     }
-    void GetMRPRetryIntervals(Optional<uint32_t> & intervalIdle, Optional<uint32_t> & intervalActive) const
-    {
-        intervalIdle   = mMrpRetryIntervalIdle;
-        intervalActive = mMrpRetryIntervalActive;
-    }
+    const Optional<ReliableMessageProtocolConfig> & GetMRPConfig() const { return mMRPConfig; }
     Derived & SetTcpSupported(Optional<bool> tcpSupported)
     {
         mTcpSupported = tcpSupported;
@@ -104,8 +99,7 @@ private:
     bool mEnableIPv4                 = true;
     uint8_t mMacStorage[kMaxMacSize] = {};
     size_t mMacLength                = 0;
-    Optional<uint32_t> mMrpRetryIntervalIdle;
-    Optional<uint32_t> mMrpRetryIntervalActive;
+    Optional<ReliableMessageProtocolConfig> mMRPConfig;
     Optional<bool> mTcpSupported;
 };
 

--- a/src/lib/dnssd/Advertiser_ImplMinimalMdns.cpp
+++ b/src/lib/dnssd/Advertiser_ImplMinimalMdns.cpp
@@ -157,8 +157,7 @@ private:
     CHIP_ERROR AddCommonTxtEntries(const BaseAdvertisingParams<Derived> & params, CommonTxtEntryStorage & storage,
                                    char ** txtFields, size_t & numTxtFields)
     {
-        Optional<uint32_t> mrpRetryIntervalIdle, mrpRetryIntervalActive;
-        params.GetMRPRetryIntervals(mrpRetryIntervalIdle, mrpRetryIntervalActive);
+        auto optionalMrp = params.GetMRPConfig();
         // TODO: Issue #5833 - MRP retry intervals should be updated on the poll period value change or device type change.
 #if CHIP_DEVICE_CONFIG_ENABLE_SED
         chip::DeviceLayer::ConnectivityManager::SEDPollingConfig sedPollingConfig;
@@ -166,44 +165,51 @@ private:
         ReturnErrorOnFailure(chip::DeviceLayer::ConnectivityMgr().GetSEDPollingConfig(sedPollingConfig));
         // Increment default MRP retry intervals by SED poll period to be on the safe side
         // and avoid unnecessary retransmissions.
-        if (mrpRetryIntervalIdle.HasValue())
+        if (optionalMrp.HasValue())
         {
-            mrpRetryIntervalIdle.SetValue(mrpRetryIntervalIdle.Value() + sedPollingConfig.SlowPollingIntervalMS);
-        }
-        if (mrpRetryIntervalActive.HasValue())
-        {
-            mrpRetryIntervalActive.SetValue(mrpRetryIntervalActive.Value() + sedPollingConfig.FastPollingIntervalMS);
+            auto mrp = optionalMrp.Value();
+            optionalMrp.SetValue(ReliableMessageProtocolConfig(
+                mrp.mIdleRetransTimeoutTick +
+                    (sedPollingConfig.SlowPollingIntervalMS >> CHIP_CONFIG_RMP_TIMER_DEFAULT_PERIOD_SHIFT),
+                mrp.mActiveRetransTimeoutTick +
+                    (sedPollingConfig.FastPollingIntervalMS >> CHIP_CONFIG_RMP_TIMER_DEFAULT_PERIOD_SHIFT)));
         }
 #endif
-        if (mrpRetryIntervalIdle.HasValue())
+        if (optionalMrp.HasValue())
         {
-            if (mrpRetryIntervalIdle.Value() > kMaxRetryInterval)
+            auto mrp = optionalMrp.Value();
             {
-                ChipLogProgress(Discovery,
-                                "MRP retry interval idle value exceeds allowed range of 1 hour, using maximum available");
-                mrpRetryIntervalIdle.SetValue(kMaxRetryInterval);
+                if ((mrp.mIdleRetransTimeoutTick << CHIP_CONFIG_RMP_TIMER_DEFAULT_PERIOD_SHIFT) > kMaxRetryInterval)
+                {
+                    ChipLogProgress(Discovery,
+                                    "MRP retry interval idle value exceeds allowed range of 1 hour, using maximum available");
+                    mrp.mIdleRetransTimeoutTick = kMaxRetryInterval >> CHIP_CONFIG_RMP_TIMER_DEFAULT_PERIOD_SHIFT;
+                }
+                size_t writtenCharactersNumber =
+                    snprintf(storage.mrpRetryIntervalIdleBuf, sizeof(storage.mrpRetryIntervalIdleBuf), "CRI=%" PRIu32,
+                             mrp.mIdleRetransTimeoutTick << CHIP_CONFIG_RMP_TIMER_DEFAULT_PERIOD_SHIFT);
+                VerifyOrReturnError((writtenCharactersNumber > 0) &&
+                                        (writtenCharactersNumber < sizeof(storage.mrpRetryIntervalIdleBuf)),
+                                    CHIP_ERROR_INVALID_STRING_LENGTH);
+
+                txtFields[numTxtFields++] = storage.mrpRetryIntervalIdleBuf;
             }
-            size_t writtenCharactersNumber = snprintf(storage.mrpRetryIntervalIdleBuf, sizeof(storage.mrpRetryIntervalIdleBuf),
-                                                      "CRI=%" PRIu32, mrpRetryIntervalIdle.Value());
-            VerifyOrReturnError((writtenCharactersNumber > 0) &&
-                                    (writtenCharactersNumber < sizeof(storage.mrpRetryIntervalIdleBuf)),
-                                CHIP_ERROR_INVALID_STRING_LENGTH);
-            txtFields[numTxtFields++] = storage.mrpRetryIntervalIdleBuf;
-        }
-        if (mrpRetryIntervalActive.HasValue())
-        {
-            if (mrpRetryIntervalActive.Value() > kMaxRetryInterval)
+
             {
-                ChipLogProgress(Discovery,
-                                "MRP retry interval active value exceeds allowed range of 1 hour, using maximum available");
-                mrpRetryIntervalActive.SetValue(kMaxRetryInterval);
+                if ((mrp.mActiveRetransTimeoutTick << CHIP_CONFIG_RMP_TIMER_DEFAULT_PERIOD_SHIFT) > kMaxRetryInterval)
+                {
+                    ChipLogProgress(Discovery,
+                                    "MRP retry interval active value exceeds allowed range of 1 hour, using maximum available");
+                    mrp.mActiveRetransTimeoutTick = kMaxRetryInterval >> CHIP_CONFIG_RMP_TIMER_DEFAULT_PERIOD_SHIFT;
+                }
+                size_t writtenCharactersNumber =
+                    snprintf(storage.mrpRetryIntervalActiveBuf, sizeof(storage.mrpRetryIntervalActiveBuf), "CRA=%" PRIu32,
+                             mrp.mActiveRetransTimeoutTick << CHIP_CONFIG_RMP_TIMER_DEFAULT_PERIOD_SHIFT);
+                VerifyOrReturnError((writtenCharactersNumber > 0) &&
+                                        (writtenCharactersNumber < sizeof(storage.mrpRetryIntervalActiveBuf)),
+                                    CHIP_ERROR_INVALID_STRING_LENGTH);
+                txtFields[numTxtFields++] = storage.mrpRetryIntervalActiveBuf;
             }
-            size_t writtenCharactersNumber = snprintf(storage.mrpRetryIntervalActiveBuf, sizeof(storage.mrpRetryIntervalActiveBuf),
-                                                      "CRA=%" PRIu32, mrpRetryIntervalActive.Value());
-            VerifyOrReturnError((writtenCharactersNumber > 0) &&
-                                    (writtenCharactersNumber < sizeof(storage.mrpRetryIntervalActiveBuf)),
-                                CHIP_ERROR_INVALID_STRING_LENGTH);
-            txtFields[numTxtFields++] = storage.mrpRetryIntervalActiveBuf;
         }
         if (params.GetTcpSupported().HasValue())
         {

--- a/src/lib/dnssd/BUILD.gn
+++ b/src/lib/dnssd/BUILD.gn
@@ -26,6 +26,7 @@ static_library("dnssd") {
     "${chip_root}/src/crypto",
     "${chip_root}/src/lib/core",
     "${chip_root}/src/lib/support",
+    "${chip_root}/src/messaging:messaging_mrp_config",
   ]
 
   sources = [

--- a/src/lib/dnssd/Discovery_ImplPlatform.cpp
+++ b/src/lib/dnssd/Discovery_ImplPlatform.cpp
@@ -128,8 +128,7 @@ CHIP_ERROR AddCommonTxtElements(const BaseAdvertisingParams<Derived> & params, c
                                 char (&mrpRetryActiveStorage)[N_active], char (&tcpSupportedStorage)[N_tcp],
                                 TextEntry txtEntryStorage[], size_t & txtEntryIdx)
 {
-    Optional<uint32_t> mrpRetryIntervalIdle, mrpRetryIntervalActive;
-    params.GetMRPRetryIntervals(mrpRetryIntervalIdle, mrpRetryIntervalActive);
+    auto optionalMrp = params.GetMRPConfig();
 
     // TODO: Issue #5833 - MRP retry intervals should be updated on the poll period value
     // change or device type change.
@@ -141,40 +140,46 @@ CHIP_ERROR AddCommonTxtElements(const BaseAdvertisingParams<Derived> & params, c
     ReturnErrorOnFailure(chip::DeviceLayer::ConnectivityMgr().GetSEDPollingConfig(sedPollingConfig));
     // Increment default MRP retry intervals by SED poll period to be on the safe side
     // and avoid unnecessary retransmissions.
-    if (mrpRetryIntervalIdle.HasValue())
+    if (optionalMrp.HasValue())
     {
-        mrpRetryIntervalIdle.SetValue(mrpRetryIntervalIdle.Value() + sedPollingConfig.SlowPollingIntervalMS);
-    }
-    if (mrpRetryIntervalActive.HasValue())
-    {
-        mrpRetryIntervalActive.SetValue(mrpRetryIntervalActive.Value() + sedPollingConfig.FastPollingIntervalMS);
+        auto mrp = optionalMrp.Value();
+        optionalMrp.SetValue(ReliableMessageProtocolConfig(
+            mrp.mIdleRetransTimeoutTick + (sedPollingConfig.SlowPollingIntervalMS >> CHIP_CONFIG_RMP_TIMER_DEFAULT_PERIOD_SHIFT),
+            mrp.mActiveRetransTimeoutTick +
+                (sedPollingConfig.FastPollingIntervalMS >> CHIP_CONFIG_RMP_TIMER_DEFAULT_PERIOD_SHIFT)));
     }
 #endif
-    if (mrpRetryIntervalIdle.HasValue())
+    if (optionalMrp.HasValue())
     {
-        if (mrpRetryIntervalIdle.Value() > kMaxRetryInterval)
+        auto mrp = optionalMrp.Value();
         {
-            ChipLogProgress(Discovery, "MRP retry interval idle value exceeds allowed range of 1 hour, using maximum available");
-            mrpRetryIntervalIdle.SetValue(kMaxRetryInterval);
+            if ((mrp.mIdleRetransTimeoutTick << CHIP_CONFIG_RMP_TIMER_DEFAULT_PERIOD_SHIFT) > kMaxRetryInterval)
+            {
+                ChipLogProgress(Discovery,
+                                "MRP retry interval idle value exceeds allowed range of 1 hour, using maximum available");
+                mrp.mIdleRetransTimeoutTick = kMaxRetryInterval >> CHIP_CONFIG_RMP_TIMER_DEFAULT_PERIOD_SHIFT;
+            }
+            size_t writtenCharactersNumber = snprintf(mrpRetryIdleStorage, sizeof(mrpRetryIdleStorage), "%" PRIu32,
+                                                      mrp.mIdleRetransTimeoutTick << CHIP_CONFIG_RMP_TIMER_DEFAULT_PERIOD_SHIFT);
+            VerifyOrReturnError((writtenCharactersNumber > 0) && (writtenCharactersNumber <= kTxtRetryIntervalIdleMaxLength),
+                                CHIP_ERROR_INVALID_STRING_LENGTH);
+            txtEntryStorage[txtEntryIdx++] = { "CRI", Uint8::from_const_char(mrpRetryIdleStorage), strlen(mrpRetryIdleStorage) };
         }
-        size_t writtenCharactersNumber =
-            snprintf(mrpRetryIdleStorage, sizeof(mrpRetryIdleStorage), "%" PRIu32, mrpRetryIntervalIdle.Value());
-        VerifyOrReturnError((writtenCharactersNumber > 0) && (writtenCharactersNumber <= kTxtRetryIntervalIdleMaxLength),
-                            CHIP_ERROR_INVALID_STRING_LENGTH);
-        txtEntryStorage[txtEntryIdx++] = { "CRI", Uint8::from_const_char(mrpRetryIdleStorage), strlen(mrpRetryIdleStorage) };
-    }
-    if (mrpRetryIntervalActive.HasValue())
-    {
-        if (mrpRetryIntervalActive.Value() > kMaxRetryInterval)
+
         {
-            ChipLogProgress(Discovery, "MRP retry interval active value exceeds allowed range of 1 hour, using maximum available");
-            mrpRetryIntervalActive.SetValue(kMaxRetryInterval);
+            if ((mrp.mActiveRetransTimeoutTick << CHIP_CONFIG_RMP_TIMER_DEFAULT_PERIOD_SHIFT) > kMaxRetryInterval)
+            {
+                ChipLogProgress(Discovery,
+                                "MRP retry interval active value exceeds allowed range of 1 hour, using maximum available");
+                mrp.mActiveRetransTimeoutTick = kMaxRetryInterval >> CHIP_CONFIG_RMP_TIMER_DEFAULT_PERIOD_SHIFT;
+            }
+            size_t writtenCharactersNumber = snprintf(mrpRetryActiveStorage, sizeof(mrpRetryActiveStorage), "%" PRIu32,
+                                                      mrp.mActiveRetransTimeoutTick << CHIP_CONFIG_RMP_TIMER_DEFAULT_PERIOD_SHIFT);
+            VerifyOrReturnError((writtenCharactersNumber > 0) && (writtenCharactersNumber <= kTxtRetryIntervalActiveMaxLength),
+                                CHIP_ERROR_INVALID_STRING_LENGTH);
+            txtEntryStorage[txtEntryIdx++] = { "CRA", Uint8::from_const_char(mrpRetryActiveStorage),
+                                               strlen(mrpRetryActiveStorage) };
         }
-        size_t writtenCharactersNumber =
-            snprintf(mrpRetryActiveStorage, sizeof(mrpRetryActiveStorage), "%" PRIu32, mrpRetryIntervalActive.Value());
-        VerifyOrReturnError((writtenCharactersNumber > 0) && (writtenCharactersNumber <= kTxtRetryIntervalActiveMaxLength),
-                            CHIP_ERROR_INVALID_STRING_LENGTH);
-        txtEntryStorage[txtEntryIdx++] = { "CRA", Uint8::from_const_char(mrpRetryActiveStorage), strlen(mrpRetryActiveStorage) };
     }
     if (params.GetTcpSupported().HasValue())
     {

--- a/src/lib/dnssd/TxtFields.cpp
+++ b/src/lib/dnssd/TxtFields.cpp
@@ -171,14 +171,15 @@ void GetPairingInstruction(const ByteSpan & value, char * pairingInstruction)
     Platform::CopyString(pairingInstruction, kMaxPairingInstructionLen + 1, value);
 }
 
-uint32_t GetRetryInterval(const ByteSpan & value)
+Optional<uint32_t> GetRetryInterval(const ByteSpan & value)
 {
-    const auto retryInterval = MakeU32FromAsciiDecimal(value, kUndefinedRetryInterval);
+    const auto undefined     = std::numeric_limits<uint32_t>::max();
+    const auto retryInterval = MakeU32FromAsciiDecimal(value, undefined);
 
-    if (retryInterval != kUndefinedRetryInterval && retryInterval <= kMaxRetryInterval)
-        return retryInterval;
+    if (retryInterval != undefined && retryInterval <= kMaxRetryInterval)
+        return MakeOptional(retryInterval);
 
-    return kUndefinedRetryInterval;
+    return NullOptional;
 }
 
 TxtFieldKey GetTxtFieldKey(const ByteSpan & key)

--- a/src/lib/dnssd/minimal_mdns/tests/TestAdvertiser.cpp
+++ b/src/lib/dnssd/minimal_mdns/tests/TestAdvertiser.cpp
@@ -78,7 +78,8 @@ OperationalAdvertisingParameters operationalParams1 =
         .SetPort(CHIP_PORT)
         .EnableIpV4(true)
         .SetTcpSupported(chip::Optional<bool>(false))
-        .SetMRPRetryIntervals(chip::Optional<uint32_t>(32), chip::Optional<uint32_t>(33));
+        .SetMRPConfig(ReliableMessageProtocolConfig(64 >> CHIP_CONFIG_RMP_TIMER_DEFAULT_PERIOD_SHIFT,
+                                                    128 >> CHIP_CONFIG_RMP_TIMER_DEFAULT_PERIOD_SHIFT));
 OperationalAdvertisingParameters operationalParams2 =
     OperationalAdvertisingParameters().SetPeerId(kPeerId2).SetMac(ByteSpan(kMac)).SetPort(CHIP_PORT).EnableIpV4(true);
 OperationalAdvertisingParameters operationalParams3 =
@@ -89,7 +90,7 @@ OperationalAdvertisingParameters operationalParams5 =
     OperationalAdvertisingParameters().SetPeerId(kPeerId5).SetMac(ByteSpan(kMac)).SetPort(CHIP_PORT).EnableIpV4(true);
 OperationalAdvertisingParameters operationalParams6 =
     OperationalAdvertisingParameters().SetPeerId(kPeerId6).SetMac(ByteSpan(kMac)).SetPort(CHIP_PORT).EnableIpV4(true);
-const QNamePart txtOperational1Parts[]  = { "CRI=32", "CRA=33", "T=0" };
+const QNamePart txtOperational1Parts[]  = { "CRI=64", "CRA=128", "T=0" };
 PtrResourceRecord ptrOperationalService = PtrResourceRecord(kDnsSdQueryName, kMatterOperationalQueryName);
 PtrResourceRecord ptrOperational1       = PtrResourceRecord(kMatterOperationalQueryName, kInstanceName1);
 SrvResourceRecord srvOperational1       = SrvResourceRecord(kInstanceName1, kHostnameName, CHIP_PORT);
@@ -178,8 +179,9 @@ CommissionAdvertisingParameters commissionableNodeParamsLargeEnhanced =
         .SetProductId(chip::Optional<uint16_t>(897))
         .SetRotatingId(chip::Optional<const char *>("id_that_spins"))
         .SetTcpSupported(chip::Optional<bool>(true))
-        .SetMRPRetryIntervals(chip::Optional<uint32_t>(3600000),
-                              chip::Optional<uint32_t>(3600005)); // 3600005 is more than the max so should be adjusted down
+        // 3600005 is more than the max so should be adjusted down
+        .SetMRPConfig(ReliableMessageProtocolConfig(3600000 >> CHIP_CONFIG_RMP_TIMER_DEFAULT_PERIOD_SHIFT,
+                                                    3600064 >> CHIP_CONFIG_RMP_TIMER_DEFAULT_PERIOD_SHIFT));
 QNamePart txtCommissionableNodeParamsLargeEnhancedParts[] = { "D=22",          "VP=555+897",       "CM=2",       "DT=25",
                                                               "DN=testy-test", "RI=id_that_spins", "PI=Pair me", "PH=3",
                                                               "CRA=3600000",   "CRI=3600000",      "T=1" };

--- a/src/lib/dnssd/platform/tests/TestPlatform.cpp
+++ b/src/lib/dnssd/platform/tests/TestPlatform.cpp
@@ -46,21 +46,23 @@ test::ExpectedCall operationalCall1 = test::ExpectedCall()
                                           .SetInstanceName("BEEFBEEFF00DF00D-1111222233334444")
                                           .SetHostName(host)
                                           .AddSubtype("_IBEEFBEEFF00DF00D");
-OperationalAdvertisingParameters operationalParams2 = OperationalAdvertisingParameters()
-                                                          .SetPeerId(kPeerId2)
-                                                          .SetMac(ByteSpan(kMac))
-                                                          .SetPort(CHIP_PORT)
-                                                          .EnableIpV4(true)
-                                                          .SetMRPRetryIntervals(Optional<uint32_t>(32), Optional<uint32_t>(33))
-                                                          .SetTcpSupported(Optional<bool>(true));
+OperationalAdvertisingParameters operationalParams2 =
+    OperationalAdvertisingParameters()
+        .SetPeerId(kPeerId2)
+        .SetMac(ByteSpan(kMac))
+        .SetPort(CHIP_PORT)
+        .EnableIpV4(true)
+        .SetMRPConfig(ReliableMessageProtocolConfig(64 >> CHIP_CONFIG_RMP_TIMER_DEFAULT_PERIOD_SHIFT,
+                                                    128 >> CHIP_CONFIG_RMP_TIMER_DEFAULT_PERIOD_SHIFT))
+        .SetTcpSupported(Optional<bool>(true));
 test::ExpectedCall operationalCall2 = test::ExpectedCall()
                                           .SetProtocol(DnssdServiceProtocol::kDnssdProtocolTcp)
                                           .SetServiceName("_matter")
                                           .SetInstanceName("5555666677778888-1212343456567878")
                                           .SetHostName(host)
                                           .AddSubtype("_I5555666677778888")
-                                          .AddTxt("CRI", "32")
-                                          .AddTxt("CRA", "33")
+                                          .AddTxt("CRI", "64")
+                                          .AddTxt("CRA", "128")
                                           .AddTxt("T", "1");
 
 CommissionAdvertisingParameters commissionableNodeParamsSmall =
@@ -94,9 +96,9 @@ CommissionAdvertisingParameters commissionableNodeParamsLargeBasic =
         .SetProductId(chip::Optional<uint16_t>(897))
         .SetRotatingId(chip::Optional<const char *>("id_that_spins"))
         .SetTcpSupported(chip::Optional<bool>(true))
-        .SetMRPRetryIntervals(
-            chip::Optional<uint32_t>(3600000),
-            chip::Optional<uint32_t>(3600005)); // 3600005 is over the max, so this should be adjusted by the platform
+        // 3600005 is over the max, so this should be adjusted by the platform
+        .SetMRPConfig(ReliableMessageProtocolConfig(3600000 >> CHIP_CONFIG_RMP_TIMER_DEFAULT_PERIOD_SHIFT,
+                                                    3600064 >> CHIP_CONFIG_RMP_TIMER_DEFAULT_PERIOD_SHIFT));
 
 test::ExpectedCall commissionableLargeBasic = test::ExpectedCall()
                                                   .SetProtocol(DnssdServiceProtocol::kDnssdProtocolUdp)

--- a/src/lib/dnssd/tests/TestTxtFields.cpp
+++ b/src/lib/dnssd/tests/TestTxtFields.cpp
@@ -281,9 +281,8 @@ bool NodeDataIsEmpty(const DiscoveredNodeData & node)
 {
 
     if (node.longDiscriminator != 0 || node.vendorId != 0 || node.productId != 0 || node.commissioningMode != 0 ||
-        node.deviceType != 0 || node.rotatingIdLen != 0 || node.pairingHint != 0 ||
-        node.mrpRetryIntervalIdle != kUndefinedRetryInterval || node.mrpRetryIntervalActive != kUndefinedRetryInterval ||
-        node.supportsTcp)
+        node.deviceType != 0 || node.rotatingIdLen != 0 || node.pairingHint != 0 || node.mrpRetryIntervalIdle.HasValue() ||
+        node.mrpRetryIntervalActive.HasValue() || node.supportsTcp)
     {
         return false;
     }
@@ -381,28 +380,27 @@ void TestFillDiscoveredNodeDataFromTxt(nlTestSuite * inSuite, void * inContext)
 bool NodeDataIsEmpty(const ResolvedNodeData & nodeData)
 {
     return nodeData.mPeerId == PeerId{} && nodeData.mNumIPs == 0 && nodeData.mPort == 0 &&
-        nodeData.mMrpRetryIntervalIdle == kUndefinedRetryInterval && nodeData.mMrpRetryIntervalActive == kUndefinedRetryInterval &&
-        !nodeData.mSupportsTcp;
+        !nodeData.mMrpRetryIntervalIdle.HasValue() && !nodeData.mMrpRetryIntervalActive.HasValue() && !nodeData.mSupportsTcp;
 }
 
 void ResetRetryIntervalIdle(DiscoveredNodeData & nodeData)
 {
-    nodeData.mrpRetryIntervalIdle = kUndefinedRetryInterval;
+    nodeData.mrpRetryIntervalIdle.ClearValue();
 }
 
 void ResetRetryIntervalIdle(ResolvedNodeData & nodeData)
 {
-    nodeData.mMrpRetryIntervalIdle = kUndefinedRetryInterval;
+    nodeData.mMrpRetryIntervalIdle.ClearValue();
 }
 
 void ResetRetryIntervalActive(DiscoveredNodeData & nodeData)
 {
-    nodeData.mrpRetryIntervalActive = kUndefinedRetryInterval;
+    nodeData.mrpRetryIntervalActive.ClearValue();
 }
 
 void ResetRetryIntervalActive(ResolvedNodeData & nodeData)
 {
-    nodeData.mMrpRetryIntervalActive = kUndefinedRetryInterval;
+    nodeData.mMrpRetryIntervalActive.ClearValue();
 }
 
 // Test CRI

--- a/src/lib/shell/commands/Ota.cpp
+++ b/src/lib/shell/commands/Ota.cpp
@@ -287,8 +287,7 @@ void ConnectDeviceAsync(intptr_t)
     OperationalDeviceProxy * deviceProxy = sOtaContext.deviceProxy;
     VerifyOrReturn(deviceProxy != nullptr);
 
-    deviceProxy->UpdateDeviceData(sOtaContext.providerAddress, deviceProxy->GetMRPIdleInterval(),
-                                  deviceProxy->GetMRPActiveInterval());
+    deviceProxy->UpdateDeviceData(sOtaContext.providerAddress, deviceProxy->GetMRPConfig());
     deviceProxy->Connect(&successCallback, &failureCallback);
 }
 

--- a/src/messaging/BUILD.gn
+++ b/src/messaging/BUILD.gn
@@ -27,6 +27,12 @@ if (chip_case_retry_delta != "") {
   ]
 }
 
+source_set("messaging_mrp_config") {
+  sources = [ "ReliableMessageProtocolConfig.h" ]
+
+  public_deps = [ "${chip_root}/src/system" ]
+}
+
 static_library("messaging") {
   output_name = "libMessagingLayer"
 
@@ -47,12 +53,13 @@ static_library("messaging") {
     "ReliableMessageContext.h",
     "ReliableMessageMgr.cpp",
     "ReliableMessageMgr.h",
-    "ReliableMessageProtocolConfig.h",
+    "ReliableMessageProtocolConfig.cpp",
   ]
 
   cflags = [ "-Wconversion" ]
 
   public_deps = [
+    ":messaging_mrp_config",
     "${chip_root}/src/crypto",
     "${chip_root}/src/inet",
     "${chip_root}/src/lib/core",

--- a/src/messaging/ExchangeContext.cpp
+++ b/src/messaging/ExchangeContext.cpp
@@ -200,7 +200,7 @@ void ExchangeContext::DoClose(bool clearRetransTable)
     // needs to clear the MRP retransmission table immediately.
     if (clearRetransTable)
     {
-        mExchangeMgr->GetReliableMessageMgr()->ClearRetransTable(static_cast<ReliableMessageContext *>(this));
+        mExchangeMgr->GetReliableMessageMgr()->ClearRetransTable(this);
     }
 
     // Cancel the response timer.
@@ -539,5 +539,11 @@ System::Clock::Milliseconds32 ExchangeContext::GetAckTimeout()
     }
     return timeout;
 }
+
+const ReliableMessageProtocolConfig & ExchangeContext::GetMRPConfig() const
+{
+    return GetSessionHandle().GetMRPConfig(GetExchangeMgr()->GetSessionManager());
+}
+
 } // namespace Messaging
 } // namespace chip

--- a/src/messaging/ExchangeContext.h
+++ b/src/messaging/ExchangeContext.h
@@ -151,7 +151,7 @@ public:
 
     ExchangeMessageDispatch * GetMessageDispatch() { return mDispatch; }
 
-    SessionHandle GetSessionHandle() { return mSession.Value(); }
+    SessionHandle GetSessionHandle() const { return mSession.Value(); }
     bool HasSessionHandle() const { return mSession.HasValue(); }
 
     uint16_t GetExchangeId() const { return mExchangeId; }
@@ -166,6 +166,7 @@ public:
 
     void SetResponseTimeout(Timeout timeout);
 
+    // TODO: move following 5 functions into SessionHandle once we can access session vars w/o using a SessionManager
     /*
      * Get the overall acknowledge timeout period for the underneath transport(MRP+UDP/TCP)
      */
@@ -174,6 +175,8 @@ public:
     bool IsUDPTransport();
     bool IsTCPTransport();
     bool IsBLETransport();
+    // Helper function for easily accessing MRP config
+    const ReliableMessageProtocolConfig & GetMRPConfig() const;
 
 private:
     Timeout mResponseTimeout{ 0 }; // Maximum time to wait for response (in milliseconds); 0 disables response timeout.

--- a/src/messaging/ExchangeMgr.cpp
+++ b/src/messaging/ExchangeMgr.cpp
@@ -119,17 +119,7 @@ CHIP_ERROR ExchangeManager::Shutdown()
 ExchangeContext * ExchangeManager::NewContext(SessionHandle session, ExchangeDelegate * delegate)
 {
     ExchangeContext * context = mContextPool.CreateObject(this, mNextExchangeId++, session, true, delegate);
-
-    uint32_t mrpIdleInterval   = CHIP_CONFIG_MRP_DEFAULT_IDLE_RETRY_INTERVAL;
-    uint32_t mrpActiveInterval = CHIP_CONFIG_MRP_DEFAULT_ACTIVE_RETRY_INTERVAL;
-
-    session.GetMRPIntervals(GetSessionManager(), mrpIdleInterval, mrpActiveInterval);
-
-    ReliableMessageProtocolConfig mrpConfig;
-    mrpConfig.mIdleRetransTimeoutTick   = mrpIdleInterval >> CHIP_CONFIG_RMP_TIMER_DEFAULT_PERIOD_SHIFT;
-    mrpConfig.mActiveRetransTimeoutTick = mrpActiveInterval >> CHIP_CONFIG_RMP_TIMER_DEFAULT_PERIOD_SHIFT;
-    context->GetReliableMessageContext()->SetConfig(mrpConfig);
-
+    context->GetReliableMessageContext()->SetConfig(session.GetMRPConfig(GetSessionManager()));
     return context;
 }
 

--- a/src/messaging/ReliableMessageContext.cpp
+++ b/src/messaging/ReliableMessageContext.cpp
@@ -39,8 +39,7 @@
 namespace chip {
 namespace Messaging {
 
-ReliableMessageContext::ReliableMessageContext() :
-    mConfig(gDefaultReliableMessageProtocolConfig), mNextAckTimeTick(0), mPendingPeerAckMessageCounter(0)
+ReliableMessageContext::ReliableMessageContext() : mConfig(gDefaultMRPConfig), mNextAckTimeTick(0), mPendingPeerAckMessageCounter(0)
 {}
 
 bool ReliableMessageContext::AutoRequestAck() const

--- a/src/messaging/ReliableMessageContext.h
+++ b/src/messaging/ReliableMessageContext.h
@@ -26,12 +26,11 @@
 #include <stdint.h>
 #include <string.h>
 
-#include <messaging/ReliableMessageProtocolConfig.h>
-
 #include <inet/InetLayer.h>
 #include <lib/core/CHIPError.h>
 #include <lib/core/ReferenceCounted.h>
 #include <lib/support/DLLUtil.h>
+#include <messaging/ReliableMessageProtocolConfig.h>
 #include <system/SystemLayer.h>
 #include <transport/raw/MessageHeader.h>
 

--- a/src/messaging/ReliableMessageProtocolConfig.cpp
+++ b/src/messaging/ReliableMessageProtocolConfig.cpp
@@ -1,0 +1,37 @@
+/*
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file defines the configuration parameters that are required
+ *      for the CHIP Reliable Messaging Protocol.
+ *
+ */
+
+#include <messaging/ReliableMessageProtocolConfig.h>
+
+#include <system/SystemClock.h>
+
+namespace chip {
+
+using namespace System::Clock::Literals;
+
+const ReliableMessageProtocolConfig
+    gDefaultMRPConfig(CHIP_CONFIG_MRP_DEFAULT_IDLE_RETRY_INTERVAL >> CHIP_CONFIG_RMP_TIMER_DEFAULT_PERIOD_SHIFT,
+                      CHIP_CONFIG_MRP_DEFAULT_ACTIVE_RETRY_INTERVAL >> CHIP_CONFIG_RMP_TIMER_DEFAULT_PERIOD_SHIFT);
+
+} // namespace chip

--- a/src/messaging/ReliableMessageProtocolConfig.h
+++ b/src/messaging/ReliableMessageProtocolConfig.h
@@ -27,8 +27,9 @@
 
 #include <system/SystemConfig.h>
 
+#include <stdint.h>
+
 namespace chip {
-namespace Messaging {
 
 /**
  *  @def CHIP_CONFIG_RMP_TIMER_DEFAULT_PERIOD_SHIFT
@@ -118,16 +119,14 @@ namespace Messaging {
  */
 struct ReliableMessageProtocolConfig
 {
+    ReliableMessageProtocolConfig(uint32_t idleInterval, uint32_t activeInterval) :
+        mIdleRetransTimeoutTick(idleInterval), mActiveRetransTimeoutTick(activeInterval)
+    {}
+
     uint32_t mIdleRetransTimeoutTick;   /**< Configurable timeout in msec for retransmission of the first sent message. */
     uint32_t mActiveRetransTimeoutTick; /**< Configurable timeout in msec for retransmission of all subsequent messages. */
 };
 
-const ReliableMessageProtocolConfig gDefaultReliableMessageProtocolConfig = {
-    CHIP_CONFIG_MRP_DEFAULT_IDLE_RETRY_INTERVAL >> CHIP_CONFIG_RMP_TIMER_DEFAULT_PERIOD_SHIFT,
-    CHIP_CONFIG_MRP_DEFAULT_ACTIVE_RETRY_INTERVAL >> CHIP_CONFIG_RMP_TIMER_DEFAULT_PERIOD_SHIFT
-};
+extern const ReliableMessageProtocolConfig gDefaultMRPConfig;
 
-// clang-format on
-
-} // namespace Messaging
 } // namespace chip

--- a/src/messaging/tests/MessagingContext.cpp
+++ b/src/messaging/tests/MessagingContext.cpp
@@ -72,12 +72,14 @@ SessionHandle MessagingContext::GetSessionBobToFriends()
 
 Messaging::ExchangeContext * MessagingContext::NewUnauthenticatedExchangeToAlice(Messaging::ExchangeDelegate * delegate)
 {
-    return mExchangeManager.NewContext(mSessionManager.CreateUnauthenticatedSession(mAliceAddress).Value(), delegate);
+    return mExchangeManager.NewContext(mSessionManager.CreateUnauthenticatedSession(mAliceAddress, gDefaultMRPConfig).Value(),
+                                       delegate);
 }
 
 Messaging::ExchangeContext * MessagingContext::NewUnauthenticatedExchangeToBob(Messaging::ExchangeDelegate * delegate)
 {
-    return mExchangeManager.NewContext(mSessionManager.CreateUnauthenticatedSession(mBobAddress).Value(), delegate);
+    return mExchangeManager.NewContext(mSessionManager.CreateUnauthenticatedSession(mBobAddress, gDefaultMRPConfig).Value(),
+                                       delegate);
 }
 
 Messaging::ExchangeContext * MessagingContext::NewExchangeToAlice(Messaging::ExchangeDelegate * delegate)

--- a/src/transport/PairingSession.h
+++ b/src/transport/PairingSession.h
@@ -83,6 +83,16 @@ public:
         return LocalSessionMessageCounter::kInitialValue;
     }
 
+    /**
+     * @brief
+     *   Get the value of peer session counter which is synced during session establishment
+     */
+    virtual const ReliableMessageProtocolConfig & GetMRPConfig() const
+    {
+        // TODO(#6652): This is a stub implementation, should be replaced by the real one when CASE and PASE is completed
+        return gDefaultMRPConfig;
+    }
+
     virtual const char * GetI2RSessionInfo() const = 0;
 
     virtual const char * GetR2ISessionInfo() const = 0;

--- a/src/transport/SecureSession.h
+++ b/src/transport/SecureSession.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <app/util/basic-types.h>
+#include <messaging/ReliableMessageProtocolConfig.h>
 #include <transport/CryptoContext.h>
 #include <transport/SessionMessageCounter.h>
 #include <transport/raw/Base.h>
@@ -50,9 +51,9 @@ class SecureSession
 {
 public:
     SecureSession(uint16_t localSessionId, NodeId peerNodeId, uint16_t peerSessionId, FabricIndex fabric,
-                  System::Clock::Timestamp currentTime) :
+                  const ReliableMessageProtocolConfig & config, System::Clock::Timestamp currentTime) :
         mPeerNodeId(peerNodeId),
-        mLocalSessionId(localSessionId), mPeerSessionId(peerSessionId), mFabric(fabric)
+        mLocalSessionId(localSessionId), mPeerSessionId(peerSessionId), mFabric(fabric), mMRPConfig(config)
     {
         SetLastActivityTime(currentTime);
     }
@@ -68,17 +69,9 @@ public:
 
     NodeId GetPeerNodeId() const { return mPeerNodeId; }
 
-    void GetMRPIntervals(uint32_t & idleInterval, uint32_t & activeInterval)
-    {
-        idleInterval   = mMRPIdleInterval;
-        activeInterval = mMRPActiveInterval;
-    }
+    void SetMRPConfig(const ReliableMessageProtocolConfig & config) { mMRPConfig = config; }
 
-    void SetMRPIntervals(uint32_t idleInterval, uint32_t activeInterval)
-    {
-        mMRPIdleInterval   = idleInterval;
-        mMRPActiveInterval = activeInterval;
-    }
+    const ReliableMessageProtocolConfig & GetMRPConfig() const { return mMRPConfig; }
 
     uint16_t GetLocalSessionId() const { return mLocalSessionId; }
     uint16_t GetPeerSessionId() const { return mPeerSessionId; }
@@ -110,9 +103,8 @@ private:
     const FabricIndex mFabric;
 
     PeerAddress mPeerAddress;
-    System::Clock::Timestamp mLastActivityTime = System::Clock::kZero;
-    uint32_t mMRPIdleInterval                  = 0;
-    uint32_t mMRPActiveInterval                = 0;
+    System::Clock::Timestamp mLastActivityTime;
+    ReliableMessageProtocolConfig mMRPConfig;
     CryptoContext mCryptoContext;
     SessionMessageCounter mSessionMessageCounter;
 };

--- a/src/transport/SecureSessionTable.h
+++ b/src/transport/SecureSessionTable.h
@@ -55,9 +55,11 @@ public:
      *          has been reached (with CHIP_ERROR_NO_MEMORY).
      */
     CHECK_RETURN_VALUE
-    SecureSession * CreateNewSecureSession(uint16_t localSessionId, NodeId peerNodeId, uint16_t peerSessionId, FabricIndex fabric)
+    SecureSession * CreateNewSecureSession(uint16_t localSessionId, NodeId peerNodeId, uint16_t peerSessionId, FabricIndex fabric,
+                                           const ReliableMessageProtocolConfig & config)
     {
-        return mEntries.CreateObject(localSessionId, peerNodeId, peerSessionId, fabric, mTimeSource.GetMonotonicTimestamp());
+        return mEntries.CreateObject(localSessionId, peerNodeId, peerSessionId, fabric, config,
+                                     mTimeSource.GetMonotonicTimestamp());
     }
 
     void ReleaseSession(SecureSession * session) { mEntries.ReleaseObject(session); }

--- a/src/transport/SessionHandle.cpp
+++ b/src/transport/SessionHandle.cpp
@@ -39,23 +39,37 @@ const PeerAddress * SessionHandle::GetPeerAddress(SessionManager * sessionManage
     return &GetUnauthenticatedSession()->GetPeerAddress();
 }
 
-CHIP_ERROR SessionHandle::GetMRPIntervals(SessionManager * sessionManager, uint32_t & mrpIdleInterval, uint32_t & mrpActiveInterval)
+const ReliableMessageProtocolConfig & SessionHandle::GetMRPConfig(SessionManager * sessionManager) const
 {
     if (IsSecure())
     {
         SecureSession * secureSession = sessionManager->GetSecureSession(*this);
         if (secureSession == nullptr)
         {
-            return CHIP_ERROR_INVALID_ARGUMENT;
+            return gDefaultMRPConfig;
         }
-        secureSession->GetMRPIntervals(mrpIdleInterval, mrpActiveInterval);
-
-        return CHIP_NO_ERROR;
+        return secureSession->GetMRPConfig();
     }
+    else
+    {
+        return GetUnauthenticatedSession()->GetMRPConfig();
+    }
+}
 
-    GetUnauthenticatedSession()->GetMRPIntervals(mrpIdleInterval, mrpActiveInterval);
-
-    return CHIP_NO_ERROR;
+void SessionHandle::SetMRPConfig(SessionManager * sessionManager, const ReliableMessageProtocolConfig & config)
+{
+    if (IsSecure())
+    {
+        SecureSession * secureSession = sessionManager->GetSecureSession(*this);
+        if (secureSession != nullptr)
+        {
+            secureSession->SetMRPConfig(config);
+        }
+    }
+    else
+    {
+        return GetUnauthenticatedSession()->SetMRPConfig(config);
+    }
 }
 
 } // namespace chip

--- a/src/transport/SessionHandle.h
+++ b/src/transport/SessionHandle.h
@@ -84,7 +84,8 @@ public:
     // torn down, at the very least.
     const Transport::PeerAddress * GetPeerAddress(SessionManager * sessionManager) const;
 
-    CHIP_ERROR GetMRPIntervals(SessionManager * sessionManager, uint32_t & mrpIdleInterval, uint32_t & mrpActiveInterval);
+    const ReliableMessageProtocolConfig & GetMRPConfig(SessionManager * sessionManager) const;
+    void SetMRPConfig(SessionManager * sessionManager, const ReliableMessageProtocolConfig & config);
 
     Transport::UnauthenticatedSessionHandle GetUnauthenticatedSession() const { return mUnauthenticatedSessionHandle.Value(); }
 

--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -289,7 +289,7 @@ CHIP_ERROR SessionManager::NewPairing(const Optional<Transport::PeerAddress> & p
 
     ChipLogDetail(Inet, "New secure session created for device 0x" ChipLogFormatX64 ", key %d!!", ChipLogValueX64(peerNodeId),
                   peerSessionId);
-    session = mSecureSessions.CreateNewSecureSession(localSessionId, peerNodeId, peerSessionId, fabric);
+    session = mSecureSessions.CreateNewSecureSession(localSessionId, peerNodeId, peerSessionId, fabric, pairing->GetMRPConfig());
     ReturnErrorCodeIf(session == nullptr, CHIP_ERROR_NO_MEMORY);
 
     if (peerAddr.HasValue() && peerAddr.Value().GetIPAddress() != Inet::IPAddress::Any)
@@ -306,8 +306,6 @@ CHIP_ERROR SessionManager::NewPairing(const Optional<Transport::PeerAddress> & p
     {
         return CHIP_ERROR_INVALID_ARGUMENT;
     }
-
-    session->SetMRPIntervals(CHIP_CONFIG_MRP_DEFAULT_IDLE_RETRY_INTERVAL, CHIP_CONFIG_MRP_DEFAULT_ACTIVE_RETRY_INTERVAL);
 
     ReturnErrorOnFailure(pairing->DeriveSecureSession(session->GetCryptoContext(), direction));
 
@@ -363,7 +361,8 @@ void SessionManager::OnMessageReceived(const PeerAddress & peerAddress, System::
 void SessionManager::MessageDispatch(const PacketHeader & packetHeader, const Transport::PeerAddress & peerAddress,
                                      System::PacketBufferHandle && msg)
 {
-    Optional<Transport::UnauthenticatedSessionHandle> optionalSession = mUnauthenticatedSessions.FindOrAllocateEntry(peerAddress);
+    Optional<Transport::UnauthenticatedSessionHandle> optionalSession =
+        mUnauthenticatedSessions.FindOrAllocateEntry(peerAddress, gDefaultMRPConfig);
     if (!optionalSession.HasValue())
     {
         ChipLogError(Inet, "UnauthenticatedSession exhausted");

--- a/src/transport/SessionManager.h
+++ b/src/transport/SessionManager.h
@@ -31,6 +31,7 @@
 #include <lib/core/CHIPCore.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/DLLUtil.h>
+#include <messaging/ReliableMessageProtocolConfig.h>
 #include <protocols/secure_channel/Constants.h>
 #include <transport/CryptoContext.h>
 #include <transport/MessageCounterManagerInterface.h>
@@ -248,9 +249,11 @@ public:
      */
     void OnMessageReceived(const Transport::PeerAddress & source, System::PacketBufferHandle && msgBuf) override;
 
-    Optional<SessionHandle> CreateUnauthenticatedSession(const Transport::PeerAddress & peerAddress)
+    Optional<SessionHandle> CreateUnauthenticatedSession(const Transport::PeerAddress & peerAddress,
+                                                         const ReliableMessageProtocolConfig & config)
     {
-        Optional<Transport::UnauthenticatedSessionHandle> session = mUnauthenticatedSessions.FindOrAllocateEntry(peerAddress);
+        Optional<Transport::UnauthenticatedSessionHandle> session =
+            mUnauthenticatedSessions.FindOrAllocateEntry(peerAddress, config);
         return session.HasValue() ? MakeOptional<SessionHandle>(session.Value()) : NullOptional;
     }
 

--- a/src/transport/UnauthenticatedSessionTable.h
+++ b/src/transport/UnauthenticatedSessionTable.h
@@ -22,6 +22,7 @@
 #include <lib/support/Pool.h>
 #include <lib/support/ReferenceCountedHandle.h>
 #include <lib/support/logging/CHIPLogging.h>
+#include <messaging/ReliableMessageProtocolConfig.h>
 #include <system/TimeSource.h>
 #include <transport/MessageCounter.h>
 #include <transport/PeerMessageCounter.h>
@@ -47,7 +48,9 @@ public:
 class UnauthenticatedSession : public ReferenceCounted<UnauthenticatedSession, UnauthenticatedSessionDeleter, 0>
 {
 public:
-    UnauthenticatedSession(const PeerAddress & address) : mPeerAddress(address) {}
+    UnauthenticatedSession(const PeerAddress & address, const ReliableMessageProtocolConfig & config) :
+        mPeerAddress(address), mMRPConfig(config)
+    {}
 
     UnauthenticatedSession(const UnauthenticatedSession &) = delete;
     UnauthenticatedSession & operator=(const UnauthenticatedSession &) = delete;
@@ -59,17 +62,9 @@ public:
 
     const PeerAddress & GetPeerAddress() const { return mPeerAddress; }
 
-    void GetMRPIntervals(uint32_t & idleInterval, uint32_t & activeInterval)
-    {
-        idleInterval   = mMRPIdleInterval;
-        activeInterval = mMRPActiveInterval;
-    }
+    void SetMRPConfig(const ReliableMessageProtocolConfig & config) { mMRPConfig = config; }
 
-    void SetMRPIntervals(uint32_t idleInterval, uint32_t activeInterval)
-    {
-        mMRPIdleInterval   = idleInterval;
-        mMRPActiveInterval = activeInterval;
-    }
+    const ReliableMessageProtocolConfig & GetMRPConfig() const { return mMRPConfig; }
 
     PeerMessageCounter & GetPeerMessageCounter() { return mPeerMessageCounter; }
 
@@ -77,8 +72,7 @@ private:
     System::Clock::Timestamp mLastActivityTime = System::Clock::kZero;
 
     const PeerAddress mPeerAddress;
-    uint32_t mMRPIdleInterval   = 0;
-    uint32_t mMRPActiveInterval = 0;
+    ReliableMessageProtocolConfig mMRPConfig;
     PeerMessageCounter mPeerMessageCounter;
 };
 
@@ -100,13 +94,14 @@ public:
      * @return the session found or allocated, nullptr if not found and allocation failed.
      */
     CHECK_RETURN_VALUE
-    Optional<UnauthenticatedSessionHandle> FindOrAllocateEntry(const PeerAddress & address)
+    Optional<UnauthenticatedSessionHandle> FindOrAllocateEntry(const PeerAddress & address,
+                                                               const ReliableMessageProtocolConfig & config)
     {
         UnauthenticatedSession * result = FindEntry(address);
         if (result != nullptr)
             return MakeOptional<UnauthenticatedSessionHandle>(*result);
 
-        CHIP_ERROR err = AllocEntry(address, result);
+        CHIP_ERROR err = AllocEntry(address, config, result);
         if (err == CHIP_NO_ERROR)
         {
             return MakeOptional<UnauthenticatedSessionHandle>(*result);
@@ -134,9 +129,10 @@ private:
      * CHIP_ERROR_NO_MEMORY).
      */
     CHECK_RETURN_VALUE
-    CHIP_ERROR AllocEntry(const PeerAddress & address, UnauthenticatedSession *& entry)
+    CHIP_ERROR AllocEntry(const PeerAddress & address, const ReliableMessageProtocolConfig & config,
+                          UnauthenticatedSession *& entry)
     {
-        entry = mEntries.CreateObject(address);
+        entry = mEntries.CreateObject(address, config);
         if (entry != nullptr)
             return CHIP_NO_ERROR;
 
@@ -146,7 +142,7 @@ private:
             return CHIP_ERROR_NO_MEMORY;
         }
 
-        mEntries.ResetObject(entry, address);
+        mEntries.ResetObject(entry, address, config);
         return CHIP_NO_ERROR;
     }
 

--- a/src/transport/tests/TestPeerConnections.cpp
+++ b/src/transport/tests/TestPeerConnections.cpp
@@ -59,17 +59,17 @@ void TestBasicFunctionality(nlTestSuite * inSuite, void * inContext)
     connections.GetTimeSource().SetMonotonicTimestamp(100_ms64);
 
     // Node ID 1, peer key 1, local key 2
-    statePtr = connections.CreateNewSecureSession(2, kPeer1NodeId, 1, 0 /* fabricIndex */);
+    statePtr = connections.CreateNewSecureSession(2, kPeer1NodeId, 1, 0 /* fabricIndex */, gDefaultMRPConfig);
     NL_TEST_ASSERT(inSuite, statePtr != nullptr);
 
     // Node ID 2, peer key 3, local key 4
-    statePtr = connections.CreateNewSecureSession(4, kPeer2NodeId, 3, 0 /* fabricIndex */);
+    statePtr = connections.CreateNewSecureSession(4, kPeer2NodeId, 3, 0 /* fabricIndex */, gDefaultMRPConfig);
     NL_TEST_ASSERT(inSuite, statePtr != nullptr);
     NL_TEST_ASSERT(inSuite, statePtr->GetPeerNodeId() == kPeer2NodeId);
     NL_TEST_ASSERT(inSuite, statePtr->GetLastActivityTime() == 100_ms64);
 
     // Insufficient space for new connections. Object is max size 2
-    statePtr = connections.CreateNewSecureSession(6, kPeer3NodeId, 5, 0 /* fabricIndex */);
+    statePtr = connections.CreateNewSecureSession(6, kPeer3NodeId, 5, 0 /* fabricIndex */, gDefaultMRPConfig);
     NL_TEST_ASSERT(inSuite, statePtr == nullptr);
 }
 
@@ -79,14 +79,14 @@ void TestFindByKeyId(nlTestSuite * inSuite, void * inContext)
     SecureSessionTable<2, Time::Source::kTest> connections;
 
     // Node ID 1, peer key 1, local key 2
-    statePtr = connections.CreateNewSecureSession(2, kPeer1NodeId, 1, 0 /* fabricIndex */);
+    statePtr = connections.CreateNewSecureSession(2, kPeer1NodeId, 1, 0 /* fabricIndex */, gDefaultMRPConfig);
     NL_TEST_ASSERT(inSuite, statePtr != nullptr);
 
     NL_TEST_ASSERT(inSuite, !connections.FindSecureSessionByLocalKey(1));
     NL_TEST_ASSERT(inSuite, connections.FindSecureSessionByLocalKey(2));
 
     // Node ID 2, peer key 3, local key 4
-    statePtr = connections.CreateNewSecureSession(4, kPeer2NodeId, 3, 0 /* fabricIndex */);
+    statePtr = connections.CreateNewSecureSession(4, kPeer2NodeId, 3, 0 /* fabricIndex */, gDefaultMRPConfig);
     NL_TEST_ASSERT(inSuite, statePtr != nullptr);
 
     NL_TEST_ASSERT(inSuite, !connections.FindSecureSessionByLocalKey(3));
@@ -109,19 +109,19 @@ void TestExpireConnections(nlTestSuite * inSuite, void * inContext)
     connections.GetTimeSource().SetMonotonicTimestamp(100_ms64);
 
     // Node ID 1, peer key 1, local key 2
-    statePtr = connections.CreateNewSecureSession(2, kPeer1NodeId, 1, 0 /* fabricIndex */);
+    statePtr = connections.CreateNewSecureSession(2, kPeer1NodeId, 1, 0 /* fabricIndex */, gDefaultMRPConfig);
     NL_TEST_ASSERT(inSuite, statePtr != nullptr);
     statePtr->SetPeerAddress(kPeer1Addr);
 
     connections.GetTimeSource().SetMonotonicTimestamp(200_ms64);
     // Node ID 2, peer key 3, local key 4
-    statePtr = connections.CreateNewSecureSession(4, kPeer2NodeId, 3, 0 /* fabricIndex */);
+    statePtr = connections.CreateNewSecureSession(4, kPeer2NodeId, 3, 0 /* fabricIndex */, gDefaultMRPConfig);
     NL_TEST_ASSERT(inSuite, statePtr != nullptr);
     statePtr->SetPeerAddress(kPeer2Addr);
 
     // cannot add before expiry
     connections.GetTimeSource().SetMonotonicTimestamp(300_ms64);
-    statePtr = connections.CreateNewSecureSession(6, kPeer3NodeId, 5, 0 /* fabricIndex */);
+    statePtr = connections.CreateNewSecureSession(6, kPeer3NodeId, 5, 0 /* fabricIndex */, gDefaultMRPConfig);
     NL_TEST_ASSERT(inSuite, statePtr == nullptr);
 
     // at time 300, this expires ip addr 1
@@ -138,7 +138,7 @@ void TestExpireConnections(nlTestSuite * inSuite, void * inContext)
     // now that the connections were expired, we can add peer3
     connections.GetTimeSource().SetMonotonicTimestamp(300_ms64);
     // Node ID 3, peer key 5, local key 6
-    statePtr = connections.CreateNewSecureSession(6, kPeer3NodeId, 5, 0 /* fabricIndex */);
+    statePtr = connections.CreateNewSecureSession(6, kPeer3NodeId, 5, 0 /* fabricIndex */, gDefaultMRPConfig);
     NL_TEST_ASSERT(inSuite, statePtr != nullptr);
     statePtr->SetPeerAddress(kPeer3Addr);
 
@@ -169,7 +169,7 @@ void TestExpireConnections(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, !connections.FindSecureSessionByLocalKey(6));
 
     // Node ID 1, peer key 1, local key 2
-    statePtr = connections.CreateNewSecureSession(2, kPeer1NodeId, 1, 0 /* fabricIndex */);
+    statePtr = connections.CreateNewSecureSession(2, kPeer1NodeId, 1, 0 /* fabricIndex */, gDefaultMRPConfig);
     NL_TEST_ASSERT(inSuite, statePtr != nullptr);
     NL_TEST_ASSERT(inSuite, connections.FindSecureSessionByLocalKey(2));
     NL_TEST_ASSERT(inSuite, connections.FindSecureSessionByLocalKey(4));


### PR DESCRIPTION
#### Problem
Passing MRP parameters as 2 int is hard to maintain.

#### Change overview
Group MRP parameters into `ReliableMessageProtocolConfig` class

#### Testing
Verified by unit-tests