### PR TITLE
Rename ExampleDeviceAttestationVerifier

### DIFF
--- a/examples/chip-tool/commands/common/CHIPCommand.cpp
+++ b/examples/chip-tool/commands/common/CHIPCommand.cpp
@@ -21,8 +21,8 @@
 #include <controller/CHIPDeviceControllerFactory.h>
 #include <credentials/DeviceAttestationCredsProvider.h>
 #include <credentials/DeviceAttestationVerifier.h>
-#include <credentials/examples/DeviceAttestationCredsExample.h>
 #include <credentials/examples/DefaultDeviceAttestationVerifier.h>
+#include <credentials/examples/DeviceAttestationCredsExample.h>
 #include <lib/core/CHIPVendorIdentifiers.hpp>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/ScopedBuffer.h>

--- a/examples/chip-tool/commands/common/CHIPCommand.cpp
+++ b/examples/chip-tool/commands/common/CHIPCommand.cpp
@@ -22,7 +22,7 @@
 #include <credentials/DeviceAttestationCredsProvider.h>
 #include <credentials/DeviceAttestationVerifier.h>
 #include <credentials/examples/DeviceAttestationCredsExample.h>
-#include <credentials/examples/DeviceAttestationVerifierExample.h>
+#include <credentials/examples/DefaultDeviceAttestationVerifier.h>
 #include <lib/core/CHIPVendorIdentifiers.hpp>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/ScopedBuffer.h>
@@ -45,7 +45,7 @@ CHIP_ERROR CHIPCommand::Run()
     chip::Platform::ScopedMemoryBuffer<uint8_t> rcac;
 
     chip::Credentials::SetDeviceAttestationCredentialsProvider(chip::Credentials::Examples::GetExampleDACProvider());
-    chip::Credentials::SetDeviceAttestationVerifier(chip::Credentials::Examples::GetExampleDACVerifier());
+    chip::Credentials::SetDeviceAttestationVerifier(chip::Credentials::GetDefaultDACVerifier());
 
     VerifyOrReturnError(noc.Alloc(chip::Controller::kMaxCHIPDERCertLength), CHIP_ERROR_NO_MEMORY);
     VerifyOrReturnError(icac.Alloc(chip::Controller::kMaxCHIPDERCertLength), CHIP_ERROR_NO_MEMORY);

--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -30,7 +30,7 @@
 #include <credentials/DeviceAttestationCredsProvider.h>
 #include <credentials/DeviceAttestationVerifier.h>
 #include <credentials/examples/DeviceAttestationCredsExample.h>
-#include <credentials/examples/DeviceAttestationVerifierExample.h>
+#include <credentials/examples/DefaultDeviceAttestationVerifier.h>
 
 #include <lib/support/CHIPMem.h>
 #include <lib/support/ScopedBuffer.h>
@@ -234,7 +234,7 @@ CHIP_ERROR InitCommissioner()
     ReturnErrorOnFailure(gCommissioner.SetUdcListenPort(LinuxDeviceOptions::GetInstance().unsecuredCommissionerPort));
 
     // Initialize device attestation verifier
-    SetDeviceAttestationVerifier(Examples::GetExampleDACVerifier());
+    SetDeviceAttestationVerifier(GetDefaultDACVerifier());
 
     chip::Platform::ScopedMemoryBuffer<uint8_t> noc;
     VerifyOrReturnError(noc.Alloc(chip::Controller::kMaxCHIPDERCertLength), CHIP_ERROR_NO_MEMORY);

--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -29,8 +29,8 @@
 
 #include <credentials/DeviceAttestationCredsProvider.h>
 #include <credentials/DeviceAttestationVerifier.h>
-#include <credentials/examples/DeviceAttestationCredsExample.h>
 #include <credentials/examples/DefaultDeviceAttestationVerifier.h>
+#include <credentials/examples/DeviceAttestationCredsExample.h>
 
 #include <lib/support/CHIPMem.h>
 #include <lib/support/ScopedBuffer.h>

--- a/examples/tv-casting-app/linux/main.cpp
+++ b/examples/tv-casting-app/linux/main.cpp
@@ -21,8 +21,8 @@
 #include <controller/CHIPCommissionableNodeController.h>
 #include <credentials/DeviceAttestationCredsProvider.h>
 #include <credentials/DeviceAttestationVerifier.h>
-#include <credentials/examples/DeviceAttestationCredsExample.h>
 #include <credentials/examples/DefaultDeviceAttestationVerifier.h>
+#include <credentials/examples/DeviceAttestationCredsExample.h>
 #include <lib/support/CHIPArgParser.hpp>
 #include <lib/support/SafeInt.h>
 #include <platform/CHIPDeviceLayer.h>

