### PR TITLE
Align heap amouts on all efr32 device examples

### DIFF
--- a/examples/lock-app/efr32/include/FreeRTOSConfig.h
+++ b/examples/lock-app/efr32/include/FreeRTOSConfig.h
@@ -237,7 +237,7 @@ See http://www.FreeRTOS.org/RTOS-Cortex-M3-M4.html. */
 #define configENABLE_BACKWARD_COMPATIBILITY (1)
 #define configSUPPORT_STATIC_ALLOCATION (1)
 #define configSUPPORT_DYNAMIC_ALLOCATION (1)
-#define configTOTAL_HEAP_SIZE ((size_t)(16 * 1024))
+#define configTOTAL_HEAP_SIZE ((size_t)(20 * 1024))
 
 /* Optional functions - most linkers will remove unused functions anyway. */
 #define INCLUDE_vTaskPrioritySet (1)

--- a/examples/window-app/efr32/include/FreeRTOSConfig.h
+++ b/examples/window-app/efr32/include/FreeRTOSConfig.h
@@ -237,7 +237,7 @@ See http://www.FreeRTOS.org/RTOS-Cortex-M3-M4.html. */
 #define configENABLE_BACKWARD_COMPATIBILITY (1)
 #define configSUPPORT_STATIC_ALLOCATION (1)
 #define configSUPPORT_DYNAMIC_ALLOCATION (1)
-#define configTOTAL_HEAP_SIZE ((size_t)(16 * 1024))
+#define configTOTAL_HEAP_SIZE ((size_t)(20 * 1024))
 
 /* Optional functions - most linkers will remove unused functions anyway. */
 #define INCLUDE_vTaskPrioritySet (1)


### PR DESCRIPTION
#### Problem
* Examples were not using the right amount of heap

#### Change overview
* Increase heap on examples that werent updated

#### Testing
* built both examples
