### PR TITLE
[Mbed] Fix resolve node action

### DIFF
--- a/examples/all-clusters-app/mbed/mbed_app.json
+++ b/examples/all-clusters-app/mbed/mbed_app.json
@@ -18,7 +18,8 @@
                 "MXCRYPTO_DISABLED",
                 "NL_ASSERT_LOG=NL_ASSERT_LOG_DEFAULT",
                 "NL_ASSERT_EXPECT_FLAGS=NL_ASSERT_FLAG_LOG",
-                "WHD_PRINT_DISABLE"
+                "WHD_PRINT_DISABLE",
+                "MBED_CONF_LWIP_NETBUF_RECVINFO_ENABLED"
             ]
         }
     },

--- a/examples/lighting-app/mbed/mbed_app.json
+++ b/examples/lighting-app/mbed/mbed_app.json
@@ -18,7 +18,8 @@
                 "MXCRYPTO_DISABLED",
                 "NL_ASSERT_LOG=NL_ASSERT_LOG_DEFAULT",
                 "NL_ASSERT_EXPECT_FLAGS=NL_ASSERT_FLAG_LOG",
-                "WHD_PRINT_DISABLE"
+                "WHD_PRINT_DISABLE",
+                "MBED_CONF_LWIP_NETBUF_RECVINFO_ENABLED"
             ],
             "target.components_add": ["capsense"],
             "lighting-state-led": "P9_6",

--- a/examples/lock-app/mbed/mbed_app.json
+++ b/examples/lock-app/mbed/mbed_app.json
@@ -18,7 +18,8 @@
                 "MXCRYPTO_DISABLED",
                 "NL_ASSERT_LOG=NL_ASSERT_LOG_DEFAULT",
                 "NL_ASSERT_EXPECT_FLAGS=NL_ASSERT_FLAG_LOG",
-                "WHD_PRINT_DISABLE"
+                "WHD_PRINT_DISABLE",
+                "MBED_CONF_LWIP_NETBUF_RECVINFO_ENABLED"
             ],
             "target.components_add": ["capsense"],
             "lock-state-led": "P9_6",

--- a/examples/shell/mbed/mbed_app.json
+++ b/examples/shell/mbed/mbed_app.json
@@ -18,7 +18,8 @@
                 "MXCRYPTO_DISABLED",
                 "NL_ASSERT_LOG=NL_ASSERT_LOG_DEFAULT",
                 "NL_ASSERT_EXPECT_FLAGS=NL_ASSERT_FLAG_LOG",
-                "WHD_PRINT_DISABLE"
+                "WHD_PRINT_DISABLE",
+                "MBED_CONF_LWIP_NETBUF_RECVINFO_ENABLED"
             ]
         }
     },


### PR DESCRIPTION
#### Problem
Resolve node command from Python Device Controller failed. The resolve node actions caused the application to get stuck receiving data from the UDP socket. The wrong LWIP configuration was responsible for this error.

#### Change overview
Fix setting node IP address in ConnectivityMgrImpl
Fix recvmsg function - enable LWIP option in mbed

#### Testing
Build and run Mbed examples with Python Device Controller testing
