### PR TITLE
[shell] Fix darwin deadlock with 'server start' command.

### DIFF
--- a/src/platform/Darwin/KeyValueStoreManagerImpl.mm
+++ b/src/platform/Darwin/KeyValueStoreManagerImpl.mm
@@ -184,7 +184,7 @@ namespace DeviceLayer {
             }
 
             // create Managed Object context
-            gContext = [[NSManagedObjectContext alloc] initWithConcurrencyType:NSMainQueueConcurrencyType];
+            gContext = [[NSManagedObjectContext alloc] initWithConcurrencyType:NSPrivateQueueConcurrencyType];
             [gContext setPersistentStoreCoordinator:coordinator];
 
             return CHIP_NO_ERROR;


### PR DESCRIPTION
#### Problem
KeyValueStore on Darwin can deadlock if `Server::Init` is called from `_PostEvent`.

#### Change overview
Use the private dispatch queue in PlatformManager rather than the main queue.

#### Testing
Local with chip-shell app.
CI.