### PR TITLE
Fix short code on dnssd advertising and chip-tool

### DIFF
--- a/src/app/server/Dnssd.cpp
+++ b/src/app/server/Dnssd.cpp
@@ -320,7 +320,7 @@ CHIP_ERROR DnssdServer::Advertise(bool commissionableNode, chip::Dnssd::Commissi
         ChipLogError(Discovery, "Setup discriminator not known. Using a default.");
         value = 840;
     }
-    advertiseParameters.SetShortDiscriminator(static_cast<uint8_t>((value >> 8) & 0xFF)).SetLongDiscriminator(value);
+    advertiseParameters.SetShortDiscriminator(static_cast<uint8_t>((value >> 8) & 0x0F)).SetLongDiscriminator(value);
 
     if (DeviceLayer::ConfigurationMgr().IsCommissionableDeviceTypeEnabled() &&
         DeviceLayer::ConfigurationMgr().GetDeviceTypeId(value) == CHIP_NO_ERROR)

--- a/src/app/server/Dnssd.cpp
+++ b/src/app/server/Dnssd.cpp
@@ -320,7 +320,7 @@ CHIP_ERROR DnssdServer::Advertise(bool commissionableNode, chip::Dnssd::Commissi
         ChipLogError(Discovery, "Setup discriminator not known. Using a default.");
         value = 840;
     }
-    advertiseParameters.SetShortDiscriminator(static_cast<uint8_t>(value & 0xFF)).SetLongDiscriminator(value);
+    advertiseParameters.SetShortDiscriminator(static_cast<uint8_t>((value >> 8) & 0xFF)).SetLongDiscriminator(value);
 
     if (DeviceLayer::ConfigurationMgr().IsCommissionableDeviceTypeEnabled() &&
         DeviceLayer::ConfigurationMgr().GetDeviceTypeId(value) == CHIP_NO_ERROR)

--- a/src/controller/SetUpCodePairer.cpp
+++ b/src/controller/SetUpCodePairer.cpp
@@ -65,7 +65,7 @@ CHIP_ERROR SetUpCodePairer::Connect(RendezvousInformationFlag rendezvousInformat
     if (searchOverAll || rendezvousInformation == RendezvousInformationFlag::kOnNetwork)
     {
         if (CHIP_NO_ERROR ==
-            (err = StartDiscoverOverIP(isShort ? static_cast<uint16_t>(discriminator >> 8) : discriminator, isShort)))
+            (err = StartDiscoverOverIP(isShort ? static_cast<uint16_t>((discriminator >> 8) & 0x0F) : discriminator, isShort)))
         {
             isRunning = true;
         }

--- a/src/controller/SetUpCodePairer.cpp
+++ b/src/controller/SetUpCodePairer.cpp
@@ -64,7 +64,8 @@ CHIP_ERROR SetUpCodePairer::Connect(RendezvousInformationFlag rendezvousInformat
 
     if (searchOverAll || rendezvousInformation == RendezvousInformationFlag::kOnNetwork)
     {
-        if (CHIP_NO_ERROR == (err = StartDiscoverOverIP(discriminator, isShort)))
+        if (CHIP_NO_ERROR ==
+            (err = StartDiscoverOverIP(isShort ? static_cast<uint16_t>(discriminator >> 8) : discriminator, isShort)))
         {
             isRunning = true;
         }


### PR DESCRIPTION
#### Problem
Short code is incorrect in chip-tool and in the advertisement.The short discriminator is stored the UPPER four bits of the discriminator when the code is parsed.

#### Change overview
Uses upper 4 bits of discriminator for short code in chip-tool and dnssd advertisement.

#### Testing
Manual code pairing chip-tool  -> IP lighting app.