### PR TITLE
Enable some complex type tests.

### DIFF
--- a/src/app/tests/suites/TestCluster.yaml
+++ b/src/app/tests/suites/TestCluster.yaml
@@ -912,7 +912,6 @@ tests:
 
     - label:
           "Send Test Command With Nested Struct Argument and arg1.c.b is true"
-      disabled: true
       command: "testNestedStructArgumentRequest"
       arguments:
           values:
@@ -939,7 +938,6 @@ tests:
                 value: true
 
     - label: "Send Test Command With Nested Struct Argument arg1.c.b is false"
-      disabled: true
       command: "testNestedStructArgumentRequest"
       arguments:
           values:
@@ -968,7 +966,6 @@ tests:
     - label:
           "Send Test Command With Nested Struct List Argument and all fields b
           of arg1.d are true"
-      disabled: true
       command: "testNestedStructListArgumentRequest"
       arguments:
           values:
@@ -1023,12 +1020,11 @@ tests:
       response:
           values:
               - name: "value"
-                value: false
+                value: true
 
     - label:
           "Send Test Command With Nested Struct List Argument and some fields b
           of arg1.d are false"
-      disabled: true
       command: "testNestedStructListArgumentRequest"
       arguments:
           values:
@@ -1236,7 +1232,6 @@ tests:
     - label:
           "Send Test Command With List of Nested Struct List Argument and all
           fields b of elements of arg1.d are true"
-      disabled: true
       command: "testListNestedStructListArgumentRequest"
       arguments:
           values:
@@ -1298,7 +1293,6 @@ tests:
     - label:
           "Send Test Command With Nested Struct List Argument and some fields b
           of elements of arg1.d are false"
-      disabled: true
       command: "testListNestedStructListArgumentRequest"
       arguments:
           values:
@@ -2084,7 +2078,6 @@ tests:
     - label: "Read attribute NULLABLE_CHAR_STRING"
       command: "readAttribute"
       attribute: "nullable_char_string"
-      disabled: true
       response:
           value: "☉T☉"
 

--- a/src/app/zap-templates/templates/app/CHIPClusters-src.zapt
+++ b/src/app/zap-templates/templates/app/CHIPClusters-src.zapt
@@ -22,7 +22,7 @@ namespace Controller {
 
 // {{asUpperCamelCase name}} Cluster Commands
 {{#chip_cluster_commands}}
-CHIP_ERROR {{asUpperCamelCase clusterName}}Cluster::{{asUpperCamelCase name}}(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback{{#chip_cluster_command_arguments_with_structs_expanded}}, {{chipType}} {{asLowerCamelCase label}}{{/chip_cluster_command_arguments_with_structs_expanded}})
+CHIP_ERROR {{asUpperCamelCase clusterName}}Cluster::{{asUpperCamelCase name}}(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback{{#chip_cluster_command_arguments_with_structs_expanded}}{{#if_is_struct type}}{{else}}, {{chipType}} {{asLowerCamelCase label}}{{/if_is_struct}}{{/chip_cluster_command_arguments_with_structs_expanded}})
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVWriter * writer     = nullptr;
@@ -44,6 +44,8 @@ CHIP_ERROR {{asUpperCamelCase clusterName}}Cluster::{{asUpperCamelCase name}}(Ca
     SuccessOrExit(err = sender->PrepareCommand(cmdParams));
 
 {{#chip_cluster_command_arguments_with_structs_expanded}}
+{{#if_is_struct type}}
+{{else}}
 {{#first}}
     VerifyOrExit((writer = sender->GetCommandDataIBTLVWriter()) != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
 {{/first}}
@@ -53,6 +55,7 @@ CHIP_ERROR {{asUpperCamelCase clusterName}}Cluster::{{asUpperCamelCase name}}(Ca
 {{else}}
     SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), {{asLowerCamelCase label}}));
 {{/if}}
+{{/if_is_struct}}
 {{else}}
     // Command takes no arguments.
 {{/chip_cluster_command_arguments_with_structs_expanded}}

--- a/src/app/zap-templates/templates/app/CHIPClusters.zapt
+++ b/src/app/zap-templates/templates/app/CHIPClusters.zapt
@@ -25,7 +25,7 @@ public:
 
     // Cluster Commands
     {{/first}}
-    CHIP_ERROR {{asUpperCamelCase name}}(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback{{#chip_cluster_command_arguments_with_structs_expanded}}, {{chipType}} {{asLowerCamelCase label}}{{/chip_cluster_command_arguments_with_structs_expanded}});
+    CHIP_ERROR {{asUpperCamelCase name}}(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback{{#chip_cluster_command_arguments_with_structs_expanded}}{{#if_is_struct type}}{{else}}, {{chipType}} {{asLowerCamelCase label}}{{/if_is_struct}}{{/chip_cluster_command_arguments_with_structs_expanded}});
     {{/chip_cluster_commands}}
 
     // Cluster Attributes

--- a/src/app/zap-templates/zcl/data-model/chip/test-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/test-cluster.xml
@@ -272,7 +272,7 @@ limitations under the License.
       <arg name="arg1" type="NestedStructList"/>
     </command>
 
-    <command source="client" code="0x0C" name="TestListNestedStructListArgumentRequest" optional="false">
+    <command source="client" code="0x0C" name="TestListNestedStructListArgumentRequest" response="BooleanResponse" optional="false">
       <description>
         Command that takes an argument which is a list of Nested Struct List.
         The response returns false if there is some struct in arg1 (either

--- a/src/controller/data_model/controller-clusters.zap
+++ b/src/controller/data_model/controller-clusters.zap
@@ -11520,7 +11520,7 @@
               "mfgCode": null,
               "source": "client",
               "incoming": 0,
-              "outgoing": 0
+              "outgoing": 1
             },
             {
               "name": "TestListStructArgumentRequest",
@@ -11544,7 +11544,7 @@
               "mfgCode": null,
               "source": "client",
               "incoming": 0,
-              "outgoing": 0
+              "outgoing": 1
             },
             {
               "name": "TestListNestedStructListArgumentRequest",
@@ -11552,7 +11552,7 @@
               "mfgCode": null,
               "source": "client",
               "incoming": 0,
-              "outgoing": 0
+              "outgoing": 1
             },
             {
               "name": "TestListInt8UReverseRequest",

--- a/src/controller/java/templates/ChipClusters-java.zapt
+++ b/src/controller/java/templates/ChipClusters-java.zapt
@@ -79,14 +79,14 @@ public class ChipClusters {
   {{#chip_cluster_commands}}
 
     public void {{asLowerCamelCase name}}({{#if hasSpecificResponse}}{{asUpperCamelCase responseName}}Callback{{else}}DefaultClusterCallback{{/if}} callback
-      {{#chip_cluster_command_arguments_with_structs_expanded}}{{>java_type_for_argument}} {{asLowerCamelCase label}}{{/chip_cluster_command_arguments_with_structs_expanded}}) {
-      {{asLowerCamelCase name}}(chipClusterPtr, callback{{#chip_cluster_command_arguments_with_structs_expanded}}, {{asLowerCamelCase label}}{{/chip_cluster_command_arguments_with_structs_expanded}});
+      {{#chip_cluster_command_arguments_with_structs_expanded}}{{#if_is_struct type}}{{else}}{{>java_type_for_argument}} {{asLowerCamelCase label}}{{/if_is_struct}}{{/chip_cluster_command_arguments_with_structs_expanded}}) {
+      {{asLowerCamelCase name}}(chipClusterPtr, callback{{#chip_cluster_command_arguments_with_structs_expanded}}{{#if_is_struct type}}{{else}}, {{asLowerCamelCase label}}{{/if_is_struct}}{{/chip_cluster_command_arguments_with_structs_expanded}});
     }
 
   {{/chip_cluster_commands}}
   {{#chip_cluster_commands}}
     private native void {{asLowerCamelCase name}}(long chipClusterPtr, {{#if hasSpecificResponse}}{{asUpperCamelCase responseName}}Callback{{else}}DefaultClusterCallback{{/if}} Callback
-      {{#chip_cluster_command_arguments_with_structs_expanded}}{{>java_type_for_argument}} {{asLowerCamelCase label}}{{/chip_cluster_command_arguments_with_structs_expanded}});
+      {{#chip_cluster_command_arguments_with_structs_expanded}}{{#if_is_struct type}}{{else}}{{>java_type_for_argument}} {{asLowerCamelCase label}}{{/if_is_struct}}{{/chip_cluster_command_arguments_with_structs_expanded}});
   {{/chip_cluster_commands}}
   {{#chip_cluster_responses}}
     public interface {{asUpperCamelCase name}}Callback {

--- a/src/controller/java/templates/ClusterInfo-java.zapt
+++ b/src/controller/java/templates/ClusterInfo-java.zapt
@@ -271,9 +271,12 @@ public class ClusterInfoMapping {
      {{! TODO: fill out parameter types }}
      {{#if (zcl_command_arguments_count this.id)}}
      {{#chip_cluster_command_arguments_with_structs_expanded}}
+     {{#if_is_struct type}}
+     {{else}}
        CommandParameterInfo {{asLowerCamelCase ../../name}}{{asLowerCamelCase ../name}}{{asLowerCamelCase label}}CommandParameterInfo = new CommandParameterInfo("{{asLowerCamelCase label}}", {{asJavaBasicType type}}.class);
        {{asLowerCamelCase ../../name}}{{asLowerCamelCase ../name}}CommandParams.put("{{asLowerCamelCase label}}",{{asLowerCamelCase ../../name}}{{asLowerCamelCase ../name}}{{asLowerCamelCase label}}CommandParameterInfo);
      {{#not_last}} {{/not_last}}
+     {{/if_is_struct}}
      {{/chip_cluster_command_arguments_with_structs_expanded}}
      {{else}}
      {{/if}}
@@ -283,9 +286,10 @@ public class ClusterInfoMapping {
          (cluster, callback, commandArguments) -> {
            ((ChipClusters.{{asUpperCamelCase ../name}}Cluster) cluster)
            .{{asLowerCamelCase name}}((ChipClusters.{{asUpperCamelCase ../name}}Cluster.{{asUpperCamelCase responseName}}Callback) callback
-           {{#chip_cluster_command_arguments_with_structs_expanded}},
+           {{#chip_cluster_command_arguments_with_structs_expanded}}{{#if_is_struct type}}{{else}},
            ({{#if isOptional}}Optional<{{/if}}{{asJavaBoxedType type}}{{#if isOptional}}>{{/if}})
            commandArguments.get("{{asLowerCamelCase label}}")
+           {{/if_is_struct}}
            {{/chip_cluster_command_arguments_with_structs_expanded}}
            );
          },

--- a/src/controller/java/templates/partials/java_type_for_argument.zapt
+++ b/src/controller/java/templates/partials/java_type_for_argument.zapt
@@ -1,1 +1,1 @@
-, {{#if isOptional}}Optional<{{else if isNullable}}@Nullable {{/if}}{{asJavaBoxedType type}}{{#if isOptional}}>{{/if}}
+{{#if_is_struct type}}{{else}}, {{#if isOptional}}Optional<{{else if isNullable}}@Nullable {{/if}}{{asJavaBoxedType type}}{{#if isOptional}}>{{/if}}{{/if_is_struct}}

--- a/src/controller/java/zap-generated/CHIPClusters-JNI.cpp
+++ b/src/controller/java/zap-generated/CHIPClusters-JNI.cpp
@@ -24458,6 +24458,47 @@ JNI_METHOD(void, TestClusterCluster, testListInt8UReverseRequest)
     onSuccess.release();
     onFailure.release();
 }
+JNI_METHOD(void, TestClusterCluster, testListNestedStructListArgumentRequest)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject a, jobject b, jobject c, jobject d, jobject e,
+ jbyteArray f, jobject g)
+{
+    chip::DeviceLayer::StackLock lock;
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    TestClusterCluster * cppCluster;
+
+    chip::app::Clusters::TestCluster::Commands::TestListNestedStructListArgumentRequest::Type request;
+
+    request.arg1 = chip::app::DataModel::List<const chip::app::Clusters::TestCluster::Structs::NestedStructList::Type>();
+
+    std::unique_ptr<CHIPTestClusterClusterBooleanResponseCallback, void (*)(CHIPTestClusterClusterBooleanResponseCallback *)>
+        onSuccess(Platform::New<CHIPTestClusterClusterBooleanResponseCallback>(callback),
+                  Platform::Delete<CHIPTestClusterClusterBooleanResponseCallback>);
+    std::unique_ptr<CHIPDefaultFailureCallback, void (*)(CHIPDefaultFailureCallback *)> onFailure(
+        Platform::New<CHIPDefaultFailureCallback>(callback), Platform::Delete<CHIPDefaultFailureCallback>);
+    VerifyOrReturn(onSuccess.get() != nullptr,
+                   AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(
+                       env, callback, "Error creating native callback", CHIP_ERROR_NO_MEMORY));
+    VerifyOrReturn(onFailure.get() != nullptr,
+                   AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(
+                       env, callback, "Error creating native callback", CHIP_ERROR_NO_MEMORY));
+
+    cppCluster = reinterpret_cast<TestClusterCluster *>(clusterPtr);
+    VerifyOrReturn(cppCluster != nullptr,
+                   AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(
+                       env, callback, "Error getting native cluster", CHIP_ERROR_INCORRECT_STATE));
+
+    auto successFn =
+        chip::Callback::Callback<CHIPTestClusterClusterBooleanResponseCallbackType>::FromCancelable(onSuccess->Cancel());
+    auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
+
+    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    VerifyOrReturn(err == CHIP_NO_ERROR,
+                   AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
+                                                                                       CHIP_ERROR_INCORRECT_STATE));
+
+    onSuccess.release();
+    onFailure.release();
+}
 JNI_METHOD(void, TestClusterCluster, testListStructArgumentRequest)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject a, jobject b, jobject c, jbyteArray d, jstring e,
  jobject f, jobject g, jobject h)
@@ -24469,6 +24510,87 @@ JNI_METHOD(void, TestClusterCluster, testListStructArgumentRequest)
     chip::app::Clusters::TestCluster::Commands::TestListStructArgumentRequest::Type request;
 
     request.arg1 = chip::app::DataModel::List<const chip::app::Clusters::TestCluster::Structs::SimpleStruct::Type>();
+
+    std::unique_ptr<CHIPTestClusterClusterBooleanResponseCallback, void (*)(CHIPTestClusterClusterBooleanResponseCallback *)>
+        onSuccess(Platform::New<CHIPTestClusterClusterBooleanResponseCallback>(callback),
+                  Platform::Delete<CHIPTestClusterClusterBooleanResponseCallback>);
+    std::unique_ptr<CHIPDefaultFailureCallback, void (*)(CHIPDefaultFailureCallback *)> onFailure(
+        Platform::New<CHIPDefaultFailureCallback>(callback), Platform::Delete<CHIPDefaultFailureCallback>);
+    VerifyOrReturn(onSuccess.get() != nullptr,
+                   AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(
+                       env, callback, "Error creating native callback", CHIP_ERROR_NO_MEMORY));
+    VerifyOrReturn(onFailure.get() != nullptr,
+                   AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(
+                       env, callback, "Error creating native callback", CHIP_ERROR_NO_MEMORY));
+
+    cppCluster = reinterpret_cast<TestClusterCluster *>(clusterPtr);
+    VerifyOrReturn(cppCluster != nullptr,
+                   AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(
+                       env, callback, "Error getting native cluster", CHIP_ERROR_INCORRECT_STATE));
+
+    auto successFn =
+        chip::Callback::Callback<CHIPTestClusterClusterBooleanResponseCallbackType>::FromCancelable(onSuccess->Cancel());
+    auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
+
+    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    VerifyOrReturn(err == CHIP_NO_ERROR,
+                   AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
+                                                                                       CHIP_ERROR_INCORRECT_STATE));
+
+    onSuccess.release();
+    onFailure.release();
+}
+JNI_METHOD(void, TestClusterCluster, testNestedStructArgumentRequest)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject a, jobject b, jobject c)
+{
+    chip::DeviceLayer::StackLock lock;
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    TestClusterCluster * cppCluster;
+
+    chip::app::Clusters::TestCluster::Commands::TestNestedStructArgumentRequest::Type request;
+
+    request.arg1 = chip::app::Clusters::TestCluster::Structs::NestedStruct::Type();
+
+    std::unique_ptr<CHIPTestClusterClusterBooleanResponseCallback, void (*)(CHIPTestClusterClusterBooleanResponseCallback *)>
+        onSuccess(Platform::New<CHIPTestClusterClusterBooleanResponseCallback>(callback),
+                  Platform::Delete<CHIPTestClusterClusterBooleanResponseCallback>);
+    std::unique_ptr<CHIPDefaultFailureCallback, void (*)(CHIPDefaultFailureCallback *)> onFailure(
+        Platform::New<CHIPDefaultFailureCallback>(callback), Platform::Delete<CHIPDefaultFailureCallback>);
+    VerifyOrReturn(onSuccess.get() != nullptr,
+                   AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(
+                       env, callback, "Error creating native callback", CHIP_ERROR_NO_MEMORY));
+    VerifyOrReturn(onFailure.get() != nullptr,
+                   AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(
+                       env, callback, "Error creating native callback", CHIP_ERROR_NO_MEMORY));
+
+    cppCluster = reinterpret_cast<TestClusterCluster *>(clusterPtr);
+    VerifyOrReturn(cppCluster != nullptr,
+                   AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(
+                       env, callback, "Error getting native cluster", CHIP_ERROR_INCORRECT_STATE));
+
+    auto successFn =
+        chip::Callback::Callback<CHIPTestClusterClusterBooleanResponseCallbackType>::FromCancelable(onSuccess->Cancel());
+    auto failureFn = chip::Callback::Callback<CHIPDefaultFailureCallbackType>::FromCancelable(onFailure->Cancel());
+
+    err = cppCluster->InvokeCommand(request, onSuccess->mContext, successFn->mCall, failureFn->mCall);
+    VerifyOrReturn(err == CHIP_NO_ERROR,
+                   AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback, "Error invoking command",
+                                                                                       CHIP_ERROR_INCORRECT_STATE));
+
+    onSuccess.release();
+    onFailure.release();
+}
+JNI_METHOD(void, TestClusterCluster, testNestedStructListArgumentRequest)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jobject a, jobject b, jobject c, jobject d, jobject e,
+ jbyteArray f, jobject g)
+{
+    chip::DeviceLayer::StackLock lock;
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    TestClusterCluster * cppCluster;
+
+    chip::app::Clusters::TestCluster::Commands::TestNestedStructListArgumentRequest::Type request;
+
+    request.arg1 = chip::app::Clusters::TestCluster::Structs::NestedStructList::Type();
 
     std::unique_ptr<CHIPTestClusterClusterBooleanResponseCallback, void (*)(CHIPTestClusterClusterBooleanResponseCallback *)>
         onSuccess(Platform::New<CHIPTestClusterClusterBooleanResponseCallback>(callback),

--- a/src/controller/java/zap-generated/chip/devicecontroller/ChipClusters.java
+++ b/src/controller/java/zap-generated/chip/devicecontroller/ChipClusters.java
@@ -10727,6 +10727,11 @@ public class ChipClusters {
       testListInt8UReverseRequest(chipClusterPtr, callback, arg1);
     }
 
+    public void testListNestedStructListArgumentRequest(
+        BooleanResponseCallback callback, Integer a, Boolean b, Long e, byte[] f, Integer g) {
+      testListNestedStructListArgumentRequest(chipClusterPtr, callback, a, b, e, f, g);
+    }
+
     public void testListStructArgumentRequest(
         BooleanResponseCallback callback,
         Integer a,
@@ -10738,6 +10743,16 @@ public class ChipClusters {
         Float g,
         Double h) {
       testListStructArgumentRequest(chipClusterPtr, callback, a, b, c, d, e, f, g, h);
+    }
+
+    public void testNestedStructArgumentRequest(
+        BooleanResponseCallback callback, Integer a, Boolean b) {
+      testNestedStructArgumentRequest(chipClusterPtr, callback, a, b);
+    }
+
+    public void testNestedStructListArgumentRequest(
+        BooleanResponseCallback callback, Integer a, Boolean b, Long e, byte[] f, Integer g) {
+      testNestedStructListArgumentRequest(chipClusterPtr, callback, a, b, e, f, g);
     }
 
     public void testNotHandled(DefaultClusterCallback callback) {
@@ -10796,6 +10811,15 @@ public class ChipClusters {
     private native void testListInt8UReverseRequest(
         long chipClusterPtr, TestListInt8UReverseResponseCallback Callback, Integer arg1);
 
+    private native void testListNestedStructListArgumentRequest(
+        long chipClusterPtr,
+        BooleanResponseCallback Callback,
+        Integer a,
+        Boolean b,
+        Long e,
+        byte[] f,
+        Integer g);
+
     private native void testListStructArgumentRequest(
         long chipClusterPtr,
         BooleanResponseCallback Callback,
@@ -10807,6 +10831,18 @@ public class ChipClusters {
         Integer f,
         Float g,
         Double h);
+
+    private native void testNestedStructArgumentRequest(
+        long chipClusterPtr, BooleanResponseCallback Callback, Integer a, Boolean b);
+
+    private native void testNestedStructListArgumentRequest(
+        long chipClusterPtr,
+        BooleanResponseCallback Callback,
+        Integer a,
+        Boolean b,
+        Long e,
+        byte[] f,
+        Integer g);
 
     private native void testNotHandled(long chipClusterPtr, DefaultClusterCallback Callback);
 

--- a/src/controller/java/zap-generated/chip/devicecontroller/ClusterInfoMapping.java
+++ b/src/controller/java/zap-generated/chip/devicecontroller/ClusterInfoMapping.java
@@ -7917,6 +7917,52 @@ public class ClusterInfoMapping {
             testClustertestListInt8UReverseRequestCommandParams);
     testClusterClusterInteractionInfoMap.put(
         "testListInt8UReverseRequest", testClustertestListInt8UReverseRequestInteractionInfo);
+    Map<String, CommandParameterInfo>
+        testClustertestListNestedStructListArgumentRequestCommandParams =
+            new LinkedHashMap<String, CommandParameterInfo>();
+    CommandParameterInfo testClustertestListNestedStructListArgumentRequestaCommandParameterInfo =
+        new CommandParameterInfo("a", int.class);
+    testClustertestListNestedStructListArgumentRequestCommandParams.put(
+        "a", testClustertestListNestedStructListArgumentRequestaCommandParameterInfo);
+
+    CommandParameterInfo testClustertestListNestedStructListArgumentRequestbCommandParameterInfo =
+        new CommandParameterInfo("b", boolean.class);
+    testClustertestListNestedStructListArgumentRequestCommandParams.put(
+        "b", testClustertestListNestedStructListArgumentRequestbCommandParameterInfo);
+
+    CommandParameterInfo testClustertestListNestedStructListArgumentRequesteCommandParameterInfo =
+        new CommandParameterInfo("e", long.class);
+    testClustertestListNestedStructListArgumentRequestCommandParams.put(
+        "e", testClustertestListNestedStructListArgumentRequesteCommandParameterInfo);
+
+    CommandParameterInfo testClustertestListNestedStructListArgumentRequestfCommandParameterInfo =
+        new CommandParameterInfo("f", byte[].class);
+    testClustertestListNestedStructListArgumentRequestCommandParams.put(
+        "f", testClustertestListNestedStructListArgumentRequestfCommandParameterInfo);
+
+    CommandParameterInfo testClustertestListNestedStructListArgumentRequestgCommandParameterInfo =
+        new CommandParameterInfo("g", int.class);
+    testClustertestListNestedStructListArgumentRequestCommandParams.put(
+        "g", testClustertestListNestedStructListArgumentRequestgCommandParameterInfo);
+
+    // Populate commands
+    InteractionInfo testClustertestListNestedStructListArgumentRequestInteractionInfo =
+        new InteractionInfo(
+            (cluster, callback, commandArguments) -> {
+              ((ChipClusters.TestClusterCluster) cluster)
+                  .testListNestedStructListArgumentRequest(
+                      (ChipClusters.TestClusterCluster.BooleanResponseCallback) callback,
+                      (Integer) commandArguments.get("a"),
+                      (Boolean) commandArguments.get("b"),
+                      (Long) commandArguments.get("e"),
+                      (byte[]) commandArguments.get("f"),
+                      (Integer) commandArguments.get("g"));
+            },
+            () -> new DelegatedBooleanResponseCallback(),
+            testClustertestListNestedStructListArgumentRequestCommandParams);
+    testClusterClusterInteractionInfoMap.put(
+        "testListNestedStructListArgumentRequest",
+        testClustertestListNestedStructListArgumentRequestInteractionInfo);
     Map<String, CommandParameterInfo> testClustertestListStructArgumentRequestCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo testClustertestListStructArgumentRequestaCommandParameterInfo =
@@ -7979,6 +8025,78 @@ public class ClusterInfoMapping {
             testClustertestListStructArgumentRequestCommandParams);
     testClusterClusterInteractionInfoMap.put(
         "testListStructArgumentRequest", testClustertestListStructArgumentRequestInteractionInfo);
+    Map<String, CommandParameterInfo> testClustertestNestedStructArgumentRequestCommandParams =
+        new LinkedHashMap<String, CommandParameterInfo>();
+    CommandParameterInfo testClustertestNestedStructArgumentRequestaCommandParameterInfo =
+        new CommandParameterInfo("a", int.class);
+    testClustertestNestedStructArgumentRequestCommandParams.put(
+        "a", testClustertestNestedStructArgumentRequestaCommandParameterInfo);
+
+    CommandParameterInfo testClustertestNestedStructArgumentRequestbCommandParameterInfo =
+        new CommandParameterInfo("b", boolean.class);
+    testClustertestNestedStructArgumentRequestCommandParams.put(
+        "b", testClustertestNestedStructArgumentRequestbCommandParameterInfo);
+
+    // Populate commands
+    InteractionInfo testClustertestNestedStructArgumentRequestInteractionInfo =
+        new InteractionInfo(
+            (cluster, callback, commandArguments) -> {
+              ((ChipClusters.TestClusterCluster) cluster)
+                  .testNestedStructArgumentRequest(
+                      (ChipClusters.TestClusterCluster.BooleanResponseCallback) callback,
+                      (Integer) commandArguments.get("a"),
+                      (Boolean) commandArguments.get("b"));
+            },
+            () -> new DelegatedBooleanResponseCallback(),
+            testClustertestNestedStructArgumentRequestCommandParams);
+    testClusterClusterInteractionInfoMap.put(
+        "testNestedStructArgumentRequest",
+        testClustertestNestedStructArgumentRequestInteractionInfo);
+    Map<String, CommandParameterInfo> testClustertestNestedStructListArgumentRequestCommandParams =
+        new LinkedHashMap<String, CommandParameterInfo>();
+    CommandParameterInfo testClustertestNestedStructListArgumentRequestaCommandParameterInfo =
+        new CommandParameterInfo("a", int.class);
+    testClustertestNestedStructListArgumentRequestCommandParams.put(
+        "a", testClustertestNestedStructListArgumentRequestaCommandParameterInfo);
+
+    CommandParameterInfo testClustertestNestedStructListArgumentRequestbCommandParameterInfo =
+        new CommandParameterInfo("b", boolean.class);
+    testClustertestNestedStructListArgumentRequestCommandParams.put(
+        "b", testClustertestNestedStructListArgumentRequestbCommandParameterInfo);
+
+    CommandParameterInfo testClustertestNestedStructListArgumentRequesteCommandParameterInfo =
+        new CommandParameterInfo("e", long.class);
+    testClustertestNestedStructListArgumentRequestCommandParams.put(
+        "e", testClustertestNestedStructListArgumentRequesteCommandParameterInfo);
+
+    CommandParameterInfo testClustertestNestedStructListArgumentRequestfCommandParameterInfo =
+        new CommandParameterInfo("f", byte[].class);
+    testClustertestNestedStructListArgumentRequestCommandParams.put(
+        "f", testClustertestNestedStructListArgumentRequestfCommandParameterInfo);
+
+    CommandParameterInfo testClustertestNestedStructListArgumentRequestgCommandParameterInfo =
+        new CommandParameterInfo("g", int.class);
+    testClustertestNestedStructListArgumentRequestCommandParams.put(
+        "g", testClustertestNestedStructListArgumentRequestgCommandParameterInfo);
+
+    // Populate commands
+    InteractionInfo testClustertestNestedStructListArgumentRequestInteractionInfo =
+        new InteractionInfo(
+            (cluster, callback, commandArguments) -> {
+              ((ChipClusters.TestClusterCluster) cluster)
+                  .testNestedStructListArgumentRequest(
+                      (ChipClusters.TestClusterCluster.BooleanResponseCallback) callback,
+                      (Integer) commandArguments.get("a"),
+                      (Boolean) commandArguments.get("b"),
+                      (Long) commandArguments.get("e"),
+                      (byte[]) commandArguments.get("f"),
+                      (Integer) commandArguments.get("g"));
+            },
+            () -> new DelegatedBooleanResponseCallback(),
+            testClustertestNestedStructListArgumentRequestCommandParams);
+    testClusterClusterInteractionInfoMap.put(
+        "testNestedStructListArgumentRequest",
+        testClustertestNestedStructListArgumentRequestInteractionInfo);
     Map<String, CommandParameterInfo> testClustertestNotHandledCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     // Populate commands

--- a/src/controller/python/chip/clusters/CHIPClusters.py
+++ b/src/controller/python/chip/clusters/CHIPClusters.py
@@ -3687,6 +3687,19 @@ class ChipClusters:
                     "arg1": "int",
                 },
             },
+            0x0000000C: {
+                "commandId": 0x0000000C,
+                "commandName": "TestListNestedStructListArgumentRequest",
+                "args": {
+                    "a": "int",
+                    "b": "bool",
+                    "c": "",
+                    "d": "",
+                    "e": "int",
+                    "f": "bytes",
+                    "g": "int",
+                },
+            },
             0x00000009: {
                 "commandId": 0x00000009,
                 "commandName": "TestListStructArgumentRequest",
@@ -3699,6 +3712,28 @@ class ChipClusters:
                     "f": "int",
                     "g": "",
                     "h": "",
+                },
+            },
+            0x00000008: {
+                "commandId": 0x00000008,
+                "commandName": "TestNestedStructArgumentRequest",
+                "args": {
+                    "a": "int",
+                    "b": "bool",
+                    "c": "",
+                },
+            },
+            0x0000000B: {
+                "commandId": 0x0000000B,
+                "commandName": "TestNestedStructListArgumentRequest",
+                "args": {
+                    "a": "int",
+                    "b": "bool",
+                    "c": "",
+                    "d": "",
+                    "e": "int",
+                    "f": "bytes",
+                    "g": "int",
                 },
             },
             0x00000001: {

--- a/src/darwin/Framework/CHIP/templates/partials/encode_value.zapt
+++ b/src/darwin/Framework/CHIP/templates/partials/encode_value.zapt
@@ -18,25 +18,25 @@
       we are right now it may not (e.g. for a nullable list we're
       inside an "else" block here).  }}
   {
-    using ListType = std::remove_reference_t<decltype({{target}})>;
-    using ListMemberType = ListMemberTypeGetter<ListType>::Type;
+    using ListType_{{depth}} = std::remove_reference_t<decltype({{target}})>;
+    using ListMemberType_{{depth}} = ListMemberTypeGetter<ListType_{{depth}}>::Type;
     if ({{source}}.count != 0) {
-      auto * listHolder_{{depth}} = new ListHolder<ListMemberType>({{source}}.count);
+      auto * listHolder_{{depth}} = new ListHolder<ListMemberType_{{depth}}>({{source}}.count);
       if (listHolder_{{depth}} == nullptr || listHolder_{{depth}}->mList == nullptr) {
         {{errorCode}}
       }
       listFreer.add(listHolder_{{depth}});
-      for (size_t i = 0; i < {{source}}.count; ++i) {
-        if (![{{source}}[i] isKindOfClass:[{{asObjectiveCClass type cluster forceNotList=true}} class]]) {
+      for (size_t i_{{depth}} = 0; i_{{depth}} < {{source}}.count; ++i_{{depth}}) {
+        if (![{{source}}[i_{{depth}}] isKindOfClass:[{{asObjectiveCClass type cluster forceNotList=true}} class]]) {
           // Wrong kind of value.
           {{errorCode}}
         }
-        auto element_{{depth}} = ({{asObjectiveCClass type cluster forceNotList=true}} *){{source}}[i];
-        {{>encode_value target=(concat "listHolder_" depth "->mList[i]") source=(concat "element_" depth) cluster=cluster errorCode=errorCode depth=(incrementDepth depth) isArray=false}}
+        auto element_{{depth}} = ({{asObjectiveCClass type cluster forceNotList=true}} *){{source}}[i_{{depth}}];
+        {{>encode_value target=(concat "listHolder_" depth "->mList[i_" depth "]") source=(concat "element_" depth) cluster=cluster errorCode=errorCode depth=(incrementDepth depth) isArray=false}}
       }
-      {{target}} = ListType(listHolder_{{depth}}->mList, {{source}}.count);
+      {{target}} = ListType_{{depth}}(listHolder_{{depth}}->mList, {{source}}.count);
     } else {
-      {{target}} = ListType();
+      {{target}} = ListType_{{depth}}();
     }
   }
 {{else if (isOctetString type)}}

--- a/src/darwin/Framework/CHIP/templates/partials/test_cluster.zapt
+++ b/src/darwin/Framework/CHIP/templates/partials/test_cluster.zapt
@@ -28,7 +28,7 @@ bool testSendCluster{{parent.filename}}_{{asTestIndex index}}_{{asUpperCamelCase
         __auto_type * params = [[CHIP{{asUpperCamelCase cluster}}Cluster{{asUpperCamelCase command}}Params alloc] init];
       {{/if}}
       {{#chip_tests_item_parameters}}
-        {{>test_value target=(concat "params." (asStructPropertyName label)) definedValue=definedValue cluster=parent.cluster}}
+        {{>test_value target=(concat "params." (asStructPropertyName label)) definedValue=definedValue cluster=parent.cluster depth=0}}
       {{/chip_tests_item_parameters}}
       [cluster {{asLowerCamelCase command}}With
       {{~#if commandObject.arguments.length~}}
@@ -63,7 +63,7 @@ bool testSendCluster{{parent.filename}}_{{asTestIndex index}}_{{asUpperCamelCase
     {{else if isWriteAttribute}}
     {{#chip_tests_item_parameters}}
     id {{asLowerCamelCase name}}Argument;
-    {{>test_value target=(concat (asLowerCamelCase name) "Argument") definedValue=definedValue cluster=parent.cluster}}
+    {{>test_value target=(concat (asLowerCamelCase name) "Argument") definedValue=definedValue cluster=parent.cluster depth=0}}
     {{/chip_tests_item_parameters}}
     [cluster writeAttribute{{asUpperCamelCase attribute}}WithValue:{{#chip_tests_item_parameters}}{{asLowerCamelCase name}}Argument{{/chip_tests_item_parameters}} completionHandler:^(NSError * _Nullable err) {
     {{/if}}

--- a/src/darwin/Framework/CHIP/templates/partials/test_value.zapt
+++ b/src/darwin/Framework/CHIP/templates/partials/test_value.zapt
@@ -1,19 +1,19 @@
 {{#if isOptional}}
   {{! Just go ahead and assign to the value, stripping the optionality bit off.  }}
-  {{>test_value target=target definedValue=definedValue cluster=cluster isOptional=false}}
+  {{>test_value target=target definedValue=definedValue cluster=cluster isOptional=false depth=(incrementDepth depth)}}
 {{else if isNullable}}
   {{#if (isLiteralNull definedValue)}}
     {{target}} = nil;
   {{else}}
-    {{>test_value target=target definedValue=definedValue cluster=cluster isNullable=false}}
+    {{>test_value target=target definedValue=definedValue cluster=cluster isNullable=false depth=(incrementDepth depth)}}
   {{/if}}
 {{else if isArray}}
   {
-    NSMutableArray * temp = [[NSMutableArray alloc] init];
+    NSMutableArray * temp_{{depth}} = [[NSMutableArray alloc] init];
     {{#each definedValue}}
-      {{>test_value target=(concat "temp[" @index "]") definedValue=this cluster=../cluster type=../type isArray=false}}
+      {{>test_value target=(concat "temp_" ../depth "[" @index "]") definedValue=this cluster=../cluster depth=(incrementDepth ../depth) type=../type isArray=false}}
     {{/each}}
-    {{target}} = temp;
+    {{target}} = temp_{{depth}};
   }
 {{else}}
   {{#if_is_struct type}}
@@ -21,7 +21,7 @@
     {{#zcl_struct_items_by_struct_name type}}
       {{! target may be some place where we lost type information (e.g. an id),
           so add explicit cast when trying to assign to our properties. }}
-      {{>test_value target=(concat "((CHIP" (asUpperCamelCase ../cluster) "Cluster" (asUpperCamelCase ../type) " *)" ../target ")." (asStructPropertyName label)) definedValue=(lookup ../definedValue name) cluster=../cluster}}
+      {{>test_value target=(concat "((CHIP" (asUpperCamelCase ../cluster) "Cluster" (asUpperCamelCase ../type) " *)" ../target ")." (asStructPropertyName label)) definedValue=(lookup ../definedValue name) cluster=../cluster depth=(incrementDepth ../depth)}}
     {{/zcl_struct_items_by_struct_name}}
 
   {{else if (isCharString type)}}

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPClustersObjc.h
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPClustersObjc.h
@@ -3271,9 +3271,19 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)testListInt8UReverseRequestWithParams:(CHIPTestClusterClusterTestListInt8UReverseRequestParams *)params
                             completionHandler:(void (^)(CHIPTestClusterClusterTestListInt8UReverseResponseParams * _Nullable data,
                                                   NSError * _Nullable error))completionHandler;
+- (void)testListNestedStructListArgumentRequestWithParams:
+            (CHIPTestClusterClusterTestListNestedStructListArgumentRequestParams *)params
+                                        completionHandler:(void (^)(CHIPTestClusterClusterBooleanResponseParams * _Nullable data,
+                                                              NSError * _Nullable error))completionHandler;
 - (void)testListStructArgumentRequestWithParams:(CHIPTestClusterClusterTestListStructArgumentRequestParams *)params
                               completionHandler:(void (^)(CHIPTestClusterClusterBooleanResponseParams * _Nullable data,
                                                     NSError * _Nullable error))completionHandler;
+- (void)testNestedStructArgumentRequestWithParams:(CHIPTestClusterClusterTestNestedStructArgumentRequestParams *)params
+                                completionHandler:(void (^)(CHIPTestClusterClusterBooleanResponseParams * _Nullable data,
+                                                      NSError * _Nullable error))completionHandler;
+- (void)testNestedStructListArgumentRequestWithParams:(CHIPTestClusterClusterTestNestedStructListArgumentRequestParams *)params
+                                    completionHandler:(void (^)(CHIPTestClusterClusterBooleanResponseParams * _Nullable data,
+                                                          NSError * _Nullable error))completionHandler;
 - (void)testNotHandledWithCompletionHandler:(StatusCompletion)completionHandler;
 - (void)testNullableOptionalRequestWithParams:(CHIPTestClusterClusterTestNullableOptionalRequestParams * _Nullable)params
                             completionHandler:(void (^)(CHIPTestClusterClusterTestNullableOptionalResponseParams * _Nullable data,

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPClustersObjc.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPClustersObjc.mm
@@ -8725,25 +8725,25 @@ using namespace chip::app::Clusters;
     ListFreer listFreer;
     Groups::Commands::GetGroupMembership::Type request;
     {
-        using ListType = std::remove_reference_t<decltype(request.groupList)>;
-        using ListMemberType = ListMemberTypeGetter<ListType>::Type;
+        using ListType_0 = std::remove_reference_t<decltype(request.groupList)>;
+        using ListMemberType_0 = ListMemberTypeGetter<ListType_0>::Type;
         if (params.groupList.count != 0) {
-            auto * listHolder_0 = new ListHolder<ListMemberType>(params.groupList.count);
+            auto * listHolder_0 = new ListHolder<ListMemberType_0>(params.groupList.count);
             if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
                 return;
             }
             listFreer.add(listHolder_0);
-            for (size_t i = 0; i < params.groupList.count; ++i) {
-                if (![params.groupList[i] isKindOfClass:[NSNumber class]]) {
+            for (size_t i_0 = 0; i_0 < params.groupList.count; ++i_0) {
+                if (![params.groupList[i_0] isKindOfClass:[NSNumber class]]) {
                     // Wrong kind of value.
                     return;
                 }
-                auto element_0 = (NSNumber *) params.groupList[i];
-                listHolder_0->mList[i] = element_0.unsignedShortValue;
+                auto element_0 = (NSNumber *) params.groupList[i_0];
+                listHolder_0->mList[i_0] = element_0.unsignedShortValue;
             }
-            request.groupList = ListType(listHolder_0->mList, params.groupList.count);
+            request.groupList = ListType_0(listHolder_0->mList, params.groupList.count);
         } else {
-            request.groupList = ListType();
+            request.groupList = ListType_0();
         }
     }
 
@@ -11668,26 +11668,26 @@ using namespace chip::app::Clusters;
     request.productId = params.productId.unsignedShortValue;
     request.softwareVersion = params.softwareVersion.unsignedIntValue;
     {
-        using ListType = std::remove_reference_t<decltype(request.protocolsSupported)>;
-        using ListMemberType = ListMemberTypeGetter<ListType>::Type;
+        using ListType_0 = std::remove_reference_t<decltype(request.protocolsSupported)>;
+        using ListMemberType_0 = ListMemberTypeGetter<ListType_0>::Type;
         if (params.protocolsSupported.count != 0) {
-            auto * listHolder_0 = new ListHolder<ListMemberType>(params.protocolsSupported.count);
+            auto * listHolder_0 = new ListHolder<ListMemberType_0>(params.protocolsSupported.count);
             if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
                 return;
             }
             listFreer.add(listHolder_0);
-            for (size_t i = 0; i < params.protocolsSupported.count; ++i) {
-                if (![params.protocolsSupported[i] isKindOfClass:[NSNumber class]]) {
+            for (size_t i_0 = 0; i_0 < params.protocolsSupported.count; ++i_0) {
+                if (![params.protocolsSupported[i_0] isKindOfClass:[NSNumber class]]) {
                     // Wrong kind of value.
                     return;
                 }
-                auto element_0 = (NSNumber *) params.protocolsSupported[i];
-                listHolder_0->mList[i]
-                    = static_cast<std::remove_reference_t<decltype(listHolder_0->mList[i])>>(element_0.unsignedCharValue);
+                auto element_0 = (NSNumber *) params.protocolsSupported[i_0];
+                listHolder_0->mList[i_0]
+                    = static_cast<std::remove_reference_t<decltype(listHolder_0->mList[i_0])>>(element_0.unsignedCharValue);
             }
-            request.protocolsSupported = ListType(listHolder_0->mList, params.protocolsSupported.count);
+            request.protocolsSupported = ListType_0(listHolder_0->mList, params.protocolsSupported.count);
         } else {
-            request.protocolsSupported = ListType();
+            request.protocolsSupported = ListType_0();
         }
     }
     if (params.hardwareVersion != nil) {
@@ -14951,27 +14951,27 @@ using namespace chip::app::Clusters;
     request.transitionTime = params.transitionTime.unsignedShortValue;
     request.sceneName = [self asCharSpan:params.sceneName];
     {
-        using ListType = std::remove_reference_t<decltype(request.extensionFieldSets)>;
-        using ListMemberType = ListMemberTypeGetter<ListType>::Type;
+        using ListType_0 = std::remove_reference_t<decltype(request.extensionFieldSets)>;
+        using ListMemberType_0 = ListMemberTypeGetter<ListType_0>::Type;
         if (params.extensionFieldSets.count != 0) {
-            auto * listHolder_0 = new ListHolder<ListMemberType>(params.extensionFieldSets.count);
+            auto * listHolder_0 = new ListHolder<ListMemberType_0>(params.extensionFieldSets.count);
             if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
                 return;
             }
             listFreer.add(listHolder_0);
-            for (size_t i = 0; i < params.extensionFieldSets.count; ++i) {
-                if (![params.extensionFieldSets[i] isKindOfClass:[CHIPScenesClusterSceneExtensionFieldSet class]]) {
+            for (size_t i_0 = 0; i_0 < params.extensionFieldSets.count; ++i_0) {
+                if (![params.extensionFieldSets[i_0] isKindOfClass:[CHIPScenesClusterSceneExtensionFieldSet class]]) {
                     // Wrong kind of value.
                     return;
                 }
-                auto element_0 = (CHIPScenesClusterSceneExtensionFieldSet *) params.extensionFieldSets[i];
-                listHolder_0->mList[i].clusterId = element_0.clusterId.unsignedIntValue;
-                listHolder_0->mList[i].length = element_0.length.unsignedCharValue;
-                listHolder_0->mList[i].value = element_0.value.unsignedCharValue;
+                auto element_0 = (CHIPScenesClusterSceneExtensionFieldSet *) params.extensionFieldSets[i_0];
+                listHolder_0->mList[i_0].clusterId = element_0.clusterId.unsignedIntValue;
+                listHolder_0->mList[i_0].length = element_0.length.unsignedCharValue;
+                listHolder_0->mList[i_0].value = element_0.value.unsignedCharValue;
             }
-            request.extensionFieldSets = ListType(listHolder_0->mList, params.extensionFieldSets.count);
+            request.extensionFieldSets = ListType_0(listHolder_0->mList, params.extensionFieldSets.count);
         } else {
-            request.extensionFieldSets = ListType();
+            request.extensionFieldSets = ListType_0();
         }
     }
 
@@ -16352,25 +16352,25 @@ using namespace chip::app::Clusters;
     ListFreer listFreer;
     TestCluster::Commands::TestListInt8UArgumentRequest::Type request;
     {
-        using ListType = std::remove_reference_t<decltype(request.arg1)>;
-        using ListMemberType = ListMemberTypeGetter<ListType>::Type;
+        using ListType_0 = std::remove_reference_t<decltype(request.arg1)>;
+        using ListMemberType_0 = ListMemberTypeGetter<ListType_0>::Type;
         if (params.arg1.count != 0) {
-            auto * listHolder_0 = new ListHolder<ListMemberType>(params.arg1.count);
+            auto * listHolder_0 = new ListHolder<ListMemberType_0>(params.arg1.count);
             if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
                 return;
             }
             listFreer.add(listHolder_0);
-            for (size_t i = 0; i < params.arg1.count; ++i) {
-                if (![params.arg1[i] isKindOfClass:[NSNumber class]]) {
+            for (size_t i_0 = 0; i_0 < params.arg1.count; ++i_0) {
+                if (![params.arg1[i_0] isKindOfClass:[NSNumber class]]) {
                     // Wrong kind of value.
                     return;
                 }
-                auto element_0 = (NSNumber *) params.arg1[i];
-                listHolder_0->mList[i] = element_0.unsignedCharValue;
+                auto element_0 = (NSNumber *) params.arg1[i_0];
+                listHolder_0->mList[i_0] = element_0.unsignedCharValue;
             }
-            request.arg1 = ListType(listHolder_0->mList, params.arg1.count);
+            request.arg1 = ListType_0(listHolder_0->mList, params.arg1.count);
         } else {
-            request.arg1 = ListType();
+            request.arg1 = ListType_0();
         }
     }
 
@@ -16393,25 +16393,25 @@ using namespace chip::app::Clusters;
     ListFreer listFreer;
     TestCluster::Commands::TestListInt8UReverseRequest::Type request;
     {
-        using ListType = std::remove_reference_t<decltype(request.arg1)>;
-        using ListMemberType = ListMemberTypeGetter<ListType>::Type;
+        using ListType_0 = std::remove_reference_t<decltype(request.arg1)>;
+        using ListMemberType_0 = ListMemberTypeGetter<ListType_0>::Type;
         if (params.arg1.count != 0) {
-            auto * listHolder_0 = new ListHolder<ListMemberType>(params.arg1.count);
+            auto * listHolder_0 = new ListHolder<ListMemberType_0>(params.arg1.count);
             if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
                 return;
             }
             listFreer.add(listHolder_0);
-            for (size_t i = 0; i < params.arg1.count; ++i) {
-                if (![params.arg1[i] isKindOfClass:[NSNumber class]]) {
+            for (size_t i_0 = 0; i_0 < params.arg1.count; ++i_0) {
+                if (![params.arg1[i_0] isKindOfClass:[NSNumber class]]) {
                     // Wrong kind of value.
                     return;
                 }
-                auto element_0 = (NSNumber *) params.arg1[i];
-                listHolder_0->mList[i] = element_0.unsignedCharValue;
+                auto element_0 = (NSNumber *) params.arg1[i_0];
+                listHolder_0->mList[i_0] = element_0.unsignedCharValue;
             }
-            request.arg1 = ListType(listHolder_0->mList, params.arg1.count);
+            request.arg1 = ListType_0(listHolder_0->mList, params.arg1.count);
         } else {
-            request.arg1 = ListType();
+            request.arg1 = ListType_0();
         }
     }
 
@@ -16427,6 +16427,156 @@ using namespace chip::app::Clusters;
         });
 }
 
+- (void)testListNestedStructListArgumentRequestWithParams:
+            (CHIPTestClusterClusterTestListNestedStructListArgumentRequestParams *)params
+                                        completionHandler:(void (^)(CHIPTestClusterClusterBooleanResponseParams * _Nullable data,
+                                                              NSError * _Nullable error))completionHandler
+{
+    ListFreer listFreer;
+    TestCluster::Commands::TestListNestedStructListArgumentRequest::Type request;
+    {
+        using ListType_0 = std::remove_reference_t<decltype(request.arg1)>;
+        using ListMemberType_0 = ListMemberTypeGetter<ListType_0>::Type;
+        if (params.arg1.count != 0) {
+            auto * listHolder_0 = new ListHolder<ListMemberType_0>(params.arg1.count);
+            if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
+                return;
+            }
+            listFreer.add(listHolder_0);
+            for (size_t i_0 = 0; i_0 < params.arg1.count; ++i_0) {
+                if (![params.arg1[i_0] isKindOfClass:[CHIPTestClusterClusterNestedStructList class]]) {
+                    // Wrong kind of value.
+                    return;
+                }
+                auto element_0 = (CHIPTestClusterClusterNestedStructList *) params.arg1[i_0];
+                listHolder_0->mList[i_0].a = element_0.a.unsignedCharValue;
+                listHolder_0->mList[i_0].b = element_0.b.boolValue;
+                listHolder_0->mList[i_0].c.a = element_0.c.a.unsignedCharValue;
+                listHolder_0->mList[i_0].c.b = element_0.c.b.boolValue;
+                listHolder_0->mList[i_0].c.c
+                    = static_cast<std::remove_reference_t<decltype(listHolder_0->mList[i_0].c.c)>>(element_0.c.c.unsignedCharValue);
+                listHolder_0->mList[i_0].c.d = [self asByteSpan:element_0.c.d];
+                listHolder_0->mList[i_0].c.e = [self asCharSpan:element_0.c.e];
+                listHolder_0->mList[i_0].c.f
+                    = static_cast<std::remove_reference_t<decltype(listHolder_0->mList[i_0].c.f)>>(element_0.c.f.unsignedCharValue);
+                listHolder_0->mList[i_0].c.g = element_0.c.g.floatValue;
+                listHolder_0->mList[i_0].c.h = element_0.c.h.doubleValue;
+                {
+                    using ListType_2 = std::remove_reference_t<decltype(listHolder_0->mList[i_0].d)>;
+                    using ListMemberType_2 = ListMemberTypeGetter<ListType_2>::Type;
+                    if (element_0.d.count != 0) {
+                        auto * listHolder_2 = new ListHolder<ListMemberType_2>(element_0.d.count);
+                        if (listHolder_2 == nullptr || listHolder_2->mList == nullptr) {
+                            return;
+                        }
+                        listFreer.add(listHolder_2);
+                        for (size_t i_2 = 0; i_2 < element_0.d.count; ++i_2) {
+                            if (![element_0.d[i_2] isKindOfClass:[CHIPTestClusterClusterSimpleStruct class]]) {
+                                // Wrong kind of value.
+                                return;
+                            }
+                            auto element_2 = (CHIPTestClusterClusterSimpleStruct *) element_0.d[i_2];
+                            listHolder_2->mList[i_2].a = element_2.a.unsignedCharValue;
+                            listHolder_2->mList[i_2].b = element_2.b.boolValue;
+                            listHolder_2->mList[i_2].c = static_cast<std::remove_reference_t<decltype(listHolder_2->mList[i_2].c)>>(
+                                element_2.c.unsignedCharValue);
+                            listHolder_2->mList[i_2].d = [self asByteSpan:element_2.d];
+                            listHolder_2->mList[i_2].e = [self asCharSpan:element_2.e];
+                            listHolder_2->mList[i_2].f = static_cast<std::remove_reference_t<decltype(listHolder_2->mList[i_2].f)>>(
+                                element_2.f.unsignedCharValue);
+                            listHolder_2->mList[i_2].g = element_2.g.floatValue;
+                            listHolder_2->mList[i_2].h = element_2.h.doubleValue;
+                        }
+                        listHolder_0->mList[i_0].d = ListType_2(listHolder_2->mList, element_0.d.count);
+                    } else {
+                        listHolder_0->mList[i_0].d = ListType_2();
+                    }
+                }
+                {
+                    using ListType_2 = std::remove_reference_t<decltype(listHolder_0->mList[i_0].e)>;
+                    using ListMemberType_2 = ListMemberTypeGetter<ListType_2>::Type;
+                    if (element_0.e.count != 0) {
+                        auto * listHolder_2 = new ListHolder<ListMemberType_2>(element_0.e.count);
+                        if (listHolder_2 == nullptr || listHolder_2->mList == nullptr) {
+                            return;
+                        }
+                        listFreer.add(listHolder_2);
+                        for (size_t i_2 = 0; i_2 < element_0.e.count; ++i_2) {
+                            if (![element_0.e[i_2] isKindOfClass:[NSNumber class]]) {
+                                // Wrong kind of value.
+                                return;
+                            }
+                            auto element_2 = (NSNumber *) element_0.e[i_2];
+                            listHolder_2->mList[i_2] = element_2.unsignedIntValue;
+                        }
+                        listHolder_0->mList[i_0].e = ListType_2(listHolder_2->mList, element_0.e.count);
+                    } else {
+                        listHolder_0->mList[i_0].e = ListType_2();
+                    }
+                }
+                {
+                    using ListType_2 = std::remove_reference_t<decltype(listHolder_0->mList[i_0].f)>;
+                    using ListMemberType_2 = ListMemberTypeGetter<ListType_2>::Type;
+                    if (element_0.f.count != 0) {
+                        auto * listHolder_2 = new ListHolder<ListMemberType_2>(element_0.f.count);
+                        if (listHolder_2 == nullptr || listHolder_2->mList == nullptr) {
+                            return;
+                        }
+                        listFreer.add(listHolder_2);
+                        for (size_t i_2 = 0; i_2 < element_0.f.count; ++i_2) {
+                            if (![element_0.f[i_2] isKindOfClass:[NSData class]]) {
+                                // Wrong kind of value.
+                                return;
+                            }
+                            auto element_2 = (NSData *) element_0.f[i_2];
+                            listHolder_2->mList[i_2] = [self asByteSpan:element_2];
+                        }
+                        listHolder_0->mList[i_0].f = ListType_2(listHolder_2->mList, element_0.f.count);
+                    } else {
+                        listHolder_0->mList[i_0].f = ListType_2();
+                    }
+                }
+                {
+                    using ListType_2 = std::remove_reference_t<decltype(listHolder_0->mList[i_0].g)>;
+                    using ListMemberType_2 = ListMemberTypeGetter<ListType_2>::Type;
+                    if (element_0.g.count != 0) {
+                        auto * listHolder_2 = new ListHolder<ListMemberType_2>(element_0.g.count);
+                        if (listHolder_2 == nullptr || listHolder_2->mList == nullptr) {
+                            return;
+                        }
+                        listFreer.add(listHolder_2);
+                        for (size_t i_2 = 0; i_2 < element_0.g.count; ++i_2) {
+                            if (![element_0.g[i_2] isKindOfClass:[NSNumber class]]) {
+                                // Wrong kind of value.
+                                return;
+                            }
+                            auto element_2 = (NSNumber *) element_0.g[i_2];
+                            listHolder_2->mList[i_2] = element_2.unsignedCharValue;
+                        }
+                        listHolder_0->mList[i_0].g = ListType_2(listHolder_2->mList, element_0.g.count);
+                    } else {
+                        listHolder_0->mList[i_0].g = ListType_2();
+                    }
+                }
+            }
+            request.arg1 = ListType_0(listHolder_0->mList, params.arg1.count);
+        } else {
+            request.arg1 = ListType_0();
+        }
+    }
+
+    new CHIPTestClusterClusterBooleanResponseCallbackBridge(
+        self.callbackQueue,
+        ^(NSError * _Nullable error, id _Nullable value) {
+            completionHandler(value, error);
+        },
+        ^(Cancelable * success, Cancelable * failure) {
+            auto successFn = Callback<CHIPTestClusterClusterBooleanResponseCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
+        });
+}
+
 - (void)testListStructArgumentRequestWithParams:(CHIPTestClusterClusterTestListStructArgumentRequestParams *)params
                               completionHandler:(void (^)(CHIPTestClusterClusterBooleanResponseParams * _Nullable data,
                                                     NSError * _Nullable error))completionHandler
@@ -16434,34 +16584,189 @@ using namespace chip::app::Clusters;
     ListFreer listFreer;
     TestCluster::Commands::TestListStructArgumentRequest::Type request;
     {
-        using ListType = std::remove_reference_t<decltype(request.arg1)>;
-        using ListMemberType = ListMemberTypeGetter<ListType>::Type;
+        using ListType_0 = std::remove_reference_t<decltype(request.arg1)>;
+        using ListMemberType_0 = ListMemberTypeGetter<ListType_0>::Type;
         if (params.arg1.count != 0) {
-            auto * listHolder_0 = new ListHolder<ListMemberType>(params.arg1.count);
+            auto * listHolder_0 = new ListHolder<ListMemberType_0>(params.arg1.count);
             if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
                 return;
             }
             listFreer.add(listHolder_0);
-            for (size_t i = 0; i < params.arg1.count; ++i) {
-                if (![params.arg1[i] isKindOfClass:[CHIPTestClusterClusterSimpleStruct class]]) {
+            for (size_t i_0 = 0; i_0 < params.arg1.count; ++i_0) {
+                if (![params.arg1[i_0] isKindOfClass:[CHIPTestClusterClusterSimpleStruct class]]) {
                     // Wrong kind of value.
                     return;
                 }
-                auto element_0 = (CHIPTestClusterClusterSimpleStruct *) params.arg1[i];
-                listHolder_0->mList[i].a = element_0.a.unsignedCharValue;
-                listHolder_0->mList[i].b = element_0.b.boolValue;
-                listHolder_0->mList[i].c
-                    = static_cast<std::remove_reference_t<decltype(listHolder_0->mList[i].c)>>(element_0.c.unsignedCharValue);
-                listHolder_0->mList[i].d = [self asByteSpan:element_0.d];
-                listHolder_0->mList[i].e = [self asCharSpan:element_0.e];
-                listHolder_0->mList[i].f
-                    = static_cast<std::remove_reference_t<decltype(listHolder_0->mList[i].f)>>(element_0.f.unsignedCharValue);
-                listHolder_0->mList[i].g = element_0.g.floatValue;
-                listHolder_0->mList[i].h = element_0.h.doubleValue;
+                auto element_0 = (CHIPTestClusterClusterSimpleStruct *) params.arg1[i_0];
+                listHolder_0->mList[i_0].a = element_0.a.unsignedCharValue;
+                listHolder_0->mList[i_0].b = element_0.b.boolValue;
+                listHolder_0->mList[i_0].c
+                    = static_cast<std::remove_reference_t<decltype(listHolder_0->mList[i_0].c)>>(element_0.c.unsignedCharValue);
+                listHolder_0->mList[i_0].d = [self asByteSpan:element_0.d];
+                listHolder_0->mList[i_0].e = [self asCharSpan:element_0.e];
+                listHolder_0->mList[i_0].f
+                    = static_cast<std::remove_reference_t<decltype(listHolder_0->mList[i_0].f)>>(element_0.f.unsignedCharValue);
+                listHolder_0->mList[i_0].g = element_0.g.floatValue;
+                listHolder_0->mList[i_0].h = element_0.h.doubleValue;
             }
-            request.arg1 = ListType(listHolder_0->mList, params.arg1.count);
+            request.arg1 = ListType_0(listHolder_0->mList, params.arg1.count);
         } else {
-            request.arg1 = ListType();
+            request.arg1 = ListType_0();
+        }
+    }
+
+    new CHIPTestClusterClusterBooleanResponseCallbackBridge(
+        self.callbackQueue,
+        ^(NSError * _Nullable error, id _Nullable value) {
+            completionHandler(value, error);
+        },
+        ^(Cancelable * success, Cancelable * failure) {
+            auto successFn = Callback<CHIPTestClusterClusterBooleanResponseCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
+        });
+}
+
+- (void)testNestedStructArgumentRequestWithParams:(CHIPTestClusterClusterTestNestedStructArgumentRequestParams *)params
+                                completionHandler:(void (^)(CHIPTestClusterClusterBooleanResponseParams * _Nullable data,
+                                                      NSError * _Nullable error))completionHandler
+{
+    ListFreer listFreer;
+    TestCluster::Commands::TestNestedStructArgumentRequest::Type request;
+    request.arg1.a = params.arg1.a.unsignedCharValue;
+    request.arg1.b = params.arg1.b.boolValue;
+    request.arg1.c.a = params.arg1.c.a.unsignedCharValue;
+    request.arg1.c.b = params.arg1.c.b.boolValue;
+    request.arg1.c.c = static_cast<std::remove_reference_t<decltype(request.arg1.c.c)>>(params.arg1.c.c.unsignedCharValue);
+    request.arg1.c.d = [self asByteSpan:params.arg1.c.d];
+    request.arg1.c.e = [self asCharSpan:params.arg1.c.e];
+    request.arg1.c.f = static_cast<std::remove_reference_t<decltype(request.arg1.c.f)>>(params.arg1.c.f.unsignedCharValue);
+    request.arg1.c.g = params.arg1.c.g.floatValue;
+    request.arg1.c.h = params.arg1.c.h.doubleValue;
+
+    new CHIPTestClusterClusterBooleanResponseCallbackBridge(
+        self.callbackQueue,
+        ^(NSError * _Nullable error, id _Nullable value) {
+            completionHandler(value, error);
+        },
+        ^(Cancelable * success, Cancelable * failure) {
+            auto successFn = Callback<CHIPTestClusterClusterBooleanResponseCallbackType>::FromCancelable(success);
+            auto failureFn = Callback<CHIPDefaultFailureCallbackType>::FromCancelable(failure);
+            return self.cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall);
+        });
+}
+
+- (void)testNestedStructListArgumentRequestWithParams:(CHIPTestClusterClusterTestNestedStructListArgumentRequestParams *)params
+                                    completionHandler:(void (^)(CHIPTestClusterClusterBooleanResponseParams * _Nullable data,
+                                                          NSError * _Nullable error))completionHandler
+{
+    ListFreer listFreer;
+    TestCluster::Commands::TestNestedStructListArgumentRequest::Type request;
+    request.arg1.a = params.arg1.a.unsignedCharValue;
+    request.arg1.b = params.arg1.b.boolValue;
+    request.arg1.c.a = params.arg1.c.a.unsignedCharValue;
+    request.arg1.c.b = params.arg1.c.b.boolValue;
+    request.arg1.c.c = static_cast<std::remove_reference_t<decltype(request.arg1.c.c)>>(params.arg1.c.c.unsignedCharValue);
+    request.arg1.c.d = [self asByteSpan:params.arg1.c.d];
+    request.arg1.c.e = [self asCharSpan:params.arg1.c.e];
+    request.arg1.c.f = static_cast<std::remove_reference_t<decltype(request.arg1.c.f)>>(params.arg1.c.f.unsignedCharValue);
+    request.arg1.c.g = params.arg1.c.g.floatValue;
+    request.arg1.c.h = params.arg1.c.h.doubleValue;
+    {
+        using ListType_1 = std::remove_reference_t<decltype(request.arg1.d)>;
+        using ListMemberType_1 = ListMemberTypeGetter<ListType_1>::Type;
+        if (params.arg1.d.count != 0) {
+            auto * listHolder_1 = new ListHolder<ListMemberType_1>(params.arg1.d.count);
+            if (listHolder_1 == nullptr || listHolder_1->mList == nullptr) {
+                return;
+            }
+            listFreer.add(listHolder_1);
+            for (size_t i_1 = 0; i_1 < params.arg1.d.count; ++i_1) {
+                if (![params.arg1.d[i_1] isKindOfClass:[CHIPTestClusterClusterSimpleStruct class]]) {
+                    // Wrong kind of value.
+                    return;
+                }
+                auto element_1 = (CHIPTestClusterClusterSimpleStruct *) params.arg1.d[i_1];
+                listHolder_1->mList[i_1].a = element_1.a.unsignedCharValue;
+                listHolder_1->mList[i_1].b = element_1.b.boolValue;
+                listHolder_1->mList[i_1].c
+                    = static_cast<std::remove_reference_t<decltype(listHolder_1->mList[i_1].c)>>(element_1.c.unsignedCharValue);
+                listHolder_1->mList[i_1].d = [self asByteSpan:element_1.d];
+                listHolder_1->mList[i_1].e = [self asCharSpan:element_1.e];
+                listHolder_1->mList[i_1].f
+                    = static_cast<std::remove_reference_t<decltype(listHolder_1->mList[i_1].f)>>(element_1.f.unsignedCharValue);
+                listHolder_1->mList[i_1].g = element_1.g.floatValue;
+                listHolder_1->mList[i_1].h = element_1.h.doubleValue;
+            }
+            request.arg1.d = ListType_1(listHolder_1->mList, params.arg1.d.count);
+        } else {
+            request.arg1.d = ListType_1();
+        }
+    }
+    {
+        using ListType_1 = std::remove_reference_t<decltype(request.arg1.e)>;
+        using ListMemberType_1 = ListMemberTypeGetter<ListType_1>::Type;
+        if (params.arg1.e.count != 0) {
+            auto * listHolder_1 = new ListHolder<ListMemberType_1>(params.arg1.e.count);
+            if (listHolder_1 == nullptr || listHolder_1->mList == nullptr) {
+                return;
+            }
+            listFreer.add(listHolder_1);
+            for (size_t i_1 = 0; i_1 < params.arg1.e.count; ++i_1) {
+                if (![params.arg1.e[i_1] isKindOfClass:[NSNumber class]]) {
+                    // Wrong kind of value.
+                    return;
+                }
+                auto element_1 = (NSNumber *) params.arg1.e[i_1];
+                listHolder_1->mList[i_1] = element_1.unsignedIntValue;
+            }
+            request.arg1.e = ListType_1(listHolder_1->mList, params.arg1.e.count);
+        } else {
+            request.arg1.e = ListType_1();
+        }
+    }
+    {
+        using ListType_1 = std::remove_reference_t<decltype(request.arg1.f)>;
+        using ListMemberType_1 = ListMemberTypeGetter<ListType_1>::Type;
+        if (params.arg1.f.count != 0) {
+            auto * listHolder_1 = new ListHolder<ListMemberType_1>(params.arg1.f.count);
+            if (listHolder_1 == nullptr || listHolder_1->mList == nullptr) {
+                return;
+            }
+            listFreer.add(listHolder_1);
+            for (size_t i_1 = 0; i_1 < params.arg1.f.count; ++i_1) {
+                if (![params.arg1.f[i_1] isKindOfClass:[NSData class]]) {
+                    // Wrong kind of value.
+                    return;
+                }
+                auto element_1 = (NSData *) params.arg1.f[i_1];
+                listHolder_1->mList[i_1] = [self asByteSpan:element_1];
+            }
+            request.arg1.f = ListType_1(listHolder_1->mList, params.arg1.f.count);
+        } else {
+            request.arg1.f = ListType_1();
+        }
+    }
+    {
+        using ListType_1 = std::remove_reference_t<decltype(request.arg1.g)>;
+        using ListMemberType_1 = ListMemberTypeGetter<ListType_1>::Type;
+        if (params.arg1.g.count != 0) {
+            auto * listHolder_1 = new ListHolder<ListMemberType_1>(params.arg1.g.count);
+            if (listHolder_1 == nullptr || listHolder_1->mList == nullptr) {
+                return;
+            }
+            listFreer.add(listHolder_1);
+            for (size_t i_1 = 0; i_1 < params.arg1.g.count; ++i_1) {
+                if (![params.arg1.g[i_1] isKindOfClass:[NSNumber class]]) {
+                    // Wrong kind of value.
+                    return;
+                }
+                auto element_1 = (NSNumber *) params.arg1.g[i_1];
+                listHolder_1->mList[i_1] = element_1.unsignedCharValue;
+            }
+            request.arg1.g = ListType_1(listHolder_1->mList, params.arg1.g.count);
+        } else {
+            request.arg1.g = ListType_1();
         }
     }
 
@@ -17498,25 +17803,25 @@ using namespace chip::app::Clusters;
             using TypeInfo = TestCluster::Attributes::ListInt8u::TypeInfo;
             TypeInfo::Type cppValue;
             {
-                using ListType = std::remove_reference_t<decltype(cppValue)>;
-                using ListMemberType = ListMemberTypeGetter<ListType>::Type;
+                using ListType_0 = std::remove_reference_t<decltype(cppValue)>;
+                using ListMemberType_0 = ListMemberTypeGetter<ListType_0>::Type;
                 if (value.count != 0) {
-                    auto * listHolder_0 = new ListHolder<ListMemberType>(value.count);
+                    auto * listHolder_0 = new ListHolder<ListMemberType_0>(value.count);
                     if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
                         return CHIP_ERROR_INVALID_ARGUMENT;
                     }
                     listFreer.add(listHolder_0);
-                    for (size_t i = 0; i < value.count; ++i) {
-                        if (![value[i] isKindOfClass:[NSNumber class]]) {
+                    for (size_t i_0 = 0; i_0 < value.count; ++i_0) {
+                        if (![value[i_0] isKindOfClass:[NSNumber class]]) {
                             // Wrong kind of value.
                             return CHIP_ERROR_INVALID_ARGUMENT;
                         }
-                        auto element_0 = (NSNumber *) value[i];
-                        listHolder_0->mList[i] = element_0.unsignedCharValue;
+                        auto element_0 = (NSNumber *) value[i_0];
+                        listHolder_0->mList[i_0] = element_0.unsignedCharValue;
                     }
-                    cppValue = ListType(listHolder_0->mList, value.count);
+                    cppValue = ListType_0(listHolder_0->mList, value.count);
                 } else {
-                    cppValue = ListType();
+                    cppValue = ListType_0();
                 }
             }
             auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
@@ -17553,25 +17858,25 @@ using namespace chip::app::Clusters;
             using TypeInfo = TestCluster::Attributes::ListOctetString::TypeInfo;
             TypeInfo::Type cppValue;
             {
-                using ListType = std::remove_reference_t<decltype(cppValue)>;
-                using ListMemberType = ListMemberTypeGetter<ListType>::Type;
+                using ListType_0 = std::remove_reference_t<decltype(cppValue)>;
+                using ListMemberType_0 = ListMemberTypeGetter<ListType_0>::Type;
                 if (value.count != 0) {
-                    auto * listHolder_0 = new ListHolder<ListMemberType>(value.count);
+                    auto * listHolder_0 = new ListHolder<ListMemberType_0>(value.count);
                     if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
                         return CHIP_ERROR_INVALID_ARGUMENT;
                     }
                     listFreer.add(listHolder_0);
-                    for (size_t i = 0; i < value.count; ++i) {
-                        if (![value[i] isKindOfClass:[NSData class]]) {
+                    for (size_t i_0 = 0; i_0 < value.count; ++i_0) {
+                        if (![value[i_0] isKindOfClass:[NSData class]]) {
                             // Wrong kind of value.
                             return CHIP_ERROR_INVALID_ARGUMENT;
                         }
-                        auto element_0 = (NSData *) value[i];
-                        listHolder_0->mList[i] = [self asByteSpan:element_0];
+                        auto element_0 = (NSData *) value[i_0];
+                        listHolder_0->mList[i_0] = [self asByteSpan:element_0];
                     }
-                    cppValue = ListType(listHolder_0->mList, value.count);
+                    cppValue = ListType_0(listHolder_0->mList, value.count);
                 } else {
-                    cppValue = ListType();
+                    cppValue = ListType_0();
                 }
             }
             auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
@@ -17608,26 +17913,26 @@ using namespace chip::app::Clusters;
             using TypeInfo = TestCluster::Attributes::ListStructOctetString::TypeInfo;
             TypeInfo::Type cppValue;
             {
-                using ListType = std::remove_reference_t<decltype(cppValue)>;
-                using ListMemberType = ListMemberTypeGetter<ListType>::Type;
+                using ListType_0 = std::remove_reference_t<decltype(cppValue)>;
+                using ListMemberType_0 = ListMemberTypeGetter<ListType_0>::Type;
                 if (value.count != 0) {
-                    auto * listHolder_0 = new ListHolder<ListMemberType>(value.count);
+                    auto * listHolder_0 = new ListHolder<ListMemberType_0>(value.count);
                     if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
                         return CHIP_ERROR_INVALID_ARGUMENT;
                     }
                     listFreer.add(listHolder_0);
-                    for (size_t i = 0; i < value.count; ++i) {
-                        if (![value[i] isKindOfClass:[CHIPTestClusterClusterTestListStructOctet class]]) {
+                    for (size_t i_0 = 0; i_0 < value.count; ++i_0) {
+                        if (![value[i_0] isKindOfClass:[CHIPTestClusterClusterTestListStructOctet class]]) {
                             // Wrong kind of value.
                             return CHIP_ERROR_INVALID_ARGUMENT;
                         }
-                        auto element_0 = (CHIPTestClusterClusterTestListStructOctet *) value[i];
-                        listHolder_0->mList[i].fabricIndex = element_0.fabricIndex.unsignedLongLongValue;
-                        listHolder_0->mList[i].operationalCert = [self asByteSpan:element_0.operationalCert];
+                        auto element_0 = (CHIPTestClusterClusterTestListStructOctet *) value[i_0];
+                        listHolder_0->mList[i_0].fabricIndex = element_0.fabricIndex.unsignedLongLongValue;
+                        listHolder_0->mList[i_0].operationalCert = [self asByteSpan:element_0.operationalCert];
                     }
-                    cppValue = ListType(listHolder_0->mList, value.count);
+                    cppValue = ListType_0(listHolder_0->mList, value.count);
                 } else {
-                    cppValue = ListType();
+                    cppValue = ListType_0();
                 }
             }
             auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
@@ -19232,25 +19537,25 @@ using namespace chip::app::Clusters;
     request.modeForSequence
         = static_cast<std::remove_reference_t<decltype(request.modeForSequence)>>(params.modeForSequence.unsignedCharValue);
     {
-        using ListType = std::remove_reference_t<decltype(request.payload)>;
-        using ListMemberType = ListMemberTypeGetter<ListType>::Type;
+        using ListType_0 = std::remove_reference_t<decltype(request.payload)>;
+        using ListMemberType_0 = ListMemberTypeGetter<ListType_0>::Type;
         if (params.payload.count != 0) {
-            auto * listHolder_0 = new ListHolder<ListMemberType>(params.payload.count);
+            auto * listHolder_0 = new ListHolder<ListMemberType_0>(params.payload.count);
             if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
                 return;
             }
             listFreer.add(listHolder_0);
-            for (size_t i = 0; i < params.payload.count; ++i) {
-                if (![params.payload[i] isKindOfClass:[NSNumber class]]) {
+            for (size_t i_0 = 0; i_0 < params.payload.count; ++i_0) {
+                if (![params.payload[i_0] isKindOfClass:[NSNumber class]]) {
                     // Wrong kind of value.
                     return;
                 }
-                auto element_0 = (NSNumber *) params.payload[i];
-                listHolder_0->mList[i] = element_0.unsignedCharValue;
+                auto element_0 = (NSNumber *) params.payload[i_0];
+                listHolder_0->mList[i_0] = element_0.unsignedCharValue;
             }
-            request.payload = ListType(listHolder_0->mList, params.payload.count);
+            request.payload = ListType_0(listHolder_0->mList, params.payload.count);
         } else {
-            request.payload = ListType();
+            request.payload = ListType_0();
         }
     }
 

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPTestClustersObjc.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPTestClustersObjc.mm
@@ -276,25 +276,25 @@ using namespace chip::app::Clusters;
             using TypeInfo = ApplicationLauncher::Attributes::ApplicationLauncherList::TypeInfo;
             TypeInfo::Type cppValue;
             {
-                using ListType = std::remove_reference_t<decltype(cppValue)>;
-                using ListMemberType = ListMemberTypeGetter<ListType>::Type;
+                using ListType_0 = std::remove_reference_t<decltype(cppValue)>;
+                using ListMemberType_0 = ListMemberTypeGetter<ListType_0>::Type;
                 if (value.count != 0) {
-                    auto * listHolder_0 = new ListHolder<ListMemberType>(value.count);
+                    auto * listHolder_0 = new ListHolder<ListMemberType_0>(value.count);
                     if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
                         return CHIP_ERROR_INVALID_ARGUMENT;
                     }
                     listFreer.add(listHolder_0);
-                    for (size_t i = 0; i < value.count; ++i) {
-                        if (![value[i] isKindOfClass:[NSNumber class]]) {
+                    for (size_t i_0 = 0; i_0 < value.count; ++i_0) {
+                        if (![value[i_0] isKindOfClass:[NSNumber class]]) {
                             // Wrong kind of value.
                             return CHIP_ERROR_INVALID_ARGUMENT;
                         }
-                        auto element_0 = (NSNumber *) value[i];
-                        listHolder_0->mList[i] = element_0.unsignedShortValue;
+                        auto element_0 = (NSNumber *) value[i_0];
+                        listHolder_0->mList[i_0] = element_0.unsignedShortValue;
                     }
-                    cppValue = ListType(listHolder_0->mList, value.count);
+                    cppValue = ListType_0(listHolder_0->mList, value.count);
                 } else {
-                    cppValue = ListType();
+                    cppValue = ListType_0();
                 }
             }
             auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
@@ -382,29 +382,29 @@ using namespace chip::app::Clusters;
             using TypeInfo = AudioOutput::Attributes::AudioOutputList::TypeInfo;
             TypeInfo::Type cppValue;
             {
-                using ListType = std::remove_reference_t<decltype(cppValue)>;
-                using ListMemberType = ListMemberTypeGetter<ListType>::Type;
+                using ListType_0 = std::remove_reference_t<decltype(cppValue)>;
+                using ListMemberType_0 = ListMemberTypeGetter<ListType_0>::Type;
                 if (value.count != 0) {
-                    auto * listHolder_0 = new ListHolder<ListMemberType>(value.count);
+                    auto * listHolder_0 = new ListHolder<ListMemberType_0>(value.count);
                     if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
                         return CHIP_ERROR_INVALID_ARGUMENT;
                     }
                     listFreer.add(listHolder_0);
-                    for (size_t i = 0; i < value.count; ++i) {
-                        if (![value[i] isKindOfClass:[CHIPAudioOutputClusterAudioOutputInfo class]]) {
+                    for (size_t i_0 = 0; i_0 < value.count; ++i_0) {
+                        if (![value[i_0] isKindOfClass:[CHIPAudioOutputClusterAudioOutputInfo class]]) {
                             // Wrong kind of value.
                             return CHIP_ERROR_INVALID_ARGUMENT;
                         }
-                        auto element_0 = (CHIPAudioOutputClusterAudioOutputInfo *) value[i];
-                        listHolder_0->mList[i].index = element_0.index.unsignedCharValue;
-                        listHolder_0->mList[i].outputType
-                            = static_cast<std::remove_reference_t<decltype(listHolder_0->mList[i].outputType)>>(
+                        auto element_0 = (CHIPAudioOutputClusterAudioOutputInfo *) value[i_0];
+                        listHolder_0->mList[i_0].index = element_0.index.unsignedCharValue;
+                        listHolder_0->mList[i_0].outputType
+                            = static_cast<std::remove_reference_t<decltype(listHolder_0->mList[i_0].outputType)>>(
                                 element_0.outputType.unsignedCharValue);
-                        listHolder_0->mList[i].name = [self asCharSpan:element_0.name];
+                        listHolder_0->mList[i_0].name = [self asCharSpan:element_0.name];
                     }
-                    cppValue = ListType(listHolder_0->mList, value.count);
+                    cppValue = ListType_0(listHolder_0->mList, value.count);
                 } else {
-                    cppValue = ListType();
+                    cppValue = ListType_0();
                 }
             }
             auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
@@ -1028,33 +1028,34 @@ using namespace chip::app::Clusters;
             using TypeInfo = BridgedActions::Attributes::ActionList::TypeInfo;
             TypeInfo::Type cppValue;
             {
-                using ListType = std::remove_reference_t<decltype(cppValue)>;
-                using ListMemberType = ListMemberTypeGetter<ListType>::Type;
+                using ListType_0 = std::remove_reference_t<decltype(cppValue)>;
+                using ListMemberType_0 = ListMemberTypeGetter<ListType_0>::Type;
                 if (value.count != 0) {
-                    auto * listHolder_0 = new ListHolder<ListMemberType>(value.count);
+                    auto * listHolder_0 = new ListHolder<ListMemberType_0>(value.count);
                     if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
                         return CHIP_ERROR_INVALID_ARGUMENT;
                     }
                     listFreer.add(listHolder_0);
-                    for (size_t i = 0; i < value.count; ++i) {
-                        if (![value[i] isKindOfClass:[CHIPBridgedActionsClusterActionStruct class]]) {
+                    for (size_t i_0 = 0; i_0 < value.count; ++i_0) {
+                        if (![value[i_0] isKindOfClass:[CHIPBridgedActionsClusterActionStruct class]]) {
                             // Wrong kind of value.
                             return CHIP_ERROR_INVALID_ARGUMENT;
                         }
-                        auto element_0 = (CHIPBridgedActionsClusterActionStruct *) value[i];
-                        listHolder_0->mList[i].actionID = element_0.actionID.unsignedShortValue;
-                        listHolder_0->mList[i].name = [self asCharSpan:element_0.name];
-                        listHolder_0->mList[i].type = static_cast<std::remove_reference_t<decltype(listHolder_0->mList[i].type)>>(
-                            element_0.type.unsignedCharValue);
-                        listHolder_0->mList[i].endpointListID = element_0.endpointListID.unsignedShortValue;
-                        listHolder_0->mList[i].supportedCommands = element_0.supportedCommands.unsignedShortValue;
-                        listHolder_0->mList[i].status
-                            = static_cast<std::remove_reference_t<decltype(listHolder_0->mList[i].status)>>(
+                        auto element_0 = (CHIPBridgedActionsClusterActionStruct *) value[i_0];
+                        listHolder_0->mList[i_0].actionID = element_0.actionID.unsignedShortValue;
+                        listHolder_0->mList[i_0].name = [self asCharSpan:element_0.name];
+                        listHolder_0->mList[i_0].type
+                            = static_cast<std::remove_reference_t<decltype(listHolder_0->mList[i_0].type)>>(
+                                element_0.type.unsignedCharValue);
+                        listHolder_0->mList[i_0].endpointListID = element_0.endpointListID.unsignedShortValue;
+                        listHolder_0->mList[i_0].supportedCommands = element_0.supportedCommands.unsignedShortValue;
+                        listHolder_0->mList[i_0].status
+                            = static_cast<std::remove_reference_t<decltype(listHolder_0->mList[i_0].status)>>(
                                 element_0.status.unsignedCharValue);
                     }
-                    cppValue = ListType(listHolder_0->mList, value.count);
+                    cppValue = ListType_0(listHolder_0->mList, value.count);
                 } else {
-                    cppValue = ListType();
+                    cppValue = ListType_0();
                 }
             }
             auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
@@ -1075,50 +1076,51 @@ using namespace chip::app::Clusters;
             using TypeInfo = BridgedActions::Attributes::EndpointList::TypeInfo;
             TypeInfo::Type cppValue;
             {
-                using ListType = std::remove_reference_t<decltype(cppValue)>;
-                using ListMemberType = ListMemberTypeGetter<ListType>::Type;
+                using ListType_0 = std::remove_reference_t<decltype(cppValue)>;
+                using ListMemberType_0 = ListMemberTypeGetter<ListType_0>::Type;
                 if (value.count != 0) {
-                    auto * listHolder_0 = new ListHolder<ListMemberType>(value.count);
+                    auto * listHolder_0 = new ListHolder<ListMemberType_0>(value.count);
                     if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
                         return CHIP_ERROR_INVALID_ARGUMENT;
                     }
                     listFreer.add(listHolder_0);
-                    for (size_t i = 0; i < value.count; ++i) {
-                        if (![value[i] isKindOfClass:[CHIPBridgedActionsClusterEndpointListStruct class]]) {
+                    for (size_t i_0 = 0; i_0 < value.count; ++i_0) {
+                        if (![value[i_0] isKindOfClass:[CHIPBridgedActionsClusterEndpointListStruct class]]) {
                             // Wrong kind of value.
                             return CHIP_ERROR_INVALID_ARGUMENT;
                         }
-                        auto element_0 = (CHIPBridgedActionsClusterEndpointListStruct *) value[i];
-                        listHolder_0->mList[i].endpointListID = element_0.endpointListID.unsignedShortValue;
-                        listHolder_0->mList[i].name = [self asCharSpan:element_0.name];
-                        listHolder_0->mList[i].type = static_cast<std::remove_reference_t<decltype(listHolder_0->mList[i].type)>>(
-                            element_0.type.unsignedCharValue);
+                        auto element_0 = (CHIPBridgedActionsClusterEndpointListStruct *) value[i_0];
+                        listHolder_0->mList[i_0].endpointListID = element_0.endpointListID.unsignedShortValue;
+                        listHolder_0->mList[i_0].name = [self asCharSpan:element_0.name];
+                        listHolder_0->mList[i_0].type
+                            = static_cast<std::remove_reference_t<decltype(listHolder_0->mList[i_0].type)>>(
+                                element_0.type.unsignedCharValue);
                         {
-                            using ListType = std::remove_reference_t<decltype(listHolder_0->mList[i].endpoints)>;
-                            using ListMemberType = ListMemberTypeGetter<ListType>::Type;
+                            using ListType_2 = std::remove_reference_t<decltype(listHolder_0->mList[i_0].endpoints)>;
+                            using ListMemberType_2 = ListMemberTypeGetter<ListType_2>::Type;
                             if (element_0.endpoints.count != 0) {
-                                auto * listHolder_2 = new ListHolder<ListMemberType>(element_0.endpoints.count);
+                                auto * listHolder_2 = new ListHolder<ListMemberType_2>(element_0.endpoints.count);
                                 if (listHolder_2 == nullptr || listHolder_2->mList == nullptr) {
                                     return CHIP_ERROR_INVALID_ARGUMENT;
                                 }
                                 listFreer.add(listHolder_2);
-                                for (size_t i = 0; i < element_0.endpoints.count; ++i) {
-                                    if (![element_0.endpoints[i] isKindOfClass:[NSNumber class]]) {
+                                for (size_t i_2 = 0; i_2 < element_0.endpoints.count; ++i_2) {
+                                    if (![element_0.endpoints[i_2] isKindOfClass:[NSNumber class]]) {
                                         // Wrong kind of value.
                                         return CHIP_ERROR_INVALID_ARGUMENT;
                                     }
-                                    auto element_2 = (NSNumber *) element_0.endpoints[i];
-                                    listHolder_2->mList[i] = element_2.unsignedShortValue;
+                                    auto element_2 = (NSNumber *) element_0.endpoints[i_2];
+                                    listHolder_2->mList[i_2] = element_2.unsignedShortValue;
                                 }
-                                listHolder_0->mList[i].endpoints = ListType(listHolder_2->mList, element_0.endpoints.count);
+                                listHolder_0->mList[i_0].endpoints = ListType_2(listHolder_2->mList, element_0.endpoints.count);
                             } else {
-                                listHolder_0->mList[i].endpoints = ListType();
+                                listHolder_0->mList[i_0].endpoints = ListType_2();
                             }
                         }
                     }
-                    cppValue = ListType(listHolder_0->mList, value.count);
+                    cppValue = ListType_0(listHolder_0->mList, value.count);
                 } else {
-                    cppValue = ListType();
+                    cppValue = ListType_0();
                 }
             }
             auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
@@ -2191,25 +2193,25 @@ using namespace chip::app::Clusters;
             using TypeInfo = ContentLauncher::Attributes::AcceptsHeaderList::TypeInfo;
             TypeInfo::Type cppValue;
             {
-                using ListType = std::remove_reference_t<decltype(cppValue)>;
-                using ListMemberType = ListMemberTypeGetter<ListType>::Type;
+                using ListType_0 = std::remove_reference_t<decltype(cppValue)>;
+                using ListMemberType_0 = ListMemberTypeGetter<ListType_0>::Type;
                 if (value.count != 0) {
-                    auto * listHolder_0 = new ListHolder<ListMemberType>(value.count);
+                    auto * listHolder_0 = new ListHolder<ListMemberType_0>(value.count);
                     if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
                         return CHIP_ERROR_INVALID_ARGUMENT;
                     }
                     listFreer.add(listHolder_0);
-                    for (size_t i = 0; i < value.count; ++i) {
-                        if (![value[i] isKindOfClass:[NSData class]]) {
+                    for (size_t i_0 = 0; i_0 < value.count; ++i_0) {
+                        if (![value[i_0] isKindOfClass:[NSData class]]) {
                             // Wrong kind of value.
                             return CHIP_ERROR_INVALID_ARGUMENT;
                         }
-                        auto element_0 = (NSData *) value[i];
-                        listHolder_0->mList[i] = [self asByteSpan:element_0];
+                        auto element_0 = (NSData *) value[i_0];
+                        listHolder_0->mList[i_0] = [self asByteSpan:element_0];
                     }
-                    cppValue = ListType(listHolder_0->mList, value.count);
+                    cppValue = ListType_0(listHolder_0->mList, value.count);
                 } else {
-                    cppValue = ListType();
+                    cppValue = ListType_0();
                 }
             }
             auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
@@ -2231,26 +2233,26 @@ using namespace chip::app::Clusters;
             using TypeInfo = ContentLauncher::Attributes::SupportedStreamingTypes::TypeInfo;
             TypeInfo::Type cppValue;
             {
-                using ListType = std::remove_reference_t<decltype(cppValue)>;
-                using ListMemberType = ListMemberTypeGetter<ListType>::Type;
+                using ListType_0 = std::remove_reference_t<decltype(cppValue)>;
+                using ListMemberType_0 = ListMemberTypeGetter<ListType_0>::Type;
                 if (value.count != 0) {
-                    auto * listHolder_0 = new ListHolder<ListMemberType>(value.count);
+                    auto * listHolder_0 = new ListHolder<ListMemberType_0>(value.count);
                     if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
                         return CHIP_ERROR_INVALID_ARGUMENT;
                     }
                     listFreer.add(listHolder_0);
-                    for (size_t i = 0; i < value.count; ++i) {
-                        if (![value[i] isKindOfClass:[NSNumber class]]) {
+                    for (size_t i_0 = 0; i_0 < value.count; ++i_0) {
+                        if (![value[i_0] isKindOfClass:[NSNumber class]]) {
                             // Wrong kind of value.
                             return CHIP_ERROR_INVALID_ARGUMENT;
                         }
-                        auto element_0 = (NSNumber *) value[i];
-                        listHolder_0->mList[i]
-                            = static_cast<std::remove_reference_t<decltype(listHolder_0->mList[i])>>(element_0.unsignedCharValue);
+                        auto element_0 = (NSNumber *) value[i_0];
+                        listHolder_0->mList[i_0]
+                            = static_cast<std::remove_reference_t<decltype(listHolder_0->mList[i_0])>>(element_0.unsignedCharValue);
                     }
-                    cppValue = ListType(listHolder_0->mList, value.count);
+                    cppValue = ListType_0(listHolder_0->mList, value.count);
                 } else {
-                    cppValue = ListType();
+                    cppValue = ListType_0();
                 }
             }
             auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
@@ -2302,26 +2304,26 @@ using namespace chip::app::Clusters;
             using TypeInfo = Descriptor::Attributes::DeviceList::TypeInfo;
             TypeInfo::Type cppValue;
             {
-                using ListType = std::remove_reference_t<decltype(cppValue)>;
-                using ListMemberType = ListMemberTypeGetter<ListType>::Type;
+                using ListType_0 = std::remove_reference_t<decltype(cppValue)>;
+                using ListMemberType_0 = ListMemberTypeGetter<ListType_0>::Type;
                 if (value.count != 0) {
-                    auto * listHolder_0 = new ListHolder<ListMemberType>(value.count);
+                    auto * listHolder_0 = new ListHolder<ListMemberType_0>(value.count);
                     if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
                         return CHIP_ERROR_INVALID_ARGUMENT;
                     }
                     listFreer.add(listHolder_0);
-                    for (size_t i = 0; i < value.count; ++i) {
-                        if (![value[i] isKindOfClass:[CHIPDescriptorClusterDeviceType class]]) {
+                    for (size_t i_0 = 0; i_0 < value.count; ++i_0) {
+                        if (![value[i_0] isKindOfClass:[CHIPDescriptorClusterDeviceType class]]) {
                             // Wrong kind of value.
                             return CHIP_ERROR_INVALID_ARGUMENT;
                         }
-                        auto element_0 = (CHIPDescriptorClusterDeviceType *) value[i];
-                        listHolder_0->mList[i].type = element_0.type.unsignedIntValue;
-                        listHolder_0->mList[i].revision = element_0.revision.unsignedShortValue;
+                        auto element_0 = (CHIPDescriptorClusterDeviceType *) value[i_0];
+                        listHolder_0->mList[i_0].type = element_0.type.unsignedIntValue;
+                        listHolder_0->mList[i_0].revision = element_0.revision.unsignedShortValue;
                     }
-                    cppValue = ListType(listHolder_0->mList, value.count);
+                    cppValue = ListType_0(listHolder_0->mList, value.count);
                 } else {
-                    cppValue = ListType();
+                    cppValue = ListType_0();
                 }
             }
             auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
@@ -2342,25 +2344,25 @@ using namespace chip::app::Clusters;
             using TypeInfo = Descriptor::Attributes::ServerList::TypeInfo;
             TypeInfo::Type cppValue;
             {
-                using ListType = std::remove_reference_t<decltype(cppValue)>;
-                using ListMemberType = ListMemberTypeGetter<ListType>::Type;
+                using ListType_0 = std::remove_reference_t<decltype(cppValue)>;
+                using ListMemberType_0 = ListMemberTypeGetter<ListType_0>::Type;
                 if (value.count != 0) {
-                    auto * listHolder_0 = new ListHolder<ListMemberType>(value.count);
+                    auto * listHolder_0 = new ListHolder<ListMemberType_0>(value.count);
                     if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
                         return CHIP_ERROR_INVALID_ARGUMENT;
                     }
                     listFreer.add(listHolder_0);
-                    for (size_t i = 0; i < value.count; ++i) {
-                        if (![value[i] isKindOfClass:[NSNumber class]]) {
+                    for (size_t i_0 = 0; i_0 < value.count; ++i_0) {
+                        if (![value[i_0] isKindOfClass:[NSNumber class]]) {
                             // Wrong kind of value.
                             return CHIP_ERROR_INVALID_ARGUMENT;
                         }
-                        auto element_0 = (NSNumber *) value[i];
-                        listHolder_0->mList[i] = element_0.unsignedIntValue;
+                        auto element_0 = (NSNumber *) value[i_0];
+                        listHolder_0->mList[i_0] = element_0.unsignedIntValue;
                     }
-                    cppValue = ListType(listHolder_0->mList, value.count);
+                    cppValue = ListType_0(listHolder_0->mList, value.count);
                 } else {
-                    cppValue = ListType();
+                    cppValue = ListType_0();
                 }
             }
             auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
@@ -2381,25 +2383,25 @@ using namespace chip::app::Clusters;
             using TypeInfo = Descriptor::Attributes::ClientList::TypeInfo;
             TypeInfo::Type cppValue;
             {
-                using ListType = std::remove_reference_t<decltype(cppValue)>;
-                using ListMemberType = ListMemberTypeGetter<ListType>::Type;
+                using ListType_0 = std::remove_reference_t<decltype(cppValue)>;
+                using ListMemberType_0 = ListMemberTypeGetter<ListType_0>::Type;
                 if (value.count != 0) {
-                    auto * listHolder_0 = new ListHolder<ListMemberType>(value.count);
+                    auto * listHolder_0 = new ListHolder<ListMemberType_0>(value.count);
                     if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
                         return CHIP_ERROR_INVALID_ARGUMENT;
                     }
                     listFreer.add(listHolder_0);
-                    for (size_t i = 0; i < value.count; ++i) {
-                        if (![value[i] isKindOfClass:[NSNumber class]]) {
+                    for (size_t i_0 = 0; i_0 < value.count; ++i_0) {
+                        if (![value[i_0] isKindOfClass:[NSNumber class]]) {
                             // Wrong kind of value.
                             return CHIP_ERROR_INVALID_ARGUMENT;
                         }
-                        auto element_0 = (NSNumber *) value[i];
-                        listHolder_0->mList[i] = element_0.unsignedIntValue;
+                        auto element_0 = (NSNumber *) value[i_0];
+                        listHolder_0->mList[i_0] = element_0.unsignedIntValue;
                     }
-                    cppValue = ListType(listHolder_0->mList, value.count);
+                    cppValue = ListType_0(listHolder_0->mList, value.count);
                 } else {
-                    cppValue = ListType();
+                    cppValue = ListType_0();
                 }
             }
             auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
@@ -2420,25 +2422,25 @@ using namespace chip::app::Clusters;
             using TypeInfo = Descriptor::Attributes::PartsList::TypeInfo;
             TypeInfo::Type cppValue;
             {
-                using ListType = std::remove_reference_t<decltype(cppValue)>;
-                using ListMemberType = ListMemberTypeGetter<ListType>::Type;
+                using ListType_0 = std::remove_reference_t<decltype(cppValue)>;
+                using ListMemberType_0 = ListMemberTypeGetter<ListType_0>::Type;
                 if (value.count != 0) {
-                    auto * listHolder_0 = new ListHolder<ListMemberType>(value.count);
+                    auto * listHolder_0 = new ListHolder<ListMemberType_0>(value.count);
                     if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
                         return CHIP_ERROR_INVALID_ARGUMENT;
                     }
                     listFreer.add(listHolder_0);
-                    for (size_t i = 0; i < value.count; ++i) {
-                        if (![value[i] isKindOfClass:[NSNumber class]]) {
+                    for (size_t i_0 = 0; i_0 < value.count; ++i_0) {
+                        if (![value[i_0] isKindOfClass:[NSNumber class]]) {
                             // Wrong kind of value.
                             return CHIP_ERROR_INVALID_ARGUMENT;
                         }
-                        auto element_0 = (NSNumber *) value[i];
-                        listHolder_0->mList[i] = element_0.unsignedShortValue;
+                        auto element_0 = (NSNumber *) value[i_0];
+                        listHolder_0->mList[i_0] = element_0.unsignedShortValue;
                     }
-                    cppValue = ListType(listHolder_0->mList, value.count);
+                    cppValue = ListType_0(listHolder_0->mList, value.count);
                 } else {
-                    cppValue = ListType();
+                    cppValue = ListType_0();
                 }
             }
             auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
@@ -3028,26 +3030,26 @@ using namespace chip::app::Clusters;
             using TypeInfo = FixedLabel::Attributes::LabelList::TypeInfo;
             TypeInfo::Type cppValue;
             {
-                using ListType = std::remove_reference_t<decltype(cppValue)>;
-                using ListMemberType = ListMemberTypeGetter<ListType>::Type;
+                using ListType_0 = std::remove_reference_t<decltype(cppValue)>;
+                using ListMemberType_0 = ListMemberTypeGetter<ListType_0>::Type;
                 if (value.count != 0) {
-                    auto * listHolder_0 = new ListHolder<ListMemberType>(value.count);
+                    auto * listHolder_0 = new ListHolder<ListMemberType_0>(value.count);
                     if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
                         return CHIP_ERROR_INVALID_ARGUMENT;
                     }
                     listFreer.add(listHolder_0);
-                    for (size_t i = 0; i < value.count; ++i) {
-                        if (![value[i] isKindOfClass:[CHIPFixedLabelClusterLabelStruct class]]) {
+                    for (size_t i_0 = 0; i_0 < value.count; ++i_0) {
+                        if (![value[i_0] isKindOfClass:[CHIPFixedLabelClusterLabelStruct class]]) {
                             // Wrong kind of value.
                             return CHIP_ERROR_INVALID_ARGUMENT;
                         }
-                        auto element_0 = (CHIPFixedLabelClusterLabelStruct *) value[i];
-                        listHolder_0->mList[i].label = [self asCharSpan:element_0.label];
-                        listHolder_0->mList[i].value = [self asCharSpan:element_0.value];
+                        auto element_0 = (CHIPFixedLabelClusterLabelStruct *) value[i_0];
+                        listHolder_0->mList[i_0].label = [self asCharSpan:element_0.label];
+                        listHolder_0->mList[i_0].value = [self asCharSpan:element_0.value];
                     }
-                    cppValue = ListType(listHolder_0->mList, value.count);
+                    cppValue = ListType_0(listHolder_0->mList, value.count);
                 } else {
-                    cppValue = ListType();
+                    cppValue = ListType_0();
                 }
             }
             auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
@@ -3203,25 +3205,25 @@ using namespace chip::app::Clusters;
             using TypeInfo = GeneralCommissioning::Attributes::BasicCommissioningInfoList::TypeInfo;
             TypeInfo::Type cppValue;
             {
-                using ListType = std::remove_reference_t<decltype(cppValue)>;
-                using ListMemberType = ListMemberTypeGetter<ListType>::Type;
+                using ListType_0 = std::remove_reference_t<decltype(cppValue)>;
+                using ListMemberType_0 = ListMemberTypeGetter<ListType_0>::Type;
                 if (value.count != 0) {
-                    auto * listHolder_0 = new ListHolder<ListMemberType>(value.count);
+                    auto * listHolder_0 = new ListHolder<ListMemberType_0>(value.count);
                     if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
                         return CHIP_ERROR_INVALID_ARGUMENT;
                     }
                     listFreer.add(listHolder_0);
-                    for (size_t i = 0; i < value.count; ++i) {
-                        if (![value[i] isKindOfClass:[CHIPGeneralCommissioningClusterBasicCommissioningInfoType class]]) {
+                    for (size_t i_0 = 0; i_0 < value.count; ++i_0) {
+                        if (![value[i_0] isKindOfClass:[CHIPGeneralCommissioningClusterBasicCommissioningInfoType class]]) {
                             // Wrong kind of value.
                             return CHIP_ERROR_INVALID_ARGUMENT;
                         }
-                        auto element_0 = (CHIPGeneralCommissioningClusterBasicCommissioningInfoType *) value[i];
-                        listHolder_0->mList[i].failSafeExpiryLengthMs = element_0.failSafeExpiryLengthMs.unsignedIntValue;
+                        auto element_0 = (CHIPGeneralCommissioningClusterBasicCommissioningInfoType *) value[i_0];
+                        listHolder_0->mList[i_0].failSafeExpiryLengthMs = element_0.failSafeExpiryLengthMs.unsignedIntValue;
                     }
-                    cppValue = ListType(listHolder_0->mList, value.count);
+                    cppValue = ListType_0(listHolder_0->mList, value.count);
                 } else {
-                    cppValue = ListType();
+                    cppValue = ListType_0();
                 }
             }
             auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
@@ -3273,33 +3275,34 @@ using namespace chip::app::Clusters;
             using TypeInfo = GeneralDiagnostics::Attributes::NetworkInterfaces::TypeInfo;
             TypeInfo::Type cppValue;
             {
-                using ListType = std::remove_reference_t<decltype(cppValue)>;
-                using ListMemberType = ListMemberTypeGetter<ListType>::Type;
+                using ListType_0 = std::remove_reference_t<decltype(cppValue)>;
+                using ListMemberType_0 = ListMemberTypeGetter<ListType_0>::Type;
                 if (value.count != 0) {
-                    auto * listHolder_0 = new ListHolder<ListMemberType>(value.count);
+                    auto * listHolder_0 = new ListHolder<ListMemberType_0>(value.count);
                     if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
                         return CHIP_ERROR_INVALID_ARGUMENT;
                     }
                     listFreer.add(listHolder_0);
-                    for (size_t i = 0; i < value.count; ++i) {
-                        if (![value[i] isKindOfClass:[CHIPGeneralDiagnosticsClusterNetworkInterfaceType class]]) {
+                    for (size_t i_0 = 0; i_0 < value.count; ++i_0) {
+                        if (![value[i_0] isKindOfClass:[CHIPGeneralDiagnosticsClusterNetworkInterfaceType class]]) {
                             // Wrong kind of value.
                             return CHIP_ERROR_INVALID_ARGUMENT;
                         }
-                        auto element_0 = (CHIPGeneralDiagnosticsClusterNetworkInterfaceType *) value[i];
-                        listHolder_0->mList[i].name = [self asCharSpan:element_0.name];
-                        listHolder_0->mList[i].fabricConnected = element_0.fabricConnected.boolValue;
-                        listHolder_0->mList[i].offPremiseServicesReachableIPv4
+                        auto element_0 = (CHIPGeneralDiagnosticsClusterNetworkInterfaceType *) value[i_0];
+                        listHolder_0->mList[i_0].name = [self asCharSpan:element_0.name];
+                        listHolder_0->mList[i_0].fabricConnected = element_0.fabricConnected.boolValue;
+                        listHolder_0->mList[i_0].offPremiseServicesReachableIPv4
                             = element_0.offPremiseServicesReachableIPv4.boolValue;
-                        listHolder_0->mList[i].offPremiseServicesReachableIPv6
+                        listHolder_0->mList[i_0].offPremiseServicesReachableIPv6
                             = element_0.offPremiseServicesReachableIPv6.boolValue;
-                        listHolder_0->mList[i].hardwareAddress = [self asByteSpan:element_0.hardwareAddress];
-                        listHolder_0->mList[i].type = static_cast<std::remove_reference_t<decltype(listHolder_0->mList[i].type)>>(
-                            element_0.type.unsignedCharValue);
+                        listHolder_0->mList[i_0].hardwareAddress = [self asByteSpan:element_0.hardwareAddress];
+                        listHolder_0->mList[i_0].type
+                            = static_cast<std::remove_reference_t<decltype(listHolder_0->mList[i_0].type)>>(
+                                element_0.type.unsignedCharValue);
                     }
-                    cppValue = ListType(listHolder_0->mList, value.count);
+                    cppValue = ListType_0(listHolder_0->mList, value.count);
                 } else {
-                    cppValue = ListType();
+                    cppValue = ListType_0();
                 }
             }
             auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
@@ -3393,25 +3396,25 @@ using namespace chip::app::Clusters;
             using TypeInfo = GeneralDiagnostics::Attributes::ActiveHardwareFaults::TypeInfo;
             TypeInfo::Type cppValue;
             {
-                using ListType = std::remove_reference_t<decltype(cppValue)>;
-                using ListMemberType = ListMemberTypeGetter<ListType>::Type;
+                using ListType_0 = std::remove_reference_t<decltype(cppValue)>;
+                using ListMemberType_0 = ListMemberTypeGetter<ListType_0>::Type;
                 if (value.count != 0) {
-                    auto * listHolder_0 = new ListHolder<ListMemberType>(value.count);
+                    auto * listHolder_0 = new ListHolder<ListMemberType_0>(value.count);
                     if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
                         return CHIP_ERROR_INVALID_ARGUMENT;
                     }
                     listFreer.add(listHolder_0);
-                    for (size_t i = 0; i < value.count; ++i) {
-                        if (![value[i] isKindOfClass:[NSNumber class]]) {
+                    for (size_t i_0 = 0; i_0 < value.count; ++i_0) {
+                        if (![value[i_0] isKindOfClass:[NSNumber class]]) {
                             // Wrong kind of value.
                             return CHIP_ERROR_INVALID_ARGUMENT;
                         }
-                        auto element_0 = (NSNumber *) value[i];
-                        listHolder_0->mList[i] = element_0.unsignedCharValue;
+                        auto element_0 = (NSNumber *) value[i_0];
+                        listHolder_0->mList[i_0] = element_0.unsignedCharValue;
                     }
-                    cppValue = ListType(listHolder_0->mList, value.count);
+                    cppValue = ListType_0(listHolder_0->mList, value.count);
                 } else {
-                    cppValue = ListType();
+                    cppValue = ListType_0();
                 }
             }
             auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
@@ -3432,25 +3435,25 @@ using namespace chip::app::Clusters;
             using TypeInfo = GeneralDiagnostics::Attributes::ActiveRadioFaults::TypeInfo;
             TypeInfo::Type cppValue;
             {
-                using ListType = std::remove_reference_t<decltype(cppValue)>;
-                using ListMemberType = ListMemberTypeGetter<ListType>::Type;
+                using ListType_0 = std::remove_reference_t<decltype(cppValue)>;
+                using ListMemberType_0 = ListMemberTypeGetter<ListType_0>::Type;
                 if (value.count != 0) {
-                    auto * listHolder_0 = new ListHolder<ListMemberType>(value.count);
+                    auto * listHolder_0 = new ListHolder<ListMemberType_0>(value.count);
                     if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
                         return CHIP_ERROR_INVALID_ARGUMENT;
                     }
                     listFreer.add(listHolder_0);
-                    for (size_t i = 0; i < value.count; ++i) {
-                        if (![value[i] isKindOfClass:[NSNumber class]]) {
+                    for (size_t i_0 = 0; i_0 < value.count; ++i_0) {
+                        if (![value[i_0] isKindOfClass:[NSNumber class]]) {
                             // Wrong kind of value.
                             return CHIP_ERROR_INVALID_ARGUMENT;
                         }
-                        auto element_0 = (NSNumber *) value[i];
-                        listHolder_0->mList[i] = element_0.unsignedCharValue;
+                        auto element_0 = (NSNumber *) value[i_0];
+                        listHolder_0->mList[i_0] = element_0.unsignedCharValue;
                     }
-                    cppValue = ListType(listHolder_0->mList, value.count);
+                    cppValue = ListType_0(listHolder_0->mList, value.count);
                 } else {
-                    cppValue = ListType();
+                    cppValue = ListType_0();
                 }
             }
             auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
@@ -3471,25 +3474,25 @@ using namespace chip::app::Clusters;
             using TypeInfo = GeneralDiagnostics::Attributes::ActiveNetworkFaults::TypeInfo;
             TypeInfo::Type cppValue;
             {
-                using ListType = std::remove_reference_t<decltype(cppValue)>;
-                using ListMemberType = ListMemberTypeGetter<ListType>::Type;
+                using ListType_0 = std::remove_reference_t<decltype(cppValue)>;
+                using ListMemberType_0 = ListMemberTypeGetter<ListType_0>::Type;
                 if (value.count != 0) {
-                    auto * listHolder_0 = new ListHolder<ListMemberType>(value.count);
+                    auto * listHolder_0 = new ListHolder<ListMemberType_0>(value.count);
                     if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
                         return CHIP_ERROR_INVALID_ARGUMENT;
                     }
                     listFreer.add(listHolder_0);
-                    for (size_t i = 0; i < value.count; ++i) {
-                        if (![value[i] isKindOfClass:[NSNumber class]]) {
+                    for (size_t i_0 = 0; i_0 < value.count; ++i_0) {
+                        if (![value[i_0] isKindOfClass:[NSNumber class]]) {
                             // Wrong kind of value.
                             return CHIP_ERROR_INVALID_ARGUMENT;
                         }
-                        auto element_0 = (NSNumber *) value[i];
-                        listHolder_0->mList[i] = element_0.unsignedCharValue;
+                        auto element_0 = (NSNumber *) value[i_0];
+                        listHolder_0->mList[i_0] = element_0.unsignedCharValue;
                     }
-                    cppValue = ListType(listHolder_0->mList, value.count);
+                    cppValue = ListType_0(listHolder_0->mList, value.count);
                 } else {
-                    cppValue = ListType();
+                    cppValue = ListType_0();
                 }
             }
             auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
@@ -3541,27 +3544,27 @@ using namespace chip::app::Clusters;
             using TypeInfo = GroupKeyManagement::Attributes::Groups::TypeInfo;
             TypeInfo::Type cppValue;
             {
-                using ListType = std::remove_reference_t<decltype(cppValue)>;
-                using ListMemberType = ListMemberTypeGetter<ListType>::Type;
+                using ListType_0 = std::remove_reference_t<decltype(cppValue)>;
+                using ListMemberType_0 = ListMemberTypeGetter<ListType_0>::Type;
                 if (value.count != 0) {
-                    auto * listHolder_0 = new ListHolder<ListMemberType>(value.count);
+                    auto * listHolder_0 = new ListHolder<ListMemberType_0>(value.count);
                     if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
                         return CHIP_ERROR_INVALID_ARGUMENT;
                     }
                     listFreer.add(listHolder_0);
-                    for (size_t i = 0; i < value.count; ++i) {
-                        if (![value[i] isKindOfClass:[CHIPGroupKeyManagementClusterGroupState class]]) {
+                    for (size_t i_0 = 0; i_0 < value.count; ++i_0) {
+                        if (![value[i_0] isKindOfClass:[CHIPGroupKeyManagementClusterGroupState class]]) {
                             // Wrong kind of value.
                             return CHIP_ERROR_INVALID_ARGUMENT;
                         }
-                        auto element_0 = (CHIPGroupKeyManagementClusterGroupState *) value[i];
-                        listHolder_0->mList[i].vendorId = element_0.vendorId.unsignedShortValue;
-                        listHolder_0->mList[i].vendorGroupId = element_0.vendorGroupId.unsignedShortValue;
-                        listHolder_0->mList[i].groupKeySetIndex = element_0.groupKeySetIndex.unsignedShortValue;
+                        auto element_0 = (CHIPGroupKeyManagementClusterGroupState *) value[i_0];
+                        listHolder_0->mList[i_0].vendorId = element_0.vendorId.unsignedShortValue;
+                        listHolder_0->mList[i_0].vendorGroupId = element_0.vendorGroupId.unsignedShortValue;
+                        listHolder_0->mList[i_0].groupKeySetIndex = element_0.groupKeySetIndex.unsignedShortValue;
                     }
-                    cppValue = ListType(listHolder_0->mList, value.count);
+                    cppValue = ListType_0(listHolder_0->mList, value.count);
                 } else {
-                    cppValue = ListType();
+                    cppValue = ListType_0();
                 }
             }
             auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
@@ -3582,31 +3585,31 @@ using namespace chip::app::Clusters;
             using TypeInfo = GroupKeyManagement::Attributes::GroupKeys::TypeInfo;
             TypeInfo::Type cppValue;
             {
-                using ListType = std::remove_reference_t<decltype(cppValue)>;
-                using ListMemberType = ListMemberTypeGetter<ListType>::Type;
+                using ListType_0 = std::remove_reference_t<decltype(cppValue)>;
+                using ListMemberType_0 = ListMemberTypeGetter<ListType_0>::Type;
                 if (value.count != 0) {
-                    auto * listHolder_0 = new ListHolder<ListMemberType>(value.count);
+                    auto * listHolder_0 = new ListHolder<ListMemberType_0>(value.count);
                     if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
                         return CHIP_ERROR_INVALID_ARGUMENT;
                     }
                     listFreer.add(listHolder_0);
-                    for (size_t i = 0; i < value.count; ++i) {
-                        if (![value[i] isKindOfClass:[CHIPGroupKeyManagementClusterGroupKey class]]) {
+                    for (size_t i_0 = 0; i_0 < value.count; ++i_0) {
+                        if (![value[i_0] isKindOfClass:[CHIPGroupKeyManagementClusterGroupKey class]]) {
                             // Wrong kind of value.
                             return CHIP_ERROR_INVALID_ARGUMENT;
                         }
-                        auto element_0 = (CHIPGroupKeyManagementClusterGroupKey *) value[i];
-                        listHolder_0->mList[i].vendorId = element_0.vendorId.unsignedShortValue;
-                        listHolder_0->mList[i].groupKeyIndex = element_0.groupKeyIndex.unsignedShortValue;
-                        listHolder_0->mList[i].groupKeyRoot = [self asByteSpan:element_0.groupKeyRoot];
-                        listHolder_0->mList[i].groupKeyEpochStartTime = element_0.groupKeyEpochStartTime.unsignedLongLongValue;
-                        listHolder_0->mList[i].groupKeySecurityPolicy
-                            = static_cast<std::remove_reference_t<decltype(listHolder_0->mList[i].groupKeySecurityPolicy)>>(
+                        auto element_0 = (CHIPGroupKeyManagementClusterGroupKey *) value[i_0];
+                        listHolder_0->mList[i_0].vendorId = element_0.vendorId.unsignedShortValue;
+                        listHolder_0->mList[i_0].groupKeyIndex = element_0.groupKeyIndex.unsignedShortValue;
+                        listHolder_0->mList[i_0].groupKeyRoot = [self asByteSpan:element_0.groupKeyRoot];
+                        listHolder_0->mList[i_0].groupKeyEpochStartTime = element_0.groupKeyEpochStartTime.unsignedLongLongValue;
+                        listHolder_0->mList[i_0].groupKeySecurityPolicy
+                            = static_cast<std::remove_reference_t<decltype(listHolder_0->mList[i_0].groupKeySecurityPolicy)>>(
                                 element_0.groupKeySecurityPolicy.unsignedCharValue);
                     }
-                    cppValue = ListType(listHolder_0->mList, value.count);
+                    cppValue = ListType_0(listHolder_0->mList, value.count);
                 } else {
-                    cppValue = ListType();
+                    cppValue = ListType_0();
                 }
             }
             auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
@@ -4116,30 +4119,30 @@ using namespace chip::app::Clusters;
             using TypeInfo = MediaInput::Attributes::MediaInputList::TypeInfo;
             TypeInfo::Type cppValue;
             {
-                using ListType = std::remove_reference_t<decltype(cppValue)>;
-                using ListMemberType = ListMemberTypeGetter<ListType>::Type;
+                using ListType_0 = std::remove_reference_t<decltype(cppValue)>;
+                using ListMemberType_0 = ListMemberTypeGetter<ListType_0>::Type;
                 if (value.count != 0) {
-                    auto * listHolder_0 = new ListHolder<ListMemberType>(value.count);
+                    auto * listHolder_0 = new ListHolder<ListMemberType_0>(value.count);
                     if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
                         return CHIP_ERROR_INVALID_ARGUMENT;
                     }
                     listFreer.add(listHolder_0);
-                    for (size_t i = 0; i < value.count; ++i) {
-                        if (![value[i] isKindOfClass:[CHIPMediaInputClusterMediaInputInfo class]]) {
+                    for (size_t i_0 = 0; i_0 < value.count; ++i_0) {
+                        if (![value[i_0] isKindOfClass:[CHIPMediaInputClusterMediaInputInfo class]]) {
                             // Wrong kind of value.
                             return CHIP_ERROR_INVALID_ARGUMENT;
                         }
-                        auto element_0 = (CHIPMediaInputClusterMediaInputInfo *) value[i];
-                        listHolder_0->mList[i].index = element_0.index.unsignedCharValue;
-                        listHolder_0->mList[i].inputType
-                            = static_cast<std::remove_reference_t<decltype(listHolder_0->mList[i].inputType)>>(
+                        auto element_0 = (CHIPMediaInputClusterMediaInputInfo *) value[i_0];
+                        listHolder_0->mList[i_0].index = element_0.index.unsignedCharValue;
+                        listHolder_0->mList[i_0].inputType
+                            = static_cast<std::remove_reference_t<decltype(listHolder_0->mList[i_0].inputType)>>(
                                 element_0.inputType.unsignedCharValue);
-                        listHolder_0->mList[i].name = [self asCharSpan:element_0.name];
-                        listHolder_0->mList[i].description = [self asCharSpan:element_0.descriptionString];
+                        listHolder_0->mList[i_0].name = [self asCharSpan:element_0.name];
+                        listHolder_0->mList[i_0].description = [self asCharSpan:element_0.descriptionString];
                     }
-                    cppValue = ListType(listHolder_0->mList, value.count);
+                    cppValue = ListType_0(listHolder_0->mList, value.count);
                 } else {
-                    cppValue = ListType();
+                    cppValue = ListType_0();
                 }
             }
             auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
@@ -4402,27 +4405,27 @@ using namespace chip::app::Clusters;
             using TypeInfo = ModeSelect::Attributes::SupportedModes::TypeInfo;
             TypeInfo::Type cppValue;
             {
-                using ListType = std::remove_reference_t<decltype(cppValue)>;
-                using ListMemberType = ListMemberTypeGetter<ListType>::Type;
+                using ListType_0 = std::remove_reference_t<decltype(cppValue)>;
+                using ListMemberType_0 = ListMemberTypeGetter<ListType_0>::Type;
                 if (value.count != 0) {
-                    auto * listHolder_0 = new ListHolder<ListMemberType>(value.count);
+                    auto * listHolder_0 = new ListHolder<ListMemberType_0>(value.count);
                     if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
                         return CHIP_ERROR_INVALID_ARGUMENT;
                     }
                     listFreer.add(listHolder_0);
-                    for (size_t i = 0; i < value.count; ++i) {
-                        if (![value[i] isKindOfClass:[CHIPModeSelectClusterModeOptionStruct class]]) {
+                    for (size_t i_0 = 0; i_0 < value.count; ++i_0) {
+                        if (![value[i_0] isKindOfClass:[CHIPModeSelectClusterModeOptionStruct class]]) {
                             // Wrong kind of value.
                             return CHIP_ERROR_INVALID_ARGUMENT;
                         }
-                        auto element_0 = (CHIPModeSelectClusterModeOptionStruct *) value[i];
-                        listHolder_0->mList[i].label = [self asCharSpan:element_0.label];
-                        listHolder_0->mList[i].mode = element_0.mode.unsignedCharValue;
-                        listHolder_0->mList[i].semanticTag = element_0.semanticTag.unsignedIntValue;
+                        auto element_0 = (CHIPModeSelectClusterModeOptionStruct *) value[i_0];
+                        listHolder_0->mList[i_0].label = [self asCharSpan:element_0.label];
+                        listHolder_0->mList[i_0].mode = element_0.mode.unsignedCharValue;
+                        listHolder_0->mList[i_0].semanticTag = element_0.semanticTag.unsignedIntValue;
                     }
-                    cppValue = ListType(listHolder_0->mList, value.count);
+                    cppValue = ListType_0(listHolder_0->mList, value.count);
                 } else {
-                    cppValue = ListType();
+                    cppValue = ListType_0();
                 }
             }
             auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
@@ -4859,30 +4862,30 @@ using namespace chip::app::Clusters;
             using TypeInfo = OperationalCredentials::Attributes::FabricsList::TypeInfo;
             TypeInfo::Type cppValue;
             {
-                using ListType = std::remove_reference_t<decltype(cppValue)>;
-                using ListMemberType = ListMemberTypeGetter<ListType>::Type;
+                using ListType_0 = std::remove_reference_t<decltype(cppValue)>;
+                using ListMemberType_0 = ListMemberTypeGetter<ListType_0>::Type;
                 if (value.count != 0) {
-                    auto * listHolder_0 = new ListHolder<ListMemberType>(value.count);
+                    auto * listHolder_0 = new ListHolder<ListMemberType_0>(value.count);
                     if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
                         return CHIP_ERROR_INVALID_ARGUMENT;
                     }
                     listFreer.add(listHolder_0);
-                    for (size_t i = 0; i < value.count; ++i) {
-                        if (![value[i] isKindOfClass:[CHIPOperationalCredentialsClusterFabricDescriptor class]]) {
+                    for (size_t i_0 = 0; i_0 < value.count; ++i_0) {
+                        if (![value[i_0] isKindOfClass:[CHIPOperationalCredentialsClusterFabricDescriptor class]]) {
                             // Wrong kind of value.
                             return CHIP_ERROR_INVALID_ARGUMENT;
                         }
-                        auto element_0 = (CHIPOperationalCredentialsClusterFabricDescriptor *) value[i];
-                        listHolder_0->mList[i].fabricIndex = element_0.fabricIndex.unsignedCharValue;
-                        listHolder_0->mList[i].rootPublicKey = [self asByteSpan:element_0.rootPublicKey];
-                        listHolder_0->mList[i].vendorId = element_0.vendorId.unsignedShortValue;
-                        listHolder_0->mList[i].fabricId = element_0.fabricId.unsignedLongLongValue;
-                        listHolder_0->mList[i].nodeId = element_0.nodeId.unsignedLongLongValue;
-                        listHolder_0->mList[i].label = [self asCharSpan:element_0.label];
+                        auto element_0 = (CHIPOperationalCredentialsClusterFabricDescriptor *) value[i_0];
+                        listHolder_0->mList[i_0].fabricIndex = element_0.fabricIndex.unsignedCharValue;
+                        listHolder_0->mList[i_0].rootPublicKey = [self asByteSpan:element_0.rootPublicKey];
+                        listHolder_0->mList[i_0].vendorId = element_0.vendorId.unsignedShortValue;
+                        listHolder_0->mList[i_0].fabricId = element_0.fabricId.unsignedLongLongValue;
+                        listHolder_0->mList[i_0].nodeId = element_0.nodeId.unsignedLongLongValue;
+                        listHolder_0->mList[i_0].label = [self asCharSpan:element_0.label];
                     }
-                    cppValue = ListType(listHolder_0->mList, value.count);
+                    cppValue = ListType_0(listHolder_0->mList, value.count);
                 } else {
-                    cppValue = ListType();
+                    cppValue = ListType_0();
                 }
             }
             auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
@@ -4940,25 +4943,25 @@ using namespace chip::app::Clusters;
             using TypeInfo = OperationalCredentials::Attributes::TrustedRootCertificates::TypeInfo;
             TypeInfo::Type cppValue;
             {
-                using ListType = std::remove_reference_t<decltype(cppValue)>;
-                using ListMemberType = ListMemberTypeGetter<ListType>::Type;
+                using ListType_0 = std::remove_reference_t<decltype(cppValue)>;
+                using ListMemberType_0 = ListMemberTypeGetter<ListType_0>::Type;
                 if (value.count != 0) {
-                    auto * listHolder_0 = new ListHolder<ListMemberType>(value.count);
+                    auto * listHolder_0 = new ListHolder<ListMemberType_0>(value.count);
                     if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
                         return CHIP_ERROR_INVALID_ARGUMENT;
                     }
                     listFreer.add(listHolder_0);
-                    for (size_t i = 0; i < value.count; ++i) {
-                        if (![value[i] isKindOfClass:[NSData class]]) {
+                    for (size_t i_0 = 0; i_0 < value.count; ++i_0) {
+                        if (![value[i_0] isKindOfClass:[NSData class]]) {
                             // Wrong kind of value.
                             return CHIP_ERROR_INVALID_ARGUMENT;
                         }
-                        auto element_0 = (NSData *) value[i];
-                        listHolder_0->mList[i] = [self asByteSpan:element_0];
+                        auto element_0 = (NSData *) value[i_0];
+                        listHolder_0->mList[i_0] = [self asByteSpan:element_0];
                     }
-                    cppValue = ListType(listHolder_0->mList, value.count);
+                    cppValue = ListType_0(listHolder_0->mList, value.count);
                 } else {
-                    cppValue = ListType();
+                    cppValue = ListType_0();
                 }
             }
             auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
@@ -5155,25 +5158,25 @@ using namespace chip::app::Clusters;
             using TypeInfo = PowerSource::Attributes::ActiveBatteryFaults::TypeInfo;
             TypeInfo::Type cppValue;
             {
-                using ListType = std::remove_reference_t<decltype(cppValue)>;
-                using ListMemberType = ListMemberTypeGetter<ListType>::Type;
+                using ListType_0 = std::remove_reference_t<decltype(cppValue)>;
+                using ListMemberType_0 = ListMemberTypeGetter<ListType_0>::Type;
                 if (value.count != 0) {
-                    auto * listHolder_0 = new ListHolder<ListMemberType>(value.count);
+                    auto * listHolder_0 = new ListHolder<ListMemberType_0>(value.count);
                     if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
                         return CHIP_ERROR_INVALID_ARGUMENT;
                     }
                     listFreer.add(listHolder_0);
-                    for (size_t i = 0; i < value.count; ++i) {
-                        if (![value[i] isKindOfClass:[NSNumber class]]) {
+                    for (size_t i_0 = 0; i_0 < value.count; ++i_0) {
+                        if (![value[i_0] isKindOfClass:[NSNumber class]]) {
                             // Wrong kind of value.
                             return CHIP_ERROR_INVALID_ARGUMENT;
                         }
-                        auto element_0 = (NSNumber *) value[i];
-                        listHolder_0->mList[i] = element_0.unsignedCharValue;
+                        auto element_0 = (NSNumber *) value[i_0];
+                        listHolder_0->mList[i_0] = element_0.unsignedCharValue;
                     }
-                    cppValue = ListType(listHolder_0->mList, value.count);
+                    cppValue = ListType_0(listHolder_0->mList, value.count);
                 } else {
-                    cppValue = ListType();
+                    cppValue = ListType_0();
                 }
             }
             auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
@@ -5981,29 +5984,29 @@ using namespace chip::app::Clusters;
             using TypeInfo = SoftwareDiagnostics::Attributes::ThreadMetrics::TypeInfo;
             TypeInfo::Type cppValue;
             {
-                using ListType = std::remove_reference_t<decltype(cppValue)>;
-                using ListMemberType = ListMemberTypeGetter<ListType>::Type;
+                using ListType_0 = std::remove_reference_t<decltype(cppValue)>;
+                using ListMemberType_0 = ListMemberTypeGetter<ListType_0>::Type;
                 if (value.count != 0) {
-                    auto * listHolder_0 = new ListHolder<ListMemberType>(value.count);
+                    auto * listHolder_0 = new ListHolder<ListMemberType_0>(value.count);
                     if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
                         return CHIP_ERROR_INVALID_ARGUMENT;
                     }
                     listFreer.add(listHolder_0);
-                    for (size_t i = 0; i < value.count; ++i) {
-                        if (![value[i] isKindOfClass:[CHIPSoftwareDiagnosticsClusterThreadMetrics class]]) {
+                    for (size_t i_0 = 0; i_0 < value.count; ++i_0) {
+                        if (![value[i_0] isKindOfClass:[CHIPSoftwareDiagnosticsClusterThreadMetrics class]]) {
                             // Wrong kind of value.
                             return CHIP_ERROR_INVALID_ARGUMENT;
                         }
-                        auto element_0 = (CHIPSoftwareDiagnosticsClusterThreadMetrics *) value[i];
-                        listHolder_0->mList[i].id = element_0.id.unsignedLongLongValue;
-                        listHolder_0->mList[i].name = [self asCharSpan:element_0.name];
-                        listHolder_0->mList[i].stackFreeCurrent = element_0.stackFreeCurrent.unsignedIntValue;
-                        listHolder_0->mList[i].stackFreeMinimum = element_0.stackFreeMinimum.unsignedIntValue;
-                        listHolder_0->mList[i].stackSize = element_0.stackSize.unsignedIntValue;
+                        auto element_0 = (CHIPSoftwareDiagnosticsClusterThreadMetrics *) value[i_0];
+                        listHolder_0->mList[i_0].id = element_0.id.unsignedLongLongValue;
+                        listHolder_0->mList[i_0].name = [self asCharSpan:element_0.name];
+                        listHolder_0->mList[i_0].stackFreeCurrent = element_0.stackFreeCurrent.unsignedIntValue;
+                        listHolder_0->mList[i_0].stackFreeMinimum = element_0.stackFreeMinimum.unsignedIntValue;
+                        listHolder_0->mList[i_0].stackSize = element_0.stackSize.unsignedIntValue;
                     }
-                    cppValue = ListType(listHolder_0->mList, value.count);
+                    cppValue = ListType_0(listHolder_0->mList, value.count);
                 } else {
-                    cppValue = ListType();
+                    cppValue = ListType_0();
                 }
             }
             auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
@@ -6231,29 +6234,29 @@ using namespace chip::app::Clusters;
             using TypeInfo = TvChannel::Attributes::TvChannelList::TypeInfo;
             TypeInfo::Type cppValue;
             {
-                using ListType = std::remove_reference_t<decltype(cppValue)>;
-                using ListMemberType = ListMemberTypeGetter<ListType>::Type;
+                using ListType_0 = std::remove_reference_t<decltype(cppValue)>;
+                using ListMemberType_0 = ListMemberTypeGetter<ListType_0>::Type;
                 if (value.count != 0) {
-                    auto * listHolder_0 = new ListHolder<ListMemberType>(value.count);
+                    auto * listHolder_0 = new ListHolder<ListMemberType_0>(value.count);
                     if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
                         return CHIP_ERROR_INVALID_ARGUMENT;
                     }
                     listFreer.add(listHolder_0);
-                    for (size_t i = 0; i < value.count; ++i) {
-                        if (![value[i] isKindOfClass:[CHIPTvChannelClusterTvChannelInfo class]]) {
+                    for (size_t i_0 = 0; i_0 < value.count; ++i_0) {
+                        if (![value[i_0] isKindOfClass:[CHIPTvChannelClusterTvChannelInfo class]]) {
                             // Wrong kind of value.
                             return CHIP_ERROR_INVALID_ARGUMENT;
                         }
-                        auto element_0 = (CHIPTvChannelClusterTvChannelInfo *) value[i];
-                        listHolder_0->mList[i].majorNumber = element_0.majorNumber.unsignedShortValue;
-                        listHolder_0->mList[i].minorNumber = element_0.minorNumber.unsignedShortValue;
-                        listHolder_0->mList[i].name = [self asCharSpan:element_0.name];
-                        listHolder_0->mList[i].callSign = [self asCharSpan:element_0.callSign];
-                        listHolder_0->mList[i].affiliateCallSign = [self asCharSpan:element_0.affiliateCallSign];
+                        auto element_0 = (CHIPTvChannelClusterTvChannelInfo *) value[i_0];
+                        listHolder_0->mList[i_0].majorNumber = element_0.majorNumber.unsignedShortValue;
+                        listHolder_0->mList[i_0].minorNumber = element_0.minorNumber.unsignedShortValue;
+                        listHolder_0->mList[i_0].name = [self asCharSpan:element_0.name];
+                        listHolder_0->mList[i_0].callSign = [self asCharSpan:element_0.callSign];
+                        listHolder_0->mList[i_0].affiliateCallSign = [self asCharSpan:element_0.affiliateCallSign];
                     }
-                    cppValue = ListType(listHolder_0->mList, value.count);
+                    cppValue = ListType_0(listHolder_0->mList, value.count);
                 } else {
-                    cppValue = ListType();
+                    cppValue = ListType_0();
                 }
             }
             auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
@@ -6341,26 +6344,26 @@ using namespace chip::app::Clusters;
             using TypeInfo = TargetNavigator::Attributes::TargetNavigatorList::TypeInfo;
             TypeInfo::Type cppValue;
             {
-                using ListType = std::remove_reference_t<decltype(cppValue)>;
-                using ListMemberType = ListMemberTypeGetter<ListType>::Type;
+                using ListType_0 = std::remove_reference_t<decltype(cppValue)>;
+                using ListMemberType_0 = ListMemberTypeGetter<ListType_0>::Type;
                 if (value.count != 0) {
-                    auto * listHolder_0 = new ListHolder<ListMemberType>(value.count);
+                    auto * listHolder_0 = new ListHolder<ListMemberType_0>(value.count);
                     if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
                         return CHIP_ERROR_INVALID_ARGUMENT;
                     }
                     listFreer.add(listHolder_0);
-                    for (size_t i = 0; i < value.count; ++i) {
-                        if (![value[i] isKindOfClass:[CHIPTargetNavigatorClusterNavigateTargetTargetInfo class]]) {
+                    for (size_t i_0 = 0; i_0 < value.count; ++i_0) {
+                        if (![value[i_0] isKindOfClass:[CHIPTargetNavigatorClusterNavigateTargetTargetInfo class]]) {
                             // Wrong kind of value.
                             return CHIP_ERROR_INVALID_ARGUMENT;
                         }
-                        auto element_0 = (CHIPTargetNavigatorClusterNavigateTargetTargetInfo *) value[i];
-                        listHolder_0->mList[i].identifier = element_0.identifier.unsignedCharValue;
-                        listHolder_0->mList[i].name = [self asCharSpan:element_0.name];
+                        auto element_0 = (CHIPTargetNavigatorClusterNavigateTargetTargetInfo *) value[i_0];
+                        listHolder_0->mList[i_0].identifier = element_0.identifier.unsignedCharValue;
+                        listHolder_0->mList[i_0].name = [self asCharSpan:element_0.name];
                     }
-                    cppValue = ListType(listHolder_0->mList, value.count);
+                    cppValue = ListType_0(listHolder_0->mList, value.count);
                 } else {
-                    cppValue = ListType();
+                    cppValue = ListType_0();
                 }
             }
             auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
@@ -6516,32 +6519,32 @@ using namespace chip::app::Clusters;
             using TypeInfo = TestCluster::Attributes::ListNullablesAndOptionalsStruct::TypeInfo;
             TypeInfo::Type cppValue;
             {
-                using ListType = std::remove_reference_t<decltype(cppValue)>;
-                using ListMemberType = ListMemberTypeGetter<ListType>::Type;
+                using ListType_0 = std::remove_reference_t<decltype(cppValue)>;
+                using ListMemberType_0 = ListMemberTypeGetter<ListType_0>::Type;
                 if (value.count != 0) {
-                    auto * listHolder_0 = new ListHolder<ListMemberType>(value.count);
+                    auto * listHolder_0 = new ListHolder<ListMemberType_0>(value.count);
                     if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
                         return CHIP_ERROR_INVALID_ARGUMENT;
                     }
                     listFreer.add(listHolder_0);
-                    for (size_t i = 0; i < value.count; ++i) {
-                        if (![value[i] isKindOfClass:[CHIPTestClusterClusterNullablesAndOptionalsStruct class]]) {
+                    for (size_t i_0 = 0; i_0 < value.count; ++i_0) {
+                        if (![value[i_0] isKindOfClass:[CHIPTestClusterClusterNullablesAndOptionalsStruct class]]) {
                             // Wrong kind of value.
                             return CHIP_ERROR_INVALID_ARGUMENT;
                         }
-                        auto element_0 = (CHIPTestClusterClusterNullablesAndOptionalsStruct *) value[i];
+                        auto element_0 = (CHIPTestClusterClusterNullablesAndOptionalsStruct *) value[i_0];
                         if (element_0.nullableInt == nil) {
-                            listHolder_0->mList[i].nullableInt.SetNull();
+                            listHolder_0->mList[i_0].nullableInt.SetNull();
                         } else {
-                            auto & nonNullValue_2 = listHolder_0->mList[i].nullableInt.SetNonNull();
+                            auto & nonNullValue_2 = listHolder_0->mList[i_0].nullableInt.SetNonNull();
                             nonNullValue_2 = element_0.nullableInt.unsignedShortValue;
                         }
                         if (element_0.optionalInt != nil) {
-                            auto & definedValue_2 = listHolder_0->mList[i].optionalInt.Emplace();
+                            auto & definedValue_2 = listHolder_0->mList[i_0].optionalInt.Emplace();
                             definedValue_2 = element_0.optionalInt.unsignedShortValue;
                         }
                         if (element_0.nullableOptionalInt != nil) {
-                            auto & definedValue_2 = listHolder_0->mList[i].nullableOptionalInt.Emplace();
+                            auto & definedValue_2 = listHolder_0->mList[i_0].nullableOptionalInt.Emplace();
                             if (element_0.nullableOptionalInt == nil) {
                                 definedValue_2.SetNull();
                             } else {
@@ -6550,17 +6553,17 @@ using namespace chip::app::Clusters;
                             }
                         }
                         if (element_0.nullableString == nil) {
-                            listHolder_0->mList[i].nullableString.SetNull();
+                            listHolder_0->mList[i_0].nullableString.SetNull();
                         } else {
-                            auto & nonNullValue_2 = listHolder_0->mList[i].nullableString.SetNonNull();
+                            auto & nonNullValue_2 = listHolder_0->mList[i_0].nullableString.SetNonNull();
                             nonNullValue_2 = [self asCharSpan:element_0.nullableString];
                         }
                         if (element_0.optionalString != nil) {
-                            auto & definedValue_2 = listHolder_0->mList[i].optionalString.Emplace();
+                            auto & definedValue_2 = listHolder_0->mList[i_0].optionalString.Emplace();
                             definedValue_2 = [self asCharSpan:element_0.optionalString];
                         }
                         if (element_0.nullableOptionalString != nil) {
-                            auto & definedValue_2 = listHolder_0->mList[i].nullableOptionalString.Emplace();
+                            auto & definedValue_2 = listHolder_0->mList[i_0].nullableOptionalString.Emplace();
                             if (element_0.nullableOptionalString == nil) {
                                 definedValue_2.SetNull();
                             } else {
@@ -6569,9 +6572,9 @@ using namespace chip::app::Clusters;
                             }
                         }
                         if (element_0.nullableStruct == nil) {
-                            listHolder_0->mList[i].nullableStruct.SetNull();
+                            listHolder_0->mList[i_0].nullableStruct.SetNull();
                         } else {
-                            auto & nonNullValue_2 = listHolder_0->mList[i].nullableStruct.SetNonNull();
+                            auto & nonNullValue_2 = listHolder_0->mList[i_0].nullableStruct.SetNonNull();
                             nonNullValue_2.a = element_0.nullableStruct.a.unsignedCharValue;
                             nonNullValue_2.b = element_0.nullableStruct.b.boolValue;
                             nonNullValue_2.c = static_cast<std::remove_reference_t<decltype(nonNullValue_2.c)>>(
@@ -6584,7 +6587,7 @@ using namespace chip::app::Clusters;
                             nonNullValue_2.h = element_0.nullableStruct.h.doubleValue;
                         }
                         if (element_0.optionalStruct != nil) {
-                            auto & definedValue_2 = listHolder_0->mList[i].optionalStruct.Emplace();
+                            auto & definedValue_2 = listHolder_0->mList[i_0].optionalStruct.Emplace();
                             definedValue_2.a = element_0.optionalStruct.a.unsignedCharValue;
                             definedValue_2.b = element_0.optionalStruct.b.boolValue;
                             definedValue_2.c = static_cast<std::remove_reference_t<decltype(definedValue_2.c)>>(
@@ -6597,7 +6600,7 @@ using namespace chip::app::Clusters;
                             definedValue_2.h = element_0.optionalStruct.h.doubleValue;
                         }
                         if (element_0.nullableOptionalStruct != nil) {
-                            auto & definedValue_2 = listHolder_0->mList[i].nullableOptionalStruct.Emplace();
+                            auto & definedValue_2 = listHolder_0->mList[i_0].nullableOptionalStruct.Emplace();
                             if (element_0.nullableOptionalStruct == nil) {
                                 definedValue_2.SetNull();
                             } else {
@@ -6615,97 +6618,98 @@ using namespace chip::app::Clusters;
                             }
                         }
                         if (element_0.nullableList == nil) {
-                            listHolder_0->mList[i].nullableList.SetNull();
+                            listHolder_0->mList[i_0].nullableList.SetNull();
                         } else {
-                            auto & nonNullValue_2 = listHolder_0->mList[i].nullableList.SetNonNull();
+                            auto & nonNullValue_2 = listHolder_0->mList[i_0].nullableList.SetNonNull();
                             {
-                                using ListType = std::remove_reference_t<decltype(nonNullValue_2)>;
-                                using ListMemberType = ListMemberTypeGetter<ListType>::Type;
+                                using ListType_3 = std::remove_reference_t<decltype(nonNullValue_2)>;
+                                using ListMemberType_3 = ListMemberTypeGetter<ListType_3>::Type;
                                 if (element_0.nullableList.count != 0) {
-                                    auto * listHolder_3 = new ListHolder<ListMemberType>(element_0.nullableList.count);
+                                    auto * listHolder_3 = new ListHolder<ListMemberType_3>(element_0.nullableList.count);
                                     if (listHolder_3 == nullptr || listHolder_3->mList == nullptr) {
                                         return CHIP_ERROR_INVALID_ARGUMENT;
                                     }
                                     listFreer.add(listHolder_3);
-                                    for (size_t i = 0; i < element_0.nullableList.count; ++i) {
-                                        if (![element_0.nullableList[i] isKindOfClass:[NSNumber class]]) {
+                                    for (size_t i_3 = 0; i_3 < element_0.nullableList.count; ++i_3) {
+                                        if (![element_0.nullableList[i_3] isKindOfClass:[NSNumber class]]) {
                                             // Wrong kind of value.
                                             return CHIP_ERROR_INVALID_ARGUMENT;
                                         }
-                                        auto element_3 = (NSNumber *) element_0.nullableList[i];
-                                        listHolder_3->mList[i]
-                                            = static_cast<std::remove_reference_t<decltype(listHolder_3->mList[i])>>(
+                                        auto element_3 = (NSNumber *) element_0.nullableList[i_3];
+                                        listHolder_3->mList[i_3]
+                                            = static_cast<std::remove_reference_t<decltype(listHolder_3->mList[i_3])>>(
                                                 element_3.unsignedCharValue);
                                     }
-                                    nonNullValue_2 = ListType(listHolder_3->mList, element_0.nullableList.count);
+                                    nonNullValue_2 = ListType_3(listHolder_3->mList, element_0.nullableList.count);
                                 } else {
-                                    nonNullValue_2 = ListType();
+                                    nonNullValue_2 = ListType_3();
                                 }
                             }
                         }
                         if (element_0.optionalList != nil) {
-                            auto & definedValue_2 = listHolder_0->mList[i].optionalList.Emplace();
+                            auto & definedValue_2 = listHolder_0->mList[i_0].optionalList.Emplace();
                             {
-                                using ListType = std::remove_reference_t<decltype(definedValue_2)>;
-                                using ListMemberType = ListMemberTypeGetter<ListType>::Type;
+                                using ListType_3 = std::remove_reference_t<decltype(definedValue_2)>;
+                                using ListMemberType_3 = ListMemberTypeGetter<ListType_3>::Type;
                                 if (element_0.optionalList.count != 0) {
-                                    auto * listHolder_3 = new ListHolder<ListMemberType>(element_0.optionalList.count);
+                                    auto * listHolder_3 = new ListHolder<ListMemberType_3>(element_0.optionalList.count);
                                     if (listHolder_3 == nullptr || listHolder_3->mList == nullptr) {
                                         return CHIP_ERROR_INVALID_ARGUMENT;
                                     }
                                     listFreer.add(listHolder_3);
-                                    for (size_t i = 0; i < element_0.optionalList.count; ++i) {
-                                        if (![element_0.optionalList[i] isKindOfClass:[NSNumber class]]) {
+                                    for (size_t i_3 = 0; i_3 < element_0.optionalList.count; ++i_3) {
+                                        if (![element_0.optionalList[i_3] isKindOfClass:[NSNumber class]]) {
                                             // Wrong kind of value.
                                             return CHIP_ERROR_INVALID_ARGUMENT;
                                         }
-                                        auto element_3 = (NSNumber *) element_0.optionalList[i];
-                                        listHolder_3->mList[i]
-                                            = static_cast<std::remove_reference_t<decltype(listHolder_3->mList[i])>>(
+                                        auto element_3 = (NSNumber *) element_0.optionalList[i_3];
+                                        listHolder_3->mList[i_3]
+                                            = static_cast<std::remove_reference_t<decltype(listHolder_3->mList[i_3])>>(
                                                 element_3.unsignedCharValue);
                                     }
-                                    definedValue_2 = ListType(listHolder_3->mList, element_0.optionalList.count);
+                                    definedValue_2 = ListType_3(listHolder_3->mList, element_0.optionalList.count);
                                 } else {
-                                    definedValue_2 = ListType();
+                                    definedValue_2 = ListType_3();
                                 }
                             }
                         }
                         if (element_0.nullableOptionalList != nil) {
-                            auto & definedValue_2 = listHolder_0->mList[i].nullableOptionalList.Emplace();
+                            auto & definedValue_2 = listHolder_0->mList[i_0].nullableOptionalList.Emplace();
                             if (element_0.nullableOptionalList == nil) {
                                 definedValue_2.SetNull();
                             } else {
                                 auto & nonNullValue_3 = definedValue_2.SetNonNull();
                                 {
-                                    using ListType = std::remove_reference_t<decltype(nonNullValue_3)>;
-                                    using ListMemberType = ListMemberTypeGetter<ListType>::Type;
+                                    using ListType_4 = std::remove_reference_t<decltype(nonNullValue_3)>;
+                                    using ListMemberType_4 = ListMemberTypeGetter<ListType_4>::Type;
                                     if (element_0.nullableOptionalList.count != 0) {
-                                        auto * listHolder_4 = new ListHolder<ListMemberType>(element_0.nullableOptionalList.count);
+                                        auto * listHolder_4
+                                            = new ListHolder<ListMemberType_4>(element_0.nullableOptionalList.count);
                                         if (listHolder_4 == nullptr || listHolder_4->mList == nullptr) {
                                             return CHIP_ERROR_INVALID_ARGUMENT;
                                         }
                                         listFreer.add(listHolder_4);
-                                        for (size_t i = 0; i < element_0.nullableOptionalList.count; ++i) {
-                                            if (![element_0.nullableOptionalList[i] isKindOfClass:[NSNumber class]]) {
+                                        for (size_t i_4 = 0; i_4 < element_0.nullableOptionalList.count; ++i_4) {
+                                            if (![element_0.nullableOptionalList[i_4] isKindOfClass:[NSNumber class]]) {
                                                 // Wrong kind of value.
                                                 return CHIP_ERROR_INVALID_ARGUMENT;
                                             }
-                                            auto element_4 = (NSNumber *) element_0.nullableOptionalList[i];
-                                            listHolder_4->mList[i]
-                                                = static_cast<std::remove_reference_t<decltype(listHolder_4->mList[i])>>(
+                                            auto element_4 = (NSNumber *) element_0.nullableOptionalList[i_4];
+                                            listHolder_4->mList[i_4]
+                                                = static_cast<std::remove_reference_t<decltype(listHolder_4->mList[i_4])>>(
                                                     element_4.unsignedCharValue);
                                         }
-                                        nonNullValue_3 = ListType(listHolder_4->mList, element_0.nullableOptionalList.count);
+                                        nonNullValue_3 = ListType_4(listHolder_4->mList, element_0.nullableOptionalList.count);
                                     } else {
-                                        nonNullValue_3 = ListType();
+                                        nonNullValue_3 = ListType_4();
                                     }
                                 }
                             }
                         }
                     }
-                    cppValue = ListType(listHolder_0->mList, value.count);
+                    cppValue = ListType_0(listHolder_0->mList, value.count);
                 } else {
-                    cppValue = ListType();
+                    cppValue = ListType_0();
                 }
             }
             auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
@@ -7113,38 +7117,38 @@ using namespace chip::app::Clusters;
             using TypeInfo = ThreadNetworkDiagnostics::Attributes::NeighborTableList::TypeInfo;
             TypeInfo::Type cppValue;
             {
-                using ListType = std::remove_reference_t<decltype(cppValue)>;
-                using ListMemberType = ListMemberTypeGetter<ListType>::Type;
+                using ListType_0 = std::remove_reference_t<decltype(cppValue)>;
+                using ListMemberType_0 = ListMemberTypeGetter<ListType_0>::Type;
                 if (value.count != 0) {
-                    auto * listHolder_0 = new ListHolder<ListMemberType>(value.count);
+                    auto * listHolder_0 = new ListHolder<ListMemberType_0>(value.count);
                     if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
                         return CHIP_ERROR_INVALID_ARGUMENT;
                     }
                     listFreer.add(listHolder_0);
-                    for (size_t i = 0; i < value.count; ++i) {
-                        if (![value[i] isKindOfClass:[CHIPThreadNetworkDiagnosticsClusterNeighborTable class]]) {
+                    for (size_t i_0 = 0; i_0 < value.count; ++i_0) {
+                        if (![value[i_0] isKindOfClass:[CHIPThreadNetworkDiagnosticsClusterNeighborTable class]]) {
                             // Wrong kind of value.
                             return CHIP_ERROR_INVALID_ARGUMENT;
                         }
-                        auto element_0 = (CHIPThreadNetworkDiagnosticsClusterNeighborTable *) value[i];
-                        listHolder_0->mList[i].extAddress = element_0.extAddress.unsignedLongLongValue;
-                        listHolder_0->mList[i].age = element_0.age.unsignedIntValue;
-                        listHolder_0->mList[i].rloc16 = element_0.rloc16.unsignedShortValue;
-                        listHolder_0->mList[i].linkFrameCounter = element_0.linkFrameCounter.unsignedIntValue;
-                        listHolder_0->mList[i].mleFrameCounter = element_0.mleFrameCounter.unsignedIntValue;
-                        listHolder_0->mList[i].lqi = element_0.lqi.unsignedCharValue;
-                        listHolder_0->mList[i].averageRssi = element_0.averageRssi.charValue;
-                        listHolder_0->mList[i].lastRssi = element_0.lastRssi.charValue;
-                        listHolder_0->mList[i].frameErrorRate = element_0.frameErrorRate.unsignedCharValue;
-                        listHolder_0->mList[i].messageErrorRate = element_0.messageErrorRate.unsignedCharValue;
-                        listHolder_0->mList[i].rxOnWhenIdle = element_0.rxOnWhenIdle.boolValue;
-                        listHolder_0->mList[i].fullThreadDevice = element_0.fullThreadDevice.boolValue;
-                        listHolder_0->mList[i].fullNetworkData = element_0.fullNetworkData.boolValue;
-                        listHolder_0->mList[i].isChild = element_0.isChild.boolValue;
+                        auto element_0 = (CHIPThreadNetworkDiagnosticsClusterNeighborTable *) value[i_0];
+                        listHolder_0->mList[i_0].extAddress = element_0.extAddress.unsignedLongLongValue;
+                        listHolder_0->mList[i_0].age = element_0.age.unsignedIntValue;
+                        listHolder_0->mList[i_0].rloc16 = element_0.rloc16.unsignedShortValue;
+                        listHolder_0->mList[i_0].linkFrameCounter = element_0.linkFrameCounter.unsignedIntValue;
+                        listHolder_0->mList[i_0].mleFrameCounter = element_0.mleFrameCounter.unsignedIntValue;
+                        listHolder_0->mList[i_0].lqi = element_0.lqi.unsignedCharValue;
+                        listHolder_0->mList[i_0].averageRssi = element_0.averageRssi.charValue;
+                        listHolder_0->mList[i_0].lastRssi = element_0.lastRssi.charValue;
+                        listHolder_0->mList[i_0].frameErrorRate = element_0.frameErrorRate.unsignedCharValue;
+                        listHolder_0->mList[i_0].messageErrorRate = element_0.messageErrorRate.unsignedCharValue;
+                        listHolder_0->mList[i_0].rxOnWhenIdle = element_0.rxOnWhenIdle.boolValue;
+                        listHolder_0->mList[i_0].fullThreadDevice = element_0.fullThreadDevice.boolValue;
+                        listHolder_0->mList[i_0].fullNetworkData = element_0.fullNetworkData.boolValue;
+                        listHolder_0->mList[i_0].isChild = element_0.isChild.boolValue;
                     }
-                    cppValue = ListType(listHolder_0->mList, value.count);
+                    cppValue = ListType_0(listHolder_0->mList, value.count);
                 } else {
-                    cppValue = ListType();
+                    cppValue = ListType_0();
                 }
             }
             auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
@@ -7165,34 +7169,34 @@ using namespace chip::app::Clusters;
             using TypeInfo = ThreadNetworkDiagnostics::Attributes::RouteTableList::TypeInfo;
             TypeInfo::Type cppValue;
             {
-                using ListType = std::remove_reference_t<decltype(cppValue)>;
-                using ListMemberType = ListMemberTypeGetter<ListType>::Type;
+                using ListType_0 = std::remove_reference_t<decltype(cppValue)>;
+                using ListMemberType_0 = ListMemberTypeGetter<ListType_0>::Type;
                 if (value.count != 0) {
-                    auto * listHolder_0 = new ListHolder<ListMemberType>(value.count);
+                    auto * listHolder_0 = new ListHolder<ListMemberType_0>(value.count);
                     if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
                         return CHIP_ERROR_INVALID_ARGUMENT;
                     }
                     listFreer.add(listHolder_0);
-                    for (size_t i = 0; i < value.count; ++i) {
-                        if (![value[i] isKindOfClass:[CHIPThreadNetworkDiagnosticsClusterRouteTable class]]) {
+                    for (size_t i_0 = 0; i_0 < value.count; ++i_0) {
+                        if (![value[i_0] isKindOfClass:[CHIPThreadNetworkDiagnosticsClusterRouteTable class]]) {
                             // Wrong kind of value.
                             return CHIP_ERROR_INVALID_ARGUMENT;
                         }
-                        auto element_0 = (CHIPThreadNetworkDiagnosticsClusterRouteTable *) value[i];
-                        listHolder_0->mList[i].extAddress = element_0.extAddress.unsignedLongLongValue;
-                        listHolder_0->mList[i].rloc16 = element_0.rloc16.unsignedShortValue;
-                        listHolder_0->mList[i].routerId = element_0.routerId.unsignedCharValue;
-                        listHolder_0->mList[i].nextHop = element_0.nextHop.unsignedCharValue;
-                        listHolder_0->mList[i].pathCost = element_0.pathCost.unsignedCharValue;
-                        listHolder_0->mList[i].LQIIn = element_0.lqiIn.unsignedCharValue;
-                        listHolder_0->mList[i].LQIOut = element_0.lqiOut.unsignedCharValue;
-                        listHolder_0->mList[i].age = element_0.age.unsignedCharValue;
-                        listHolder_0->mList[i].allocated = element_0.allocated.boolValue;
-                        listHolder_0->mList[i].linkEstablished = element_0.linkEstablished.boolValue;
+                        auto element_0 = (CHIPThreadNetworkDiagnosticsClusterRouteTable *) value[i_0];
+                        listHolder_0->mList[i_0].extAddress = element_0.extAddress.unsignedLongLongValue;
+                        listHolder_0->mList[i_0].rloc16 = element_0.rloc16.unsignedShortValue;
+                        listHolder_0->mList[i_0].routerId = element_0.routerId.unsignedCharValue;
+                        listHolder_0->mList[i_0].nextHop = element_0.nextHop.unsignedCharValue;
+                        listHolder_0->mList[i_0].pathCost = element_0.pathCost.unsignedCharValue;
+                        listHolder_0->mList[i_0].LQIIn = element_0.lqiIn.unsignedCharValue;
+                        listHolder_0->mList[i_0].LQIOut = element_0.lqiOut.unsignedCharValue;
+                        listHolder_0->mList[i_0].age = element_0.age.unsignedCharValue;
+                        listHolder_0->mList[i_0].allocated = element_0.allocated.boolValue;
+                        listHolder_0->mList[i_0].linkEstablished = element_0.linkEstablished.boolValue;
                     }
-                    cppValue = ListType(listHolder_0->mList, value.count);
+                    cppValue = ListType_0(listHolder_0->mList, value.count);
                 } else {
-                    cppValue = ListType();
+                    cppValue = ListType_0();
                 }
             }
             auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
@@ -8123,26 +8127,26 @@ using namespace chip::app::Clusters;
             using TypeInfo = ThreadNetworkDiagnostics::Attributes::SecurityPolicy::TypeInfo;
             TypeInfo::Type cppValue;
             {
-                using ListType = std::remove_reference_t<decltype(cppValue)>;
-                using ListMemberType = ListMemberTypeGetter<ListType>::Type;
+                using ListType_0 = std::remove_reference_t<decltype(cppValue)>;
+                using ListMemberType_0 = ListMemberTypeGetter<ListType_0>::Type;
                 if (value.count != 0) {
-                    auto * listHolder_0 = new ListHolder<ListMemberType>(value.count);
+                    auto * listHolder_0 = new ListHolder<ListMemberType_0>(value.count);
                     if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
                         return CHIP_ERROR_INVALID_ARGUMENT;
                     }
                     listFreer.add(listHolder_0);
-                    for (size_t i = 0; i < value.count; ++i) {
-                        if (![value[i] isKindOfClass:[CHIPThreadNetworkDiagnosticsClusterSecurityPolicy class]]) {
+                    for (size_t i_0 = 0; i_0 < value.count; ++i_0) {
+                        if (![value[i_0] isKindOfClass:[CHIPThreadNetworkDiagnosticsClusterSecurityPolicy class]]) {
                             // Wrong kind of value.
                             return CHIP_ERROR_INVALID_ARGUMENT;
                         }
-                        auto element_0 = (CHIPThreadNetworkDiagnosticsClusterSecurityPolicy *) value[i];
-                        listHolder_0->mList[i].rotationTime = element_0.rotationTime.unsignedShortValue;
-                        listHolder_0->mList[i].flags = element_0.flags.unsignedShortValue;
+                        auto element_0 = (CHIPThreadNetworkDiagnosticsClusterSecurityPolicy *) value[i_0];
+                        listHolder_0->mList[i_0].rotationTime = element_0.rotationTime.unsignedShortValue;
+                        listHolder_0->mList[i_0].flags = element_0.flags.unsignedShortValue;
                     }
-                    cppValue = ListType(listHolder_0->mList, value.count);
+                    cppValue = ListType_0(listHolder_0->mList, value.count);
                 } else {
-                    cppValue = ListType();
+                    cppValue = ListType_0();
                 }
             }
             auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
@@ -8182,36 +8186,36 @@ using namespace chip::app::Clusters;
             using TypeInfo = ThreadNetworkDiagnostics::Attributes::OperationalDatasetComponents::TypeInfo;
             TypeInfo::Type cppValue;
             {
-                using ListType = std::remove_reference_t<decltype(cppValue)>;
-                using ListMemberType = ListMemberTypeGetter<ListType>::Type;
+                using ListType_0 = std::remove_reference_t<decltype(cppValue)>;
+                using ListMemberType_0 = ListMemberTypeGetter<ListType_0>::Type;
                 if (value.count != 0) {
-                    auto * listHolder_0 = new ListHolder<ListMemberType>(value.count);
+                    auto * listHolder_0 = new ListHolder<ListMemberType_0>(value.count);
                     if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
                         return CHIP_ERROR_INVALID_ARGUMENT;
                     }
                     listFreer.add(listHolder_0);
-                    for (size_t i = 0; i < value.count; ++i) {
-                        if (![value[i] isKindOfClass:[CHIPThreadNetworkDiagnosticsClusterOperationalDatasetComponents class]]) {
+                    for (size_t i_0 = 0; i_0 < value.count; ++i_0) {
+                        if (![value[i_0] isKindOfClass:[CHIPThreadNetworkDiagnosticsClusterOperationalDatasetComponents class]]) {
                             // Wrong kind of value.
                             return CHIP_ERROR_INVALID_ARGUMENT;
                         }
-                        auto element_0 = (CHIPThreadNetworkDiagnosticsClusterOperationalDatasetComponents *) value[i];
-                        listHolder_0->mList[i].activeTimestampPresent = element_0.activeTimestampPresent.boolValue;
-                        listHolder_0->mList[i].pendingTimestampPresent = element_0.pendingTimestampPresent.boolValue;
-                        listHolder_0->mList[i].masterKeyPresent = element_0.masterKeyPresent.boolValue;
-                        listHolder_0->mList[i].networkNamePresent = element_0.networkNamePresent.boolValue;
-                        listHolder_0->mList[i].extendedPanIdPresent = element_0.extendedPanIdPresent.boolValue;
-                        listHolder_0->mList[i].meshLocalPrefixPresent = element_0.meshLocalPrefixPresent.boolValue;
-                        listHolder_0->mList[i].delayPresent = element_0.delayPresent.boolValue;
-                        listHolder_0->mList[i].panIdPresent = element_0.panIdPresent.boolValue;
-                        listHolder_0->mList[i].channelPresent = element_0.channelPresent.boolValue;
-                        listHolder_0->mList[i].pskcPresent = element_0.pskcPresent.boolValue;
-                        listHolder_0->mList[i].securityPolicyPresent = element_0.securityPolicyPresent.boolValue;
-                        listHolder_0->mList[i].channelMaskPresent = element_0.channelMaskPresent.boolValue;
+                        auto element_0 = (CHIPThreadNetworkDiagnosticsClusterOperationalDatasetComponents *) value[i_0];
+                        listHolder_0->mList[i_0].activeTimestampPresent = element_0.activeTimestampPresent.boolValue;
+                        listHolder_0->mList[i_0].pendingTimestampPresent = element_0.pendingTimestampPresent.boolValue;
+                        listHolder_0->mList[i_0].masterKeyPresent = element_0.masterKeyPresent.boolValue;
+                        listHolder_0->mList[i_0].networkNamePresent = element_0.networkNamePresent.boolValue;
+                        listHolder_0->mList[i_0].extendedPanIdPresent = element_0.extendedPanIdPresent.boolValue;
+                        listHolder_0->mList[i_0].meshLocalPrefixPresent = element_0.meshLocalPrefixPresent.boolValue;
+                        listHolder_0->mList[i_0].delayPresent = element_0.delayPresent.boolValue;
+                        listHolder_0->mList[i_0].panIdPresent = element_0.panIdPresent.boolValue;
+                        listHolder_0->mList[i_0].channelPresent = element_0.channelPresent.boolValue;
+                        listHolder_0->mList[i_0].pskcPresent = element_0.pskcPresent.boolValue;
+                        listHolder_0->mList[i_0].securityPolicyPresent = element_0.securityPolicyPresent.boolValue;
+                        listHolder_0->mList[i_0].channelMaskPresent = element_0.channelMaskPresent.boolValue;
                     }
-                    cppValue = ListType(listHolder_0->mList, value.count);
+                    cppValue = ListType_0(listHolder_0->mList, value.count);
                 } else {
-                    cppValue = ListType();
+                    cppValue = ListType_0();
                 }
             }
             auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);
@@ -8233,26 +8237,26 @@ using namespace chip::app::Clusters;
             using TypeInfo = ThreadNetworkDiagnostics::Attributes::ActiveNetworkFaultsList::TypeInfo;
             TypeInfo::Type cppValue;
             {
-                using ListType = std::remove_reference_t<decltype(cppValue)>;
-                using ListMemberType = ListMemberTypeGetter<ListType>::Type;
+                using ListType_0 = std::remove_reference_t<decltype(cppValue)>;
+                using ListMemberType_0 = ListMemberTypeGetter<ListType_0>::Type;
                 if (value.count != 0) {
-                    auto * listHolder_0 = new ListHolder<ListMemberType>(value.count);
+                    auto * listHolder_0 = new ListHolder<ListMemberType_0>(value.count);
                     if (listHolder_0 == nullptr || listHolder_0->mList == nullptr) {
                         return CHIP_ERROR_INVALID_ARGUMENT;
                     }
                     listFreer.add(listHolder_0);
-                    for (size_t i = 0; i < value.count; ++i) {
-                        if (![value[i] isKindOfClass:[NSNumber class]]) {
+                    for (size_t i_0 = 0; i_0 < value.count; ++i_0) {
+                        if (![value[i_0] isKindOfClass:[NSNumber class]]) {
                             // Wrong kind of value.
                             return CHIP_ERROR_INVALID_ARGUMENT;
                         }
-                        auto element_0 = (NSNumber *) value[i];
-                        listHolder_0->mList[i]
-                            = static_cast<std::remove_reference_t<decltype(listHolder_0->mList[i])>>(element_0.unsignedCharValue);
+                        auto element_0 = (NSNumber *) value[i_0];
+                        listHolder_0->mList[i_0]
+                            = static_cast<std::remove_reference_t<decltype(listHolder_0->mList[i_0])>>(element_0.unsignedCharValue);
                     }
-                    cppValue = ListType(listHolder_0->mList, value.count);
+                    cppValue = ListType_0(listHolder_0->mList, value.count);
                 } else {
-                    cppValue = ListType();
+                    cppValue = ListType_0();
                 }
             }
             auto successFn = Callback<CHIPDefaultSuccessCallbackType>::FromCancelable(success);

--- a/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
+++ b/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
@@ -21584,7 +21584,294 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000131_SimpleStructEchoRequest
+- (void)testSendClusterTestCluster_000131_TestNestedStructArgumentRequest
+{
+    XCTestExpectation * expectation =
+        [self expectationWithDescription:@"Send Test Command With Nested Struct Argument and arg1.c.b is true"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    __auto_type * params = [[CHIPTestClusterClusterTestNestedStructArgumentRequestParams alloc] init];
+    params.arg1 = [[CHIPTestClusterClusterNestedStruct alloc] init];
+    ((CHIPTestClusterClusterNestedStruct *) params.arg1).a = [NSNumber numberWithUnsignedChar:0];
+    ((CHIPTestClusterClusterNestedStruct *) params.arg1).b = [NSNumber numberWithBool:true];
+    ((CHIPTestClusterClusterNestedStruct *) params.arg1).c = [[CHIPTestClusterClusterSimpleStruct alloc] init];
+    ((CHIPTestClusterClusterSimpleStruct *) ((CHIPTestClusterClusterNestedStruct *) params.arg1).c).a =
+        [NSNumber numberWithUnsignedChar:0];
+    ((CHIPTestClusterClusterSimpleStruct *) ((CHIPTestClusterClusterNestedStruct *) params.arg1).c).b =
+        [NSNumber numberWithBool:true];
+    ((CHIPTestClusterClusterSimpleStruct *) ((CHIPTestClusterClusterNestedStruct *) params.arg1).c).c =
+        [NSNumber numberWithUnsignedChar:2];
+    ((CHIPTestClusterClusterSimpleStruct *) ((CHIPTestClusterClusterNestedStruct *) params.arg1).c).d =
+        [[NSData alloc] initWithBytes:"octet_string" length:12];
+    ((CHIPTestClusterClusterSimpleStruct *) ((CHIPTestClusterClusterNestedStruct *) params.arg1).c).e = @"char_string";
+    ((CHIPTestClusterClusterSimpleStruct *) ((CHIPTestClusterClusterNestedStruct *) params.arg1).c).f =
+        [NSNumber numberWithUnsignedChar:1];
+    ((CHIPTestClusterClusterSimpleStruct *) ((CHIPTestClusterClusterNestedStruct *) params.arg1).c).g =
+        [NSNumber numberWithFloat:0];
+    ((CHIPTestClusterClusterSimpleStruct *) ((CHIPTestClusterClusterNestedStruct *) params.arg1).c).h =
+        [NSNumber numberWithDouble:0];
+
+    [cluster
+        testNestedStructArgumentRequestWithParams:params
+                                completionHandler:^(
+                                    CHIPTestClusterClusterBooleanResponseParams * _Nullable values, NSError * _Nullable err) {
+                                    NSLog(@"Send Test Command With Nested Struct Argument and arg1.c.b is true Error: %@", err);
+
+                                    XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+                                    {
+                                        id actualValue = values.value;
+                                        XCTAssertEqual([actualValue boolValue], true);
+                                    }
+
+                                    [expectation fulfill];
+                                }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestCluster_000132_TestNestedStructArgumentRequest
+{
+    XCTestExpectation * expectation =
+        [self expectationWithDescription:@"Send Test Command With Nested Struct Argument arg1.c.b is false"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    __auto_type * params = [[CHIPTestClusterClusterTestNestedStructArgumentRequestParams alloc] init];
+    params.arg1 = [[CHIPTestClusterClusterNestedStruct alloc] init];
+    ((CHIPTestClusterClusterNestedStruct *) params.arg1).a = [NSNumber numberWithUnsignedChar:0];
+    ((CHIPTestClusterClusterNestedStruct *) params.arg1).b = [NSNumber numberWithBool:true];
+    ((CHIPTestClusterClusterNestedStruct *) params.arg1).c = [[CHIPTestClusterClusterSimpleStruct alloc] init];
+    ((CHIPTestClusterClusterSimpleStruct *) ((CHIPTestClusterClusterNestedStruct *) params.arg1).c).a =
+        [NSNumber numberWithUnsignedChar:0];
+    ((CHIPTestClusterClusterSimpleStruct *) ((CHIPTestClusterClusterNestedStruct *) params.arg1).c).b =
+        [NSNumber numberWithBool:false];
+    ((CHIPTestClusterClusterSimpleStruct *) ((CHIPTestClusterClusterNestedStruct *) params.arg1).c).c =
+        [NSNumber numberWithUnsignedChar:2];
+    ((CHIPTestClusterClusterSimpleStruct *) ((CHIPTestClusterClusterNestedStruct *) params.arg1).c).d =
+        [[NSData alloc] initWithBytes:"octet_string" length:12];
+    ((CHIPTestClusterClusterSimpleStruct *) ((CHIPTestClusterClusterNestedStruct *) params.arg1).c).e = @"char_string";
+    ((CHIPTestClusterClusterSimpleStruct *) ((CHIPTestClusterClusterNestedStruct *) params.arg1).c).f =
+        [NSNumber numberWithUnsignedChar:1];
+    ((CHIPTestClusterClusterSimpleStruct *) ((CHIPTestClusterClusterNestedStruct *) params.arg1).c).g =
+        [NSNumber numberWithFloat:0];
+    ((CHIPTestClusterClusterSimpleStruct *) ((CHIPTestClusterClusterNestedStruct *) params.arg1).c).h =
+        [NSNumber numberWithDouble:0];
+
+    [cluster testNestedStructArgumentRequestWithParams:params
+                                     completionHandler:^(
+                                         CHIPTestClusterClusterBooleanResponseParams * _Nullable values, NSError * _Nullable err) {
+                                         NSLog(@"Send Test Command With Nested Struct Argument arg1.c.b is false Error: %@", err);
+
+                                         XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+                                         {
+                                             id actualValue = values.value;
+                                             XCTAssertEqual([actualValue boolValue], false);
+                                         }
+
+                                         [expectation fulfill];
+                                     }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestCluster_000133_TestNestedStructListArgumentRequest
+{
+    XCTestExpectation * expectation =
+        [self expectationWithDescription:@"Send Test Command With Nested Struct List Argument and all fields b of arg1.d are true"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    __auto_type * params = [[CHIPTestClusterClusterTestNestedStructListArgumentRequestParams alloc] init];
+    params.arg1 = [[CHIPTestClusterClusterNestedStructList alloc] init];
+    ((CHIPTestClusterClusterNestedStructList *) params.arg1).a = [NSNumber numberWithUnsignedChar:0];
+    ((CHIPTestClusterClusterNestedStructList *) params.arg1).b = [NSNumber numberWithBool:true];
+    ((CHIPTestClusterClusterNestedStructList *) params.arg1).c = [[CHIPTestClusterClusterSimpleStruct alloc] init];
+    ((CHIPTestClusterClusterSimpleStruct *) ((CHIPTestClusterClusterNestedStructList *) params.arg1).c).a =
+        [NSNumber numberWithUnsignedChar:0];
+    ((CHIPTestClusterClusterSimpleStruct *) ((CHIPTestClusterClusterNestedStructList *) params.arg1).c).b =
+        [NSNumber numberWithBool:true];
+    ((CHIPTestClusterClusterSimpleStruct *) ((CHIPTestClusterClusterNestedStructList *) params.arg1).c).c =
+        [NSNumber numberWithUnsignedChar:2];
+    ((CHIPTestClusterClusterSimpleStruct *) ((CHIPTestClusterClusterNestedStructList *) params.arg1).c).d =
+        [[NSData alloc] initWithBytes:"octet_string" length:12];
+    ((CHIPTestClusterClusterSimpleStruct *) ((CHIPTestClusterClusterNestedStructList *) params.arg1).c).e = @"char_string";
+    ((CHIPTestClusterClusterSimpleStruct *) ((CHIPTestClusterClusterNestedStructList *) params.arg1).c).f =
+        [NSNumber numberWithUnsignedChar:1];
+    ((CHIPTestClusterClusterSimpleStruct *) ((CHIPTestClusterClusterNestedStructList *) params.arg1).c).g =
+        [NSNumber numberWithFloat:0];
+    ((CHIPTestClusterClusterSimpleStruct *) ((CHIPTestClusterClusterNestedStructList *) params.arg1).c).h =
+        [NSNumber numberWithDouble:0];
+
+    {
+        NSMutableArray * temp_1 = [[NSMutableArray alloc] init];
+        temp_1[0] = [[CHIPTestClusterClusterSimpleStruct alloc] init];
+        ((CHIPTestClusterClusterSimpleStruct *) temp_1[0]).a = [NSNumber numberWithUnsignedChar:1];
+        ((CHIPTestClusterClusterSimpleStruct *) temp_1[0]).b = [NSNumber numberWithBool:true];
+        ((CHIPTestClusterClusterSimpleStruct *) temp_1[0]).c = [NSNumber numberWithUnsignedChar:3];
+        ((CHIPTestClusterClusterSimpleStruct *) temp_1[0]).d = [[NSData alloc] initWithBytes:"nested_octet_string" length:19];
+        ((CHIPTestClusterClusterSimpleStruct *) temp_1[0]).e = @"nested_char_string";
+        ((CHIPTestClusterClusterSimpleStruct *) temp_1[0]).f = [NSNumber numberWithUnsignedChar:1];
+        ((CHIPTestClusterClusterSimpleStruct *) temp_1[0]).g = [NSNumber numberWithFloat:0];
+        ((CHIPTestClusterClusterSimpleStruct *) temp_1[0]).h = [NSNumber numberWithDouble:0];
+
+        temp_1[1] = [[CHIPTestClusterClusterSimpleStruct alloc] init];
+        ((CHIPTestClusterClusterSimpleStruct *) temp_1[1]).a = [NSNumber numberWithUnsignedChar:2];
+        ((CHIPTestClusterClusterSimpleStruct *) temp_1[1]).b = [NSNumber numberWithBool:true];
+        ((CHIPTestClusterClusterSimpleStruct *) temp_1[1]).c = [NSNumber numberWithUnsignedChar:3];
+        ((CHIPTestClusterClusterSimpleStruct *) temp_1[1]).d = [[NSData alloc] initWithBytes:"nested_octet_string" length:19];
+        ((CHIPTestClusterClusterSimpleStruct *) temp_1[1]).e = @"nested_char_string";
+        ((CHIPTestClusterClusterSimpleStruct *) temp_1[1]).f = [NSNumber numberWithUnsignedChar:1];
+        ((CHIPTestClusterClusterSimpleStruct *) temp_1[1]).g = [NSNumber numberWithFloat:0];
+        ((CHIPTestClusterClusterSimpleStruct *) temp_1[1]).h = [NSNumber numberWithDouble:0];
+
+        ((CHIPTestClusterClusterNestedStructList *) params.arg1).d = temp_1;
+    }
+    {
+        NSMutableArray * temp_1 = [[NSMutableArray alloc] init];
+        temp_1[0] = [NSNumber numberWithUnsignedInt:1UL];
+        temp_1[1] = [NSNumber numberWithUnsignedInt:2UL];
+        temp_1[2] = [NSNumber numberWithUnsignedInt:3UL];
+        ((CHIPTestClusterClusterNestedStructList *) params.arg1).e = temp_1;
+    }
+    {
+        NSMutableArray * temp_1 = [[NSMutableArray alloc] init];
+        temp_1[0] = [[NSData alloc] initWithBytes:"octet_string_1" length:14];
+        temp_1[1] = [[NSData alloc] initWithBytes:"octect_string_2" length:15];
+        temp_1[2] = [[NSData alloc] initWithBytes:"octet_string_3" length:14];
+        ((CHIPTestClusterClusterNestedStructList *) params.arg1).f = temp_1;
+    }
+    {
+        NSMutableArray * temp_1 = [[NSMutableArray alloc] init];
+        temp_1[0] = [NSNumber numberWithUnsignedChar:0];
+        temp_1[1] = [NSNumber numberWithUnsignedChar:255];
+        ((CHIPTestClusterClusterNestedStructList *) params.arg1).g = temp_1;
+    }
+
+    [cluster testNestedStructListArgumentRequestWithParams:params
+                                         completionHandler:^(CHIPTestClusterClusterBooleanResponseParams * _Nullable values,
+                                             NSError * _Nullable err) {
+                                             NSLog(@"Send Test Command With Nested Struct List Argument and all fields b of arg1.d "
+                                                   @"are true Error: %@",
+                                                 err);
+
+                                             XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+                                             {
+                                                 id actualValue = values.value;
+                                                 XCTAssertEqual([actualValue boolValue], true);
+                                             }
+
+                                             [expectation fulfill];
+                                         }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestCluster_000134_TestNestedStructListArgumentRequest
+{
+    XCTestExpectation * expectation = [self
+        expectationWithDescription:@"Send Test Command With Nested Struct List Argument and some fields b of arg1.d are false"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    __auto_type * params = [[CHIPTestClusterClusterTestNestedStructListArgumentRequestParams alloc] init];
+    params.arg1 = [[CHIPTestClusterClusterNestedStructList alloc] init];
+    ((CHIPTestClusterClusterNestedStructList *) params.arg1).a = [NSNumber numberWithUnsignedChar:0];
+    ((CHIPTestClusterClusterNestedStructList *) params.arg1).b = [NSNumber numberWithBool:true];
+    ((CHIPTestClusterClusterNestedStructList *) params.arg1).c = [[CHIPTestClusterClusterSimpleStruct alloc] init];
+    ((CHIPTestClusterClusterSimpleStruct *) ((CHIPTestClusterClusterNestedStructList *) params.arg1).c).a =
+        [NSNumber numberWithUnsignedChar:0];
+    ((CHIPTestClusterClusterSimpleStruct *) ((CHIPTestClusterClusterNestedStructList *) params.arg1).c).b =
+        [NSNumber numberWithBool:true];
+    ((CHIPTestClusterClusterSimpleStruct *) ((CHIPTestClusterClusterNestedStructList *) params.arg1).c).c =
+        [NSNumber numberWithUnsignedChar:2];
+    ((CHIPTestClusterClusterSimpleStruct *) ((CHIPTestClusterClusterNestedStructList *) params.arg1).c).d =
+        [[NSData alloc] initWithBytes:"octet_string" length:12];
+    ((CHIPTestClusterClusterSimpleStruct *) ((CHIPTestClusterClusterNestedStructList *) params.arg1).c).e = @"char_string";
+    ((CHIPTestClusterClusterSimpleStruct *) ((CHIPTestClusterClusterNestedStructList *) params.arg1).c).f =
+        [NSNumber numberWithUnsignedChar:1];
+    ((CHIPTestClusterClusterSimpleStruct *) ((CHIPTestClusterClusterNestedStructList *) params.arg1).c).g =
+        [NSNumber numberWithFloat:0];
+    ((CHIPTestClusterClusterSimpleStruct *) ((CHIPTestClusterClusterNestedStructList *) params.arg1).c).h =
+        [NSNumber numberWithDouble:0];
+
+    {
+        NSMutableArray * temp_1 = [[NSMutableArray alloc] init];
+        temp_1[0] = [[CHIPTestClusterClusterSimpleStruct alloc] init];
+        ((CHIPTestClusterClusterSimpleStruct *) temp_1[0]).a = [NSNumber numberWithUnsignedChar:1];
+        ((CHIPTestClusterClusterSimpleStruct *) temp_1[0]).b = [NSNumber numberWithBool:true];
+        ((CHIPTestClusterClusterSimpleStruct *) temp_1[0]).c = [NSNumber numberWithUnsignedChar:3];
+        ((CHIPTestClusterClusterSimpleStruct *) temp_1[0]).d = [[NSData alloc] initWithBytes:"nested_octet_string" length:19];
+        ((CHIPTestClusterClusterSimpleStruct *) temp_1[0]).e = @"nested_char_string";
+        ((CHIPTestClusterClusterSimpleStruct *) temp_1[0]).f = [NSNumber numberWithUnsignedChar:1];
+        ((CHIPTestClusterClusterSimpleStruct *) temp_1[0]).g = [NSNumber numberWithFloat:0];
+        ((CHIPTestClusterClusterSimpleStruct *) temp_1[0]).h = [NSNumber numberWithDouble:0];
+
+        temp_1[1] = [[CHIPTestClusterClusterSimpleStruct alloc] init];
+        ((CHIPTestClusterClusterSimpleStruct *) temp_1[1]).a = [NSNumber numberWithUnsignedChar:2];
+        ((CHIPTestClusterClusterSimpleStruct *) temp_1[1]).b = [NSNumber numberWithBool:false];
+        ((CHIPTestClusterClusterSimpleStruct *) temp_1[1]).c = [NSNumber numberWithUnsignedChar:3];
+        ((CHIPTestClusterClusterSimpleStruct *) temp_1[1]).d = [[NSData alloc] initWithBytes:"nested_octet_string" length:19];
+        ((CHIPTestClusterClusterSimpleStruct *) temp_1[1]).e = @"nested_char_string";
+        ((CHIPTestClusterClusterSimpleStruct *) temp_1[1]).f = [NSNumber numberWithUnsignedChar:1];
+        ((CHIPTestClusterClusterSimpleStruct *) temp_1[1]).g = [NSNumber numberWithFloat:0];
+        ((CHIPTestClusterClusterSimpleStruct *) temp_1[1]).h = [NSNumber numberWithDouble:0];
+
+        ((CHIPTestClusterClusterNestedStructList *) params.arg1).d = temp_1;
+    }
+    {
+        NSMutableArray * temp_1 = [[NSMutableArray alloc] init];
+        temp_1[0] = [NSNumber numberWithUnsignedInt:1UL];
+        temp_1[1] = [NSNumber numberWithUnsignedInt:2UL];
+        temp_1[2] = [NSNumber numberWithUnsignedInt:3UL];
+        ((CHIPTestClusterClusterNestedStructList *) params.arg1).e = temp_1;
+    }
+    {
+        NSMutableArray * temp_1 = [[NSMutableArray alloc] init];
+        temp_1[0] = [[NSData alloc] initWithBytes:"octet_string_1" length:14];
+        temp_1[1] = [[NSData alloc] initWithBytes:"octect_string_2" length:15];
+        temp_1[2] = [[NSData alloc] initWithBytes:"octet_string_3" length:14];
+        ((CHIPTestClusterClusterNestedStructList *) params.arg1).f = temp_1;
+    }
+    {
+        NSMutableArray * temp_1 = [[NSMutableArray alloc] init];
+        temp_1[0] = [NSNumber numberWithUnsignedChar:0];
+        temp_1[1] = [NSNumber numberWithUnsignedChar:255];
+        ((CHIPTestClusterClusterNestedStructList *) params.arg1).g = temp_1;
+    }
+
+    [cluster testNestedStructListArgumentRequestWithParams:params
+                                         completionHandler:^(CHIPTestClusterClusterBooleanResponseParams * _Nullable values,
+                                             NSError * _Nullable err) {
+                                             NSLog(@"Send Test Command With Nested Struct List Argument and some fields b of "
+                                                   @"arg1.d are false Error: %@",
+                                                 err);
+
+                                             XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+                                             {
+                                                 id actualValue = values.value;
+                                                 XCTAssertEqual([actualValue boolValue], false);
+                                             }
+
+                                             [expectation fulfill];
+                                         }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestCluster_000135_SimpleStructEchoRequest
 {
     XCTestExpectation * expectation =
         [self expectationWithDescription:@"Send Test Command With Struct Argument and see what we get back"];
@@ -21631,7 +21918,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000132_TestListInt8UArgumentRequest
+- (void)testSendClusterTestCluster_000136_TestListInt8UArgumentRequest
 {
     XCTestExpectation * expectation =
         [self expectationWithDescription:@"Send Test Command With List of INT8U and none of them is set to 0"];
@@ -21643,17 +21930,17 @@ CHIPDevice * GetConnectedDevice()
 
     __auto_type * params = [[CHIPTestClusterClusterTestListInt8UArgumentRequestParams alloc] init];
     {
-        NSMutableArray * temp = [[NSMutableArray alloc] init];
-        temp[0] = [NSNumber numberWithUnsignedChar:1];
-        temp[1] = [NSNumber numberWithUnsignedChar:2];
-        temp[2] = [NSNumber numberWithUnsignedChar:3];
-        temp[3] = [NSNumber numberWithUnsignedChar:4];
-        temp[4] = [NSNumber numberWithUnsignedChar:5];
-        temp[5] = [NSNumber numberWithUnsignedChar:6];
-        temp[6] = [NSNumber numberWithUnsignedChar:7];
-        temp[7] = [NSNumber numberWithUnsignedChar:8];
-        temp[8] = [NSNumber numberWithUnsignedChar:9];
-        params.arg1 = temp;
+        NSMutableArray * temp_0 = [[NSMutableArray alloc] init];
+        temp_0[0] = [NSNumber numberWithUnsignedChar:1];
+        temp_0[1] = [NSNumber numberWithUnsignedChar:2];
+        temp_0[2] = [NSNumber numberWithUnsignedChar:3];
+        temp_0[3] = [NSNumber numberWithUnsignedChar:4];
+        temp_0[4] = [NSNumber numberWithUnsignedChar:5];
+        temp_0[5] = [NSNumber numberWithUnsignedChar:6];
+        temp_0[6] = [NSNumber numberWithUnsignedChar:7];
+        temp_0[7] = [NSNumber numberWithUnsignedChar:8];
+        temp_0[8] = [NSNumber numberWithUnsignedChar:9];
+        params.arg1 = temp_0;
     }
     [cluster testListInt8UArgumentRequestWithParams:params
                                   completionHandler:^(
@@ -21672,7 +21959,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000133_TestListInt8UArgumentRequest
+- (void)testSendClusterTestCluster_000137_TestListInt8UArgumentRequest
 {
     XCTestExpectation * expectation =
         [self expectationWithDescription:@"Send Test Command With List of INT8U and one of them is set to 0"];
@@ -21684,18 +21971,18 @@ CHIPDevice * GetConnectedDevice()
 
     __auto_type * params = [[CHIPTestClusterClusterTestListInt8UArgumentRequestParams alloc] init];
     {
-        NSMutableArray * temp = [[NSMutableArray alloc] init];
-        temp[0] = [NSNumber numberWithUnsignedChar:1];
-        temp[1] = [NSNumber numberWithUnsignedChar:2];
-        temp[2] = [NSNumber numberWithUnsignedChar:3];
-        temp[3] = [NSNumber numberWithUnsignedChar:4];
-        temp[4] = [NSNumber numberWithUnsignedChar:5];
-        temp[5] = [NSNumber numberWithUnsignedChar:6];
-        temp[6] = [NSNumber numberWithUnsignedChar:7];
-        temp[7] = [NSNumber numberWithUnsignedChar:8];
-        temp[8] = [NSNumber numberWithUnsignedChar:9];
-        temp[9] = [NSNumber numberWithUnsignedChar:0];
-        params.arg1 = temp;
+        NSMutableArray * temp_0 = [[NSMutableArray alloc] init];
+        temp_0[0] = [NSNumber numberWithUnsignedChar:1];
+        temp_0[1] = [NSNumber numberWithUnsignedChar:2];
+        temp_0[2] = [NSNumber numberWithUnsignedChar:3];
+        temp_0[3] = [NSNumber numberWithUnsignedChar:4];
+        temp_0[4] = [NSNumber numberWithUnsignedChar:5];
+        temp_0[5] = [NSNumber numberWithUnsignedChar:6];
+        temp_0[6] = [NSNumber numberWithUnsignedChar:7];
+        temp_0[7] = [NSNumber numberWithUnsignedChar:8];
+        temp_0[8] = [NSNumber numberWithUnsignedChar:9];
+        temp_0[9] = [NSNumber numberWithUnsignedChar:0];
+        params.arg1 = temp_0;
     }
     [cluster testListInt8UArgumentRequestWithParams:params
                                   completionHandler:^(
@@ -21714,7 +22001,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000134_TestListInt8UReverseRequest
+- (void)testSendClusterTestCluster_000138_TestListInt8UReverseRequest
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Send Test Command With List of INT8U and get it reversed"];
 
@@ -21725,17 +22012,17 @@ CHIPDevice * GetConnectedDevice()
 
     __auto_type * params = [[CHIPTestClusterClusterTestListInt8UReverseRequestParams alloc] init];
     {
-        NSMutableArray * temp = [[NSMutableArray alloc] init];
-        temp[0] = [NSNumber numberWithUnsignedChar:1];
-        temp[1] = [NSNumber numberWithUnsignedChar:2];
-        temp[2] = [NSNumber numberWithUnsignedChar:3];
-        temp[3] = [NSNumber numberWithUnsignedChar:4];
-        temp[4] = [NSNumber numberWithUnsignedChar:5];
-        temp[5] = [NSNumber numberWithUnsignedChar:6];
-        temp[6] = [NSNumber numberWithUnsignedChar:7];
-        temp[7] = [NSNumber numberWithUnsignedChar:8];
-        temp[8] = [NSNumber numberWithUnsignedChar:9];
-        params.arg1 = temp;
+        NSMutableArray * temp_0 = [[NSMutableArray alloc] init];
+        temp_0[0] = [NSNumber numberWithUnsignedChar:1];
+        temp_0[1] = [NSNumber numberWithUnsignedChar:2];
+        temp_0[2] = [NSNumber numberWithUnsignedChar:3];
+        temp_0[3] = [NSNumber numberWithUnsignedChar:4];
+        temp_0[4] = [NSNumber numberWithUnsignedChar:5];
+        temp_0[5] = [NSNumber numberWithUnsignedChar:6];
+        temp_0[6] = [NSNumber numberWithUnsignedChar:7];
+        temp_0[7] = [NSNumber numberWithUnsignedChar:8];
+        temp_0[8] = [NSNumber numberWithUnsignedChar:9];
+        params.arg1 = temp_0;
     }
     [cluster testListInt8UReverseRequestWithParams:params
                                  completionHandler:^(CHIPTestClusterClusterTestListInt8UReverseResponseParams * _Nullable values,
@@ -21763,7 +22050,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000135_TestListInt8UReverseRequest
+- (void)testSendClusterTestCluster_000139_TestListInt8UReverseRequest
 {
     XCTestExpectation * expectation =
         [self expectationWithDescription:@"Send Test Command With empty List of INT8U and get an empty list back"];
@@ -21775,8 +22062,8 @@ CHIPDevice * GetConnectedDevice()
 
     __auto_type * params = [[CHIPTestClusterClusterTestListInt8UReverseRequestParams alloc] init];
     {
-        NSMutableArray * temp = [[NSMutableArray alloc] init];
-        params.arg1 = temp;
+        NSMutableArray * temp_0 = [[NSMutableArray alloc] init];
+        params.arg1 = temp_0;
     }
     [cluster testListInt8UReverseRequestWithParams:params
                                  completionHandler:^(CHIPTestClusterClusterTestListInt8UReverseResponseParams * _Nullable values,
@@ -21795,7 +22082,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000136_TestListStructArgumentRequest
+- (void)testSendClusterTestCluster_000140_TestListStructArgumentRequest
 {
     XCTestExpectation * expectation =
         [self expectationWithDescription:@"Send Test Command With List of Struct Argument and arg1.b of first item is true"];
@@ -21807,28 +22094,28 @@ CHIPDevice * GetConnectedDevice()
 
     __auto_type * params = [[CHIPTestClusterClusterTestListStructArgumentRequestParams alloc] init];
     {
-        NSMutableArray * temp = [[NSMutableArray alloc] init];
-        temp[0] = [[CHIPTestClusterClusterSimpleStruct alloc] init];
-        ((CHIPTestClusterClusterSimpleStruct *) temp[0]).a = [NSNumber numberWithUnsignedChar:0];
-        ((CHIPTestClusterClusterSimpleStruct *) temp[0]).b = [NSNumber numberWithBool:true];
-        ((CHIPTestClusterClusterSimpleStruct *) temp[0]).c = [NSNumber numberWithUnsignedChar:2];
-        ((CHIPTestClusterClusterSimpleStruct *) temp[0]).d = [[NSData alloc] initWithBytes:"first_octet_string" length:18];
-        ((CHIPTestClusterClusterSimpleStruct *) temp[0]).e = @"first_char_string";
-        ((CHIPTestClusterClusterSimpleStruct *) temp[0]).f = [NSNumber numberWithUnsignedChar:1];
-        ((CHIPTestClusterClusterSimpleStruct *) temp[0]).g = [NSNumber numberWithFloat:0];
-        ((CHIPTestClusterClusterSimpleStruct *) temp[0]).h = [NSNumber numberWithDouble:0];
+        NSMutableArray * temp_0 = [[NSMutableArray alloc] init];
+        temp_0[0] = [[CHIPTestClusterClusterSimpleStruct alloc] init];
+        ((CHIPTestClusterClusterSimpleStruct *) temp_0[0]).a = [NSNumber numberWithUnsignedChar:0];
+        ((CHIPTestClusterClusterSimpleStruct *) temp_0[0]).b = [NSNumber numberWithBool:true];
+        ((CHIPTestClusterClusterSimpleStruct *) temp_0[0]).c = [NSNumber numberWithUnsignedChar:2];
+        ((CHIPTestClusterClusterSimpleStruct *) temp_0[0]).d = [[NSData alloc] initWithBytes:"first_octet_string" length:18];
+        ((CHIPTestClusterClusterSimpleStruct *) temp_0[0]).e = @"first_char_string";
+        ((CHIPTestClusterClusterSimpleStruct *) temp_0[0]).f = [NSNumber numberWithUnsignedChar:1];
+        ((CHIPTestClusterClusterSimpleStruct *) temp_0[0]).g = [NSNumber numberWithFloat:0];
+        ((CHIPTestClusterClusterSimpleStruct *) temp_0[0]).h = [NSNumber numberWithDouble:0];
 
-        temp[1] = [[CHIPTestClusterClusterSimpleStruct alloc] init];
-        ((CHIPTestClusterClusterSimpleStruct *) temp[1]).a = [NSNumber numberWithUnsignedChar:1];
-        ((CHIPTestClusterClusterSimpleStruct *) temp[1]).b = [NSNumber numberWithBool:true];
-        ((CHIPTestClusterClusterSimpleStruct *) temp[1]).c = [NSNumber numberWithUnsignedChar:3];
-        ((CHIPTestClusterClusterSimpleStruct *) temp[1]).d = [[NSData alloc] initWithBytes:"second_octet_string" length:19];
-        ((CHIPTestClusterClusterSimpleStruct *) temp[1]).e = @"second_char_string";
-        ((CHIPTestClusterClusterSimpleStruct *) temp[1]).f = [NSNumber numberWithUnsignedChar:1];
-        ((CHIPTestClusterClusterSimpleStruct *) temp[1]).g = [NSNumber numberWithFloat:0];
-        ((CHIPTestClusterClusterSimpleStruct *) temp[1]).h = [NSNumber numberWithDouble:0];
+        temp_0[1] = [[CHIPTestClusterClusterSimpleStruct alloc] init];
+        ((CHIPTestClusterClusterSimpleStruct *) temp_0[1]).a = [NSNumber numberWithUnsignedChar:1];
+        ((CHIPTestClusterClusterSimpleStruct *) temp_0[1]).b = [NSNumber numberWithBool:true];
+        ((CHIPTestClusterClusterSimpleStruct *) temp_0[1]).c = [NSNumber numberWithUnsignedChar:3];
+        ((CHIPTestClusterClusterSimpleStruct *) temp_0[1]).d = [[NSData alloc] initWithBytes:"second_octet_string" length:19];
+        ((CHIPTestClusterClusterSimpleStruct *) temp_0[1]).e = @"second_char_string";
+        ((CHIPTestClusterClusterSimpleStruct *) temp_0[1]).f = [NSNumber numberWithUnsignedChar:1];
+        ((CHIPTestClusterClusterSimpleStruct *) temp_0[1]).g = [NSNumber numberWithFloat:0];
+        ((CHIPTestClusterClusterSimpleStruct *) temp_0[1]).h = [NSNumber numberWithDouble:0];
 
-        params.arg1 = temp;
+        params.arg1 = temp_0;
     }
     [cluster
         testListStructArgumentRequestWithParams:params
@@ -21850,7 +22137,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000137_TestListStructArgumentRequest
+- (void)testSendClusterTestCluster_000141_TestListStructArgumentRequest
 {
     XCTestExpectation * expectation =
         [self expectationWithDescription:@"Send Test Command With List of Struct Argument and arg1.b of first item is false"];
@@ -21862,28 +22149,28 @@ CHIPDevice * GetConnectedDevice()
 
     __auto_type * params = [[CHIPTestClusterClusterTestListStructArgumentRequestParams alloc] init];
     {
-        NSMutableArray * temp = [[NSMutableArray alloc] init];
-        temp[0] = [[CHIPTestClusterClusterSimpleStruct alloc] init];
-        ((CHIPTestClusterClusterSimpleStruct *) temp[0]).a = [NSNumber numberWithUnsignedChar:1];
-        ((CHIPTestClusterClusterSimpleStruct *) temp[0]).b = [NSNumber numberWithBool:true];
-        ((CHIPTestClusterClusterSimpleStruct *) temp[0]).c = [NSNumber numberWithUnsignedChar:3];
-        ((CHIPTestClusterClusterSimpleStruct *) temp[0]).d = [[NSData alloc] initWithBytes:"second_octet_string" length:19];
-        ((CHIPTestClusterClusterSimpleStruct *) temp[0]).e = @"second_char_string";
-        ((CHIPTestClusterClusterSimpleStruct *) temp[0]).f = [NSNumber numberWithUnsignedChar:1];
-        ((CHIPTestClusterClusterSimpleStruct *) temp[0]).g = [NSNumber numberWithFloat:0];
-        ((CHIPTestClusterClusterSimpleStruct *) temp[0]).h = [NSNumber numberWithDouble:0];
+        NSMutableArray * temp_0 = [[NSMutableArray alloc] init];
+        temp_0[0] = [[CHIPTestClusterClusterSimpleStruct alloc] init];
+        ((CHIPTestClusterClusterSimpleStruct *) temp_0[0]).a = [NSNumber numberWithUnsignedChar:1];
+        ((CHIPTestClusterClusterSimpleStruct *) temp_0[0]).b = [NSNumber numberWithBool:true];
+        ((CHIPTestClusterClusterSimpleStruct *) temp_0[0]).c = [NSNumber numberWithUnsignedChar:3];
+        ((CHIPTestClusterClusterSimpleStruct *) temp_0[0]).d = [[NSData alloc] initWithBytes:"second_octet_string" length:19];
+        ((CHIPTestClusterClusterSimpleStruct *) temp_0[0]).e = @"second_char_string";
+        ((CHIPTestClusterClusterSimpleStruct *) temp_0[0]).f = [NSNumber numberWithUnsignedChar:1];
+        ((CHIPTestClusterClusterSimpleStruct *) temp_0[0]).g = [NSNumber numberWithFloat:0];
+        ((CHIPTestClusterClusterSimpleStruct *) temp_0[0]).h = [NSNumber numberWithDouble:0];
 
-        temp[1] = [[CHIPTestClusterClusterSimpleStruct alloc] init];
-        ((CHIPTestClusterClusterSimpleStruct *) temp[1]).a = [NSNumber numberWithUnsignedChar:0];
-        ((CHIPTestClusterClusterSimpleStruct *) temp[1]).b = [NSNumber numberWithBool:false];
-        ((CHIPTestClusterClusterSimpleStruct *) temp[1]).c = [NSNumber numberWithUnsignedChar:2];
-        ((CHIPTestClusterClusterSimpleStruct *) temp[1]).d = [[NSData alloc] initWithBytes:"first_octet_string" length:18];
-        ((CHIPTestClusterClusterSimpleStruct *) temp[1]).e = @"first_char_string";
-        ((CHIPTestClusterClusterSimpleStruct *) temp[1]).f = [NSNumber numberWithUnsignedChar:1];
-        ((CHIPTestClusterClusterSimpleStruct *) temp[1]).g = [NSNumber numberWithFloat:0];
-        ((CHIPTestClusterClusterSimpleStruct *) temp[1]).h = [NSNumber numberWithDouble:0];
+        temp_0[1] = [[CHIPTestClusterClusterSimpleStruct alloc] init];
+        ((CHIPTestClusterClusterSimpleStruct *) temp_0[1]).a = [NSNumber numberWithUnsignedChar:0];
+        ((CHIPTestClusterClusterSimpleStruct *) temp_0[1]).b = [NSNumber numberWithBool:false];
+        ((CHIPTestClusterClusterSimpleStruct *) temp_0[1]).c = [NSNumber numberWithUnsignedChar:2];
+        ((CHIPTestClusterClusterSimpleStruct *) temp_0[1]).d = [[NSData alloc] initWithBytes:"first_octet_string" length:18];
+        ((CHIPTestClusterClusterSimpleStruct *) temp_0[1]).e = @"first_char_string";
+        ((CHIPTestClusterClusterSimpleStruct *) temp_0[1]).f = [NSNumber numberWithUnsignedChar:1];
+        ((CHIPTestClusterClusterSimpleStruct *) temp_0[1]).g = [NSNumber numberWithFloat:0];
+        ((CHIPTestClusterClusterSimpleStruct *) temp_0[1]).h = [NSNumber numberWithDouble:0];
 
-        params.arg1 = temp;
+        params.arg1 = temp_0;
     }
     [cluster
         testListStructArgumentRequestWithParams:params
@@ -21905,7 +22192,207 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000138_WriteAttribute
+- (void)testSendClusterTestCluster_000142_TestListNestedStructListArgumentRequest
+{
+    XCTestExpectation * expectation =
+        [self expectationWithDescription:
+                  @"Send Test Command With List of Nested Struct List Argument and all fields b of elements of arg1.d are true"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    __auto_type * params = [[CHIPTestClusterClusterTestListNestedStructListArgumentRequestParams alloc] init];
+    {
+        NSMutableArray * temp_0 = [[NSMutableArray alloc] init];
+        temp_0[0] = [[CHIPTestClusterClusterNestedStructList alloc] init];
+        ((CHIPTestClusterClusterNestedStructList *) temp_0[0]).a = [NSNumber numberWithUnsignedChar:0];
+        ((CHIPTestClusterClusterNestedStructList *) temp_0[0]).b = [NSNumber numberWithBool:true];
+        ((CHIPTestClusterClusterNestedStructList *) temp_0[0]).c = [[CHIPTestClusterClusterSimpleStruct alloc] init];
+        ((CHIPTestClusterClusterSimpleStruct *) ((CHIPTestClusterClusterNestedStructList *) temp_0[0]).c).a =
+            [NSNumber numberWithUnsignedChar:0];
+        ((CHIPTestClusterClusterSimpleStruct *) ((CHIPTestClusterClusterNestedStructList *) temp_0[0]).c).b =
+            [NSNumber numberWithBool:true];
+        ((CHIPTestClusterClusterSimpleStruct *) ((CHIPTestClusterClusterNestedStructList *) temp_0[0]).c).c =
+            [NSNumber numberWithUnsignedChar:2];
+        ((CHIPTestClusterClusterSimpleStruct *) ((CHIPTestClusterClusterNestedStructList *) temp_0[0]).c).d =
+            [[NSData alloc] initWithBytes:"octet_string" length:12];
+        ((CHIPTestClusterClusterSimpleStruct *) ((CHIPTestClusterClusterNestedStructList *) temp_0[0]).c).e = @"char_string";
+        ((CHIPTestClusterClusterSimpleStruct *) ((CHIPTestClusterClusterNestedStructList *) temp_0[0]).c).f =
+            [NSNumber numberWithUnsignedChar:1];
+        ((CHIPTestClusterClusterSimpleStruct *) ((CHIPTestClusterClusterNestedStructList *) temp_0[0]).c).g =
+            [NSNumber numberWithFloat:0];
+        ((CHIPTestClusterClusterSimpleStruct *) ((CHIPTestClusterClusterNestedStructList *) temp_0[0]).c).h =
+            [NSNumber numberWithDouble:0];
+
+        {
+            NSMutableArray * temp_2 = [[NSMutableArray alloc] init];
+            temp_2[0] = [[CHIPTestClusterClusterSimpleStruct alloc] init];
+            ((CHIPTestClusterClusterSimpleStruct *) temp_2[0]).a = [NSNumber numberWithUnsignedChar:1];
+            ((CHIPTestClusterClusterSimpleStruct *) temp_2[0]).b = [NSNumber numberWithBool:true];
+            ((CHIPTestClusterClusterSimpleStruct *) temp_2[0]).c = [NSNumber numberWithUnsignedChar:3];
+            ((CHIPTestClusterClusterSimpleStruct *) temp_2[0]).d = [[NSData alloc] initWithBytes:"nested_octet_string" length:19];
+            ((CHIPTestClusterClusterSimpleStruct *) temp_2[0]).e = @"nested_char_string";
+            ((CHIPTestClusterClusterSimpleStruct *) temp_2[0]).f = [NSNumber numberWithUnsignedChar:1];
+            ((CHIPTestClusterClusterSimpleStruct *) temp_2[0]).g = [NSNumber numberWithFloat:0];
+            ((CHIPTestClusterClusterSimpleStruct *) temp_2[0]).h = [NSNumber numberWithDouble:0];
+
+            temp_2[1] = [[CHIPTestClusterClusterSimpleStruct alloc] init];
+            ((CHIPTestClusterClusterSimpleStruct *) temp_2[1]).a = [NSNumber numberWithUnsignedChar:2];
+            ((CHIPTestClusterClusterSimpleStruct *) temp_2[1]).b = [NSNumber numberWithBool:true];
+            ((CHIPTestClusterClusterSimpleStruct *) temp_2[1]).c = [NSNumber numberWithUnsignedChar:3];
+            ((CHIPTestClusterClusterSimpleStruct *) temp_2[1]).d = [[NSData alloc] initWithBytes:"nested_octet_string" length:19];
+            ((CHIPTestClusterClusterSimpleStruct *) temp_2[1]).e = @"nested_char_string";
+            ((CHIPTestClusterClusterSimpleStruct *) temp_2[1]).f = [NSNumber numberWithUnsignedChar:1];
+            ((CHIPTestClusterClusterSimpleStruct *) temp_2[1]).g = [NSNumber numberWithFloat:0];
+            ((CHIPTestClusterClusterSimpleStruct *) temp_2[1]).h = [NSNumber numberWithDouble:0];
+
+            ((CHIPTestClusterClusterNestedStructList *) temp_0[0]).d = temp_2;
+        }
+        {
+            NSMutableArray * temp_2 = [[NSMutableArray alloc] init];
+            temp_2[0] = [NSNumber numberWithUnsignedInt:1UL];
+            temp_2[1] = [NSNumber numberWithUnsignedInt:2UL];
+            temp_2[2] = [NSNumber numberWithUnsignedInt:3UL];
+            ((CHIPTestClusterClusterNestedStructList *) temp_0[0]).e = temp_2;
+        }
+        {
+            NSMutableArray * temp_2 = [[NSMutableArray alloc] init];
+            temp_2[0] = [[NSData alloc] initWithBytes:"octet_string_1" length:14];
+            temp_2[1] = [[NSData alloc] initWithBytes:"octect_string_2" length:15];
+            temp_2[2] = [[NSData alloc] initWithBytes:"octet_string_3" length:14];
+            ((CHIPTestClusterClusterNestedStructList *) temp_0[0]).f = temp_2;
+        }
+        {
+            NSMutableArray * temp_2 = [[NSMutableArray alloc] init];
+            temp_2[0] = [NSNumber numberWithUnsignedChar:0];
+            temp_2[1] = [NSNumber numberWithUnsignedChar:255];
+            ((CHIPTestClusterClusterNestedStructList *) temp_0[0]).g = temp_2;
+        }
+
+        params.arg1 = temp_0;
+    }
+    [cluster testListNestedStructListArgumentRequestWithParams:params
+                                             completionHandler:^(CHIPTestClusterClusterBooleanResponseParams * _Nullable values,
+                                                 NSError * _Nullable err) {
+                                                 NSLog(@"Send Test Command With List of Nested Struct List Argument and all fields "
+                                                       @"b of elements of arg1.d are true Error: %@",
+                                                     err);
+
+                                                 XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+                                                 {
+                                                     id actualValue = values.value;
+                                                     XCTAssertEqual([actualValue boolValue], true);
+                                                 }
+
+                                                 [expectation fulfill];
+                                             }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestCluster_000143_TestListNestedStructListArgumentRequest
+{
+    XCTestExpectation * expectation =
+        [self expectationWithDescription:
+                  @"Send Test Command With Nested Struct List Argument and some fields b of elements of arg1.d are false"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    __auto_type * params = [[CHIPTestClusterClusterTestListNestedStructListArgumentRequestParams alloc] init];
+    {
+        NSMutableArray * temp_0 = [[NSMutableArray alloc] init];
+        temp_0[0] = [[CHIPTestClusterClusterNestedStructList alloc] init];
+        ((CHIPTestClusterClusterNestedStructList *) temp_0[0]).a = [NSNumber numberWithUnsignedChar:0];
+        ((CHIPTestClusterClusterNestedStructList *) temp_0[0]).b = [NSNumber numberWithBool:true];
+        ((CHIPTestClusterClusterNestedStructList *) temp_0[0]).c = [[CHIPTestClusterClusterSimpleStruct alloc] init];
+        ((CHIPTestClusterClusterSimpleStruct *) ((CHIPTestClusterClusterNestedStructList *) temp_0[0]).c).a =
+            [NSNumber numberWithUnsignedChar:0];
+        ((CHIPTestClusterClusterSimpleStruct *) ((CHIPTestClusterClusterNestedStructList *) temp_0[0]).c).b =
+            [NSNumber numberWithBool:true];
+        ((CHIPTestClusterClusterSimpleStruct *) ((CHIPTestClusterClusterNestedStructList *) temp_0[0]).c).c =
+            [NSNumber numberWithUnsignedChar:2];
+        ((CHIPTestClusterClusterSimpleStruct *) ((CHIPTestClusterClusterNestedStructList *) temp_0[0]).c).d =
+            [[NSData alloc] initWithBytes:"octet_string" length:12];
+        ((CHIPTestClusterClusterSimpleStruct *) ((CHIPTestClusterClusterNestedStructList *) temp_0[0]).c).e = @"char_string";
+        ((CHIPTestClusterClusterSimpleStruct *) ((CHIPTestClusterClusterNestedStructList *) temp_0[0]).c).f =
+            [NSNumber numberWithUnsignedChar:1];
+        ((CHIPTestClusterClusterSimpleStruct *) ((CHIPTestClusterClusterNestedStructList *) temp_0[0]).c).g =
+            [NSNumber numberWithFloat:0];
+        ((CHIPTestClusterClusterSimpleStruct *) ((CHIPTestClusterClusterNestedStructList *) temp_0[0]).c).h =
+            [NSNumber numberWithDouble:0];
+
+        {
+            NSMutableArray * temp_2 = [[NSMutableArray alloc] init];
+            temp_2[0] = [[CHIPTestClusterClusterSimpleStruct alloc] init];
+            ((CHIPTestClusterClusterSimpleStruct *) temp_2[0]).a = [NSNumber numberWithUnsignedChar:1];
+            ((CHIPTestClusterClusterSimpleStruct *) temp_2[0]).b = [NSNumber numberWithBool:true];
+            ((CHIPTestClusterClusterSimpleStruct *) temp_2[0]).c = [NSNumber numberWithUnsignedChar:3];
+            ((CHIPTestClusterClusterSimpleStruct *) temp_2[0]).d = [[NSData alloc] initWithBytes:"nested_octet_string" length:19];
+            ((CHIPTestClusterClusterSimpleStruct *) temp_2[0]).e = @"nested_char_string";
+            ((CHIPTestClusterClusterSimpleStruct *) temp_2[0]).f = [NSNumber numberWithUnsignedChar:1];
+            ((CHIPTestClusterClusterSimpleStruct *) temp_2[0]).g = [NSNumber numberWithFloat:0];
+            ((CHIPTestClusterClusterSimpleStruct *) temp_2[0]).h = [NSNumber numberWithDouble:0];
+
+            temp_2[1] = [[CHIPTestClusterClusterSimpleStruct alloc] init];
+            ((CHIPTestClusterClusterSimpleStruct *) temp_2[1]).a = [NSNumber numberWithUnsignedChar:2];
+            ((CHIPTestClusterClusterSimpleStruct *) temp_2[1]).b = [NSNumber numberWithBool:false];
+            ((CHIPTestClusterClusterSimpleStruct *) temp_2[1]).c = [NSNumber numberWithUnsignedChar:3];
+            ((CHIPTestClusterClusterSimpleStruct *) temp_2[1]).d = [[NSData alloc] initWithBytes:"nested_octet_string" length:19];
+            ((CHIPTestClusterClusterSimpleStruct *) temp_2[1]).e = @"nested_char_string";
+            ((CHIPTestClusterClusterSimpleStruct *) temp_2[1]).f = [NSNumber numberWithUnsignedChar:1];
+            ((CHIPTestClusterClusterSimpleStruct *) temp_2[1]).g = [NSNumber numberWithFloat:0];
+            ((CHIPTestClusterClusterSimpleStruct *) temp_2[1]).h = [NSNumber numberWithDouble:0];
+
+            ((CHIPTestClusterClusterNestedStructList *) temp_0[0]).d = temp_2;
+        }
+        {
+            NSMutableArray * temp_2 = [[NSMutableArray alloc] init];
+            temp_2[0] = [NSNumber numberWithUnsignedInt:1UL];
+            temp_2[1] = [NSNumber numberWithUnsignedInt:2UL];
+            temp_2[2] = [NSNumber numberWithUnsignedInt:3UL];
+            ((CHIPTestClusterClusterNestedStructList *) temp_0[0]).e = temp_2;
+        }
+        {
+            NSMutableArray * temp_2 = [[NSMutableArray alloc] init];
+            temp_2[0] = [[NSData alloc] initWithBytes:"octet_string_1" length:14];
+            temp_2[1] = [[NSData alloc] initWithBytes:"octect_string_2" length:15];
+            temp_2[2] = [[NSData alloc] initWithBytes:"octet_string_3" length:14];
+            ((CHIPTestClusterClusterNestedStructList *) temp_0[0]).f = temp_2;
+        }
+        {
+            NSMutableArray * temp_2 = [[NSMutableArray alloc] init];
+            temp_2[0] = [NSNumber numberWithUnsignedChar:0];
+            temp_2[1] = [NSNumber numberWithUnsignedChar:255];
+            ((CHIPTestClusterClusterNestedStructList *) temp_0[0]).g = temp_2;
+        }
+
+        params.arg1 = temp_0;
+    }
+    [cluster testListNestedStructListArgumentRequestWithParams:params
+                                             completionHandler:^(CHIPTestClusterClusterBooleanResponseParams * _Nullable values,
+                                                 NSError * _Nullable err) {
+                                                 NSLog(@"Send Test Command With Nested Struct List Argument and some fields b of "
+                                                       @"elements of arg1.d are false Error: %@",
+                                                     err);
+
+                                                 XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+                                                 {
+                                                     id actualValue = values.value;
+                                                     XCTAssertEqual([actualValue boolValue], false);
+                                                 }
+
+                                                 [expectation fulfill];
+                                             }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestCluster_000144_WriteAttribute
 {
     XCTestExpectation * expectation =
         [self expectationWithDescription:@"Write attribute LIST With List of INT8U and none of them is set to 0"];
@@ -21917,12 +22404,12 @@ CHIPDevice * GetConnectedDevice()
 
     id listInt8uArgument;
     {
-        NSMutableArray * temp = [[NSMutableArray alloc] init];
-        temp[0] = [NSNumber numberWithUnsignedChar:1];
-        temp[1] = [NSNumber numberWithUnsignedChar:2];
-        temp[2] = [NSNumber numberWithUnsignedChar:3];
-        temp[3] = [NSNumber numberWithUnsignedChar:4];
-        listInt8uArgument = temp;
+        NSMutableArray * temp_0 = [[NSMutableArray alloc] init];
+        temp_0[0] = [NSNumber numberWithUnsignedChar:1];
+        temp_0[1] = [NSNumber numberWithUnsignedChar:2];
+        temp_0[2] = [NSNumber numberWithUnsignedChar:3];
+        temp_0[3] = [NSNumber numberWithUnsignedChar:4];
+        listInt8uArgument = temp_0;
     }
     [cluster writeAttributeListInt8uWithValue:listInt8uArgument
                             completionHandler:^(NSError * _Nullable err) {
@@ -21935,7 +22422,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000139_ReadAttribute
+- (void)testSendClusterTestCluster_000145_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute LIST With List of INT8U"];
 
@@ -21963,7 +22450,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000140_WriteAttribute
+- (void)testSendClusterTestCluster_000146_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute LIST With List of OCTET_STRING"];
 
@@ -21974,12 +22461,12 @@ CHIPDevice * GetConnectedDevice()
 
     id listOctetStringArgument;
     {
-        NSMutableArray * temp = [[NSMutableArray alloc] init];
-        temp[0] = [[NSData alloc] initWithBytes:"Test0" length:5];
-        temp[1] = [[NSData alloc] initWithBytes:"Test1" length:5];
-        temp[2] = [[NSData alloc] initWithBytes:"Test2" length:5];
-        temp[3] = [[NSData alloc] initWithBytes:"Test3" length:5];
-        listOctetStringArgument = temp;
+        NSMutableArray * temp_0 = [[NSMutableArray alloc] init];
+        temp_0[0] = [[NSData alloc] initWithBytes:"Test0" length:5];
+        temp_0[1] = [[NSData alloc] initWithBytes:"Test1" length:5];
+        temp_0[2] = [[NSData alloc] initWithBytes:"Test2" length:5];
+        temp_0[3] = [[NSData alloc] initWithBytes:"Test3" length:5];
+        listOctetStringArgument = temp_0;
     }
     [cluster writeAttributeListOctetStringWithValue:listOctetStringArgument
                                   completionHandler:^(NSError * _Nullable err) {
@@ -21992,7 +22479,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000141_ReadAttribute
+- (void)testSendClusterTestCluster_000147_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute LIST With List of OCTET_STRING"];
 
@@ -22020,7 +22507,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000142_WriteAttribute
+- (void)testSendClusterTestCluster_000148_WriteAttribute
 {
     XCTestExpectation * expectation =
         [self expectationWithDescription:@"Write attribute LIST With List of LIST_STRUCT_OCTET_STRING"];
@@ -22032,24 +22519,24 @@ CHIPDevice * GetConnectedDevice()
 
     id listStructOctetStringArgument;
     {
-        NSMutableArray * temp = [[NSMutableArray alloc] init];
-        temp[0] = [[CHIPTestClusterClusterTestListStructOctet alloc] init];
-        ((CHIPTestClusterClusterTestListStructOctet *) temp[0]).fabricIndex = [NSNumber numberWithUnsignedLongLong:0ULL];
-        ((CHIPTestClusterClusterTestListStructOctet *) temp[0]).operationalCert = [[NSData alloc] initWithBytes:"Test0" length:5];
+        NSMutableArray * temp_0 = [[NSMutableArray alloc] init];
+        temp_0[0] = [[CHIPTestClusterClusterTestListStructOctet alloc] init];
+        ((CHIPTestClusterClusterTestListStructOctet *) temp_0[0]).fabricIndex = [NSNumber numberWithUnsignedLongLong:0ULL];
+        ((CHIPTestClusterClusterTestListStructOctet *) temp_0[0]).operationalCert = [[NSData alloc] initWithBytes:"Test0" length:5];
 
-        temp[1] = [[CHIPTestClusterClusterTestListStructOctet alloc] init];
-        ((CHIPTestClusterClusterTestListStructOctet *) temp[1]).fabricIndex = [NSNumber numberWithUnsignedLongLong:1ULL];
-        ((CHIPTestClusterClusterTestListStructOctet *) temp[1]).operationalCert = [[NSData alloc] initWithBytes:"Test1" length:5];
+        temp_0[1] = [[CHIPTestClusterClusterTestListStructOctet alloc] init];
+        ((CHIPTestClusterClusterTestListStructOctet *) temp_0[1]).fabricIndex = [NSNumber numberWithUnsignedLongLong:1ULL];
+        ((CHIPTestClusterClusterTestListStructOctet *) temp_0[1]).operationalCert = [[NSData alloc] initWithBytes:"Test1" length:5];
 
-        temp[2] = [[CHIPTestClusterClusterTestListStructOctet alloc] init];
-        ((CHIPTestClusterClusterTestListStructOctet *) temp[2]).fabricIndex = [NSNumber numberWithUnsignedLongLong:2ULL];
-        ((CHIPTestClusterClusterTestListStructOctet *) temp[2]).operationalCert = [[NSData alloc] initWithBytes:"Test2" length:5];
+        temp_0[2] = [[CHIPTestClusterClusterTestListStructOctet alloc] init];
+        ((CHIPTestClusterClusterTestListStructOctet *) temp_0[2]).fabricIndex = [NSNumber numberWithUnsignedLongLong:2ULL];
+        ((CHIPTestClusterClusterTestListStructOctet *) temp_0[2]).operationalCert = [[NSData alloc] initWithBytes:"Test2" length:5];
 
-        temp[3] = [[CHIPTestClusterClusterTestListStructOctet alloc] init];
-        ((CHIPTestClusterClusterTestListStructOctet *) temp[3]).fabricIndex = [NSNumber numberWithUnsignedLongLong:3ULL];
-        ((CHIPTestClusterClusterTestListStructOctet *) temp[3]).operationalCert = [[NSData alloc] initWithBytes:"Test3" length:5];
+        temp_0[3] = [[CHIPTestClusterClusterTestListStructOctet alloc] init];
+        ((CHIPTestClusterClusterTestListStructOctet *) temp_0[3]).fabricIndex = [NSNumber numberWithUnsignedLongLong:3ULL];
+        ((CHIPTestClusterClusterTestListStructOctet *) temp_0[3]).operationalCert = [[NSData alloc] initWithBytes:"Test3" length:5];
 
-        listStructOctetStringArgument = temp;
+        listStructOctetStringArgument = temp_0;
     }
     [cluster writeAttributeListStructOctetStringWithValue:listStructOctetStringArgument
                                         completionHandler:^(NSError * _Nullable err) {
@@ -22062,7 +22549,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000143_ReadAttribute
+- (void)testSendClusterTestCluster_000149_ReadAttribute
 {
     XCTestExpectation * expectation =
         [self expectationWithDescription:@"Read attribute LIST With List of LIST_STRUCT_OCTET_STRING"];
@@ -22103,7 +22590,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000144_TestNullableOptionalRequest
+- (void)testSendClusterTestCluster_000150_TestNullableOptionalRequest
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Send Test Command with optional arg set."];
 
@@ -22144,7 +22631,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000145_TestNullableOptionalRequest
+- (void)testSendClusterTestCluster_000151_TestNullableOptionalRequest
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Send Test Command without its optional arg."];
 
@@ -22171,7 +22658,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000146_WriteAttribute
+- (void)testSendClusterTestCluster_000152_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute NULLABLE_BOOLEAN null"];
 
@@ -22193,7 +22680,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000147_ReadAttribute
+- (void)testSendClusterTestCluster_000153_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute NULLABLE_BOOLEAN null"];
 
@@ -22217,7 +22704,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000148_WriteAttribute
+- (void)testSendClusterTestCluster_000154_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute NULLABLE_BOOLEAN True"];
 
@@ -22239,7 +22726,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000149_ReadAttribute
+- (void)testSendClusterTestCluster_000155_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute NULLABLE_BOOLEAN True"];
 
@@ -22264,7 +22751,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000150_WriteAttribute
+- (void)testSendClusterTestCluster_000156_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute NULLABLE_BITMAP8 Max Value"];
 
@@ -22286,7 +22773,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000151_ReadAttribute
+- (void)testSendClusterTestCluster_000157_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute NULLABLE_BITMAP8 Max Value"];
 
@@ -22311,7 +22798,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000152_WriteAttribute
+- (void)testSendClusterTestCluster_000158_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute NULLABLE_BITMAP8 Invalid Value"];
 
@@ -22332,7 +22819,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000153_ReadAttribute
+- (void)testSendClusterTestCluster_000159_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute NULLABLE_BITMAP8 unchanged Value"];
 
@@ -22357,7 +22844,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000154_WriteAttribute
+- (void)testSendClusterTestCluster_000160_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute NULLABLE_BITMAP8 null Value"];
 
@@ -22379,7 +22866,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000155_ReadAttribute
+- (void)testSendClusterTestCluster_000161_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute NULLABLE_BITMAP8 null Value"];
 
@@ -22403,7 +22890,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000156_WriteAttribute
+- (void)testSendClusterTestCluster_000162_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute NULLABLE_BITMAP16 Max Value"];
 
@@ -22425,7 +22912,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000157_ReadAttribute
+- (void)testSendClusterTestCluster_000163_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute NULLABLE_BITMAP16 Max Value"];
 
@@ -22450,7 +22937,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000158_WriteAttribute
+- (void)testSendClusterTestCluster_000164_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute NULLABLE_BITMAP16 Invalid Value"];
 
@@ -22471,7 +22958,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000159_ReadAttribute
+- (void)testSendClusterTestCluster_000165_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute NULLABLE_BITMAP16 unchanged Value"];
 
@@ -22496,7 +22983,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000160_WriteAttribute
+- (void)testSendClusterTestCluster_000166_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute NULLABLE_BITMAP16 null Value"];
 
@@ -22518,7 +23005,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000161_ReadAttribute
+- (void)testSendClusterTestCluster_000167_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute NULLABLE_BITMAP16 null Value"];
 
@@ -22542,7 +23029,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000162_WriteAttribute
+- (void)testSendClusterTestCluster_000168_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute NULLABLE_BITMAP32 Max Value"];
 
@@ -22564,7 +23051,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000163_ReadAttribute
+- (void)testSendClusterTestCluster_000169_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute NULLABLE_BITMAP32 Max Value"];
 
@@ -22589,7 +23076,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000164_WriteAttribute
+- (void)testSendClusterTestCluster_000170_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute NULLABLE_BITMAP32 Invalid Value"];
 
@@ -22610,7 +23097,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000165_ReadAttribute
+- (void)testSendClusterTestCluster_000171_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute NULLABLE_BITMAP32 unchanged Value"];
 
@@ -22635,7 +23122,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000166_WriteAttribute
+- (void)testSendClusterTestCluster_000172_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute NULLABLE_BITMAP32 null Value"];
 
@@ -22657,7 +23144,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000167_ReadAttribute
+- (void)testSendClusterTestCluster_000173_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute NULLABLE_BITMAP32 null Value"];
 
@@ -22681,7 +23168,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000168_WriteAttribute
+- (void)testSendClusterTestCluster_000174_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute NULLABLE_BITMAP64 Max Value"];
 
@@ -22703,7 +23190,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000169_ReadAttribute
+- (void)testSendClusterTestCluster_000175_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute NULLABLE_BITMAP64 Max Value"];
 
@@ -22728,7 +23215,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000170_WriteAttribute
+- (void)testSendClusterTestCluster_000176_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute NULLABLE_BITMAP64 Invalid Value"];
 
@@ -22749,7 +23236,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000171_ReadAttribute
+- (void)testSendClusterTestCluster_000177_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute NULLABLE_BITMAP64 unchanged Value"];
 
@@ -22774,7 +23261,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000172_WriteAttribute
+- (void)testSendClusterTestCluster_000178_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute NULLABLE_BITMAP64 null Value"];
 
@@ -22796,7 +23283,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000173_ReadAttribute
+- (void)testSendClusterTestCluster_000179_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute NULLABLE_BITMAP64 null Value"];
 
@@ -22820,7 +23307,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000174_WriteAttribute
+- (void)testSendClusterTestCluster_000180_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute NULLABLE_INT8U Max Value"];
 
@@ -22842,7 +23329,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000175_ReadAttribute
+- (void)testSendClusterTestCluster_000181_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute NULLABLE_INT8U Max Value"];
 
@@ -22867,7 +23354,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000176_WriteAttribute
+- (void)testSendClusterTestCluster_000182_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute NULLABLE_INT8U Invalid Value"];
 
@@ -22888,7 +23375,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000177_ReadAttribute
+- (void)testSendClusterTestCluster_000183_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute NULLABLE_INT8U unchanged Value"];
 
@@ -22913,7 +23400,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000178_WriteAttribute
+- (void)testSendClusterTestCluster_000184_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute NULLABLE_INT8U null Value"];
 
@@ -22935,7 +23422,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000179_ReadAttribute
+- (void)testSendClusterTestCluster_000185_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute NULLABLE_INT8U null Value"];
 
@@ -22959,7 +23446,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000180_WriteAttribute
+- (void)testSendClusterTestCluster_000186_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute NULLABLE_INT16U Max Value"];
 
@@ -22981,7 +23468,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000181_ReadAttribute
+- (void)testSendClusterTestCluster_000187_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute NULLABLE_INT16U Max Value"];
 
@@ -23006,7 +23493,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000182_WriteAttribute
+- (void)testSendClusterTestCluster_000188_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute NULLABLE_INT16U Invalid Value"];
 
@@ -23027,7 +23514,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000183_ReadAttribute
+- (void)testSendClusterTestCluster_000189_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute NULLABLE_INT16U unchanged Value"];
 
@@ -23052,7 +23539,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000184_WriteAttribute
+- (void)testSendClusterTestCluster_000190_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute NULLABLE_INT16U null Value"];
 
@@ -23074,7 +23561,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000185_ReadAttribute
+- (void)testSendClusterTestCluster_000191_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute NULLABLE_INT16U null Value"];
 
@@ -23098,7 +23585,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000186_WriteAttribute
+- (void)testSendClusterTestCluster_000192_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute NULLABLE_INT32U Max Value"];
 
@@ -23120,7 +23607,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000187_ReadAttribute
+- (void)testSendClusterTestCluster_000193_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute NULLABLE_INT32U Max Value"];
 
@@ -23145,7 +23632,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000188_WriteAttribute
+- (void)testSendClusterTestCluster_000194_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute NULLABLE_INT32U Invalid Value"];
 
@@ -23166,7 +23653,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000189_ReadAttribute
+- (void)testSendClusterTestCluster_000195_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute NULLABLE_INT32U unchanged Value"];
 
@@ -23191,7 +23678,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000190_WriteAttribute
+- (void)testSendClusterTestCluster_000196_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute NULLABLE_INT32U null Value"];
 
@@ -23213,7 +23700,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000191_ReadAttribute
+- (void)testSendClusterTestCluster_000197_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute NULLABLE_INT32U null Value"];
 
@@ -23237,7 +23724,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000192_WriteAttribute
+- (void)testSendClusterTestCluster_000198_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute NULLABLE_INT64U Max Value"];
 
@@ -23259,7 +23746,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000193_ReadAttribute
+- (void)testSendClusterTestCluster_000199_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute NULLABLE_INT64U Max Value"];
 
@@ -23284,7 +23771,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000194_WriteAttribute
+- (void)testSendClusterTestCluster_000200_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute NULLABLE_INT64U Invalid Value"];
 
@@ -23305,7 +23792,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000195_ReadAttribute
+- (void)testSendClusterTestCluster_000201_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute NULLABLE_INT64U unchanged Value"];
 
@@ -23330,7 +23817,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000196_WriteAttribute
+- (void)testSendClusterTestCluster_000202_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute NULLABLE_INT64U null Value"];
 
@@ -23352,7 +23839,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000197_ReadAttribute
+- (void)testSendClusterTestCluster_000203_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute NULLABLE_INT64U null Value"];
 
@@ -23376,7 +23863,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000198_WriteAttribute
+- (void)testSendClusterTestCluster_000204_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute NULLABLE_INT8S Min Value"];
 
@@ -23398,7 +23885,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000199_ReadAttribute
+- (void)testSendClusterTestCluster_000205_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute NULLABLE_INT8S Min Value"];
 
@@ -23423,7 +23910,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000200_WriteAttribute
+- (void)testSendClusterTestCluster_000206_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute NULLABLE_INT8S Invalid Value"];
 
@@ -23444,7 +23931,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000201_ReadAttribute
+- (void)testSendClusterTestCluster_000207_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute NULLABLE_INT8S unchanged Value"];
 
@@ -23469,7 +23956,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000202_WriteAttribute
+- (void)testSendClusterTestCluster_000208_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute NULLABLE_INT8S null Value"];
 
@@ -23491,7 +23978,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000203_ReadAttribute
+- (void)testSendClusterTestCluster_000209_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute NULLABLE_INT8S null Value"];
 
@@ -23515,7 +24002,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000204_WriteAttribute
+- (void)testSendClusterTestCluster_000210_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute NULLABLE_INT16S Min Value"];
 
@@ -23537,7 +24024,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000205_ReadAttribute
+- (void)testSendClusterTestCluster_000211_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute NULLABLE_INT16S Min Value"];
 
@@ -23562,7 +24049,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000206_WriteAttribute
+- (void)testSendClusterTestCluster_000212_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute NULLABLE_INT16S Invalid Value"];
 
@@ -23583,7 +24070,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000207_ReadAttribute
+- (void)testSendClusterTestCluster_000213_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute NULLABLE_INT16S unchanged Value"];
 
@@ -23608,7 +24095,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000208_WriteAttribute
+- (void)testSendClusterTestCluster_000214_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute NULLABLE_INT16S null Value"];
 
@@ -23630,7 +24117,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000209_ReadAttribute
+- (void)testSendClusterTestCluster_000215_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute NULLABLE_INT16S null Value"];
 
@@ -23654,7 +24141,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000210_WriteAttribute
+- (void)testSendClusterTestCluster_000216_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute NULLABLE_INT32S Min Value"];
 
@@ -23676,7 +24163,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000211_ReadAttribute
+- (void)testSendClusterTestCluster_000217_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute NULLABLE_INT32S Min Value"];
 
@@ -23701,7 +24188,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000212_WriteAttribute
+- (void)testSendClusterTestCluster_000218_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute NULLABLE_INT32S Invalid Value"];
 
@@ -23722,7 +24209,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000213_ReadAttribute
+- (void)testSendClusterTestCluster_000219_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute NULLABLE_INT32S unchanged Value"];
 
@@ -23747,7 +24234,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000214_WriteAttribute
+- (void)testSendClusterTestCluster_000220_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute NULLABLE_INT32S null Value"];
 
@@ -23769,7 +24256,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000215_ReadAttribute
+- (void)testSendClusterTestCluster_000221_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute NULLABLE_INT32S null Value"];
 
@@ -23793,7 +24280,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000216_WriteAttribute
+- (void)testSendClusterTestCluster_000222_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute NULLABLE_INT64S Min Value"];
 
@@ -23815,7 +24302,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000217_ReadAttribute
+- (void)testSendClusterTestCluster_000223_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute NULLABLE_INT64S Min Value"];
 
@@ -23840,7 +24327,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000218_WriteAttribute
+- (void)testSendClusterTestCluster_000224_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute NULLABLE_INT64S Invalid Value"];
 
@@ -23861,7 +24348,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000219_ReadAttribute
+- (void)testSendClusterTestCluster_000225_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute NULLABLE_INT64S unchanged Value"];
 
@@ -23886,7 +24373,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000220_WriteAttribute
+- (void)testSendClusterTestCluster_000226_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute NULLABLE_INT64S null Value"];
 
@@ -23908,7 +24395,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000221_ReadAttribute
+- (void)testSendClusterTestCluster_000227_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute NULLABLE_INT64S null Value"];
 
@@ -23932,7 +24419,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000222_WriteAttribute
+- (void)testSendClusterTestCluster_000228_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute NULLABLE_ENUM8 Max Value"];
 
@@ -23954,7 +24441,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000223_ReadAttribute
+- (void)testSendClusterTestCluster_000229_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute NULLABLE_ENUM8 Max Value"];
 
@@ -23979,7 +24466,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000224_WriteAttribute
+- (void)testSendClusterTestCluster_000230_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute NULLABLE_ENUM8 Invalid Value"];
 
@@ -24000,7 +24487,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000225_ReadAttribute
+- (void)testSendClusterTestCluster_000231_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute NULLABLE_ENUM8 unchanged Value"];
 
@@ -24025,7 +24512,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000226_WriteAttribute
+- (void)testSendClusterTestCluster_000232_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute NULLABLE_ENUM8 null Value"];
 
@@ -24047,7 +24534,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000227_ReadAttribute
+- (void)testSendClusterTestCluster_000233_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute NULLABLE_ENUM8 null Value"];
 
@@ -24071,7 +24558,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000228_WriteAttribute
+- (void)testSendClusterTestCluster_000234_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute NULLABLE_ENUM16 Max Value"];
 
@@ -24093,7 +24580,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000229_ReadAttribute
+- (void)testSendClusterTestCluster_000235_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute NULLABLE_ENUM16 Max Value"];
 
@@ -24118,7 +24605,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000230_WriteAttribute
+- (void)testSendClusterTestCluster_000236_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute NULLABLE_ENUM16 Invalid Value"];
 
@@ -24139,7 +24626,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000231_ReadAttribute
+- (void)testSendClusterTestCluster_000237_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute NULLABLE_ENUM16 unchanged Value"];
 
@@ -24164,7 +24651,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000232_WriteAttribute
+- (void)testSendClusterTestCluster_000238_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute NULLABLE_ENUM16 null Value"];
 
@@ -24186,7 +24673,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000233_ReadAttribute
+- (void)testSendClusterTestCluster_000239_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute NULLABLE_ENUM16 null Value"];
 
@@ -24210,7 +24697,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000234_ReadAttribute
+- (void)testSendClusterTestCluster_000240_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute NULLABLE_OCTET_STRING Default Value"];
 
@@ -24235,7 +24722,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000235_WriteAttribute
+- (void)testSendClusterTestCluster_000241_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute NULLABLE_OCTET_STRING"];
 
@@ -24257,7 +24744,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000236_ReadAttribute
+- (void)testSendClusterTestCluster_000242_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute NULLABLE_OCTET_STRING"];
 
@@ -24282,7 +24769,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000237_WriteAttribute
+- (void)testSendClusterTestCluster_000243_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute NULLABLE_OCTET_STRING"];
 
@@ -24304,7 +24791,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000238_ReadAttribute
+- (void)testSendClusterTestCluster_000244_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute NULLABLE_OCTET_STRING"];
 
@@ -24328,7 +24815,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000239_WriteAttribute
+- (void)testSendClusterTestCluster_000245_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute NULLABLE_OCTET_STRING"];
 
@@ -24350,7 +24837,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000240_ReadAttribute
+- (void)testSendClusterTestCluster_000246_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute NULLABLE_OCTET_STRING"];
 
@@ -24375,7 +24862,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000241_ReadAttribute
+- (void)testSendClusterTestCluster_000247_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute NULLABLE_CHAR_STRING Default Value"];
 
@@ -24400,7 +24887,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000242_WriteAttribute
+- (void)testSendClusterTestCluster_000248_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute NULLABLE_CHAR_STRING"];
 
@@ -24422,7 +24909,32 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000243_WriteAttribute
+- (void)testSendClusterTestCluster_000249_ReadAttribute
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute NULLABLE_CHAR_STRING"];
+
+    CHIPDevice * device = GetConnectedDevice();
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster readAttributeNullableCharStringWithCompletionHandler:^(NSString * _Nullable value, NSError * _Nullable err) {
+        NSLog(@"Read attribute NULLABLE_CHAR_STRING Error: %@", err);
+
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 0);
+
+        {
+            id actualValue = value;
+            XCTAssertFalse(actualValue == nil);
+            XCTAssertTrue([actualValue isEqualToString:@"☉T☉"]);
+        }
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTestCluster_000250_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute NULLABLE_CHAR_STRING - Value too long"];
 
@@ -24444,7 +24956,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000244_ReadAttribute
+- (void)testSendClusterTestCluster_000251_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute NULLABLE_CHAR_STRING"];
 
@@ -24468,7 +24980,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000245_WriteAttribute
+- (void)testSendClusterTestCluster_000252_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute NULLABLE_CHAR_STRING - Empty"];
 
@@ -24490,7 +25002,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000246_ReadAttribute
+- (void)testSendClusterTestCluster_000253_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute NULLABLE_CHAR_STRING"];
 
@@ -24515,7 +25027,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000247_ReadAttribute
+- (void)testSendClusterTestCluster_000254_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute from nonexistent endpoint."];
 
@@ -24533,7 +25045,7 @@ CHIPDevice * GetConnectedDevice()
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestCluster_000248_ReadAttribute
+- (void)testSendClusterTestCluster_000255_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute from nonexistent cluster."];
 

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
@@ -28411,7 +28411,7 @@ public:
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 
-    using ResponseType = DataModel::NullObjectType;
+    using ResponseType = Clusters::TestCluster::Commands::BooleanResponse::DecodableType;
 };
 
 struct DecodableType

--- a/zzz_generated/chip-tool/zap-generated/cluster/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/cluster/Commands.h
@@ -36302,7 +36302,10 @@ private:
 | * TestEnumsRequest                                                  |   0x0E |
 | * TestListInt8UArgumentRequest                                      |   0x0A |
 | * TestListInt8UReverseRequest                                       |   0x0D |
+| * TestListNestedStructListArgumentRequest                           |   0x0C |
 | * TestListStructArgumentRequest                                     |   0x09 |
+| * TestNestedStructArgumentRequest                                   |   0x08 |
+| * TestNestedStructListArgumentRequest                               |   0x0B |
 | * TestNotHandled                                                    |   0x01 |
 | * TestNullableOptionalRequest                                       |   0x0F |
 | * TestSpecific                                                      |   0x02 |
@@ -36499,6 +36502,30 @@ private:
 };
 
 /*
+ * Command TestListNestedStructListArgumentRequest
+ */
+class TestClusterTestListNestedStructListArgumentRequest : public ModelCommand
+{
+public:
+    TestClusterTestListNestedStructListArgumentRequest() : ModelCommand("test-list-nested-struct-list-argument-request")
+    {
+        // arg1 Array parsing is not supported yet
+        ModelCommand::AddArguments();
+    }
+
+    CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
+    {
+        ChipLogProgress(chipTool, "Sending cluster (0x0000050F) command (0x0000000C) on endpoint %" PRIu8, endpointId);
+
+        return chip::Controller::InvokeCommand(device, this, OnTestClusterBooleanResponseSuccess, OnDefaultFailure, endpointId,
+                                               mRequest);
+    }
+
+private:
+    chip::app::Clusters::TestCluster::Commands::TestListNestedStructListArgumentRequest::Type mRequest;
+};
+
+/*
  * Command TestListStructArgumentRequest
  */
 class TestClusterTestListStructArgumentRequest : public ModelCommand
@@ -36520,6 +36547,54 @@ public:
 
 private:
     chip::app::Clusters::TestCluster::Commands::TestListStructArgumentRequest::Type mRequest;
+};
+
+/*
+ * Command TestNestedStructArgumentRequest
+ */
+class TestClusterTestNestedStructArgumentRequest : public ModelCommand
+{
+public:
+    TestClusterTestNestedStructArgumentRequest() : ModelCommand("test-nested-struct-argument-request")
+    {
+        // arg1 Struct parsing is not supported yet
+        ModelCommand::AddArguments();
+    }
+
+    CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
+    {
+        ChipLogProgress(chipTool, "Sending cluster (0x0000050F) command (0x00000008) on endpoint %" PRIu8, endpointId);
+
+        return chip::Controller::InvokeCommand(device, this, OnTestClusterBooleanResponseSuccess, OnDefaultFailure, endpointId,
+                                               mRequest);
+    }
+
+private:
+    chip::app::Clusters::TestCluster::Commands::TestNestedStructArgumentRequest::Type mRequest;
+};
+
+/*
+ * Command TestNestedStructListArgumentRequest
+ */
+class TestClusterTestNestedStructListArgumentRequest : public ModelCommand
+{
+public:
+    TestClusterTestNestedStructListArgumentRequest() : ModelCommand("test-nested-struct-list-argument-request")
+    {
+        // arg1 Struct parsing is not supported yet
+        ModelCommand::AddArguments();
+    }
+
+    CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
+    {
+        ChipLogProgress(chipTool, "Sending cluster (0x0000050F) command (0x0000000B) on endpoint %" PRIu8, endpointId);
+
+        return chip::Controller::InvokeCommand(device, this, OnTestClusterBooleanResponseSuccess, OnDefaultFailure, endpointId,
+                                               mRequest);
+    }
+
+private:
+    chip::app::Clusters::TestCluster::Commands::TestNestedStructListArgumentRequest::Type mRequest;
 };
 
 /*
@@ -54213,144 +54288,147 @@ void registerClusterTestCluster(Commands & commands)
     const char * clusterName = "TestCluster";
 
     commands_list clusterCommands = {
-        make_unique<TestClusterSimpleStructEchoRequest>(),             //
-        make_unique<TestClusterTest>(),                                //
-        make_unique<TestClusterTestAddArguments>(),                    //
-        make_unique<TestClusterTestEnumsRequest>(),                    //
-        make_unique<TestClusterTestListInt8UArgumentRequest>(),        //
-        make_unique<TestClusterTestListInt8UReverseRequest>(),         //
-        make_unique<TestClusterTestListStructArgumentRequest>(),       //
-        make_unique<TestClusterTestNotHandled>(),                      //
-        make_unique<TestClusterTestNullableOptionalRequest>(),         //
-        make_unique<TestClusterTestSpecific>(),                        //
-        make_unique<TestClusterTestStructArgumentRequest>(),           //
-        make_unique<TestClusterTestUnknownCommand>(),                  //
-        make_unique<ReadTestClusterBoolean>(),                         //
-        make_unique<WriteTestClusterBoolean>(),                        //
-        make_unique<ReportTestClusterBoolean>(),                       //
-        make_unique<ReadTestClusterBitmap8>(),                         //
-        make_unique<WriteTestClusterBitmap8>(),                        //
-        make_unique<ReportTestClusterBitmap8>(),                       //
-        make_unique<ReadTestClusterBitmap16>(),                        //
-        make_unique<WriteTestClusterBitmap16>(),                       //
-        make_unique<ReportTestClusterBitmap16>(),                      //
-        make_unique<ReadTestClusterBitmap32>(),                        //
-        make_unique<WriteTestClusterBitmap32>(),                       //
-        make_unique<ReportTestClusterBitmap32>(),                      //
-        make_unique<ReadTestClusterBitmap64>(),                        //
-        make_unique<WriteTestClusterBitmap64>(),                       //
-        make_unique<ReportTestClusterBitmap64>(),                      //
-        make_unique<ReadTestClusterInt8u>(),                           //
-        make_unique<WriteTestClusterInt8u>(),                          //
-        make_unique<ReportTestClusterInt8u>(),                         //
-        make_unique<ReadTestClusterInt16u>(),                          //
-        make_unique<WriteTestClusterInt16u>(),                         //
-        make_unique<ReportTestClusterInt16u>(),                        //
-        make_unique<ReadTestClusterInt32u>(),                          //
-        make_unique<WriteTestClusterInt32u>(),                         //
-        make_unique<ReportTestClusterInt32u>(),                        //
-        make_unique<ReadTestClusterInt64u>(),                          //
-        make_unique<WriteTestClusterInt64u>(),                         //
-        make_unique<ReportTestClusterInt64u>(),                        //
-        make_unique<ReadTestClusterInt8s>(),                           //
-        make_unique<WriteTestClusterInt8s>(),                          //
-        make_unique<ReportTestClusterInt8s>(),                         //
-        make_unique<ReadTestClusterInt16s>(),                          //
-        make_unique<WriteTestClusterInt16s>(),                         //
-        make_unique<ReportTestClusterInt16s>(),                        //
-        make_unique<ReadTestClusterInt32s>(),                          //
-        make_unique<WriteTestClusterInt32s>(),                         //
-        make_unique<ReportTestClusterInt32s>(),                        //
-        make_unique<ReadTestClusterInt64s>(),                          //
-        make_unique<WriteTestClusterInt64s>(),                         //
-        make_unique<ReportTestClusterInt64s>(),                        //
-        make_unique<ReadTestClusterEnum8>(),                           //
-        make_unique<WriteTestClusterEnum8>(),                          //
-        make_unique<ReportTestClusterEnum8>(),                         //
-        make_unique<ReadTestClusterEnum16>(),                          //
-        make_unique<WriteTestClusterEnum16>(),                         //
-        make_unique<ReportTestClusterEnum16>(),                        //
-        make_unique<ReadTestClusterOctetString>(),                     //
-        make_unique<WriteTestClusterOctetString>(),                    //
-        make_unique<ReportTestClusterOctetString>(),                   //
-        make_unique<ReadTestClusterListInt8u>(),                       //
-        make_unique<ReadTestClusterListOctetString>(),                 //
-        make_unique<ReadTestClusterListStructOctetString>(),           //
-        make_unique<ReadTestClusterLongOctetString>(),                 //
-        make_unique<WriteTestClusterLongOctetString>(),                //
-        make_unique<ReportTestClusterLongOctetString>(),               //
-        make_unique<ReadTestClusterCharString>(),                      //
-        make_unique<WriteTestClusterCharString>(),                     //
-        make_unique<ReportTestClusterCharString>(),                    //
-        make_unique<ReadTestClusterLongCharString>(),                  //
-        make_unique<WriteTestClusterLongCharString>(),                 //
-        make_unique<ReportTestClusterLongCharString>(),                //
-        make_unique<ReadTestClusterEpochUs>(),                         //
-        make_unique<WriteTestClusterEpochUs>(),                        //
-        make_unique<ReportTestClusterEpochUs>(),                       //
-        make_unique<ReadTestClusterEpochS>(),                          //
-        make_unique<WriteTestClusterEpochS>(),                         //
-        make_unique<ReportTestClusterEpochS>(),                        //
-        make_unique<ReadTestClusterVendorId>(),                        //
-        make_unique<WriteTestClusterVendorId>(),                       //
-        make_unique<ReportTestClusterVendorId>(),                      //
-        make_unique<ReadTestClusterListNullablesAndOptionalsStruct>(), //
-        make_unique<ReadTestClusterUnsupported>(),                     //
-        make_unique<WriteTestClusterUnsupported>(),                    //
-        make_unique<ReportTestClusterUnsupported>(),                   //
-        make_unique<ReadTestClusterNullableBoolean>(),                 //
-        make_unique<WriteTestClusterNullableBoolean>(),                //
-        make_unique<ReportTestClusterNullableBoolean>(),               //
-        make_unique<ReadTestClusterNullableBitmap8>(),                 //
-        make_unique<WriteTestClusterNullableBitmap8>(),                //
-        make_unique<ReportTestClusterNullableBitmap8>(),               //
-        make_unique<ReadTestClusterNullableBitmap16>(),                //
-        make_unique<WriteTestClusterNullableBitmap16>(),               //
-        make_unique<ReportTestClusterNullableBitmap16>(),              //
-        make_unique<ReadTestClusterNullableBitmap32>(),                //
-        make_unique<WriteTestClusterNullableBitmap32>(),               //
-        make_unique<ReportTestClusterNullableBitmap32>(),              //
-        make_unique<ReadTestClusterNullableBitmap64>(),                //
-        make_unique<WriteTestClusterNullableBitmap64>(),               //
-        make_unique<ReportTestClusterNullableBitmap64>(),              //
-        make_unique<ReadTestClusterNullableInt8u>(),                   //
-        make_unique<WriteTestClusterNullableInt8u>(),                  //
-        make_unique<ReportTestClusterNullableInt8u>(),                 //
-        make_unique<ReadTestClusterNullableInt16u>(),                  //
-        make_unique<WriteTestClusterNullableInt16u>(),                 //
-        make_unique<ReportTestClusterNullableInt16u>(),                //
-        make_unique<ReadTestClusterNullableInt32u>(),                  //
-        make_unique<WriteTestClusterNullableInt32u>(),                 //
-        make_unique<ReportTestClusterNullableInt32u>(),                //
-        make_unique<ReadTestClusterNullableInt64u>(),                  //
-        make_unique<WriteTestClusterNullableInt64u>(),                 //
-        make_unique<ReportTestClusterNullableInt64u>(),                //
-        make_unique<ReadTestClusterNullableInt8s>(),                   //
-        make_unique<WriteTestClusterNullableInt8s>(),                  //
-        make_unique<ReportTestClusterNullableInt8s>(),                 //
-        make_unique<ReadTestClusterNullableInt16s>(),                  //
-        make_unique<WriteTestClusterNullableInt16s>(),                 //
-        make_unique<ReportTestClusterNullableInt16s>(),                //
-        make_unique<ReadTestClusterNullableInt32s>(),                  //
-        make_unique<WriteTestClusterNullableInt32s>(),                 //
-        make_unique<ReportTestClusterNullableInt32s>(),                //
-        make_unique<ReadTestClusterNullableInt64s>(),                  //
-        make_unique<WriteTestClusterNullableInt64s>(),                 //
-        make_unique<ReportTestClusterNullableInt64s>(),                //
-        make_unique<ReadTestClusterNullableEnum8>(),                   //
-        make_unique<WriteTestClusterNullableEnum8>(),                  //
-        make_unique<ReportTestClusterNullableEnum8>(),                 //
-        make_unique<ReadTestClusterNullableEnum16>(),                  //
-        make_unique<WriteTestClusterNullableEnum16>(),                 //
-        make_unique<ReportTestClusterNullableEnum16>(),                //
-        make_unique<ReadTestClusterNullableOctetString>(),             //
-        make_unique<WriteTestClusterNullableOctetString>(),            //
-        make_unique<ReportTestClusterNullableOctetString>(),           //
-        make_unique<ReadTestClusterNullableCharString>(),              //
-        make_unique<WriteTestClusterNullableCharString>(),             //
-        make_unique<ReportTestClusterNullableCharString>(),            //
-        make_unique<ReadTestClusterClusterRevision>(),                 //
-        make_unique<ReportTestClusterClusterRevision>(),               //
+        make_unique<TestClusterSimpleStructEchoRequest>(),                 //
+        make_unique<TestClusterTest>(),                                    //
+        make_unique<TestClusterTestAddArguments>(),                        //
+        make_unique<TestClusterTestEnumsRequest>(),                        //
+        make_unique<TestClusterTestListInt8UArgumentRequest>(),            //
+        make_unique<TestClusterTestListInt8UReverseRequest>(),             //
+        make_unique<TestClusterTestListNestedStructListArgumentRequest>(), //
+        make_unique<TestClusterTestListStructArgumentRequest>(),           //
+        make_unique<TestClusterTestNestedStructArgumentRequest>(),         //
+        make_unique<TestClusterTestNestedStructListArgumentRequest>(),     //
+        make_unique<TestClusterTestNotHandled>(),                          //
+        make_unique<TestClusterTestNullableOptionalRequest>(),             //
+        make_unique<TestClusterTestSpecific>(),                            //
+        make_unique<TestClusterTestStructArgumentRequest>(),               //
+        make_unique<TestClusterTestUnknownCommand>(),                      //
+        make_unique<ReadTestClusterBoolean>(),                             //
+        make_unique<WriteTestClusterBoolean>(),                            //
+        make_unique<ReportTestClusterBoolean>(),                           //
+        make_unique<ReadTestClusterBitmap8>(),                             //
+        make_unique<WriteTestClusterBitmap8>(),                            //
+        make_unique<ReportTestClusterBitmap8>(),                           //
+        make_unique<ReadTestClusterBitmap16>(),                            //
+        make_unique<WriteTestClusterBitmap16>(),                           //
+        make_unique<ReportTestClusterBitmap16>(),                          //
+        make_unique<ReadTestClusterBitmap32>(),                            //
+        make_unique<WriteTestClusterBitmap32>(),                           //
+        make_unique<ReportTestClusterBitmap32>(),                          //
+        make_unique<ReadTestClusterBitmap64>(),                            //
+        make_unique<WriteTestClusterBitmap64>(),                           //
+        make_unique<ReportTestClusterBitmap64>(),                          //
+        make_unique<ReadTestClusterInt8u>(),                               //
+        make_unique<WriteTestClusterInt8u>(),                              //
+        make_unique<ReportTestClusterInt8u>(),                             //
+        make_unique<ReadTestClusterInt16u>(),                              //
+        make_unique<WriteTestClusterInt16u>(),                             //
+        make_unique<ReportTestClusterInt16u>(),                            //
+        make_unique<ReadTestClusterInt32u>(),                              //
+        make_unique<WriteTestClusterInt32u>(),                             //
+        make_unique<ReportTestClusterInt32u>(),                            //
+        make_unique<ReadTestClusterInt64u>(),                              //
+        make_unique<WriteTestClusterInt64u>(),                             //
+        make_unique<ReportTestClusterInt64u>(),                            //
+        make_unique<ReadTestClusterInt8s>(),                               //
+        make_unique<WriteTestClusterInt8s>(),                              //
+        make_unique<ReportTestClusterInt8s>(),                             //
+        make_unique<ReadTestClusterInt16s>(),                              //
+        make_unique<WriteTestClusterInt16s>(),                             //
+        make_unique<ReportTestClusterInt16s>(),                            //
+        make_unique<ReadTestClusterInt32s>(),                              //
+        make_unique<WriteTestClusterInt32s>(),                             //
+        make_unique<ReportTestClusterInt32s>(),                            //
+        make_unique<ReadTestClusterInt64s>(),                              //
+        make_unique<WriteTestClusterInt64s>(),                             //
+        make_unique<ReportTestClusterInt64s>(),                            //
+        make_unique<ReadTestClusterEnum8>(),                               //
+        make_unique<WriteTestClusterEnum8>(),                              //
+        make_unique<ReportTestClusterEnum8>(),                             //
+        make_unique<ReadTestClusterEnum16>(),                              //
+        make_unique<WriteTestClusterEnum16>(),                             //
+        make_unique<ReportTestClusterEnum16>(),                            //
+        make_unique<ReadTestClusterOctetString>(),                         //
+        make_unique<WriteTestClusterOctetString>(),                        //
+        make_unique<ReportTestClusterOctetString>(),                       //
+        make_unique<ReadTestClusterListInt8u>(),                           //
+        make_unique<ReadTestClusterListOctetString>(),                     //
+        make_unique<ReadTestClusterListStructOctetString>(),               //
+        make_unique<ReadTestClusterLongOctetString>(),                     //
+        make_unique<WriteTestClusterLongOctetString>(),                    //
+        make_unique<ReportTestClusterLongOctetString>(),                   //
+        make_unique<ReadTestClusterCharString>(),                          //
+        make_unique<WriteTestClusterCharString>(),                         //
+        make_unique<ReportTestClusterCharString>(),                        //
+        make_unique<ReadTestClusterLongCharString>(),                      //
+        make_unique<WriteTestClusterLongCharString>(),                     //
+        make_unique<ReportTestClusterLongCharString>(),                    //
+        make_unique<ReadTestClusterEpochUs>(),                             //
+        make_unique<WriteTestClusterEpochUs>(),                            //
+        make_unique<ReportTestClusterEpochUs>(),                           //
+        make_unique<ReadTestClusterEpochS>(),                              //
+        make_unique<WriteTestClusterEpochS>(),                             //
+        make_unique<ReportTestClusterEpochS>(),                            //
+        make_unique<ReadTestClusterVendorId>(),                            //
+        make_unique<WriteTestClusterVendorId>(),                           //
+        make_unique<ReportTestClusterVendorId>(),                          //
+        make_unique<ReadTestClusterListNullablesAndOptionalsStruct>(),     //
+        make_unique<ReadTestClusterUnsupported>(),                         //
+        make_unique<WriteTestClusterUnsupported>(),                        //
+        make_unique<ReportTestClusterUnsupported>(),                       //
+        make_unique<ReadTestClusterNullableBoolean>(),                     //
+        make_unique<WriteTestClusterNullableBoolean>(),                    //
+        make_unique<ReportTestClusterNullableBoolean>(),                   //
+        make_unique<ReadTestClusterNullableBitmap8>(),                     //
+        make_unique<WriteTestClusterNullableBitmap8>(),                    //
+        make_unique<ReportTestClusterNullableBitmap8>(),                   //
+        make_unique<ReadTestClusterNullableBitmap16>(),                    //
+        make_unique<WriteTestClusterNullableBitmap16>(),                   //
+        make_unique<ReportTestClusterNullableBitmap16>(),                  //
+        make_unique<ReadTestClusterNullableBitmap32>(),                    //
+        make_unique<WriteTestClusterNullableBitmap32>(),                   //
+        make_unique<ReportTestClusterNullableBitmap32>(),                  //
+        make_unique<ReadTestClusterNullableBitmap64>(),                    //
+        make_unique<WriteTestClusterNullableBitmap64>(),                   //
+        make_unique<ReportTestClusterNullableBitmap64>(),                  //
+        make_unique<ReadTestClusterNullableInt8u>(),                       //
+        make_unique<WriteTestClusterNullableInt8u>(),                      //
+        make_unique<ReportTestClusterNullableInt8u>(),                     //
+        make_unique<ReadTestClusterNullableInt16u>(),                      //
+        make_unique<WriteTestClusterNullableInt16u>(),                     //
+        make_unique<ReportTestClusterNullableInt16u>(),                    //
+        make_unique<ReadTestClusterNullableInt32u>(),                      //
+        make_unique<WriteTestClusterNullableInt32u>(),                     //
+        make_unique<ReportTestClusterNullableInt32u>(),                    //
+        make_unique<ReadTestClusterNullableInt64u>(),                      //
+        make_unique<WriteTestClusterNullableInt64u>(),                     //
+        make_unique<ReportTestClusterNullableInt64u>(),                    //
+        make_unique<ReadTestClusterNullableInt8s>(),                       //
+        make_unique<WriteTestClusterNullableInt8s>(),                      //
+        make_unique<ReportTestClusterNullableInt8s>(),                     //
+        make_unique<ReadTestClusterNullableInt16s>(),                      //
+        make_unique<WriteTestClusterNullableInt16s>(),                     //
+        make_unique<ReportTestClusterNullableInt16s>(),                    //
+        make_unique<ReadTestClusterNullableInt32s>(),                      //
+        make_unique<WriteTestClusterNullableInt32s>(),                     //
+        make_unique<ReportTestClusterNullableInt32s>(),                    //
+        make_unique<ReadTestClusterNullableInt64s>(),                      //
+        make_unique<WriteTestClusterNullableInt64s>(),                     //
+        make_unique<ReportTestClusterNullableInt64s>(),                    //
+        make_unique<ReadTestClusterNullableEnum8>(),                       //
+        make_unique<WriteTestClusterNullableEnum8>(),                      //
+        make_unique<ReportTestClusterNullableEnum8>(),                     //
+        make_unique<ReadTestClusterNullableEnum16>(),                      //
+        make_unique<WriteTestClusterNullableEnum16>(),                     //
+        make_unique<ReportTestClusterNullableEnum16>(),                    //
+        make_unique<ReadTestClusterNullableOctetString>(),                 //
+        make_unique<WriteTestClusterNullableOctetString>(),                //
+        make_unique<ReportTestClusterNullableOctetString>(),               //
+        make_unique<ReadTestClusterNullableCharString>(),                  //
+        make_unique<WriteTestClusterNullableCharString>(),                 //
+        make_unique<ReportTestClusterNullableCharString>(),                //
+        make_unique<ReadTestClusterClusterRevision>(),                     //
+        make_unique<ReportTestClusterClusterRevision>(),                   //
     };
 
     commands.Register(clusterName, clusterCommands);

--- a/zzz_generated/chip-tool/zap-generated/test/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/test/Commands.h
@@ -31689,482 +31689,519 @@ public:
             err = TestSendTestCommandWithStructArgumentAndArg1bIsFalse_130();
             break;
         case 131:
-            ChipLogProgress(chipTool, " ***** Test Step 131 : Send Test Command With Struct Argument and see what we get back\n");
-            err = TestSendTestCommandWithStructArgumentAndSeeWhatWeGetBack_131();
+            ChipLogProgress(chipTool,
+                            " ***** Test Step 131 : Send Test Command With Nested Struct Argument and arg1.c.b is true\n");
+            err = TestSendTestCommandWithNestedStructArgumentAndArg1cbIsTrue_131();
             break;
         case 132:
-            ChipLogProgress(chipTool, " ***** Test Step 132 : Send Test Command With List of INT8U and none of them is set to 0\n");
-            err = TestSendTestCommandWithListOfInt8uAndNoneOfThemIsSetTo0_132();
+            ChipLogProgress(chipTool, " ***** Test Step 132 : Send Test Command With Nested Struct Argument arg1.c.b is false\n");
+            err = TestSendTestCommandWithNestedStructArgumentArg1cbIsFalse_132();
             break;
         case 133:
-            ChipLogProgress(chipTool, " ***** Test Step 133 : Send Test Command With List of INT8U and one of them is set to 0\n");
-            err = TestSendTestCommandWithListOfInt8uAndOneOfThemIsSetTo0_133();
+            ChipLogProgress(
+                chipTool,
+                " ***** Test Step 133 : Send Test Command With Nested Struct List Argument and all fields b of arg1.d are true\n");
+            err = TestSendTestCommandWithNestedStructListArgumentAndAllFieldsBOfArg1dAreTrue_133();
             break;
         case 134:
-            ChipLogProgress(chipTool, " ***** Test Step 134 : Send Test Command With List of INT8U and get it reversed\n");
-            err = TestSendTestCommandWithListOfInt8uAndGetItReversed_134();
+            ChipLogProgress(chipTool,
+                            " ***** Test Step 134 : Send Test Command With Nested Struct List Argument and some fields b of arg1.d "
+                            "are false\n");
+            err = TestSendTestCommandWithNestedStructListArgumentAndSomeFieldsBOfArg1dAreFalse_134();
             break;
         case 135:
-            ChipLogProgress(chipTool,
-                            " ***** Test Step 135 : Send Test Command With empty List of INT8U and get an empty list back\n");
-            err = TestSendTestCommandWithEmptyListOfInt8uAndGetAnEmptyListBack_135();
+            ChipLogProgress(chipTool, " ***** Test Step 135 : Send Test Command With Struct Argument and see what we get back\n");
+            err = TestSendTestCommandWithStructArgumentAndSeeWhatWeGetBack_135();
             break;
         case 136:
-            ChipLogProgress(
-                chipTool,
-                " ***** Test Step 136 : Send Test Command With List of Struct Argument and arg1.b of first item is true\n");
-            err = TestSendTestCommandWithListOfStructArgumentAndArg1bOfFirstItemIsTrue_136();
+            ChipLogProgress(chipTool, " ***** Test Step 136 : Send Test Command With List of INT8U and none of them is set to 0\n");
+            err = TestSendTestCommandWithListOfInt8uAndNoneOfThemIsSetTo0_136();
             break;
         case 137:
-            ChipLogProgress(
-                chipTool,
-                " ***** Test Step 137 : Send Test Command With List of Struct Argument and arg1.b of first item is false\n");
-            err = TestSendTestCommandWithListOfStructArgumentAndArg1bOfFirstItemIsFalse_137();
+            ChipLogProgress(chipTool, " ***** Test Step 137 : Send Test Command With List of INT8U and one of them is set to 0\n");
+            err = TestSendTestCommandWithListOfInt8uAndOneOfThemIsSetTo0_137();
             break;
         case 138:
-            ChipLogProgress(chipTool,
-                            " ***** Test Step 138 : Write attribute LIST With List of INT8U and none of them is set to 0\n");
-            err = TestWriteAttributeListWithListOfInt8uAndNoneOfThemIsSetTo0_138();
+            ChipLogProgress(chipTool, " ***** Test Step 138 : Send Test Command With List of INT8U and get it reversed\n");
+            err = TestSendTestCommandWithListOfInt8uAndGetItReversed_138();
             break;
         case 139:
-            ChipLogProgress(chipTool, " ***** Test Step 139 : Read attribute LIST With List of INT8U\n");
-            err = TestReadAttributeListWithListOfInt8u_139();
+            ChipLogProgress(chipTool,
+                            " ***** Test Step 139 : Send Test Command With empty List of INT8U and get an empty list back\n");
+            err = TestSendTestCommandWithEmptyListOfInt8uAndGetAnEmptyListBack_139();
             break;
         case 140:
-            ChipLogProgress(chipTool, " ***** Test Step 140 : Write attribute LIST With List of OCTET_STRING\n");
-            err = TestWriteAttributeListWithListOfOctetString_140();
+            ChipLogProgress(
+                chipTool,
+                " ***** Test Step 140 : Send Test Command With List of Struct Argument and arg1.b of first item is true\n");
+            err = TestSendTestCommandWithListOfStructArgumentAndArg1bOfFirstItemIsTrue_140();
             break;
         case 141:
-            ChipLogProgress(chipTool, " ***** Test Step 141 : Read attribute LIST With List of OCTET_STRING\n");
-            err = TestReadAttributeListWithListOfOctetString_141();
+            ChipLogProgress(
+                chipTool,
+                " ***** Test Step 141 : Send Test Command With List of Struct Argument and arg1.b of first item is false\n");
+            err = TestSendTestCommandWithListOfStructArgumentAndArg1bOfFirstItemIsFalse_141();
             break;
         case 142:
-            ChipLogProgress(chipTool, " ***** Test Step 142 : Write attribute LIST With List of LIST_STRUCT_OCTET_STRING\n");
-            err = TestWriteAttributeListWithListOfListStructOctetString_142();
+            ChipLogProgress(chipTool,
+                            " ***** Test Step 142 : Send Test Command With List of Nested Struct List Argument and all fields b of "
+                            "elements of arg1.d are true\n");
+            err = TestSendTestCommandWithListOfNestedStructListArgumentAndAllFieldsBOfElementsOfArg1dAreTrue_142();
             break;
         case 143:
-            ChipLogProgress(chipTool, " ***** Test Step 143 : Read attribute LIST With List of LIST_STRUCT_OCTET_STRING\n");
-            err = TestReadAttributeListWithListOfListStructOctetString_143();
+            ChipLogProgress(chipTool,
+                            " ***** Test Step 143 : Send Test Command With Nested Struct List Argument and some fields b of "
+                            "elements of arg1.d are false\n");
+            err = TestSendTestCommandWithNestedStructListArgumentAndSomeFieldsBOfElementsOfArg1dAreFalse_143();
             break;
         case 144:
-            ChipLogProgress(chipTool, " ***** Test Step 144 : Send Test Command with optional arg set.\n");
-            err = TestSendTestCommandWithOptionalArgSet_144();
+            ChipLogProgress(chipTool,
+                            " ***** Test Step 144 : Write attribute LIST With List of INT8U and none of them is set to 0\n");
+            err = TestWriteAttributeListWithListOfInt8uAndNoneOfThemIsSetTo0_144();
             break;
         case 145:
-            ChipLogProgress(chipTool, " ***** Test Step 145 : Send Test Command without its optional arg.\n");
-            err = TestSendTestCommandWithoutItsOptionalArg_145();
+            ChipLogProgress(chipTool, " ***** Test Step 145 : Read attribute LIST With List of INT8U\n");
+            err = TestReadAttributeListWithListOfInt8u_145();
             break;
         case 146:
-            ChipLogProgress(chipTool, " ***** Test Step 146 : Write attribute NULLABLE_BOOLEAN null\n");
-            err = TestWriteAttributeNullableBooleanNull_146();
+            ChipLogProgress(chipTool, " ***** Test Step 146 : Write attribute LIST With List of OCTET_STRING\n");
+            err = TestWriteAttributeListWithListOfOctetString_146();
             break;
         case 147:
-            ChipLogProgress(chipTool, " ***** Test Step 147 : Read attribute NULLABLE_BOOLEAN null\n");
-            err = TestReadAttributeNullableBooleanNull_147();
+            ChipLogProgress(chipTool, " ***** Test Step 147 : Read attribute LIST With List of OCTET_STRING\n");
+            err = TestReadAttributeListWithListOfOctetString_147();
             break;
         case 148:
-            ChipLogProgress(chipTool, " ***** Test Step 148 : Write attribute NULLABLE_BOOLEAN True\n");
-            err = TestWriteAttributeNullableBooleanTrue_148();
+            ChipLogProgress(chipTool, " ***** Test Step 148 : Write attribute LIST With List of LIST_STRUCT_OCTET_STRING\n");
+            err = TestWriteAttributeListWithListOfListStructOctetString_148();
             break;
         case 149:
-            ChipLogProgress(chipTool, " ***** Test Step 149 : Read attribute NULLABLE_BOOLEAN True\n");
-            err = TestReadAttributeNullableBooleanTrue_149();
+            ChipLogProgress(chipTool, " ***** Test Step 149 : Read attribute LIST With List of LIST_STRUCT_OCTET_STRING\n");
+            err = TestReadAttributeListWithListOfListStructOctetString_149();
             break;
         case 150:
-            ChipLogProgress(chipTool, " ***** Test Step 150 : Write attribute NULLABLE_BITMAP8 Max Value\n");
-            err = TestWriteAttributeNullableBitmap8MaxValue_150();
+            ChipLogProgress(chipTool, " ***** Test Step 150 : Send Test Command with optional arg set.\n");
+            err = TestSendTestCommandWithOptionalArgSet_150();
             break;
         case 151:
-            ChipLogProgress(chipTool, " ***** Test Step 151 : Read attribute NULLABLE_BITMAP8 Max Value\n");
-            err = TestReadAttributeNullableBitmap8MaxValue_151();
+            ChipLogProgress(chipTool, " ***** Test Step 151 : Send Test Command without its optional arg.\n");
+            err = TestSendTestCommandWithoutItsOptionalArg_151();
             break;
         case 152:
-            ChipLogProgress(chipTool, " ***** Test Step 152 : Write attribute NULLABLE_BITMAP8 Invalid Value\n");
-            err = TestWriteAttributeNullableBitmap8InvalidValue_152();
+            ChipLogProgress(chipTool, " ***** Test Step 152 : Write attribute NULLABLE_BOOLEAN null\n");
+            err = TestWriteAttributeNullableBooleanNull_152();
             break;
         case 153:
-            ChipLogProgress(chipTool, " ***** Test Step 153 : Read attribute NULLABLE_BITMAP8 unchanged Value\n");
-            err = TestReadAttributeNullableBitmap8UnchangedValue_153();
+            ChipLogProgress(chipTool, " ***** Test Step 153 : Read attribute NULLABLE_BOOLEAN null\n");
+            err = TestReadAttributeNullableBooleanNull_153();
             break;
         case 154:
-            ChipLogProgress(chipTool, " ***** Test Step 154 : Write attribute NULLABLE_BITMAP8 null Value\n");
-            err = TestWriteAttributeNullableBitmap8NullValue_154();
+            ChipLogProgress(chipTool, " ***** Test Step 154 : Write attribute NULLABLE_BOOLEAN True\n");
+            err = TestWriteAttributeNullableBooleanTrue_154();
             break;
         case 155:
-            ChipLogProgress(chipTool, " ***** Test Step 155 : Read attribute NULLABLE_BITMAP8 null Value\n");
-            err = TestReadAttributeNullableBitmap8NullValue_155();
+            ChipLogProgress(chipTool, " ***** Test Step 155 : Read attribute NULLABLE_BOOLEAN True\n");
+            err = TestReadAttributeNullableBooleanTrue_155();
             break;
         case 156:
-            ChipLogProgress(chipTool, " ***** Test Step 156 : Write attribute NULLABLE_BITMAP16 Max Value\n");
-            err = TestWriteAttributeNullableBitmap16MaxValue_156();
+            ChipLogProgress(chipTool, " ***** Test Step 156 : Write attribute NULLABLE_BITMAP8 Max Value\n");
+            err = TestWriteAttributeNullableBitmap8MaxValue_156();
             break;
         case 157:
-            ChipLogProgress(chipTool, " ***** Test Step 157 : Read attribute NULLABLE_BITMAP16 Max Value\n");
-            err = TestReadAttributeNullableBitmap16MaxValue_157();
+            ChipLogProgress(chipTool, " ***** Test Step 157 : Read attribute NULLABLE_BITMAP8 Max Value\n");
+            err = TestReadAttributeNullableBitmap8MaxValue_157();
             break;
         case 158:
-            ChipLogProgress(chipTool, " ***** Test Step 158 : Write attribute NULLABLE_BITMAP16 Invalid Value\n");
-            err = TestWriteAttributeNullableBitmap16InvalidValue_158();
+            ChipLogProgress(chipTool, " ***** Test Step 158 : Write attribute NULLABLE_BITMAP8 Invalid Value\n");
+            err = TestWriteAttributeNullableBitmap8InvalidValue_158();
             break;
         case 159:
-            ChipLogProgress(chipTool, " ***** Test Step 159 : Read attribute NULLABLE_BITMAP16 unchanged Value\n");
-            err = TestReadAttributeNullableBitmap16UnchangedValue_159();
+            ChipLogProgress(chipTool, " ***** Test Step 159 : Read attribute NULLABLE_BITMAP8 unchanged Value\n");
+            err = TestReadAttributeNullableBitmap8UnchangedValue_159();
             break;
         case 160:
-            ChipLogProgress(chipTool, " ***** Test Step 160 : Write attribute NULLABLE_BITMAP16 null Value\n");
-            err = TestWriteAttributeNullableBitmap16NullValue_160();
+            ChipLogProgress(chipTool, " ***** Test Step 160 : Write attribute NULLABLE_BITMAP8 null Value\n");
+            err = TestWriteAttributeNullableBitmap8NullValue_160();
             break;
         case 161:
-            ChipLogProgress(chipTool, " ***** Test Step 161 : Read attribute NULLABLE_BITMAP16 null Value\n");
-            err = TestReadAttributeNullableBitmap16NullValue_161();
+            ChipLogProgress(chipTool, " ***** Test Step 161 : Read attribute NULLABLE_BITMAP8 null Value\n");
+            err = TestReadAttributeNullableBitmap8NullValue_161();
             break;
         case 162:
-            ChipLogProgress(chipTool, " ***** Test Step 162 : Write attribute NULLABLE_BITMAP32 Max Value\n");
-            err = TestWriteAttributeNullableBitmap32MaxValue_162();
+            ChipLogProgress(chipTool, " ***** Test Step 162 : Write attribute NULLABLE_BITMAP16 Max Value\n");
+            err = TestWriteAttributeNullableBitmap16MaxValue_162();
             break;
         case 163:
-            ChipLogProgress(chipTool, " ***** Test Step 163 : Read attribute NULLABLE_BITMAP32 Max Value\n");
-            err = TestReadAttributeNullableBitmap32MaxValue_163();
+            ChipLogProgress(chipTool, " ***** Test Step 163 : Read attribute NULLABLE_BITMAP16 Max Value\n");
+            err = TestReadAttributeNullableBitmap16MaxValue_163();
             break;
         case 164:
-            ChipLogProgress(chipTool, " ***** Test Step 164 : Write attribute NULLABLE_BITMAP32 Invalid Value\n");
-            err = TestWriteAttributeNullableBitmap32InvalidValue_164();
+            ChipLogProgress(chipTool, " ***** Test Step 164 : Write attribute NULLABLE_BITMAP16 Invalid Value\n");
+            err = TestWriteAttributeNullableBitmap16InvalidValue_164();
             break;
         case 165:
-            ChipLogProgress(chipTool, " ***** Test Step 165 : Read attribute NULLABLE_BITMAP32 unchanged Value\n");
-            err = TestReadAttributeNullableBitmap32UnchangedValue_165();
+            ChipLogProgress(chipTool, " ***** Test Step 165 : Read attribute NULLABLE_BITMAP16 unchanged Value\n");
+            err = TestReadAttributeNullableBitmap16UnchangedValue_165();
             break;
         case 166:
-            ChipLogProgress(chipTool, " ***** Test Step 166 : Write attribute NULLABLE_BITMAP32 null Value\n");
-            err = TestWriteAttributeNullableBitmap32NullValue_166();
+            ChipLogProgress(chipTool, " ***** Test Step 166 : Write attribute NULLABLE_BITMAP16 null Value\n");
+            err = TestWriteAttributeNullableBitmap16NullValue_166();
             break;
         case 167:
-            ChipLogProgress(chipTool, " ***** Test Step 167 : Read attribute NULLABLE_BITMAP32 null Value\n");
-            err = TestReadAttributeNullableBitmap32NullValue_167();
+            ChipLogProgress(chipTool, " ***** Test Step 167 : Read attribute NULLABLE_BITMAP16 null Value\n");
+            err = TestReadAttributeNullableBitmap16NullValue_167();
             break;
         case 168:
-            ChipLogProgress(chipTool, " ***** Test Step 168 : Write attribute NULLABLE_BITMAP64 Max Value\n");
-            err = TestWriteAttributeNullableBitmap64MaxValue_168();
+            ChipLogProgress(chipTool, " ***** Test Step 168 : Write attribute NULLABLE_BITMAP32 Max Value\n");
+            err = TestWriteAttributeNullableBitmap32MaxValue_168();
             break;
         case 169:
-            ChipLogProgress(chipTool, " ***** Test Step 169 : Read attribute NULLABLE_BITMAP64 Max Value\n");
-            err = TestReadAttributeNullableBitmap64MaxValue_169();
+            ChipLogProgress(chipTool, " ***** Test Step 169 : Read attribute NULLABLE_BITMAP32 Max Value\n");
+            err = TestReadAttributeNullableBitmap32MaxValue_169();
             break;
         case 170:
-            ChipLogProgress(chipTool, " ***** Test Step 170 : Write attribute NULLABLE_BITMAP64 Invalid Value\n");
-            err = TestWriteAttributeNullableBitmap64InvalidValue_170();
+            ChipLogProgress(chipTool, " ***** Test Step 170 : Write attribute NULLABLE_BITMAP32 Invalid Value\n");
+            err = TestWriteAttributeNullableBitmap32InvalidValue_170();
             break;
         case 171:
-            ChipLogProgress(chipTool, " ***** Test Step 171 : Read attribute NULLABLE_BITMAP64 unchanged Value\n");
-            err = TestReadAttributeNullableBitmap64UnchangedValue_171();
+            ChipLogProgress(chipTool, " ***** Test Step 171 : Read attribute NULLABLE_BITMAP32 unchanged Value\n");
+            err = TestReadAttributeNullableBitmap32UnchangedValue_171();
             break;
         case 172:
-            ChipLogProgress(chipTool, " ***** Test Step 172 : Write attribute NULLABLE_BITMAP64 null Value\n");
-            err = TestWriteAttributeNullableBitmap64NullValue_172();
+            ChipLogProgress(chipTool, " ***** Test Step 172 : Write attribute NULLABLE_BITMAP32 null Value\n");
+            err = TestWriteAttributeNullableBitmap32NullValue_172();
             break;
         case 173:
-            ChipLogProgress(chipTool, " ***** Test Step 173 : Read attribute NULLABLE_BITMAP64 null Value\n");
-            err = TestReadAttributeNullableBitmap64NullValue_173();
+            ChipLogProgress(chipTool, " ***** Test Step 173 : Read attribute NULLABLE_BITMAP32 null Value\n");
+            err = TestReadAttributeNullableBitmap32NullValue_173();
             break;
         case 174:
-            ChipLogProgress(chipTool, " ***** Test Step 174 : Write attribute NULLABLE_INT8U Max Value\n");
-            err = TestWriteAttributeNullableInt8uMaxValue_174();
+            ChipLogProgress(chipTool, " ***** Test Step 174 : Write attribute NULLABLE_BITMAP64 Max Value\n");
+            err = TestWriteAttributeNullableBitmap64MaxValue_174();
             break;
         case 175:
-            ChipLogProgress(chipTool, " ***** Test Step 175 : Read attribute NULLABLE_INT8U Max Value\n");
-            err = TestReadAttributeNullableInt8uMaxValue_175();
+            ChipLogProgress(chipTool, " ***** Test Step 175 : Read attribute NULLABLE_BITMAP64 Max Value\n");
+            err = TestReadAttributeNullableBitmap64MaxValue_175();
             break;
         case 176:
-            ChipLogProgress(chipTool, " ***** Test Step 176 : Write attribute NULLABLE_INT8U Invalid Value\n");
-            err = TestWriteAttributeNullableInt8uInvalidValue_176();
+            ChipLogProgress(chipTool, " ***** Test Step 176 : Write attribute NULLABLE_BITMAP64 Invalid Value\n");
+            err = TestWriteAttributeNullableBitmap64InvalidValue_176();
             break;
         case 177:
-            ChipLogProgress(chipTool, " ***** Test Step 177 : Read attribute NULLABLE_INT8U unchanged Value\n");
-            err = TestReadAttributeNullableInt8uUnchangedValue_177();
+            ChipLogProgress(chipTool, " ***** Test Step 177 : Read attribute NULLABLE_BITMAP64 unchanged Value\n");
+            err = TestReadAttributeNullableBitmap64UnchangedValue_177();
             break;
         case 178:
-            ChipLogProgress(chipTool, " ***** Test Step 178 : Write attribute NULLABLE_INT8U null Value\n");
-            err = TestWriteAttributeNullableInt8uNullValue_178();
+            ChipLogProgress(chipTool, " ***** Test Step 178 : Write attribute NULLABLE_BITMAP64 null Value\n");
+            err = TestWriteAttributeNullableBitmap64NullValue_178();
             break;
         case 179:
-            ChipLogProgress(chipTool, " ***** Test Step 179 : Read attribute NULLABLE_INT8U null Value\n");
-            err = TestReadAttributeNullableInt8uNullValue_179();
+            ChipLogProgress(chipTool, " ***** Test Step 179 : Read attribute NULLABLE_BITMAP64 null Value\n");
+            err = TestReadAttributeNullableBitmap64NullValue_179();
             break;
         case 180:
-            ChipLogProgress(chipTool, " ***** Test Step 180 : Write attribute NULLABLE_INT16U Max Value\n");
-            err = TestWriteAttributeNullableInt16uMaxValue_180();
+            ChipLogProgress(chipTool, " ***** Test Step 180 : Write attribute NULLABLE_INT8U Max Value\n");
+            err = TestWriteAttributeNullableInt8uMaxValue_180();
             break;
         case 181:
-            ChipLogProgress(chipTool, " ***** Test Step 181 : Read attribute NULLABLE_INT16U Max Value\n");
-            err = TestReadAttributeNullableInt16uMaxValue_181();
+            ChipLogProgress(chipTool, " ***** Test Step 181 : Read attribute NULLABLE_INT8U Max Value\n");
+            err = TestReadAttributeNullableInt8uMaxValue_181();
             break;
         case 182:
-            ChipLogProgress(chipTool, " ***** Test Step 182 : Write attribute NULLABLE_INT16U Invalid Value\n");
-            err = TestWriteAttributeNullableInt16uInvalidValue_182();
+            ChipLogProgress(chipTool, " ***** Test Step 182 : Write attribute NULLABLE_INT8U Invalid Value\n");
+            err = TestWriteAttributeNullableInt8uInvalidValue_182();
             break;
         case 183:
-            ChipLogProgress(chipTool, " ***** Test Step 183 : Read attribute NULLABLE_INT16U unchanged Value\n");
-            err = TestReadAttributeNullableInt16uUnchangedValue_183();
+            ChipLogProgress(chipTool, " ***** Test Step 183 : Read attribute NULLABLE_INT8U unchanged Value\n");
+            err = TestReadAttributeNullableInt8uUnchangedValue_183();
             break;
         case 184:
-            ChipLogProgress(chipTool, " ***** Test Step 184 : Write attribute NULLABLE_INT16U null Value\n");
-            err = TestWriteAttributeNullableInt16uNullValue_184();
+            ChipLogProgress(chipTool, " ***** Test Step 184 : Write attribute NULLABLE_INT8U null Value\n");
+            err = TestWriteAttributeNullableInt8uNullValue_184();
             break;
         case 185:
-            ChipLogProgress(chipTool, " ***** Test Step 185 : Read attribute NULLABLE_INT16U null Value\n");
-            err = TestReadAttributeNullableInt16uNullValue_185();
+            ChipLogProgress(chipTool, " ***** Test Step 185 : Read attribute NULLABLE_INT8U null Value\n");
+            err = TestReadAttributeNullableInt8uNullValue_185();
             break;
         case 186:
-            ChipLogProgress(chipTool, " ***** Test Step 186 : Write attribute NULLABLE_INT32U Max Value\n");
-            err = TestWriteAttributeNullableInt32uMaxValue_186();
+            ChipLogProgress(chipTool, " ***** Test Step 186 : Write attribute NULLABLE_INT16U Max Value\n");
+            err = TestWriteAttributeNullableInt16uMaxValue_186();
             break;
         case 187:
-            ChipLogProgress(chipTool, " ***** Test Step 187 : Read attribute NULLABLE_INT32U Max Value\n");
-            err = TestReadAttributeNullableInt32uMaxValue_187();
+            ChipLogProgress(chipTool, " ***** Test Step 187 : Read attribute NULLABLE_INT16U Max Value\n");
+            err = TestReadAttributeNullableInt16uMaxValue_187();
             break;
         case 188:
-            ChipLogProgress(chipTool, " ***** Test Step 188 : Write attribute NULLABLE_INT32U Invalid Value\n");
-            err = TestWriteAttributeNullableInt32uInvalidValue_188();
+            ChipLogProgress(chipTool, " ***** Test Step 188 : Write attribute NULLABLE_INT16U Invalid Value\n");
+            err = TestWriteAttributeNullableInt16uInvalidValue_188();
             break;
         case 189:
-            ChipLogProgress(chipTool, " ***** Test Step 189 : Read attribute NULLABLE_INT32U unchanged Value\n");
-            err = TestReadAttributeNullableInt32uUnchangedValue_189();
+            ChipLogProgress(chipTool, " ***** Test Step 189 : Read attribute NULLABLE_INT16U unchanged Value\n");
+            err = TestReadAttributeNullableInt16uUnchangedValue_189();
             break;
         case 190:
-            ChipLogProgress(chipTool, " ***** Test Step 190 : Write attribute NULLABLE_INT32U null Value\n");
-            err = TestWriteAttributeNullableInt32uNullValue_190();
+            ChipLogProgress(chipTool, " ***** Test Step 190 : Write attribute NULLABLE_INT16U null Value\n");
+            err = TestWriteAttributeNullableInt16uNullValue_190();
             break;
         case 191:
-            ChipLogProgress(chipTool, " ***** Test Step 191 : Read attribute NULLABLE_INT32U null Value\n");
-            err = TestReadAttributeNullableInt32uNullValue_191();
+            ChipLogProgress(chipTool, " ***** Test Step 191 : Read attribute NULLABLE_INT16U null Value\n");
+            err = TestReadAttributeNullableInt16uNullValue_191();
             break;
         case 192:
-            ChipLogProgress(chipTool, " ***** Test Step 192 : Write attribute NULLABLE_INT64U Max Value\n");
-            err = TestWriteAttributeNullableInt64uMaxValue_192();
+            ChipLogProgress(chipTool, " ***** Test Step 192 : Write attribute NULLABLE_INT32U Max Value\n");
+            err = TestWriteAttributeNullableInt32uMaxValue_192();
             break;
         case 193:
-            ChipLogProgress(chipTool, " ***** Test Step 193 : Read attribute NULLABLE_INT64U Max Value\n");
-            err = TestReadAttributeNullableInt64uMaxValue_193();
+            ChipLogProgress(chipTool, " ***** Test Step 193 : Read attribute NULLABLE_INT32U Max Value\n");
+            err = TestReadAttributeNullableInt32uMaxValue_193();
             break;
         case 194:
-            ChipLogProgress(chipTool, " ***** Test Step 194 : Write attribute NULLABLE_INT64U Invalid Value\n");
-            err = TestWriteAttributeNullableInt64uInvalidValue_194();
+            ChipLogProgress(chipTool, " ***** Test Step 194 : Write attribute NULLABLE_INT32U Invalid Value\n");
+            err = TestWriteAttributeNullableInt32uInvalidValue_194();
             break;
         case 195:
-            ChipLogProgress(chipTool, " ***** Test Step 195 : Read attribute NULLABLE_INT64U unchanged Value\n");
-            err = TestReadAttributeNullableInt64uUnchangedValue_195();
+            ChipLogProgress(chipTool, " ***** Test Step 195 : Read attribute NULLABLE_INT32U unchanged Value\n");
+            err = TestReadAttributeNullableInt32uUnchangedValue_195();
             break;
         case 196:
-            ChipLogProgress(chipTool, " ***** Test Step 196 : Write attribute NULLABLE_INT64U null Value\n");
-            err = TestWriteAttributeNullableInt64uNullValue_196();
+            ChipLogProgress(chipTool, " ***** Test Step 196 : Write attribute NULLABLE_INT32U null Value\n");
+            err = TestWriteAttributeNullableInt32uNullValue_196();
             break;
         case 197:
-            ChipLogProgress(chipTool, " ***** Test Step 197 : Read attribute NULLABLE_INT64U null Value\n");
-            err = TestReadAttributeNullableInt64uNullValue_197();
+            ChipLogProgress(chipTool, " ***** Test Step 197 : Read attribute NULLABLE_INT32U null Value\n");
+            err = TestReadAttributeNullableInt32uNullValue_197();
             break;
         case 198:
-            ChipLogProgress(chipTool, " ***** Test Step 198 : Write attribute NULLABLE_INT8S Min Value\n");
-            err = TestWriteAttributeNullableInt8sMinValue_198();
+            ChipLogProgress(chipTool, " ***** Test Step 198 : Write attribute NULLABLE_INT64U Max Value\n");
+            err = TestWriteAttributeNullableInt64uMaxValue_198();
             break;
         case 199:
-            ChipLogProgress(chipTool, " ***** Test Step 199 : Read attribute NULLABLE_INT8S Min Value\n");
-            err = TestReadAttributeNullableInt8sMinValue_199();
+            ChipLogProgress(chipTool, " ***** Test Step 199 : Read attribute NULLABLE_INT64U Max Value\n");
+            err = TestReadAttributeNullableInt64uMaxValue_199();
             break;
         case 200:
-            ChipLogProgress(chipTool, " ***** Test Step 200 : Write attribute NULLABLE_INT8S Invalid Value\n");
-            err = TestWriteAttributeNullableInt8sInvalidValue_200();
+            ChipLogProgress(chipTool, " ***** Test Step 200 : Write attribute NULLABLE_INT64U Invalid Value\n");
+            err = TestWriteAttributeNullableInt64uInvalidValue_200();
             break;
         case 201:
-            ChipLogProgress(chipTool, " ***** Test Step 201 : Read attribute NULLABLE_INT8S unchanged Value\n");
-            err = TestReadAttributeNullableInt8sUnchangedValue_201();
+            ChipLogProgress(chipTool, " ***** Test Step 201 : Read attribute NULLABLE_INT64U unchanged Value\n");
+            err = TestReadAttributeNullableInt64uUnchangedValue_201();
             break;
         case 202:
-            ChipLogProgress(chipTool, " ***** Test Step 202 : Write attribute NULLABLE_INT8S null Value\n");
-            err = TestWriteAttributeNullableInt8sNullValue_202();
+            ChipLogProgress(chipTool, " ***** Test Step 202 : Write attribute NULLABLE_INT64U null Value\n");
+            err = TestWriteAttributeNullableInt64uNullValue_202();
             break;
         case 203:
-            ChipLogProgress(chipTool, " ***** Test Step 203 : Read attribute NULLABLE_INT8S null Value\n");
-            err = TestReadAttributeNullableInt8sNullValue_203();
+            ChipLogProgress(chipTool, " ***** Test Step 203 : Read attribute NULLABLE_INT64U null Value\n");
+            err = TestReadAttributeNullableInt64uNullValue_203();
             break;
         case 204:
-            ChipLogProgress(chipTool, " ***** Test Step 204 : Write attribute NULLABLE_INT16S Min Value\n");
-            err = TestWriteAttributeNullableInt16sMinValue_204();
+            ChipLogProgress(chipTool, " ***** Test Step 204 : Write attribute NULLABLE_INT8S Min Value\n");
+            err = TestWriteAttributeNullableInt8sMinValue_204();
             break;
         case 205:
-            ChipLogProgress(chipTool, " ***** Test Step 205 : Read attribute NULLABLE_INT16S Min Value\n");
-            err = TestReadAttributeNullableInt16sMinValue_205();
+            ChipLogProgress(chipTool, " ***** Test Step 205 : Read attribute NULLABLE_INT8S Min Value\n");
+            err = TestReadAttributeNullableInt8sMinValue_205();
             break;
         case 206:
-            ChipLogProgress(chipTool, " ***** Test Step 206 : Write attribute NULLABLE_INT16S Invalid Value\n");
-            err = TestWriteAttributeNullableInt16sInvalidValue_206();
+            ChipLogProgress(chipTool, " ***** Test Step 206 : Write attribute NULLABLE_INT8S Invalid Value\n");
+            err = TestWriteAttributeNullableInt8sInvalidValue_206();
             break;
         case 207:
-            ChipLogProgress(chipTool, " ***** Test Step 207 : Read attribute NULLABLE_INT16S unchanged Value\n");
-            err = TestReadAttributeNullableInt16sUnchangedValue_207();
+            ChipLogProgress(chipTool, " ***** Test Step 207 : Read attribute NULLABLE_INT8S unchanged Value\n");
+            err = TestReadAttributeNullableInt8sUnchangedValue_207();
             break;
         case 208:
-            ChipLogProgress(chipTool, " ***** Test Step 208 : Write attribute NULLABLE_INT16S null Value\n");
-            err = TestWriteAttributeNullableInt16sNullValue_208();
+            ChipLogProgress(chipTool, " ***** Test Step 208 : Write attribute NULLABLE_INT8S null Value\n");
+            err = TestWriteAttributeNullableInt8sNullValue_208();
             break;
         case 209:
-            ChipLogProgress(chipTool, " ***** Test Step 209 : Read attribute NULLABLE_INT16S null Value\n");
-            err = TestReadAttributeNullableInt16sNullValue_209();
+            ChipLogProgress(chipTool, " ***** Test Step 209 : Read attribute NULLABLE_INT8S null Value\n");
+            err = TestReadAttributeNullableInt8sNullValue_209();
             break;
         case 210:
-            ChipLogProgress(chipTool, " ***** Test Step 210 : Write attribute NULLABLE_INT32S Min Value\n");
-            err = TestWriteAttributeNullableInt32sMinValue_210();
+            ChipLogProgress(chipTool, " ***** Test Step 210 : Write attribute NULLABLE_INT16S Min Value\n");
+            err = TestWriteAttributeNullableInt16sMinValue_210();
             break;
         case 211:
-            ChipLogProgress(chipTool, " ***** Test Step 211 : Read attribute NULLABLE_INT32S Min Value\n");
-            err = TestReadAttributeNullableInt32sMinValue_211();
+            ChipLogProgress(chipTool, " ***** Test Step 211 : Read attribute NULLABLE_INT16S Min Value\n");
+            err = TestReadAttributeNullableInt16sMinValue_211();
             break;
         case 212:
-            ChipLogProgress(chipTool, " ***** Test Step 212 : Write attribute NULLABLE_INT32S Invalid Value\n");
-            err = TestWriteAttributeNullableInt32sInvalidValue_212();
+            ChipLogProgress(chipTool, " ***** Test Step 212 : Write attribute NULLABLE_INT16S Invalid Value\n");
+            err = TestWriteAttributeNullableInt16sInvalidValue_212();
             break;
         case 213:
-            ChipLogProgress(chipTool, " ***** Test Step 213 : Read attribute NULLABLE_INT32S unchanged Value\n");
-            err = TestReadAttributeNullableInt32sUnchangedValue_213();
+            ChipLogProgress(chipTool, " ***** Test Step 213 : Read attribute NULLABLE_INT16S unchanged Value\n");
+            err = TestReadAttributeNullableInt16sUnchangedValue_213();
             break;
         case 214:
-            ChipLogProgress(chipTool, " ***** Test Step 214 : Write attribute NULLABLE_INT32S null Value\n");
-            err = TestWriteAttributeNullableInt32sNullValue_214();
+            ChipLogProgress(chipTool, " ***** Test Step 214 : Write attribute NULLABLE_INT16S null Value\n");
+            err = TestWriteAttributeNullableInt16sNullValue_214();
             break;
         case 215:
-            ChipLogProgress(chipTool, " ***** Test Step 215 : Read attribute NULLABLE_INT32S null Value\n");
-            err = TestReadAttributeNullableInt32sNullValue_215();
+            ChipLogProgress(chipTool, " ***** Test Step 215 : Read attribute NULLABLE_INT16S null Value\n");
+            err = TestReadAttributeNullableInt16sNullValue_215();
             break;
         case 216:
-            ChipLogProgress(chipTool, " ***** Test Step 216 : Write attribute NULLABLE_INT64S Min Value\n");
-            err = TestWriteAttributeNullableInt64sMinValue_216();
+            ChipLogProgress(chipTool, " ***** Test Step 216 : Write attribute NULLABLE_INT32S Min Value\n");
+            err = TestWriteAttributeNullableInt32sMinValue_216();
             break;
         case 217:
-            ChipLogProgress(chipTool, " ***** Test Step 217 : Read attribute NULLABLE_INT64S Min Value\n");
-            err = TestReadAttributeNullableInt64sMinValue_217();
+            ChipLogProgress(chipTool, " ***** Test Step 217 : Read attribute NULLABLE_INT32S Min Value\n");
+            err = TestReadAttributeNullableInt32sMinValue_217();
             break;
         case 218:
-            ChipLogProgress(chipTool, " ***** Test Step 218 : Write attribute NULLABLE_INT64S Invalid Value\n");
-            err = TestWriteAttributeNullableInt64sInvalidValue_218();
+            ChipLogProgress(chipTool, " ***** Test Step 218 : Write attribute NULLABLE_INT32S Invalid Value\n");
+            err = TestWriteAttributeNullableInt32sInvalidValue_218();
             break;
         case 219:
-            ChipLogProgress(chipTool, " ***** Test Step 219 : Read attribute NULLABLE_INT64S unchanged Value\n");
-            err = TestReadAttributeNullableInt64sUnchangedValue_219();
+            ChipLogProgress(chipTool, " ***** Test Step 219 : Read attribute NULLABLE_INT32S unchanged Value\n");
+            err = TestReadAttributeNullableInt32sUnchangedValue_219();
             break;
         case 220:
-            ChipLogProgress(chipTool, " ***** Test Step 220 : Write attribute NULLABLE_INT64S null Value\n");
-            err = TestWriteAttributeNullableInt64sNullValue_220();
+            ChipLogProgress(chipTool, " ***** Test Step 220 : Write attribute NULLABLE_INT32S null Value\n");
+            err = TestWriteAttributeNullableInt32sNullValue_220();
             break;
         case 221:
-            ChipLogProgress(chipTool, " ***** Test Step 221 : Read attribute NULLABLE_INT64S null Value\n");
-            err = TestReadAttributeNullableInt64sNullValue_221();
+            ChipLogProgress(chipTool, " ***** Test Step 221 : Read attribute NULLABLE_INT32S null Value\n");
+            err = TestReadAttributeNullableInt32sNullValue_221();
             break;
         case 222:
-            ChipLogProgress(chipTool, " ***** Test Step 222 : Write attribute NULLABLE_ENUM8 Max Value\n");
-            err = TestWriteAttributeNullableEnum8MaxValue_222();
+            ChipLogProgress(chipTool, " ***** Test Step 222 : Write attribute NULLABLE_INT64S Min Value\n");
+            err = TestWriteAttributeNullableInt64sMinValue_222();
             break;
         case 223:
-            ChipLogProgress(chipTool, " ***** Test Step 223 : Read attribute NULLABLE_ENUM8 Max Value\n");
-            err = TestReadAttributeNullableEnum8MaxValue_223();
+            ChipLogProgress(chipTool, " ***** Test Step 223 : Read attribute NULLABLE_INT64S Min Value\n");
+            err = TestReadAttributeNullableInt64sMinValue_223();
             break;
         case 224:
-            ChipLogProgress(chipTool, " ***** Test Step 224 : Write attribute NULLABLE_ENUM8 Invalid Value\n");
-            err = TestWriteAttributeNullableEnum8InvalidValue_224();
+            ChipLogProgress(chipTool, " ***** Test Step 224 : Write attribute NULLABLE_INT64S Invalid Value\n");
+            err = TestWriteAttributeNullableInt64sInvalidValue_224();
             break;
         case 225:
-            ChipLogProgress(chipTool, " ***** Test Step 225 : Read attribute NULLABLE_ENUM8 unchanged Value\n");
-            err = TestReadAttributeNullableEnum8UnchangedValue_225();
+            ChipLogProgress(chipTool, " ***** Test Step 225 : Read attribute NULLABLE_INT64S unchanged Value\n");
+            err = TestReadAttributeNullableInt64sUnchangedValue_225();
             break;
         case 226:
-            ChipLogProgress(chipTool, " ***** Test Step 226 : Write attribute NULLABLE_ENUM8 null Value\n");
-            err = TestWriteAttributeNullableEnum8NullValue_226();
+            ChipLogProgress(chipTool, " ***** Test Step 226 : Write attribute NULLABLE_INT64S null Value\n");
+            err = TestWriteAttributeNullableInt64sNullValue_226();
             break;
         case 227:
-            ChipLogProgress(chipTool, " ***** Test Step 227 : Read attribute NULLABLE_ENUM8 null Value\n");
-            err = TestReadAttributeNullableEnum8NullValue_227();
+            ChipLogProgress(chipTool, " ***** Test Step 227 : Read attribute NULLABLE_INT64S null Value\n");
+            err = TestReadAttributeNullableInt64sNullValue_227();
             break;
         case 228:
-            ChipLogProgress(chipTool, " ***** Test Step 228 : Write attribute NULLABLE_ENUM16 Max Value\n");
-            err = TestWriteAttributeNullableEnum16MaxValue_228();
+            ChipLogProgress(chipTool, " ***** Test Step 228 : Write attribute NULLABLE_ENUM8 Max Value\n");
+            err = TestWriteAttributeNullableEnum8MaxValue_228();
             break;
         case 229:
-            ChipLogProgress(chipTool, " ***** Test Step 229 : Read attribute NULLABLE_ENUM16 Max Value\n");
-            err = TestReadAttributeNullableEnum16MaxValue_229();
+            ChipLogProgress(chipTool, " ***** Test Step 229 : Read attribute NULLABLE_ENUM8 Max Value\n");
+            err = TestReadAttributeNullableEnum8MaxValue_229();
             break;
         case 230:
-            ChipLogProgress(chipTool, " ***** Test Step 230 : Write attribute NULLABLE_ENUM16 Invalid Value\n");
-            err = TestWriteAttributeNullableEnum16InvalidValue_230();
+            ChipLogProgress(chipTool, " ***** Test Step 230 : Write attribute NULLABLE_ENUM8 Invalid Value\n");
+            err = TestWriteAttributeNullableEnum8InvalidValue_230();
             break;
         case 231:
-            ChipLogProgress(chipTool, " ***** Test Step 231 : Read attribute NULLABLE_ENUM16 unchanged Value\n");
-            err = TestReadAttributeNullableEnum16UnchangedValue_231();
+            ChipLogProgress(chipTool, " ***** Test Step 231 : Read attribute NULLABLE_ENUM8 unchanged Value\n");
+            err = TestReadAttributeNullableEnum8UnchangedValue_231();
             break;
         case 232:
-            ChipLogProgress(chipTool, " ***** Test Step 232 : Write attribute NULLABLE_ENUM16 null Value\n");
-            err = TestWriteAttributeNullableEnum16NullValue_232();
+            ChipLogProgress(chipTool, " ***** Test Step 232 : Write attribute NULLABLE_ENUM8 null Value\n");
+            err = TestWriteAttributeNullableEnum8NullValue_232();
             break;
         case 233:
-            ChipLogProgress(chipTool, " ***** Test Step 233 : Read attribute NULLABLE_ENUM16 null Value\n");
-            err = TestReadAttributeNullableEnum16NullValue_233();
+            ChipLogProgress(chipTool, " ***** Test Step 233 : Read attribute NULLABLE_ENUM8 null Value\n");
+            err = TestReadAttributeNullableEnum8NullValue_233();
             break;
         case 234:
-            ChipLogProgress(chipTool, " ***** Test Step 234 : Read attribute NULLABLE_OCTET_STRING Default Value\n");
-            err = TestReadAttributeNullableOctetStringDefaultValue_234();
+            ChipLogProgress(chipTool, " ***** Test Step 234 : Write attribute NULLABLE_ENUM16 Max Value\n");
+            err = TestWriteAttributeNullableEnum16MaxValue_234();
             break;
         case 235:
-            ChipLogProgress(chipTool, " ***** Test Step 235 : Write attribute NULLABLE_OCTET_STRING\n");
-            err = TestWriteAttributeNullableOctetString_235();
+            ChipLogProgress(chipTool, " ***** Test Step 235 : Read attribute NULLABLE_ENUM16 Max Value\n");
+            err = TestReadAttributeNullableEnum16MaxValue_235();
             break;
         case 236:
-            ChipLogProgress(chipTool, " ***** Test Step 236 : Read attribute NULLABLE_OCTET_STRING\n");
-            err = TestReadAttributeNullableOctetString_236();
+            ChipLogProgress(chipTool, " ***** Test Step 236 : Write attribute NULLABLE_ENUM16 Invalid Value\n");
+            err = TestWriteAttributeNullableEnum16InvalidValue_236();
             break;
         case 237:
-            ChipLogProgress(chipTool, " ***** Test Step 237 : Write attribute NULLABLE_OCTET_STRING\n");
-            err = TestWriteAttributeNullableOctetString_237();
+            ChipLogProgress(chipTool, " ***** Test Step 237 : Read attribute NULLABLE_ENUM16 unchanged Value\n");
+            err = TestReadAttributeNullableEnum16UnchangedValue_237();
             break;
         case 238:
-            ChipLogProgress(chipTool, " ***** Test Step 238 : Read attribute NULLABLE_OCTET_STRING\n");
-            err = TestReadAttributeNullableOctetString_238();
+            ChipLogProgress(chipTool, " ***** Test Step 238 : Write attribute NULLABLE_ENUM16 null Value\n");
+            err = TestWriteAttributeNullableEnum16NullValue_238();
             break;
         case 239:
-            ChipLogProgress(chipTool, " ***** Test Step 239 : Write attribute NULLABLE_OCTET_STRING\n");
-            err = TestWriteAttributeNullableOctetString_239();
+            ChipLogProgress(chipTool, " ***** Test Step 239 : Read attribute NULLABLE_ENUM16 null Value\n");
+            err = TestReadAttributeNullableEnum16NullValue_239();
             break;
         case 240:
-            ChipLogProgress(chipTool, " ***** Test Step 240 : Read attribute NULLABLE_OCTET_STRING\n");
-            err = TestReadAttributeNullableOctetString_240();
+            ChipLogProgress(chipTool, " ***** Test Step 240 : Read attribute NULLABLE_OCTET_STRING Default Value\n");
+            err = TestReadAttributeNullableOctetStringDefaultValue_240();
             break;
         case 241:
-            ChipLogProgress(chipTool, " ***** Test Step 241 : Read attribute NULLABLE_CHAR_STRING Default Value\n");
-            err = TestReadAttributeNullableCharStringDefaultValue_241();
+            ChipLogProgress(chipTool, " ***** Test Step 241 : Write attribute NULLABLE_OCTET_STRING\n");
+            err = TestWriteAttributeNullableOctetString_241();
             break;
         case 242:
-            ChipLogProgress(chipTool, " ***** Test Step 242 : Write attribute NULLABLE_CHAR_STRING\n");
-            err = TestWriteAttributeNullableCharString_242();
+            ChipLogProgress(chipTool, " ***** Test Step 242 : Read attribute NULLABLE_OCTET_STRING\n");
+            err = TestReadAttributeNullableOctetString_242();
             break;
         case 243:
-            ChipLogProgress(chipTool, " ***** Test Step 243 : Write attribute NULLABLE_CHAR_STRING - Value too long\n");
-            err = TestWriteAttributeNullableCharStringValueTooLong_243();
+            ChipLogProgress(chipTool, " ***** Test Step 243 : Write attribute NULLABLE_OCTET_STRING\n");
+            err = TestWriteAttributeNullableOctetString_243();
             break;
         case 244:
-            ChipLogProgress(chipTool, " ***** Test Step 244 : Read attribute NULLABLE_CHAR_STRING\n");
-            err = TestReadAttributeNullableCharString_244();
+            ChipLogProgress(chipTool, " ***** Test Step 244 : Read attribute NULLABLE_OCTET_STRING\n");
+            err = TestReadAttributeNullableOctetString_244();
             break;
         case 245:
-            ChipLogProgress(chipTool, " ***** Test Step 245 : Write attribute NULLABLE_CHAR_STRING - Empty\n");
-            err = TestWriteAttributeNullableCharStringEmpty_245();
+            ChipLogProgress(chipTool, " ***** Test Step 245 : Write attribute NULLABLE_OCTET_STRING\n");
+            err = TestWriteAttributeNullableOctetString_245();
             break;
         case 246:
-            ChipLogProgress(chipTool, " ***** Test Step 246 : Read attribute NULLABLE_CHAR_STRING\n");
-            err = TestReadAttributeNullableCharString_246();
+            ChipLogProgress(chipTool, " ***** Test Step 246 : Read attribute NULLABLE_OCTET_STRING\n");
+            err = TestReadAttributeNullableOctetString_246();
             break;
         case 247:
-            ChipLogProgress(chipTool, " ***** Test Step 247 : Read attribute from nonexistent endpoint.\n");
-            err = TestReadAttributeFromNonexistentEndpoint_247();
+            ChipLogProgress(chipTool, " ***** Test Step 247 : Read attribute NULLABLE_CHAR_STRING Default Value\n");
+            err = TestReadAttributeNullableCharStringDefaultValue_247();
             break;
         case 248:
-            ChipLogProgress(chipTool, " ***** Test Step 248 : Read attribute from nonexistent cluster.\n");
-            err = TestReadAttributeFromNonexistentCluster_248();
+            ChipLogProgress(chipTool, " ***** Test Step 248 : Write attribute NULLABLE_CHAR_STRING\n");
+            err = TestWriteAttributeNullableCharString_248();
+            break;
+        case 249:
+            ChipLogProgress(chipTool, " ***** Test Step 249 : Read attribute NULLABLE_CHAR_STRING\n");
+            err = TestReadAttributeNullableCharString_249();
+            break;
+        case 250:
+            ChipLogProgress(chipTool, " ***** Test Step 250 : Write attribute NULLABLE_CHAR_STRING - Value too long\n");
+            err = TestWriteAttributeNullableCharStringValueTooLong_250();
+            break;
+        case 251:
+            ChipLogProgress(chipTool, " ***** Test Step 251 : Read attribute NULLABLE_CHAR_STRING\n");
+            err = TestReadAttributeNullableCharString_251();
+            break;
+        case 252:
+            ChipLogProgress(chipTool, " ***** Test Step 252 : Write attribute NULLABLE_CHAR_STRING - Empty\n");
+            err = TestWriteAttributeNullableCharStringEmpty_252();
+            break;
+        case 253:
+            ChipLogProgress(chipTool, " ***** Test Step 253 : Read attribute NULLABLE_CHAR_STRING\n");
+            err = TestReadAttributeNullableCharString_253();
+            break;
+        case 254:
+            ChipLogProgress(chipTool, " ***** Test Step 254 : Read attribute from nonexistent endpoint.\n");
+            err = TestReadAttributeFromNonexistentEndpoint_254();
+            break;
+        case 255:
+            ChipLogProgress(chipTool, " ***** Test Step 255 : Read attribute from nonexistent cluster.\n");
+            err = TestReadAttributeFromNonexistentCluster_255();
             break;
         }
 
@@ -32177,7 +32214,7 @@ public:
 
 private:
     std::atomic_uint16_t mTestIndex;
-    const uint16_t mTestCount = 249;
+    const uint16_t mTestCount = 256;
 
     static void OnFailureCallback_5(void * context, EmberAfStatus status)
     {
@@ -33233,58 +33270,21 @@ private:
 
     static void OnSuccessCallback_127(void * context) { (static_cast<TestCluster *>(context))->OnSuccessResponse_127(); }
 
-    static void OnFailureCallback_138(void * context, EmberAfStatus status)
+    static void OnFailureCallback_144(void * context, EmberAfStatus status)
     {
-        (static_cast<TestCluster *>(context))->OnFailureResponse_138(chip::to_underlying(status));
+        (static_cast<TestCluster *>(context))->OnFailureResponse_144(chip::to_underlying(status));
     }
 
-    static void OnSuccessCallback_138(void * context) { (static_cast<TestCluster *>(context))->OnSuccessResponse_138(); }
+    static void OnSuccessCallback_144(void * context) { (static_cast<TestCluster *>(context))->OnSuccessResponse_144(); }
 
-    static void OnFailureCallback_139(void * context, EmberAfStatus status)
+    static void OnFailureCallback_145(void * context, EmberAfStatus status)
     {
-        (static_cast<TestCluster *>(context))->OnFailureResponse_139(chip::to_underlying(status));
+        (static_cast<TestCluster *>(context))->OnFailureResponse_145(chip::to_underlying(status));
     }
 
-    static void OnSuccessCallback_139(void * context, const chip::app::DataModel::DecodableList<uint8_t> & listInt8u)
+    static void OnSuccessCallback_145(void * context, const chip::app::DataModel::DecodableList<uint8_t> & listInt8u)
     {
-        (static_cast<TestCluster *>(context))->OnSuccessResponse_139(listInt8u);
-    }
-
-    static void OnFailureCallback_140(void * context, EmberAfStatus status)
-    {
-        (static_cast<TestCluster *>(context))->OnFailureResponse_140(chip::to_underlying(status));
-    }
-
-    static void OnSuccessCallback_140(void * context) { (static_cast<TestCluster *>(context))->OnSuccessResponse_140(); }
-
-    static void OnFailureCallback_141(void * context, EmberAfStatus status)
-    {
-        (static_cast<TestCluster *>(context))->OnFailureResponse_141(chip::to_underlying(status));
-    }
-
-    static void OnSuccessCallback_141(void * context, const chip::app::DataModel::DecodableList<chip::ByteSpan> & listOctetString)
-    {
-        (static_cast<TestCluster *>(context))->OnSuccessResponse_141(listOctetString);
-    }
-
-    static void OnFailureCallback_142(void * context, EmberAfStatus status)
-    {
-        (static_cast<TestCluster *>(context))->OnFailureResponse_142(chip::to_underlying(status));
-    }
-
-    static void OnSuccessCallback_142(void * context) { (static_cast<TestCluster *>(context))->OnSuccessResponse_142(); }
-
-    static void OnFailureCallback_143(void * context, EmberAfStatus status)
-    {
-        (static_cast<TestCluster *>(context))->OnFailureResponse_143(chip::to_underlying(status));
-    }
-
-    static void OnSuccessCallback_143(
-        void * context,
-        const chip::app::DataModel::DecodableList<chip::app::Clusters::TestCluster::Structs::TestListStructOctet::DecodableType> &
-            listStructOctetString)
-    {
-        (static_cast<TestCluster *>(context))->OnSuccessResponse_143(listStructOctetString);
+        (static_cast<TestCluster *>(context))->OnSuccessResponse_145(listInt8u);
     }
 
     static void OnFailureCallback_146(void * context, EmberAfStatus status)
@@ -33299,9 +33299,9 @@ private:
         (static_cast<TestCluster *>(context))->OnFailureResponse_147(chip::to_underlying(status));
     }
 
-    static void OnSuccessCallback_147(void * context, const chip::app::DataModel::Nullable<bool> & nullableBoolean)
+    static void OnSuccessCallback_147(void * context, const chip::app::DataModel::DecodableList<chip::ByteSpan> & listOctetString)
     {
-        (static_cast<TestCluster *>(context))->OnSuccessResponse_147(nullableBoolean);
+        (static_cast<TestCluster *>(context))->OnSuccessResponse_147(listOctetString);
     }
 
     static void OnFailureCallback_148(void * context, EmberAfStatus status)
@@ -33316,26 +33316,12 @@ private:
         (static_cast<TestCluster *>(context))->OnFailureResponse_149(chip::to_underlying(status));
     }
 
-    static void OnSuccessCallback_149(void * context, const chip::app::DataModel::Nullable<bool> & nullableBoolean)
+    static void OnSuccessCallback_149(
+        void * context,
+        const chip::app::DataModel::DecodableList<chip::app::Clusters::TestCluster::Structs::TestListStructOctet::DecodableType> &
+            listStructOctetString)
     {
-        (static_cast<TestCluster *>(context))->OnSuccessResponse_149(nullableBoolean);
-    }
-
-    static void OnFailureCallback_150(void * context, EmberAfStatus status)
-    {
-        (static_cast<TestCluster *>(context))->OnFailureResponse_150(chip::to_underlying(status));
-    }
-
-    static void OnSuccessCallback_150(void * context) { (static_cast<TestCluster *>(context))->OnSuccessResponse_150(); }
-
-    static void OnFailureCallback_151(void * context, EmberAfStatus status)
-    {
-        (static_cast<TestCluster *>(context))->OnFailureResponse_151(chip::to_underlying(status));
-    }
-
-    static void OnSuccessCallback_151(void * context, const chip::app::DataModel::Nullable<uint8_t> & nullableBitmap8)
-    {
-        (static_cast<TestCluster *>(context))->OnSuccessResponse_151(nullableBitmap8);
+        (static_cast<TestCluster *>(context))->OnSuccessResponse_149(listStructOctetString);
     }
 
     static void OnFailureCallback_152(void * context, EmberAfStatus status)
@@ -33350,9 +33336,9 @@ private:
         (static_cast<TestCluster *>(context))->OnFailureResponse_153(chip::to_underlying(status));
     }
 
-    static void OnSuccessCallback_153(void * context, const chip::app::DataModel::Nullable<uint8_t> & nullableBitmap8)
+    static void OnSuccessCallback_153(void * context, const chip::app::DataModel::Nullable<bool> & nullableBoolean)
     {
-        (static_cast<TestCluster *>(context))->OnSuccessResponse_153(nullableBitmap8);
+        (static_cast<TestCluster *>(context))->OnSuccessResponse_153(nullableBoolean);
     }
 
     static void OnFailureCallback_154(void * context, EmberAfStatus status)
@@ -33367,9 +33353,9 @@ private:
         (static_cast<TestCluster *>(context))->OnFailureResponse_155(chip::to_underlying(status));
     }
 
-    static void OnSuccessCallback_155(void * context, const chip::app::DataModel::Nullable<uint8_t> & nullableBitmap8)
+    static void OnSuccessCallback_155(void * context, const chip::app::DataModel::Nullable<bool> & nullableBoolean)
     {
-        (static_cast<TestCluster *>(context))->OnSuccessResponse_155(nullableBitmap8);
+        (static_cast<TestCluster *>(context))->OnSuccessResponse_155(nullableBoolean);
     }
 
     static void OnFailureCallback_156(void * context, EmberAfStatus status)
@@ -33384,9 +33370,9 @@ private:
         (static_cast<TestCluster *>(context))->OnFailureResponse_157(chip::to_underlying(status));
     }
 
-    static void OnSuccessCallback_157(void * context, const chip::app::DataModel::Nullable<uint16_t> & nullableBitmap16)
+    static void OnSuccessCallback_157(void * context, const chip::app::DataModel::Nullable<uint8_t> & nullableBitmap8)
     {
-        (static_cast<TestCluster *>(context))->OnSuccessResponse_157(nullableBitmap16);
+        (static_cast<TestCluster *>(context))->OnSuccessResponse_157(nullableBitmap8);
     }
 
     static void OnFailureCallback_158(void * context, EmberAfStatus status)
@@ -33401,9 +33387,9 @@ private:
         (static_cast<TestCluster *>(context))->OnFailureResponse_159(chip::to_underlying(status));
     }
 
-    static void OnSuccessCallback_159(void * context, const chip::app::DataModel::Nullable<uint16_t> & nullableBitmap16)
+    static void OnSuccessCallback_159(void * context, const chip::app::DataModel::Nullable<uint8_t> & nullableBitmap8)
     {
-        (static_cast<TestCluster *>(context))->OnSuccessResponse_159(nullableBitmap16);
+        (static_cast<TestCluster *>(context))->OnSuccessResponse_159(nullableBitmap8);
     }
 
     static void OnFailureCallback_160(void * context, EmberAfStatus status)
@@ -33418,9 +33404,9 @@ private:
         (static_cast<TestCluster *>(context))->OnFailureResponse_161(chip::to_underlying(status));
     }
 
-    static void OnSuccessCallback_161(void * context, const chip::app::DataModel::Nullable<uint16_t> & nullableBitmap16)
+    static void OnSuccessCallback_161(void * context, const chip::app::DataModel::Nullable<uint8_t> & nullableBitmap8)
     {
-        (static_cast<TestCluster *>(context))->OnSuccessResponse_161(nullableBitmap16);
+        (static_cast<TestCluster *>(context))->OnSuccessResponse_161(nullableBitmap8);
     }
 
     static void OnFailureCallback_162(void * context, EmberAfStatus status)
@@ -33435,9 +33421,9 @@ private:
         (static_cast<TestCluster *>(context))->OnFailureResponse_163(chip::to_underlying(status));
     }
 
-    static void OnSuccessCallback_163(void * context, const chip::app::DataModel::Nullable<uint32_t> & nullableBitmap32)
+    static void OnSuccessCallback_163(void * context, const chip::app::DataModel::Nullable<uint16_t> & nullableBitmap16)
     {
-        (static_cast<TestCluster *>(context))->OnSuccessResponse_163(nullableBitmap32);
+        (static_cast<TestCluster *>(context))->OnSuccessResponse_163(nullableBitmap16);
     }
 
     static void OnFailureCallback_164(void * context, EmberAfStatus status)
@@ -33452,9 +33438,9 @@ private:
         (static_cast<TestCluster *>(context))->OnFailureResponse_165(chip::to_underlying(status));
     }
 
-    static void OnSuccessCallback_165(void * context, const chip::app::DataModel::Nullable<uint32_t> & nullableBitmap32)
+    static void OnSuccessCallback_165(void * context, const chip::app::DataModel::Nullable<uint16_t> & nullableBitmap16)
     {
-        (static_cast<TestCluster *>(context))->OnSuccessResponse_165(nullableBitmap32);
+        (static_cast<TestCluster *>(context))->OnSuccessResponse_165(nullableBitmap16);
     }
 
     static void OnFailureCallback_166(void * context, EmberAfStatus status)
@@ -33469,9 +33455,9 @@ private:
         (static_cast<TestCluster *>(context))->OnFailureResponse_167(chip::to_underlying(status));
     }
 
-    static void OnSuccessCallback_167(void * context, const chip::app::DataModel::Nullable<uint32_t> & nullableBitmap32)
+    static void OnSuccessCallback_167(void * context, const chip::app::DataModel::Nullable<uint16_t> & nullableBitmap16)
     {
-        (static_cast<TestCluster *>(context))->OnSuccessResponse_167(nullableBitmap32);
+        (static_cast<TestCluster *>(context))->OnSuccessResponse_167(nullableBitmap16);
     }
 
     static void OnFailureCallback_168(void * context, EmberAfStatus status)
@@ -33486,9 +33472,9 @@ private:
         (static_cast<TestCluster *>(context))->OnFailureResponse_169(chip::to_underlying(status));
     }
 
-    static void OnSuccessCallback_169(void * context, const chip::app::DataModel::Nullable<uint64_t> & nullableBitmap64)
+    static void OnSuccessCallback_169(void * context, const chip::app::DataModel::Nullable<uint32_t> & nullableBitmap32)
     {
-        (static_cast<TestCluster *>(context))->OnSuccessResponse_169(nullableBitmap64);
+        (static_cast<TestCluster *>(context))->OnSuccessResponse_169(nullableBitmap32);
     }
 
     static void OnFailureCallback_170(void * context, EmberAfStatus status)
@@ -33503,9 +33489,9 @@ private:
         (static_cast<TestCluster *>(context))->OnFailureResponse_171(chip::to_underlying(status));
     }
 
-    static void OnSuccessCallback_171(void * context, const chip::app::DataModel::Nullable<uint64_t> & nullableBitmap64)
+    static void OnSuccessCallback_171(void * context, const chip::app::DataModel::Nullable<uint32_t> & nullableBitmap32)
     {
-        (static_cast<TestCluster *>(context))->OnSuccessResponse_171(nullableBitmap64);
+        (static_cast<TestCluster *>(context))->OnSuccessResponse_171(nullableBitmap32);
     }
 
     static void OnFailureCallback_172(void * context, EmberAfStatus status)
@@ -33520,9 +33506,9 @@ private:
         (static_cast<TestCluster *>(context))->OnFailureResponse_173(chip::to_underlying(status));
     }
 
-    static void OnSuccessCallback_173(void * context, const chip::app::DataModel::Nullable<uint64_t> & nullableBitmap64)
+    static void OnSuccessCallback_173(void * context, const chip::app::DataModel::Nullable<uint32_t> & nullableBitmap32)
     {
-        (static_cast<TestCluster *>(context))->OnSuccessResponse_173(nullableBitmap64);
+        (static_cast<TestCluster *>(context))->OnSuccessResponse_173(nullableBitmap32);
     }
 
     static void OnFailureCallback_174(void * context, EmberAfStatus status)
@@ -33537,9 +33523,9 @@ private:
         (static_cast<TestCluster *>(context))->OnFailureResponse_175(chip::to_underlying(status));
     }
 
-    static void OnSuccessCallback_175(void * context, const chip::app::DataModel::Nullable<uint8_t> & nullableInt8u)
+    static void OnSuccessCallback_175(void * context, const chip::app::DataModel::Nullable<uint64_t> & nullableBitmap64)
     {
-        (static_cast<TestCluster *>(context))->OnSuccessResponse_175(nullableInt8u);
+        (static_cast<TestCluster *>(context))->OnSuccessResponse_175(nullableBitmap64);
     }
 
     static void OnFailureCallback_176(void * context, EmberAfStatus status)
@@ -33554,9 +33540,9 @@ private:
         (static_cast<TestCluster *>(context))->OnFailureResponse_177(chip::to_underlying(status));
     }
 
-    static void OnSuccessCallback_177(void * context, const chip::app::DataModel::Nullable<uint8_t> & nullableInt8u)
+    static void OnSuccessCallback_177(void * context, const chip::app::DataModel::Nullable<uint64_t> & nullableBitmap64)
     {
-        (static_cast<TestCluster *>(context))->OnSuccessResponse_177(nullableInt8u);
+        (static_cast<TestCluster *>(context))->OnSuccessResponse_177(nullableBitmap64);
     }
 
     static void OnFailureCallback_178(void * context, EmberAfStatus status)
@@ -33571,9 +33557,9 @@ private:
         (static_cast<TestCluster *>(context))->OnFailureResponse_179(chip::to_underlying(status));
     }
 
-    static void OnSuccessCallback_179(void * context, const chip::app::DataModel::Nullable<uint8_t> & nullableInt8u)
+    static void OnSuccessCallback_179(void * context, const chip::app::DataModel::Nullable<uint64_t> & nullableBitmap64)
     {
-        (static_cast<TestCluster *>(context))->OnSuccessResponse_179(nullableInt8u);
+        (static_cast<TestCluster *>(context))->OnSuccessResponse_179(nullableBitmap64);
     }
 
     static void OnFailureCallback_180(void * context, EmberAfStatus status)
@@ -33588,9 +33574,9 @@ private:
         (static_cast<TestCluster *>(context))->OnFailureResponse_181(chip::to_underlying(status));
     }
 
-    static void OnSuccessCallback_181(void * context, const chip::app::DataModel::Nullable<uint16_t> & nullableInt16u)
+    static void OnSuccessCallback_181(void * context, const chip::app::DataModel::Nullable<uint8_t> & nullableInt8u)
     {
-        (static_cast<TestCluster *>(context))->OnSuccessResponse_181(nullableInt16u);
+        (static_cast<TestCluster *>(context))->OnSuccessResponse_181(nullableInt8u);
     }
 
     static void OnFailureCallback_182(void * context, EmberAfStatus status)
@@ -33605,9 +33591,9 @@ private:
         (static_cast<TestCluster *>(context))->OnFailureResponse_183(chip::to_underlying(status));
     }
 
-    static void OnSuccessCallback_183(void * context, const chip::app::DataModel::Nullable<uint16_t> & nullableInt16u)
+    static void OnSuccessCallback_183(void * context, const chip::app::DataModel::Nullable<uint8_t> & nullableInt8u)
     {
-        (static_cast<TestCluster *>(context))->OnSuccessResponse_183(nullableInt16u);
+        (static_cast<TestCluster *>(context))->OnSuccessResponse_183(nullableInt8u);
     }
 
     static void OnFailureCallback_184(void * context, EmberAfStatus status)
@@ -33622,9 +33608,9 @@ private:
         (static_cast<TestCluster *>(context))->OnFailureResponse_185(chip::to_underlying(status));
     }
 
-    static void OnSuccessCallback_185(void * context, const chip::app::DataModel::Nullable<uint16_t> & nullableInt16u)
+    static void OnSuccessCallback_185(void * context, const chip::app::DataModel::Nullable<uint8_t> & nullableInt8u)
     {
-        (static_cast<TestCluster *>(context))->OnSuccessResponse_185(nullableInt16u);
+        (static_cast<TestCluster *>(context))->OnSuccessResponse_185(nullableInt8u);
     }
 
     static void OnFailureCallback_186(void * context, EmberAfStatus status)
@@ -33639,9 +33625,9 @@ private:
         (static_cast<TestCluster *>(context))->OnFailureResponse_187(chip::to_underlying(status));
     }
 
-    static void OnSuccessCallback_187(void * context, const chip::app::DataModel::Nullable<uint32_t> & nullableInt32u)
+    static void OnSuccessCallback_187(void * context, const chip::app::DataModel::Nullable<uint16_t> & nullableInt16u)
     {
-        (static_cast<TestCluster *>(context))->OnSuccessResponse_187(nullableInt32u);
+        (static_cast<TestCluster *>(context))->OnSuccessResponse_187(nullableInt16u);
     }
 
     static void OnFailureCallback_188(void * context, EmberAfStatus status)
@@ -33656,9 +33642,9 @@ private:
         (static_cast<TestCluster *>(context))->OnFailureResponse_189(chip::to_underlying(status));
     }
 
-    static void OnSuccessCallback_189(void * context, const chip::app::DataModel::Nullable<uint32_t> & nullableInt32u)
+    static void OnSuccessCallback_189(void * context, const chip::app::DataModel::Nullable<uint16_t> & nullableInt16u)
     {
-        (static_cast<TestCluster *>(context))->OnSuccessResponse_189(nullableInt32u);
+        (static_cast<TestCluster *>(context))->OnSuccessResponse_189(nullableInt16u);
     }
 
     static void OnFailureCallback_190(void * context, EmberAfStatus status)
@@ -33673,9 +33659,9 @@ private:
         (static_cast<TestCluster *>(context))->OnFailureResponse_191(chip::to_underlying(status));
     }
 
-    static void OnSuccessCallback_191(void * context, const chip::app::DataModel::Nullable<uint32_t> & nullableInt32u)
+    static void OnSuccessCallback_191(void * context, const chip::app::DataModel::Nullable<uint16_t> & nullableInt16u)
     {
-        (static_cast<TestCluster *>(context))->OnSuccessResponse_191(nullableInt32u);
+        (static_cast<TestCluster *>(context))->OnSuccessResponse_191(nullableInt16u);
     }
 
     static void OnFailureCallback_192(void * context, EmberAfStatus status)
@@ -33690,9 +33676,9 @@ private:
         (static_cast<TestCluster *>(context))->OnFailureResponse_193(chip::to_underlying(status));
     }
 
-    static void OnSuccessCallback_193(void * context, const chip::app::DataModel::Nullable<uint64_t> & nullableInt64u)
+    static void OnSuccessCallback_193(void * context, const chip::app::DataModel::Nullable<uint32_t> & nullableInt32u)
     {
-        (static_cast<TestCluster *>(context))->OnSuccessResponse_193(nullableInt64u);
+        (static_cast<TestCluster *>(context))->OnSuccessResponse_193(nullableInt32u);
     }
 
     static void OnFailureCallback_194(void * context, EmberAfStatus status)
@@ -33707,9 +33693,9 @@ private:
         (static_cast<TestCluster *>(context))->OnFailureResponse_195(chip::to_underlying(status));
     }
 
-    static void OnSuccessCallback_195(void * context, const chip::app::DataModel::Nullable<uint64_t> & nullableInt64u)
+    static void OnSuccessCallback_195(void * context, const chip::app::DataModel::Nullable<uint32_t> & nullableInt32u)
     {
-        (static_cast<TestCluster *>(context))->OnSuccessResponse_195(nullableInt64u);
+        (static_cast<TestCluster *>(context))->OnSuccessResponse_195(nullableInt32u);
     }
 
     static void OnFailureCallback_196(void * context, EmberAfStatus status)
@@ -33724,9 +33710,9 @@ private:
         (static_cast<TestCluster *>(context))->OnFailureResponse_197(chip::to_underlying(status));
     }
 
-    static void OnSuccessCallback_197(void * context, const chip::app::DataModel::Nullable<uint64_t> & nullableInt64u)
+    static void OnSuccessCallback_197(void * context, const chip::app::DataModel::Nullable<uint32_t> & nullableInt32u)
     {
-        (static_cast<TestCluster *>(context))->OnSuccessResponse_197(nullableInt64u);
+        (static_cast<TestCluster *>(context))->OnSuccessResponse_197(nullableInt32u);
     }
 
     static void OnFailureCallback_198(void * context, EmberAfStatus status)
@@ -33741,9 +33727,9 @@ private:
         (static_cast<TestCluster *>(context))->OnFailureResponse_199(chip::to_underlying(status));
     }
 
-    static void OnSuccessCallback_199(void * context, const chip::app::DataModel::Nullable<int8_t> & nullableInt8s)
+    static void OnSuccessCallback_199(void * context, const chip::app::DataModel::Nullable<uint64_t> & nullableInt64u)
     {
-        (static_cast<TestCluster *>(context))->OnSuccessResponse_199(nullableInt8s);
+        (static_cast<TestCluster *>(context))->OnSuccessResponse_199(nullableInt64u);
     }
 
     static void OnFailureCallback_200(void * context, EmberAfStatus status)
@@ -33758,9 +33744,9 @@ private:
         (static_cast<TestCluster *>(context))->OnFailureResponse_201(chip::to_underlying(status));
     }
 
-    static void OnSuccessCallback_201(void * context, const chip::app::DataModel::Nullable<int8_t> & nullableInt8s)
+    static void OnSuccessCallback_201(void * context, const chip::app::DataModel::Nullable<uint64_t> & nullableInt64u)
     {
-        (static_cast<TestCluster *>(context))->OnSuccessResponse_201(nullableInt8s);
+        (static_cast<TestCluster *>(context))->OnSuccessResponse_201(nullableInt64u);
     }
 
     static void OnFailureCallback_202(void * context, EmberAfStatus status)
@@ -33775,9 +33761,9 @@ private:
         (static_cast<TestCluster *>(context))->OnFailureResponse_203(chip::to_underlying(status));
     }
 
-    static void OnSuccessCallback_203(void * context, const chip::app::DataModel::Nullable<int8_t> & nullableInt8s)
+    static void OnSuccessCallback_203(void * context, const chip::app::DataModel::Nullable<uint64_t> & nullableInt64u)
     {
-        (static_cast<TestCluster *>(context))->OnSuccessResponse_203(nullableInt8s);
+        (static_cast<TestCluster *>(context))->OnSuccessResponse_203(nullableInt64u);
     }
 
     static void OnFailureCallback_204(void * context, EmberAfStatus status)
@@ -33792,9 +33778,9 @@ private:
         (static_cast<TestCluster *>(context))->OnFailureResponse_205(chip::to_underlying(status));
     }
 
-    static void OnSuccessCallback_205(void * context, const chip::app::DataModel::Nullable<int16_t> & nullableInt16s)
+    static void OnSuccessCallback_205(void * context, const chip::app::DataModel::Nullable<int8_t> & nullableInt8s)
     {
-        (static_cast<TestCluster *>(context))->OnSuccessResponse_205(nullableInt16s);
+        (static_cast<TestCluster *>(context))->OnSuccessResponse_205(nullableInt8s);
     }
 
     static void OnFailureCallback_206(void * context, EmberAfStatus status)
@@ -33809,9 +33795,9 @@ private:
         (static_cast<TestCluster *>(context))->OnFailureResponse_207(chip::to_underlying(status));
     }
 
-    static void OnSuccessCallback_207(void * context, const chip::app::DataModel::Nullable<int16_t> & nullableInt16s)
+    static void OnSuccessCallback_207(void * context, const chip::app::DataModel::Nullable<int8_t> & nullableInt8s)
     {
-        (static_cast<TestCluster *>(context))->OnSuccessResponse_207(nullableInt16s);
+        (static_cast<TestCluster *>(context))->OnSuccessResponse_207(nullableInt8s);
     }
 
     static void OnFailureCallback_208(void * context, EmberAfStatus status)
@@ -33826,9 +33812,9 @@ private:
         (static_cast<TestCluster *>(context))->OnFailureResponse_209(chip::to_underlying(status));
     }
 
-    static void OnSuccessCallback_209(void * context, const chip::app::DataModel::Nullable<int16_t> & nullableInt16s)
+    static void OnSuccessCallback_209(void * context, const chip::app::DataModel::Nullable<int8_t> & nullableInt8s)
     {
-        (static_cast<TestCluster *>(context))->OnSuccessResponse_209(nullableInt16s);
+        (static_cast<TestCluster *>(context))->OnSuccessResponse_209(nullableInt8s);
     }
 
     static void OnFailureCallback_210(void * context, EmberAfStatus status)
@@ -33843,9 +33829,9 @@ private:
         (static_cast<TestCluster *>(context))->OnFailureResponse_211(chip::to_underlying(status));
     }
 
-    static void OnSuccessCallback_211(void * context, const chip::app::DataModel::Nullable<int32_t> & nullableInt32s)
+    static void OnSuccessCallback_211(void * context, const chip::app::DataModel::Nullable<int16_t> & nullableInt16s)
     {
-        (static_cast<TestCluster *>(context))->OnSuccessResponse_211(nullableInt32s);
+        (static_cast<TestCluster *>(context))->OnSuccessResponse_211(nullableInt16s);
     }
 
     static void OnFailureCallback_212(void * context, EmberAfStatus status)
@@ -33860,9 +33846,9 @@ private:
         (static_cast<TestCluster *>(context))->OnFailureResponse_213(chip::to_underlying(status));
     }
 
-    static void OnSuccessCallback_213(void * context, const chip::app::DataModel::Nullable<int32_t> & nullableInt32s)
+    static void OnSuccessCallback_213(void * context, const chip::app::DataModel::Nullable<int16_t> & nullableInt16s)
     {
-        (static_cast<TestCluster *>(context))->OnSuccessResponse_213(nullableInt32s);
+        (static_cast<TestCluster *>(context))->OnSuccessResponse_213(nullableInt16s);
     }
 
     static void OnFailureCallback_214(void * context, EmberAfStatus status)
@@ -33877,9 +33863,9 @@ private:
         (static_cast<TestCluster *>(context))->OnFailureResponse_215(chip::to_underlying(status));
     }
 
-    static void OnSuccessCallback_215(void * context, const chip::app::DataModel::Nullable<int32_t> & nullableInt32s)
+    static void OnSuccessCallback_215(void * context, const chip::app::DataModel::Nullable<int16_t> & nullableInt16s)
     {
-        (static_cast<TestCluster *>(context))->OnSuccessResponse_215(nullableInt32s);
+        (static_cast<TestCluster *>(context))->OnSuccessResponse_215(nullableInt16s);
     }
 
     static void OnFailureCallback_216(void * context, EmberAfStatus status)
@@ -33894,9 +33880,9 @@ private:
         (static_cast<TestCluster *>(context))->OnFailureResponse_217(chip::to_underlying(status));
     }
 
-    static void OnSuccessCallback_217(void * context, const chip::app::DataModel::Nullable<int64_t> & nullableInt64s)
+    static void OnSuccessCallback_217(void * context, const chip::app::DataModel::Nullable<int32_t> & nullableInt32s)
     {
-        (static_cast<TestCluster *>(context))->OnSuccessResponse_217(nullableInt64s);
+        (static_cast<TestCluster *>(context))->OnSuccessResponse_217(nullableInt32s);
     }
 
     static void OnFailureCallback_218(void * context, EmberAfStatus status)
@@ -33911,9 +33897,9 @@ private:
         (static_cast<TestCluster *>(context))->OnFailureResponse_219(chip::to_underlying(status));
     }
 
-    static void OnSuccessCallback_219(void * context, const chip::app::DataModel::Nullable<int64_t> & nullableInt64s)
+    static void OnSuccessCallback_219(void * context, const chip::app::DataModel::Nullable<int32_t> & nullableInt32s)
     {
-        (static_cast<TestCluster *>(context))->OnSuccessResponse_219(nullableInt64s);
+        (static_cast<TestCluster *>(context))->OnSuccessResponse_219(nullableInt32s);
     }
 
     static void OnFailureCallback_220(void * context, EmberAfStatus status)
@@ -33928,9 +33914,9 @@ private:
         (static_cast<TestCluster *>(context))->OnFailureResponse_221(chip::to_underlying(status));
     }
 
-    static void OnSuccessCallback_221(void * context, const chip::app::DataModel::Nullable<int64_t> & nullableInt64s)
+    static void OnSuccessCallback_221(void * context, const chip::app::DataModel::Nullable<int32_t> & nullableInt32s)
     {
-        (static_cast<TestCluster *>(context))->OnSuccessResponse_221(nullableInt64s);
+        (static_cast<TestCluster *>(context))->OnSuccessResponse_221(nullableInt32s);
     }
 
     static void OnFailureCallback_222(void * context, EmberAfStatus status)
@@ -33945,9 +33931,9 @@ private:
         (static_cast<TestCluster *>(context))->OnFailureResponse_223(chip::to_underlying(status));
     }
 
-    static void OnSuccessCallback_223(void * context, const chip::app::DataModel::Nullable<uint8_t> & nullableEnum8)
+    static void OnSuccessCallback_223(void * context, const chip::app::DataModel::Nullable<int64_t> & nullableInt64s)
     {
-        (static_cast<TestCluster *>(context))->OnSuccessResponse_223(nullableEnum8);
+        (static_cast<TestCluster *>(context))->OnSuccessResponse_223(nullableInt64s);
     }
 
     static void OnFailureCallback_224(void * context, EmberAfStatus status)
@@ -33962,9 +33948,9 @@ private:
         (static_cast<TestCluster *>(context))->OnFailureResponse_225(chip::to_underlying(status));
     }
 
-    static void OnSuccessCallback_225(void * context, const chip::app::DataModel::Nullable<uint8_t> & nullableEnum8)
+    static void OnSuccessCallback_225(void * context, const chip::app::DataModel::Nullable<int64_t> & nullableInt64s)
     {
-        (static_cast<TestCluster *>(context))->OnSuccessResponse_225(nullableEnum8);
+        (static_cast<TestCluster *>(context))->OnSuccessResponse_225(nullableInt64s);
     }
 
     static void OnFailureCallback_226(void * context, EmberAfStatus status)
@@ -33979,9 +33965,9 @@ private:
         (static_cast<TestCluster *>(context))->OnFailureResponse_227(chip::to_underlying(status));
     }
 
-    static void OnSuccessCallback_227(void * context, const chip::app::DataModel::Nullable<uint8_t> & nullableEnum8)
+    static void OnSuccessCallback_227(void * context, const chip::app::DataModel::Nullable<int64_t> & nullableInt64s)
     {
-        (static_cast<TestCluster *>(context))->OnSuccessResponse_227(nullableEnum8);
+        (static_cast<TestCluster *>(context))->OnSuccessResponse_227(nullableInt64s);
     }
 
     static void OnFailureCallback_228(void * context, EmberAfStatus status)
@@ -33996,9 +33982,9 @@ private:
         (static_cast<TestCluster *>(context))->OnFailureResponse_229(chip::to_underlying(status));
     }
 
-    static void OnSuccessCallback_229(void * context, const chip::app::DataModel::Nullable<uint16_t> & nullableEnum16)
+    static void OnSuccessCallback_229(void * context, const chip::app::DataModel::Nullable<uint8_t> & nullableEnum8)
     {
-        (static_cast<TestCluster *>(context))->OnSuccessResponse_229(nullableEnum16);
+        (static_cast<TestCluster *>(context))->OnSuccessResponse_229(nullableEnum8);
     }
 
     static void OnFailureCallback_230(void * context, EmberAfStatus status)
@@ -34013,9 +33999,9 @@ private:
         (static_cast<TestCluster *>(context))->OnFailureResponse_231(chip::to_underlying(status));
     }
 
-    static void OnSuccessCallback_231(void * context, const chip::app::DataModel::Nullable<uint16_t> & nullableEnum16)
+    static void OnSuccessCallback_231(void * context, const chip::app::DataModel::Nullable<uint8_t> & nullableEnum8)
     {
-        (static_cast<TestCluster *>(context))->OnSuccessResponse_231(nullableEnum16);
+        (static_cast<TestCluster *>(context))->OnSuccessResponse_231(nullableEnum8);
     }
 
     static void OnFailureCallback_232(void * context, EmberAfStatus status)
@@ -34030,9 +34016,9 @@ private:
         (static_cast<TestCluster *>(context))->OnFailureResponse_233(chip::to_underlying(status));
     }
 
-    static void OnSuccessCallback_233(void * context, const chip::app::DataModel::Nullable<uint16_t> & nullableEnum16)
+    static void OnSuccessCallback_233(void * context, const chip::app::DataModel::Nullable<uint8_t> & nullableEnum8)
     {
-        (static_cast<TestCluster *>(context))->OnSuccessResponse_233(nullableEnum16);
+        (static_cast<TestCluster *>(context))->OnSuccessResponse_233(nullableEnum8);
     }
 
     static void OnFailureCallback_234(void * context, EmberAfStatus status)
@@ -34040,51 +34026,51 @@ private:
         (static_cast<TestCluster *>(context))->OnFailureResponse_234(chip::to_underlying(status));
     }
 
-    static void OnSuccessCallback_234(void * context, const chip::app::DataModel::Nullable<chip::ByteSpan> & nullableOctetString)
-    {
-        (static_cast<TestCluster *>(context))->OnSuccessResponse_234(nullableOctetString);
-    }
+    static void OnSuccessCallback_234(void * context) { (static_cast<TestCluster *>(context))->OnSuccessResponse_234(); }
 
     static void OnFailureCallback_235(void * context, EmberAfStatus status)
     {
         (static_cast<TestCluster *>(context))->OnFailureResponse_235(chip::to_underlying(status));
     }
 
-    static void OnSuccessCallback_235(void * context) { (static_cast<TestCluster *>(context))->OnSuccessResponse_235(); }
+    static void OnSuccessCallback_235(void * context, const chip::app::DataModel::Nullable<uint16_t> & nullableEnum16)
+    {
+        (static_cast<TestCluster *>(context))->OnSuccessResponse_235(nullableEnum16);
+    }
 
     static void OnFailureCallback_236(void * context, EmberAfStatus status)
     {
         (static_cast<TestCluster *>(context))->OnFailureResponse_236(chip::to_underlying(status));
     }
 
-    static void OnSuccessCallback_236(void * context, const chip::app::DataModel::Nullable<chip::ByteSpan> & nullableOctetString)
-    {
-        (static_cast<TestCluster *>(context))->OnSuccessResponse_236(nullableOctetString);
-    }
+    static void OnSuccessCallback_236(void * context) { (static_cast<TestCluster *>(context))->OnSuccessResponse_236(); }
 
     static void OnFailureCallback_237(void * context, EmberAfStatus status)
     {
         (static_cast<TestCluster *>(context))->OnFailureResponse_237(chip::to_underlying(status));
     }
 
-    static void OnSuccessCallback_237(void * context) { (static_cast<TestCluster *>(context))->OnSuccessResponse_237(); }
+    static void OnSuccessCallback_237(void * context, const chip::app::DataModel::Nullable<uint16_t> & nullableEnum16)
+    {
+        (static_cast<TestCluster *>(context))->OnSuccessResponse_237(nullableEnum16);
+    }
 
     static void OnFailureCallback_238(void * context, EmberAfStatus status)
     {
         (static_cast<TestCluster *>(context))->OnFailureResponse_238(chip::to_underlying(status));
     }
 
-    static void OnSuccessCallback_238(void * context, const chip::app::DataModel::Nullable<chip::ByteSpan> & nullableOctetString)
-    {
-        (static_cast<TestCluster *>(context))->OnSuccessResponse_238(nullableOctetString);
-    }
+    static void OnSuccessCallback_238(void * context) { (static_cast<TestCluster *>(context))->OnSuccessResponse_238(); }
 
     static void OnFailureCallback_239(void * context, EmberAfStatus status)
     {
         (static_cast<TestCluster *>(context))->OnFailureResponse_239(chip::to_underlying(status));
     }
 
-    static void OnSuccessCallback_239(void * context) { (static_cast<TestCluster *>(context))->OnSuccessResponse_239(); }
+    static void OnSuccessCallback_239(void * context, const chip::app::DataModel::Nullable<uint16_t> & nullableEnum16)
+    {
+        (static_cast<TestCluster *>(context))->OnSuccessResponse_239(nullableEnum16);
+    }
 
     static void OnFailureCallback_240(void * context, EmberAfStatus status)
     {
@@ -34101,17 +34087,17 @@ private:
         (static_cast<TestCluster *>(context))->OnFailureResponse_241(chip::to_underlying(status));
     }
 
-    static void OnSuccessCallback_241(void * context, const chip::app::DataModel::Nullable<chip::CharSpan> & nullableCharString)
-    {
-        (static_cast<TestCluster *>(context))->OnSuccessResponse_241(nullableCharString);
-    }
+    static void OnSuccessCallback_241(void * context) { (static_cast<TestCluster *>(context))->OnSuccessResponse_241(); }
 
     static void OnFailureCallback_242(void * context, EmberAfStatus status)
     {
         (static_cast<TestCluster *>(context))->OnFailureResponse_242(chip::to_underlying(status));
     }
 
-    static void OnSuccessCallback_242(void * context) { (static_cast<TestCluster *>(context))->OnSuccessResponse_242(); }
+    static void OnSuccessCallback_242(void * context, const chip::app::DataModel::Nullable<chip::ByteSpan> & nullableOctetString)
+    {
+        (static_cast<TestCluster *>(context))->OnSuccessResponse_242(nullableOctetString);
+    }
 
     static void OnFailureCallback_243(void * context, EmberAfStatus status)
     {
@@ -34125,9 +34111,9 @@ private:
         (static_cast<TestCluster *>(context))->OnFailureResponse_244(chip::to_underlying(status));
     }
 
-    static void OnSuccessCallback_244(void * context, const chip::app::DataModel::Nullable<chip::CharSpan> & nullableCharString)
+    static void OnSuccessCallback_244(void * context, const chip::app::DataModel::Nullable<chip::ByteSpan> & nullableOctetString)
     {
-        (static_cast<TestCluster *>(context))->OnSuccessResponse_244(nullableCharString);
+        (static_cast<TestCluster *>(context))->OnSuccessResponse_244(nullableOctetString);
     }
 
     static void OnFailureCallback_245(void * context, EmberAfStatus status)
@@ -34142,9 +34128,9 @@ private:
         (static_cast<TestCluster *>(context))->OnFailureResponse_246(chip::to_underlying(status));
     }
 
-    static void OnSuccessCallback_246(void * context, const chip::app::DataModel::Nullable<chip::CharSpan> & nullableCharString)
+    static void OnSuccessCallback_246(void * context, const chip::app::DataModel::Nullable<chip::ByteSpan> & nullableOctetString)
     {
-        (static_cast<TestCluster *>(context))->OnSuccessResponse_246(nullableCharString);
+        (static_cast<TestCluster *>(context))->OnSuccessResponse_246(nullableOctetString);
     }
 
     static void OnFailureCallback_247(void * context, EmberAfStatus status)
@@ -34152,9 +34138,9 @@ private:
         (static_cast<TestCluster *>(context))->OnFailureResponse_247(chip::to_underlying(status));
     }
 
-    static void OnSuccessCallback_247(void * context, const chip::app::DataModel::DecodableList<uint8_t> & listInt8u)
+    static void OnSuccessCallback_247(void * context, const chip::app::DataModel::Nullable<chip::CharSpan> & nullableCharString)
     {
-        (static_cast<TestCluster *>(context))->OnSuccessResponse_247(listInt8u);
+        (static_cast<TestCluster *>(context))->OnSuccessResponse_247(nullableCharString);
     }
 
     static void OnFailureCallback_248(void * context, EmberAfStatus status)
@@ -34162,9 +34148,70 @@ private:
         (static_cast<TestCluster *>(context))->OnFailureResponse_248(chip::to_underlying(status));
     }
 
-    static void OnSuccessCallback_248(void * context, const chip::app::DataModel::DecodableList<uint8_t> & listInt8u)
+    static void OnSuccessCallback_248(void * context) { (static_cast<TestCluster *>(context))->OnSuccessResponse_248(); }
+
+    static void OnFailureCallback_249(void * context, EmberAfStatus status)
     {
-        (static_cast<TestCluster *>(context))->OnSuccessResponse_248(listInt8u);
+        (static_cast<TestCluster *>(context))->OnFailureResponse_249(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_249(void * context, const chip::app::DataModel::Nullable<chip::CharSpan> & nullableCharString)
+    {
+        (static_cast<TestCluster *>(context))->OnSuccessResponse_249(nullableCharString);
+    }
+
+    static void OnFailureCallback_250(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestCluster *>(context))->OnFailureResponse_250(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_250(void * context) { (static_cast<TestCluster *>(context))->OnSuccessResponse_250(); }
+
+    static void OnFailureCallback_251(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestCluster *>(context))->OnFailureResponse_251(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_251(void * context, const chip::app::DataModel::Nullable<chip::CharSpan> & nullableCharString)
+    {
+        (static_cast<TestCluster *>(context))->OnSuccessResponse_251(nullableCharString);
+    }
+
+    static void OnFailureCallback_252(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestCluster *>(context))->OnFailureResponse_252(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_252(void * context) { (static_cast<TestCluster *>(context))->OnSuccessResponse_252(); }
+
+    static void OnFailureCallback_253(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestCluster *>(context))->OnFailureResponse_253(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_253(void * context, const chip::app::DataModel::Nullable<chip::CharSpan> & nullableCharString)
+    {
+        (static_cast<TestCluster *>(context))->OnSuccessResponse_253(nullableCharString);
+    }
+
+    static void OnFailureCallback_254(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestCluster *>(context))->OnFailureResponse_254(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_254(void * context, const chip::app::DataModel::DecodableList<uint8_t> & listInt8u)
+    {
+        (static_cast<TestCluster *>(context))->OnSuccessResponse_254(listInt8u);
+    }
+
+    static void OnFailureCallback_255(void * context, EmberAfStatus status)
+    {
+        (static_cast<TestCluster *>(context))->OnFailureResponse_255(chip::to_underlying(status));
+    }
+
+    static void OnSuccessCallback_255(void * context, const chip::app::DataModel::DecodableList<uint8_t> & listInt8u)
+    {
+        (static_cast<TestCluster *>(context))->OnSuccessResponse_255(listInt8u);
     }
 
     //
@@ -36702,7 +36749,245 @@ private:
         NextTest();
     }
 
-    CHIP_ERROR TestSendTestCommandWithStructArgumentAndSeeWhatWeGetBack_131()
+    CHIP_ERROR TestSendTestCommandWithNestedStructArgumentAndArg1cbIsTrue_131()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        using RequestType               = chip::app::Clusters::TestCluster::Commands::TestNestedStructArgumentRequest::Type;
+
+        RequestType request;
+
+        request.arg1.a = 0;
+        request.arg1.b = true;
+
+        request.arg1.c.a = 0;
+        request.arg1.c.b = true;
+        request.arg1.c.c = static_cast<chip::app::Clusters::TestCluster::SimpleEnum>(2);
+        request.arg1.c.d = chip::ByteSpan(chip::Uint8::from_const_char("octet_stringgarbage: not in length on purpose"), 12);
+        request.arg1.c.e = chip::Span<const char>("char_stringgarbage: not in length on purpose", 11);
+        request.arg1.c.f = static_cast<chip::BitFlags<chip::app::Clusters::TestCluster::SimpleBitmap>>(1);
+        request.arg1.c.g = 0;
+        request.arg1.c.h = 0;
+
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
+            (static_cast<TestCluster *>(context))->OnSuccessResponse_131(data.value);
+        };
+
+        auto failure = [](void * context, EmberAfStatus status) {
+            (static_cast<TestCluster *>(context))->OnFailureResponse_131(status);
+        };
+
+        ReturnErrorOnFailure(chip::Controller::InvokeCommand(mDevice, this, success, failure, endpoint, request));
+        return CHIP_NO_ERROR;
+    }
+
+    void OnFailureResponse_131(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_131(bool value)
+    {
+        VerifyOrReturn(CheckValue("value", value, true));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestSendTestCommandWithNestedStructArgumentArg1cbIsFalse_132()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        using RequestType               = chip::app::Clusters::TestCluster::Commands::TestNestedStructArgumentRequest::Type;
+
+        RequestType request;
+
+        request.arg1.a = 0;
+        request.arg1.b = true;
+
+        request.arg1.c.a = 0;
+        request.arg1.c.b = false;
+        request.arg1.c.c = static_cast<chip::app::Clusters::TestCluster::SimpleEnum>(2);
+        request.arg1.c.d = chip::ByteSpan(chip::Uint8::from_const_char("octet_stringgarbage: not in length on purpose"), 12);
+        request.arg1.c.e = chip::Span<const char>("char_stringgarbage: not in length on purpose", 11);
+        request.arg1.c.f = static_cast<chip::BitFlags<chip::app::Clusters::TestCluster::SimpleBitmap>>(1);
+        request.arg1.c.g = 0;
+        request.arg1.c.h = 0;
+
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
+            (static_cast<TestCluster *>(context))->OnSuccessResponse_132(data.value);
+        };
+
+        auto failure = [](void * context, EmberAfStatus status) {
+            (static_cast<TestCluster *>(context))->OnFailureResponse_132(status);
+        };
+
+        ReturnErrorOnFailure(chip::Controller::InvokeCommand(mDevice, this, success, failure, endpoint, request));
+        return CHIP_NO_ERROR;
+    }
+
+    void OnFailureResponse_132(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_132(bool value)
+    {
+        VerifyOrReturn(CheckValue("value", value, false));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestSendTestCommandWithNestedStructListArgumentAndAllFieldsBOfArg1dAreTrue_133()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        using RequestType               = chip::app::Clusters::TestCluster::Commands::TestNestedStructListArgumentRequest::Type;
+
+        RequestType request;
+
+        request.arg1.a = 0;
+        request.arg1.b = true;
+
+        request.arg1.c.a = 0;
+        request.arg1.c.b = true;
+        request.arg1.c.c = static_cast<chip::app::Clusters::TestCluster::SimpleEnum>(2);
+        request.arg1.c.d = chip::ByteSpan(chip::Uint8::from_const_char("octet_stringgarbage: not in length on purpose"), 12);
+        request.arg1.c.e = chip::Span<const char>("char_stringgarbage: not in length on purpose", 11);
+        request.arg1.c.f = static_cast<chip::BitFlags<chip::app::Clusters::TestCluster::SimpleBitmap>>(1);
+        request.arg1.c.g = 0;
+        request.arg1.c.h = 0;
+
+        chip::app::Clusters::TestCluster::Structs::SimpleStruct::Type dList[2];
+
+        dList[0].a = 1;
+        dList[0].b = true;
+        dList[0].c = static_cast<chip::app::Clusters::TestCluster::SimpleEnum>(3);
+        dList[0].d = chip::ByteSpan(chip::Uint8::from_const_char("nested_octet_stringgarbage: not in length on purpose"), 19);
+        dList[0].e = chip::Span<const char>("nested_char_stringgarbage: not in length on purpose", 18);
+        dList[0].f = static_cast<chip::BitFlags<chip::app::Clusters::TestCluster::SimpleBitmap>>(1);
+        dList[0].g = 0;
+        dList[0].h = 0;
+
+        dList[1].a = 2;
+        dList[1].b = true;
+        dList[1].c = static_cast<chip::app::Clusters::TestCluster::SimpleEnum>(3);
+        dList[1].d = chip::ByteSpan(chip::Uint8::from_const_char("nested_octet_stringgarbage: not in length on purpose"), 19);
+        dList[1].e = chip::Span<const char>("nested_char_stringgarbage: not in length on purpose", 18);
+        dList[1].f = static_cast<chip::BitFlags<chip::app::Clusters::TestCluster::SimpleBitmap>>(1);
+        dList[1].g = 0;
+        dList[1].h = 0;
+
+        request.arg1.d = dList;
+
+        uint32_t eList[3];
+        eList[0]       = 1UL;
+        eList[1]       = 2UL;
+        eList[2]       = 3UL;
+        request.arg1.e = eList;
+
+        chip::ByteSpan fList[3];
+        fList[0]       = chip::ByteSpan(chip::Uint8::from_const_char("octet_string_1garbage: not in length on purpose"), 14);
+        fList[1]       = chip::ByteSpan(chip::Uint8::from_const_char("octect_string_2garbage: not in length on purpose"), 15);
+        fList[2]       = chip::ByteSpan(chip::Uint8::from_const_char("octet_string_3garbage: not in length on purpose"), 14);
+        request.arg1.f = fList;
+
+        uint8_t gList[2];
+        gList[0]       = 0;
+        gList[1]       = 255;
+        request.arg1.g = gList;
+
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
+            (static_cast<TestCluster *>(context))->OnSuccessResponse_133(data.value);
+        };
+
+        auto failure = [](void * context, EmberAfStatus status) {
+            (static_cast<TestCluster *>(context))->OnFailureResponse_133(status);
+        };
+
+        ReturnErrorOnFailure(chip::Controller::InvokeCommand(mDevice, this, success, failure, endpoint, request));
+        return CHIP_NO_ERROR;
+    }
+
+    void OnFailureResponse_133(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_133(bool value)
+    {
+        VerifyOrReturn(CheckValue("value", value, true));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestSendTestCommandWithNestedStructListArgumentAndSomeFieldsBOfArg1dAreFalse_134()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        using RequestType               = chip::app::Clusters::TestCluster::Commands::TestNestedStructListArgumentRequest::Type;
+
+        RequestType request;
+
+        request.arg1.a = 0;
+        request.arg1.b = true;
+
+        request.arg1.c.a = 0;
+        request.arg1.c.b = true;
+        request.arg1.c.c = static_cast<chip::app::Clusters::TestCluster::SimpleEnum>(2);
+        request.arg1.c.d = chip::ByteSpan(chip::Uint8::from_const_char("octet_stringgarbage: not in length on purpose"), 12);
+        request.arg1.c.e = chip::Span<const char>("char_stringgarbage: not in length on purpose", 11);
+        request.arg1.c.f = static_cast<chip::BitFlags<chip::app::Clusters::TestCluster::SimpleBitmap>>(1);
+        request.arg1.c.g = 0;
+        request.arg1.c.h = 0;
+
+        chip::app::Clusters::TestCluster::Structs::SimpleStruct::Type dList[2];
+
+        dList[0].a = 1;
+        dList[0].b = true;
+        dList[0].c = static_cast<chip::app::Clusters::TestCluster::SimpleEnum>(3);
+        dList[0].d = chip::ByteSpan(chip::Uint8::from_const_char("nested_octet_stringgarbage: not in length on purpose"), 19);
+        dList[0].e = chip::Span<const char>("nested_char_stringgarbage: not in length on purpose", 18);
+        dList[0].f = static_cast<chip::BitFlags<chip::app::Clusters::TestCluster::SimpleBitmap>>(1);
+        dList[0].g = 0;
+        dList[0].h = 0;
+
+        dList[1].a = 2;
+        dList[1].b = false;
+        dList[1].c = static_cast<chip::app::Clusters::TestCluster::SimpleEnum>(3);
+        dList[1].d = chip::ByteSpan(chip::Uint8::from_const_char("nested_octet_stringgarbage: not in length on purpose"), 19);
+        dList[1].e = chip::Span<const char>("nested_char_stringgarbage: not in length on purpose", 18);
+        dList[1].f = static_cast<chip::BitFlags<chip::app::Clusters::TestCluster::SimpleBitmap>>(1);
+        dList[1].g = 0;
+        dList[1].h = 0;
+
+        request.arg1.d = dList;
+
+        uint32_t eList[3];
+        eList[0]       = 1UL;
+        eList[1]       = 2UL;
+        eList[2]       = 3UL;
+        request.arg1.e = eList;
+
+        chip::ByteSpan fList[3];
+        fList[0]       = chip::ByteSpan(chip::Uint8::from_const_char("octet_string_1garbage: not in length on purpose"), 14);
+        fList[1]       = chip::ByteSpan(chip::Uint8::from_const_char("octect_string_2garbage: not in length on purpose"), 15);
+        fList[2]       = chip::ByteSpan(chip::Uint8::from_const_char("octet_string_3garbage: not in length on purpose"), 14);
+        request.arg1.f = fList;
+
+        uint8_t gList[2];
+        gList[0]       = 0;
+        gList[1]       = 255;
+        request.arg1.g = gList;
+
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
+            (static_cast<TestCluster *>(context))->OnSuccessResponse_134(data.value);
+        };
+
+        auto failure = [](void * context, EmberAfStatus status) {
+            (static_cast<TestCluster *>(context))->OnFailureResponse_134(status);
+        };
+
+        ReturnErrorOnFailure(chip::Controller::InvokeCommand(mDevice, this, success, failure, endpoint, request));
+        return CHIP_NO_ERROR;
+    }
+
+    void OnFailureResponse_134(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_134(bool value)
+    {
+        VerifyOrReturn(CheckValue("value", value, false));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestSendTestCommandWithStructArgumentAndSeeWhatWeGetBack_135()
     {
         const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
         using RequestType               = chip::app::Clusters::TestCluster::Commands::SimpleStructEchoRequest::Type;
@@ -36719,20 +37004,20 @@ private:
         request.arg1.h = 0.1;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
-            (static_cast<TestCluster *>(context))->OnSuccessResponse_131(data.arg1);
+            (static_cast<TestCluster *>(context))->OnSuccessResponse_135(data.arg1);
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
-            (static_cast<TestCluster *>(context))->OnFailureResponse_131(status);
+            (static_cast<TestCluster *>(context))->OnFailureResponse_135(status);
         };
 
         ReturnErrorOnFailure(chip::Controller::InvokeCommand(mDevice, this, success, failure, endpoint, request));
         return CHIP_NO_ERROR;
     }
 
-    void OnFailureResponse_131(uint8_t status) { ThrowFailureResponse(); }
+    void OnFailureResponse_135(uint8_t status) { ThrowFailureResponse(); }
 
-    void OnSuccessResponse_131(const chip::app::Clusters::TestCluster::Structs::SimpleStruct::DecodableType & arg1)
+    void OnSuccessResponse_135(const chip::app::Clusters::TestCluster::Structs::SimpleStruct::DecodableType & arg1)
     {
         VerifyOrReturn(CheckValue("arg1.a", arg1.a, 17));
         VerifyOrReturn(CheckValue("arg1.b", arg1.b, false));
@@ -36746,7 +37031,7 @@ private:
         NextTest();
     }
 
-    CHIP_ERROR TestSendTestCommandWithListOfInt8uAndNoneOfThemIsSetTo0_132()
+    CHIP_ERROR TestSendTestCommandWithListOfInt8uAndNoneOfThemIsSetTo0_136()
     {
         const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
         using RequestType               = chip::app::Clusters::TestCluster::Commands::TestListInt8UArgumentRequest::Type;
@@ -36766,27 +37051,27 @@ private:
         request.arg1 = arg1List;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
-            (static_cast<TestCluster *>(context))->OnSuccessResponse_132(data.value);
+            (static_cast<TestCluster *>(context))->OnSuccessResponse_136(data.value);
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
-            (static_cast<TestCluster *>(context))->OnFailureResponse_132(status);
+            (static_cast<TestCluster *>(context))->OnFailureResponse_136(status);
         };
 
         ReturnErrorOnFailure(chip::Controller::InvokeCommand(mDevice, this, success, failure, endpoint, request));
         return CHIP_NO_ERROR;
     }
 
-    void OnFailureResponse_132(uint8_t status) { ThrowFailureResponse(); }
+    void OnFailureResponse_136(uint8_t status) { ThrowFailureResponse(); }
 
-    void OnSuccessResponse_132(bool value)
+    void OnSuccessResponse_136(bool value)
     {
         VerifyOrReturn(CheckValue("value", value, true));
 
         NextTest();
     }
 
-    CHIP_ERROR TestSendTestCommandWithListOfInt8uAndOneOfThemIsSetTo0_133()
+    CHIP_ERROR TestSendTestCommandWithListOfInt8uAndOneOfThemIsSetTo0_137()
     {
         const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
         using RequestType               = chip::app::Clusters::TestCluster::Commands::TestListInt8UArgumentRequest::Type;
@@ -36807,27 +37092,27 @@ private:
         request.arg1 = arg1List;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
-            (static_cast<TestCluster *>(context))->OnSuccessResponse_133(data.value);
+            (static_cast<TestCluster *>(context))->OnSuccessResponse_137(data.value);
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
-            (static_cast<TestCluster *>(context))->OnFailureResponse_133(status);
+            (static_cast<TestCluster *>(context))->OnFailureResponse_137(status);
         };
 
         ReturnErrorOnFailure(chip::Controller::InvokeCommand(mDevice, this, success, failure, endpoint, request));
         return CHIP_NO_ERROR;
     }
 
-    void OnFailureResponse_133(uint8_t status) { ThrowFailureResponse(); }
+    void OnFailureResponse_137(uint8_t status) { ThrowFailureResponse(); }
 
-    void OnSuccessResponse_133(bool value)
+    void OnSuccessResponse_137(bool value)
     {
         VerifyOrReturn(CheckValue("value", value, false));
 
         NextTest();
     }
 
-    CHIP_ERROR TestSendTestCommandWithListOfInt8uAndGetItReversed_134()
+    CHIP_ERROR TestSendTestCommandWithListOfInt8uAndGetItReversed_138()
     {
         const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
         using RequestType               = chip::app::Clusters::TestCluster::Commands::TestListInt8UReverseRequest::Type;
@@ -36847,20 +37132,20 @@ private:
         request.arg1 = arg1List;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
-            (static_cast<TestCluster *>(context))->OnSuccessResponse_134(data.arg1);
+            (static_cast<TestCluster *>(context))->OnSuccessResponse_138(data.arg1);
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
-            (static_cast<TestCluster *>(context))->OnFailureResponse_134(status);
+            (static_cast<TestCluster *>(context))->OnFailureResponse_138(status);
         };
 
         ReturnErrorOnFailure(chip::Controller::InvokeCommand(mDevice, this, success, failure, endpoint, request));
         return CHIP_NO_ERROR;
     }
 
-    void OnFailureResponse_134(uint8_t status) { ThrowFailureResponse(); }
+    void OnFailureResponse_138(uint8_t status) { ThrowFailureResponse(); }
 
-    void OnSuccessResponse_134(const chip::app::DataModel::DecodableList<uint8_t> & arg1)
+    void OnSuccessResponse_138(const chip::app::DataModel::DecodableList<uint8_t> & arg1)
     {
         auto iter = arg1.begin();
         VerifyOrReturn(CheckNextListItemDecodes<decltype(arg1)>("arg1", iter, 0));
@@ -36886,7 +37171,7 @@ private:
         NextTest();
     }
 
-    CHIP_ERROR TestSendTestCommandWithEmptyListOfInt8uAndGetAnEmptyListBack_135()
+    CHIP_ERROR TestSendTestCommandWithEmptyListOfInt8uAndGetAnEmptyListBack_139()
     {
         const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
         using RequestType               = chip::app::Clusters::TestCluster::Commands::TestListInt8UReverseRequest::Type;
@@ -36896,20 +37181,20 @@ private:
         request.arg1 = chip::app::DataModel::List<uint8_t>();
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
-            (static_cast<TestCluster *>(context))->OnSuccessResponse_135(data.arg1);
+            (static_cast<TestCluster *>(context))->OnSuccessResponse_139(data.arg1);
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
-            (static_cast<TestCluster *>(context))->OnFailureResponse_135(status);
+            (static_cast<TestCluster *>(context))->OnFailureResponse_139(status);
         };
 
         ReturnErrorOnFailure(chip::Controller::InvokeCommand(mDevice, this, success, failure, endpoint, request));
         return CHIP_NO_ERROR;
     }
 
-    void OnFailureResponse_135(uint8_t status) { ThrowFailureResponse(); }
+    void OnFailureResponse_139(uint8_t status) { ThrowFailureResponse(); }
 
-    void OnSuccessResponse_135(const chip::app::DataModel::DecodableList<uint8_t> & arg1)
+    void OnSuccessResponse_139(const chip::app::DataModel::DecodableList<uint8_t> & arg1)
     {
         auto iter = arg1.begin();
         VerifyOrReturn(CheckNoMoreListItems<decltype(arg1)>("arg1", iter, 0));
@@ -36917,7 +37202,7 @@ private:
         NextTest();
     }
 
-    CHIP_ERROR TestSendTestCommandWithListOfStructArgumentAndArg1bOfFirstItemIsTrue_136()
+    CHIP_ERROR TestSendTestCommandWithListOfStructArgumentAndArg1bOfFirstItemIsTrue_140()
     {
         const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
         using RequestType               = chip::app::Clusters::TestCluster::Commands::TestListStructArgumentRequest::Type;
@@ -36947,27 +37232,27 @@ private:
         request.arg1 = arg1List;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
-            (static_cast<TestCluster *>(context))->OnSuccessResponse_136(data.value);
+            (static_cast<TestCluster *>(context))->OnSuccessResponse_140(data.value);
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
-            (static_cast<TestCluster *>(context))->OnFailureResponse_136(status);
+            (static_cast<TestCluster *>(context))->OnFailureResponse_140(status);
         };
 
         ReturnErrorOnFailure(chip::Controller::InvokeCommand(mDevice, this, success, failure, endpoint, request));
         return CHIP_NO_ERROR;
     }
 
-    void OnFailureResponse_136(uint8_t status) { ThrowFailureResponse(); }
+    void OnFailureResponse_140(uint8_t status) { ThrowFailureResponse(); }
 
-    void OnSuccessResponse_136(bool value)
+    void OnSuccessResponse_140(bool value)
     {
         VerifyOrReturn(CheckValue("value", value, true));
 
         NextTest();
     }
 
-    CHIP_ERROR TestSendTestCommandWithListOfStructArgumentAndArg1bOfFirstItemIsFalse_137()
+    CHIP_ERROR TestSendTestCommandWithListOfStructArgumentAndArg1bOfFirstItemIsFalse_141()
     {
         const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
         using RequestType               = chip::app::Clusters::TestCluster::Commands::TestListStructArgumentRequest::Type;
@@ -36997,27 +37282,193 @@ private:
         request.arg1 = arg1List;
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
-            (static_cast<TestCluster *>(context))->OnSuccessResponse_137(data.value);
+            (static_cast<TestCluster *>(context))->OnSuccessResponse_141(data.value);
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
-            (static_cast<TestCluster *>(context))->OnFailureResponse_137(status);
+            (static_cast<TestCluster *>(context))->OnFailureResponse_141(status);
         };
 
         ReturnErrorOnFailure(chip::Controller::InvokeCommand(mDevice, this, success, failure, endpoint, request));
         return CHIP_NO_ERROR;
     }
 
-    void OnFailureResponse_137(uint8_t status) { ThrowFailureResponse(); }
+    void OnFailureResponse_141(uint8_t status) { ThrowFailureResponse(); }
 
-    void OnSuccessResponse_137(bool value)
+    void OnSuccessResponse_141(bool value)
     {
         VerifyOrReturn(CheckValue("value", value, false));
 
         NextTest();
     }
 
-    CHIP_ERROR TestWriteAttributeListWithListOfInt8uAndNoneOfThemIsSetTo0_138()
+    CHIP_ERROR TestSendTestCommandWithListOfNestedStructListArgumentAndAllFieldsBOfElementsOfArg1dAreTrue_142()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        using RequestType               = chip::app::Clusters::TestCluster::Commands::TestListNestedStructListArgumentRequest::Type;
+
+        RequestType request;
+
+        chip::app::Clusters::TestCluster::Structs::NestedStructList::Type arg1List[1];
+
+        arg1List[0].a = 0;
+        arg1List[0].b = true;
+
+        arg1List[0].c.a = 0;
+        arg1List[0].c.b = true;
+        arg1List[0].c.c = static_cast<chip::app::Clusters::TestCluster::SimpleEnum>(2);
+        arg1List[0].c.d = chip::ByteSpan(chip::Uint8::from_const_char("octet_stringgarbage: not in length on purpose"), 12);
+        arg1List[0].c.e = chip::Span<const char>("char_stringgarbage: not in length on purpose", 11);
+        arg1List[0].c.f = static_cast<chip::BitFlags<chip::app::Clusters::TestCluster::SimpleBitmap>>(1);
+        arg1List[0].c.g = 0;
+        arg1List[0].c.h = 0;
+
+        chip::app::Clusters::TestCluster::Structs::SimpleStruct::Type dList[2];
+
+        dList[0].a = 1;
+        dList[0].b = true;
+        dList[0].c = static_cast<chip::app::Clusters::TestCluster::SimpleEnum>(3);
+        dList[0].d = chip::ByteSpan(chip::Uint8::from_const_char("nested_octet_stringgarbage: not in length on purpose"), 19);
+        dList[0].e = chip::Span<const char>("nested_char_stringgarbage: not in length on purpose", 18);
+        dList[0].f = static_cast<chip::BitFlags<chip::app::Clusters::TestCluster::SimpleBitmap>>(1);
+        dList[0].g = 0;
+        dList[0].h = 0;
+
+        dList[1].a = 2;
+        dList[1].b = true;
+        dList[1].c = static_cast<chip::app::Clusters::TestCluster::SimpleEnum>(3);
+        dList[1].d = chip::ByteSpan(chip::Uint8::from_const_char("nested_octet_stringgarbage: not in length on purpose"), 19);
+        dList[1].e = chip::Span<const char>("nested_char_stringgarbage: not in length on purpose", 18);
+        dList[1].f = static_cast<chip::BitFlags<chip::app::Clusters::TestCluster::SimpleBitmap>>(1);
+        dList[1].g = 0;
+        dList[1].h = 0;
+
+        arg1List[0].d = dList;
+
+        uint32_t eList[3];
+        eList[0]      = 1UL;
+        eList[1]      = 2UL;
+        eList[2]      = 3UL;
+        arg1List[0].e = eList;
+
+        chip::ByteSpan fList[3];
+        fList[0]      = chip::ByteSpan(chip::Uint8::from_const_char("octet_string_1garbage: not in length on purpose"), 14);
+        fList[1]      = chip::ByteSpan(chip::Uint8::from_const_char("octect_string_2garbage: not in length on purpose"), 15);
+        fList[2]      = chip::ByteSpan(chip::Uint8::from_const_char("octet_string_3garbage: not in length on purpose"), 14);
+        arg1List[0].f = fList;
+
+        uint8_t gList[2];
+        gList[0]      = 0;
+        gList[1]      = 255;
+        arg1List[0].g = gList;
+
+        request.arg1 = arg1List;
+
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
+            (static_cast<TestCluster *>(context))->OnSuccessResponse_142(data.value);
+        };
+
+        auto failure = [](void * context, EmberAfStatus status) {
+            (static_cast<TestCluster *>(context))->OnFailureResponse_142(status);
+        };
+
+        ReturnErrorOnFailure(chip::Controller::InvokeCommand(mDevice, this, success, failure, endpoint, request));
+        return CHIP_NO_ERROR;
+    }
+
+    void OnFailureResponse_142(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_142(bool value)
+    {
+        VerifyOrReturn(CheckValue("value", value, true));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestSendTestCommandWithNestedStructListArgumentAndSomeFieldsBOfElementsOfArg1dAreFalse_143()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        using RequestType               = chip::app::Clusters::TestCluster::Commands::TestListNestedStructListArgumentRequest::Type;
+
+        RequestType request;
+
+        chip::app::Clusters::TestCluster::Structs::NestedStructList::Type arg1List[1];
+
+        arg1List[0].a = 0;
+        arg1List[0].b = true;
+
+        arg1List[0].c.a = 0;
+        arg1List[0].c.b = true;
+        arg1List[0].c.c = static_cast<chip::app::Clusters::TestCluster::SimpleEnum>(2);
+        arg1List[0].c.d = chip::ByteSpan(chip::Uint8::from_const_char("octet_stringgarbage: not in length on purpose"), 12);
+        arg1List[0].c.e = chip::Span<const char>("char_stringgarbage: not in length on purpose", 11);
+        arg1List[0].c.f = static_cast<chip::BitFlags<chip::app::Clusters::TestCluster::SimpleBitmap>>(1);
+        arg1List[0].c.g = 0;
+        arg1List[0].c.h = 0;
+
+        chip::app::Clusters::TestCluster::Structs::SimpleStruct::Type dList[2];
+
+        dList[0].a = 1;
+        dList[0].b = true;
+        dList[0].c = static_cast<chip::app::Clusters::TestCluster::SimpleEnum>(3);
+        dList[0].d = chip::ByteSpan(chip::Uint8::from_const_char("nested_octet_stringgarbage: not in length on purpose"), 19);
+        dList[0].e = chip::Span<const char>("nested_char_stringgarbage: not in length on purpose", 18);
+        dList[0].f = static_cast<chip::BitFlags<chip::app::Clusters::TestCluster::SimpleBitmap>>(1);
+        dList[0].g = 0;
+        dList[0].h = 0;
+
+        dList[1].a = 2;
+        dList[1].b = false;
+        dList[1].c = static_cast<chip::app::Clusters::TestCluster::SimpleEnum>(3);
+        dList[1].d = chip::ByteSpan(chip::Uint8::from_const_char("nested_octet_stringgarbage: not in length on purpose"), 19);
+        dList[1].e = chip::Span<const char>("nested_char_stringgarbage: not in length on purpose", 18);
+        dList[1].f = static_cast<chip::BitFlags<chip::app::Clusters::TestCluster::SimpleBitmap>>(1);
+        dList[1].g = 0;
+        dList[1].h = 0;
+
+        arg1List[0].d = dList;
+
+        uint32_t eList[3];
+        eList[0]      = 1UL;
+        eList[1]      = 2UL;
+        eList[2]      = 3UL;
+        arg1List[0].e = eList;
+
+        chip::ByteSpan fList[3];
+        fList[0]      = chip::ByteSpan(chip::Uint8::from_const_char("octet_string_1garbage: not in length on purpose"), 14);
+        fList[1]      = chip::ByteSpan(chip::Uint8::from_const_char("octect_string_2garbage: not in length on purpose"), 15);
+        fList[2]      = chip::ByteSpan(chip::Uint8::from_const_char("octet_string_3garbage: not in length on purpose"), 14);
+        arg1List[0].f = fList;
+
+        uint8_t gList[2];
+        gList[0]      = 0;
+        gList[1]      = 255;
+        arg1List[0].g = gList;
+
+        request.arg1 = arg1List;
+
+        auto success = [](void * context, const typename RequestType::ResponseType & data) {
+            (static_cast<TestCluster *>(context))->OnSuccessResponse_143(data.value);
+        };
+
+        auto failure = [](void * context, EmberAfStatus status) {
+            (static_cast<TestCluster *>(context))->OnFailureResponse_143(status);
+        };
+
+        ReturnErrorOnFailure(chip::Controller::InvokeCommand(mDevice, this, success, failure, endpoint, request));
+        return CHIP_NO_ERROR;
+    }
+
+    void OnFailureResponse_143(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_143(bool value)
+    {
+        VerifyOrReturn(CheckValue("value", value, false));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestWriteAttributeListWithListOfInt8uAndNoneOfThemIsSetTo0_144()
     {
         const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
@@ -37033,26 +37484,26 @@ private:
         listInt8uArgument = listInt8uList;
 
         return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::ListInt8u::TypeInfo>(
-            listInt8uArgument, this, OnSuccessCallback_138, OnFailureCallback_138);
+            listInt8uArgument, this, OnSuccessCallback_144, OnFailureCallback_144);
     }
 
-    void OnFailureResponse_138(uint8_t status) { ThrowFailureResponse(); }
+    void OnFailureResponse_144(uint8_t status) { ThrowFailureResponse(); }
 
-    void OnSuccessResponse_138() { NextTest(); }
+    void OnSuccessResponse_144() { NextTest(); }
 
-    CHIP_ERROR TestReadAttributeListWithListOfInt8u_139()
+    CHIP_ERROR TestReadAttributeListWithListOfInt8u_145()
     {
         const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, endpoint);
 
-        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::ListInt8u::TypeInfo>(this, OnSuccessCallback_139,
-                                                                                                        OnFailureCallback_139);
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::ListInt8u::TypeInfo>(this, OnSuccessCallback_145,
+                                                                                                        OnFailureCallback_145);
     }
 
-    void OnFailureResponse_139(uint8_t status) { ThrowFailureResponse(); }
+    void OnFailureResponse_145(uint8_t status) { ThrowFailureResponse(); }
 
-    void OnSuccessResponse_139(const chip::app::DataModel::DecodableList<uint8_t> & listInt8u)
+    void OnSuccessResponse_145(const chip::app::DataModel::DecodableList<uint8_t> & listInt8u)
     {
         auto iter = listInt8u.begin();
         VerifyOrReturn(CheckNextListItemDecodes<decltype(listInt8u)>("listInt8u", iter, 0));
@@ -37068,7 +37519,7 @@ private:
         NextTest();
     }
 
-    CHIP_ERROR TestWriteAttributeListWithListOfOctetString_140()
+    CHIP_ERROR TestWriteAttributeListWithListOfOctetString_146()
     {
         const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
@@ -37084,26 +37535,26 @@ private:
         listOctetStringArgument = listOctetStringList;
 
         return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::ListOctetString::TypeInfo>(
-            listOctetStringArgument, this, OnSuccessCallback_140, OnFailureCallback_140);
+            listOctetStringArgument, this, OnSuccessCallback_146, OnFailureCallback_146);
     }
 
-    void OnFailureResponse_140(uint8_t status) { ThrowFailureResponse(); }
+    void OnFailureResponse_146(uint8_t status) { ThrowFailureResponse(); }
 
-    void OnSuccessResponse_140() { NextTest(); }
+    void OnSuccessResponse_146() { NextTest(); }
 
-    CHIP_ERROR TestReadAttributeListWithListOfOctetString_141()
+    CHIP_ERROR TestReadAttributeListWithListOfOctetString_147()
     {
         const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, endpoint);
 
         return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::ListOctetString::TypeInfo>(
-            this, OnSuccessCallback_141, OnFailureCallback_141);
+            this, OnSuccessCallback_147, OnFailureCallback_147);
     }
 
-    void OnFailureResponse_141(uint8_t status) { ThrowFailureResponse(); }
+    void OnFailureResponse_147(uint8_t status) { ThrowFailureResponse(); }
 
-    void OnSuccessResponse_141(const chip::app::DataModel::DecodableList<chip::ByteSpan> & listOctetString)
+    void OnSuccessResponse_147(const chip::app::DataModel::DecodableList<chip::ByteSpan> & listOctetString)
     {
         auto iter = listOctetString.begin();
         VerifyOrReturn(CheckNextListItemDecodes<decltype(listOctetString)>("listOctetString", iter, 0));
@@ -37123,7 +37574,7 @@ private:
         NextTest();
     }
 
-    CHIP_ERROR TestWriteAttributeListWithListOfListStructOctetString_142()
+    CHIP_ERROR TestWriteAttributeListWithListOfListStructOctetString_148()
     {
         const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
@@ -37153,26 +37604,26 @@ private:
         listStructOctetStringArgument = listStructOctetStringList;
 
         return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::ListStructOctetString::TypeInfo>(
-            listStructOctetStringArgument, this, OnSuccessCallback_142, OnFailureCallback_142);
+            listStructOctetStringArgument, this, OnSuccessCallback_148, OnFailureCallback_148);
     }
 
-    void OnFailureResponse_142(uint8_t status) { ThrowFailureResponse(); }
+    void OnFailureResponse_148(uint8_t status) { ThrowFailureResponse(); }
 
-    void OnSuccessResponse_142() { NextTest(); }
+    void OnSuccessResponse_148() { NextTest(); }
 
-    CHIP_ERROR TestReadAttributeListWithListOfListStructOctetString_143()
+    CHIP_ERROR TestReadAttributeListWithListOfListStructOctetString_149()
     {
         const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, endpoint);
 
         return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::ListStructOctetString::TypeInfo>(
-            this, OnSuccessCallback_143, OnFailureCallback_143);
+            this, OnSuccessCallback_149, OnFailureCallback_149);
     }
 
-    void OnFailureResponse_143(uint8_t status) { ThrowFailureResponse(); }
+    void OnFailureResponse_149(uint8_t status) { ThrowFailureResponse(); }
 
-    void OnSuccessResponse_143(
+    void OnSuccessResponse_149(
         const chip::app::DataModel::DecodableList<chip::app::Clusters::TestCluster::Structs::TestListStructOctet::DecodableType> &
             listStructOctetString)
     {
@@ -37198,7 +37649,7 @@ private:
         NextTest();
     }
 
-    CHIP_ERROR TestSendTestCommandWithOptionalArgSet_144()
+    CHIP_ERROR TestSendTestCommandWithOptionalArgSet_150()
     {
         const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
         using RequestType               = chip::app::Clusters::TestCluster::Commands::TestNullableOptionalRequest::Type;
@@ -37208,20 +37659,20 @@ private:
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<TestCluster *>(context))
-                ->OnSuccessResponse_144(data.wasPresent, data.wasNull, data.value, data.originalValue);
+                ->OnSuccessResponse_150(data.wasPresent, data.wasNull, data.value, data.originalValue);
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
-            (static_cast<TestCluster *>(context))->OnFailureResponse_144(status);
+            (static_cast<TestCluster *>(context))->OnFailureResponse_150(status);
         };
 
         ReturnErrorOnFailure(chip::Controller::InvokeCommand(mDevice, this, success, failure, endpoint, request));
         return CHIP_NO_ERROR;
     }
 
-    void OnFailureResponse_144(uint8_t status) { ThrowFailureResponse(); }
+    void OnFailureResponse_150(uint8_t status) { ThrowFailureResponse(); }
 
-    void OnSuccessResponse_144(bool wasPresent, const chip::Optional<bool> & wasNull, const chip::Optional<uint8_t> & value,
+    void OnSuccessResponse_150(bool wasPresent, const chip::Optional<bool> & wasNull, const chip::Optional<uint8_t> & value,
                                const chip::Optional<chip::app::DataModel::Nullable<uint8_t>> & originalValue)
     {
         VerifyOrReturn(CheckValue("wasPresent", wasPresent, true));
@@ -37239,7 +37690,7 @@ private:
         NextTest();
     }
 
-    CHIP_ERROR TestSendTestCommandWithoutItsOptionalArg_145()
+    CHIP_ERROR TestSendTestCommandWithoutItsOptionalArg_151()
     {
         const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
         using RequestType               = chip::app::Clusters::TestCluster::Commands::TestNullableOptionalRequest::Type;
@@ -37248,20 +37699,20 @@ private:
 
         auto success = [](void * context, const typename RequestType::ResponseType & data) {
             (static_cast<TestCluster *>(context))
-                ->OnSuccessResponse_145(data.wasPresent, data.wasNull, data.value, data.originalValue);
+                ->OnSuccessResponse_151(data.wasPresent, data.wasNull, data.value, data.originalValue);
         };
 
         auto failure = [](void * context, EmberAfStatus status) {
-            (static_cast<TestCluster *>(context))->OnFailureResponse_145(status);
+            (static_cast<TestCluster *>(context))->OnFailureResponse_151(status);
         };
 
         ReturnErrorOnFailure(chip::Controller::InvokeCommand(mDevice, this, success, failure, endpoint, request));
         return CHIP_NO_ERROR;
     }
 
-    void OnFailureResponse_145(uint8_t status) { ThrowFailureResponse(); }
+    void OnFailureResponse_151(uint8_t status) { ThrowFailureResponse(); }
 
-    void OnSuccessResponse_145(bool wasPresent, const chip::Optional<bool> & wasNull, const chip::Optional<uint8_t> & value,
+    void OnSuccessResponse_151(bool wasPresent, const chip::Optional<bool> & wasNull, const chip::Optional<uint8_t> & value,
                                const chip::Optional<chip::app::DataModel::Nullable<uint8_t>> & originalValue)
     {
         VerifyOrReturn(CheckValue("wasPresent", wasPresent, false));
@@ -37269,7 +37720,7 @@ private:
         NextTest();
     }
 
-    CHIP_ERROR TestWriteAttributeNullableBooleanNull_146()
+    CHIP_ERROR TestWriteAttributeNullableBooleanNull_152()
     {
         const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
@@ -37279,33 +37730,33 @@ private:
         nullableBooleanArgument.SetNull();
 
         return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::NullableBoolean::TypeInfo>(
-            nullableBooleanArgument, this, OnSuccessCallback_146, OnFailureCallback_146);
+            nullableBooleanArgument, this, OnSuccessCallback_152, OnFailureCallback_152);
     }
 
-    void OnFailureResponse_146(uint8_t status) { ThrowFailureResponse(); }
+    void OnFailureResponse_152(uint8_t status) { ThrowFailureResponse(); }
 
-    void OnSuccessResponse_146() { NextTest(); }
+    void OnSuccessResponse_152() { NextTest(); }
 
-    CHIP_ERROR TestReadAttributeNullableBooleanNull_147()
+    CHIP_ERROR TestReadAttributeNullableBooleanNull_153()
     {
         const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, endpoint);
 
         return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableBoolean::TypeInfo>(
-            this, OnSuccessCallback_147, OnFailureCallback_147);
+            this, OnSuccessCallback_153, OnFailureCallback_153);
     }
 
-    void OnFailureResponse_147(uint8_t status) { ThrowFailureResponse(); }
+    void OnFailureResponse_153(uint8_t status) { ThrowFailureResponse(); }
 
-    void OnSuccessResponse_147(const chip::app::DataModel::Nullable<bool> & nullableBoolean)
+    void OnSuccessResponse_153(const chip::app::DataModel::Nullable<bool> & nullableBoolean)
     {
         VerifyOrReturn(CheckValueNull("nullableBoolean", nullableBoolean));
 
         NextTest();
     }
 
-    CHIP_ERROR TestWriteAttributeNullableBooleanTrue_148()
+    CHIP_ERROR TestWriteAttributeNullableBooleanTrue_154()
     {
         const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
@@ -37315,26 +37766,26 @@ private:
         nullableBooleanArgument.SetNonNull() = true;
 
         return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::NullableBoolean::TypeInfo>(
-            nullableBooleanArgument, this, OnSuccessCallback_148, OnFailureCallback_148);
+            nullableBooleanArgument, this, OnSuccessCallback_154, OnFailureCallback_154);
     }
 
-    void OnFailureResponse_148(uint8_t status) { ThrowFailureResponse(); }
+    void OnFailureResponse_154(uint8_t status) { ThrowFailureResponse(); }
 
-    void OnSuccessResponse_148() { NextTest(); }
+    void OnSuccessResponse_154() { NextTest(); }
 
-    CHIP_ERROR TestReadAttributeNullableBooleanTrue_149()
+    CHIP_ERROR TestReadAttributeNullableBooleanTrue_155()
     {
         const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, endpoint);
 
         return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableBoolean::TypeInfo>(
-            this, OnSuccessCallback_149, OnFailureCallback_149);
+            this, OnSuccessCallback_155, OnFailureCallback_155);
     }
 
-    void OnFailureResponse_149(uint8_t status) { ThrowFailureResponse(); }
+    void OnFailureResponse_155(uint8_t status) { ThrowFailureResponse(); }
 
-    void OnSuccessResponse_149(const chip::app::DataModel::Nullable<bool> & nullableBoolean)
+    void OnSuccessResponse_155(const chip::app::DataModel::Nullable<bool> & nullableBoolean)
     {
         VerifyOrReturn(CheckValueNonNull("nullableBoolean", nullableBoolean));
         VerifyOrReturn(CheckValue("nullableBoolean.Value()", nullableBoolean.Value(), true));
@@ -37342,7 +37793,7 @@ private:
         NextTest();
     }
 
-    CHIP_ERROR TestWriteAttributeNullableBitmap8MaxValue_150()
+    CHIP_ERROR TestWriteAttributeNullableBitmap8MaxValue_156()
     {
         const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
@@ -37352,26 +37803,26 @@ private:
         nullableBitmap8Argument.SetNonNull() = 254;
 
         return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::NullableBitmap8::TypeInfo>(
-            nullableBitmap8Argument, this, OnSuccessCallback_150, OnFailureCallback_150);
+            nullableBitmap8Argument, this, OnSuccessCallback_156, OnFailureCallback_156);
     }
 
-    void OnFailureResponse_150(uint8_t status) { ThrowFailureResponse(); }
+    void OnFailureResponse_156(uint8_t status) { ThrowFailureResponse(); }
 
-    void OnSuccessResponse_150() { NextTest(); }
+    void OnSuccessResponse_156() { NextTest(); }
 
-    CHIP_ERROR TestReadAttributeNullableBitmap8MaxValue_151()
+    CHIP_ERROR TestReadAttributeNullableBitmap8MaxValue_157()
     {
         const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, endpoint);
 
         return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableBitmap8::TypeInfo>(
-            this, OnSuccessCallback_151, OnFailureCallback_151);
+            this, OnSuccessCallback_157, OnFailureCallback_157);
     }
 
-    void OnFailureResponse_151(uint8_t status) { ThrowFailureResponse(); }
+    void OnFailureResponse_157(uint8_t status) { ThrowFailureResponse(); }
 
-    void OnSuccessResponse_151(const chip::app::DataModel::Nullable<uint8_t> & nullableBitmap8)
+    void OnSuccessResponse_157(const chip::app::DataModel::Nullable<uint8_t> & nullableBitmap8)
     {
         VerifyOrReturn(CheckValueNonNull("nullableBitmap8", nullableBitmap8));
         VerifyOrReturn(CheckValue("nullableBitmap8.Value()", nullableBitmap8.Value(), 254));
@@ -37379,7 +37830,7 @@ private:
         NextTest();
     }
 
-    CHIP_ERROR TestWriteAttributeNullableBitmap8InvalidValue_152()
+    CHIP_ERROR TestWriteAttributeNullableBitmap8InvalidValue_158()
     {
         const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
@@ -37389,121 +37840,7 @@ private:
         nullableBitmap8Argument.SetNonNull() = 255;
 
         return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::NullableBitmap8::TypeInfo>(
-            nullableBitmap8Argument, this, OnSuccessCallback_152, OnFailureCallback_152);
-    }
-
-    void OnFailureResponse_152(uint8_t status)
-    {
-        VerifyOrReturn(CheckValue("status", status, 135));
-        NextTest();
-    }
-
-    void OnSuccessResponse_152() { ThrowSuccessResponse(); }
-
-    CHIP_ERROR TestReadAttributeNullableBitmap8UnchangedValue_153()
-    {
-        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
-        chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, endpoint);
-
-        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableBitmap8::TypeInfo>(
-            this, OnSuccessCallback_153, OnFailureCallback_153);
-    }
-
-    void OnFailureResponse_153(uint8_t status) { ThrowFailureResponse(); }
-
-    void OnSuccessResponse_153(const chip::app::DataModel::Nullable<uint8_t> & nullableBitmap8)
-    {
-        VerifyOrReturn(CheckValueNonNull("nullableBitmap8", nullableBitmap8));
-        VerifyOrReturn(CheckValue("nullableBitmap8.Value()", nullableBitmap8.Value(), 254));
-
-        NextTest();
-    }
-
-    CHIP_ERROR TestWriteAttributeNullableBitmap8NullValue_154()
-    {
-        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
-        chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, endpoint);
-
-        chip::app::DataModel::Nullable<uint8_t> nullableBitmap8Argument;
-        nullableBitmap8Argument.SetNull();
-
-        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::NullableBitmap8::TypeInfo>(
-            nullableBitmap8Argument, this, OnSuccessCallback_154, OnFailureCallback_154);
-    }
-
-    void OnFailureResponse_154(uint8_t status) { ThrowFailureResponse(); }
-
-    void OnSuccessResponse_154() { NextTest(); }
-
-    CHIP_ERROR TestReadAttributeNullableBitmap8NullValue_155()
-    {
-        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
-        chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, endpoint);
-
-        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableBitmap8::TypeInfo>(
-            this, OnSuccessCallback_155, OnFailureCallback_155);
-    }
-
-    void OnFailureResponse_155(uint8_t status) { ThrowFailureResponse(); }
-
-    void OnSuccessResponse_155(const chip::app::DataModel::Nullable<uint8_t> & nullableBitmap8)
-    {
-        VerifyOrReturn(CheckValueNull("nullableBitmap8", nullableBitmap8));
-
-        NextTest();
-    }
-
-    CHIP_ERROR TestWriteAttributeNullableBitmap16MaxValue_156()
-    {
-        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
-        chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, endpoint);
-
-        chip::app::DataModel::Nullable<uint16_t> nullableBitmap16Argument;
-        nullableBitmap16Argument.SetNonNull() = 65534U;
-
-        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::NullableBitmap16::TypeInfo>(
-            nullableBitmap16Argument, this, OnSuccessCallback_156, OnFailureCallback_156);
-    }
-
-    void OnFailureResponse_156(uint8_t status) { ThrowFailureResponse(); }
-
-    void OnSuccessResponse_156() { NextTest(); }
-
-    CHIP_ERROR TestReadAttributeNullableBitmap16MaxValue_157()
-    {
-        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
-        chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, endpoint);
-
-        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableBitmap16::TypeInfo>(
-            this, OnSuccessCallback_157, OnFailureCallback_157);
-    }
-
-    void OnFailureResponse_157(uint8_t status) { ThrowFailureResponse(); }
-
-    void OnSuccessResponse_157(const chip::app::DataModel::Nullable<uint16_t> & nullableBitmap16)
-    {
-        VerifyOrReturn(CheckValueNonNull("nullableBitmap16", nullableBitmap16));
-        VerifyOrReturn(CheckValue("nullableBitmap16.Value()", nullableBitmap16.Value(), 65534U));
-
-        NextTest();
-    }
-
-    CHIP_ERROR TestWriteAttributeNullableBitmap16InvalidValue_158()
-    {
-        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
-        chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, endpoint);
-
-        chip::app::DataModel::Nullable<uint16_t> nullableBitmap16Argument;
-        nullableBitmap16Argument.SetNonNull() = 65535U;
-
-        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::NullableBitmap16::TypeInfo>(
-            nullableBitmap16Argument, this, OnSuccessCallback_158, OnFailureCallback_158);
+            nullableBitmap8Argument, this, OnSuccessCallback_158, OnFailureCallback_158);
     }
 
     void OnFailureResponse_158(uint8_t status)
@@ -37514,19 +37851,92 @@ private:
 
     void OnSuccessResponse_158() { ThrowSuccessResponse(); }
 
-    CHIP_ERROR TestReadAttributeNullableBitmap16UnchangedValue_159()
+    CHIP_ERROR TestReadAttributeNullableBitmap8UnchangedValue_159()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableBitmap8::TypeInfo>(
+            this, OnSuccessCallback_159, OnFailureCallback_159);
+    }
+
+    void OnFailureResponse_159(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_159(const chip::app::DataModel::Nullable<uint8_t> & nullableBitmap8)
+    {
+        VerifyOrReturn(CheckValueNonNull("nullableBitmap8", nullableBitmap8));
+        VerifyOrReturn(CheckValue("nullableBitmap8.Value()", nullableBitmap8.Value(), 254));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestWriteAttributeNullableBitmap8NullValue_160()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        chip::app::DataModel::Nullable<uint8_t> nullableBitmap8Argument;
+        nullableBitmap8Argument.SetNull();
+
+        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::NullableBitmap8::TypeInfo>(
+            nullableBitmap8Argument, this, OnSuccessCallback_160, OnFailureCallback_160);
+    }
+
+    void OnFailureResponse_160(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_160() { NextTest(); }
+
+    CHIP_ERROR TestReadAttributeNullableBitmap8NullValue_161()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableBitmap8::TypeInfo>(
+            this, OnSuccessCallback_161, OnFailureCallback_161);
+    }
+
+    void OnFailureResponse_161(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_161(const chip::app::DataModel::Nullable<uint8_t> & nullableBitmap8)
+    {
+        VerifyOrReturn(CheckValueNull("nullableBitmap8", nullableBitmap8));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestWriteAttributeNullableBitmap16MaxValue_162()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        chip::app::DataModel::Nullable<uint16_t> nullableBitmap16Argument;
+        nullableBitmap16Argument.SetNonNull() = 65534U;
+
+        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::NullableBitmap16::TypeInfo>(
+            nullableBitmap16Argument, this, OnSuccessCallback_162, OnFailureCallback_162);
+    }
+
+    void OnFailureResponse_162(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_162() { NextTest(); }
+
+    CHIP_ERROR TestReadAttributeNullableBitmap16MaxValue_163()
     {
         const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, endpoint);
 
         return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableBitmap16::TypeInfo>(
-            this, OnSuccessCallback_159, OnFailureCallback_159);
+            this, OnSuccessCallback_163, OnFailureCallback_163);
     }
 
-    void OnFailureResponse_159(uint8_t status) { ThrowFailureResponse(); }
+    void OnFailureResponse_163(uint8_t status) { ThrowFailureResponse(); }
 
-    void OnSuccessResponse_159(const chip::app::DataModel::Nullable<uint16_t> & nullableBitmap16)
+    void OnSuccessResponse_163(const chip::app::DataModel::Nullable<uint16_t> & nullableBitmap16)
     {
         VerifyOrReturn(CheckValueNonNull("nullableBitmap16", nullableBitmap16));
         VerifyOrReturn(CheckValue("nullableBitmap16.Value()", nullableBitmap16.Value(), 65534U));
@@ -37534,90 +37944,17 @@ private:
         NextTest();
     }
 
-    CHIP_ERROR TestWriteAttributeNullableBitmap16NullValue_160()
+    CHIP_ERROR TestWriteAttributeNullableBitmap16InvalidValue_164()
     {
         const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, endpoint);
 
         chip::app::DataModel::Nullable<uint16_t> nullableBitmap16Argument;
-        nullableBitmap16Argument.SetNull();
+        nullableBitmap16Argument.SetNonNull() = 65535U;
 
         return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::NullableBitmap16::TypeInfo>(
-            nullableBitmap16Argument, this, OnSuccessCallback_160, OnFailureCallback_160);
-    }
-
-    void OnFailureResponse_160(uint8_t status) { ThrowFailureResponse(); }
-
-    void OnSuccessResponse_160() { NextTest(); }
-
-    CHIP_ERROR TestReadAttributeNullableBitmap16NullValue_161()
-    {
-        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
-        chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, endpoint);
-
-        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableBitmap16::TypeInfo>(
-            this, OnSuccessCallback_161, OnFailureCallback_161);
-    }
-
-    void OnFailureResponse_161(uint8_t status) { ThrowFailureResponse(); }
-
-    void OnSuccessResponse_161(const chip::app::DataModel::Nullable<uint16_t> & nullableBitmap16)
-    {
-        VerifyOrReturn(CheckValueNull("nullableBitmap16", nullableBitmap16));
-
-        NextTest();
-    }
-
-    CHIP_ERROR TestWriteAttributeNullableBitmap32MaxValue_162()
-    {
-        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
-        chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, endpoint);
-
-        chip::app::DataModel::Nullable<uint32_t> nullableBitmap32Argument;
-        nullableBitmap32Argument.SetNonNull() = 4294967294UL;
-
-        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::NullableBitmap32::TypeInfo>(
-            nullableBitmap32Argument, this, OnSuccessCallback_162, OnFailureCallback_162);
-    }
-
-    void OnFailureResponse_162(uint8_t status) { ThrowFailureResponse(); }
-
-    void OnSuccessResponse_162() { NextTest(); }
-
-    CHIP_ERROR TestReadAttributeNullableBitmap32MaxValue_163()
-    {
-        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
-        chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, endpoint);
-
-        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableBitmap32::TypeInfo>(
-            this, OnSuccessCallback_163, OnFailureCallback_163);
-    }
-
-    void OnFailureResponse_163(uint8_t status) { ThrowFailureResponse(); }
-
-    void OnSuccessResponse_163(const chip::app::DataModel::Nullable<uint32_t> & nullableBitmap32)
-    {
-        VerifyOrReturn(CheckValueNonNull("nullableBitmap32", nullableBitmap32));
-        VerifyOrReturn(CheckValue("nullableBitmap32.Value()", nullableBitmap32.Value(), 4294967294UL));
-
-        NextTest();
-    }
-
-    CHIP_ERROR TestWriteAttributeNullableBitmap32InvalidValue_164()
-    {
-        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
-        chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, endpoint);
-
-        chip::app::DataModel::Nullable<uint32_t> nullableBitmap32Argument;
-        nullableBitmap32Argument.SetNonNull() = 4294967295UL;
-
-        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::NullableBitmap32::TypeInfo>(
-            nullableBitmap32Argument, this, OnSuccessCallback_164, OnFailureCallback_164);
+            nullableBitmap16Argument, this, OnSuccessCallback_164, OnFailureCallback_164);
     }
 
     void OnFailureResponse_164(uint8_t status)
@@ -37628,19 +37965,92 @@ private:
 
     void OnSuccessResponse_164() { ThrowSuccessResponse(); }
 
-    CHIP_ERROR TestReadAttributeNullableBitmap32UnchangedValue_165()
+    CHIP_ERROR TestReadAttributeNullableBitmap16UnchangedValue_165()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableBitmap16::TypeInfo>(
+            this, OnSuccessCallback_165, OnFailureCallback_165);
+    }
+
+    void OnFailureResponse_165(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_165(const chip::app::DataModel::Nullable<uint16_t> & nullableBitmap16)
+    {
+        VerifyOrReturn(CheckValueNonNull("nullableBitmap16", nullableBitmap16));
+        VerifyOrReturn(CheckValue("nullableBitmap16.Value()", nullableBitmap16.Value(), 65534U));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestWriteAttributeNullableBitmap16NullValue_166()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        chip::app::DataModel::Nullable<uint16_t> nullableBitmap16Argument;
+        nullableBitmap16Argument.SetNull();
+
+        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::NullableBitmap16::TypeInfo>(
+            nullableBitmap16Argument, this, OnSuccessCallback_166, OnFailureCallback_166);
+    }
+
+    void OnFailureResponse_166(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_166() { NextTest(); }
+
+    CHIP_ERROR TestReadAttributeNullableBitmap16NullValue_167()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableBitmap16::TypeInfo>(
+            this, OnSuccessCallback_167, OnFailureCallback_167);
+    }
+
+    void OnFailureResponse_167(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_167(const chip::app::DataModel::Nullable<uint16_t> & nullableBitmap16)
+    {
+        VerifyOrReturn(CheckValueNull("nullableBitmap16", nullableBitmap16));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestWriteAttributeNullableBitmap32MaxValue_168()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        chip::app::DataModel::Nullable<uint32_t> nullableBitmap32Argument;
+        nullableBitmap32Argument.SetNonNull() = 4294967294UL;
+
+        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::NullableBitmap32::TypeInfo>(
+            nullableBitmap32Argument, this, OnSuccessCallback_168, OnFailureCallback_168);
+    }
+
+    void OnFailureResponse_168(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_168() { NextTest(); }
+
+    CHIP_ERROR TestReadAttributeNullableBitmap32MaxValue_169()
     {
         const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, endpoint);
 
         return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableBitmap32::TypeInfo>(
-            this, OnSuccessCallback_165, OnFailureCallback_165);
+            this, OnSuccessCallback_169, OnFailureCallback_169);
     }
 
-    void OnFailureResponse_165(uint8_t status) { ThrowFailureResponse(); }
+    void OnFailureResponse_169(uint8_t status) { ThrowFailureResponse(); }
 
-    void OnSuccessResponse_165(const chip::app::DataModel::Nullable<uint32_t> & nullableBitmap32)
+    void OnSuccessResponse_169(const chip::app::DataModel::Nullable<uint32_t> & nullableBitmap32)
     {
         VerifyOrReturn(CheckValueNonNull("nullableBitmap32", nullableBitmap32));
         VerifyOrReturn(CheckValue("nullableBitmap32.Value()", nullableBitmap32.Value(), 4294967294UL));
@@ -37648,90 +38058,17 @@ private:
         NextTest();
     }
 
-    CHIP_ERROR TestWriteAttributeNullableBitmap32NullValue_166()
+    CHIP_ERROR TestWriteAttributeNullableBitmap32InvalidValue_170()
     {
         const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, endpoint);
 
         chip::app::DataModel::Nullable<uint32_t> nullableBitmap32Argument;
-        nullableBitmap32Argument.SetNull();
+        nullableBitmap32Argument.SetNonNull() = 4294967295UL;
 
         return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::NullableBitmap32::TypeInfo>(
-            nullableBitmap32Argument, this, OnSuccessCallback_166, OnFailureCallback_166);
-    }
-
-    void OnFailureResponse_166(uint8_t status) { ThrowFailureResponse(); }
-
-    void OnSuccessResponse_166() { NextTest(); }
-
-    CHIP_ERROR TestReadAttributeNullableBitmap32NullValue_167()
-    {
-        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
-        chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, endpoint);
-
-        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableBitmap32::TypeInfo>(
-            this, OnSuccessCallback_167, OnFailureCallback_167);
-    }
-
-    void OnFailureResponse_167(uint8_t status) { ThrowFailureResponse(); }
-
-    void OnSuccessResponse_167(const chip::app::DataModel::Nullable<uint32_t> & nullableBitmap32)
-    {
-        VerifyOrReturn(CheckValueNull("nullableBitmap32", nullableBitmap32));
-
-        NextTest();
-    }
-
-    CHIP_ERROR TestWriteAttributeNullableBitmap64MaxValue_168()
-    {
-        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
-        chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, endpoint);
-
-        chip::app::DataModel::Nullable<uint64_t> nullableBitmap64Argument;
-        nullableBitmap64Argument.SetNonNull() = 18446744073709551614ULL;
-
-        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::NullableBitmap64::TypeInfo>(
-            nullableBitmap64Argument, this, OnSuccessCallback_168, OnFailureCallback_168);
-    }
-
-    void OnFailureResponse_168(uint8_t status) { ThrowFailureResponse(); }
-
-    void OnSuccessResponse_168() { NextTest(); }
-
-    CHIP_ERROR TestReadAttributeNullableBitmap64MaxValue_169()
-    {
-        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
-        chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, endpoint);
-
-        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableBitmap64::TypeInfo>(
-            this, OnSuccessCallback_169, OnFailureCallback_169);
-    }
-
-    void OnFailureResponse_169(uint8_t status) { ThrowFailureResponse(); }
-
-    void OnSuccessResponse_169(const chip::app::DataModel::Nullable<uint64_t> & nullableBitmap64)
-    {
-        VerifyOrReturn(CheckValueNonNull("nullableBitmap64", nullableBitmap64));
-        VerifyOrReturn(CheckValue("nullableBitmap64.Value()", nullableBitmap64.Value(), 18446744073709551614ULL));
-
-        NextTest();
-    }
-
-    CHIP_ERROR TestWriteAttributeNullableBitmap64InvalidValue_170()
-    {
-        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
-        chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, endpoint);
-
-        chip::app::DataModel::Nullable<uint64_t> nullableBitmap64Argument;
-        nullableBitmap64Argument.SetNonNull() = 18446744073709551615ULL;
-
-        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::NullableBitmap64::TypeInfo>(
-            nullableBitmap64Argument, this, OnSuccessCallback_170, OnFailureCallback_170);
+            nullableBitmap32Argument, this, OnSuccessCallback_170, OnFailureCallback_170);
     }
 
     void OnFailureResponse_170(uint8_t status)
@@ -37742,19 +38079,92 @@ private:
 
     void OnSuccessResponse_170() { ThrowSuccessResponse(); }
 
-    CHIP_ERROR TestReadAttributeNullableBitmap64UnchangedValue_171()
+    CHIP_ERROR TestReadAttributeNullableBitmap32UnchangedValue_171()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableBitmap32::TypeInfo>(
+            this, OnSuccessCallback_171, OnFailureCallback_171);
+    }
+
+    void OnFailureResponse_171(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_171(const chip::app::DataModel::Nullable<uint32_t> & nullableBitmap32)
+    {
+        VerifyOrReturn(CheckValueNonNull("nullableBitmap32", nullableBitmap32));
+        VerifyOrReturn(CheckValue("nullableBitmap32.Value()", nullableBitmap32.Value(), 4294967294UL));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestWriteAttributeNullableBitmap32NullValue_172()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        chip::app::DataModel::Nullable<uint32_t> nullableBitmap32Argument;
+        nullableBitmap32Argument.SetNull();
+
+        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::NullableBitmap32::TypeInfo>(
+            nullableBitmap32Argument, this, OnSuccessCallback_172, OnFailureCallback_172);
+    }
+
+    void OnFailureResponse_172(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_172() { NextTest(); }
+
+    CHIP_ERROR TestReadAttributeNullableBitmap32NullValue_173()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableBitmap32::TypeInfo>(
+            this, OnSuccessCallback_173, OnFailureCallback_173);
+    }
+
+    void OnFailureResponse_173(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_173(const chip::app::DataModel::Nullable<uint32_t> & nullableBitmap32)
+    {
+        VerifyOrReturn(CheckValueNull("nullableBitmap32", nullableBitmap32));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestWriteAttributeNullableBitmap64MaxValue_174()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        chip::app::DataModel::Nullable<uint64_t> nullableBitmap64Argument;
+        nullableBitmap64Argument.SetNonNull() = 18446744073709551614ULL;
+
+        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::NullableBitmap64::TypeInfo>(
+            nullableBitmap64Argument, this, OnSuccessCallback_174, OnFailureCallback_174);
+    }
+
+    void OnFailureResponse_174(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_174() { NextTest(); }
+
+    CHIP_ERROR TestReadAttributeNullableBitmap64MaxValue_175()
     {
         const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, endpoint);
 
         return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableBitmap64::TypeInfo>(
-            this, OnSuccessCallback_171, OnFailureCallback_171);
+            this, OnSuccessCallback_175, OnFailureCallback_175);
     }
 
-    void OnFailureResponse_171(uint8_t status) { ThrowFailureResponse(); }
+    void OnFailureResponse_175(uint8_t status) { ThrowFailureResponse(); }
 
-    void OnSuccessResponse_171(const chip::app::DataModel::Nullable<uint64_t> & nullableBitmap64)
+    void OnSuccessResponse_175(const chip::app::DataModel::Nullable<uint64_t> & nullableBitmap64)
     {
         VerifyOrReturn(CheckValueNonNull("nullableBitmap64", nullableBitmap64));
         VerifyOrReturn(CheckValue("nullableBitmap64.Value()", nullableBitmap64.Value(), 18446744073709551614ULL));
@@ -37762,90 +38172,17 @@ private:
         NextTest();
     }
 
-    CHIP_ERROR TestWriteAttributeNullableBitmap64NullValue_172()
+    CHIP_ERROR TestWriteAttributeNullableBitmap64InvalidValue_176()
     {
         const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, endpoint);
 
         chip::app::DataModel::Nullable<uint64_t> nullableBitmap64Argument;
-        nullableBitmap64Argument.SetNull();
+        nullableBitmap64Argument.SetNonNull() = 18446744073709551615ULL;
 
         return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::NullableBitmap64::TypeInfo>(
-            nullableBitmap64Argument, this, OnSuccessCallback_172, OnFailureCallback_172);
-    }
-
-    void OnFailureResponse_172(uint8_t status) { ThrowFailureResponse(); }
-
-    void OnSuccessResponse_172() { NextTest(); }
-
-    CHIP_ERROR TestReadAttributeNullableBitmap64NullValue_173()
-    {
-        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
-        chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, endpoint);
-
-        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableBitmap64::TypeInfo>(
-            this, OnSuccessCallback_173, OnFailureCallback_173);
-    }
-
-    void OnFailureResponse_173(uint8_t status) { ThrowFailureResponse(); }
-
-    void OnSuccessResponse_173(const chip::app::DataModel::Nullable<uint64_t> & nullableBitmap64)
-    {
-        VerifyOrReturn(CheckValueNull("nullableBitmap64", nullableBitmap64));
-
-        NextTest();
-    }
-
-    CHIP_ERROR TestWriteAttributeNullableInt8uMaxValue_174()
-    {
-        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
-        chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, endpoint);
-
-        chip::app::DataModel::Nullable<uint8_t> nullableInt8uArgument;
-        nullableInt8uArgument.SetNonNull() = 254;
-
-        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt8u::TypeInfo>(
-            nullableInt8uArgument, this, OnSuccessCallback_174, OnFailureCallback_174);
-    }
-
-    void OnFailureResponse_174(uint8_t status) { ThrowFailureResponse(); }
-
-    void OnSuccessResponse_174() { NextTest(); }
-
-    CHIP_ERROR TestReadAttributeNullableInt8uMaxValue_175()
-    {
-        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
-        chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, endpoint);
-
-        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt8u::TypeInfo>(
-            this, OnSuccessCallback_175, OnFailureCallback_175);
-    }
-
-    void OnFailureResponse_175(uint8_t status) { ThrowFailureResponse(); }
-
-    void OnSuccessResponse_175(const chip::app::DataModel::Nullable<uint8_t> & nullableInt8u)
-    {
-        VerifyOrReturn(CheckValueNonNull("nullableInt8u", nullableInt8u));
-        VerifyOrReturn(CheckValue("nullableInt8u.Value()", nullableInt8u.Value(), 254));
-
-        NextTest();
-    }
-
-    CHIP_ERROR TestWriteAttributeNullableInt8uInvalidValue_176()
-    {
-        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
-        chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, endpoint);
-
-        chip::app::DataModel::Nullable<uint8_t> nullableInt8uArgument;
-        nullableInt8uArgument.SetNonNull() = 255;
-
-        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt8u::TypeInfo>(
-            nullableInt8uArgument, this, OnSuccessCallback_176, OnFailureCallback_176);
+            nullableBitmap64Argument, this, OnSuccessCallback_176, OnFailureCallback_176);
     }
 
     void OnFailureResponse_176(uint8_t status)
@@ -37856,19 +38193,92 @@ private:
 
     void OnSuccessResponse_176() { ThrowSuccessResponse(); }
 
-    CHIP_ERROR TestReadAttributeNullableInt8uUnchangedValue_177()
+    CHIP_ERROR TestReadAttributeNullableBitmap64UnchangedValue_177()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableBitmap64::TypeInfo>(
+            this, OnSuccessCallback_177, OnFailureCallback_177);
+    }
+
+    void OnFailureResponse_177(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_177(const chip::app::DataModel::Nullable<uint64_t> & nullableBitmap64)
+    {
+        VerifyOrReturn(CheckValueNonNull("nullableBitmap64", nullableBitmap64));
+        VerifyOrReturn(CheckValue("nullableBitmap64.Value()", nullableBitmap64.Value(), 18446744073709551614ULL));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestWriteAttributeNullableBitmap64NullValue_178()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        chip::app::DataModel::Nullable<uint64_t> nullableBitmap64Argument;
+        nullableBitmap64Argument.SetNull();
+
+        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::NullableBitmap64::TypeInfo>(
+            nullableBitmap64Argument, this, OnSuccessCallback_178, OnFailureCallback_178);
+    }
+
+    void OnFailureResponse_178(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_178() { NextTest(); }
+
+    CHIP_ERROR TestReadAttributeNullableBitmap64NullValue_179()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableBitmap64::TypeInfo>(
+            this, OnSuccessCallback_179, OnFailureCallback_179);
+    }
+
+    void OnFailureResponse_179(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_179(const chip::app::DataModel::Nullable<uint64_t> & nullableBitmap64)
+    {
+        VerifyOrReturn(CheckValueNull("nullableBitmap64", nullableBitmap64));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestWriteAttributeNullableInt8uMaxValue_180()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        chip::app::DataModel::Nullable<uint8_t> nullableInt8uArgument;
+        nullableInt8uArgument.SetNonNull() = 254;
+
+        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt8u::TypeInfo>(
+            nullableInt8uArgument, this, OnSuccessCallback_180, OnFailureCallback_180);
+    }
+
+    void OnFailureResponse_180(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_180() { NextTest(); }
+
+    CHIP_ERROR TestReadAttributeNullableInt8uMaxValue_181()
     {
         const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, endpoint);
 
         return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt8u::TypeInfo>(
-            this, OnSuccessCallback_177, OnFailureCallback_177);
+            this, OnSuccessCallback_181, OnFailureCallback_181);
     }
 
-    void OnFailureResponse_177(uint8_t status) { ThrowFailureResponse(); }
+    void OnFailureResponse_181(uint8_t status) { ThrowFailureResponse(); }
 
-    void OnSuccessResponse_177(const chip::app::DataModel::Nullable<uint8_t> & nullableInt8u)
+    void OnSuccessResponse_181(const chip::app::DataModel::Nullable<uint8_t> & nullableInt8u)
     {
         VerifyOrReturn(CheckValueNonNull("nullableInt8u", nullableInt8u));
         VerifyOrReturn(CheckValue("nullableInt8u.Value()", nullableInt8u.Value(), 254));
@@ -37876,90 +38286,17 @@ private:
         NextTest();
     }
 
-    CHIP_ERROR TestWriteAttributeNullableInt8uNullValue_178()
+    CHIP_ERROR TestWriteAttributeNullableInt8uInvalidValue_182()
     {
         const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, endpoint);
 
         chip::app::DataModel::Nullable<uint8_t> nullableInt8uArgument;
-        nullableInt8uArgument.SetNull();
+        nullableInt8uArgument.SetNonNull() = 255;
 
         return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt8u::TypeInfo>(
-            nullableInt8uArgument, this, OnSuccessCallback_178, OnFailureCallback_178);
-    }
-
-    void OnFailureResponse_178(uint8_t status) { ThrowFailureResponse(); }
-
-    void OnSuccessResponse_178() { NextTest(); }
-
-    CHIP_ERROR TestReadAttributeNullableInt8uNullValue_179()
-    {
-        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
-        chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, endpoint);
-
-        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt8u::TypeInfo>(
-            this, OnSuccessCallback_179, OnFailureCallback_179);
-    }
-
-    void OnFailureResponse_179(uint8_t status) { ThrowFailureResponse(); }
-
-    void OnSuccessResponse_179(const chip::app::DataModel::Nullable<uint8_t> & nullableInt8u)
-    {
-        VerifyOrReturn(CheckValueNull("nullableInt8u", nullableInt8u));
-
-        NextTest();
-    }
-
-    CHIP_ERROR TestWriteAttributeNullableInt16uMaxValue_180()
-    {
-        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
-        chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, endpoint);
-
-        chip::app::DataModel::Nullable<uint16_t> nullableInt16uArgument;
-        nullableInt16uArgument.SetNonNull() = 65534U;
-
-        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt16u::TypeInfo>(
-            nullableInt16uArgument, this, OnSuccessCallback_180, OnFailureCallback_180);
-    }
-
-    void OnFailureResponse_180(uint8_t status) { ThrowFailureResponse(); }
-
-    void OnSuccessResponse_180() { NextTest(); }
-
-    CHIP_ERROR TestReadAttributeNullableInt16uMaxValue_181()
-    {
-        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
-        chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, endpoint);
-
-        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt16u::TypeInfo>(
-            this, OnSuccessCallback_181, OnFailureCallback_181);
-    }
-
-    void OnFailureResponse_181(uint8_t status) { ThrowFailureResponse(); }
-
-    void OnSuccessResponse_181(const chip::app::DataModel::Nullable<uint16_t> & nullableInt16u)
-    {
-        VerifyOrReturn(CheckValueNonNull("nullableInt16u", nullableInt16u));
-        VerifyOrReturn(CheckValue("nullableInt16u.Value()", nullableInt16u.Value(), 65534U));
-
-        NextTest();
-    }
-
-    CHIP_ERROR TestWriteAttributeNullableInt16uInvalidValue_182()
-    {
-        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
-        chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, endpoint);
-
-        chip::app::DataModel::Nullable<uint16_t> nullableInt16uArgument;
-        nullableInt16uArgument.SetNonNull() = 65535U;
-
-        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt16u::TypeInfo>(
-            nullableInt16uArgument, this, OnSuccessCallback_182, OnFailureCallback_182);
+            nullableInt8uArgument, this, OnSuccessCallback_182, OnFailureCallback_182);
     }
 
     void OnFailureResponse_182(uint8_t status)
@@ -37970,19 +38307,92 @@ private:
 
     void OnSuccessResponse_182() { ThrowSuccessResponse(); }
 
-    CHIP_ERROR TestReadAttributeNullableInt16uUnchangedValue_183()
+    CHIP_ERROR TestReadAttributeNullableInt8uUnchangedValue_183()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt8u::TypeInfo>(
+            this, OnSuccessCallback_183, OnFailureCallback_183);
+    }
+
+    void OnFailureResponse_183(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_183(const chip::app::DataModel::Nullable<uint8_t> & nullableInt8u)
+    {
+        VerifyOrReturn(CheckValueNonNull("nullableInt8u", nullableInt8u));
+        VerifyOrReturn(CheckValue("nullableInt8u.Value()", nullableInt8u.Value(), 254));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestWriteAttributeNullableInt8uNullValue_184()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        chip::app::DataModel::Nullable<uint8_t> nullableInt8uArgument;
+        nullableInt8uArgument.SetNull();
+
+        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt8u::TypeInfo>(
+            nullableInt8uArgument, this, OnSuccessCallback_184, OnFailureCallback_184);
+    }
+
+    void OnFailureResponse_184(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_184() { NextTest(); }
+
+    CHIP_ERROR TestReadAttributeNullableInt8uNullValue_185()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt8u::TypeInfo>(
+            this, OnSuccessCallback_185, OnFailureCallback_185);
+    }
+
+    void OnFailureResponse_185(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_185(const chip::app::DataModel::Nullable<uint8_t> & nullableInt8u)
+    {
+        VerifyOrReturn(CheckValueNull("nullableInt8u", nullableInt8u));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestWriteAttributeNullableInt16uMaxValue_186()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        chip::app::DataModel::Nullable<uint16_t> nullableInt16uArgument;
+        nullableInt16uArgument.SetNonNull() = 65534U;
+
+        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt16u::TypeInfo>(
+            nullableInt16uArgument, this, OnSuccessCallback_186, OnFailureCallback_186);
+    }
+
+    void OnFailureResponse_186(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_186() { NextTest(); }
+
+    CHIP_ERROR TestReadAttributeNullableInt16uMaxValue_187()
     {
         const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, endpoint);
 
         return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt16u::TypeInfo>(
-            this, OnSuccessCallback_183, OnFailureCallback_183);
+            this, OnSuccessCallback_187, OnFailureCallback_187);
     }
 
-    void OnFailureResponse_183(uint8_t status) { ThrowFailureResponse(); }
+    void OnFailureResponse_187(uint8_t status) { ThrowFailureResponse(); }
 
-    void OnSuccessResponse_183(const chip::app::DataModel::Nullable<uint16_t> & nullableInt16u)
+    void OnSuccessResponse_187(const chip::app::DataModel::Nullable<uint16_t> & nullableInt16u)
     {
         VerifyOrReturn(CheckValueNonNull("nullableInt16u", nullableInt16u));
         VerifyOrReturn(CheckValue("nullableInt16u.Value()", nullableInt16u.Value(), 65534U));
@@ -37990,90 +38400,17 @@ private:
         NextTest();
     }
 
-    CHIP_ERROR TestWriteAttributeNullableInt16uNullValue_184()
+    CHIP_ERROR TestWriteAttributeNullableInt16uInvalidValue_188()
     {
         const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, endpoint);
 
         chip::app::DataModel::Nullable<uint16_t> nullableInt16uArgument;
-        nullableInt16uArgument.SetNull();
+        nullableInt16uArgument.SetNonNull() = 65535U;
 
         return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt16u::TypeInfo>(
-            nullableInt16uArgument, this, OnSuccessCallback_184, OnFailureCallback_184);
-    }
-
-    void OnFailureResponse_184(uint8_t status) { ThrowFailureResponse(); }
-
-    void OnSuccessResponse_184() { NextTest(); }
-
-    CHIP_ERROR TestReadAttributeNullableInt16uNullValue_185()
-    {
-        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
-        chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, endpoint);
-
-        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt16u::TypeInfo>(
-            this, OnSuccessCallback_185, OnFailureCallback_185);
-    }
-
-    void OnFailureResponse_185(uint8_t status) { ThrowFailureResponse(); }
-
-    void OnSuccessResponse_185(const chip::app::DataModel::Nullable<uint16_t> & nullableInt16u)
-    {
-        VerifyOrReturn(CheckValueNull("nullableInt16u", nullableInt16u));
-
-        NextTest();
-    }
-
-    CHIP_ERROR TestWriteAttributeNullableInt32uMaxValue_186()
-    {
-        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
-        chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, endpoint);
-
-        chip::app::DataModel::Nullable<uint32_t> nullableInt32uArgument;
-        nullableInt32uArgument.SetNonNull() = 4294967294UL;
-
-        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt32u::TypeInfo>(
-            nullableInt32uArgument, this, OnSuccessCallback_186, OnFailureCallback_186);
-    }
-
-    void OnFailureResponse_186(uint8_t status) { ThrowFailureResponse(); }
-
-    void OnSuccessResponse_186() { NextTest(); }
-
-    CHIP_ERROR TestReadAttributeNullableInt32uMaxValue_187()
-    {
-        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
-        chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, endpoint);
-
-        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt32u::TypeInfo>(
-            this, OnSuccessCallback_187, OnFailureCallback_187);
-    }
-
-    void OnFailureResponse_187(uint8_t status) { ThrowFailureResponse(); }
-
-    void OnSuccessResponse_187(const chip::app::DataModel::Nullable<uint32_t> & nullableInt32u)
-    {
-        VerifyOrReturn(CheckValueNonNull("nullableInt32u", nullableInt32u));
-        VerifyOrReturn(CheckValue("nullableInt32u.Value()", nullableInt32u.Value(), 4294967294UL));
-
-        NextTest();
-    }
-
-    CHIP_ERROR TestWriteAttributeNullableInt32uInvalidValue_188()
-    {
-        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
-        chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, endpoint);
-
-        chip::app::DataModel::Nullable<uint32_t> nullableInt32uArgument;
-        nullableInt32uArgument.SetNonNull() = 4294967295UL;
-
-        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt32u::TypeInfo>(
-            nullableInt32uArgument, this, OnSuccessCallback_188, OnFailureCallback_188);
+            nullableInt16uArgument, this, OnSuccessCallback_188, OnFailureCallback_188);
     }
 
     void OnFailureResponse_188(uint8_t status)
@@ -38084,19 +38421,92 @@ private:
 
     void OnSuccessResponse_188() { ThrowSuccessResponse(); }
 
-    CHIP_ERROR TestReadAttributeNullableInt32uUnchangedValue_189()
+    CHIP_ERROR TestReadAttributeNullableInt16uUnchangedValue_189()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt16u::TypeInfo>(
+            this, OnSuccessCallback_189, OnFailureCallback_189);
+    }
+
+    void OnFailureResponse_189(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_189(const chip::app::DataModel::Nullable<uint16_t> & nullableInt16u)
+    {
+        VerifyOrReturn(CheckValueNonNull("nullableInt16u", nullableInt16u));
+        VerifyOrReturn(CheckValue("nullableInt16u.Value()", nullableInt16u.Value(), 65534U));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestWriteAttributeNullableInt16uNullValue_190()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        chip::app::DataModel::Nullable<uint16_t> nullableInt16uArgument;
+        nullableInt16uArgument.SetNull();
+
+        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt16u::TypeInfo>(
+            nullableInt16uArgument, this, OnSuccessCallback_190, OnFailureCallback_190);
+    }
+
+    void OnFailureResponse_190(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_190() { NextTest(); }
+
+    CHIP_ERROR TestReadAttributeNullableInt16uNullValue_191()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt16u::TypeInfo>(
+            this, OnSuccessCallback_191, OnFailureCallback_191);
+    }
+
+    void OnFailureResponse_191(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_191(const chip::app::DataModel::Nullable<uint16_t> & nullableInt16u)
+    {
+        VerifyOrReturn(CheckValueNull("nullableInt16u", nullableInt16u));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestWriteAttributeNullableInt32uMaxValue_192()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        chip::app::DataModel::Nullable<uint32_t> nullableInt32uArgument;
+        nullableInt32uArgument.SetNonNull() = 4294967294UL;
+
+        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt32u::TypeInfo>(
+            nullableInt32uArgument, this, OnSuccessCallback_192, OnFailureCallback_192);
+    }
+
+    void OnFailureResponse_192(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_192() { NextTest(); }
+
+    CHIP_ERROR TestReadAttributeNullableInt32uMaxValue_193()
     {
         const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, endpoint);
 
         return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt32u::TypeInfo>(
-            this, OnSuccessCallback_189, OnFailureCallback_189);
+            this, OnSuccessCallback_193, OnFailureCallback_193);
     }
 
-    void OnFailureResponse_189(uint8_t status) { ThrowFailureResponse(); }
+    void OnFailureResponse_193(uint8_t status) { ThrowFailureResponse(); }
 
-    void OnSuccessResponse_189(const chip::app::DataModel::Nullable<uint32_t> & nullableInt32u)
+    void OnSuccessResponse_193(const chip::app::DataModel::Nullable<uint32_t> & nullableInt32u)
     {
         VerifyOrReturn(CheckValueNonNull("nullableInt32u", nullableInt32u));
         VerifyOrReturn(CheckValue("nullableInt32u.Value()", nullableInt32u.Value(), 4294967294UL));
@@ -38104,90 +38514,17 @@ private:
         NextTest();
     }
 
-    CHIP_ERROR TestWriteAttributeNullableInt32uNullValue_190()
+    CHIP_ERROR TestWriteAttributeNullableInt32uInvalidValue_194()
     {
         const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, endpoint);
 
         chip::app::DataModel::Nullable<uint32_t> nullableInt32uArgument;
-        nullableInt32uArgument.SetNull();
+        nullableInt32uArgument.SetNonNull() = 4294967295UL;
 
         return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt32u::TypeInfo>(
-            nullableInt32uArgument, this, OnSuccessCallback_190, OnFailureCallback_190);
-    }
-
-    void OnFailureResponse_190(uint8_t status) { ThrowFailureResponse(); }
-
-    void OnSuccessResponse_190() { NextTest(); }
-
-    CHIP_ERROR TestReadAttributeNullableInt32uNullValue_191()
-    {
-        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
-        chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, endpoint);
-
-        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt32u::TypeInfo>(
-            this, OnSuccessCallback_191, OnFailureCallback_191);
-    }
-
-    void OnFailureResponse_191(uint8_t status) { ThrowFailureResponse(); }
-
-    void OnSuccessResponse_191(const chip::app::DataModel::Nullable<uint32_t> & nullableInt32u)
-    {
-        VerifyOrReturn(CheckValueNull("nullableInt32u", nullableInt32u));
-
-        NextTest();
-    }
-
-    CHIP_ERROR TestWriteAttributeNullableInt64uMaxValue_192()
-    {
-        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
-        chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, endpoint);
-
-        chip::app::DataModel::Nullable<uint64_t> nullableInt64uArgument;
-        nullableInt64uArgument.SetNonNull() = 18446744073709551614ULL;
-
-        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt64u::TypeInfo>(
-            nullableInt64uArgument, this, OnSuccessCallback_192, OnFailureCallback_192);
-    }
-
-    void OnFailureResponse_192(uint8_t status) { ThrowFailureResponse(); }
-
-    void OnSuccessResponse_192() { NextTest(); }
-
-    CHIP_ERROR TestReadAttributeNullableInt64uMaxValue_193()
-    {
-        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
-        chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, endpoint);
-
-        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt64u::TypeInfo>(
-            this, OnSuccessCallback_193, OnFailureCallback_193);
-    }
-
-    void OnFailureResponse_193(uint8_t status) { ThrowFailureResponse(); }
-
-    void OnSuccessResponse_193(const chip::app::DataModel::Nullable<uint64_t> & nullableInt64u)
-    {
-        VerifyOrReturn(CheckValueNonNull("nullableInt64u", nullableInt64u));
-        VerifyOrReturn(CheckValue("nullableInt64u.Value()", nullableInt64u.Value(), 18446744073709551614ULL));
-
-        NextTest();
-    }
-
-    CHIP_ERROR TestWriteAttributeNullableInt64uInvalidValue_194()
-    {
-        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
-        chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, endpoint);
-
-        chip::app::DataModel::Nullable<uint64_t> nullableInt64uArgument;
-        nullableInt64uArgument.SetNonNull() = 18446744073709551615ULL;
-
-        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt64u::TypeInfo>(
-            nullableInt64uArgument, this, OnSuccessCallback_194, OnFailureCallback_194);
+            nullableInt32uArgument, this, OnSuccessCallback_194, OnFailureCallback_194);
     }
 
     void OnFailureResponse_194(uint8_t status)
@@ -38198,19 +38535,92 @@ private:
 
     void OnSuccessResponse_194() { ThrowSuccessResponse(); }
 
-    CHIP_ERROR TestReadAttributeNullableInt64uUnchangedValue_195()
+    CHIP_ERROR TestReadAttributeNullableInt32uUnchangedValue_195()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt32u::TypeInfo>(
+            this, OnSuccessCallback_195, OnFailureCallback_195);
+    }
+
+    void OnFailureResponse_195(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_195(const chip::app::DataModel::Nullable<uint32_t> & nullableInt32u)
+    {
+        VerifyOrReturn(CheckValueNonNull("nullableInt32u", nullableInt32u));
+        VerifyOrReturn(CheckValue("nullableInt32u.Value()", nullableInt32u.Value(), 4294967294UL));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestWriteAttributeNullableInt32uNullValue_196()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        chip::app::DataModel::Nullable<uint32_t> nullableInt32uArgument;
+        nullableInt32uArgument.SetNull();
+
+        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt32u::TypeInfo>(
+            nullableInt32uArgument, this, OnSuccessCallback_196, OnFailureCallback_196);
+    }
+
+    void OnFailureResponse_196(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_196() { NextTest(); }
+
+    CHIP_ERROR TestReadAttributeNullableInt32uNullValue_197()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt32u::TypeInfo>(
+            this, OnSuccessCallback_197, OnFailureCallback_197);
+    }
+
+    void OnFailureResponse_197(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_197(const chip::app::DataModel::Nullable<uint32_t> & nullableInt32u)
+    {
+        VerifyOrReturn(CheckValueNull("nullableInt32u", nullableInt32u));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestWriteAttributeNullableInt64uMaxValue_198()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        chip::app::DataModel::Nullable<uint64_t> nullableInt64uArgument;
+        nullableInt64uArgument.SetNonNull() = 18446744073709551614ULL;
+
+        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt64u::TypeInfo>(
+            nullableInt64uArgument, this, OnSuccessCallback_198, OnFailureCallback_198);
+    }
+
+    void OnFailureResponse_198(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_198() { NextTest(); }
+
+    CHIP_ERROR TestReadAttributeNullableInt64uMaxValue_199()
     {
         const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, endpoint);
 
         return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt64u::TypeInfo>(
-            this, OnSuccessCallback_195, OnFailureCallback_195);
+            this, OnSuccessCallback_199, OnFailureCallback_199);
     }
 
-    void OnFailureResponse_195(uint8_t status) { ThrowFailureResponse(); }
+    void OnFailureResponse_199(uint8_t status) { ThrowFailureResponse(); }
 
-    void OnSuccessResponse_195(const chip::app::DataModel::Nullable<uint64_t> & nullableInt64u)
+    void OnSuccessResponse_199(const chip::app::DataModel::Nullable<uint64_t> & nullableInt64u)
     {
         VerifyOrReturn(CheckValueNonNull("nullableInt64u", nullableInt64u));
         VerifyOrReturn(CheckValue("nullableInt64u.Value()", nullableInt64u.Value(), 18446744073709551614ULL));
@@ -38218,90 +38628,17 @@ private:
         NextTest();
     }
 
-    CHIP_ERROR TestWriteAttributeNullableInt64uNullValue_196()
+    CHIP_ERROR TestWriteAttributeNullableInt64uInvalidValue_200()
     {
         const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, endpoint);
 
         chip::app::DataModel::Nullable<uint64_t> nullableInt64uArgument;
-        nullableInt64uArgument.SetNull();
+        nullableInt64uArgument.SetNonNull() = 18446744073709551615ULL;
 
         return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt64u::TypeInfo>(
-            nullableInt64uArgument, this, OnSuccessCallback_196, OnFailureCallback_196);
-    }
-
-    void OnFailureResponse_196(uint8_t status) { ThrowFailureResponse(); }
-
-    void OnSuccessResponse_196() { NextTest(); }
-
-    CHIP_ERROR TestReadAttributeNullableInt64uNullValue_197()
-    {
-        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
-        chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, endpoint);
-
-        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt64u::TypeInfo>(
-            this, OnSuccessCallback_197, OnFailureCallback_197);
-    }
-
-    void OnFailureResponse_197(uint8_t status) { ThrowFailureResponse(); }
-
-    void OnSuccessResponse_197(const chip::app::DataModel::Nullable<uint64_t> & nullableInt64u)
-    {
-        VerifyOrReturn(CheckValueNull("nullableInt64u", nullableInt64u));
-
-        NextTest();
-    }
-
-    CHIP_ERROR TestWriteAttributeNullableInt8sMinValue_198()
-    {
-        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
-        chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, endpoint);
-
-        chip::app::DataModel::Nullable<int8_t> nullableInt8sArgument;
-        nullableInt8sArgument.SetNonNull() = -127;
-
-        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt8s::TypeInfo>(
-            nullableInt8sArgument, this, OnSuccessCallback_198, OnFailureCallback_198);
-    }
-
-    void OnFailureResponse_198(uint8_t status) { ThrowFailureResponse(); }
-
-    void OnSuccessResponse_198() { NextTest(); }
-
-    CHIP_ERROR TestReadAttributeNullableInt8sMinValue_199()
-    {
-        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
-        chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, endpoint);
-
-        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt8s::TypeInfo>(
-            this, OnSuccessCallback_199, OnFailureCallback_199);
-    }
-
-    void OnFailureResponse_199(uint8_t status) { ThrowFailureResponse(); }
-
-    void OnSuccessResponse_199(const chip::app::DataModel::Nullable<int8_t> & nullableInt8s)
-    {
-        VerifyOrReturn(CheckValueNonNull("nullableInt8s", nullableInt8s));
-        VerifyOrReturn(CheckValue("nullableInt8s.Value()", nullableInt8s.Value(), -127));
-
-        NextTest();
-    }
-
-    CHIP_ERROR TestWriteAttributeNullableInt8sInvalidValue_200()
-    {
-        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
-        chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, endpoint);
-
-        chip::app::DataModel::Nullable<int8_t> nullableInt8sArgument;
-        nullableInt8sArgument.SetNonNull() = -128;
-
-        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt8s::TypeInfo>(
-            nullableInt8sArgument, this, OnSuccessCallback_200, OnFailureCallback_200);
+            nullableInt64uArgument, this, OnSuccessCallback_200, OnFailureCallback_200);
     }
 
     void OnFailureResponse_200(uint8_t status)
@@ -38312,19 +38649,92 @@ private:
 
     void OnSuccessResponse_200() { ThrowSuccessResponse(); }
 
-    CHIP_ERROR TestReadAttributeNullableInt8sUnchangedValue_201()
+    CHIP_ERROR TestReadAttributeNullableInt64uUnchangedValue_201()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt64u::TypeInfo>(
+            this, OnSuccessCallback_201, OnFailureCallback_201);
+    }
+
+    void OnFailureResponse_201(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_201(const chip::app::DataModel::Nullable<uint64_t> & nullableInt64u)
+    {
+        VerifyOrReturn(CheckValueNonNull("nullableInt64u", nullableInt64u));
+        VerifyOrReturn(CheckValue("nullableInt64u.Value()", nullableInt64u.Value(), 18446744073709551614ULL));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestWriteAttributeNullableInt64uNullValue_202()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        chip::app::DataModel::Nullable<uint64_t> nullableInt64uArgument;
+        nullableInt64uArgument.SetNull();
+
+        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt64u::TypeInfo>(
+            nullableInt64uArgument, this, OnSuccessCallback_202, OnFailureCallback_202);
+    }
+
+    void OnFailureResponse_202(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_202() { NextTest(); }
+
+    CHIP_ERROR TestReadAttributeNullableInt64uNullValue_203()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt64u::TypeInfo>(
+            this, OnSuccessCallback_203, OnFailureCallback_203);
+    }
+
+    void OnFailureResponse_203(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_203(const chip::app::DataModel::Nullable<uint64_t> & nullableInt64u)
+    {
+        VerifyOrReturn(CheckValueNull("nullableInt64u", nullableInt64u));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestWriteAttributeNullableInt8sMinValue_204()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        chip::app::DataModel::Nullable<int8_t> nullableInt8sArgument;
+        nullableInt8sArgument.SetNonNull() = -127;
+
+        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt8s::TypeInfo>(
+            nullableInt8sArgument, this, OnSuccessCallback_204, OnFailureCallback_204);
+    }
+
+    void OnFailureResponse_204(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_204() { NextTest(); }
+
+    CHIP_ERROR TestReadAttributeNullableInt8sMinValue_205()
     {
         const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, endpoint);
 
         return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt8s::TypeInfo>(
-            this, OnSuccessCallback_201, OnFailureCallback_201);
+            this, OnSuccessCallback_205, OnFailureCallback_205);
     }
 
-    void OnFailureResponse_201(uint8_t status) { ThrowFailureResponse(); }
+    void OnFailureResponse_205(uint8_t status) { ThrowFailureResponse(); }
 
-    void OnSuccessResponse_201(const chip::app::DataModel::Nullable<int8_t> & nullableInt8s)
+    void OnSuccessResponse_205(const chip::app::DataModel::Nullable<int8_t> & nullableInt8s)
     {
         VerifyOrReturn(CheckValueNonNull("nullableInt8s", nullableInt8s));
         VerifyOrReturn(CheckValue("nullableInt8s.Value()", nullableInt8s.Value(), -127));
@@ -38332,90 +38742,17 @@ private:
         NextTest();
     }
 
-    CHIP_ERROR TestWriteAttributeNullableInt8sNullValue_202()
+    CHIP_ERROR TestWriteAttributeNullableInt8sInvalidValue_206()
     {
         const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, endpoint);
 
         chip::app::DataModel::Nullable<int8_t> nullableInt8sArgument;
-        nullableInt8sArgument.SetNull();
+        nullableInt8sArgument.SetNonNull() = -128;
 
         return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt8s::TypeInfo>(
-            nullableInt8sArgument, this, OnSuccessCallback_202, OnFailureCallback_202);
-    }
-
-    void OnFailureResponse_202(uint8_t status) { ThrowFailureResponse(); }
-
-    void OnSuccessResponse_202() { NextTest(); }
-
-    CHIP_ERROR TestReadAttributeNullableInt8sNullValue_203()
-    {
-        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
-        chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, endpoint);
-
-        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt8s::TypeInfo>(
-            this, OnSuccessCallback_203, OnFailureCallback_203);
-    }
-
-    void OnFailureResponse_203(uint8_t status) { ThrowFailureResponse(); }
-
-    void OnSuccessResponse_203(const chip::app::DataModel::Nullable<int8_t> & nullableInt8s)
-    {
-        VerifyOrReturn(CheckValueNull("nullableInt8s", nullableInt8s));
-
-        NextTest();
-    }
-
-    CHIP_ERROR TestWriteAttributeNullableInt16sMinValue_204()
-    {
-        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
-        chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, endpoint);
-
-        chip::app::DataModel::Nullable<int16_t> nullableInt16sArgument;
-        nullableInt16sArgument.SetNonNull() = -32767;
-
-        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt16s::TypeInfo>(
-            nullableInt16sArgument, this, OnSuccessCallback_204, OnFailureCallback_204);
-    }
-
-    void OnFailureResponse_204(uint8_t status) { ThrowFailureResponse(); }
-
-    void OnSuccessResponse_204() { NextTest(); }
-
-    CHIP_ERROR TestReadAttributeNullableInt16sMinValue_205()
-    {
-        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
-        chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, endpoint);
-
-        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt16s::TypeInfo>(
-            this, OnSuccessCallback_205, OnFailureCallback_205);
-    }
-
-    void OnFailureResponse_205(uint8_t status) { ThrowFailureResponse(); }
-
-    void OnSuccessResponse_205(const chip::app::DataModel::Nullable<int16_t> & nullableInt16s)
-    {
-        VerifyOrReturn(CheckValueNonNull("nullableInt16s", nullableInt16s));
-        VerifyOrReturn(CheckValue("nullableInt16s.Value()", nullableInt16s.Value(), -32767));
-
-        NextTest();
-    }
-
-    CHIP_ERROR TestWriteAttributeNullableInt16sInvalidValue_206()
-    {
-        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
-        chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, endpoint);
-
-        chip::app::DataModel::Nullable<int16_t> nullableInt16sArgument;
-        nullableInt16sArgument.SetNonNull() = -32768;
-
-        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt16s::TypeInfo>(
-            nullableInt16sArgument, this, OnSuccessCallback_206, OnFailureCallback_206);
+            nullableInt8sArgument, this, OnSuccessCallback_206, OnFailureCallback_206);
     }
 
     void OnFailureResponse_206(uint8_t status)
@@ -38426,19 +38763,92 @@ private:
 
     void OnSuccessResponse_206() { ThrowSuccessResponse(); }
 
-    CHIP_ERROR TestReadAttributeNullableInt16sUnchangedValue_207()
+    CHIP_ERROR TestReadAttributeNullableInt8sUnchangedValue_207()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt8s::TypeInfo>(
+            this, OnSuccessCallback_207, OnFailureCallback_207);
+    }
+
+    void OnFailureResponse_207(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_207(const chip::app::DataModel::Nullable<int8_t> & nullableInt8s)
+    {
+        VerifyOrReturn(CheckValueNonNull("nullableInt8s", nullableInt8s));
+        VerifyOrReturn(CheckValue("nullableInt8s.Value()", nullableInt8s.Value(), -127));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestWriteAttributeNullableInt8sNullValue_208()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        chip::app::DataModel::Nullable<int8_t> nullableInt8sArgument;
+        nullableInt8sArgument.SetNull();
+
+        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt8s::TypeInfo>(
+            nullableInt8sArgument, this, OnSuccessCallback_208, OnFailureCallback_208);
+    }
+
+    void OnFailureResponse_208(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_208() { NextTest(); }
+
+    CHIP_ERROR TestReadAttributeNullableInt8sNullValue_209()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt8s::TypeInfo>(
+            this, OnSuccessCallback_209, OnFailureCallback_209);
+    }
+
+    void OnFailureResponse_209(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_209(const chip::app::DataModel::Nullable<int8_t> & nullableInt8s)
+    {
+        VerifyOrReturn(CheckValueNull("nullableInt8s", nullableInt8s));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestWriteAttributeNullableInt16sMinValue_210()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        chip::app::DataModel::Nullable<int16_t> nullableInt16sArgument;
+        nullableInt16sArgument.SetNonNull() = -32767;
+
+        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt16s::TypeInfo>(
+            nullableInt16sArgument, this, OnSuccessCallback_210, OnFailureCallback_210);
+    }
+
+    void OnFailureResponse_210(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_210() { NextTest(); }
+
+    CHIP_ERROR TestReadAttributeNullableInt16sMinValue_211()
     {
         const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, endpoint);
 
         return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt16s::TypeInfo>(
-            this, OnSuccessCallback_207, OnFailureCallback_207);
+            this, OnSuccessCallback_211, OnFailureCallback_211);
     }
 
-    void OnFailureResponse_207(uint8_t status) { ThrowFailureResponse(); }
+    void OnFailureResponse_211(uint8_t status) { ThrowFailureResponse(); }
 
-    void OnSuccessResponse_207(const chip::app::DataModel::Nullable<int16_t> & nullableInt16s)
+    void OnSuccessResponse_211(const chip::app::DataModel::Nullable<int16_t> & nullableInt16s)
     {
         VerifyOrReturn(CheckValueNonNull("nullableInt16s", nullableInt16s));
         VerifyOrReturn(CheckValue("nullableInt16s.Value()", nullableInt16s.Value(), -32767));
@@ -38446,90 +38856,17 @@ private:
         NextTest();
     }
 
-    CHIP_ERROR TestWriteAttributeNullableInt16sNullValue_208()
+    CHIP_ERROR TestWriteAttributeNullableInt16sInvalidValue_212()
     {
         const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, endpoint);
 
         chip::app::DataModel::Nullable<int16_t> nullableInt16sArgument;
-        nullableInt16sArgument.SetNull();
+        nullableInt16sArgument.SetNonNull() = -32768;
 
         return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt16s::TypeInfo>(
-            nullableInt16sArgument, this, OnSuccessCallback_208, OnFailureCallback_208);
-    }
-
-    void OnFailureResponse_208(uint8_t status) { ThrowFailureResponse(); }
-
-    void OnSuccessResponse_208() { NextTest(); }
-
-    CHIP_ERROR TestReadAttributeNullableInt16sNullValue_209()
-    {
-        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
-        chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, endpoint);
-
-        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt16s::TypeInfo>(
-            this, OnSuccessCallback_209, OnFailureCallback_209);
-    }
-
-    void OnFailureResponse_209(uint8_t status) { ThrowFailureResponse(); }
-
-    void OnSuccessResponse_209(const chip::app::DataModel::Nullable<int16_t> & nullableInt16s)
-    {
-        VerifyOrReturn(CheckValueNull("nullableInt16s", nullableInt16s));
-
-        NextTest();
-    }
-
-    CHIP_ERROR TestWriteAttributeNullableInt32sMinValue_210()
-    {
-        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
-        chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, endpoint);
-
-        chip::app::DataModel::Nullable<int32_t> nullableInt32sArgument;
-        nullableInt32sArgument.SetNonNull() = -2147483647L;
-
-        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt32s::TypeInfo>(
-            nullableInt32sArgument, this, OnSuccessCallback_210, OnFailureCallback_210);
-    }
-
-    void OnFailureResponse_210(uint8_t status) { ThrowFailureResponse(); }
-
-    void OnSuccessResponse_210() { NextTest(); }
-
-    CHIP_ERROR TestReadAttributeNullableInt32sMinValue_211()
-    {
-        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
-        chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, endpoint);
-
-        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt32s::TypeInfo>(
-            this, OnSuccessCallback_211, OnFailureCallback_211);
-    }
-
-    void OnFailureResponse_211(uint8_t status) { ThrowFailureResponse(); }
-
-    void OnSuccessResponse_211(const chip::app::DataModel::Nullable<int32_t> & nullableInt32s)
-    {
-        VerifyOrReturn(CheckValueNonNull("nullableInt32s", nullableInt32s));
-        VerifyOrReturn(CheckValue("nullableInt32s.Value()", nullableInt32s.Value(), -2147483647L));
-
-        NextTest();
-    }
-
-    CHIP_ERROR TestWriteAttributeNullableInt32sInvalidValue_212()
-    {
-        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
-        chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, endpoint);
-
-        chip::app::DataModel::Nullable<int32_t> nullableInt32sArgument;
-        nullableInt32sArgument.SetNonNull() = -2147483648L;
-
-        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt32s::TypeInfo>(
-            nullableInt32sArgument, this, OnSuccessCallback_212, OnFailureCallback_212);
+            nullableInt16sArgument, this, OnSuccessCallback_212, OnFailureCallback_212);
     }
 
     void OnFailureResponse_212(uint8_t status)
@@ -38540,19 +38877,92 @@ private:
 
     void OnSuccessResponse_212() { ThrowSuccessResponse(); }
 
-    CHIP_ERROR TestReadAttributeNullableInt32sUnchangedValue_213()
+    CHIP_ERROR TestReadAttributeNullableInt16sUnchangedValue_213()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt16s::TypeInfo>(
+            this, OnSuccessCallback_213, OnFailureCallback_213);
+    }
+
+    void OnFailureResponse_213(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_213(const chip::app::DataModel::Nullable<int16_t> & nullableInt16s)
+    {
+        VerifyOrReturn(CheckValueNonNull("nullableInt16s", nullableInt16s));
+        VerifyOrReturn(CheckValue("nullableInt16s.Value()", nullableInt16s.Value(), -32767));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestWriteAttributeNullableInt16sNullValue_214()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        chip::app::DataModel::Nullable<int16_t> nullableInt16sArgument;
+        nullableInt16sArgument.SetNull();
+
+        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt16s::TypeInfo>(
+            nullableInt16sArgument, this, OnSuccessCallback_214, OnFailureCallback_214);
+    }
+
+    void OnFailureResponse_214(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_214() { NextTest(); }
+
+    CHIP_ERROR TestReadAttributeNullableInt16sNullValue_215()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt16s::TypeInfo>(
+            this, OnSuccessCallback_215, OnFailureCallback_215);
+    }
+
+    void OnFailureResponse_215(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_215(const chip::app::DataModel::Nullable<int16_t> & nullableInt16s)
+    {
+        VerifyOrReturn(CheckValueNull("nullableInt16s", nullableInt16s));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestWriteAttributeNullableInt32sMinValue_216()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        chip::app::DataModel::Nullable<int32_t> nullableInt32sArgument;
+        nullableInt32sArgument.SetNonNull() = -2147483647L;
+
+        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt32s::TypeInfo>(
+            nullableInt32sArgument, this, OnSuccessCallback_216, OnFailureCallback_216);
+    }
+
+    void OnFailureResponse_216(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_216() { NextTest(); }
+
+    CHIP_ERROR TestReadAttributeNullableInt32sMinValue_217()
     {
         const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, endpoint);
 
         return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt32s::TypeInfo>(
-            this, OnSuccessCallback_213, OnFailureCallback_213);
+            this, OnSuccessCallback_217, OnFailureCallback_217);
     }
 
-    void OnFailureResponse_213(uint8_t status) { ThrowFailureResponse(); }
+    void OnFailureResponse_217(uint8_t status) { ThrowFailureResponse(); }
 
-    void OnSuccessResponse_213(const chip::app::DataModel::Nullable<int32_t> & nullableInt32s)
+    void OnSuccessResponse_217(const chip::app::DataModel::Nullable<int32_t> & nullableInt32s)
     {
         VerifyOrReturn(CheckValueNonNull("nullableInt32s", nullableInt32s));
         VerifyOrReturn(CheckValue("nullableInt32s.Value()", nullableInt32s.Value(), -2147483647L));
@@ -38560,90 +38970,17 @@ private:
         NextTest();
     }
 
-    CHIP_ERROR TestWriteAttributeNullableInt32sNullValue_214()
+    CHIP_ERROR TestWriteAttributeNullableInt32sInvalidValue_218()
     {
         const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, endpoint);
 
         chip::app::DataModel::Nullable<int32_t> nullableInt32sArgument;
-        nullableInt32sArgument.SetNull();
+        nullableInt32sArgument.SetNonNull() = -2147483648L;
 
         return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt32s::TypeInfo>(
-            nullableInt32sArgument, this, OnSuccessCallback_214, OnFailureCallback_214);
-    }
-
-    void OnFailureResponse_214(uint8_t status) { ThrowFailureResponse(); }
-
-    void OnSuccessResponse_214() { NextTest(); }
-
-    CHIP_ERROR TestReadAttributeNullableInt32sNullValue_215()
-    {
-        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
-        chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, endpoint);
-
-        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt32s::TypeInfo>(
-            this, OnSuccessCallback_215, OnFailureCallback_215);
-    }
-
-    void OnFailureResponse_215(uint8_t status) { ThrowFailureResponse(); }
-
-    void OnSuccessResponse_215(const chip::app::DataModel::Nullable<int32_t> & nullableInt32s)
-    {
-        VerifyOrReturn(CheckValueNull("nullableInt32s", nullableInt32s));
-
-        NextTest();
-    }
-
-    CHIP_ERROR TestWriteAttributeNullableInt64sMinValue_216()
-    {
-        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
-        chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, endpoint);
-
-        chip::app::DataModel::Nullable<int64_t> nullableInt64sArgument;
-        nullableInt64sArgument.SetNonNull() = -9223372036854775807LL;
-
-        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt64s::TypeInfo>(
-            nullableInt64sArgument, this, OnSuccessCallback_216, OnFailureCallback_216);
-    }
-
-    void OnFailureResponse_216(uint8_t status) { ThrowFailureResponse(); }
-
-    void OnSuccessResponse_216() { NextTest(); }
-
-    CHIP_ERROR TestReadAttributeNullableInt64sMinValue_217()
-    {
-        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
-        chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, endpoint);
-
-        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt64s::TypeInfo>(
-            this, OnSuccessCallback_217, OnFailureCallback_217);
-    }
-
-    void OnFailureResponse_217(uint8_t status) { ThrowFailureResponse(); }
-
-    void OnSuccessResponse_217(const chip::app::DataModel::Nullable<int64_t> & nullableInt64s)
-    {
-        VerifyOrReturn(CheckValueNonNull("nullableInt64s", nullableInt64s));
-        VerifyOrReturn(CheckValue("nullableInt64s.Value()", nullableInt64s.Value(), -9223372036854775807LL));
-
-        NextTest();
-    }
-
-    CHIP_ERROR TestWriteAttributeNullableInt64sInvalidValue_218()
-    {
-        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
-        chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, endpoint);
-
-        chip::app::DataModel::Nullable<int64_t> nullableInt64sArgument;
-        nullableInt64sArgument.SetNonNull() = -9223372036854775807LL - 1;
-
-        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt64s::TypeInfo>(
-            nullableInt64sArgument, this, OnSuccessCallback_218, OnFailureCallback_218);
+            nullableInt32sArgument, this, OnSuccessCallback_218, OnFailureCallback_218);
     }
 
     void OnFailureResponse_218(uint8_t status)
@@ -38654,19 +38991,92 @@ private:
 
     void OnSuccessResponse_218() { ThrowSuccessResponse(); }
 
-    CHIP_ERROR TestReadAttributeNullableInt64sUnchangedValue_219()
+    CHIP_ERROR TestReadAttributeNullableInt32sUnchangedValue_219()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt32s::TypeInfo>(
+            this, OnSuccessCallback_219, OnFailureCallback_219);
+    }
+
+    void OnFailureResponse_219(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_219(const chip::app::DataModel::Nullable<int32_t> & nullableInt32s)
+    {
+        VerifyOrReturn(CheckValueNonNull("nullableInt32s", nullableInt32s));
+        VerifyOrReturn(CheckValue("nullableInt32s.Value()", nullableInt32s.Value(), -2147483647L));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestWriteAttributeNullableInt32sNullValue_220()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        chip::app::DataModel::Nullable<int32_t> nullableInt32sArgument;
+        nullableInt32sArgument.SetNull();
+
+        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt32s::TypeInfo>(
+            nullableInt32sArgument, this, OnSuccessCallback_220, OnFailureCallback_220);
+    }
+
+    void OnFailureResponse_220(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_220() { NextTest(); }
+
+    CHIP_ERROR TestReadAttributeNullableInt32sNullValue_221()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt32s::TypeInfo>(
+            this, OnSuccessCallback_221, OnFailureCallback_221);
+    }
+
+    void OnFailureResponse_221(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_221(const chip::app::DataModel::Nullable<int32_t> & nullableInt32s)
+    {
+        VerifyOrReturn(CheckValueNull("nullableInt32s", nullableInt32s));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestWriteAttributeNullableInt64sMinValue_222()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        chip::app::DataModel::Nullable<int64_t> nullableInt64sArgument;
+        nullableInt64sArgument.SetNonNull() = -9223372036854775807LL;
+
+        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt64s::TypeInfo>(
+            nullableInt64sArgument, this, OnSuccessCallback_222, OnFailureCallback_222);
+    }
+
+    void OnFailureResponse_222(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_222() { NextTest(); }
+
+    CHIP_ERROR TestReadAttributeNullableInt64sMinValue_223()
     {
         const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, endpoint);
 
         return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt64s::TypeInfo>(
-            this, OnSuccessCallback_219, OnFailureCallback_219);
+            this, OnSuccessCallback_223, OnFailureCallback_223);
     }
 
-    void OnFailureResponse_219(uint8_t status) { ThrowFailureResponse(); }
+    void OnFailureResponse_223(uint8_t status) { ThrowFailureResponse(); }
 
-    void OnSuccessResponse_219(const chip::app::DataModel::Nullable<int64_t> & nullableInt64s)
+    void OnSuccessResponse_223(const chip::app::DataModel::Nullable<int64_t> & nullableInt64s)
     {
         VerifyOrReturn(CheckValueNonNull("nullableInt64s", nullableInt64s));
         VerifyOrReturn(CheckValue("nullableInt64s.Value()", nullableInt64s.Value(), -9223372036854775807LL));
@@ -38674,90 +39084,17 @@ private:
         NextTest();
     }
 
-    CHIP_ERROR TestWriteAttributeNullableInt64sNullValue_220()
+    CHIP_ERROR TestWriteAttributeNullableInt64sInvalidValue_224()
     {
         const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, endpoint);
 
         chip::app::DataModel::Nullable<int64_t> nullableInt64sArgument;
-        nullableInt64sArgument.SetNull();
+        nullableInt64sArgument.SetNonNull() = -9223372036854775807LL - 1;
 
         return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt64s::TypeInfo>(
-            nullableInt64sArgument, this, OnSuccessCallback_220, OnFailureCallback_220);
-    }
-
-    void OnFailureResponse_220(uint8_t status) { ThrowFailureResponse(); }
-
-    void OnSuccessResponse_220() { NextTest(); }
-
-    CHIP_ERROR TestReadAttributeNullableInt64sNullValue_221()
-    {
-        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
-        chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, endpoint);
-
-        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt64s::TypeInfo>(
-            this, OnSuccessCallback_221, OnFailureCallback_221);
-    }
-
-    void OnFailureResponse_221(uint8_t status) { ThrowFailureResponse(); }
-
-    void OnSuccessResponse_221(const chip::app::DataModel::Nullable<int64_t> & nullableInt64s)
-    {
-        VerifyOrReturn(CheckValueNull("nullableInt64s", nullableInt64s));
-
-        NextTest();
-    }
-
-    CHIP_ERROR TestWriteAttributeNullableEnum8MaxValue_222()
-    {
-        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
-        chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, endpoint);
-
-        chip::app::DataModel::Nullable<uint8_t> nullableEnum8Argument;
-        nullableEnum8Argument.SetNonNull() = static_cast<uint8_t>(254);
-
-        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::NullableEnum8::TypeInfo>(
-            nullableEnum8Argument, this, OnSuccessCallback_222, OnFailureCallback_222);
-    }
-
-    void OnFailureResponse_222(uint8_t status) { ThrowFailureResponse(); }
-
-    void OnSuccessResponse_222() { NextTest(); }
-
-    CHIP_ERROR TestReadAttributeNullableEnum8MaxValue_223()
-    {
-        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
-        chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, endpoint);
-
-        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableEnum8::TypeInfo>(
-            this, OnSuccessCallback_223, OnFailureCallback_223);
-    }
-
-    void OnFailureResponse_223(uint8_t status) { ThrowFailureResponse(); }
-
-    void OnSuccessResponse_223(const chip::app::DataModel::Nullable<uint8_t> & nullableEnum8)
-    {
-        VerifyOrReturn(CheckValueNonNull("nullableEnum8", nullableEnum8));
-        VerifyOrReturn(CheckValue("nullableEnum8.Value()", nullableEnum8.Value(), 254));
-
-        NextTest();
-    }
-
-    CHIP_ERROR TestWriteAttributeNullableEnum8InvalidValue_224()
-    {
-        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
-        chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, endpoint);
-
-        chip::app::DataModel::Nullable<uint8_t> nullableEnum8Argument;
-        nullableEnum8Argument.SetNonNull() = static_cast<uint8_t>(255);
-
-        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::NullableEnum8::TypeInfo>(
-            nullableEnum8Argument, this, OnSuccessCallback_224, OnFailureCallback_224);
+            nullableInt64sArgument, this, OnSuccessCallback_224, OnFailureCallback_224);
     }
 
     void OnFailureResponse_224(uint8_t status)
@@ -38768,19 +39105,92 @@ private:
 
     void OnSuccessResponse_224() { ThrowSuccessResponse(); }
 
-    CHIP_ERROR TestReadAttributeNullableEnum8UnchangedValue_225()
+    CHIP_ERROR TestReadAttributeNullableInt64sUnchangedValue_225()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt64s::TypeInfo>(
+            this, OnSuccessCallback_225, OnFailureCallback_225);
+    }
+
+    void OnFailureResponse_225(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_225(const chip::app::DataModel::Nullable<int64_t> & nullableInt64s)
+    {
+        VerifyOrReturn(CheckValueNonNull("nullableInt64s", nullableInt64s));
+        VerifyOrReturn(CheckValue("nullableInt64s.Value()", nullableInt64s.Value(), -9223372036854775807LL));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestWriteAttributeNullableInt64sNullValue_226()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        chip::app::DataModel::Nullable<int64_t> nullableInt64sArgument;
+        nullableInt64sArgument.SetNull();
+
+        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt64s::TypeInfo>(
+            nullableInt64sArgument, this, OnSuccessCallback_226, OnFailureCallback_226);
+    }
+
+    void OnFailureResponse_226(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_226() { NextTest(); }
+
+    CHIP_ERROR TestReadAttributeNullableInt64sNullValue_227()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableInt64s::TypeInfo>(
+            this, OnSuccessCallback_227, OnFailureCallback_227);
+    }
+
+    void OnFailureResponse_227(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_227(const chip::app::DataModel::Nullable<int64_t> & nullableInt64s)
+    {
+        VerifyOrReturn(CheckValueNull("nullableInt64s", nullableInt64s));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestWriteAttributeNullableEnum8MaxValue_228()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        chip::app::DataModel::Nullable<uint8_t> nullableEnum8Argument;
+        nullableEnum8Argument.SetNonNull() = static_cast<uint8_t>(254);
+
+        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::NullableEnum8::TypeInfo>(
+            nullableEnum8Argument, this, OnSuccessCallback_228, OnFailureCallback_228);
+    }
+
+    void OnFailureResponse_228(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_228() { NextTest(); }
+
+    CHIP_ERROR TestReadAttributeNullableEnum8MaxValue_229()
     {
         const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, endpoint);
 
         return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableEnum8::TypeInfo>(
-            this, OnSuccessCallback_225, OnFailureCallback_225);
+            this, OnSuccessCallback_229, OnFailureCallback_229);
     }
 
-    void OnFailureResponse_225(uint8_t status) { ThrowFailureResponse(); }
+    void OnFailureResponse_229(uint8_t status) { ThrowFailureResponse(); }
 
-    void OnSuccessResponse_225(const chip::app::DataModel::Nullable<uint8_t> & nullableEnum8)
+    void OnSuccessResponse_229(const chip::app::DataModel::Nullable<uint8_t> & nullableEnum8)
     {
         VerifyOrReturn(CheckValueNonNull("nullableEnum8", nullableEnum8));
         VerifyOrReturn(CheckValue("nullableEnum8.Value()", nullableEnum8.Value(), 254));
@@ -38788,90 +39198,17 @@ private:
         NextTest();
     }
 
-    CHIP_ERROR TestWriteAttributeNullableEnum8NullValue_226()
+    CHIP_ERROR TestWriteAttributeNullableEnum8InvalidValue_230()
     {
         const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, endpoint);
 
         chip::app::DataModel::Nullable<uint8_t> nullableEnum8Argument;
-        nullableEnum8Argument.SetNull();
+        nullableEnum8Argument.SetNonNull() = static_cast<uint8_t>(255);
 
         return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::NullableEnum8::TypeInfo>(
-            nullableEnum8Argument, this, OnSuccessCallback_226, OnFailureCallback_226);
-    }
-
-    void OnFailureResponse_226(uint8_t status) { ThrowFailureResponse(); }
-
-    void OnSuccessResponse_226() { NextTest(); }
-
-    CHIP_ERROR TestReadAttributeNullableEnum8NullValue_227()
-    {
-        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
-        chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, endpoint);
-
-        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableEnum8::TypeInfo>(
-            this, OnSuccessCallback_227, OnFailureCallback_227);
-    }
-
-    void OnFailureResponse_227(uint8_t status) { ThrowFailureResponse(); }
-
-    void OnSuccessResponse_227(const chip::app::DataModel::Nullable<uint8_t> & nullableEnum8)
-    {
-        VerifyOrReturn(CheckValueNull("nullableEnum8", nullableEnum8));
-
-        NextTest();
-    }
-
-    CHIP_ERROR TestWriteAttributeNullableEnum16MaxValue_228()
-    {
-        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
-        chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, endpoint);
-
-        chip::app::DataModel::Nullable<uint16_t> nullableEnum16Argument;
-        nullableEnum16Argument.SetNonNull() = static_cast<uint16_t>(65534);
-
-        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::NullableEnum16::TypeInfo>(
-            nullableEnum16Argument, this, OnSuccessCallback_228, OnFailureCallback_228);
-    }
-
-    void OnFailureResponse_228(uint8_t status) { ThrowFailureResponse(); }
-
-    void OnSuccessResponse_228() { NextTest(); }
-
-    CHIP_ERROR TestReadAttributeNullableEnum16MaxValue_229()
-    {
-        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
-        chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, endpoint);
-
-        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableEnum16::TypeInfo>(
-            this, OnSuccessCallback_229, OnFailureCallback_229);
-    }
-
-    void OnFailureResponse_229(uint8_t status) { ThrowFailureResponse(); }
-
-    void OnSuccessResponse_229(const chip::app::DataModel::Nullable<uint16_t> & nullableEnum16)
-    {
-        VerifyOrReturn(CheckValueNonNull("nullableEnum16", nullableEnum16));
-        VerifyOrReturn(CheckValue("nullableEnum16.Value()", nullableEnum16.Value(), 65534U));
-
-        NextTest();
-    }
-
-    CHIP_ERROR TestWriteAttributeNullableEnum16InvalidValue_230()
-    {
-        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
-        chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, endpoint);
-
-        chip::app::DataModel::Nullable<uint16_t> nullableEnum16Argument;
-        nullableEnum16Argument.SetNonNull() = static_cast<uint16_t>(65535);
-
-        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::NullableEnum16::TypeInfo>(
-            nullableEnum16Argument, this, OnSuccessCallback_230, OnFailureCallback_230);
+            nullableEnum8Argument, this, OnSuccessCallback_230, OnFailureCallback_230);
     }
 
     void OnFailureResponse_230(uint8_t status)
@@ -38882,19 +39219,92 @@ private:
 
     void OnSuccessResponse_230() { ThrowSuccessResponse(); }
 
-    CHIP_ERROR TestReadAttributeNullableEnum16UnchangedValue_231()
+    CHIP_ERROR TestReadAttributeNullableEnum8UnchangedValue_231()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableEnum8::TypeInfo>(
+            this, OnSuccessCallback_231, OnFailureCallback_231);
+    }
+
+    void OnFailureResponse_231(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_231(const chip::app::DataModel::Nullable<uint8_t> & nullableEnum8)
+    {
+        VerifyOrReturn(CheckValueNonNull("nullableEnum8", nullableEnum8));
+        VerifyOrReturn(CheckValue("nullableEnum8.Value()", nullableEnum8.Value(), 254));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestWriteAttributeNullableEnum8NullValue_232()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        chip::app::DataModel::Nullable<uint8_t> nullableEnum8Argument;
+        nullableEnum8Argument.SetNull();
+
+        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::NullableEnum8::TypeInfo>(
+            nullableEnum8Argument, this, OnSuccessCallback_232, OnFailureCallback_232);
+    }
+
+    void OnFailureResponse_232(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_232() { NextTest(); }
+
+    CHIP_ERROR TestReadAttributeNullableEnum8NullValue_233()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableEnum8::TypeInfo>(
+            this, OnSuccessCallback_233, OnFailureCallback_233);
+    }
+
+    void OnFailureResponse_233(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_233(const chip::app::DataModel::Nullable<uint8_t> & nullableEnum8)
+    {
+        VerifyOrReturn(CheckValueNull("nullableEnum8", nullableEnum8));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestWriteAttributeNullableEnum16MaxValue_234()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        chip::app::DataModel::Nullable<uint16_t> nullableEnum16Argument;
+        nullableEnum16Argument.SetNonNull() = static_cast<uint16_t>(65534);
+
+        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::NullableEnum16::TypeInfo>(
+            nullableEnum16Argument, this, OnSuccessCallback_234, OnFailureCallback_234);
+    }
+
+    void OnFailureResponse_234(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_234() { NextTest(); }
+
+    CHIP_ERROR TestReadAttributeNullableEnum16MaxValue_235()
     {
         const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, endpoint);
 
         return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableEnum16::TypeInfo>(
-            this, OnSuccessCallback_231, OnFailureCallback_231);
+            this, OnSuccessCallback_235, OnFailureCallback_235);
     }
 
-    void OnFailureResponse_231(uint8_t status) { ThrowFailureResponse(); }
+    void OnFailureResponse_235(uint8_t status) { ThrowFailureResponse(); }
 
-    void OnSuccessResponse_231(const chip::app::DataModel::Nullable<uint16_t> & nullableEnum16)
+    void OnSuccessResponse_235(const chip::app::DataModel::Nullable<uint16_t> & nullableEnum16)
     {
         VerifyOrReturn(CheckValueNonNull("nullableEnum16", nullableEnum16));
         VerifyOrReturn(CheckValue("nullableEnum16.Value()", nullableEnum16.Value(), 65534U));
@@ -38902,7 +39312,48 @@ private:
         NextTest();
     }
 
-    CHIP_ERROR TestWriteAttributeNullableEnum16NullValue_232()
+    CHIP_ERROR TestWriteAttributeNullableEnum16InvalidValue_236()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        chip::app::DataModel::Nullable<uint16_t> nullableEnum16Argument;
+        nullableEnum16Argument.SetNonNull() = static_cast<uint16_t>(65535);
+
+        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::NullableEnum16::TypeInfo>(
+            nullableEnum16Argument, this, OnSuccessCallback_236, OnFailureCallback_236);
+    }
+
+    void OnFailureResponse_236(uint8_t status)
+    {
+        VerifyOrReturn(CheckValue("status", status, 135));
+        NextTest();
+    }
+
+    void OnSuccessResponse_236() { ThrowSuccessResponse(); }
+
+    CHIP_ERROR TestReadAttributeNullableEnum16UnchangedValue_237()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableEnum16::TypeInfo>(
+            this, OnSuccessCallback_237, OnFailureCallback_237);
+    }
+
+    void OnFailureResponse_237(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_237(const chip::app::DataModel::Nullable<uint16_t> & nullableEnum16)
+    {
+        VerifyOrReturn(CheckValueNonNull("nullableEnum16", nullableEnum16));
+        VerifyOrReturn(CheckValue("nullableEnum16.Value()", nullableEnum16.Value(), 65534U));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestWriteAttributeNullableEnum16NullValue_238()
     {
         const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
@@ -38912,147 +39363,33 @@ private:
         nullableEnum16Argument.SetNull();
 
         return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::NullableEnum16::TypeInfo>(
-            nullableEnum16Argument, this, OnSuccessCallback_232, OnFailureCallback_232);
+            nullableEnum16Argument, this, OnSuccessCallback_238, OnFailureCallback_238);
     }
 
-    void OnFailureResponse_232(uint8_t status) { ThrowFailureResponse(); }
+    void OnFailureResponse_238(uint8_t status) { ThrowFailureResponse(); }
 
-    void OnSuccessResponse_232() { NextTest(); }
+    void OnSuccessResponse_238() { NextTest(); }
 
-    CHIP_ERROR TestReadAttributeNullableEnum16NullValue_233()
+    CHIP_ERROR TestReadAttributeNullableEnum16NullValue_239()
     {
         const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, endpoint);
 
         return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableEnum16::TypeInfo>(
-            this, OnSuccessCallback_233, OnFailureCallback_233);
+            this, OnSuccessCallback_239, OnFailureCallback_239);
     }
 
-    void OnFailureResponse_233(uint8_t status) { ThrowFailureResponse(); }
+    void OnFailureResponse_239(uint8_t status) { ThrowFailureResponse(); }
 
-    void OnSuccessResponse_233(const chip::app::DataModel::Nullable<uint16_t> & nullableEnum16)
+    void OnSuccessResponse_239(const chip::app::DataModel::Nullable<uint16_t> & nullableEnum16)
     {
         VerifyOrReturn(CheckValueNull("nullableEnum16", nullableEnum16));
 
         NextTest();
     }
 
-    CHIP_ERROR TestReadAttributeNullableOctetStringDefaultValue_234()
-    {
-        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
-        chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, endpoint);
-
-        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableOctetString::TypeInfo>(
-            this, OnSuccessCallback_234, OnFailureCallback_234);
-    }
-
-    void OnFailureResponse_234(uint8_t status) { ThrowFailureResponse(); }
-
-    void OnSuccessResponse_234(const chip::app::DataModel::Nullable<chip::ByteSpan> & nullableOctetString)
-    {
-        VerifyOrReturn(CheckValueNonNull("nullableOctetString", nullableOctetString));
-        VerifyOrReturn(CheckValueAsString("nullableOctetString.Value()", nullableOctetString.Value(),
-                                          chip::ByteSpan(chip::Uint8::from_const_char(""), 0)));
-
-        NextTest();
-    }
-
-    CHIP_ERROR TestWriteAttributeNullableOctetString_235()
-    {
-        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
-        chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, endpoint);
-
-        chip::app::DataModel::Nullable<chip::ByteSpan> nullableOctetStringArgument;
-        nullableOctetStringArgument.SetNonNull() =
-            chip::ByteSpan(chip::Uint8::from_const_char("TestValuegarbage: not in length on purpose"), 9);
-
-        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::NullableOctetString::TypeInfo>(
-            nullableOctetStringArgument, this, OnSuccessCallback_235, OnFailureCallback_235);
-    }
-
-    void OnFailureResponse_235(uint8_t status) { ThrowFailureResponse(); }
-
-    void OnSuccessResponse_235() { NextTest(); }
-
-    CHIP_ERROR TestReadAttributeNullableOctetString_236()
-    {
-        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
-        chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, endpoint);
-
-        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableOctetString::TypeInfo>(
-            this, OnSuccessCallback_236, OnFailureCallback_236);
-    }
-
-    void OnFailureResponse_236(uint8_t status) { ThrowFailureResponse(); }
-
-    void OnSuccessResponse_236(const chip::app::DataModel::Nullable<chip::ByteSpan> & nullableOctetString)
-    {
-        VerifyOrReturn(CheckValueNonNull("nullableOctetString", nullableOctetString));
-        VerifyOrReturn(CheckValueAsString("nullableOctetString.Value()", nullableOctetString.Value(),
-                                          chip::ByteSpan(chip::Uint8::from_const_char("TestValue"), 9)));
-
-        NextTest();
-    }
-
-    CHIP_ERROR TestWriteAttributeNullableOctetString_237()
-    {
-        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
-        chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, endpoint);
-
-        chip::app::DataModel::Nullable<chip::ByteSpan> nullableOctetStringArgument;
-        nullableOctetStringArgument.SetNull();
-
-        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::NullableOctetString::TypeInfo>(
-            nullableOctetStringArgument, this, OnSuccessCallback_237, OnFailureCallback_237);
-    }
-
-    void OnFailureResponse_237(uint8_t status) { ThrowFailureResponse(); }
-
-    void OnSuccessResponse_237() { NextTest(); }
-
-    CHIP_ERROR TestReadAttributeNullableOctetString_238()
-    {
-        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
-        chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, endpoint);
-
-        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableOctetString::TypeInfo>(
-            this, OnSuccessCallback_238, OnFailureCallback_238);
-    }
-
-    void OnFailureResponse_238(uint8_t status) { ThrowFailureResponse(); }
-
-    void OnSuccessResponse_238(const chip::app::DataModel::Nullable<chip::ByteSpan> & nullableOctetString)
-    {
-        VerifyOrReturn(CheckValueNull("nullableOctetString", nullableOctetString));
-
-        NextTest();
-    }
-
-    CHIP_ERROR TestWriteAttributeNullableOctetString_239()
-    {
-        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
-        chip::Controller::TestClusterClusterTest cluster;
-        cluster.Associate(mDevice, endpoint);
-
-        chip::app::DataModel::Nullable<chip::ByteSpan> nullableOctetStringArgument;
-        nullableOctetStringArgument.SetNonNull() =
-            chip::ByteSpan(chip::Uint8::from_const_char("garbage: not in length on purpose"), 0);
-
-        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::NullableOctetString::TypeInfo>(
-            nullableOctetStringArgument, this, OnSuccessCallback_239, OnFailureCallback_239);
-    }
-
-    void OnFailureResponse_239(uint8_t status) { ThrowFailureResponse(); }
-
-    void OnSuccessResponse_239() { NextTest(); }
-
-    CHIP_ERROR TestReadAttributeNullableOctetString_240()
+    CHIP_ERROR TestReadAttributeNullableOctetStringDefaultValue_240()
     {
         const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
@@ -39073,19 +39410,133 @@ private:
         NextTest();
     }
 
-    CHIP_ERROR TestReadAttributeNullableCharStringDefaultValue_241()
+    CHIP_ERROR TestWriteAttributeNullableOctetString_241()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        chip::app::DataModel::Nullable<chip::ByteSpan> nullableOctetStringArgument;
+        nullableOctetStringArgument.SetNonNull() =
+            chip::ByteSpan(chip::Uint8::from_const_char("TestValuegarbage: not in length on purpose"), 9);
+
+        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::NullableOctetString::TypeInfo>(
+            nullableOctetStringArgument, this, OnSuccessCallback_241, OnFailureCallback_241);
+    }
+
+    void OnFailureResponse_241(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_241() { NextTest(); }
+
+    CHIP_ERROR TestReadAttributeNullableOctetString_242()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableOctetString::TypeInfo>(
+            this, OnSuccessCallback_242, OnFailureCallback_242);
+    }
+
+    void OnFailureResponse_242(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_242(const chip::app::DataModel::Nullable<chip::ByteSpan> & nullableOctetString)
+    {
+        VerifyOrReturn(CheckValueNonNull("nullableOctetString", nullableOctetString));
+        VerifyOrReturn(CheckValueAsString("nullableOctetString.Value()", nullableOctetString.Value(),
+                                          chip::ByteSpan(chip::Uint8::from_const_char("TestValue"), 9)));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestWriteAttributeNullableOctetString_243()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        chip::app::DataModel::Nullable<chip::ByteSpan> nullableOctetStringArgument;
+        nullableOctetStringArgument.SetNull();
+
+        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::NullableOctetString::TypeInfo>(
+            nullableOctetStringArgument, this, OnSuccessCallback_243, OnFailureCallback_243);
+    }
+
+    void OnFailureResponse_243(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_243() { NextTest(); }
+
+    CHIP_ERROR TestReadAttributeNullableOctetString_244()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableOctetString::TypeInfo>(
+            this, OnSuccessCallback_244, OnFailureCallback_244);
+    }
+
+    void OnFailureResponse_244(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_244(const chip::app::DataModel::Nullable<chip::ByteSpan> & nullableOctetString)
+    {
+        VerifyOrReturn(CheckValueNull("nullableOctetString", nullableOctetString));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestWriteAttributeNullableOctetString_245()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        chip::app::DataModel::Nullable<chip::ByteSpan> nullableOctetStringArgument;
+        nullableOctetStringArgument.SetNonNull() =
+            chip::ByteSpan(chip::Uint8::from_const_char("garbage: not in length on purpose"), 0);
+
+        return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::NullableOctetString::TypeInfo>(
+            nullableOctetStringArgument, this, OnSuccessCallback_245, OnFailureCallback_245);
+    }
+
+    void OnFailureResponse_245(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_245() { NextTest(); }
+
+    CHIP_ERROR TestReadAttributeNullableOctetString_246()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableOctetString::TypeInfo>(
+            this, OnSuccessCallback_246, OnFailureCallback_246);
+    }
+
+    void OnFailureResponse_246(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_246(const chip::app::DataModel::Nullable<chip::ByteSpan> & nullableOctetString)
+    {
+        VerifyOrReturn(CheckValueNonNull("nullableOctetString", nullableOctetString));
+        VerifyOrReturn(CheckValueAsString("nullableOctetString.Value()", nullableOctetString.Value(),
+                                          chip::ByteSpan(chip::Uint8::from_const_char(""), 0)));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestReadAttributeNullableCharStringDefaultValue_247()
     {
         const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, endpoint);
 
         return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableCharString::TypeInfo>(
-            this, OnSuccessCallback_241, OnFailureCallback_241);
+            this, OnSuccessCallback_247, OnFailureCallback_247);
     }
 
-    void OnFailureResponse_241(uint8_t status) { ThrowFailureResponse(); }
+    void OnFailureResponse_247(uint8_t status) { ThrowFailureResponse(); }
 
-    void OnSuccessResponse_241(const chip::app::DataModel::Nullable<chip::CharSpan> & nullableCharString)
+    void OnSuccessResponse_247(const chip::app::DataModel::Nullable<chip::CharSpan> & nullableCharString)
     {
         VerifyOrReturn(CheckValueNonNull("nullableCharString", nullableCharString));
         VerifyOrReturn(CheckValueAsString("nullableCharString.Value()", nullableCharString.Value(), chip::CharSpan("", 0)));
@@ -39093,7 +39544,7 @@ private:
         NextTest();
     }
 
-    CHIP_ERROR TestWriteAttributeNullableCharString_242()
+    CHIP_ERROR TestWriteAttributeNullableCharString_248()
     {
         const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
@@ -39103,14 +39554,34 @@ private:
         nullableCharStringArgument.SetNonNull() = chip::Span<const char>("☉T☉garbage: not in length on purpose", 7);
 
         return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::NullableCharString::TypeInfo>(
-            nullableCharStringArgument, this, OnSuccessCallback_242, OnFailureCallback_242);
+            nullableCharStringArgument, this, OnSuccessCallback_248, OnFailureCallback_248);
     }
 
-    void OnFailureResponse_242(uint8_t status) { ThrowFailureResponse(); }
+    void OnFailureResponse_248(uint8_t status) { ThrowFailureResponse(); }
 
-    void OnSuccessResponse_242() { NextTest(); }
+    void OnSuccessResponse_248() { NextTest(); }
 
-    CHIP_ERROR TestWriteAttributeNullableCharStringValueTooLong_243()
+    CHIP_ERROR TestReadAttributeNullableCharString_249()
+    {
+        const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
+        chip::Controller::TestClusterClusterTest cluster;
+        cluster.Associate(mDevice, endpoint);
+
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableCharString::TypeInfo>(
+            this, OnSuccessCallback_249, OnFailureCallback_249);
+    }
+
+    void OnFailureResponse_249(uint8_t status) { ThrowFailureResponse(); }
+
+    void OnSuccessResponse_249(const chip::app::DataModel::Nullable<chip::CharSpan> & nullableCharString)
+    {
+        VerifyOrReturn(CheckValueNonNull("nullableCharString", nullableCharString));
+        VerifyOrReturn(CheckValueAsString("nullableCharString.Value()", nullableCharString.Value(), chip::CharSpan("☉T☉", 7)));
+
+        NextTest();
+    }
+
+    CHIP_ERROR TestWriteAttributeNullableCharStringValueTooLong_250()
     {
         const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
@@ -39120,33 +39591,33 @@ private:
         nullableCharStringArgument.SetNull();
 
         return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::NullableCharString::TypeInfo>(
-            nullableCharStringArgument, this, OnSuccessCallback_243, OnFailureCallback_243);
+            nullableCharStringArgument, this, OnSuccessCallback_250, OnFailureCallback_250);
     }
 
-    void OnFailureResponse_243(uint8_t status) { ThrowFailureResponse(); }
+    void OnFailureResponse_250(uint8_t status) { ThrowFailureResponse(); }
 
-    void OnSuccessResponse_243() { NextTest(); }
+    void OnSuccessResponse_250() { NextTest(); }
 
-    CHIP_ERROR TestReadAttributeNullableCharString_244()
+    CHIP_ERROR TestReadAttributeNullableCharString_251()
     {
         const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, endpoint);
 
         return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableCharString::TypeInfo>(
-            this, OnSuccessCallback_244, OnFailureCallback_244);
+            this, OnSuccessCallback_251, OnFailureCallback_251);
     }
 
-    void OnFailureResponse_244(uint8_t status) { ThrowFailureResponse(); }
+    void OnFailureResponse_251(uint8_t status) { ThrowFailureResponse(); }
 
-    void OnSuccessResponse_244(const chip::app::DataModel::Nullable<chip::CharSpan> & nullableCharString)
+    void OnSuccessResponse_251(const chip::app::DataModel::Nullable<chip::CharSpan> & nullableCharString)
     {
         VerifyOrReturn(CheckValueNull("nullableCharString", nullableCharString));
 
         NextTest();
     }
 
-    CHIP_ERROR TestWriteAttributeNullableCharStringEmpty_245()
+    CHIP_ERROR TestWriteAttributeNullableCharStringEmpty_252()
     {
         const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
@@ -39156,26 +39627,26 @@ private:
         nullableCharStringArgument.SetNonNull() = chip::Span<const char>("garbage: not in length on purpose", 0);
 
         return cluster.WriteAttribute<chip::app::Clusters::TestCluster::Attributes::NullableCharString::TypeInfo>(
-            nullableCharStringArgument, this, OnSuccessCallback_245, OnFailureCallback_245);
+            nullableCharStringArgument, this, OnSuccessCallback_252, OnFailureCallback_252);
     }
 
-    void OnFailureResponse_245(uint8_t status) { ThrowFailureResponse(); }
+    void OnFailureResponse_252(uint8_t status) { ThrowFailureResponse(); }
 
-    void OnSuccessResponse_245() { NextTest(); }
+    void OnSuccessResponse_252() { NextTest(); }
 
-    CHIP_ERROR TestReadAttributeNullableCharString_246()
+    CHIP_ERROR TestReadAttributeNullableCharString_253()
     {
         const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 1;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, endpoint);
 
         return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::NullableCharString::TypeInfo>(
-            this, OnSuccessCallback_246, OnFailureCallback_246);
+            this, OnSuccessCallback_253, OnFailureCallback_253);
     }
 
-    void OnFailureResponse_246(uint8_t status) { ThrowFailureResponse(); }
+    void OnFailureResponse_253(uint8_t status) { ThrowFailureResponse(); }
 
-    void OnSuccessResponse_246(const chip::app::DataModel::Nullable<chip::CharSpan> & nullableCharString)
+    void OnSuccessResponse_253(const chip::app::DataModel::Nullable<chip::CharSpan> & nullableCharString)
     {
         VerifyOrReturn(CheckValueNonNull("nullableCharString", nullableCharString));
         VerifyOrReturn(CheckValueAsString("nullableCharString.Value()", nullableCharString.Value(), chip::CharSpan("", 0)));
@@ -39183,41 +39654,41 @@ private:
         NextTest();
     }
 
-    CHIP_ERROR TestReadAttributeFromNonexistentEndpoint_247()
+    CHIP_ERROR TestReadAttributeFromNonexistentEndpoint_254()
     {
         const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 200;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, endpoint);
 
-        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::ListInt8u::TypeInfo>(this, OnSuccessCallback_247,
-                                                                                                        OnFailureCallback_247);
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::ListInt8u::TypeInfo>(this, OnSuccessCallback_254,
+                                                                                                        OnFailureCallback_254);
     }
 
-    void OnFailureResponse_247(uint8_t status)
+    void OnFailureResponse_254(uint8_t status)
     {
         VerifyOrReturn(CheckConstraintNotValue("status", status, 0));
         NextTest();
     }
 
-    void OnSuccessResponse_247(const chip::app::DataModel::DecodableList<uint8_t> & listInt8u) { ThrowSuccessResponse(); }
+    void OnSuccessResponse_254(const chip::app::DataModel::DecodableList<uint8_t> & listInt8u) { ThrowSuccessResponse(); }
 
-    CHIP_ERROR TestReadAttributeFromNonexistentCluster_248()
+    CHIP_ERROR TestReadAttributeFromNonexistentCluster_255()
     {
         const chip::EndpointId endpoint = mEndpointId.HasValue() ? mEndpointId.Value() : 0;
         chip::Controller::TestClusterClusterTest cluster;
         cluster.Associate(mDevice, endpoint);
 
-        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::ListInt8u::TypeInfo>(this, OnSuccessCallback_248,
-                                                                                                        OnFailureCallback_248);
+        return cluster.ReadAttribute<chip::app::Clusters::TestCluster::Attributes::ListInt8u::TypeInfo>(this, OnSuccessCallback_255,
+                                                                                                        OnFailureCallback_255);
     }
 
-    void OnFailureResponse_248(uint8_t status)
+    void OnFailureResponse_255(uint8_t status)
     {
         VerifyOrReturn(CheckConstraintNotValue("status", status, 0));
         NextTest();
     }
 
-    void OnSuccessResponse_248(const chip::app::DataModel::DecodableList<uint8_t> & listInt8u) { ThrowSuccessResponse(); }
+    void OnSuccessResponse_255(const chip::app::DataModel::DecodableList<uint8_t> & listInt8u) { ThrowSuccessResponse(); }
 };
 
 class TestClusterComplexTypes : public TestCommand

--- a/zzz_generated/controller-clusters/zap-generated/CHIPClusters.cpp
+++ b/zzz_generated/controller-clusters/zap-generated/CHIPClusters.cpp
@@ -15930,6 +15930,57 @@ exit:
     return err;
 }
 
+CHIP_ERROR TestClusterCluster::TestListNestedStructListArgumentRequest(Callback::Cancelable * onSuccessCallback,
+                                                                       Callback::Cancelable * onFailureCallback, uint8_t a, bool b,
+                                                                       uint32_t e, chip::ByteSpan f, uint8_t g)
+{
+    CHIP_ERROR err          = CHIP_NO_ERROR;
+    TLV::TLVWriter * writer = nullptr;
+    uint8_t argSeqNumber    = 0;
+
+    // Used when encoding non-empty command. Suppress error message when encoding empty commands.
+    (void) writer;
+    (void) argSeqNumber;
+
+    VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
+
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId,
+                                         TestCluster::Commands::TestListNestedStructListArgumentRequest::Id,
+                                         (app::CommandPathFlags::kEndpointIdValid) };
+
+    CommandSenderHandle sender(
+        Platform::New<app::CommandSender>(mDevice->GetInteractionModelDelegate(), mDevice->GetExchangeManager()));
+
+    VerifyOrReturnError(sender != nullptr, CHIP_ERROR_NO_MEMORY);
+
+    SuccessOrExit(err = sender->PrepareCommand(cmdParams));
+
+    VerifyOrExit((writer = sender->GetCommandDataIBTLVWriter()) != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
+    // a: int8u
+    SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), a));
+    // b: boolean
+    SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), b));
+    // e: int32u
+    SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), e));
+    // f: octetString
+    SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), f));
+    // g: int8u
+    SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), g));
+
+    SuccessOrExit(err = sender->FinishCommand());
+
+    // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
+    mDevice->AddIMResponseHandler(sender.get(), onSuccessCallback, onFailureCallback);
+
+    SuccessOrExit(err = mDevice->SendCommands(sender.get()));
+
+    // We have successfully sent the command, and the callback handler will be responsible to free the object, release the object
+    // now.
+    sender.release();
+exit:
+    return err;
+}
+
 CHIP_ERROR TestClusterCluster::TestListStructArgumentRequest(Callback::Cancelable * onSuccessCallback,
                                                              Callback::Cancelable * onFailureCallback, uint8_t a, bool b, uint8_t c,
                                                              chip::ByteSpan d, chip::CharSpan e, uint8_t f, float g, double h)
@@ -15972,6 +16023,101 @@ CHIP_ERROR TestClusterCluster::TestListStructArgumentRequest(Callback::Cancelabl
     SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), g));
     // h: double
     SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), h));
+
+    SuccessOrExit(err = sender->FinishCommand());
+
+    // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
+    mDevice->AddIMResponseHandler(sender.get(), onSuccessCallback, onFailureCallback);
+
+    SuccessOrExit(err = mDevice->SendCommands(sender.get()));
+
+    // We have successfully sent the command, and the callback handler will be responsible to free the object, release the object
+    // now.
+    sender.release();
+exit:
+    return err;
+}
+
+CHIP_ERROR TestClusterCluster::TestNestedStructArgumentRequest(Callback::Cancelable * onSuccessCallback,
+                                                               Callback::Cancelable * onFailureCallback, uint8_t a, bool b)
+{
+    CHIP_ERROR err          = CHIP_NO_ERROR;
+    TLV::TLVWriter * writer = nullptr;
+    uint8_t argSeqNumber    = 0;
+
+    // Used when encoding non-empty command. Suppress error message when encoding empty commands.
+    (void) writer;
+    (void) argSeqNumber;
+
+    VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
+
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId,
+                                         TestCluster::Commands::TestNestedStructArgumentRequest::Id,
+                                         (app::CommandPathFlags::kEndpointIdValid) };
+
+    CommandSenderHandle sender(
+        Platform::New<app::CommandSender>(mDevice->GetInteractionModelDelegate(), mDevice->GetExchangeManager()));
+
+    VerifyOrReturnError(sender != nullptr, CHIP_ERROR_NO_MEMORY);
+
+    SuccessOrExit(err = sender->PrepareCommand(cmdParams));
+
+    VerifyOrExit((writer = sender->GetCommandDataIBTLVWriter()) != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
+    // a: int8u
+    SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), a));
+    // b: boolean
+    SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), b));
+
+    SuccessOrExit(err = sender->FinishCommand());
+
+    // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
+    mDevice->AddIMResponseHandler(sender.get(), onSuccessCallback, onFailureCallback);
+
+    SuccessOrExit(err = mDevice->SendCommands(sender.get()));
+
+    // We have successfully sent the command, and the callback handler will be responsible to free the object, release the object
+    // now.
+    sender.release();
+exit:
+    return err;
+}
+
+CHIP_ERROR TestClusterCluster::TestNestedStructListArgumentRequest(Callback::Cancelable * onSuccessCallback,
+                                                                   Callback::Cancelable * onFailureCallback, uint8_t a, bool b,
+                                                                   uint32_t e, chip::ByteSpan f, uint8_t g)
+{
+    CHIP_ERROR err          = CHIP_NO_ERROR;
+    TLV::TLVWriter * writer = nullptr;
+    uint8_t argSeqNumber    = 0;
+
+    // Used when encoding non-empty command. Suppress error message when encoding empty commands.
+    (void) writer;
+    (void) argSeqNumber;
+
+    VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
+
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId,
+                                         TestCluster::Commands::TestNestedStructListArgumentRequest::Id,
+                                         (app::CommandPathFlags::kEndpointIdValid) };
+
+    CommandSenderHandle sender(
+        Platform::New<app::CommandSender>(mDevice->GetInteractionModelDelegate(), mDevice->GetExchangeManager()));
+
+    VerifyOrReturnError(sender != nullptr, CHIP_ERROR_NO_MEMORY);
+
+    SuccessOrExit(err = sender->PrepareCommand(cmdParams));
+
+    VerifyOrExit((writer = sender->GetCommandDataIBTLVWriter()) != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
+    // a: int8u
+    SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), a));
+    // b: boolean
+    SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), b));
+    // e: int32u
+    SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), e));
+    // f: octetString
+    SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), f));
+    // g: int8u
+    SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), g));
 
     SuccessOrExit(err = sender->FinishCommand());
 

--- a/zzz_generated/controller-clusters/zap-generated/CHIPClusters.h
+++ b/zzz_generated/controller-clusters/zap-generated/CHIPClusters.h
@@ -2285,9 +2285,17 @@ public:
                                             uint8_t arg1);
     CHIP_ERROR TestListInt8UReverseRequest(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                            uint8_t arg1);
+    CHIP_ERROR TestListNestedStructListArgumentRequest(Callback::Cancelable * onSuccessCallback,
+                                                       Callback::Cancelable * onFailureCallback, uint8_t a, bool b, uint32_t e,
+                                                       chip::ByteSpan f, uint8_t g);
     CHIP_ERROR TestListStructArgumentRequest(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                              uint8_t a, bool b, uint8_t c, chip::ByteSpan d, chip::CharSpan e, uint8_t f, float g,
                                              double h);
+    CHIP_ERROR TestNestedStructArgumentRequest(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
+                                               uint8_t a, bool b);
+    CHIP_ERROR TestNestedStructListArgumentRequest(Callback::Cancelable * onSuccessCallback,
+                                                   Callback::Cancelable * onFailureCallback, uint8_t a, bool b, uint32_t e,
+                                                   chip::ByteSpan f, uint8_t g);
     CHIP_ERROR TestNotHandled(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR TestNullableOptionalRequest(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                            uint8_t arg1);


### PR DESCRIPTION
Codegen fixes are as follows:

* CHIPClusters: just skip structs-inside-structs as command arguments.
  This is pretty much dead code anyway, that is close to being
  removed, and existing uses of it don't involve such arguments.

* java: skip structs-inside-structs inside command arguments for now, so codegen does not fail.

* darwin: fix shadowing problems in handling of
  lists-inside-structs-indside-lists.

#### Problem
Tests are disabled.

#### Change overview
Enable them.

#### Testing
Ran the tests locally and in my fork's CI.