### PR TITLE
Pin versions on Cirque Device Docker image

### DIFF
--- a/integrations/docker/ci-only-images/chip-cirque-device-base/Dockerfile
+++ b/integrations/docker/ci-only-images/chip-cirque-device-base/Dockerfile
@@ -14,9 +14,28 @@ WORKDIR /app
 # TODO: Use multi stage build for smaller image size.
 
 RUN apt-get update \
-  && apt-get install --no-install-recommends -y sudo git ca-certificates psmisc dhcpcd5 wpasupplicant wireless-tools \
-                                                gdb python3 python3-pip libcairo2-dev libjpeg-dev libgif-dev python3-dev \
-  && apt-get install -y avahi-daemon libavahi-client3 avahi-utils iproute2 libglib2.0-dev libgirepository1.0-dev libdbus-1-dev gdb \
+  && apt-get install --no-install-recommends -y \
+  avahi-daemon=0.7-4ubuntu7.1 \
+  avahi-utils=0.7-4ubuntu7.1 \
+  ca-certificates=20210119~20.04.2 \
+  dhcpcd5=7.1.0-2build1 \
+  gdb=9.2-0ubuntu1~20.04 \
+  git=1:2.25.1-1ubuntu3.2 \
+  iproute2=5.5.0-1ubuntu1 \
+  libavahi-client3=0.7-4ubuntu7.1 \
+  libcairo2-dev=1.16.0-4ubuntu1 \
+  libdbus-1-dev=1.12.16-2ubuntu2.1 \
+  libgif-dev=5.1.9-1 \
+  libgirepository1.0-dev=1.64.1-1~ubuntu20.04.1 \
+  libglib2.0-dev=2.64.6-1~ubuntu20.04.4 \
+  libjpeg-dev=8c-2ubuntu8 \
+  psmisc=23.3-1 \
+  python3-dev=3.8.2-0ubuntu2 \
+  python3-pip=20.0.2-5ubuntu1.6 \
+  python3=3.8.2-0ubuntu2 \
+  sudo=1.8.31-1ubuntu1.2 \
+  wireless-tools=30~pre9-13ubuntu1 \
+  wpasupplicant=2:2.9-1ubuntu4.3 \
   && ln -fs /usr/share/zoneinfo/UTC /etc/localtime \
   && git clone https://github.com/openthread/ot-br-posix . \
   && git checkout $OT_BR_POSIX_CHECKOUT \
@@ -24,23 +43,21 @@ RUN apt-get update \
   && ./script/bootstrap \
   && ./script/setup \
   && chmod 644 /etc/bind/named.conf.options \
-  && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false git psmisc ninja-build cmake wget \
-                          libreadline-dev libncurses-dev libcpputest-dev libavahi-common-dev \
-                          libavahi-client-dev libboost-dev libboost-filesystem-dev libboost-system-dev libjsoncpp-dev \
-                          libnetfilter-queue-dev \
-  && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false cmake cpputest doxygen \
+  && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
+  git psmisc ninja-build cmake wget libreadline-dev libncurses-dev libcpputest-dev \
+  libavahi-common-dev libavahi-client-dev libboost-dev libboost-filesystem-dev \
+  libboost-system-dev libjsoncpp-dev libnetfilter-queue-dev cmake cpputest doxygen \
   && mkdir -p /etc/wpa_supplicant \
   && echo "ctrl_interface=/run/wpa_supplicant" >> /etc/wpa_supplicant/wpa_supplicant.conf \
   && echo "update_config=1" >> /etc/wpa_supplicant/wpa_supplicant.conf \
   && rm -rf /var/lib/apt/lists/* \
-  && pip3 install click
+  && pip3 install --no-cache-dir click==8.0.3
 
 COPY CHIPCirqueDaemon.py /bin/CHIPCirqueDaemon.py
+COPY entrypoint.sh /opt/entrypoint.sh
 
 WORKDIR /
 
-ENTRYPOINT service dbus start && \
-           service avahi-daemon start && \
-           /bin/CHIPCirqueDaemon.py --server otbr-agent
+ENTRYPOINT ["/opt/entrypoint.sh"]
 
 EXPOSE 80

--- a/integrations/docker/ci-only-images/chip-cirque-device-base/entrypoint.sh
+++ b/integrations/docker/ci-only-images/chip-cirque-device-base/entrypoint.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+#
+# Copyright (c) 2021 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+service dbus start
+service avahi-daemon start
+/bin/CHIPCirqueDaemon.py --server otbr-agent


### PR DESCRIPTION
#### Problem
[Version pinning](https://github.com/hadolint/hadolint/wiki/DL3008) allows building a docker image over the time and get the expected result, it also reduces failures due to unanticipated changes in required packages.

#### Change overview
This change includes the version of the packages required by Cirque Device base image.


#### Testing
The change was tested locally using the act CI tool.
