### PR TITLE
SetUpCodePairer: don't use DeviceDiscoveryDelegate

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1608,18 +1608,22 @@ void DeviceCommissioner::OnUserDirectedCommissioningRequest(UDCClientState state
 
     ChipLogDetail(Controller, "------To Accept Enter: discover udc-commission <pincode> <udc-client-index>");
 }
+#endif // CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY
+
+#if CHIP_DEVICE_CONFIG_ENABLE_DNSSD
 
 void DeviceCommissioner::OnNodeDiscoveryComplete(const chip::Dnssd::DiscoveredNodeData & nodeData)
 {
+#if CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY
     if (mUdcServer != nullptr)
     {
         mUdcServer->OnCommissionableNodeFound(nodeData);
     }
-
-    AbstractDnssdDiscoveryController::OnNodeDiscoveryComplete(nodeData);
-}
-
 #endif // CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY
+    AbstractDnssdDiscoveryController::OnNodeDiscoveryComplete(nodeData);
+    mSetUpCodePairer.NotifyCommissionableDeviceDiscovered(nodeData);
+}
+#endif // CHIP_DEVICE_CONFIG_ENABLE_DNSSD
 
 void BasicSuccess(void * context, uint16_t val)
 {

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -635,6 +635,7 @@ public:
     UserDirectedCommissioningServer * GetUserDirectedCommissioningServer() { return mUdcServer; }
 #endif // CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY
 
+#if CHIP_DEVICE_CONFIG_ENABLE_DNSSD
     /**
      * @brief
      *   Overrides method from AbstractDnssdDiscoveryController
@@ -643,6 +644,7 @@ public:
      *
      */
     void OnNodeDiscoveryComplete(const chip::Dnssd::DiscoveredNodeData & nodeData) override;
+#endif
 
     void RegisterPairingDelegate(DevicePairingDelegate * pairingDelegate) { mPairingDelegate = pairingDelegate; }
 

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -629,20 +629,20 @@ public:
 
     /**
      * @brief
+     *   Return the UDC Server instance
+     *
+     */
+    UserDirectedCommissioningServer * GetUserDirectedCommissioningServer() { return mUdcServer; }
+#endif // CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY
+
+    /**
+     * @brief
      *   Overrides method from AbstractDnssdDiscoveryController
      *
      * @param nodeData DNS-SD node information
      *
      */
     void OnNodeDiscoveryComplete(const chip::Dnssd::DiscoveredNodeData & nodeData) override;
-
-    /**
-     * @brief
-     *   Return the UDC Server instance
-     *
-     */
-    UserDirectedCommissioningServer * GetUserDirectedCommissioningServer() { return mUdcServer; }
-#endif // CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY
 
     void RegisterPairingDelegate(DevicePairingDelegate * pairingDelegate) { mPairingDelegate = pairingDelegate; }
 

--- a/src/controller/SetUpCodePairer.cpp
+++ b/src/controller/SetUpCodePairer.cpp
@@ -168,23 +168,15 @@ bool SetUpCodePairer::NodeMatchesCurrentFilter(const Dnssd::DiscoveredNodeData &
     switch (currentFilter.type)
     {
     case Dnssd::DiscoveryFilterType::kShort:
-        return (nodeData.longDiscriminator >> 8) == currentFilter.code;
+        return ((nodeData.longDiscriminator >> 8) & 0x0F) == currentFilter.code;
     case Dnssd::DiscoveryFilterType::kLong:
         return nodeData.longDiscriminator == currentFilter.code;
-    case Dnssd::DiscoveryFilterType::kVendor:
-        return nodeData.vendorId == currentFilter.code;
-    case Dnssd::DiscoveryFilterType::kDeviceType:
-        return nodeData.deviceType == currentFilter.code;
-    case Dnssd::DiscoveryFilterType::kCommissioningMode:
-        return nodeData.commissioningMode == currentFilter.code;
-    case Dnssd::DiscoveryFilterType::kNone:
-    case Dnssd::DiscoveryFilterType::kInstanceName:
-    case Dnssd::DiscoveryFilterType::kCommissioner:
-    case Dnssd::DiscoveryFilterType::kCompressedFabricId:
+    default:
         return false;
     }
     return false;
 }
+
 void SetUpCodePairer::NotifyCommissionableDeviceDiscovered(const Dnssd::DiscoveredNodeData & nodeData)
 {
     if (!NodeMatchesCurrentFilter(nodeData))

--- a/src/controller/SetUpCodePairer.cpp
+++ b/src/controller/SetUpCodePairer.cpp
@@ -108,9 +108,9 @@ CHIP_ERROR SetUpCodePairer::StopConnectOverBle()
 CHIP_ERROR SetUpCodePairer::StartDiscoverOverIP(uint16_t discriminator, bool isShort)
 {
 #if CHIP_DEVICE_CONFIG_ENABLE_DNSSD
-    mCommissioner->RegisterDeviceDiscoveryDelegate(this);
-    Dnssd::DiscoveryFilter filter(isShort ? Dnssd::DiscoveryFilterType::kShort : Dnssd::DiscoveryFilterType::kLong, discriminator);
-    return mCommissioner->DiscoverCommissionableNodes(filter);
+    currentFilter.type = isShort ? Dnssd::DiscoveryFilterType::kShort : Dnssd::DiscoveryFilterType::kLong;
+    currentFilter.code = discriminator;
+    return mCommissioner->DiscoverCommissionableNodes(currentFilter);
 #else
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 #endif // CHIP_DEVICE_CONFIG_ENABLE_DNSSD
@@ -119,7 +119,7 @@ CHIP_ERROR SetUpCodePairer::StartDiscoverOverIP(uint16_t discriminator, bool isS
 CHIP_ERROR SetUpCodePairer::StopConnectOverIP()
 {
 #if CHIP_DEVICE_CONFIG_ENABLE_DNSSD
-    mCommissioner->RegisterDeviceDiscoveryDelegate(nullptr);
+    currentFilter.type = Dnssd::DiscoveryFilterType::kNone;
 #endif // CHIP_DEVICE_CONFIG_ENABLE_DNSSD
     return CHIP_NO_ERROR;
 }
@@ -162,8 +162,35 @@ void SetUpCodePairer::OnDiscoveredDeviceOverBleError(void * appState, CHIP_ERROR
 #endif // CONFIG_NETWORK_LAYER_BLE
 
 #if CHIP_DEVICE_CONFIG_ENABLE_DNSSD
-void SetUpCodePairer::OnDiscoveredDevice(const Dnssd::DiscoveredNodeData & nodeData)
+
+bool SetUpCodePairer::NodeMatchesCurrentFilter(const Dnssd::DiscoveredNodeData & nodeData)
 {
+    switch (currentFilter.type)
+    {
+    case Dnssd::DiscoveryFilterType::kShort:
+        return (nodeData.longDiscriminator >> 8) == currentFilter.code;
+    case Dnssd::DiscoveryFilterType::kLong:
+        return nodeData.longDiscriminator == currentFilter.code;
+    case Dnssd::DiscoveryFilterType::kVendor:
+        return nodeData.vendorId == currentFilter.code;
+    case Dnssd::DiscoveryFilterType::kDeviceType:
+        return nodeData.deviceType == currentFilter.code;
+    case Dnssd::DiscoveryFilterType::kCommissioningMode:
+        return nodeData.commissioningMode == currentFilter.code;
+    case Dnssd::DiscoveryFilterType::kNone:
+    case Dnssd::DiscoveryFilterType::kInstanceName:
+    case Dnssd::DiscoveryFilterType::kCommissioner:
+    case Dnssd::DiscoveryFilterType::kCompressedFabricId:
+        return false;
+    }
+    return false;
+}
+void SetUpCodePairer::NotifyCommissionableDeviceDiscovered(const Dnssd::DiscoveredNodeData & nodeData)
+{
+    if (!NodeMatchesCurrentFilter(nodeData))
+    {
+        return;
+    }
     LogErrorOnFailure(StopConnectOverBle());
     LogErrorOnFailure(StopConnectOverIP());
     LogErrorOnFailure(StopConnectOverSoftAP());

--- a/src/controller/SetUpCodePairer.h
+++ b/src/controller/SetUpCodePairer.h
@@ -48,15 +48,17 @@ namespace Controller {
 class DeviceCommissioner;
 
 class DLL_EXPORT SetUpCodePairer
-#if CHIP_DEVICE_CONFIG_ENABLE_DNSSD
-    : public DeviceDiscoveryDelegate
-#endif // CHIP_DEVICE_CONFIG_ENABLE_DNSSD
 {
 public:
     SetUpCodePairer(DeviceCommissioner * commissioner) : mCommissioner(commissioner) {}
     virtual ~SetUpCodePairer() {}
 
     CHIP_ERROR PairDevice(chip::NodeId remoteId, const char * setUpCode);
+
+// Called by the DeviceCommissioner to notify that we have discovered a new device.
+#if CHIP_DEVICE_CONFIG_ENABLE_DNSSD
+    void NotifyCommissionableDeviceDiscovered(const chip::Dnssd::DiscoveredNodeData & nodeData);
+#endif // CHIP_DEVICE_CONFIG_ENABLE_DNSSD
 
 #if CONFIG_NETWORK_LAYER_BLE
     void SetBleLayer(Ble::BleLayer * bleLayer) { mBleLayer = bleLayer; };
@@ -73,11 +75,6 @@ private:
 
     void OnDeviceDiscovered(RendezvousParameters & params);
 
-#if CHIP_DEVICE_CONFIG_ENABLE_DNSSD
-    /////////// DeviceDiscoveryDelegate Interface /////////
-    void OnDiscoveredDevice(const chip::Dnssd::DiscoveredNodeData & nodeData) override;
-#endif // CHIP_DEVICE_CONFIG_ENABLE_DNSSD
-
 #if CONFIG_NETWORK_LAYER_BLE
     Ble::BleLayer * mBleLayer = nullptr;
     void OnDiscoveredDeviceOverBle(BLE_CONNECTION_OBJECT connObj);
@@ -85,6 +82,11 @@ private:
     static void OnDiscoveredDeviceOverBleSuccess(void * appState, BLE_CONNECTION_OBJECT connObj);
     static void OnDiscoveredDeviceOverBleError(void * appState, CHIP_ERROR err);
 #endif // CONFIG_NETWORK_LAYER_BLE
+
+#if CHIP_DEVICE_CONFIG_ENABLE_DNSSD
+    bool NodeMatchesCurrentFilter(const Dnssd::DiscoveredNodeData & nodeData);
+    Dnssd::DiscoveryFilter currentFilter;
+#endif
 
     DeviceCommissioner * mCommissioner = nullptr;
     chip::NodeId mRemoteId;


### PR DESCRIPTION
#### Problem
SetUpCodePairer replaces the delegate that was set up during commissioner initialization and doesn't put it back. There is also a chance of a race from spurious dns-sd responses.

#### Change overview
This class replaces the device discovery delegate that gets passed
in in the commissioning parameters which will cause the original
delegate to stop receiving callbacks if this class is used.
Instead, just have the commissioner notify this class directly.
The commissioner owns this part, so it doesn't need to use a derived
delegate because we know what we're talking to.

Also adding a discovery filter. This wasn't as necessary before
because the class would stop receiving notifications by setting the
delegate to null. However, that is still a race because it is
possible to get spurious mdns responses.

#### Testing
With #12319, tested manual and qr code pairing.
