### PR TITLE
[TIZEN] Fix the potential build warnings for ARM64

### DIFF
--- a/src/platform/Tizen/BLEManagerImpl.cpp
+++ b/src/platform/Tizen/BLEManagerImpl.cpp
@@ -806,7 +806,7 @@ void BLEManagerImpl::HandleC1CharWriteEvent(BLE_CONNECTION_OBJECT conId, const u
     CHIP_ERROR err = CHIP_NO_ERROR;
     System::PacketBufferHandle buf;
 
-    ChipLogProgress(DeviceLayer, "Write request received for CHIPoBLE Client TX characteristic (data len %u)", len);
+    ChipLogProgress(DeviceLayer, "Write request received for CHIPoBLE Client TX characteristic (data len %zu)", len);
     // Copy the data to a packet buffer.
     buf = System::PacketBufferHandle::NewWithData(value, len);
     VerifyOrExit(!buf.IsNull(), err = CHIP_ERROR_NO_MEMORY);
@@ -824,7 +824,7 @@ void BLEManagerImpl::HandleRXCharChanged(BLE_CONNECTION_OBJECT conId, const uint
     CHIP_ERROR err = CHIP_NO_ERROR;
     System::PacketBufferHandle buf;
 
-    ChipLogProgress(DeviceLayer, "Notification received on CHIPoBLE Client RX characteristic (data len %u)", len);
+    ChipLogProgress(DeviceLayer, "Notification received on CHIPoBLE Client RX characteristic (data len %zu)", len);
     // Copy the data to a packet buffer.
     buf = System::PacketBufferHandle::NewWithData(value, len);
     VerifyOrExit(!buf.IsNull(), err = CHIP_ERROR_NO_MEMORY);


### PR DESCRIPTION
Problem
Potential build warnings for ARM64 build

[ 84s] ../../src/platform/Tizen/BLEManagerImpl.cpp:807:34: error: format '%u' expects argument of type 'unsigned int', but argument 4 has type 'size_t' {aka 'long unsigned int'} [-Werror=format=]
[ 84s] 807 | ChipLogProgress(DeviceLayer, "Write request received for CHIPoBLE Client TX characteristic (data len %u)", len);

Change overview
Modify the type of log print

Testing
lighting-app example.