### PR TITLE
Re-enable test coverage that the python test suite runner disabled.

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -174,7 +174,7 @@ jobs:
               run: |
                   ./scripts/run_in_build_env.sh \
                   "./scripts/tests/run_test_suite.py \
-                     --target-skip-glob 'tv-*' \
+                     --target-skip-glob 'TV_*' \
                      run \
                      --iterations 2 \
                      --chip-tool ./out/debug/standalone/chip-tool \

--- a/scripts/tests/chiptest/__init__.py
+++ b/scripts/tests/chiptest/__init__.py
@@ -32,17 +32,15 @@ def AllTests(root: str):
         logging.debug('Found YAML: %s' % path)
 
         # grab the name without the extension
-        name = path.stem.lower()
+        name = path.stem
 
-        if 'simulated' in name:
+        if 'Simulated' in name:
             continue
 
-        if name.startswith('tv_'):
+        if name.startswith('TV_'):
             target = TestTarget.TV
-            name = 'tv-' + name[3:]
-        elif name.startswith('test_'):
+        elif name.startswith('Test'):
             target = TestTarget.ALL_CLUSTERS
-            name = 'app-' + name[5:]
         else:
             continue
 

--- a/scripts/tests/run_test_suite.py
+++ b/scripts/tests/run_test_suite.py
@@ -122,7 +122,7 @@ def main(context, log_level, target, target_glob, target_skip_glob, no_log_times
             tests.extend(targeted)
 
     if target_glob:
-        matcher = GlobMatcher(target_glob)
+        matcher = GlobMatcher(target_glob.lower())
         tests = [test for test in tests if matcher.matches(test.name.lower())]
 
     if len(tests) == 0:
@@ -132,7 +132,7 @@ def main(context, log_level, target, target_glob, target_skip_glob, no_log_times
         exit(1)
 
     if target_skip_glob:
-        matcher = GlobMatcher(target_skip_glob)
+        matcher = GlobMatcher(target_skip_glob.lower())
         tests = [test for test in tests if not matcher.matches(
             test.name.lower())]
 


### PR DESCRIPTION
The pattern for tests is not "`test_*`"; there are a bunch of tests
(e.g. TestCluster) that don't match that.  The correct pattern is
"`Test*`" (and "`TV_*`" for the TV tests).  "`test*`" also does not work
right because it includes
src/app/tests/suites/certification/tests.yaml which is not a test yaml
we want to be running.

Summary of changes:

1. Stop lowercasing test names in creating the test definitions, so we
   can actually match against "`Test*`" sanely.  This also makes the test
   names match what consumers see in the actual filenames.
2. Change the test name detection to match on "`Test*`", which fixes the actual
   regression.
3. Move the lowercasing to the --target and --target-glob matching.
4. Add more useful error output when unrecognized --target values are
   specified, and exit with a failure in that case instead of silently
   succeeding.

#### Problem
See above.

#### Change overview
See above.

#### Testing
Verified that "TestCluster" not appears in the list of tests the script knows about.