### PR TITLE
Refactor read/write ember compatibility functions

### DIFF
--- a/src/app/util/ember-compatibility-functions.cpp
+++ b/src/app/util/ember-compatibility-functions.cpp
@@ -518,7 +518,7 @@ CHIP_ERROR ReadSingleClusterData(FabricIndex aAccessingFabricIndex, const Concre
     Protocols::InteractionModel::Status imStatus = ToInteractionModelStatus(emberStatus);
     if (imStatus == Protocols::InteractionModel::Status::Success)
     {
-        SendSuccessStatus(attributeDataIBBuilder);
+        return SendSuccessStatus(attributeDataIBBuilder);
     }
 
     return SendFailureStatus(aPath, aAttributeReport, imStatus, backup);

--- a/src/app/util/ember-compatibility-functions.cpp
+++ b/src/app/util/ember-compatibility-functions.cpp
@@ -670,9 +670,7 @@ CHIP_ERROR WriteSingleClusterData(ClusterInfo & aClusterInfo, TLV::TLVReader & a
     const EmberAfAttributeMetadata * attributeMetadata =
         emberAfLocateAttributeMetadata(aPath.mEndpointId, aPath.mClusterId, aPath.mAttributeId, CLUSTER_MASK_SERVER, 0);
 
-    AttributePathParams attributePathParams = { .mEndpointId  = aPath.mEndpointId,
-                                                .mClusterId   = aPath.mClusterId,
-                                                .mAttributeId = aPath.mAttributeId };
+    AttributePathParams attributePathParams(aPath.mEndpointId, aPath.mClusterId, aPath.mAttributeId);
 
     if (attributeMetadata == nullptr)
     {


### PR DESCRIPTION
Refactor the code within ReadSingleClusterData and
WriteSingleClusterData so it has better support for early exit while
returning status in the message response.

This will be needed soon when Access Control starts denying access.

Tested by running unit tests, and running chip-tool against all-clusters-app
for some reads and writes.