### PR TITLE
Update esp32 4.4. branch forward, to fix dockerfile builds

### DIFF
--- a/integrations/docker/images/chip-build-esp32/Dockerfile
+++ b/integrations/docker/images/chip-build-esp32/Dockerfile
@@ -11,7 +11,7 @@ RUN set -x \
 
 RUN set -x \
     && git clone --depth 1 --recursive -b release/v4.4 https://github.com/espressif/esp-idf.git /tmp/esp-idf \
-    && git -C /tmp/esp-idf checkout 6a7d83af1984b93ebaefa7ca9be36304806c3dc8 \
+    && git -C /tmp/esp-idf checkout ddc44956bf718540d5451e17e1becf6c7dffe5b8 \
     && : # last line
 
 FROM connectedhomeip/chip-build:${VERSION}

--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.5.29 Version bump reason: [K32W0] Update K32W0 Env variable name
+0.5.30 Version bump reason: ESP32 update to newest 4.4 commit: ddc44956bf718540d5451e17e1becf6c7dffe5b8


### PR DESCRIPTION
#### Problem
ESP32 docker fails.

#### Change overview
Move ESP32 4.4 branch forward.

#### Testing
ran build.sh locally after the change
