### PR TITLE
Revert "Fix some alerts founded the LGTM system (#11966)"

### DIFF
--- a/scripts/build/builders/mbed.py
+++ b/scripts/build/builders/mbed.py
@@ -12,8 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 import os
+import platform
+import glob
 import shlex
+import pathlib
 
 from enum import Enum, auto
 from .builder import Builder

--- a/scripts/tools/memory/memdf/df.py
+++ b/scripts/tools/memory/memdf/df.py
@@ -32,8 +32,7 @@ class DF(pd.DataFrame):  # pylint: disable=too-many-ancestors
                 self[c] = pd.Series()
         types = {c: self.dtype[c] for c in self.columns if c in self.dtype}
         typed_columns = list(types.keys())
-        self[typed_columns] = self.astype(types, copy=False)[
-            typed_columns]  # lgtm [py/hash-unhashable-value]
+        self[typed_columns] = self.astype(types, copy=False)[typed_columns]
         self.attrs['name'] = self.name
 
 

--- a/scripts/tools/memory/report_summary.py
+++ b/scripts/tools/memory/report_summary.py
@@ -28,6 +28,8 @@ Use `--output-format=help` to see available output formats.
 
 import sys
 
+import numpy  # type: ignore
+
 import memdf.collect
 import memdf.report
 import memdf.select

--- a/src/controller/python/chip-repl.py
+++ b/src/controller/python/chip-repl.py
@@ -18,7 +18,15 @@
 #
 
 import IPython
+import chip
+import chip.logging
+import coloredlogs
+import logging
 from traitlets.config import Config
+from rich import print
+from rich import pretty
+from rich import inspect
+import builtins
 import argparse
 import sys
 

--- a/src/controller/python/chip/ChipDeviceCtrl.py
+++ b/src/controller/python/chip/ChipDeviceCtrl.py
@@ -346,11 +346,11 @@ class ChipDeviceController(object):
 
         # The callback might have been received synchronously (during self._ChipStack.Call()).
         # Check if the device is already set before waiting for the callback.
-        if returnDevice.value is None:
+        if returnDevice.value == None:
             with deviceAvailableCV:
                 deviceAvailableCV.wait()
 
-        if returnDevice.value is None:
+        if returnDevice.value == None:
             raise self._ChipStack.ErrorToException(CHIP_ERROR_INTERNAL)
         return returnDevice
 

--- a/src/controller/python/chip/ChipReplStartup.py
+++ b/src/controller/python/chip/ChipReplStartup.py
@@ -8,6 +8,7 @@ from chip import ChipDeviceCtrl
 import chip.clusters as Clusters
 import coloredlogs
 import chip.logging
+import argparse
 import builtins
 
 
@@ -40,7 +41,7 @@ def ReplInit():
 
 
 def matterhelp(classOrObj=None):
-    if (classOrObj is None):
+    if (classOrObj == None):
         inspect(builtins.devCtrl, methods=True, help=True, private=False)
     else:
         inspect(classOrObj, methods=True, help=True, private=False)

--- a/src/controller/python/chip/clusters/Attribute.py
+++ b/src/controller/python/chip/clusters/Attribute.py
@@ -18,8 +18,8 @@
 from asyncio.futures import Future
 import ctypes
 from dataclasses import dataclass
-from typing import Union, List, Any
-from ctypes import CFUNCTYPE, c_char_p, c_size_t, c_uint32,  c_uint16, py_object
+from typing import Type, Union, List, Any
+from ctypes import CFUNCTYPE, c_char_p, c_size_t, c_void_p, c_uint32,  c_uint16, py_object
 
 from .ClusterObjects import ClusterAttributeDescriptor
 import chip.exceptions

--- a/src/controller/python/chip/clusters/Command.py
+++ b/src/controller/python/chip/clusters/Command.py
@@ -74,7 +74,7 @@ class AsyncCommandTransaction:
             self._future.set_result(None)
         else:
             # If a type hasn't been assigned, let's auto-deduce it.
-            if (self._expect_type is None):
+            if (self._expect_type == None):
                 self._expect_type = FindCommandClusterObject(False, path)
 
             if self._expect_type:

--- a/src/controller/python/chip/interaction_model/__init__.py
+++ b/src/controller/python/chip/interaction_model/__init__.py
@@ -26,7 +26,7 @@ from .delegate import OnSubscriptionReport, SetAttributeReportCallback, Attribut
 
 from chip.exceptions import ChipStackException
 
-__all__ = ["Status", "InteractionModelError"]
+__all__ = ["IMDelegate", "Status", "InteractionModelError"]
 
 
 class Status(enum.IntEnum):


### PR DESCRIPTION
This reverts commit 22255ab2297747145ebd2bd444a4a3d8f588f373.

#### Problem
```
======================================================================
ERROR: test_generated_clusterobjects (unittest.loader._FailedTest)
----------------------------------------------------------------------
ImportError: Failed to import test module: test_generated_clusterobjects
Traceback (most recent call last):
  File "/usr/lib/python3.9/unittest/loader.py", line 436, in _find_test_path
    module = self._get_module_from_name(name)
  File "/usr/lib/python3.9/unittest/loader.py", line 377, in _get_module_from_name
    __import__(name)
  File "/__w/connectedhomeip/connectedhomeip/src/controller/python/test/unit_tests/test_generated_clusterobjects.py", line 2, in <module>
    import chip.clusters as Clusters
  File "/__w/connectedhomeip/connectedhomeip/.environment/pigweed-venv/lib/python3.9/site-packages/chip/clusters/__init__.py", line 25, in <module>
    from . import Attribute
  File "/__w/connectedhomeip/connectedhomeip/.environment/pigweed-venv/lib/python3.9/site-packages/chip/clusters/Attribute.py", line 199, in <module>
    None, py_object, c_uint16, c_uint32, c_uint32, c_uint16, c_void_p, c_size_t)
NameError: name 'c_void_p' is not defined
```

#### Change overview
PR revert.
