### PR TITLE
Inet: Make InetLayer virtual

### DIFF
--- a/src/inet/TCPEndPoint.cpp
+++ b/src/inet/TCPEndPoint.cpp
@@ -89,8 +89,6 @@ namespace Inet {
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
 
-BitMapObjectPool<TCPEndPointImplLwIP, INET_CONFIG_NUM_TCP_ENDPOINTS> TCPEndPointImplLwIP::sPool;
-
 namespace {
 
 /*
@@ -1180,8 +1178,6 @@ void TCPEndPointImplLwIP::LwIPHandleError(void * arg, err_t lwipErr)
 #endif // CHIP_SYSTEM_CONFIG_USE_LWIP
 
 #if CHIP_SYSTEM_CONFIG_USE_SOCKETS
-
-BitMapObjectPool<TCPEndPointImplSockets, INET_CONFIG_NUM_TCP_ENDPOINTS> TCPEndPointImplSockets::sPool;
 
 CHIP_ERROR TCPEndPointImplSockets::BindImpl(IPAddressType addrType, const IPAddress & addr, uint16_t port, bool reuseAddr)
 {
@@ -2782,6 +2778,11 @@ void TCPEndPoint::TCPUserTimeoutHandler(chip::System::Layer * aSystemLayer, void
 }
 
 #endif // INET_CONFIG_OVERRIDE_SYSTEM_TCP_USER_TIMEOUT
+
+void TCPEndPointDeletor::Release(TCPEndPoint * obj)
+{
+    obj->Layer().DeleteTCPEndPoint(obj);
+}
 
 } // namespace Inet
 } // namespace chip

--- a/src/inet/UDPEndPoint.cpp
+++ b/src/inet/UDPEndPoint.cpp
@@ -147,8 +147,6 @@ CHIP_ERROR CheckMulticastGroupArgs(InterfaceId aInterfaceId, const IPAddress & a
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
 
-BitMapObjectPool<UDPEndPointImplLwIP, INET_CONFIG_NUM_UDP_ENDPOINTS> UDPEndPointImplLwIP::sPool;
-
 CHIP_ERROR UDPEndPointImplLwIP::BindImpl(IPAddressType addressType, const IPAddress & address, uint16_t port,
                                          InterfaceId interfaceId)
 {
@@ -702,8 +700,6 @@ IPPacketInfo * UDPEndPointImplLwIP::GetPacketInfo(const System::PacketBufferHand
 #endif // CHIP_SYSTEM_CONFIG_USE_LWIP
 
 #if CHIP_SYSTEM_CONFIG_USE_SOCKETS
-
-BitMapObjectPool<UDPEndPointImplSockets, INET_CONFIG_NUM_UDP_ENDPOINTS> UDPEndPointImplSockets::sPool;
 
 namespace {
 
@@ -1449,8 +1445,6 @@ CHIP_ERROR UDPEndPointImplSockets::IPv6JoinLeaveMulticastGroupImpl(InterfaceId a
 
 #if CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK
 
-BitMapObjectPool<UDPEndPointImplNetworkFramework, INET_CONFIG_NUM_UDP_ENDPOINTS> UDPEndPointImplNetworkFramework::sPool;
-
 CHIP_ERROR UDPEndPointImplNetworkFramework::BindImpl(IPAddressType addressType, const IPAddress & address, uint16_t port,
                                                      InterfaceId intfId)
 {
@@ -2090,6 +2084,11 @@ CHIP_ERROR UDPEndPoint::LeaveMulticastGroup(InterfaceId aInterfaceId, const IPAd
 
 exit:
     return (lRetval);
+}
+
+void UDPEndPointDeletor::Release(UDPEndPoint * obj)
+{
+    obj->Layer().DeleteUDPEndPoint(obj);
 }
 
 } // namespace Inet

--- a/src/inet/UDPEndPoint.h
+++ b/src/inet/UDPEndPoint.h
@@ -73,16 +73,10 @@ public:
 class DLL_EXPORT UDPEndPoint : public EndPointBase, public ReferenceCounted<UDPEndPoint, UDPEndPointDeletor>
 {
 public:
-    UDPEndPoint(InetLayer & inetLayer, void * appState = nullptr) :
-        EndPointBase(inetLayer, appState), mState(State::kReady), OnMessageReceived(nullptr), OnReceiveError(nullptr)
-    {}
-
     UDPEndPoint(const UDPEndPoint &) = delete;
     UDPEndPoint(UDPEndPoint &&)      = delete;
     UDPEndPoint & operator=(const UDPEndPoint &) = delete;
     UDPEndPoint & operator=(UDPEndPoint &&) = delete;
-
-    virtual ~UDPEndPoint() = default;
 
     /**
      * Type of message text reception event handling function.
@@ -274,6 +268,12 @@ public:
     virtual void Free() = 0;
 
 protected:
+    UDPEndPoint(InetLayer & inetLayer, void * appState = nullptr) :
+        EndPointBase(inetLayer, appState), mState(State::kReady), OnMessageReceived(nullptr), OnReceiveError(nullptr)
+    {}
+
+    virtual ~UDPEndPoint() = default;
+
     /**
      * Basic dynamic state of the underlying endpoint.
      *
@@ -296,9 +296,6 @@ protected:
     /** The endpoint's receive error event handling function delegate. */
     OnReceiveErrorFunct OnReceiveError;
 
-    friend class UDPEndPointDeletor;
-    virtual void Delete() = 0;
-
     /*
      * Implementation helpers for shared methods.
      */
@@ -313,11 +310,6 @@ protected:
     virtual CHIP_ERROR SendMsgImpl(const IPPacketInfo * pktInfo, chip::System::PacketBufferHandle && msg)                     = 0;
     virtual void CloseImpl()                                                                                                  = 0;
 };
-
-inline void UDPEndPointDeletor::Release(UDPEndPoint * obj)
-{
-    obj->Delete();
-}
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
 
@@ -334,9 +326,6 @@ public:
 
 private:
     friend class InetLayer;
-    friend class BitMapObjectPool<UDPEndPointImplLwIP, INET_CONFIG_NUM_UDP_ENDPOINTS>;
-    static BitMapObjectPool<UDPEndPointImplLwIP, INET_CONFIG_NUM_UDP_ENDPOINTS> sPool;
-    void Delete() override { sPool.ReleaseObject(this); }
 
     // UDPEndPoint overrides.
 #if INET_CONFIG_ENABLE_IPV4
@@ -404,9 +393,6 @@ public:
 
 private:
     friend class InetLayer;
-    friend class BitMapObjectPool<UDPEndPointImplSockets, INET_CONFIG_NUM_UDP_ENDPOINTS>;
-    static BitMapObjectPool<UDPEndPointImplSockets, INET_CONFIG_NUM_UDP_ENDPOINTS> sPool;
-    void Delete() override { sPool.ReleaseObject(this); }
 
     // UDPEndPoint overrides.
 #if INET_CONFIG_ENABLE_IPV4
@@ -461,9 +447,6 @@ public:
 
 private:
     friend class InetLayer;
-    friend class BitMapObjectPool<UDPEndPointImplNetworkFramework, INET_CONFIG_NUM_UDP_ENDPOINTS>;
-    static BitMapObjectPool<UDPEndPointImplNetworkFramework, INET_CONFIG_NUM_UDP_ENDPOINTS> sPool;
-    void Delete() override { sPool.ReleaseObject(this); }
 
     // UDPEndPoint overrides.
 #if INET_CONFIG_ENABLE_IPV4

--- a/src/inet/tests/TestInetCommon.h
+++ b/src/inet/tests/TestInetCommon.h
@@ -53,7 +53,7 @@
 
 extern chip::System::LayerImpl gSystemLayer;
 
-extern chip::Inet::InetLayer gInet;
+extern chip::Inet::InetLayerImpl gInet;
 
 extern bool gDone;
 

--- a/src/inet/tests/TestInetCommonPosix.cpp
+++ b/src/inet/tests/TestInetCommonPosix.cpp
@@ -80,7 +80,7 @@ using namespace chip::Inet;
 
 System::LayerImpl gSystemLayer;
 
-Inet::InetLayer gInet;
+Inet::InetLayerImpl gInet;
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
 static sys_mbox_t * sLwIPEventQueue   = NULL;

--- a/src/platform/Globals.cpp
+++ b/src/platform/Globals.cpp
@@ -27,7 +27,7 @@ namespace DeviceLayer {
 
 chip::Inet::InetLayer & InetLayer()
 {
-    static chip::Inet::InetLayer gInetLayer;
+    static chip::Inet::InetLayerImpl gInetLayer;
     return gInetLayer;
 }
 


### PR DESCRIPTION
#### Problem

This is a step toward #7715 _Virtualize System and Inet interfaces_,
building on recent virtualization of Inet endpoints and changes to
object allocation pools.

#### Change overview

- Make implementation-dependent `InetLayer` methods virtual.
- For this step, provide a single `InetLayerPoolImpl` templated
  on concrete implemenations of `TCPEndPoint` and `UDPEndPoint`.

#### Testing

CI; no changes to functionality.
