### PR TITLE
Add fabricIndex as a member of ControllerInitParams

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -143,6 +143,7 @@ CHIP_ERROR DeviceController::Init(ControllerInitParams params)
     VerifyOrReturnError(params.operationalCredentialsDelegate != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     mOperationalCredentialsDelegate = params.operationalCredentialsDelegate;
 
+    mFabricIndex = params.fabricIndex;
     ReturnErrorOnFailure(ProcessControllerNOCChain(params));
 
     DeviceProxyInitParams deviceInitParams = {

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -107,7 +107,8 @@ struct ControllerInitParams
 
     uint16_t controllerVendorId;
 
-    FabricId fabricId = kUndefinedFabricId;
+    FabricIndex fabricIndex = kMinValidFabricIndex;
+    FabricId fabricId       = kUndefinedFabricId;
 };
 
 enum CommissioningStage : uint8_t

--- a/src/controller/CHIPDeviceControllerFactory.cpp
+++ b/src/controller/CHIPDeviceControllerFactory.cpp
@@ -159,6 +159,7 @@ void DeviceControllerFactory::PopulateInitParams(ControllerInitParams & controll
     controllerParams.controllerNOC                  = params.controllerNOC;
     controllerParams.controllerICAC                 = params.controllerICAC;
     controllerParams.controllerRCAC                 = params.controllerRCAC;
+    controllerParams.fabricIndex                    = params.fabricIndex;
     controllerParams.fabricId                       = params.fabricId;
     controllerParams.storageDelegate                = params.storageDelegate;
 

--- a/src/controller/CHIPDeviceControllerFactory.h
+++ b/src/controller/CHIPDeviceControllerFactory.h
@@ -54,7 +54,8 @@ struct SetupParams
     ByteSpan controllerICAC;
     ByteSpan controllerRCAC;
 
-    FabricId fabricId = kUndefinedFabricId;
+    FabricIndex fabricIndex = kMinValidFabricIndex;
+    FabricId fabricId       = kUndefinedFabricId;
 
     uint16_t controllerVendorId;
 


### PR DESCRIPTION
#### Problem

When building an application with multiples `CHIPDeviceController` instances, the fabric index is always assume to be `kMinValidFabricIndex` which is not correct in this case.

#### Change overview
 * Allow specifying the fabric index when initialising the controller.

#### Testing
I have locally tested it into a modified instance of `chip-tool` that contains multiple controllers. Patches for `chip-tool` are coming soon...