### PR TITLE
[shell] Add `server` command to shell to start/stop all-clusters.

### DIFF
--- a/examples/shell/shell_common/BUILD.gn
+++ b/examples/shell/shell_common/BUILD.gn
@@ -17,6 +17,8 @@ import("//build_overrides/openthread.gni")
 
 import("${chip_root}/src/platform/device.gni")
 
+chip_enable_app_server = true
+
 config("shell_common_config") {
   include_dirs = [
     ".",
@@ -51,6 +53,24 @@ static_library("shell_common") {
     public_deps += [
       "${openthread_root}:libopenthread-cli-ftd",
       "${openthread_root}:libopenthread-ftd",
+    ]
+  }
+
+  if (chip_enable_app_server) {
+    sources += [ "cmd_server.cpp", ]
+
+    import("${chip_root}/src/app/chip_data_model.gni")
+
+    sources += [
+      "${chip_root}/examples/all-clusters-app/all-clusters-common/src/static-supported-modes-manager.cpp",
+      "${chip_root}/examples/all-clusters-app/all-clusters-common/src/bridged-actions-stub.cpp",
+    ]
+
+    include_dirs =
+      [ "${chip_root}/examples/all-clusters-app/all-clusters-common/include" ]
+
+    public_deps += [
+      "${chip_root}/examples/all-clusters-app/all-clusters-common",
     ]
   }
 

--- a/examples/shell/shell_common/BUILD.gn
+++ b/examples/shell/shell_common/BUILD.gn
@@ -57,21 +57,20 @@ static_library("shell_common") {
   }
 
   if (chip_enable_app_server) {
-    sources += [ "cmd_server.cpp", ]
+    sources += [ "cmd_server.cpp" ]
 
     import("${chip_root}/src/app/chip_data_model.gni")
 
     sources += [
-      "${chip_root}/examples/all-clusters-app/all-clusters-common/src/static-supported-modes-manager.cpp",
       "${chip_root}/examples/all-clusters-app/all-clusters-common/src/bridged-actions-stub.cpp",
+      "${chip_root}/examples/all-clusters-app/all-clusters-common/src/static-supported-modes-manager.cpp",
     ]
 
     include_dirs =
-      [ "${chip_root}/examples/all-clusters-app/all-clusters-common/include" ]
+        [ "${chip_root}/examples/all-clusters-app/all-clusters-common/include" ]
 
-    public_deps += [
-      "${chip_root}/examples/all-clusters-app/all-clusters-common",
-    ]
+    public_deps +=
+        [ "${chip_root}/examples/all-clusters-app/all-clusters-common" ]
   }
 
   public_configs = [ ":shell_common_config" ]

--- a/examples/shell/shell_common/cmd_server.cpp
+++ b/examples/shell/shell_common/cmd_server.cpp
@@ -32,11 +32,13 @@ using namespace chip::Shell;
 using namespace chip::Credentials;
 using namespace chip::ArgParser;
 
-bool lowPowerClusterSleep() { return true; }
-
+bool lowPowerClusterSleep()
+{
+    return true;
+}
 
 static chip::Shell::Engine sShellServerSubcommands;
-static uint16_t sServerPortOperational = CHIP_PORT;
+static uint16_t sServerPortOperational   = CHIP_PORT;
 static uint16_t sServerPortCommissioning = CHIP_UDC_PORT;
 
 static CHIP_ERROR CmdAppServerHelp(int argc, char ** argv)
@@ -71,7 +73,8 @@ static CHIP_ERROR CmdAppServerPort(int argc, char ** argv)
     else
     {
         bool success = ParseInt(argv[0], sServerPortOperational);
-        if (!success) return CHIP_ERROR_INVALID_ARGUMENT;
+        if (!success)
+            return CHIP_ERROR_INVALID_ARGUMENT;
     }
 
     return CHIP_NO_ERROR;
@@ -86,20 +89,18 @@ static CHIP_ERROR CmdAppServerUdcPort(int argc, char ** argv)
     else
     {
         bool success = ParseInt(argv[0], sServerPortCommissioning);
-        if (!success) return CHIP_ERROR_INVALID_ARGUMENT;
+        if (!success)
+            return CHIP_ERROR_INVALID_ARGUMENT;
     }
 
     return CHIP_NO_ERROR;
 }
 
-static bool PrintServerSession(void *context, SessionHandle &session)
+static bool PrintServerSession(void * context, SessionHandle & session)
 {
-    streamer_printf(streamer_get(),
-        "session id=0x%04x peerSessionId=0x%04x peerNodeId=0x%016" PRIx64 " fabricIdx=%d\r\n",
-        session.GetLocalSessionId().Value(),
-        session.GetPeerSessionId().Value(),
-        session.GetPeerNodeId(),
-        session.GetFabricIndex());
+    streamer_printf(streamer_get(), "session id=0x%04x peerSessionId=0x%04x peerNodeId=0x%016" PRIx64 " fabricIdx=%d\r\n",
+                    session.GetLocalSessionId().Value(), session.GetPeerSessionId().Value(), session.GetPeerNodeId(),
+                    session.GetFabricIndex());
     return true;
 }
 
@@ -112,7 +113,7 @@ static CHIP_ERROR CmdAppServerSessions(int argc, char ** argv)
 
 static CHIP_ERROR CmdAppServerExchanges(int argc, char ** argv)
 {
-    //Messaging::ExchangeManager * exchangeMgr = &Server::GetInstance().GetExchangeManager();
+    // Messaging::ExchangeManager * exchangeMgr = &Server::GetInstance().GetExchangeManager();
 
     return CHIP_NO_ERROR;
 }
@@ -124,8 +125,7 @@ static CHIP_ERROR CmdAppServer(int argc, char ** argv)
     case 0:
         return CmdAppServerHelp(argc, argv);
     case 1:
-        if ((strcmp(argv[0], "help") == 0) || 
-            (strcmp(argv[0], "-h") == 0))
+        if ((strcmp(argv[0], "help") == 0) || (strcmp(argv[0], "-h") == 0))
         {
             return CmdAppServerHelp(argc, argv);
         }
@@ -141,7 +141,7 @@ static void CmdAppServerAtExit()
 void cmd_app_server_init()
 {
     static const shell_command_t sServerComand = { &CmdAppServer, "server",
-                                                   "Manage the ZCL application server. Usage: server [help|start|stop]"};
+                                                   "Manage the ZCL application server. Usage: server [help|start|stop]" };
 
     static const shell_command_t sServerSubCommands[] = {
         { &CmdAppServerHelp, "help", "Usage: server <subcommand>" },

--- a/examples/shell/shell_common/cmd_server.cpp
+++ b/examples/shell/shell_common/cmd_server.cpp
@@ -23,7 +23,6 @@
 #include <lib/support/CHIPArgParser.hpp>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CodeUtils.h>
-#include <platform/CHIPDeviceLayer.h>
 
 #include <app/server/Server.h>
 #include <credentials/examples/DeviceAttestationCredsExample.h>
@@ -40,8 +39,7 @@ static chip::Shell::Engine sShellServerSubcommands;
 static uint16_t sServerPortOperational = CHIP_PORT;
 static uint16_t sServerPortCommissioning = CHIP_UDC_PORT;
 
-
-CHIP_ERROR CmdAppServerHelp(int argc, char ** argv)
+static CHIP_ERROR CmdAppServerHelp(int argc, char ** argv)
 {
     sShellServerSubcommands.ForEachCommand(PrintCommandHelp, nullptr);
     return CHIP_NO_ERROR;
@@ -94,7 +92,7 @@ static CHIP_ERROR CmdAppServerUdcPort(int argc, char ** argv)
     return CHIP_NO_ERROR;
 }
 
-static bool CmdAppServerSession(void *context, SessionHandle &session)
+static bool PrintServerSession(void *context, SessionHandle &session)
 {
     streamer_printf(streamer_get(),
         "session id=0x%04x peerSessionId=0x%04x peerNodeId=0x%016" PRIx64 " fabricIdx=%d\r\n",
@@ -107,7 +105,7 @@ static bool CmdAppServerSession(void *context, SessionHandle &session)
 
 static CHIP_ERROR CmdAppServerSessions(int argc, char ** argv)
 {
-    Server::GetInstance().GetSecureSessionManager().ForEachSessionHandle(nullptr, CmdAppServerSession);
+    Server::GetInstance().GetSecureSessionManager().ForEachSessionHandle(nullptr, PrintServerSession);
 
     return CHIP_NO_ERROR;
 }
@@ -135,9 +133,13 @@ static CHIP_ERROR CmdAppServer(int argc, char ** argv)
     return sShellServerSubcommands.ExecCommand(argc, argv);
 }
 
+static void CmdAppServerAtExit()
+{
+    CmdAppServerStop(0, nullptr);
+}
+
 void cmd_app_server_init()
 {
-
     static const shell_command_t sServerComand = { &CmdAppServer, "server",
                                                    "Manage the ZCL application server. Usage: server [help|start|stop]"};
 
@@ -151,10 +153,11 @@ void cmd_app_server_init()
         { &CmdAppServerExchanges, "exchanges", "Manage active exchanges on the server." },
     };
 
+    std::atexit(CmdAppServerAtExit);
+
     // Register `config` subcommands with the local shell dispatcher.
     sShellServerSubcommands.RegisterCommands(sServerSubCommands, ArraySize(sServerSubCommands));
 
     // Register the root `config` command with the top-level shell.
     Engine::Root().RegisterCommands(&sServerComand, 1);
-    return;
 }

--- a/examples/shell/shell_common/cmd_server.cpp
+++ b/examples/shell/shell_common/cmd_server.cpp
@@ -1,0 +1,160 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <inttypes.h>
+#include <lib/core/CHIPCore.h>
+#include <lib/shell/Commands.h>
+#include <lib/shell/Engine.h>
+#include <lib/shell/commands/Help.h>
+#include <lib/support/CHIPArgParser.hpp>
+#include <lib/support/CHIPMem.h>
+#include <lib/support/CodeUtils.h>
+#include <platform/CHIPDeviceLayer.h>
+
+#include <app/server/Server.h>
+#include <credentials/examples/DeviceAttestationCredsExample.h>
+
+using namespace chip;
+using namespace chip::Shell;
+using namespace chip::Credentials;
+using namespace chip::ArgParser;
+
+bool lowPowerClusterSleep() { return true; }
+
+
+static chip::Shell::Engine sShellServerSubcommands;
+static uint16_t sServerPortOperational = CHIP_PORT;
+static uint16_t sServerPortCommissioning = CHIP_UDC_PORT;
+
+
+CHIP_ERROR CmdAppServerHelp(int argc, char ** argv)
+{
+    sShellServerSubcommands.ForEachCommand(PrintCommandHelp, nullptr);
+    return CHIP_NO_ERROR;
+}
+
+static CHIP_ERROR CmdAppServerStart(int argc, char ** argv)
+{
+    // Init ZCL Data Model and CHIP App Server
+    chip::Server::GetInstance().Init(nullptr, sServerPortOperational, sServerPortCommissioning);
+
+    // Initialize device attestation config
+    SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
+
+    return CHIP_NO_ERROR;
+}
+
+static CHIP_ERROR CmdAppServerStop(int argc, char ** argv)
+{
+    chip::Server::GetInstance().Shutdown();
+    return CHIP_NO_ERROR;
+}
+
+static CHIP_ERROR CmdAppServerPort(int argc, char ** argv)
+{
+    if (argc == 0)
+    {
+        streamer_printf(streamer_get(), "%d\r\n", sServerPortOperational);
+    }
+    else
+    {
+        bool success = ParseInt(argv[0], sServerPortOperational);
+        if (!success) return CHIP_ERROR_INVALID_ARGUMENT;
+    }
+
+    return CHIP_NO_ERROR;
+}
+
+static CHIP_ERROR CmdAppServerUdcPort(int argc, char ** argv)
+{
+    if (argc == 0)
+    {
+        streamer_printf(streamer_get(), "%d\r\n", sServerPortCommissioning);
+    }
+    else
+    {
+        bool success = ParseInt(argv[0], sServerPortCommissioning);
+        if (!success) return CHIP_ERROR_INVALID_ARGUMENT;
+    }
+
+    return CHIP_NO_ERROR;
+}
+
+static bool CmdAppServerSession(void *context, SessionHandle &session)
+{
+    streamer_printf(streamer_get(),
+        "session id=0x%04x peerSessionId=0x%04x peerNodeId=0x%016" PRIx64 " fabricIdx=%d\r\n",
+        session.GetLocalSessionId().Value(),
+        session.GetPeerSessionId().Value(),
+        session.GetPeerNodeId(),
+        session.GetFabricIndex());
+    return true;
+}
+
+static CHIP_ERROR CmdAppServerSessions(int argc, char ** argv)
+{
+    Server::GetInstance().GetSecureSessionManager().ForEachSessionHandle(nullptr, CmdAppServerSession);
+
+    return CHIP_NO_ERROR;
+}
+
+static CHIP_ERROR CmdAppServerExchanges(int argc, char ** argv)
+{
+    //Messaging::ExchangeManager * exchangeMgr = &Server::GetInstance().GetExchangeManager();
+
+    return CHIP_NO_ERROR;
+}
+
+static CHIP_ERROR CmdAppServer(int argc, char ** argv)
+{
+    switch (argc)
+    {
+    case 0:
+        return CmdAppServerHelp(argc, argv);
+    case 1:
+        if ((strcmp(argv[0], "help") == 0) || 
+            (strcmp(argv[0], "-h") == 0))
+        {
+            return CmdAppServerHelp(argc, argv);
+        }
+    }
+    return sShellServerSubcommands.ExecCommand(argc, argv);
+}
+
+void cmd_app_server_init()
+{
+
+    static const shell_command_t sServerComand = { &CmdAppServer, "server",
+                                                   "Manage the ZCL application server. Usage: server [help|start|stop]"};
+
+    static const shell_command_t sServerSubCommands[] = {
+        { &CmdAppServerHelp, "help", "Usage: server <subcommand>" },
+        { &CmdAppServerStart, "start", "Start the ZCL application server." },
+        { &CmdAppServerStop, "stop", "Stop the ZCL application server." },
+        { &CmdAppServerPort, "port", "Get/Set operational port of server." },
+        { &CmdAppServerUdcPort, "udcport", "Get/Set commissioning port of server." },
+        { &CmdAppServerSessions, "sessions", "Manage active sessions on the server." },
+        { &CmdAppServerExchanges, "exchanges", "Manage active exchanges on the server." },
+    };
+
+    // Register `config` subcommands with the local shell dispatcher.
+    sShellServerSubcommands.RegisterCommands(sServerSubCommands, ArraySize(sServerSubCommands));
+
+    // Register the root `config` command with the top-level shell.
+    Engine::Root().RegisterCommands(&sServerComand, 1);
+    return;
+}

--- a/examples/shell/shell_common/include/ChipShellCollection.h
+++ b/examples/shell/shell_common/include/ChipShellCollection.h
@@ -17,10 +17,9 @@
 
 #pragma once
 
-extern "C" {
 // A list of shell commands provided by ChipShell
 void cmd_misc_init(void);
 void cmd_otcli_init(void);
 void cmd_ping_init(void);
 void cmd_send_init(void);
-}
+void cmd_app_server_init(void);

--- a/examples/shell/standalone/main.cpp
+++ b/examples/shell/standalone/main.cpp
@@ -51,6 +51,7 @@ int main()
     cmd_otcli_init();
     cmd_ping_init();
     cmd_send_init();
+    cmd_app_server_init();
 
     Engine::Root().RunMainLoop();
     return 0;

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -181,7 +181,8 @@ exit:
 
 void Server::Shutdown()
 {
-    if (mState == ServerState::Disabled) return;
+    if (mState == ServerState::Disabled)
+        return;
 
     chip::Dnssd::ServiceAdvertiser::Instance().Shutdown();
     chip::app::InteractionModelEngine::GetInstance()->Shutdown();

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -165,6 +165,8 @@ CHIP_ERROR Server::Init(AppDelegate * delegate, uint16_t secureServicePort, uint
                                                     &mSessions, &mFabrics, &mSessionIDAllocator);
     SuccessOrExit(err);
 
+    mState = ServerState::Enabled;
+
 exit:
     if (err != CHIP_NO_ERROR)
     {
@@ -179,6 +181,8 @@ exit:
 
 void Server::Shutdown()
 {
+    if (mState == ServerState::Disabled) return;
+
     chip::Dnssd::ServiceAdvertiser::Instance().Shutdown();
     chip::app::InteractionModelEngine::GetInstance()->Shutdown();
     mExchangeMgr.Shutdown();
@@ -186,6 +190,8 @@ void Server::Shutdown()
     mTransports.Close();
     mCommissioningWindowManager.Shutdown();
     chip::Platform::MemoryShutdown();
+
+    mState = ServerState::Disabled;
 }
 
 #if CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY_CLIENT

--- a/src/app/server/Server.h
+++ b/src/app/server/Server.h
@@ -132,11 +132,11 @@ private:
 
     enum class ServerState
     {
-        Disabled,        ///< The Server is inactive and disabled.
-        Enabled,         ///< The Server is active and enabled.
+        Disabled, ///< The Server is inactive and disabled.
+        Enabled,  ///< The Server is active and enabled.
     };
 
-    ServerState mState                        = ServerState::Disabled;
+    ServerState mState = ServerState::Disabled;
 
 #if CONFIG_NETWORK_LAYER_BLE
     Ble::BleLayer * mBleLayer = nullptr;

--- a/src/app/server/Server.h
+++ b/src/app/server/Server.h
@@ -130,6 +130,14 @@ private:
         CHIP_ERROR SyncDelete(FabricIndex fabricIndex, const char * key) override { return SyncDeleteKeyValue(key); };
     };
 
+    enum class ServerState
+    {
+        Disabled,        ///< The Server is inactive and disabled.
+        Enabled,         ///< The Server is active and enabled.
+    };
+
+    ServerState mState                        = ServerState::Disabled;
+
 #if CONFIG_NETWORK_LAYER_BLE
     Ble::BleLayer * mBleLayer = nullptr;
 #endif

--- a/src/inet/UDPEndPoint.cpp
+++ b/src/inet/UDPEndPoint.cpp
@@ -1055,7 +1055,8 @@ void UDPEndPointImplSockets::CloseImpl()
     if (mSocket != kInvalidSocketFd)
     {
         auto * layer = static_cast<System::LayerSockets *>(Layer().SystemLayer());
-        if (layer && layer->IsInitialized()) {
+        if (layer && layer->IsInitialized())
+        {
             static_cast<System::LayerSockets *>(layer)->StopWatchingSocket(&mWatch);
         }
         close(mSocket);

--- a/src/inet/UDPEndPoint.cpp
+++ b/src/inet/UDPEndPoint.cpp
@@ -1054,7 +1054,10 @@ void UDPEndPointImplSockets::CloseImpl()
 {
     if (mSocket != kInvalidSocketFd)
     {
-        static_cast<System::LayerSockets *>(Layer().SystemLayer())->StopWatchingSocket(&mWatch);
+        auto * layer = static_cast<System::LayerSockets *>(Layer().SystemLayer());
+        if (layer && layer->IsInitialized()) {
+            static_cast<System::LayerSockets *>(layer)->StopWatchingSocket(&mWatch);
+        }
         close(mSocket);
         mSocket = kInvalidSocketFd;
     }

--- a/src/lib/dnssd/minimal_mdns/Server.cpp
+++ b/src/lib/dnssd/minimal_mdns/Server.cpp
@@ -128,7 +128,8 @@ ServerBase::~ServerBase()
 
 void ServerBase::Shutdown()
 {
-    if (!IsListening()) return;
+    if (!IsListening())
+        return;
 
     for (size_t i = 0; i < mEndpointCount; i++)
     {

--- a/src/lib/dnssd/minimal_mdns/Server.cpp
+++ b/src/lib/dnssd/minimal_mdns/Server.cpp
@@ -128,6 +128,8 @@ ServerBase::~ServerBase()
 
 void ServerBase::Shutdown()
 {
+    if (!IsListening()) return;
+
     for (size_t i = 0; i < mEndpointCount; i++)
     {
         if (mEndpoints[i].udp != nullptr)

--- a/src/platform/Darwin/KeyValueStoreManagerImpl.mm
+++ b/src/platform/Darwin/KeyValueStoreManagerImpl.mm
@@ -184,7 +184,7 @@ namespace DeviceLayer {
             }
 
             // create Managed Object context
-            gContext = [[NSManagedObjectContext alloc] initWithConcurrencyType:NSMainQueueConcurrencyType];
+            gContext = [[NSManagedObjectContext alloc] initWithConcurrencyType:NSPrivateQueueConcurrencyType];
             [gContext setPersistentStoreCoordinator:coordinator];
 
             return CHIP_NO_ERROR;

--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -604,4 +604,17 @@ SessionHandle SessionManager::FindSecureSessionForNode(NodeId peerNodeId)
     return SessionHandle(found->GetPeerNodeId(), found->GetLocalSessionId(), found->GetPeerSessionId(), found->GetFabricIndex());
 }
 
+/**
+ * Provides a means to get diagnositic information such as number of sessions.
+ */
+CHIP_ERROR SessionManager::ForEachSessionHandle(void * context, SessionHandleCallback lambda)
+{
+    mSecureSessions.ForEachSession([&](auto session) {
+        SessionHandle handle(session->GetPeerNodeId(), session->GetLocalSessionId(), session->GetPeerSessionId(), session->GetFabricIndex());
+        lambda(context, handle);
+        return true;
+    });
+    return CHIP_NO_ERROR;
+}
+
 } // namespace chip

--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -610,7 +610,8 @@ SessionHandle SessionManager::FindSecureSessionForNode(NodeId peerNodeId)
 CHIP_ERROR SessionManager::ForEachSessionHandle(void * context, SessionHandleCallback lambda)
 {
     mSecureSessions.ForEachSession([&](auto session) {
-        SessionHandle handle(session->GetPeerNodeId(), session->GetLocalSessionId(), session->GetPeerSessionId(), session->GetFabricIndex());
+        SessionHandle handle(session->GetPeerNodeId(), session->GetLocalSessionId(), session->GetPeerSessionId(),
+                             session->GetFabricIndex());
         lambda(context, handle);
         return true;
     });

--- a/src/transport/SessionManager.h
+++ b/src/transport/SessionManager.h
@@ -257,6 +257,9 @@ public:
     // TODO: this is a temporary solution for legacy tests which use nodeId to send packets
     SessionHandle FindSecureSessionForNode(NodeId peerNodeId);
 
+    using SessionHandleCallback = bool (*)(void * context, SessionHandle &sessionHandle);
+    CHIP_ERROR ForEachSessionHandle(void * context, SessionHandleCallback callback);
+
 private:
     /**
      *    The State of a secure transport object.

--- a/src/transport/SessionManager.h
+++ b/src/transport/SessionManager.h
@@ -257,7 +257,7 @@ public:
     // TODO: this is a temporary solution for legacy tests which use nodeId to send packets
     SessionHandle FindSecureSessionForNode(NodeId peerNodeId);
 
-    using SessionHandleCallback = bool (*)(void * context, SessionHandle &sessionHandle);
+    using SessionHandleCallback = bool (*)(void * context, SessionHandle & sessionHandle);
     CHIP_ERROR ForEachSessionHandle(void * context, SessionHandleCallback callback);
 
 private:


### PR DESCRIPTION
#### Problem
The shell app has limited functionality.  It doesn't provide access to core device functionality such as pairing or IM/ZCL command handling.

#### Change overview
Adds the `server` command to provide the ability to `server start` or `server stop` the equivalent of the all-clusters-app peripheral.  Once the server is started, one can pair the device with `chip-tool` and send commands to it.

This work is an incremental step towards making the chip-shell capable of being either a client or a server (or potentially both with enough rework of the core).  Once chip-shell can act as both these roles, there is potential for using it as a basis for scripted functional tests where chip-shell in a process can serve as a simulated node, and a collection of such nodes can form a topology for more advanced N-node tests.

#### Testing
Local testing on linux and darwin.
CI for other embedded builds.
