### PR TITLE
Update ZAP and set defaultReportable to true for attributes.

### DIFF
--- a/src/app/zap-templates/zcl/zcl.json
+++ b/src/app/zap-templates/zcl/zcl.json
@@ -82,5 +82,6 @@
         "bool": {
             "commandDiscovery": true
         }
-    }
+    },
+    "defaultReportable": true
 }


### PR DESCRIPTION
This should cause IS_REPORTABLE to be true for attributes unless the
XML has reportable="false".  Still waiting on
https://github.com/project-chip/zap/issues/318 to be fixed to then get
us the behavior we really want.

#### Problem
Attributes do not default to reportable in ZAP for Matter.

#### Change overview
Add infrastructure to make the ZAP database have the right state for the attributes; still needs to be properly propagated to the .zap file.

#### Testing
Checked what the sqlite database has with this fix and verified that attributes are reportable unless `reportable="false"` is set.