### PR TITLE
Disable rotating device id by default

### DIFF
--- a/src/platform/BUILD.gn
+++ b/src/platform/BUILD.gn
@@ -53,7 +53,7 @@ if (chip_device_platform != "none") {
     # Enable including the additional data in the advertisement packets
     chip_enable_additional_data_advertising = true
 
-    # Enable adding rotating device id to the additional data.
+    # Enable adding optional rotating device id to the additional data.
     chip_enable_rotating_device_id = false
 
     # lock tracking: none/log/fatal or auto for a platform-dependent choice

--- a/src/platform/BUILD.gn
+++ b/src/platform/BUILD.gn
@@ -54,7 +54,7 @@ if (chip_device_platform != "none") {
     chip_enable_additional_data_advertising = true
 
     # Enable adding rotating device id to the additional data.
-    chip_enable_rotating_device_id = true
+    chip_enable_rotating_device_id = false
 
     # lock tracking: none/log/fatal or auto for a platform-dependent choice
     chip_stack_lock_tracking = "auto"


### PR DESCRIPTION
#### Problem
Rotating device ID is an optional feature that makes flash usage bigger and increases mDNS reply sizes. Disable it by default to ensure constrained devices can run without it (qpg already disables it)

#### Change overview
Set the RDID false by default

#### Testing
CI will cover this.