### PR TITLE
Correctly call OnReportBegin/End.

### DIFF
--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -391,12 +391,18 @@ CHIP_ERROR ReadClient::ProcessReportData(System::PacketBufferHandle && aPayload)
         TLV::TLVReader attributeReportIBsReader;
         attributeReportIBs.GetReader(&attributeReportIBsReader);
 
-        mpCallback->OnReportBegin(this);
+        if (IsInitialReport())
+        {
+            mpCallback->OnReportBegin(this);
+        }
 
         err = ProcessAttributeReportIBs(attributeReportIBsReader);
         SuccessOrExit(err);
 
-        mpCallback->OnReportEnd(this);
+        if (!mPendingMoreChunks)
+        {
+            mpCallback->OnReportEnd(this);
+        }
     }
 
     if (!suppressResponse)
@@ -503,6 +509,10 @@ CHIP_ERROR ReadClient::ProcessAttributeReportIBs(TLV::TLVReader & aAttributeRepo
 
             ConcreteDataAttributePath attributePath(clusterInfo.mEndpointId, clusterInfo.mClusterId, clusterInfo.mAttributeId);
 
+            //
+            // TODO: Add support for correctly handling appends/updates whenever list chunking support
+            // on the server side is added.
+            //
             if (dataReader.GetType() == TLV::kTLVType_Array)
             {
                 attributePath.mListOp = ConcreteDataAttributePath::ListOperation::ReplaceAll;

--- a/src/app/ReadHandler.h
+++ b/src/app/ReadHandler.h
@@ -129,7 +129,7 @@ public:
     bool IsReadType() { return mInteractionType == InteractionType::Read; }
     bool IsSubscriptionType() { return mInteractionType == InteractionType::Subscribe; }
     bool IsChunkedReport() { return mIsChunkedReport; }
-    bool IsInitialReport() { return mInitialReport; }
+    bool IsPriming() { return mIsPrimingReports; }
     bool IsActiveSubscription() const { return mActiveSubscription; }
     CHIP_ERROR OnSubscribeRequest(Messaging::ExchangeContext * apExchangeContext, System::PacketBufferHandle && aPayload);
     void GetSubscriptionId(uint64_t & aSubscriptionId) { aSubscriptionId = mSubscriptionId; }
@@ -193,11 +193,15 @@ private:
     EventNumber mLastScheduledEventNumber[kNumPriorityLevel];
     Messaging::ExchangeManager * mpExchangeMgr = nullptr;
     InteractionModelDelegate * mpDelegate      = nullptr;
-    bool mInitialReport                        = false;
-    InteractionType mInteractionType           = InteractionType::Read;
-    uint64_t mSubscriptionId                   = 0;
-    uint16_t mMinIntervalFloorSeconds          = 0;
-    uint16_t mMaxIntervalCeilingSeconds        = 0;
+
+    // Tracks whether we're in the initial phase of receiving priming
+    // reports, which is always true for reads and true for subscriptions
+    // prior to receiving a subscribe response.
+    bool mIsPrimingReports              = false;
+    InteractionType mInteractionType    = InteractionType::Read;
+    uint64_t mSubscriptionId            = 0;
+    uint16_t mMinIntervalFloorSeconds   = 0;
+    uint16_t mMaxIntervalCeilingSeconds = 0;
     Optional<SessionHandle> mSessionHandle;
     bool mHoldReport         = false;
     bool mDirty              = false;

--- a/src/app/reporting/Engine.cpp
+++ b/src/app/reporting/Engine.cpp
@@ -106,7 +106,7 @@ CHIP_ERROR Engine::BuildSingleReportDataAttributeReportIBs(ReportDataMessage::Bu
         for (; apReadHandler->GetAttributePathExpandIterator()->Get(readPath);
              apReadHandler->GetAttributePathExpandIterator()->Next())
         {
-            if (!apReadHandler->IsInitialReport())
+            if (!apReadHandler->IsPriming())
             {
                 bool concretePathDirty = false;
                 // TODO: Optimize this implementation by making the iterator only emit intersected paths.


### PR DESCRIPTION
With basic chunking support already in the tree, This fixes up the logic bug where
OnReportBegin/End were not being called at the right times on incoming
report processing.

This also fixes up some terminology confusion in ReadClient/Handler
where the use of `mIsInitialReport` meant two different things in those
two contexts: In ReadClient, it literally meant the first report in a
train of priming reports, while on the handler, it referred to the
entire priming phase of reporting.