### PR TITLE
[nrfconnect] Don't erase factory keys on the factory reset

### DIFF
--- a/src/platform/Zephyr/ZephyrConfig.cpp
+++ b/src/platform/Zephyr/ZephyrConfig.cpp
@@ -45,7 +45,7 @@ namespace Internal {
 // CHIP_DEVICE_CONFIG_SETTINGS_KEY subtree so that they get erased when
 // KeyValueStoreManagerImpl::DoFactoryReset() is called.
 #define NAMESPACE_FACTORY CHIP_DEVICE_CONFIG_SETTINGS_KEY "-fct/"
-#define NAMESPACE_CONFIG   CHIP_DEVICE_CONFIG_SETTINGS_KEY "/cfg/"
+#define NAMESPACE_CONFIG CHIP_DEVICE_CONFIG_SETTINGS_KEY "/cfg/"
 #define NAMESPACE_COUNTERS CHIP_DEVICE_CONFIG_SETTINGS_KEY "/ctr/"
 
 // Keys stored in the chip factory nam

--- a/src/platform/Zephyr/ZephyrConfig.cpp
+++ b/src/platform/Zephyr/ZephyrConfig.cpp
@@ -41,13 +41,12 @@ namespace Internal {
     (key);                                                                                                                         \
     static_assert(sizeof(key) <= SETTINGS_MAX_NAME_LEN, "Config key too long: " key)
 
-// Define the configuration keys to be part of the CHIP_DEVICE_CONFIG_SETTINGS_KEY subtree
-// so that they get erased when KeyValueStoreManagerImpl::DoFactoryReset() is called.
-// clang-format off
-#define NAMESPACE_FACTORY  CHIP_DEVICE_CONFIG_SETTINGS_KEY "/fct/"
+// Define the configuration keys (except the factory keys) to be part of the
+// CHIP_DEVICE_CONFIG_SETTINGS_KEY subtree so that they get erased when
+// KeyValueStoreManagerImpl::DoFactoryReset() is called.
+#define NAMESPACE_FACTORY CHIP_DEVICE_CONFIG_SETTINGS_KEY "-fct/"
 #define NAMESPACE_CONFIG   CHIP_DEVICE_CONFIG_SETTINGS_KEY "/cfg/"
 #define NAMESPACE_COUNTERS CHIP_DEVICE_CONFIG_SETTINGS_KEY "/ctr/"
-// clang-format on
 
 // Keys stored in the chip factory nam
 const ZephyrConfig::Key ZephyrConfig::kConfigKey_SerialNum           = CONFIG_KEY(NAMESPACE_FACTORY "serial-num");


### PR DESCRIPTION
#### Problem
The factory reset on nRF Connect platforms erases all settings starting with "mt/", including the factory settings.

#### Change overview
Make sure that factory configuration keys are not descendants of the "mt" subtree, so use "mt-fact" prefix for them.

#### Testing
Tested on nRF Connect platform.
