### PR TITLE
[K32W0] Check module type

### DIFF
--- a/src/platform/nxp/k32w/k32w0/PlatformManagerImpl.cpp
+++ b/src/platform/nxp/k32w/k32w0/PlatformManagerImpl.cpp
@@ -34,6 +34,8 @@
 
 #include <openthread/platform/entropy.h>
 
+#include "K32W061.h"
+
 namespace chip {
 namespace DeviceLayer {
 
@@ -59,6 +61,15 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
     // Initialize the configuration system.
     err = Internal::K32WConfig::Init();
     SuccessOrExit(err);
+
+    if (Chip_GetType() != CHIP_K32W061)
+    {
+        err = CHIP_ERROR_INTERNAL;
+        ChipLogError(DeviceLayer, "Invalid chip type, expected K32W061");
+
+        goto exit;
+    }
+
     SetConfigurationMgr(&ConfigurationManagerImpl::GetDefaultInstance());
     SetDiagnosticDataProvider(&DiagnosticDataProviderImpl::GetDefaultInstance());
 


### PR DESCRIPTION


Signed-off-by: Doru Gucea <doru-cristian.gucea@nxp.com>

#### Problem
What is being fixed?
* Return error in case the K32W demo apps are run on JN5189

#### Change overview
Make sure that the application runs on K32W061 (Thread + BLE).

#### Testing
How was this tested?
* manual testing