### PR TITLE
[admin] Do not enable BLE advertising in response to admin commands

### DIFF
--- a/src/app/clusters/administrator-commissioning-server/administrator-commissioning-server.cpp
+++ b/src/app/clusters/administrator-commissioning-server/administrator-commissioning-server.cpp
@@ -96,8 +96,8 @@ bool emberAfAdministratorCommissioningClusterOpenBasicCommissioningWindowCallbac
                  status.Emplace(StatusCode::EMBER_ZCL_STATUS_CODE_BUSY));
     VerifyOrExit(commissioningTimeout <= kMaxCommissionioningTimeoutSeconds,
                  status.Emplace(StatusCode::EMBER_ZCL_STATUS_CODE_PAKE_PARAMETER_ERROR));
-    VerifyOrExit(Server::GetInstance().GetCommissioningWindowManager().OpenBasicCommissioningWindow(commissioningTimeout) ==
-                     CHIP_NO_ERROR,
+    VerifyOrExit(Server::GetInstance().GetCommissioningWindowManager().OpenBasicCommissioningWindow(
+                     commissioningTimeout, CommissioningWindowAdvertisement::kDnssdOnly) == CHIP_NO_ERROR,
                  status.Emplace(StatusCode::EMBER_ZCL_STATUS_CODE_PAKE_PARAMETER_ERROR));
     ChipLogProgress(Zcl, "Commissioning window is now open");
 

--- a/src/app/server/CommissioningWindowManager.cpp
+++ b/src/app/server/CommissioningWindowManager.cpp
@@ -229,12 +229,9 @@ CHIP_ERROR CommissioningWindowManager::OpenEnhancedCommissioningWindow(uint16_t 
                                                                        PASEVerifier & verifier, uint32_t iterations, ByteSpan salt,
                                                                        uint16_t passcodeID)
 {
-#if CONFIG_NETWORK_LAYER_BLE
-    // TODO: Don't use BLE for commissioning additional fabrics on a device
-    SetBLE(true);
-#else
+    // Once a device is operational, it shall be commissioned into subsequent fabrics using
+    // the operational network only.
     SetBLE(false);
-#endif
 
     VerifyOrReturnError(salt.size() <= sizeof(mECMSalt), CHIP_ERROR_INVALID_ARGUMENT);
 

--- a/src/app/tests/TestCommissionManager.cpp
+++ b/src/app/tests/TestCommissionManager.cpp
@@ -47,8 +47,9 @@ void InitializeChip(nlTestSuite * suite)
     err = chip::DeviceLayer::PlatformMgr().InitChipStack();
     NL_TEST_ASSERT(suite, err == CHIP_NO_ERROR);
     err = Server::GetInstance().Init();
-    chip::DeviceLayer::PlatformMgr().StartEventLoopTask();
     NL_TEST_ASSERT(suite, err == CHIP_NO_ERROR);
+    Server::GetInstance().GetCommissioningWindowManager().CloseCommissioningWindow();
+    chip::DeviceLayer::PlatformMgr().StartEventLoopTask();
 }
 
 void CheckCommissioningWindowManagerBasicWindowOpenCloseTask(intptr_t context)
@@ -59,6 +60,7 @@ void CheckCommissioningWindowManagerBasicWindowOpenCloseTask(intptr_t context)
         commissionMgr.OpenBasicCommissioningWindow(kNoCommissioningTimeout, CommissioningWindowAdvertisement::kDnssdOnly);
     NL_TEST_ASSERT(suite, err == CHIP_NO_ERROR);
     NL_TEST_ASSERT(suite, commissionMgr.IsCommissioningWindowOpen());
+    NL_TEST_ASSERT(suite, !chip::DeviceLayer::ConnectivityMgr().IsBLEAdvertisingEnabled());
     commissionMgr.CloseCommissioningWindow();
     NL_TEST_ASSERT(suite, !commissionMgr.IsCommissioningWindowOpen());
 }
@@ -87,6 +89,7 @@ void CheckCommissioningWindowManagerWindowTimeoutTask(intptr_t context)
     CHIP_ERROR err = commissionMgr.OpenBasicCommissioningWindow(kTimeoutSeconds, CommissioningWindowAdvertisement::kDnssdOnly);
     NL_TEST_ASSERT(suite, err == CHIP_NO_ERROR);
     NL_TEST_ASSERT(suite, commissionMgr.IsCommissioningWindowOpen());
+    NL_TEST_ASSERT(suite, !chip::DeviceLayer::ConnectivityMgr().IsBLEAdvertisingEnabled());
     chip::DeviceLayer::SystemLayer().StartTimer(chip::System::Clock::Milliseconds32(kTimeoutMs + kSleepPadding),
                                                 CheckCommissioningWindowManagerWindowClosedTask, suite);
 }
@@ -117,6 +120,7 @@ void CheckCommissioningWindowManagerEnhancedWindowTask(intptr_t context)
                                                         kPasscodeID);
     NL_TEST_ASSERT(suite, err == CHIP_NO_ERROR);
     NL_TEST_ASSERT(suite, commissionMgr.IsCommissioningWindowOpen());
+    NL_TEST_ASSERT(suite, !chip::DeviceLayer::ConnectivityMgr().IsBLEAdvertisingEnabled());
     err = chip::DeviceLayer::ConfigurationMgr().GetSetupDiscriminator(currentDiscriminator);
     NL_TEST_ASSERT(suite, err == CHIP_NO_ERROR);
     NL_TEST_ASSERT(suite, currentDiscriminator == newDiscriminator);


### PR DESCRIPTION
#### Problem
AdministratorCommissioning commands for opening the commissioning window on a peer device, enable BLE
advertising while only the operational network shall be used for subsequent commissionings.

#### Change overview
Make OpenBasicCommissioningWindow and OpenEnhancedCommissioningWindow commands use only IP for the commissioning.

#### Testing
Unit tests + manual tests using nRF Connect Lock.
