### PR TITLE
Make use of 'ephemeral unicast udp port' for minmdns optional

### DIFF
--- a/src/lib/dnssd/minimal_mdns/BUILD.gn
+++ b/src/lib/dnssd/minimal_mdns/BUILD.gn
@@ -14,6 +14,32 @@
 
 import("//build_overrides/chip.gni")
 
+declare_args() {
+  # Makes unicast queries use a separate UDP endpoint that have an ephemeral port
+  #
+  # In practice this means unicast replies will be received on a dedicated port
+  # and will work even if competing mdns servers (including other chip apps)
+  # run on the same machine.
+  #
+  # Downside is that replies sent to a port other than 5353 are considered 
+  # LEGACY by mDNS and will include the query section in them (i.e. larger 
+  # payloads) and clients need to allocate more resources for this (need one
+  # more UDP socket and corresponding code for the unicast query sending)
+  chip_use_ephemeral_port_for_mdns_unicast_query =
+        (current_os == "mac" || current_os == "linux" || current_os == "android")
+}
+
+config("config") {
+  defines = []
+
+  if (chip_use_ephemeral_port_for_mdns_unicast_query) {
+    defines += [ "CHIP_MINMDNS_USE_EPHEMERAL_UNICAST_PORT=1" ]
+  } else {
+    defines += [ "CHIP_MINMDNS_USE_EPHEMERAL_UNICAST_PORT=0" ]
+  }
+}
+
+
 static_library("minimal_mdns") {
   sources = [
     "ActiveResolveAttempts.cpp",
@@ -39,4 +65,6 @@ static_library("minimal_mdns") {
     "${chip_root}/src/lib/dnssd/minimal_mdns/responders",
     "${chip_root}/src/platform",
   ]
+
+  public_configs = [ ":config" ]
 }

--- a/src/lib/dnssd/minimal_mdns/BUILD.gn
+++ b/src/lib/dnssd/minimal_mdns/BUILD.gn
@@ -21,12 +21,12 @@ declare_args() {
   # and will work even if competing mdns servers (including other chip apps)
   # run on the same machine.
   #
-  # Downside is that replies sent to a port other than 5353 are considered 
-  # LEGACY by mDNS and will include the query section in them (i.e. larger 
+  # Downside is that replies sent to a port other than 5353 are considered
+  # LEGACY by mDNS and will include the query section in them (i.e. larger
   # payloads) and clients need to allocate more resources for this (need one
   # more UDP socket and corresponding code for the unicast query sending)
   chip_use_ephemeral_port_for_mdns_unicast_query =
-        (current_os == "mac" || current_os == "linux" || current_os == "android")
+      current_os == "mac" || current_os == "linux" || current_os == "android"
 }
 
 config("config") {
@@ -38,7 +38,6 @@ config("config") {
     defines += [ "CHIP_MINMDNS_USE_EPHEMERAL_UNICAST_PORT=0" ]
   }
 }
-
 
 static_library("minimal_mdns") {
   sources = [

--- a/src/lib/dnssd/minimal_mdns/Server.h
+++ b/src/lib/dnssd/minimal_mdns/Server.h
@@ -80,7 +80,9 @@ public:
         chip::Inet::InterfaceId interfaceId = chip::Inet::InterfaceId::Null();
         chip::Inet::IPAddressType addressType;
         chip::Inet::UDPEndPoint * listen_udp        = nullptr;
+#if CHIP_MINMDNS_USE_EPHEMERAL_UNICAST_PORT
         chip::Inet::UDPEndPoint * unicast_query_udp = nullptr;
+#endif
     };
 
     /**
@@ -104,7 +106,9 @@ public:
         for (size_t i = 0; i < mEndpointCount; i++)
         {
             mEndpoints[i].listen_udp        = nullptr;
+#if CHIP_MINMDNS_USE_EPHEMERAL_UNICAST_PORT
             mEndpoints[i].unicast_query_udp = nullptr;
+#endif
         }
 
         BroadcastIpAddresses::GetIpv6Into(mIpv6BroadcastAddress);

--- a/src/lib/dnssd/minimal_mdns/Server.h
+++ b/src/lib/dnssd/minimal_mdns/Server.h
@@ -79,7 +79,7 @@ public:
     {
         chip::Inet::InterfaceId interfaceId = chip::Inet::InterfaceId::Null();
         chip::Inet::IPAddressType addressType;
-        chip::Inet::UDPEndPoint * listen_udp        = nullptr;
+        chip::Inet::UDPEndPoint * listen_udp = nullptr;
 #if CHIP_MINMDNS_USE_EPHEMERAL_UNICAST_PORT
         chip::Inet::UDPEndPoint * unicast_query_udp = nullptr;
 #endif
@@ -105,7 +105,7 @@ public:
     {
         for (size_t i = 0; i < mEndpointCount; i++)
         {
-            mEndpoints[i].listen_udp        = nullptr;
+            mEndpoints[i].listen_udp = nullptr;
 #if CHIP_MINMDNS_USE_EPHEMERAL_UNICAST_PORT
             mEndpoints[i].unicast_query_udp = nullptr;
 #endif


### PR DESCRIPTION
#### Problem
Ephemeral port usage is only useful if there is a chance of conflict on listening on port 5353. This can be the case for large platforms (linux + avahi, mac + bonjour, others that may have mdns  daemons or run multiple chip applications) however not the case  for embedded (only  a chip app).

Using ephemeral port is more code and extra udp port usage and pointers (some minor ram hit). Make this optional.

#### Change overview
Add an argument for separate port, default only on larger platform.

#### Testing
CI will cover this (compile on embedded and actual yaml tests on linux and mac)
