### PR TITLE
Fix template function in TagBoundEncoder

### DIFF
--- a/src/app/data-model/TagBoundEncoder.h
+++ b/src/app/data-model/TagBoundEncoder.h
@@ -39,7 +39,7 @@ public:
     TagBoundEncoder(TLV::TLVWriter * aWriter, TLV::Tag aTag) : mWriter(aWriter), mTag(aTag) {}
 
     template <typename... Ts>
-    CHIP_ERROR Encode(Ts... aArgs) const
+    CHIP_ERROR Encode(Ts &&... aArgs) const
     {
         VerifyOrReturnError(mWriter != nullptr, CHIP_ERROR_INCORRECT_STATE);
         return DataModel::Encode(*mWriter, mTag, std::forward<Ts>(aArgs)...);


### PR DESCRIPTION
Should take argument with perfect forwarding, otherwise non-copyable
arguments don't work.

#### Problem
Can't encode non-copyable/non-movable type.

#### Change overview
Fix template function signature.

#### Testing
Built, ran cert tests.
