### PR TITLE
[K32W0] Fix BLE commissioning failure

### DIFF
--- a/third_party/k32w_sdk/nxp/k32w/k32w0/k32w0_sdk.gni
+++ b/third_party/k32w_sdk/nxp/k32w/k32w0/k32w0_sdk.gni
@@ -154,7 +154,7 @@ template("k32w0_sdk") {
       "gTimestamp_Enabled_d=0",
       "K32W_LOG_ENABLED=1",
       "CHIP_ENABLE_OPENTHREAD=1",
-      "PoolsDetails_c=_block_size_ 32 _number_of_blocks_ 6 _pool_id_(0) _eol_ _block_size_ 512 _number_of_blocks_ 2 _pool_id_(0) _eol_ _block_size_ 768 _number_of_blocks_ 1 _pool_id_(0) _eol_",
+      "PoolsDetails_c=_block_size_ 32 _number_of_blocks_ 6 _pool_id_(0) _eol_ _block_size_ 256 _number_of_blocks_ 3 _pool_id_(0) _eol_ _block_size_ 512 _number_of_blocks_ 2 _pool_id_(0) _eol_ _block_size_ 768 _number_of_blocks_ 1 _pool_id_(0) _eol_",
       "SUPPORT_FOR_15_4=1",
       "gAppMaxConnections_c=1",
       "gAppUseBonding_d=0",


### PR DESCRIPTION
### Problem

* DUT refused the send the PBKDF param response due to insufficient memory on the BLE Host side.

### Change overview
* The fix is to increase the memory pool.

### Testing
* tested using chip-device-ctrl

Duplicate of https://github.com/project-chip/connectedhomeip/pull/11910, but targeted for the master branch