### PR TITLE
Improve doxygen Docker Image

### DIFF
--- a/.github/workflows/docker_img.yaml
+++ b/.github/workflows/docker_img.yaml
@@ -32,7 +32,7 @@ jobs:
             fail-fast: false
             matrix:
                 # TODO: Enables "-crosscompile" and "-vscode" images
-                img: ["", "-android", "-cirque", "-efr32", "-esp32", "-esp32-qemu", "-infineon", "-k32w", "-mbed-os", "-nrf-platform", "-telink", "-tizen"]
+                img: ["", "-android", "-cirque", "-doxygen", "-efr32", "-esp32", "-esp32-qemu", "-infineon", "-k32w", "-mbed-os", "-nrf-platform", "-telink", "-tizen"]
         steps:
             - name: Checkout
               uses: actions/checkout@v2

--- a/.github/workflows/doxygen.yaml
+++ b/.github/workflows/doxygen.yaml
@@ -29,6 +29,9 @@ jobs:
         timeout-minutes: 5
 
         runs-on: ubuntu-20.04
+        container:
+            image: connectedhomeip/chip-build-doxygen:0.5.30
+
         if: github.actor != 'restyled-io[bot]'
 
         steps:

--- a/integrations/docker/images/chip-build-doxygen/Dockerfile
+++ b/integrations/docker/images/chip-build-doxygen/Dockerfile
@@ -1,20 +1,6 @@
-ARG VERSION=latest
-FROM connectedhomeip/chip-build:${VERSION}
+FROM alpine:3.15
 
-# Docker dependencies
-RUN set -x \
-    && apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -fy \
-       libclang1-9 \
-       libclang-cpp9 \
-    && rm -rf /var/lib/apt/lists/ \
-    && : # last line
-
-# Latest version of doxygen
-RUN set -x \
-    && cd /opt \
-    && wget https://www.doxygen.nl/files/doxygen-1.9.2.linux.bin.tar.gz \
-    && tar xfvz doxygen-1.9.2.linux.bin.tar.gz \
-    && rm doxygen-1.9.2.linux.bin.tar.gz \
-    && ln -s /opt/doxygen-1.9.2/bin/doxygen /usr/bin/ \
-    && : # last line
+RUN apk --no-cache add \
+  doxygen=1.9.2-r1 \
+  graphviz=2.49.3-r0 \
+  bash=5.1.8-r0

--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.5.31 Version bump reason: Upgrade wget package version to 1.20.3-1ubuntu2
+0.5.32 Version bump reason: Reduce size doxygen image

--- a/src/transport/SecureSessionTable.h
+++ b/src/transport/SecureSessionTable.h
@@ -50,6 +50,7 @@ public:
      * @param peerCATs represents peer CASE Authenticated Tags
      * @param peerSessionId represents the encryption key ID assigned by peer node
      * @param fabric represents fabric ID for the session
+     * @param config represents the reliable message protocol configuration
      *
      * @note the newly created state will have an 'active' time set based on the current time source.
      *


### PR DESCRIPTION
#### Problem
The [Doxygen GitHub action](https://github.com/project-chip/connectedhomeip/blob/master/.github/workflows/doxygen.yaml) is not using the [connectedhomeip/chip-build-doxygen](https://hub.docker.com/r/connectedhomeip/chip-build-doxygen) image and also executes a [script](https://github.com/project-chip/connectedhomeip/blob/master/scripts/helpers/doxygen.sh) which only requires two external tools (doxygen and graphviz).

#### Change overview
This change fixes the source code to pass the doxygen execution and includes a lighter Docker image (from 2.83GB to 41.9MB) for Doxygen CI execution.

#### Testing
These changes was tested using the `act -j doxygen` command