--- a/examples/tv-casting-app/linux/main.cpp
+++ b/examples/tv-casting-app/linux/main.cpp
@@ -22,7 +22,7 @@
 #include <credentials/DeviceAttestationCredsProvider.h>
 #include <credentials/DeviceAttestationVerifier.h>
 #include <credentials/examples/DeviceAttestationCredsExample.h>
-#include <credentials/examples/DeviceAttestationVerifierExample.h>
+#include <credentials/examples/DefaultDeviceAttestationVerifier.h>
 #include <lib/support/CHIPArgParser.hpp>
 #include <lib/support/SafeInt.h>
 #include <platform/CHIPDeviceLayer.h>
@@ -196,7 +196,7 @@ int main(int argc, char * argv[])
     SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
 
     // Initialize device attestation verifier
-    SetDeviceAttestationVerifier(Examples::GetExampleDACVerifier());
+    SetDeviceAttestationVerifier(GetDefaultDACVerifier());
 
     if (!chip::ArgParser::ParseArgs(argv[0], argc, argv, allOptions))
     {

--- a/src/controller/java/AndroidDeviceControllerWrapper.cpp
+++ b/src/controller/java/AndroidDeviceControllerWrapper.cpp
@@ -26,7 +26,7 @@
 
 #include <controller/CHIPDeviceControllerFactory.h>
 #include <credentials/DeviceAttestationVerifier.h>
-#include <credentials/examples/DeviceAttestationVerifierExample.h>
+#include <credentials/examples/DefaultDeviceAttestationVerifier.h>
 #include <lib/core/CHIPTLV.h>
 #include <lib/support/PersistentStorageMacros.h>
 #include <lib/support/SafeInt.h>
@@ -204,7 +204,7 @@ AndroidDeviceControllerWrapper * AndroidDeviceControllerWrapper::AllocateNew(Jav
     wrapper->SetJavaObjectRef(vm, deviceControllerObj);
 
     // Initialize device attestation verifier
-    SetDeviceAttestationVerifier(Examples::GetExampleDACVerifier());
+    SetDeviceAttestationVerifier(GetDefaultDACVerifier());
 
     chip::Controller::FactoryInitParams initParams;
     chip::Controller::SetupParams setupParams;

--- a/src/controller/python/ChipDeviceController-ScriptBinding.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptBinding.cpp
@@ -54,7 +54,7 @@
 #include <controller/CHIPDeviceControllerFactory.h>
 #include <controller/ExampleOperationalCredentialsIssuer.h>
 #include <credentials/DeviceAttestationVerifier.h>
-#include <credentials/examples/DeviceAttestationVerifierExample.h>
+#include <credentials/examples/DefaultDeviceAttestationVerifier.h>
 #include <inet/IPAddress.h>
 #include <lib/dnssd/Resolver.h>
 #include <lib/support/BytesToHex.h>
@@ -182,7 +182,7 @@ ChipError::StorageType pychip_DeviceController_NewDeviceController(chip::Control
     }
 
     // Initialize device attestation verifier
-    SetDeviceAttestationVerifier(Examples::GetExampleDACVerifier());
+    SetDeviceAttestationVerifier(GetDefaultDACVerifier());
 
     CHIP_ERROR err = sOperationalCredentialsIssuer.Initialize(sStorageDelegate);
     VerifyOrReturnError(err == CHIP_NO_ERROR, err.AsInteger());

--- a/src/controller/python/chip/internal/CommissionerImpl.cpp
+++ b/src/controller/python/chip/internal/CommissionerImpl.cpp
@@ -20,7 +20,7 @@
 #include <controller/CHIPDeviceControllerFactory.h>
 #include <controller/ExampleOperationalCredentialsIssuer.h>
 #include <credentials/DeviceAttestationVerifier.h>
-#include <credentials/examples/DeviceAttestationVerifierExample.h>
+#include <credentials/examples/DefaultDeviceAttestationVerifier.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/ScopedBuffer.h>
 #include <lib/support/ThreadOperationalDataset.h>
@@ -117,7 +117,7 @@ extern "C" chip::Controller::DeviceCommissioner * pychip_internal_Commissioner_N
         commissionerParams.storageDelegate = &gServerStorage;
 
         // Initialize device attestation verifier
-        chip::Credentials::SetDeviceAttestationVerifier(chip::Credentials::Examples::GetExampleDACVerifier());
+        chip::Credentials::SetDeviceAttestationVerifier(chip::Credentials::GetDefaultDACVerifier());
 
         err = ephemeralKey.Initialize();
         SuccessOrExit(err);

--- a/src/credentials/BUILD.gn
+++ b/src/credentials/BUILD.gn
@@ -38,8 +38,8 @@ static_library("credentials") {
     "GroupDataProvider.h",
     "examples/DeviceAttestationCredsExample.cpp",
     "examples/DeviceAttestationCredsExample.h",
-    "examples/DeviceAttestationVerifierExample.cpp",
-    "examples/DeviceAttestationVerifierExample.h",
+    "examples/DefaultDeviceAttestationVerifier.cpp",
+    "examples/DefaultDeviceAttestationVerifier.h",
     "examples/GroupDataProviderExample.cpp",
   ]
 

--- a/src/credentials/BUILD.gn
+++ b/src/credentials/BUILD.gn
@@ -36,10 +36,10 @@ static_library("credentials") {
     "FabricTable.h",
     "GenerateChipX509Cert.cpp",
     "GroupDataProvider.h",
-    "examples/DeviceAttestationCredsExample.cpp",
-    "examples/DeviceAttestationCredsExample.h",
     "examples/DefaultDeviceAttestationVerifier.cpp",
     "examples/DefaultDeviceAttestationVerifier.h",
+    "examples/DeviceAttestationCredsExample.cpp",
+    "examples/DeviceAttestationCredsExample.h",
     "examples/GroupDataProviderExample.cpp",
   ]
 

--- a/src/credentials/examples/DefaultDeviceAttestationVerifier.cpp
+++ b/src/credentials/examples/DefaultDeviceAttestationVerifier.cpp
@@ -14,7 +14,7 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-#include "DeviceAttestationVerifierExample.h"
+#include "DefaultDeviceAttestationVerifier.h"
 
 #include <credentials/CHIPCert.h>
 #include <credentials/CertificationDeclaration.h>
@@ -31,7 +31,6 @@ using namespace chip::Crypto;
 
 namespace chip {
 namespace Credentials {
-namespace Examples {
 
 namespace {
 
@@ -189,7 +188,7 @@ CHIP_ERROR GetCertificationDeclarationCertificate(const ByteSpan & skid, Mutable
     return CopySpanToMutableSpan(ByteSpan{ sCertChainLookupTable[certChainLookupTableIdx].mCertificate }, outCertificate);
 }
 
-class ExampleDACVerifier : public DeviceAttestationVerifier
+class DefaultDACVerifier : public DeviceAttestationVerifier
 {
 public:
     AttestationVerificationResult VerifyAttestationInformation(const ByteSpan & attestationInfoBuffer,
@@ -206,7 +205,7 @@ public:
                                                                         const DeviceInfoForAttestation & deviceInfo) override;
 };
 
-AttestationVerificationResult ExampleDACVerifier::VerifyAttestationInformation(const ByteSpan & attestationInfoBuffer,
+AttestationVerificationResult DefaultDACVerifier::VerifyAttestationInformation(const ByteSpan & attestationInfoBuffer,
                                                                                const ByteSpan & attestationChallengeBuffer,
                                                                                const ByteSpan & attestationSignatureBuffer,
                                                                                const ByteSpan & paiCertDerBuffer,
@@ -310,7 +309,7 @@ AttestationVerificationResult ExampleDACVerifier::VerifyAttestationInformation(c
     return ValidateCertificateDeclarationPayload(certificationDeclarationPayload, firmwareInfoSpan, deviceInfo);
 }
 
-AttestationVerificationResult ExampleDACVerifier::ValidateCertificationDeclarationSignature(const ByteSpan & cmsEnvelopeBuffer,
+AttestationVerificationResult DefaultDACVerifier::ValidateCertificationDeclarationSignature(const ByteSpan & cmsEnvelopeBuffer,
                                                                                             ByteSpan & certDeclBuffer)
 {
     uint8_t certificate[Credentials::kMaxDERCertLength];
@@ -329,7 +328,7 @@ AttestationVerificationResult ExampleDACVerifier::ValidateCertificationDeclarati
     return AttestationVerificationResult::kSuccess;
 }
 
-AttestationVerificationResult ExampleDACVerifier::ValidateCertificateDeclarationPayload(const ByteSpan & certDeclBuffer,
+AttestationVerificationResult DefaultDACVerifier::ValidateCertificateDeclarationPayload(const ByteSpan & certDeclBuffer,
                                                                                         const ByteSpan & firmwareInfo,
                                                                                         const DeviceInfoForAttestation & deviceInfo)
 {
@@ -398,13 +397,12 @@ AttestationVerificationResult ExampleDACVerifier::ValidateCertificateDeclaration
 
 } // namespace
 
-DeviceAttestationVerifier * GetExampleDACVerifier()
+DeviceAttestationVerifier * GetDefaultDACVerifier()
 {
-    static ExampleDACVerifier exampleDacVerifier;
+    static DefaultDACVerifier defaultDACVerifier;
 
-    return &exampleDacVerifier;
+    return &defaultDACVerifier;
 }
 
-} // namespace Examples
 } // namespace Credentials
 } // namespace chip

--- a/src/credentials/examples/DefaultDeviceAttestationVerifier.h
+++ b/src/credentials/examples/DefaultDeviceAttestationVerifier.h
@@ -20,7 +20,6 @@
 
 namespace chip {
 namespace Credentials {
-namespace Examples {
 
 /**
  * @brief Get implementation of a sample DAC verifier to validate device
@@ -29,8 +28,7 @@ namespace Examples {
  * @returns a singleton DeviceAttestationVerifier that relies on no
  *          storage abstractions.
  */
-DeviceAttestationVerifier * GetExampleDACVerifier();
+DeviceAttestationVerifier * GetDefaultDACVerifier();
 
-} // namespace Examples
 } // namespace Credentials
 } // namespace chip

--- a/src/credentials/tests/TestDeviceAttestationCredentials.cpp
+++ b/src/credentials/tests/TestDeviceAttestationCredentials.cpp
@@ -22,7 +22,7 @@
 #include <credentials/DeviceAttestationCredsProvider.h>
 #include <credentials/DeviceAttestationVerifier.h>
 #include <credentials/examples/DeviceAttestationCredsExample.h>
-#include <credentials/examples/DeviceAttestationVerifierExample.h>
+#include <credentials/examples/DefaultDeviceAttestationVerifier.h>
 
 #include <lib/core/CHIPError.h>
 #include <lib/support/CHIPMem.h>
@@ -196,7 +196,7 @@ static void TestDACVerifierExample_AttestationInfoVerification(nlTestSuite * inS
     NL_TEST_ASSERT(inSuite, attestation_result == AttestationVerificationResult::kNotImplemented);
 
     // Replace default verifier with example verifier
-    DeviceAttestationVerifier * example_dac_verifier = Examples::GetExampleDACVerifier();
+    DeviceAttestationVerifier * example_dac_verifier = GetDefaultDACVerifier();
     NL_TEST_ASSERT(inSuite, example_dac_verifier != nullptr);
     NL_TEST_ASSERT(inSuite, default_verifier != example_dac_verifier);
 
@@ -252,7 +252,7 @@ static void TestDACVerifierExample_CertDeclarationVerification(nlTestSuite * inS
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     // Replace default verifier with example verifier
-    DeviceAttestationVerifier * example_dac_verifier = Examples::GetExampleDACVerifier();
+    DeviceAttestationVerifier * example_dac_verifier = GetDefaultDACVerifier();
     NL_TEST_ASSERT(inSuite, example_dac_verifier != nullptr);
 
     SetDeviceAttestationVerifier(example_dac_verifier);

--- a/src/credentials/tests/TestDeviceAttestationCredentials.cpp
+++ b/src/credentials/tests/TestDeviceAttestationCredentials.cpp
@@ -21,8 +21,8 @@
 #include <credentials/CertificationDeclaration.h>
 #include <credentials/DeviceAttestationCredsProvider.h>
 #include <credentials/DeviceAttestationVerifier.h>
-#include <credentials/examples/DeviceAttestationCredsExample.h>
 #include <credentials/examples/DefaultDeviceAttestationVerifier.h>
+#include <credentials/examples/DeviceAttestationCredsExample.h>
 
 #include <lib/core/CHIPError.h>
 #include <lib/support/CHIPMem.h>

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.mm
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.mm
@@ -36,7 +36,7 @@
 #include <controller/CHIPDeviceController.h>
 #include <controller/CHIPDeviceControllerFactory.h>
 #include <credentials/DeviceAttestationVerifier.h>
-#include <credentials/examples/DeviceAttestationVerifierExample.h>
+#include <credentials/examples/DefaultDeviceAttestationVerifier.h>
 #include <lib/support/CHIPMem.h>
 #include <platform/PlatformManager.h>
 #include <setup_payload/ManualSetupPayloadGenerator.h>
@@ -190,7 +190,7 @@ static NSString * const kErrorSetupCodeGen = @"Generating Manual Pairing Code fa
         }
 
         // Initialize device attestation verifier
-        chip::Credentials::SetDeviceAttestationVerifier(chip::Credentials::Examples::GetExampleDACVerifier());
+        chip::Credentials::SetDeviceAttestationVerifier(chip::Credentials::GetDefaultDACVerifier());
 
         params.fabricStorage = _fabricStorage;
         commissionerParams.storageDelegate = _persistentStorageDelegateBridge;


### PR DESCRIPTION
#### Change overview
- Rename ExampleDeviceAttestationVerifier to DefaultDeviceAttestationVerifier
  since it is now used commonly and becoming fully spec-compliant.

Fixes #11919

#### Testing
- Unit tests pass
- Certification integration tests pass