### PR TITLE
[build] Fix SECURITY_TEST_MODE to be disabled for all builds.

### DIFF
--- a/config/standalone/CHIPProjectConfig.h
+++ b/config/standalone/CHIPProjectConfig.h
@@ -53,6 +53,8 @@
 //    WARNING: These options make it possible to circumvent basic Chip security functionality,
 //    including message encryption. Because of this they MUST NEVER BE ENABLED IN PRODUCTION BUILDS.
 //
+//    To build with this flag, pass 'treat_warnings_as_errors=false' to gn/ninja.
+//
 #define CHIP_CONFIG_SECURITY_TEST_MODE 0
 #define CHIP_CONFIG_REQUIRE_AUTH 1
 

--- a/examples/lock-app/cc13x2x7_26x2x7/main/include/CHIPProjectConfig.h
+++ b/examples/lock-app/cc13x2x7_26x2x7/main/include/CHIPProjectConfig.h
@@ -41,7 +41,7 @@
 // authentication in various protocols.
 // WARNING: These options make it possible to circumvent basic CHIP security functionality,
 // including message encryption. Because of this they MUST NEVER BE ENABLED IN PRODUCTION BUILDS.
-#define CHIP_CONFIG_SECURITY_TEST_MODE 1
+#define CHIP_CONFIG_SECURITY_TEST_MODE 0
 #define CHIP_CONFIG_REQUIRE_AUTH 0
 
 // Use a default pairing code if one hasn't been provisioned in flash.

--- a/examples/persistent-storage/cc13x2x7_26x2x7/include/CHIPProjectConfig.h
+++ b/examples/persistent-storage/cc13x2x7_26x2x7/include/CHIPProjectConfig.h
@@ -41,7 +41,7 @@
 // authentication in various protocols.
 // WARNING: These options make it possible to circumvent basic CHIP security functionality,
 // including message encryption. Because of this they MUST NEVER BE ENABLED IN PRODUCTION BUILDS.
-#define CHIP_CONFIG_SECURITY_TEST_MODE 1
+#define CHIP_CONFIG_SECURITY_TEST_MODE 0
 #define CHIP_CONFIG_REQUIRE_AUTH 0
 
 // Use a default pairing code if one hasn't been provisioned in flash.

--- a/examples/platform/qpg/project_include/CHIPProjectConfig.h
+++ b/examples/platform/qpg/project_include/CHIPProjectConfig.h
@@ -41,7 +41,7 @@
 //    WARNING: These options make it possible to circumvent basic Chip security functionality,
 //    including message encryption. Because of this they MUST NEVER BE ENABLED IN PRODUCTION BUILDS.
 //
-#define CHIP_CONFIG_SECURITY_TEST_MODE 1
+#define CHIP_CONFIG_SECURITY_TEST_MODE 0
 #define CHIP_CONFIG_REQUIRE_AUTH 0
 
 /**

--- a/src/lib/core/CHIPConfig.h
+++ b/src/lib/core/CHIPConfig.h
@@ -1403,6 +1403,8 @@
  *  @note
  *    WARNING: This option makes it possible to circumvent basic chip security functionality,
  *    including message encryption. Because of this it SHOULD NEVER BE ENABLED IN PRODUCTION BUILDS.
+ *
+ *    To build with this flag, pass 'treat_warnings_as_errors=false' to gn/ninja.
  */
 #ifndef CHIP_CONFIG_SECURITY_TEST_MODE
 #define CHIP_CONFIG_SECURITY_TEST_MODE 0

--- a/src/transport/CryptoContext.cpp
+++ b/src/transport/CryptoContext.cpp
@@ -96,7 +96,7 @@ CHIP_ERROR CryptoContext::InitFromSecret(const ByteSpan & secret, const ByteSpan
     (void) info;
     (void) infoLen;
 
-#pragma message                                                                                                                    \
+#warning                                                                                                                           \
     "Warning: CONFIG_SECURITY_TEST_MODE=1 bypassing key negotiation... All sessions will use known, fixed test key.  Node can only communicate with other nodes built with this flag set."
     ChipLogError(SecureChannel,
                  "Warning: CONFIG_SECURITY_TEST_MODE=1 bypassing key negotiation... All sessions will use known, fixed test key.  "


### PR DESCRIPTION
#### Problem
`#pragma mesage` warning developers that `CHIP_CONFIG_SECURITY_TEST_MODE` is enabled is creating excessive noise and spam in build logs.

Also, the flag is enabled on some platforms.

#### Change overview
* Use `#warning` instead of `#pragma message` so builds will fail if SECURITY_TEST_MODE is inadvertently enabled.
* Default to disabled on all platforms.
* Add documentation to pass `treat_warnings_as_errors=false` to the build when enabling SECURITY_TEST_MODE.

#### Testing
CI and local builds with and without flag enabled.