### PR TITLE
Multiple Controllers: DND-SD should be able to support multiple consu…

### DIFF
--- a/examples/chip-tool/commands/discover/Commands.h
+++ b/examples/chip-tool/commands/discover/Commands.h
@@ -33,7 +33,7 @@ public:
     CHIP_ERROR RunCommand(NodeId remoteId, uint64_t fabricId) override
     {
         ReturnErrorOnFailure(chip::Dnssd::Resolver::Instance().Init(&chip::DeviceLayer::InetLayer()));
-        chip::Dnssd::Resolver::Instance().SetResolverDelegate(this);
+        chip::Dnssd::Resolver::Instance().RegisterResolverDelegate(this);
         ChipLogProgress(chipTool, "Dnssd: Searching for NodeId: %" PRIx64 " FabricId: %" PRIx64 " ...", remoteId, fabricId);
         return chip::Dnssd::Resolver::Instance().ResolveNodeId(chip::PeerId().SetNodeId(remoteId).SetCompressedFabricId(fabricId),
                                                                chip::Inet::IPAddressType::kAny);

--- a/src/controller/AbstractDnssdDiscoveryController.cpp
+++ b/src/controller/AbstractDnssdDiscoveryController.cpp
@@ -69,7 +69,7 @@ CHIP_ERROR AbstractDnssdDiscoveryController::SetUpNodeDiscovery()
 #if CONFIG_DEVICE_LAYER
     ReturnErrorOnFailure(mResolver->Init(&DeviceLayer::InetLayer()));
 #endif
-    mResolver->SetResolverDelegate(this);
+    mResolver->RegisterResolverDelegate(this);
 
     auto discoveredNodes = GetDiscoveredNodes();
     for (auto & discoveredNode : discoveredNodes)

--- a/src/controller/python/chip/discovery/NodeResolution.cpp
+++ b/src/controller/python/chip/discovery/NodeResolution.cpp
@@ -97,7 +97,7 @@ extern "C" ChipError::StorageType pychip_discovery_resolve(uint64_t fabricId, ui
     chip::python::ChipMainThreadScheduleAndWait([&] {
         result = Resolver::Instance().Init(&chip::DeviceLayer::InetLayer());
         ReturnOnFailure(result);
-        Resolver::Instance().SetResolverDelegate(&gPythonResolverDelegate);
+        Resolver::Instance().RegisterResolverDelegate(&gPythonResolverDelegate);
 
         result = Resolver::Instance().ResolveNodeId(chip::PeerId().SetCompressedFabricId(fabricId).SetNodeId(nodeId),
                                                     chip::Inet::IPAddressType::kAny);

--- a/src/controller/tests/TestCommissionableNodeController.cpp
+++ b/src/controller/tests/TestCommissionableNodeController.cpp
@@ -33,7 +33,8 @@ class MockResolver : public Resolver
 public:
     CHIP_ERROR Init(chip::Inet::InetLayer * inetLayer) override { return InitStatus; }
     void Shutdown() override {}
-    void SetResolverDelegate(ResolverDelegate *) override {}
+    void RegisterResolverDelegate(ResolverDelegate *) override {}
+    void UnregisterResolverDelegate(ResolverDelegate *) override {}
     CHIP_ERROR ResolveNodeId(const PeerId & peerId, Inet::IPAddressType type) override { return ResolveNodeIdStatus; }
     CHIP_ERROR FindCommissioners(DiscoveryFilter filter = DiscoveryFilter()) override { return FindCommissionersStatus; }
     CHIP_ERROR FindCommissionableNodes(DiscoveryFilter filter = DiscoveryFilter()) override { return CHIP_ERROR_NOT_IMPLEMENTED; }

--- a/src/lib/core/CHIPConfig.h
+++ b/src/lib/core/CHIPConfig.h
@@ -2401,6 +2401,16 @@ extern const char CHIP_NON_PRODUCTION_MARKER[];
 #endif
 
 /**
+ * @def CHIP_CONFIG_MDNS_MAX_RESOLVER_DELEGATES
+ *
+ * @brief
+ *      Define the maximum number of delegates that will be informed of node address resolution.
+ */
+#ifndef CHIP_CONFIG_MDNS_MAX_RESOLVER_DELEGATES
+#define CHIP_CONFIG_MDNS_MAX_RESOLVER_DELEGATES 4
+#endif
+
+/**
  * @def CHIP_CONFIG_MDNS_CACHE_SIZE
  *
  * @brief
@@ -2412,6 +2422,7 @@ extern const char CHIP_NON_PRODUCTION_MARKER[];
 #ifndef CHIP_CONFIG_MDNS_CACHE_SIZE
 #define CHIP_CONFIG_MDNS_CACHE_SIZE 20
 #endif
+
 /**
  *  @name Interaction Model object pool configuration.
  *

--- a/src/lib/dnssd/Discovery_ImplPlatform.h
+++ b/src/lib/dnssd/Discovery_ImplPlatform.h
@@ -48,7 +48,8 @@ public:
     CHIP_ERROR GetCommissionableInstanceName(char * instanceName, size_t maxLength) override;
 
     // Members that implement Resolver interface.
-    void SetResolverDelegate(ResolverDelegate * delegate) override { mResolverDelegate = delegate; }
+    void RegisterResolverDelegate(ResolverDelegate * delegate) override;
+    void UnregisterResolverDelegate(ResolverDelegate * delegate) override;
     CHIP_ERROR ResolveNodeId(const PeerId & peerId, Inet::IPAddressType type) override;
     CHIP_ERROR FindCommissionableNodes(DiscoveryFilter filter = DiscoveryFilter()) override;
     CHIP_ERROR FindCommissioners(DiscoveryFilter filter = DiscoveryFilter()) override;
@@ -83,8 +84,8 @@ private:
     bool mIsCommissionerPublishing       = false;
     uint8_t mCommissionableInstanceName[sizeof(uint64_t)];
 
-    bool mDnssdInitialized               = false;
-    ResolverDelegate * mResolverDelegate = nullptr;
+    bool mDnssdInitialized                                                         = false;
+    ResolverDelegate * mResolverDelegates[CHIP_CONFIG_MDNS_MAX_RESOLVER_DELEGATES] = {};
 
     static DiscoveryImplPlatform sManager;
 #if CHIP_CONFIG_MDNS_CACHE_SIZE > 0

--- a/src/lib/dnssd/Resolver.h
+++ b/src/lib/dnssd/Resolver.h
@@ -268,10 +268,14 @@ public:
     virtual void Shutdown() = 0;
 
     /**
-     * Registers a resolver delegate. If nullptr is passed, the previously registered delegate
-     * is unregistered.
+     * Registers a resolver delegate.
      */
-    virtual void SetResolverDelegate(ResolverDelegate * delegate) = 0;
+    virtual void RegisterResolverDelegate(ResolverDelegate * delegate) = 0;
+
+    /**
+     * Unregisters a resolver delegate.
+     */
+    virtual void UnregisterResolverDelegate(ResolverDelegate * delegate) = 0;
 
     /**
      * Requests resolution of the given operational node service.

--- a/src/lib/dnssd/Resolver_ImplMinimalMdns.cpp
+++ b/src/lib/dnssd/Resolver_ImplMinimalMdns.cpp
@@ -344,7 +344,8 @@ public:
     ///// Resolver implementation
     CHIP_ERROR Init(chip::Inet::InetLayer * inetLayer) override;
     void Shutdown() override;
-    void SetResolverDelegate(ResolverDelegate * delegate) override { mDelegate = delegate; }
+    void RegisterResolverDelegate(ResolverDelegate * delegate) override { mDelegate = delegate; }
+    void UnregisterResolverDelegate(ResolverDelegate * delegate) override { mDelegate = nullptr; }
     CHIP_ERROR ResolveNodeId(const PeerId & peerId, Inet::IPAddressType type) override;
     CHIP_ERROR FindCommissionableNodes(DiscoveryFilter filter = DiscoveryFilter()) override;
     CHIP_ERROR FindCommissioners(DiscoveryFilter filter = DiscoveryFilter()) override;

--- a/src/lib/dnssd/Resolver_ImplNone.cpp
+++ b/src/lib/dnssd/Resolver_ImplNone.cpp
@@ -28,7 +28,8 @@ class NoneResolver : public Resolver
 public:
     CHIP_ERROR Init(chip::Inet::InetLayer *) override { return CHIP_NO_ERROR; }
     void Shutdown() override {}
-    void SetResolverDelegate(ResolverDelegate *) override {}
+    void RegisterResolverDelegate(ResolverDelegate *) override {}
+    void UnregisterResolverDelegate(ResolverDelegate *) override {}
 
     CHIP_ERROR ResolveNodeId(const PeerId & peerId, Inet::IPAddressType type) override
     {

--- a/src/lib/shell/commands/Dns.cpp
+++ b/src/lib/shell/commands/Dns.cpp
@@ -222,7 +222,7 @@ CHIP_ERROR DnsHandler(int argc, char ** argv)
     }
 
     Dnssd::Resolver::Instance().Init(&DeviceLayer::InetLayer());
-    Dnssd::Resolver::Instance().SetResolverDelegate(&sDnsShellResolverDelegate);
+    Dnssd::Resolver::Instance().RegisterResolverDelegate(&sDnsShellResolverDelegate);
 
     return sShellDnsSubcommands.ExecCommand(argc, argv);
 }


### PR DESCRIPTION
…mers

#### Problem
DNS-SD only supports 1 resolver delegate.

This is a problem for #10089 and for having multiple controller/commissioner objects in a single process.

#### Change overview
 * Add support for multiple delegates

#### Testing
It was tested by locally modifying `chip-tool` by having multiple instances of the `CHIPDeviceController` into the same process.

Fix #11562
