### PR TITLE
Fix broken gn_build.sh builds

### DIFF
--- a/src/platform/fake/ConfigurationManagerImpl.h
+++ b/src/platform/fake/ConfigurationManagerImpl.h
@@ -60,9 +60,7 @@ private:
     CHIP_ERROR StoreSetupPinCode(uint32_t setupPinCode) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
     CHIP_ERROR GetSetupDiscriminator(uint16_t & setupDiscriminator) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
     CHIP_ERROR StoreSetupDiscriminator(uint16_t setupDiscriminator) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
-#if CHIP_ENABLE_ROTATING_DEVICE_ID
     CHIP_ERROR GetLifetimeCounter(uint16_t & lifetimeCounter) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
-#endif
     CHIP_ERROR GetFailSafeArmed(bool & val) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
     CHIP_ERROR SetFailSafeArmed(bool val) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
     CHIP_ERROR GetBLEDeviceIdentificationInfo(Ble::ChipBLEDeviceIdentificationInfo & deviceIdInfo) override


### PR DESCRIPTION
#### Problem

Builds of the ‘fake’ platform (which are included in `gn_build.sh`)
fail since commit e0a8db72ee2. That changed the default state of the
`CHIP_ENABLE_ROTATING_DEVICE_ID` flag, which excludes a definition
in `ConfigurationManagerImpl` in `src/platform/fake/ConfigurationManagerImpl.h`
but not in the corresponding base class.

#### Change overview

Remove the `#if`

#### Testing

`gn_build.sh`
