### PR TITLE
Add transitional support to access control

### DIFF
--- a/src/access/AccessControl.cpp
+++ b/src/access/AccessControl.cpp
@@ -83,6 +83,9 @@ CHIP_ERROR AccessControl::Finish()
 CHIP_ERROR AccessControl::Check(const SubjectDescriptor & subjectDescriptor, const RequestPath & requestPath,
                                 Privilege requestPrivilege)
 {
+    // During development, allow access if delegate is transitional
+    ReturnErrorCodeIf(mDelegate.IsTransitional(), CHIP_NO_ERROR);
+
     EntryIterator iterator;
     ReturnErrorOnFailure(Entries(iterator, &subjectDescriptor.fabricIndex));
 

--- a/src/access/AccessControl.h
+++ b/src/access/AccessControl.h
@@ -319,6 +319,9 @@ public:
             return CHIP_ERROR_NOT_IMPLEMENTED;
         }
 
+        // Transitional (during development, will be removed later)
+        virtual bool IsTransitional() const { return true; }
+
         // Listening
         virtual void SetListener(Listener & listener) { mListener = &listener; }
         virtual void ClearListener() { mListener = nullptr; }

--- a/src/access/examples/ExampleAccessControlDelegate.cpp
+++ b/src/access/examples/ExampleAccessControlDelegate.cpp
@@ -1081,6 +1081,8 @@ public:
         return CHIP_ERROR_BUFFER_TOO_SMALL;
     }
 
+    bool IsTransitional() const override { return false; }
+
 private:
     CHIP_ERROR LoadFromFlash() { return CHIP_NO_ERROR; }
 


### PR DESCRIPTION
During development, let access control delegates declare they are
transitional, so access is allowed. This is the default for now,
but won't be once the rest of the system is in place.

In particular, unit tests are not transitional and do test functional
access control (allow and deny).
