### PR TITLE
Reporting relevant attribute change when various faults are detected

### DIFF
--- a/src/app/clusters/general_diagnostics_server/general_diagnostics_server.cpp
+++ b/src/app/clusters/general_diagnostics_server/general_diagnostics_server.cpp
@@ -250,14 +250,14 @@ class GeneralDiagnosticDelegate : public DeviceLayer::ConnectivityManagerDelegat
                 {
                     // If General Diagnostics cluster is implemented on this endpoint
                     MatterReportingAttributeChangeCallback(endpointId, GeneralDiagnostics::Id,
-                                                           GeneralDiagnostics::Attributes::GetActiveRadioFaults::Id);
+                                                           GeneralDiagnostics::Attributes::ActiveRadioFaults::Id);
                 }
             }
         }
     }
 
     // Get called when the Node detects a network fault has been raised.
-    void OnHardwareFaultsDetected() override
+    void OnNetworkFaultsDetected() override
     {
         ChipLogProgress(Zcl, "GeneralDiagnosticDelegate: OnHardwareFaultsDetected");
 
@@ -271,7 +271,7 @@ class GeneralDiagnosticDelegate : public DeviceLayer::ConnectivityManagerDelegat
                 {
                     // If General Diagnostics cluster is implemented on this endpoint
                     MatterReportingAttributeChangeCallback(endpointId, GeneralDiagnostics::Id,
-                                                           GeneralDiagnostics::Attributes::GetActiveNetworkFaults::Id);
+                                                           GeneralDiagnostics::Attributes::ActiveNetworkFaults::Id);
                 }
             }
         }

--- a/src/app/clusters/general_diagnostics_server/general_diagnostics_server.cpp
+++ b/src/app/clusters/general_diagnostics_server/general_diagnostics_server.cpp
@@ -213,6 +213,69 @@ class GeneralDiagnosticDelegate : public DeviceLayer::ConnectivityManagerDelegat
             }
         }
     }
+
+    // Get called when the Node detects a hardware fault has been raised.
+    void OnHardwareFaultsDetected() override
+    {
+        ChipLogProgress(Zcl, "GeneralDiagnosticDelegate: OnHardwareFaultsDetected");
+
+        for (uint16_t index = 0; index < emberAfEndpointCount(); index++)
+        {
+            if (emberAfEndpointIndexIsEnabled(index))
+            {
+                EndpointId endpointId = emberAfEndpointFromIndex(index);
+
+                if (emberAfContainsServer(endpointId, GeneralDiagnostics::Id))
+                {
+                    // If General Diagnostics cluster is implemented on this endpoint
+                    MatterReportingAttributeChangeCallback(endpointId, GeneralDiagnostics::Id,
+                                                           GeneralDiagnostics::Attributes::ActiveHardwareFaults::Id);
+                }
+            }
+        }
+    }
+
+    // Get called when the Node detects a radio fault has been raised.
+    void OnHardwareFaultsDetected() override
+    {
+        ChipLogProgress(Zcl, "GeneralDiagnosticDelegate: OnHardwareFaultsDetected");
+
+        for (uint16_t index = 0; index < emberAfEndpointCount(); index++)
+        {
+            if (emberAfEndpointIndexIsEnabled(index))
+            {
+                EndpointId endpointId = emberAfEndpointFromIndex(index);
+
+                if (emberAfContainsServer(endpointId, GeneralDiagnostics::Id))
+                {
+                    // If General Diagnostics cluster is implemented on this endpoint
+                    MatterReportingAttributeChangeCallback(endpointId, GeneralDiagnostics::Id,
+                                                           GeneralDiagnostics::Attributes::GetActiveRadioFaults::Id);
+                }
+            }
+        }
+    }
+
+    // Get called when the Node detects a network fault has been raised.
+    void OnHardwareFaultsDetected() override
+    {
+        ChipLogProgress(Zcl, "GeneralDiagnosticDelegate: OnHardwareFaultsDetected");
+
+        for (uint16_t index = 0; index < emberAfEndpointCount(); index++)
+        {
+            if (emberAfEndpointIndexIsEnabled(index))
+            {
+                EndpointId endpointId = emberAfEndpointFromIndex(index);
+
+                if (emberAfContainsServer(endpointId, GeneralDiagnostics::Id))
+                {
+                    // If General Diagnostics cluster is implemented on this endpoint
+                    MatterReportingAttributeChangeCallback(endpointId, GeneralDiagnostics::Id,
+                                                           GeneralDiagnostics::Attributes::GetActiveNetworkFaults::Id);
+                }
+            }
+        }
+    }
 };
 
 GeneralDiagnosticDelegate gDiagnosticDelegate;

--- a/src/app/clusters/general_diagnostics_server/general_diagnostics_server.cpp
+++ b/src/app/clusters/general_diagnostics_server/general_diagnostics_server.cpp
@@ -236,7 +236,7 @@ class GeneralDiagnosticDelegate : public DeviceLayer::ConnectivityManagerDelegat
     }
 
     // Get called when the Node detects a radio fault has been raised.
-    void OnHardwareFaultsDetected() override
+    void OnRadioFaultsDetected() override
     {
         ChipLogProgress(Zcl, "GeneralDiagnosticDelegate: OnHardwareFaultsDetected");
 

--- a/src/include/platform/DiagnosticDataProvider.h
+++ b/src/include/platform/DiagnosticDataProvider.h
@@ -49,9 +49,27 @@ public:
 
     /**
      * @brief
-     *   Called after the current device is rebooted
+     *   Called after the current device is rebooted.
      */
     virtual void OnDeviceRebooted() {}
+
+    /**
+     * @brief
+     *   Called when the Node detects a hardware fault has been raised.
+     */
+    virtual void OnHardwareFaultsDetected() {}
+
+    /**
+     * @brief
+     *   Called when the Node detects a radio fault has been raised.
+     */
+    virtual void OnRadioFaultsDetected() {}
+
+    /**
+     * @brief
+     *   Called when the Node detects a network fault has been raised.
+     */
+    virtual void OnNetworkFaultsDetected() {}
 };
 
 /**


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* We need to mark relevant attributes dirty and notify reporting engine when various device faults are detected.

#### Change overview
Add interface to report relevant attribute change when various faults are detected.

Please note, the actual user scenarios of this feature is embedded system. Each embedded platform need to call the corresponding defined delegate API when various faults are detected. No reference implementation on Linux to simulate those device faults.   

#### Testing
How was this tested? (at least one bullet point required)
* No good way to test this feature until any embedded platform support this feature. No reference implementation is implemented on Linux simulation. Regression is covered by CI. 