### PR TITLE
OperationalDataset: Add ByteSpan extendedPanID

### DIFF
--- a/src/lib/support/ThreadOperationalDataset.cpp
+++ b/src/lib/support/ThreadOperationalDataset.cpp
@@ -288,6 +288,19 @@ CHIP_ERROR OperationalDataset::GetExtendedPanId(uint8_t (&aExtendedPanId)[kSizeE
     return CHIP_ERROR_TLV_TAG_NOT_FOUND;
 }
 
+CHIP_ERROR OperationalDataset::GetExtendedPanIdAsByteSpan(ByteSpan & span) const
+{
+    const ThreadTLV * tlv = Locate(ThreadTLV::kExtendedPanId);
+
+    if (tlv != nullptr)
+    {
+        span = ByteSpan(reinterpret_cast<const uint8_t *>(tlv->GetValue()), tlv->GetLength());
+        return CHIP_NO_ERROR;
+    }
+
+    return CHIP_ERROR_TLV_TAG_NOT_FOUND;
+}
+
 CHIP_ERROR OperationalDataset::SetExtendedPanId(const uint8_t (&aExtendedPanId)[kSizeExtendedPanId])
 {
     ThreadTLV * tlv = MakeRoom(ThreadTLV::kExtendedPanId, sizeof(*tlv) + sizeof(aExtendedPanId));

--- a/src/lib/support/ThreadOperationalDataset.h
+++ b/src/lib/support/ThreadOperationalDataset.h
@@ -114,6 +114,18 @@ public:
     CHIP_ERROR GetExtendedPanId(uint8_t (&aExtendedPanId)[kSizeExtendedPanId]) const;
 
     /**
+     * This method returns a const ByteSpan to the extended PAN ID in the dataset.
+     * This can be used to pass the extended PAN ID to a cluster command without the use of external memory.
+     *
+     * @param[out]  span  A reference to receive the location of the extended PAN ID.
+     *
+     * @retval CHIP_NO_ERROR                    Successfully retrieved the extended PAN ID.
+     * @retval CHIP_ERROR_TLV_TAG_NOT_FOUND     Thread extended PAN ID is not present in the dataset.
+     *
+     */
+    CHIP_ERROR GetExtendedPanIdAsByteSpan(ByteSpan & span) const;
+
+    /**
      * This method sets Thread extended PAN ID to the dataset.
      *
      * @param[in]   aExtendedPanId  The Thread extended PAN ID.

--- a/src/lib/support/tests/TestThreadOperationalDataset.cpp
+++ b/src/lib/support/tests/TestThreadOperationalDataset.cpp
@@ -80,6 +80,11 @@ void TestExtendedPanId(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, dataset.SetExtendedPanId(kExtendedPanId) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, dataset.GetExtendedPanId(extendedPanId) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, memcmp(extendedPanId, kExtendedPanId, sizeof(kExtendedPanId)) == 0);
+
+    ByteSpan span;
+    NL_TEST_ASSERT(inSuite, dataset.GetExtendedPanIdAsByteSpan(span) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, span.size() == sizeof(kExtendedPanId));
+    NL_TEST_ASSERT(inSuite, memcmp(extendedPanId, span.data(), sizeof(kExtendedPanId)) == 0);
 }
 
 void TestMasterKey(nlTestSuite * inSuite, void * inContext)


### PR DESCRIPTION
#### Problem
A class that owns a thread OperationalDataset already has memory allocated for the various pieces, but also needs to keep memory for the individual pieces. A direct ByteSpan reference eliminates a copy and doesn't require maintaining separate memory for something that's already owned. We already have a ByteSpan reference for the entire data set.

#### Change overview
Adds a byte span reference for the extendedPanId (required to enable the network using the network commissioning cluster).

#### Testing
Test added in the unit test section. Not yet used in the SDK code.
