### PR TITLE
[linux]: Fix reading TotalOperationalHours failure

### DIFF
--- a/src/platform/Linux/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/Linux/DiagnosticDataProviderImpl.cpp
@@ -349,6 +349,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetTotalOperationalHours(uint32_t & total
         {
             VerifyOrReturnError(upTime / 3600 <= UINT32_MAX, CHIP_ERROR_INVALID_INTEGER_VALUE);
             totalOperationalHours = totalHours + static_cast<uint32_t>(upTime / 3600);
+            return CHIP_NO_ERROR;
         }
     }
 


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* Fail to read TotalOperationalHours with following error.

```
[1637710953.159896][504656:504661] CHIP:CTL: Address resolved for node: 0x0000000000BC5C01
[1637710953.160296][504656:504661] CHIP:DIS: Discovered node without a pending query
[1637710953.160304][504656:504661] CHIP:DIS: Node ID resolved for 0x0000000000BC5C01
[1637710953.160309][504656:504661] CHIP:DIS:     Addr 0: [172.23.0.1]:5540
[1637710953.160312][504656:504661] CHIP:CTL: OperationalDiscoveryComplete for device ID 0x0000000000BC5C01
[1637710953.160318][504656:504661] CHIP:CTL: Device connected callback with null pairing delegate. Ignoring
[1637710953.160321][504656:504661] CHIP:CTL: Address resolved for node: 0x0000000000BC5C01
[1637710953.160676][504656:504661] CHIP:DIS: Discovered node without a pending query
[1637710953.160684][504656:504661] CHIP:DIS: Node ID resolved for 0x0000000000BC5C01
[1637710953.160688][504656:504661] CHIP:DIS:     Addr 0: [172.23.0.1]:5540
[1637710953.160692][504656:504661] CHIP:CTL: OperationalDiscoveryComplete for device ID 0x0000000000BC5C01
[1637710953.160698][504656:504661] CHIP:CTL: Device connected callback with null pairing delegate. Ignoring
[1637710953.160701][504656:504661] CHIP:CTL: Address resolved for node: 0x0000000000BC5C01
[1637710953.161091][504656:504661] CHIP:DIS: Discovered node without a pending query
[1637710953.161099][504656:504661] CHIP:DIS: Node ID resolved for 0x0000000000BC5C01
[1637710953.161104][504656:504661] CHIP:DIS:     Addr 0: [172.23.0.1]:5540
[1637710953.161107][504656:504661] CHIP:CTL: OperationalDiscoveryComplete for device ID 0x0000000000BC5C01
[1637710953.161113][504656:504661] CHIP:CTL: Device connected callback with null pairing delegate. Ignoring
[1637710953.161116][504656:504661] CHIP:CTL: Address resolved for node: 0x0000000000BC5C01
[1637710963.133560][504656:504656] CHIP:-: ../../../examples/chip-tool/commands/common/CHIPCommand.cpp:125: CHIP Error 0x00000032: Timeout at ../../../examples/chip-tool/commands/common/CHIPCommand.cpp:84
[1637710963.133681][504656:504656] CHIP:TOO: Run command failure: ../../../examples/chip-tool/commands/common/CHIPCommand.cpp:125: CHIP Error 0x00000032: Timeout
[1637710963.144419][504656:504656] CHIP:CTL: Shutting down the System State, this will teardown the CHIP Stack
pure virtual method called
```

#### Change overview
Return CHIP_NO_ERROR after TotalOperationalHours is successfully read

#### Testing
How was this tested? (at least one bullet point required)
* Confirm the TotalOperationalHours can be successfully read.
```
yufengw@yufengw-SEi:~/connectedhomeip/out/debug/standalone$ ./chip-tool generaldiagnostics read total-operational-hours 12344321 0
....
[1637711900.202479][509986:509991] CHIP:DMG: ReportDataMessage =
[1637711900.202484][509986:509991] CHIP:DMG: {
[1637711900.202487][509986:509991] CHIP:DMG: 	AttributeReportIBs =
[1637711900.202490][509986:509991] CHIP:DMG: 	[
[1637711900.202494][509986:509991] CHIP:DMG: 		AttributeReportIB =
[1637711900.202499][509986:509991] CHIP:DMG: 		{
[1637711900.202533][509986:509991] CHIP:DMG: 			AttributeDataIB =
[1637711900.202538][509986:509991] CHIP:DMG: 			{
[1637711900.202542][509986:509991] CHIP:DMG: 				AttributePathIB =
[1637711900.202546][509986:509991] CHIP:DMG: 				{
[1637711900.202552][509986:509991] CHIP:DMG: 					Endpoint = 0x0,
[1637711900.202557][509986:509991] CHIP:DMG: 					Cluster = 0x33,
[1637711900.202562][509986:509991] CHIP:DMG: 					Attribute = 0x0000_0003,
[1637711900.202581][509986:509991] CHIP:DMG: 				}
[1637711900.202586][509986:509991] CHIP:DMG: 					
[1637711900.202591][509986:509991] CHIP:DMG: 					Data = 0, 
[1637711900.202613][509986:509991] CHIP:DMG: 				DataVersion = 0x0,
[1637711900.202617][509986:509991] CHIP:DMG: 			},
[1637711900.202623][509986:509991] CHIP:DMG: 			
[1637711900.202626][509986:509991] CHIP:DMG: 		},
[1637711900.202631][509986:509991] CHIP:DMG: 		
[1637711900.202634][509986:509991] CHIP:DMG: 	],
[1637711900.202639][509986:509991] CHIP:DMG: 	
[1637711900.202642][509986:509991] CHIP:DMG: 	SuppressResponse = true, 
[1637711900.202646][509986:509991] CHIP:DMG: }
[1637711900.202666][509986:509991] CHIP:ZCL: ReadAttributesResponse:
[1637711900.202669][509986:509991] CHIP:ZCL:   ClusterId: 0x0000_0033
[1637711900.202673][509986:509991] CHIP:ZCL:   attributeId: 0x0000_0003
[1637711900.202677][509986:509991] CHIP:ZCL:   status: Success                (0x0000)
[1637711900.202680][509986:509991] CHIP:ZCL:   attribute TLV Type: 0x04
[1637711900.202684][509986:509991] CHIP:TOO: Int32u attribute Response: 0

```