### PR TITLE
[YAML] Get simulated clusters related code to merge clusters/commands/attributes for real clusters and simulated clusters to be into a dedicated file

### DIFF
--- a/src/app/zap-templates/common/ClusterTestGeneration.js
+++ b/src/app/zap-templates/common/ClusterTestGeneration.js
@@ -26,10 +26,8 @@ const path              = require('path');
 // Import helpers from zap core
 const templateUtil = require(zapPath + 'dist/src-electron/generator/template-util.js')
 
-const { DelayCommands }                 = require('./simulated-clusters/TestDelayCommands.js');
-const { LogCommands }                   = require('./simulated-clusters/TestLogCommands.js');
-const { Clusters, asBlocks, asPromise } = require('./ClustersHelper.js');
-const { asUpperCamelCase }              = require(basePath + 'src/app/zap-templates/templates/app/helper.js');
+const { getClusters, getCommands, getAttributes, isTestOnlyCluster } = require('./simulated-clusters/SimulatedClusters.js');
+const { asBlocks }                                                   = require('./ClustersHelper.js');
 
 const kClusterName       = 'cluster';
 const kEndpointName      = 'endpoint';
@@ -341,37 +339,6 @@ function printErrorAndExit(context, msg)
   process.exit(1);
 }
 
-function getClusters()
-{
-  // Create a new array to merge the configured clusters list and test
-  // simulated clusters.
-  return Clusters.getClusters().then(clusters => clusters.concat(DelayCommands, LogCommands));
-}
-
-function getCommands(clusterName)
-{
-  switch (clusterName) {
-  case DelayCommands.name:
-    return Promise.resolve(DelayCommands.commands);
-  case LogCommands.name:
-    return Promise.resolve(LogCommands.commands);
-  default:
-    return Clusters.getClientCommands(clusterName);
-  }
-}
-
-function getAttributes(clusterName)
-{
-  switch (clusterName) {
-  case DelayCommands.name:
-    return Promise.resolve(DelayCommands.attributes);
-  case LogCommands.name:
-    return Promise.resolve(LogCommands.attributes);
-  default:
-    return Clusters.getServerAttributes(clusterName);
-  }
-}
-
 function assertCommandOrAttribute(context)
 {
   const clusterName = context.cluster;
@@ -467,15 +434,6 @@ async function chip_tests(list, options)
 function chip_tests_items(options)
 {
   return templateUtil.collectBlocks(this.tests, options, this);
-}
-
-function isTestOnlyCluster(name)
-{
-  const testOnlyClusters = [
-    DelayCommands.name,
-    LogCommands.name,
-  ];
-  return testOnlyClusters.includes(name);
 }
 
 // test_cluster_command_value and test_cluster_value-equals are recursive partials using #each. At some point the |global|

--- a/src/app/zap-templates/common/simulated-clusters/SimulatedClusters.js
+++ b/src/app/zap-templates/common/simulated-clusters/SimulatedClusters.js
@@ -1,0 +1,60 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+const { Clusters }      = require('../ClustersHelper.js');
+const { DelayCommands } = require('./TestDelayCommands.js');
+const { LogCommands }   = require('./TestLogCommands.js');
+
+const SimulatedClusters = [
+  DelayCommands,
+  LogCommands,
+];
+
+function getSimulatedCluster(clusterName)
+{
+  return SimulatedClusters.find(cluster => cluster.name == clusterName);
+}
+
+function getClusters()
+{
+  return Clusters.getClusters().then(clusters => clusters.concat(SimulatedClusters).flat(1));
+}
+
+function getCommands(clusterName)
+{
+  const cluster = getSimulatedCluster(clusterName);
+  return cluster ? Promise.resolve(cluster.commands) : Clusters.getClientCommands(clusterName);
+}
+
+function getAttributes(clusterName)
+{
+  const cluster = getSimulatedCluster(clusterName);
+  return cluster ? Promise.resolve(cluster.attributes) : Clusters.getServerAttributes(clusterName);
+}
+
+function isTestOnlyCluster(clusterName)
+{
+  return !!getSimulatedCluster(clusterName);
+}
+
+//
+// Module exports
+//
+exports.getClusters       = getClusters;
+exports.getCommands       = getCommands;
+exports.getAttributes     = getAttributes;
+exports.isTestOnlyCluster = isTestOnlyCluster;


### PR DESCRIPTION
#### Problem

When adding some test commands for YAML, there are multiple places where the new simulated cluster code needs to be added. This patch just shuffle the code so there is a single place.

#### Testing
I have verified that codegen does not change with this PR.