### PR TITLE
Allow using symbolic error names in YAML.

### DIFF
--- a/src/app/tests/suites/TestCluster.yaml
+++ b/src/app/tests/suites/TestCluster.yaml
@@ -25,7 +25,7 @@ tests:
     - label: "Send Test Not Handled Command"
       command: "testNotHandled"
       response:
-          error: 0x85 # INVALID_COMMAND
+          error: INVALID_COMMAND
 
     - label: "Send Test Specific Command"
       command: "testSpecific"
@@ -56,7 +56,7 @@ tests:
               - name: "arg2"
                 value: 6
       response:
-          error: 0x85 # INVALID_COMMAND
+          error: INVALID_COMMAND
 
     # Tests for Boolean attribute
 
@@ -624,7 +624,7 @@ tests:
       arguments:
           value: "TestValueLongerThan10"
       response:
-          error: 0x87 # CONSTRAINT_ERROR
+          error: CONSTRAINT_ERROR
 
     - label: "Read attribute OCTET_STRING"
       command: "readAttribute"
@@ -690,7 +690,7 @@ tests:
       arguments:
           value: "☉TestValueLongerThan10☉"
       response:
-          error: 0x87 # CONSTRAINT_ERROR
+          error: CONSTRAINT_ERROR
 
     - label: "Read attribute CHAR_STRING"
       command: "readAttribute"
@@ -816,7 +816,7 @@ tests:
       response:
           # No such endpoint, so expect an error.
           # SDK returning wrong error code here so far.
-          errorWrongValue: 0x7F # UNSUPPORTED_ENDPOINT
+          errorWrongValue: UNSUPPORTED_ENDPOINT
 
     - label: "Send Test Command to unsupported cluster"
       command: "test"
@@ -824,7 +824,7 @@ tests:
       response:
           # No TestCluster on that, so expect an error.
           # SDK returning wrong error code here so far.
-          errorWrongValue: 0xC3 # UNSUPPORTED_CLUSTER
+          errorWrongValue: UNSUPPORTED_CLUSTER
 
     # Tests for vendor id
 
@@ -1480,7 +1480,7 @@ tests:
       arguments:
           value: 255
       response:
-          error: 0x87 # CONSTRAINT_ERROR
+          error: CONSTRAINT_ERROR
 
     - label: "Read attribute NULLABLE_BITMAP8 unchanged Value"
       command: "readAttribute"
@@ -1520,7 +1520,7 @@ tests:
       arguments:
           value: 65535
       response:
-          error: 0x87 # CONSTRAINT_ERROR
+          error: CONSTRAINT_ERROR
 
     - label: "Read attribute NULLABLE_BITMAP16 unchanged Value"
       command: "readAttribute"
@@ -1560,7 +1560,7 @@ tests:
       arguments:
           value: 4294967295
       response:
-          error: 0x87 # CONSTRAINT_ERROR
+          error: CONSTRAINT_ERROR
 
     - label: "Read attribute NULLABLE_BITMAP32 unchanged Value"
       command: "readAttribute"
@@ -1600,7 +1600,7 @@ tests:
       arguments:
           value: "18446744073709551615"
       response:
-          error: 0x87 # CONSTRAINT_ERROR
+          error: CONSTRAINT_ERROR
 
     - label: "Read attribute NULLABLE_BITMAP64 unchanged Value"
       command: "readAttribute"
@@ -1640,7 +1640,7 @@ tests:
       arguments:
           value: 255
       response:
-          error: 0x87 # CONSTRAINT_ERROR
+          error: CONSTRAINT_ERROR
 
     - label: "Read attribute NULLABLE_INT8U unchanged Value"
       command: "readAttribute"
@@ -1680,7 +1680,7 @@ tests:
       arguments:
           value: 65535
       response:
-          error: 0x87 # CONSTRAINT_ERROR
+          error: CONSTRAINT_ERROR
 
     - label: "Read attribute NULLABLE_INT16U unchanged Value"
       command: "readAttribute"
@@ -1720,7 +1720,7 @@ tests:
       arguments:
           value: 4294967295
       response:
-          error: 0x87 # CONSTRAINT_ERROR
+          error: CONSTRAINT_ERROR
 
     - label: "Read attribute NULLABLE_INT32U unchanged Value"
       command: "readAttribute"
@@ -1760,7 +1760,7 @@ tests:
       arguments:
           value: "18446744073709551615"
       response:
-          error: 0x87 # CONSTRAINT_ERROR
+          error: CONSTRAINT_ERROR
 
     - label: "Read attribute NULLABLE_INT64U unchanged Value"
       command: "readAttribute"
@@ -1800,7 +1800,7 @@ tests:
       arguments:
           value: -128
       response:
-          error: 0x87 # CONSTRAINT_ERROR
+          error: CONSTRAINT_ERROR
 
     - label: "Read attribute NULLABLE_INT8S unchanged Value"
       command: "readAttribute"
@@ -1840,7 +1840,7 @@ tests:
       arguments:
           value: -32768
       response:
-          error: 0x87 # CONSTRAINT_ERROR
+          error: CONSTRAINT_ERROR
 
     - label: "Read attribute NULLABLE_INT16S unchanged Value"
       command: "readAttribute"
@@ -1880,7 +1880,7 @@ tests:
       arguments:
           value: -2147483648
       response:
-          error: 0x87 # CONSTRAINT_ERROR
+          error: CONSTRAINT_ERROR
 
     - label: "Read attribute NULLABLE_INT32S unchanged Value"
       command: "readAttribute"
@@ -1923,7 +1923,7 @@ tests:
           # work around that.
           value: "-9223372036854775807LL - 1"
       response:
-          error: 0x87 # CONSTRAINT_ERROR
+          error: CONSTRAINT_ERROR
 
     - label: "Read attribute NULLABLE_INT64S unchanged Value"
       command: "readAttribute"
@@ -1963,7 +1963,7 @@ tests:
       arguments:
           value: 255
       response:
-          error: 0x87 # CONSTRAINT_ERROR
+          error: CONSTRAINT_ERROR
 
     - label: "Read attribute NULLABLE_ENUM8 unchanged Value"
       command: "readAttribute"
@@ -2003,7 +2003,7 @@ tests:
       arguments:
           value: 65535
       response:
-          error: 0x87 # CONSTRAINT_ERROR
+          error: CONSTRAINT_ERROR
 
     - label: "Read attribute NULLABLE_ENUM16 unchanged Value"
       command: "readAttribute"
@@ -2118,7 +2118,7 @@ tests:
       attribute: "list_int8u"
       response:
           # SDK returning wrong error code here so far.
-          errorWrongValue: 0x7F # UNSUPPORTED_ENDPOINT
+          errorWrongValue: UNSUPPORTED_ENDPOINT
 
     - label: "Read attribute from nonexistent cluster."
       endpoint: 0
@@ -2126,4 +2126,4 @@ tests:
       attribute: "list_int8u"
       response:
           # SDK returning wrong error code here so far.
-          errorWrongValue: 0xC3 # UNSUPPORTED_CLUSTER
+          errorWrongValue: UNSUPPORTED_CLUSTER

--- a/src/app/tests/suites/TestGroupsCluster.yaml
+++ b/src/app/tests/suites/TestGroupsCluster.yaml
@@ -334,8 +334,6 @@ tests:
 
     - label: "Remove All"
       command: "RemoveAllGroups"
-      response:
-          error: 0x00
 
     - label: "View Group 1 (removed)"
       command: "ViewGroup"

--- a/src/app/tests/suites/TestModeSelectCluster.yaml
+++ b/src/app/tests/suites/TestModeSelectCluster.yaml
@@ -64,8 +64,6 @@ tests:
           values:
               - name: "NewMode"
                 value: 4
-      response:
-          error: 0
 
     - label: "Verify Current Mode Change"
       command: "readAttribute"
@@ -80,4 +78,4 @@ tests:
               - name: "NewMode"
                 value: 2
       response:
-          error: 0x87 # CONSTRAINT_ERROR
+          error: CONSTRAINT_ERROR

--- a/src/app/tests/suites/certification/Test_TC_BI_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_BI_1_1.yaml
@@ -33,7 +33,7 @@ tests:
       arguments:
           value: 1
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "reads back global attribute: ClusterRevision"
       command: "readAttribute"

--- a/src/app/tests/suites/certification/Test_TC_BI_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_BI_2_1.yaml
@@ -90,7 +90,7 @@ tests:
       arguments:
           value: 0
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "Reads back the mandatory non-global attribute: StatusFlags"
       command: "readAttribute"
@@ -214,7 +214,7 @@ tests:
       arguments:
           value: 0
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "Reads back the optional non-global attribute: Polarity"
       disabled: true
@@ -273,7 +273,7 @@ tests:
       arguments:
           value: 0
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "Reads back the optional non-global attribute: ApplicationType"
       disabled: true

--- a/src/app/tests/suites/certification/Test_TC_BOOL_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_BOOL_1_1.yaml
@@ -33,7 +33,7 @@ tests:
       arguments:
           value: 1
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "reads back global attribute: ClusterRevision"
       command: "readAttribute"

--- a/src/app/tests/suites/certification/Test_TC_BOOL_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_BOOL_2_1.yaml
@@ -39,7 +39,7 @@ tests:
       arguments:
           value: 1
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "Reads back the mandatory non-global attribute: StateValue"
       command: "readAttribute"

--- a/src/app/tests/suites/certification/Test_TC_CC_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_1_1.yaml
@@ -34,7 +34,7 @@ tests:
       arguments:
           value: 4
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "reads back global attribute: ClusterRevision"
       disabled: true
@@ -57,7 +57,7 @@ tests:
       arguments:
           value: 0
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "reads back optional global attribute: FeatureMap"
       disabled: true

--- a/src/app/tests/suites/certification/Test_TC_CC_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_2_1.yaml
@@ -40,7 +40,7 @@ tests:
       arguments:
           value: 0
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "Reads back mandatory attribute: CurrentHue"
       command: "readAttribute"
@@ -69,7 +69,7 @@ tests:
       arguments:
           value: 0
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "Reads back mandatory attribute: CurrentSaturation"
       command: "readAttribute"
@@ -98,7 +98,7 @@ tests:
       arguments:
           value: 24939
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "Reads back mandatory attribute: CurrentX"
       command: "readAttribute"
@@ -127,7 +127,7 @@ tests:
       arguments:
           value: 24701
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "Reads back mandatory attribute: CurrentY"
       command: "readAttribute"
@@ -160,7 +160,7 @@ tests:
       arguments:
           value: 250
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "Reads back mandatory attribute: ColorTemperatureMireds"
       disabled: true
@@ -192,7 +192,7 @@ tests:
       arguments:
           value: 1
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "Reads back mandatory attribute: ColorMode"
       disabled: true
@@ -246,7 +246,7 @@ tests:
       arguments:
           value: 0
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "Reads back mandatory attribute: EnhancedCurrentHue"
       command: "readAttribute"
@@ -276,7 +276,7 @@ tests:
       arguments:
           value: 1
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "Reads back mandatory attribute: EnhancedColorMode"
       disabled: true
@@ -304,7 +304,7 @@ tests:
       arguments:
           value: 0
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "Reads back mandatory attribute: ColorLoopActive"
       command: "readAttribute"
@@ -332,7 +332,7 @@ tests:
       arguments:
           value: 0
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "Reads back mandatory attribute: ColorLoopDirection"
       command: "readAttribute"
@@ -359,7 +359,7 @@ tests:
       arguments:
           value: 25
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "Reads back mandatory attribute: ColorLoopTime"
       command: "readAttribute"
@@ -388,7 +388,7 @@ tests:
       arguments:
           value: 8960
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "Reads back mandatory attribute: ColorLoopStartEnhancedHue"
       command: "readAttribute"
@@ -417,7 +417,7 @@ tests:
       arguments:
           value: 0
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "Reads back mandatory attribute: ColorLoopStoredEnhancedHue"
       command: "readAttribute"
@@ -447,7 +447,7 @@ tests:
       arguments:
           value: 0
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "Reads back mandatory attribute: ColorCapabilities"
       command: "readAttribute"
@@ -478,7 +478,7 @@ tests:
       arguments:
           value: 0
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "Reads back mandatory attribute: ColorTempPhysicalMinMireds"
       command: "readAttribute"
@@ -509,7 +509,7 @@ tests:
       arguments:
           value: 65279
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "Reads back mandatory attribute: ColorTempPhysicalMaxMireds"
       command: "readAttribute"
@@ -532,7 +532,7 @@ tests:
       arguments:
           value: 0
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "Reads back optional attribute: CoupleColorTempToLevelMinMireds"
       command: "readAttribute"
@@ -584,7 +584,7 @@ tests:
       arguments:
           value: 0
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "Reads back optional attribute: RemainingTime"
       command: "readAttribute"
@@ -607,7 +607,7 @@ tests:
       arguments:
           value: 0
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "Reads back optional attribute: DriftCompensation"
       command: "readAttribute"
@@ -630,7 +630,7 @@ tests:
       arguments:
           value: ""
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "Reads back optional attribute: CompensationText"
       disabled: true
@@ -656,7 +656,7 @@ tests:
       arguments:
           value: 0
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "Read back the mandatory attribute: NumberOfPrimaries"
       command: "readAttribute"
@@ -679,7 +679,7 @@ tests:
       arguments:
           value: 0
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "Read back the mandatory attribute: Primary1X"
       command: "readAttribute"
@@ -702,7 +702,7 @@ tests:
       arguments:
           value: 0
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "Read back the mandatory attribute: Primary1Y"
       command: "readAttribute"
@@ -724,7 +724,7 @@ tests:
       arguments:
           value: 0
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "Read back the mandatory attribute: Primary1Intensity"
       disabled: true
@@ -748,7 +748,7 @@ tests:
       arguments:
           value: 0
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "Read back the mandatory attribute: Primary2X"
       command: "readAttribute"
@@ -771,7 +771,7 @@ tests:
       arguments:
           value: 0
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "Read back the mandatory attribute: Primary2Y"
       command: "readAttribute"
@@ -793,7 +793,7 @@ tests:
       arguments:
           value: 0
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "Read back the mandatory attribute: Primary2Intensity"
       disabled: true
@@ -817,7 +817,7 @@ tests:
       arguments:
           value: 0
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "Read back the mandatory attribute: Primary3X"
       command: "readAttribute"
@@ -840,7 +840,7 @@ tests:
       arguments:
           value: 0
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "Read back the mandatory attribute: Primary3Y"
       command: "readAttribute"
@@ -862,7 +862,7 @@ tests:
       arguments:
           value: 0
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "Read back the mandatory attribute: Primary3Intensity"
       disabled: true
@@ -887,7 +887,7 @@ tests:
       arguments:
           value: 0
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "Read back the mandatory attribute: Primary4X"
       command: "readAttribute"
@@ -910,7 +910,7 @@ tests:
       arguments:
           value: 0
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "Read back the mandatory attribute: Primary4Y"
       command: "readAttribute"
@@ -932,7 +932,7 @@ tests:
       arguments:
           value: 0
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "Read back the mandatory attribute: Primary4Intensity"
       disabled: true
@@ -956,7 +956,7 @@ tests:
       arguments:
           value: 0
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "Read back the mandatory attribute: Primary5X"
       command: "readAttribute"
@@ -979,7 +979,7 @@ tests:
       arguments:
           value: 0
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "Read back the mandatory attribute: Primary5Y"
       command: "readAttribute"
@@ -1001,7 +1001,7 @@ tests:
       arguments:
           value: 0
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "Read back the mandatory attribute: Primary5Intensity"
       disabled: true
@@ -1025,7 +1025,7 @@ tests:
       arguments:
           value: 0
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "Read back the mandatory attribute: Primary6X"
       command: "readAttribute"
@@ -1048,7 +1048,7 @@ tests:
       arguments:
           value: 0
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "Read back the mandatory attribute: Primary6Y"
       command: "readAttribute"
@@ -1070,7 +1070,7 @@ tests:
       arguments:
           value: 0
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "Read back the mandatory attribute: Primary6Intensity"
       disabled: true

--- a/src/app/tests/suites/certification/Test_TC_DIAGTH_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_DIAGTH_1_1.yaml
@@ -33,7 +33,7 @@ tests:
       arguments:
           value: 1
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "reads back global attribute: ClusterRevision"
       command: "readAttribute"
@@ -55,7 +55,7 @@ tests:
       arguments:
           value: 0
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "reads back optional global attribute: FeatureMap"
       disabled: true

--- a/src/app/tests/suites/certification/Test_TC_EMR_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_EMR_1_1.yaml
@@ -33,7 +33,7 @@ tests:
       arguments:
           value: 1
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "reads back global attribute: ClusterRevision"
       command: "readAttribute"

--- a/src/app/tests/suites/certification/Test_TC_FLW_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_FLW_1_1.yaml
@@ -34,7 +34,7 @@ tests:
       arguments:
           value: 2
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "reads back global attribute: ClusterRevision"
       disabled: true

--- a/src/app/tests/suites/certification/Test_TC_FLW_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_FLW_2_1.yaml
@@ -47,7 +47,7 @@ tests:
       arguments:
           value: 0
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "write the default value to optional attribute: MinMeasuredValue"
       command: "writeAttribute"
@@ -55,7 +55,7 @@ tests:
       arguments:
           value: 0
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "write the default value to optional attribute: MaxMeasuredValue"
       command: "writeAttribute"
@@ -63,7 +63,7 @@ tests:
       arguments:
           value: 0
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "read the mandatory attribute: MeasuredValue"
       command: "readAttribute"
@@ -110,7 +110,7 @@ tests:
       arguments:
           value: 0
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "read the optional attribute: Tolerance"
       disabled: true

--- a/src/app/tests/suites/certification/Test_TC_ILL_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_ILL_1_1.yaml
@@ -33,7 +33,7 @@ tests:
       arguments:
           value: 1
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "reads back global attribute: ClusterRevision"
       command: "readAttribute"

--- a/src/app/tests/suites/certification/Test_TC_LVL_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_LVL_1_1.yaml
@@ -34,7 +34,7 @@ tests:
       arguments:
           value: 4
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "reads back global attribute: ClusterRevision"
       disabled: true
@@ -57,7 +57,7 @@ tests:
       arguments:
           value: 0
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "reads back optional global attribute: FeatureMap"
       disabled: true

--- a/src/app/tests/suites/certification/Test_TC_LVL_3_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_LVL_3_1.yaml
@@ -96,8 +96,6 @@ tests:
       attribute: "default move rate"
       arguments:
           value: 20
-      response:
-          error: 0
 
     - label: "reads default move rate attribute from DUT"
       command: "readAttribute"

--- a/src/app/tests/suites/certification/Test_TC_MC_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_MC_1_1.yaml
@@ -34,7 +34,7 @@ tests:
       arguments:
           value: 1
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "reads back global attribute: ClusterRevision"
       disabled: true
@@ -57,7 +57,7 @@ tests:
       arguments:
           value: 0
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "reads back optional global attribute: FeatureMap"
       disabled: true

--- a/src/app/tests/suites/certification/Test_TC_MC_3_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_MC_3_1.yaml
@@ -138,5 +138,5 @@ tests:
               - name: "keyCode"
                 value: 0xFF
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
     # TODO: Add Step 10 (TH sends <Any Navigation> Keycode to DUT, when DUT in a processing state)

--- a/src/app/tests/suites/certification/Test_TC_MC_3_7.yaml
+++ b/src/app/tests/suites/certification/Test_TC_MC_3_7.yaml
@@ -54,7 +54,7 @@ tests:
               - name: "applicationId"
                 value: "NonAvailableApp"
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     # TODO: Update the corresponding values when feature is supported
     - label: "Launch an app with the provided a application ID"
@@ -82,4 +82,4 @@ tests:
               - name: "applicationId"
                 value: "HelloWorldApp2"
       response:
-          error: 2
+          error: INVALID_COMMAND

--- a/src/app/tests/suites/certification/Test_TC_OCC_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_OCC_1_1.yaml
@@ -33,7 +33,7 @@ tests:
       arguments:
           value: 2
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "reads back global attribute: ClusterRevision"
       disabled: true

--- a/src/app/tests/suites/certification/Test_TC_OCC_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_OCC_2_1.yaml
@@ -42,7 +42,7 @@ tests:
       arguments:
           value: 0
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "Reads back mandatory attribute: Occupancy"
       command: "readAttribute"
@@ -74,7 +74,7 @@ tests:
       arguments:
           value: 0
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "Reads back mandatory attribute: OccupancySensorType"
       command: "readAttribute"
@@ -106,7 +106,7 @@ tests:
       arguments:
           value: 1
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "Reads back mandatory attribute: OccupancySensorTypeBitmap"
       command: "readAttribute"

--- a/src/app/tests/suites/certification/Test_TC_OO_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_OO_1_1.yaml
@@ -33,7 +33,7 @@ tests:
       arguments:
           value: 3
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "reads back global attribute: ClusterRevision"
       command: "readAttribute"
@@ -53,7 +53,7 @@ tests:
       arguments:
           value: 0
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "reads back optional global attribute: FeatureMap"
       command: "readAttribute"

--- a/src/app/tests/suites/certification/Test_TC_OO_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_OO_2_1.yaml
@@ -32,7 +32,7 @@ tests:
       arguments:
           value: 0
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "reads back mandatory attribute: OnOff"
       command: "readAttribute"
@@ -71,7 +71,7 @@ tests:
       arguments:
           value: 0
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "write the default value to LT attribute: OnTime"
       command: "writeAttribute"

--- a/src/app/tests/suites/certification/Test_TC_PCC_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_PCC_1_1.yaml
@@ -34,7 +34,7 @@ tests:
       arguments:
           value: 3
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "reads back global attribute: ClusterRevision"
       disabled: true
@@ -57,7 +57,7 @@ tests:
       arguments:
           value: 0
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "reads back optional global attribute: FeatureMap"
       disabled: true

--- a/src/app/tests/suites/certification/Test_TC_PCC_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_PCC_2_1.yaml
@@ -112,7 +112,7 @@ tests:
       arguments:
           value: null
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "write to the mandatory attribute: MaxSpeed"
       disabled: true
@@ -121,7 +121,7 @@ tests:
       arguments:
           value: null
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "write to the mandatory attribute: MaxFlow"
       disabled: true
@@ -130,7 +130,7 @@ tests:
       arguments:
           value: null
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "write to the mandatory attribute: EffectiveOperationMode"
       disabled: true
@@ -139,7 +139,7 @@ tests:
       arguments:
           value: desc
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "write to the mandatory attribute: EffectiveControlMode"
       disabled: true
@@ -148,7 +148,7 @@ tests:
       arguments:
           value: desc
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "write to the mandatory attribute: Capacity"
       disabled: true
@@ -157,7 +157,7 @@ tests:
       arguments:
           value: null
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "read the mandatory attribute: MaxPressure"
       disabled: true
@@ -479,7 +479,7 @@ tests:
       arguments:
           value: null
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "write to the optional attribute: MaxConstPressure"
       disabled: true
@@ -488,7 +488,7 @@ tests:
       arguments:
           value: null
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "write to the optional attribute: MinCompPressure"
       disabled: true
@@ -497,7 +497,7 @@ tests:
       arguments:
           value: null
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "write to the optional attribute: MaxCompPressure"
       disabled: true
@@ -506,7 +506,7 @@ tests:
       arguments:
           value: null
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "write to the optional attribute: MinConstSpeed"
       disabled: true
@@ -515,7 +515,7 @@ tests:
       arguments:
           value: null
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "write to the optional attribute: MaxConstSpeed"
       disabled: true
@@ -524,7 +524,7 @@ tests:
       arguments:
           value: null
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "write to the optional attribute: MinConstFlow"
       disabled: true
@@ -533,7 +533,7 @@ tests:
       arguments:
           value: null
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "write to the optional attribute: MaxConstFlow"
       disabled: true
@@ -542,7 +542,7 @@ tests:
       arguments:
           value: null
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "write to the optional attribute: MinConstTemp"
       disabled: true
@@ -551,7 +551,7 @@ tests:
       arguments:
           value: null
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "write to the optional attribute: MaxConstTemp"
       disabled: true
@@ -560,7 +560,7 @@ tests:
       arguments:
           value: null
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "write to the optional attribute: PumpStatus"
       disabled: true
@@ -569,7 +569,7 @@ tests:
       arguments:
           value: 0
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "write to the optional attribute: Speed"
       disabled: true
@@ -578,7 +578,7 @@ tests:
       arguments:
           value: null
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "write to the optional attribute: LifetimeRunningHours"
       disabled: true
@@ -586,8 +586,6 @@ tests:
       attribute: "LifetimeRunningHours"
       arguments:
           value: 0
-      response:
-          error: 0
 
     - label: "write to the optional attribute: Power"
       disabled: true
@@ -596,7 +594,7 @@ tests:
       arguments:
           value: null
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "write to the optional attribute: LifetimeEnergyConsumed"
       disabled: true
@@ -604,8 +602,6 @@ tests:
       attribute: "LifetimeEnergyConsumed"
       arguments:
           value: 0
-      response:
-          error: 0
 
     - label: "read the optional attribute: MinConstPressure"
       disabled: true

--- a/src/app/tests/suites/certification/Test_TC_PRS_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_PRS_1_1.yaml
@@ -40,7 +40,7 @@ tests:
       arguments:
           value: 2
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "Reads back global attribute: ClusterRevision"
       command: "readAttribute"
@@ -71,7 +71,7 @@ tests:
       arguments:
           value: 0
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "Reads back mandatory global attribute: AttributeList"
       disabled: true
@@ -103,7 +103,7 @@ tests:
       arguments:
           value: 0
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "Reads back mandatory global attribute: CommandList"
       disabled: true
@@ -134,7 +134,7 @@ tests:
       arguments:
           value: 0
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "Reads back mandatory global attribute: EventList"
       disabled: true
@@ -165,7 +165,7 @@ tests:
       arguments:
           value: 0
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "Reads back optional global attribute: FeatureMap"
       disabled: true

--- a/src/app/tests/suites/certification/Test_TC_PRS_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_PRS_2_1.yaml
@@ -32,7 +32,7 @@ tests:
       arguments:
           value: 0
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "Reads back mandatory attribute: MeasuredValue"
       command: "readAttribute"
@@ -53,7 +53,7 @@ tests:
       arguments:
           value: 0
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "Reads back mandatory attribute: MinMeasuredValue"
       command: "readAttribute"
@@ -74,7 +74,7 @@ tests:
       arguments:
           value: 0
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "Reads back mandatory attribute: MaxMeasuredValue"
       command: "readAttribute"
@@ -96,7 +96,7 @@ tests:
       arguments:
           value: 0
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "Reads back optional attribute: Tolerance"
       disabled: true
@@ -120,7 +120,7 @@ tests:
       arguments:
           value: 0
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "Reads back optional attribute: ScaledValue"
       disabled: true
@@ -143,7 +143,7 @@ tests:
       arguments:
           value: 0
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "Reads back optional attribute: MinScaledValue"
       disabled: true
@@ -166,7 +166,7 @@ tests:
       arguments:
           value: 0
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "Reads back optional attribute: MaxScaledValue"
       disabled: true
@@ -189,7 +189,7 @@ tests:
       arguments:
           value: 0
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "Reads back optional attribute: ScaledTolerance"
       disabled: true
@@ -212,7 +212,7 @@ tests:
       arguments:
           value: 0
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "Reads back optional attribute: Scale"
       disabled: true

--- a/src/app/tests/suites/certification/Test_TC_RH_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_RH_1_1.yaml
@@ -34,7 +34,7 @@ tests:
       arguments:
           value: 1
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "reads back global attribute: ClusterRevision"
       disabled: true
@@ -57,7 +57,7 @@ tests:
       arguments:
           value: 0
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "reads back optional global attribute: FeatureMap"
       disabled: true

--- a/src/app/tests/suites/certification/Test_TC_TM_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_TM_1_1.yaml
@@ -33,7 +33,7 @@ tests:
       arguments:
           value: 3
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "reads back global attribute: ClusterRevision"
       command: "readAttribute"

--- a/src/app/tests/suites/certification/Test_TC_TSTAT_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_TSTAT_1_1.yaml
@@ -34,7 +34,7 @@ tests:
       arguments:
           value: 5
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "reads back global attribute: ClusterRevision"
       disabled: true
@@ -57,7 +57,7 @@ tests:
       arguments:
           value: 0
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "reads back optional global attribute: FeatureMap"
       disabled: true

--- a/src/app/tests/suites/certification/Test_TC_TSTAT_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_TSTAT_2_1.yaml
@@ -44,7 +44,7 @@ tests:
       arguments:
           value: null
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "Read back mandatory attributes from DUT: LocalTemperature"
       disabled: true
@@ -78,7 +78,7 @@ tests:
       arguments:
           value: 700
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "Read back mandatory attributes from DUT: AbsMinHeatSetpointLimit"
       command: "readAttribute"
@@ -111,7 +111,7 @@ tests:
       arguments:
           value: 3000
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "Read back mandatory attributes from DUT: AbsMaxHeatSetpointLimit"
       command: "readAttribute"
@@ -144,7 +144,7 @@ tests:
       arguments:
           value: 1600
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "Read back mandatory attributes from DUT: AbsMinCoolSetpointLimit"
       command: "readAttribute"
@@ -177,7 +177,7 @@ tests:
       arguments:
           value: 3200
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "Read back mandatory attributes from DUT: AbsMaxCoolSetpointLimit"
       command: "readAttribute"
@@ -205,7 +205,7 @@ tests:
       arguments:
           value: 0
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "Read back mandatory attributes from DUT: PICoolingDemand"
       disabled: true
@@ -234,7 +234,7 @@ tests:
       arguments:
           value: 0
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "Read back mandatory attributes from DUT: PIHeatingDemand"
       disabled: true
@@ -787,7 +787,7 @@ tests:
       arguments:
           value: 0
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "Read back optional attributes from DUT: AlarmMask"
       disabled: true
@@ -824,7 +824,7 @@ tests:
       arguments:
           value: 0
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "Read back optional attributes from DUT: ThermostatRunningMode"
       disabled: true
@@ -850,7 +850,7 @@ tests:
       arguments:
           value: 0
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "Read back optional attributes from DUT: StartOfWeek"
       command: "readAttribute"
@@ -883,7 +883,7 @@ tests:
       arguments:
           value: 0
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "Read back optional attributes from DUT: NumberOfWeeklyTransitions"
       disabled: true
@@ -917,7 +917,7 @@ tests:
       arguments:
           value: 0
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "Read back optional attributes from DUT: NumberOfDailyTransitions"
       disabled: true
@@ -1059,7 +1059,7 @@ tests:
       arguments:
           value: 0
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "Read back optional attributes from DUT: ThermostatRunningState"
       disabled: true
@@ -1096,7 +1096,7 @@ tests:
       arguments:
           value: 0
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "Read back optional attributes from DUT: SetpointChangeSource"
       disabled: true
@@ -1131,7 +1131,7 @@ tests:
       arguments:
           value: null
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "Read back optional attributes from DUT: SetpointChangeAmount"
       disabled: true
@@ -1166,7 +1166,7 @@ tests:
       arguments:
           value: 0
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label:
           "Read back optional attributes from DUT: SetpointChangeSourceTimestamp"
@@ -1203,7 +1203,7 @@ tests:
       arguments:
           value: null
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "Read back optional attributes from DUT: OccupiedSetback"
       disabled: true
@@ -1307,7 +1307,7 @@ tests:
       arguments:
           value: null
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "Read back optional attributes from DUT: UnoccupiedSetback"
       disabled: true
@@ -1640,7 +1640,7 @@ tests:
       arguments:
           value: null
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "Read back optional attributes from DUT: ACCoilTemperature"
       disabled: true

--- a/src/app/tests/suites/certification/Test_TC_TSUIC_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_TSUIC_1_1.yaml
@@ -34,7 +34,7 @@ tests:
       arguments:
           value: 2
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "reads back global attribute: ClusterRevision"
       disabled: true
@@ -57,7 +57,7 @@ tests:
       arguments:
           value: 0
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "reads back optional global attribute: FeatureMap"
       disabled: true

--- a/src/app/tests/suites/certification/Test_TC_TSUIC_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_TSUIC_2_1.yaml
@@ -37,8 +37,6 @@ tests:
       attribute: "temperature display mode"
       arguments:
           value: 0
-      response:
-          error: 0
 
     - label: "read the mandatory attribute: TemperatureDisplayMode"
       command: "readAttribute"
@@ -71,8 +69,6 @@ tests:
       attribute: "keypad lockout"
       arguments:
           value: 0
-      response:
-          error: 0
 
     - label: "read the mandatory attribute: KeypadLockout"
       command: "readAttribute"
@@ -105,8 +101,6 @@ tests:
       attribute: "schedule programming visibility"
       arguments:
           value: 0
-      response:
-          error: 0
 
     - label: "read the optional attribute: ScheduleProgrammingVisibility"
       command: "readAttribute"

--- a/src/app/tests/suites/certification/Test_TC_TSUIC_2_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_TSUIC_2_2.yaml
@@ -49,7 +49,7 @@ tests:
       arguments:
           value: 2
       response:
-          error: 135
+          error: CONSTRAINT_ERROR
 
     - label: "Writes a value of 0 to KeypadLockout attribute of DUT"
       command: "writeAttribute"
@@ -120,7 +120,7 @@ tests:
       arguments:
           value: 6
       response:
-          error: 135
+          error: CONSTRAINT_ERROR
 
     - label:
           "Writes a value of 0 to ScheduleProgrammingVisibility attribute of DUT"
@@ -158,4 +158,4 @@ tests:
       arguments:
           value: 2
       response:
-          error: 135
+          error: CONSTRAINT_ERROR

--- a/src/app/tests/suites/certification/Test_TC_WNCV_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_WNCV_1_1.yaml
@@ -38,7 +38,7 @@ tests:
       arguments:
           value: 201
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "3b: reads back global attribute: ClusterRevision"
       command: "readAttribute"
@@ -65,7 +65,7 @@ tests:
       arguments:
           value: 32769
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "3b: reads back global attribute: FeatureMap"
       command: "readAttribute"

--- a/src/app/tests/suites/certification/Test_TC_WNCV_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_WNCV_2_1.yaml
@@ -38,7 +38,7 @@ tests:
       arguments:
           value: 250
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "3b: reads back the RO mandatory attribute: Type"
       command: "readAttribute"
@@ -64,7 +64,7 @@ tests:
       arguments:
           value: 128
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "3b: reads back the RO mandatory attribute: ConfigStatus"
       command: "readAttribute"
@@ -91,7 +91,7 @@ tests:
       arguments:
           value: 128
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "3b: reads back the RO mandatory attribute: OperationalStatus"
       command: "readAttribute"
@@ -117,7 +117,7 @@ tests:
       arguments:
           value: 250
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "3b: reads back the RO mandatory attribute: EndProductType"
       command: "readAttribute"
@@ -142,8 +142,6 @@ tests:
       attribute: "Mode"
       arguments:
           value: 8
-      response:
-          error: 0
 
     - label: "3b: reads back the RW mandatory attribute: Mode"
       command: "readAttribute"
@@ -172,7 +170,7 @@ tests:
       arguments:
           value: 20000
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label:
           "3b: reads back the RO optional attribute:
@@ -204,7 +202,7 @@ tests:
       arguments:
           value: 20000
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label:
           "3b: reads back the RO optional attribute:
@@ -236,7 +234,7 @@ tests:
       arguments:
           value: 20000
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label:
           "3b: reads back the RO optional attribute:
@@ -268,7 +266,7 @@ tests:
       arguments:
           value: 20000
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label:
           "3b: reads back the RO optional attribute:
@@ -298,7 +296,7 @@ tests:
       arguments:
           value: 255
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "3b: reads back the RO optional attribute: InstalledOpenLimitLift"
       command: "readAttribute"
@@ -328,7 +326,7 @@ tests:
       arguments:
           value: 255
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label:
           "3b: reads back the RO optional attribute: InstalledClosedLimitLift"
@@ -358,7 +356,7 @@ tests:
       arguments:
           value: 255
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "3b: reads back the RO optional attribute: InstalledOpenLimitTilt"
       command: "readAttribute"
@@ -388,7 +386,7 @@ tests:
       arguments:
           value: 255
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label:
           "3b: reads back the RO optional attribute: InstalledClosedLimitTilt"
@@ -417,7 +415,7 @@ tests:
       arguments:
           value: 4096
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "5b: reads back the RO mandatory attribute: SafetyStatus"
       command: "readAttribute"
@@ -448,7 +446,7 @@ tests:
       arguments:
           value: 255
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "5b: reads back the RO optional attribute: PhysicalClosedLimitLift"
       disabled: true
@@ -481,7 +479,7 @@ tests:
       arguments:
           value: 255
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "5b: reads back the RO optional attribute: PhysicalClosedLimitTilt"
       disabled: true
@@ -510,7 +508,7 @@ tests:
       arguments:
           value: 255
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "5b: reads back the RO optional attribute: CurrentPositionLift"
       command: "readAttribute"
@@ -538,7 +536,7 @@ tests:
       arguments:
           value: 255
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "5b: reads back the RO optional attribute: CurrentPositionTilt"
       command: "readAttribute"
@@ -569,7 +567,7 @@ tests:
       arguments:
           value: 255
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "5b: reads back the RO optional attribute: NumberOfActuationsLift"
       disabled: true
@@ -601,7 +599,7 @@ tests:
       arguments:
           value: 255
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label: "5b: reads back the RO optional attribute: NumberOfActuationsTilt"
       disabled: true
@@ -633,7 +631,7 @@ tests:
       arguments:
           value: 200
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label:
           "5b: reads back the RO optional attribute:
@@ -665,7 +663,7 @@ tests:
       arguments:
           value: 200
       response:
-          error: 0x88 # UNSUPPORTED_WRITE
+          error: UNSUPPORTED_WRITE
 
     - label:
           "5b: reads back the RO optional attribute:

--- a/src/darwin/Framework/CHIP/templates/clusters-tests.zapt
+++ b/src/darwin/Framework/CHIP/templates/clusters-tests.zapt
@@ -9,6 +9,8 @@
 
 #import "CHIPErrorTestUtils.h"
 
+#import <app/util/af-enums.h>
+
 // system dependencies
 #import <XCTest/XCTest.h>
 

--- a/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
+++ b/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
@@ -26,6 +26,8 @@
 
 #import "CHIPErrorTestUtils.h"
 
+#import <app/util/af-enums.h>
+
 // system dependencies
 #import <XCTest/XCTest.h>
 
@@ -221,7 +223,7 @@ CHIPDevice * GetConnectedDevice()
                              completionHandler:^(NSError * _Nullable err) {
                                  NSLog(@"write the default values to mandatory global attribute: ClusterRevision Error: %@", err);
 
-                                 XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 136);
+                                 XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
                                  [expectation fulfill];
                              }];
 
@@ -479,7 +481,7 @@ CHIPDevice * GetConnectedDevice()
                               completionHandler:^(NSError * _Nullable err) {
                                   NSLog(@"Write the default values to mandatory non-global attribute: StatusFlags Error: %@", err);
 
-                                  XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 136);
+                                  XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
                                   [expectation fulfill];
                               }];
 
@@ -745,7 +747,7 @@ CHIPDevice * GetConnectedDevice()
                              completionHandler:^(NSError * _Nullable err) {
                                  NSLog(@"write the default values to mandatory global attribute: ClusterRevision Error: %@", err);
 
-                                 XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 136);
+                                 XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
                                  [expectation fulfill];
                              }];
 
@@ -836,7 +838,7 @@ CHIPDevice * GetConnectedDevice()
                              completionHandler:^(NSError * _Nullable err) {
                                  NSLog(@"Write the default value to mandatory non-global attribute: StateValue Error: %@", err);
 
-                                 XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 136);
+                                 XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
                                  [expectation fulfill];
                              }];
 
@@ -885,7 +887,7 @@ CHIPDevice * GetConnectedDevice()
                              completionHandler:^(NSError * _Nullable err) {
                                  NSLog(@"write the default values to mandatory global attribute: ClusterRevision Error: %@", err);
 
-                                 XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 136);
+                                 XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
                                  [expectation fulfill];
                              }];
 
@@ -956,7 +958,7 @@ CHIPDevice * GetConnectedDevice()
                              completionHandler:^(NSError * _Nullable err) {
                                  NSLog(@"Write the default value to mandatory attribute: CurrentHue Error: %@", err);
 
-                                 XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 136);
+                                 XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
                                  [expectation fulfill];
                              }];
 
@@ -1046,13 +1048,14 @@ CHIPDevice * GetConnectedDevice()
 
     id currentSaturationArgument;
     currentSaturationArgument = [NSNumber numberWithUnsignedChar:0];
-    [cluster writeAttributeCurrentSaturationWithValue:currentSaturationArgument
-                                    completionHandler:^(NSError * _Nullable err) {
-                                        NSLog(@"Write the default value to mandatory attribute: CurrentSaturation Error: %@", err);
+    [cluster
+        writeAttributeCurrentSaturationWithValue:currentSaturationArgument
+                               completionHandler:^(NSError * _Nullable err) {
+                                   NSLog(@"Write the default value to mandatory attribute: CurrentSaturation Error: %@", err);
 
-                                        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 136);
-                                        [expectation fulfill];
-                                    }];
+                                   XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
+                                   [expectation fulfill];
+                               }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -1143,7 +1146,7 @@ CHIPDevice * GetConnectedDevice()
                            completionHandler:^(NSError * _Nullable err) {
                                NSLog(@"Write the default value to mandatory attribute: CurrentX Error: %@", err);
 
-                               XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 136);
+                               XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
                                [expectation fulfill];
                            }];
 
@@ -1237,7 +1240,7 @@ CHIPDevice * GetConnectedDevice()
                            completionHandler:^(NSError * _Nullable err) {
                                NSLog(@"Write the default values to mandatory attribute: CurrentY Error: %@", err);
 
-                               XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 136);
+                               XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
                                [expectation fulfill];
                            }];
 
@@ -1465,7 +1468,8 @@ CHIPDevice * GetConnectedDevice()
                                 completionHandler:^(NSError * _Nullable err) {
                                     NSLog(@"Write the default values to mandatory attribute: EnhancedCurrentHue Error: %@", err);
 
-                                    XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 136);
+                                    XCTAssertEqual(
+                                        [CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
                                     [expectation fulfill];
                                 }];
 
@@ -1569,13 +1573,14 @@ CHIPDevice * GetConnectedDevice()
 
     id colorLoopActiveArgument;
     colorLoopActiveArgument = [NSNumber numberWithUnsignedChar:0];
-    [cluster writeAttributeColorLoopActiveWithValue:colorLoopActiveArgument
-                                  completionHandler:^(NSError * _Nullable err) {
-                                      NSLog(@"Write the default values to mandatory attribute: ColorLoopActive Error: %@", err);
+    [cluster
+        writeAttributeColorLoopActiveWithValue:colorLoopActiveArgument
+                             completionHandler:^(NSError * _Nullable err) {
+                                 NSLog(@"Write the default values to mandatory attribute: ColorLoopActive Error: %@", err);
 
-                                      XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 136);
-                                      [expectation fulfill];
-                                  }];
+                                 XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
+                                 [expectation fulfill];
+                             }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -1663,7 +1668,8 @@ CHIPDevice * GetConnectedDevice()
                                 completionHandler:^(NSError * _Nullable err) {
                                     NSLog(@"Write the default values to mandatory attribute: ColorLoopDirection Error: %@", err);
 
-                                    XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 136);
+                                    XCTAssertEqual(
+                                        [CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
                                     [expectation fulfill];
                                 }];
 
@@ -1748,13 +1754,14 @@ CHIPDevice * GetConnectedDevice()
 
     id colorLoopTimeArgument;
     colorLoopTimeArgument = [NSNumber numberWithUnsignedShort:25U];
-    [cluster writeAttributeColorLoopTimeWithValue:colorLoopTimeArgument
-                                completionHandler:^(NSError * _Nullable err) {
-                                    NSLog(@"Write the default values to mandatory attribute: ColorLoopTime Error: %@", err);
+    [cluster
+        writeAttributeColorLoopTimeWithValue:colorLoopTimeArgument
+                           completionHandler:^(NSError * _Nullable err) {
+                               NSLog(@"Write the default values to mandatory attribute: ColorLoopTime Error: %@", err);
 
-                                    XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 136);
-                                    [expectation fulfill];
-                                }];
+                               XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
+                               [expectation fulfill];
+                           }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -1844,7 +1851,8 @@ CHIPDevice * GetConnectedDevice()
                                                       @"Error: %@",
                                                     err);
 
-                                                XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 136);
+                                                XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err],
+                                                    EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
                                                 [expectation fulfill];
                                             }];
 
@@ -1937,7 +1945,8 @@ CHIPDevice * GetConnectedDevice()
                                                        @"ColorLoopStoredEnhancedHue Error: %@",
                                                      err);
 
-                                                 XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 136);
+                                                 XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err],
+                                                     EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
                                                  [expectation fulfill];
                                              }];
 
@@ -2028,13 +2037,14 @@ CHIPDevice * GetConnectedDevice()
 
     id colorCapabilitiesArgument;
     colorCapabilitiesArgument = [NSNumber numberWithUnsignedShort:0U];
-    [cluster writeAttributeColorCapabilitiesWithValue:colorCapabilitiesArgument
-                                    completionHandler:^(NSError * _Nullable err) {
-                                        NSLog(@"Write the default values to mandatory attribute: ColorCapabilities Error: %@", err);
+    [cluster
+        writeAttributeColorCapabilitiesWithValue:colorCapabilitiesArgument
+                               completionHandler:^(NSError * _Nullable err) {
+                                   NSLog(@"Write the default values to mandatory attribute: ColorCapabilities Error: %@", err);
 
-                                        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 136);
-                                        [expectation fulfill];
-                                    }];
+                                   XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
+                                   [expectation fulfill];
+                               }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -2130,7 +2140,8 @@ CHIPDevice * GetConnectedDevice()
                                           @"Write the default values to mandatory  attribute: ColorTempPhysicalMinMireds Error: %@",
                                           err);
 
-                                      XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 136);
+                                      XCTAssertEqual(
+                                          [CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
                                       [expectation fulfill];
                                   }];
 
@@ -2229,7 +2240,8 @@ CHIPDevice * GetConnectedDevice()
                                           @"Write the default values to mandatory attribute: ColorTempPhysicalMaxMireds Error: %@",
                                           err);
 
-                                      XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 136);
+                                      XCTAssertEqual(
+                                          [CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
                                       [expectation fulfill];
                                   }];
 
@@ -2299,7 +2311,8 @@ CHIPDevice * GetConnectedDevice()
                                                             @"CoupleColorTempToLevelMinMireds Error: %@",
                                                           err);
 
-                                                      XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 136);
+                                                      XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err],
+                                                          EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
                                                       [expectation fulfill];
                                                   }];
 
@@ -2468,13 +2481,14 @@ CHIPDevice * GetConnectedDevice()
 
     id remainingTimeArgument;
     remainingTimeArgument = [NSNumber numberWithUnsignedShort:0U];
-    [cluster writeAttributeRemainingTimeWithValue:remainingTimeArgument
-                                completionHandler:^(NSError * _Nullable err) {
-                                    NSLog(@"Write the default values to optional attribute: RemainingTime Error: %@", err);
+    [cluster
+        writeAttributeRemainingTimeWithValue:remainingTimeArgument
+                           completionHandler:^(NSError * _Nullable err) {
+                               NSLog(@"Write the default values to optional attribute: RemainingTime Error: %@", err);
 
-                                    XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 136);
-                                    [expectation fulfill];
-                                }];
+                               XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
+                               [expectation fulfill];
+                           }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -2538,13 +2552,14 @@ CHIPDevice * GetConnectedDevice()
 
     id driftCompensationArgument;
     driftCompensationArgument = [NSNumber numberWithUnsignedChar:0];
-    [cluster writeAttributeDriftCompensationWithValue:driftCompensationArgument
-                                    completionHandler:^(NSError * _Nullable err) {
-                                        NSLog(@"Write the default values to optional attribute: DriftCompensation Error: %@", err);
+    [cluster
+        writeAttributeDriftCompensationWithValue:driftCompensationArgument
+                               completionHandler:^(NSError * _Nullable err) {
+                                   NSLog(@"Write the default values to optional attribute: DriftCompensation Error: %@", err);
 
-                                        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 136);
-                                        [expectation fulfill];
-                                    }];
+                                   XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
+                                   [expectation fulfill];
+                               }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -2631,13 +2646,14 @@ CHIPDevice * GetConnectedDevice()
 
     id numberOfPrimariesArgument;
     numberOfPrimariesArgument = [NSNumber numberWithUnsignedChar:0];
-    [cluster writeAttributeNumberOfPrimariesWithValue:numberOfPrimariesArgument
-                                    completionHandler:^(NSError * _Nullable err) {
-                                        NSLog(@"Write the default mandatory attribute: NumberOfPrimaries Error: %@", err);
+    [cluster
+        writeAttributeNumberOfPrimariesWithValue:numberOfPrimariesArgument
+                               completionHandler:^(NSError * _Nullable err) {
+                                   NSLog(@"Write the default mandatory attribute: NumberOfPrimaries Error: %@", err);
 
-                                        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 136);
-                                        [expectation fulfill];
-                                    }];
+                                   XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
+                                   [expectation fulfill];
+                               }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -2704,7 +2720,7 @@ CHIPDevice * GetConnectedDevice()
                             completionHandler:^(NSError * _Nullable err) {
                                 NSLog(@"Write the default mandatory attribute: Primary1X Error: %@", err);
 
-                                XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 136);
+                                XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
                                 [expectation fulfill];
                             }];
 
@@ -2773,7 +2789,7 @@ CHIPDevice * GetConnectedDevice()
                             completionHandler:^(NSError * _Nullable err) {
                                 NSLog(@"Write the default mandatory attribute: Primary1Y Error: %@", err);
 
-                                XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 136);
+                                XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
                                 [expectation fulfill];
                             }];
 
@@ -2861,7 +2877,7 @@ CHIPDevice * GetConnectedDevice()
                             completionHandler:^(NSError * _Nullable err) {
                                 NSLog(@"Write the default mandatory attribute: Primary2X Error: %@", err);
 
-                                XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 136);
+                                XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
                                 [expectation fulfill];
                             }];
 
@@ -2930,7 +2946,7 @@ CHIPDevice * GetConnectedDevice()
                             completionHandler:^(NSError * _Nullable err) {
                                 NSLog(@"Write the default mandatory attribute: Primary2Y Error: %@", err);
 
-                                XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 136);
+                                XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
                                 [expectation fulfill];
                             }];
 
@@ -3018,7 +3034,7 @@ CHIPDevice * GetConnectedDevice()
                             completionHandler:^(NSError * _Nullable err) {
                                 NSLog(@"Write the default mandatory attribute: Primary3X Error: %@", err);
 
-                                XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 136);
+                                XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
                                 [expectation fulfill];
                             }];
 
@@ -3087,7 +3103,7 @@ CHIPDevice * GetConnectedDevice()
                             completionHandler:^(NSError * _Nullable err) {
                                 NSLog(@"Write the default mandatory attribute: Primary3Y Error: %@", err);
 
-                                XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 136);
+                                XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
                                 [expectation fulfill];
                             }];
 
@@ -3175,7 +3191,7 @@ CHIPDevice * GetConnectedDevice()
                             completionHandler:^(NSError * _Nullable err) {
                                 NSLog(@"Write the default mandatory attribute: Primary4X Error: %@", err);
 
-                                XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 136);
+                                XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
                                 [expectation fulfill];
                             }];
 
@@ -3244,7 +3260,7 @@ CHIPDevice * GetConnectedDevice()
                             completionHandler:^(NSError * _Nullable err) {
                                 NSLog(@"Write the default mandatory attribute: Primary4Y Error: %@", err);
 
-                                XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 136);
+                                XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
                                 [expectation fulfill];
                             }];
 
@@ -3332,7 +3348,7 @@ CHIPDevice * GetConnectedDevice()
                             completionHandler:^(NSError * _Nullable err) {
                                 NSLog(@"Write the default mandatory attribute: Primary5X Error: %@", err);
 
-                                XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 136);
+                                XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
                                 [expectation fulfill];
                             }];
 
@@ -3401,7 +3417,7 @@ CHIPDevice * GetConnectedDevice()
                             completionHandler:^(NSError * _Nullable err) {
                                 NSLog(@"Write the default mandatory attribute: Primary5Y Error: %@", err);
 
-                                XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 136);
+                                XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
                                 [expectation fulfill];
                             }];
 
@@ -3489,7 +3505,7 @@ CHIPDevice * GetConnectedDevice()
                             completionHandler:^(NSError * _Nullable err) {
                                 NSLog(@"Write the default mandatory attribute: Primary6X Error: %@", err);
 
-                                XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 136);
+                                XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
                                 [expectation fulfill];
                             }];
 
@@ -3558,7 +3574,7 @@ CHIPDevice * GetConnectedDevice()
                             completionHandler:^(NSError * _Nullable err) {
                                 NSLog(@"Write the default mandatory attribute: Primary6Y Error: %@", err);
 
-                                XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 136);
+                                XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
                                 [expectation fulfill];
                             }];
 
@@ -9100,7 +9116,7 @@ CHIPDevice * GetConnectedDevice()
                              completionHandler:^(NSError * _Nullable err) {
                                  NSLog(@"write the default values to mandatory global attribute: ClusterRevision Error: %@", err);
 
-                                 XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 136);
+                                 XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
                                  [expectation fulfill];
                              }];
 
@@ -9148,7 +9164,7 @@ CHIPDevice * GetConnectedDevice()
                              completionHandler:^(NSError * _Nullable err) {
                                  NSLog(@"write the default values to mandatory global attribute: ClusterRevision Error: %@", err);
 
-                                 XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 136);
+                                 XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
                                  [expectation fulfill];
                              }];
 
@@ -9224,13 +9240,14 @@ CHIPDevice * GetConnectedDevice()
 
     id minMeasuredValueArgument;
     minMeasuredValueArgument = [NSNumber numberWithShort:0];
-    [cluster writeAttributeMinMeasuredValueWithValue:minMeasuredValueArgument
-                                   completionHandler:^(NSError * _Nullable err) {
-                                       NSLog(@"write the default value to optional attribute: MinMeasuredValue Error: %@", err);
+    [cluster
+        writeAttributeMinMeasuredValueWithValue:minMeasuredValueArgument
+                              completionHandler:^(NSError * _Nullable err) {
+                                  NSLog(@"write the default value to optional attribute: MinMeasuredValue Error: %@", err);
 
-                                       XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 136);
-                                       [expectation fulfill];
-                                   }];
+                                  XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
+                                  [expectation fulfill];
+                              }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -9246,13 +9263,14 @@ CHIPDevice * GetConnectedDevice()
 
     id maxMeasuredValueArgument;
     maxMeasuredValueArgument = [NSNumber numberWithShort:0];
-    [cluster writeAttributeMaxMeasuredValueWithValue:maxMeasuredValueArgument
-                                   completionHandler:^(NSError * _Nullable err) {
-                                       NSLog(@"write the default value to optional attribute: MaxMeasuredValue Error: %@", err);
+    [cluster
+        writeAttributeMaxMeasuredValueWithValue:maxMeasuredValueArgument
+                              completionHandler:^(NSError * _Nullable err) {
+                                  NSLog(@"write the default value to optional attribute: MaxMeasuredValue Error: %@", err);
 
-                                       XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 136);
-                                       [expectation fulfill];
-                                   }];
+                                  XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
+                                  [expectation fulfill];
+                              }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -9398,7 +9416,7 @@ CHIPDevice * GetConnectedDevice()
                              completionHandler:^(NSError * _Nullable err) {
                                  NSLog(@"write the default values to mandatory global attribute: ClusterRevision Error: %@", err);
 
-                                 XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 136);
+                                 XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
                                  [expectation fulfill];
                              }];
 
@@ -9448,7 +9466,7 @@ CHIPDevice * GetConnectedDevice()
                              completionHandler:^(NSError * _Nullable err) {
                                  NSLog(@"write the default values to mandatory global attribute: ClusterRevision Error: %@", err);
 
-                                 XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 136);
+                                 XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
                                  [expectation fulfill];
                              }];
 
@@ -10359,7 +10377,7 @@ CHIPDevice * GetConnectedDevice()
                              completionHandler:^(NSError * _Nullable err) {
                                  NSLog(@"write the default values to mandatory global attribute: ClusterRevision Error: %@", err);
 
-                                 XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 136);
+                                 XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
                                  [expectation fulfill];
                              }];
 
@@ -10427,7 +10445,7 @@ CHIPDevice * GetConnectedDevice()
                              completionHandler:^(NSError * _Nullable err) {
                                  NSLog(@"write the default values to mandatory global attribute: ClusterRevision Error: %@", err);
 
-                                 XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 136);
+                                 XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
                                  [expectation fulfill];
                              }];
 
@@ -10474,7 +10492,7 @@ CHIPDevice * GetConnectedDevice()
                             completionHandler:^(NSError * _Nullable err) {
                                 NSLog(@"Writes the respective default value to mandatory attribute: Occupancy Error: %@", err);
 
-                                XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 136);
+                                XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
                                 [expectation fulfill];
                             }];
 
@@ -10547,7 +10565,8 @@ CHIPDevice * GetConnectedDevice()
                                                 @"Error: %@",
                                               err);
 
-                                          XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 136);
+                                          XCTAssertEqual(
+                                              [CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
                                           [expectation fulfill];
                                       }];
 
@@ -10624,7 +10643,8 @@ CHIPDevice * GetConnectedDevice()
                                                       @"OccupancySensorTypeBitmap Error: %@",
                                                     err);
 
-                                                XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 136);
+                                                XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err],
+                                                    EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
                                                 [expectation fulfill];
                                             }];
 
@@ -10736,7 +10756,7 @@ CHIPDevice * GetConnectedDevice()
                              completionHandler:^(NSError * _Nullable err) {
                                  NSLog(@"write the default values to mandatory global attribute: ClusterRevision Error: %@", err);
 
-                                 XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 136);
+                                 XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
                                  [expectation fulfill];
                              }];
 
@@ -10806,7 +10826,7 @@ CHIPDevice * GetConnectedDevice()
                              completionHandler:^(NSError * _Nullable err) {
                                  NSLog(@"write the default values to optional global attribute: FeatureMap Error: %@", err);
 
-                                 XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 136);
+                                 XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
                                  [expectation fulfill];
                              }];
 
@@ -12491,7 +12511,7 @@ CHIPDevice * GetConnectedDevice()
                              completionHandler:^(NSError * _Nullable err) {
                                  NSLog(@"Write the default values to mandatory global attribute: ClusterRevision Error: %@", err);
 
-                                 XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 136);
+                                 XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
                                  [expectation fulfill];
                              }];
 
@@ -12553,13 +12573,14 @@ CHIPDevice * GetConnectedDevice()
 
     id measuredValueArgument;
     measuredValueArgument = [NSNumber numberWithShort:0];
-    [cluster writeAttributeMeasuredValueWithValue:measuredValueArgument
-                                completionHandler:^(NSError * _Nullable err) {
-                                    NSLog(@"Write the default values to mandatory attribute: MeasuredValue Error: %@", err);
+    [cluster
+        writeAttributeMeasuredValueWithValue:measuredValueArgument
+                           completionHandler:^(NSError * _Nullable err) {
+                               NSLog(@"Write the default values to mandatory attribute: MeasuredValue Error: %@", err);
 
-                                    XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 136);
-                                    [expectation fulfill];
-                                }];
+                               XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
+                               [expectation fulfill];
+                           }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -12619,13 +12640,14 @@ CHIPDevice * GetConnectedDevice()
 
     id minMeasuredValueArgument;
     minMeasuredValueArgument = [NSNumber numberWithShort:0];
-    [cluster writeAttributeMinMeasuredValueWithValue:minMeasuredValueArgument
-                                   completionHandler:^(NSError * _Nullable err) {
-                                       NSLog(@"Write the default values to mandatory attribute: MinMeasuredValue Error: %@", err);
+    [cluster
+        writeAttributeMinMeasuredValueWithValue:minMeasuredValueArgument
+                              completionHandler:^(NSError * _Nullable err) {
+                                  NSLog(@"Write the default values to mandatory attribute: MinMeasuredValue Error: %@", err);
 
-                                       XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 136);
-                                       [expectation fulfill];
-                                   }];
+                                  XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
+                                  [expectation fulfill];
+                              }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -12685,13 +12707,14 @@ CHIPDevice * GetConnectedDevice()
 
     id maxMeasuredValueArgument;
     maxMeasuredValueArgument = [NSNumber numberWithShort:0];
-    [cluster writeAttributeMaxMeasuredValueWithValue:maxMeasuredValueArgument
-                                   completionHandler:^(NSError * _Nullable err) {
-                                       NSLog(@"Write the default values to mandatory attribute: MaxMeasuredValue Error: %@", err);
+    [cluster
+        writeAttributeMaxMeasuredValueWithValue:maxMeasuredValueArgument
+                              completionHandler:^(NSError * _Nullable err) {
+                                  NSLog(@"Write the default values to mandatory attribute: MaxMeasuredValue Error: %@", err);
 
-                                       XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 136);
-                                       [expectation fulfill];
-                                   }];
+                                  XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
+                                  [expectation fulfill];
+                              }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -12739,7 +12762,7 @@ CHIPDevice * GetConnectedDevice()
                              completionHandler:^(NSError * _Nullable err) {
                                  NSLog(@"write the default values to mandatory global attribute: ClusterRevision Error: %@", err);
 
-                                 XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 136);
+                                 XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
                                  [expectation fulfill];
                              }];
 
@@ -13061,7 +13084,7 @@ CHIPDevice * GetConnectedDevice()
                              completionHandler:^(NSError * _Nullable err) {
                                  NSLog(@"write the default values to mandatory global attribute: ClusterRevision Error: %@", err);
 
-                                 XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 136);
+                                 XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
                                  [expectation fulfill];
                              }];
 
@@ -13204,7 +13227,7 @@ CHIPDevice * GetConnectedDevice()
                              completionHandler:^(NSError * _Nullable err) {
                                  NSLog(@"write the default values to mandatory global attribute: ClusterRevision Error: %@", err);
 
-                                 XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 136);
+                                 XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
                                  [expectation fulfill];
                              }];
 
@@ -13319,7 +13342,7 @@ CHIPDevice * GetConnectedDevice()
                              completionHandler:^(NSError * _Nullable err) {
                                  NSLog(@"write the default values to mandatory global attribute: ClusterRevision Error: %@", err);
 
-                                 XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 136);
+                                 XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
                                  [expectation fulfill];
                              }];
 
@@ -13418,7 +13441,8 @@ CHIPDevice * GetConnectedDevice()
                                                     @"AbsMinHeatSetpointLimit Error: %@",
                                                   err);
 
-                                              XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 136);
+                                              XCTAssertEqual(
+                                                  [CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
                                               [expectation fulfill];
                                           }];
 
@@ -13521,7 +13545,8 @@ CHIPDevice * GetConnectedDevice()
                                                     @"AbsMaxHeatSetpointLimit Error: %@",
                                                   err);
 
-                                              XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 136);
+                                              XCTAssertEqual(
+                                                  [CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
                                               [expectation fulfill];
                                           }];
 
@@ -13624,7 +13649,8 @@ CHIPDevice * GetConnectedDevice()
                                                     @"AbsMinCoolSetpointLimit Error: %@",
                                                   err);
 
-                                              XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 136);
+                                              XCTAssertEqual(
+                                                  [CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
                                               [expectation fulfill];
                                           }];
 
@@ -13727,7 +13753,8 @@ CHIPDevice * GetConnectedDevice()
                                                     @"AbsMaxCoolSetpointLimit Error: %@",
                                                   err);
 
-                                              XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 136);
+                                              XCTAssertEqual(
+                                                  [CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
                                               [expectation fulfill];
                                           }];
 
@@ -14721,7 +14748,7 @@ CHIPDevice * GetConnectedDevice()
                                   NSLog(@"Writes the respective default value to optional attributes to DUT: StartOfWeek Error: %@",
                                       err);
 
-                                  XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 136);
+                                  XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
                                   [expectation fulfill];
                               }];
 
@@ -14789,7 +14816,8 @@ CHIPDevice * GetConnectedDevice()
                                                       @"NumberOfWeeklyTransitions Error: %@",
                                                     err);
 
-                                                XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 136);
+                                                XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err],
+                                                    EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
                                                 [expectation fulfill];
                                             }];
 
@@ -14833,7 +14861,8 @@ CHIPDevice * GetConnectedDevice()
                                                      @"NumberOfDailyTransitions Error: %@",
                                                    err);
 
-                                               XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 136);
+                                               XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err],
+                                                   EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
                                                [expectation fulfill];
                                            }];
 
@@ -16067,7 +16096,7 @@ CHIPDevice * GetConnectedDevice()
                              completionHandler:^(NSError * _Nullable err) {
                                  NSLog(@"write the default values to mandatory global attribute: ClusterRevision Error: %@", err);
 
-                                 XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 136);
+                                 XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
                                  [expectation fulfill];
                              }];
 
@@ -16711,7 +16740,7 @@ CHIPDevice * GetConnectedDevice()
                              completionHandler:^(NSError * _Nullable err) {
                                  NSLog(@"write the default values to mandatory global attribute: ClusterRevision Error: %@", err);
 
-                                 XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 136);
+                                 XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
                                  [expectation fulfill];
                              }];
 
@@ -16789,7 +16818,7 @@ CHIPDevice * GetConnectedDevice()
                              completionHandler:^(NSError * _Nullable err) {
                                  NSLog(@"3a: write a value into the RO mandatory global attribute: ClusterRevision Error: %@", err);
 
-                                 XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 136);
+                                 XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
                                  [expectation fulfill];
                              }];
 
@@ -16859,7 +16888,7 @@ CHIPDevice * GetConnectedDevice()
                              completionHandler:^(NSError * _Nullable err) {
                                  NSLog(@"3a: write the default value to optional global attribute: FeatureMap Error: %@", err);
 
-                                 XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 136);
+                                 XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
                                  [expectation fulfill];
                              }];
 
@@ -16929,7 +16958,7 @@ CHIPDevice * GetConnectedDevice()
                        completionHandler:^(NSError * _Nullable err) {
                            NSLog(@"3a: write a value into the RO mandatory attribute: Type Error: %@", err);
 
-                           XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 136);
+                           XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
                            [expectation fulfill];
                        }];
 
@@ -16999,7 +17028,7 @@ CHIPDevice * GetConnectedDevice()
                                completionHandler:^(NSError * _Nullable err) {
                                    NSLog(@"3a: write a value into the RO mandatory attribute: ConfigStatus Error: %@", err);
 
-                                   XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 136);
+                                   XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
                                    [expectation fulfill];
                                }];
 
@@ -17071,7 +17100,7 @@ CHIPDevice * GetConnectedDevice()
                                completionHandler:^(NSError * _Nullable err) {
                                    NSLog(@"3a: write a value into the RO mandatory attribute: OperationalStatus Error: %@", err);
 
-                                   XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 136);
+                                   XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
                                    [expectation fulfill];
                                }];
 
@@ -17139,13 +17168,14 @@ CHIPDevice * GetConnectedDevice()
 
     id endProductTypeArgument;
     endProductTypeArgument = [NSNumber numberWithUnsignedChar:250];
-    [cluster writeAttributeEndProductTypeWithValue:endProductTypeArgument
-                                 completionHandler:^(NSError * _Nullable err) {
-                                     NSLog(@"3a: write a value into the RO mandatory attribute: EndProductType Error: %@", err);
+    [cluster
+        writeAttributeEndProductTypeWithValue:endProductTypeArgument
+                            completionHandler:^(NSError * _Nullable err) {
+                                NSLog(@"3a: write a value into the RO mandatory attribute: EndProductType Error: %@", err);
 
-                                     XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 136);
-                                     [expectation fulfill];
-                                 }];
+                                XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
+                                [expectation fulfill];
+                            }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -17288,7 +17318,8 @@ CHIPDevice * GetConnectedDevice()
                                                             @"TargetPositionLiftPercent100ths Error: %@",
                                                           err);
 
-                                                      XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 136);
+                                                      XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err],
+                                                          EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
                                                       [expectation fulfill];
                                                   }];
 
@@ -17364,7 +17395,8 @@ CHIPDevice * GetConnectedDevice()
                                                             @"TargetPositionTiltPercent100ths Error: %@",
                                                           err);
 
-                                                      XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 136);
+                                                      XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err],
+                                                          EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
                                                       [expectation fulfill];
                                                   }];
 
@@ -17440,7 +17472,8 @@ CHIPDevice * GetConnectedDevice()
                                                              @"CurrentPositionLiftPercent100ths Error: %@",
                                                            err);
 
-                                                       XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 136);
+                                                       XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err],
+                                                           EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
                                                        [expectation fulfill];
                                                    }];
 
@@ -17516,7 +17549,8 @@ CHIPDevice * GetConnectedDevice()
                                                              @"CurrentPositionTiltPercent100ths Error: %@",
                                                            err);
 
-                                                       XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 136);
+                                                       XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err],
+                                                           EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
                                                        [expectation fulfill];
                                                    }];
 
@@ -17591,7 +17625,8 @@ CHIPDevice * GetConnectedDevice()
                                         NSLog(@"3a: write a value into the RO optional attribute: InstalledOpenLimitLift Error: %@",
                                             err);
 
-                                        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 136);
+                                        XCTAssertEqual(
+                                            [CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
                                         [expectation fulfill];
                                     }];
 
@@ -17665,7 +17700,8 @@ CHIPDevice * GetConnectedDevice()
                                                      @"Error: %@",
                                                    err);
 
-                                               XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 136);
+                                               XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err],
+                                                   EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
                                                [expectation fulfill];
                                            }];
 
@@ -17739,7 +17775,8 @@ CHIPDevice * GetConnectedDevice()
                                         NSLog(@"3a: write a value into the RO optional attribute: InstalledOpenLimitTilt Error: %@",
                                             err);
 
-                                        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 136);
+                                        XCTAssertEqual(
+                                            [CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
                                         [expectation fulfill];
                                     }];
 
@@ -17813,7 +17850,8 @@ CHIPDevice * GetConnectedDevice()
                                                      @"Error: %@",
                                                    err);
 
-                                               XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 136);
+                                               XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err],
+                                                   EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
                                                [expectation fulfill];
                                            }];
 
@@ -17884,7 +17922,7 @@ CHIPDevice * GetConnectedDevice()
                                completionHandler:^(NSError * _Nullable err) {
                                    NSLog(@"5a: write a value into the RO mandatory attribute: SafetyStatus Error: %@", err);
 
-                                   XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 136);
+                                   XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
                                    [expectation fulfill];
                                }];
 
@@ -17956,7 +17994,8 @@ CHIPDevice * GetConnectedDevice()
                                  completionHandler:^(NSError * _Nullable err) {
                                      NSLog(@"5a: write a value into the RO optional attribute: CurrentPositionLift Error: %@", err);
 
-                                     XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 136);
+                                     XCTAssertEqual(
+                                         [CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
                                      [expectation fulfill];
                                  }];
 
@@ -18029,7 +18068,8 @@ CHIPDevice * GetConnectedDevice()
                                  completionHandler:^(NSError * _Nullable err) {
                                      NSLog(@"5a: write a value into the RO optional attribute: CurrentPositionTilt Error: %@", err);
 
-                                     XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 136);
+                                     XCTAssertEqual(
+                                         [CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
                                      [expectation fulfill];
                                  }];
 
@@ -18104,7 +18144,8 @@ CHIPDevice * GetConnectedDevice()
                                                           @"CurrentPositionLiftPercentage Error: %@",
                                                         err);
 
-                                                    XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 136);
+                                                    XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err],
+                                                        EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
                                                     [expectation fulfill];
                                                 }];
 
@@ -18180,7 +18221,8 @@ CHIPDevice * GetConnectedDevice()
                                                           @"CurrentPositionTiltPercentage Error: %@",
                                                         err);
 
-                                                    XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 136);
+                                                    XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err],
+                                                        EMBER_ZCL_STATUS_UNSUPPORTED_WRITE);
                                                     [expectation fulfill];
                                                 }];
 
@@ -18531,7 +18573,7 @@ CHIPDevice * GetConnectedDevice()
     [cluster testNotHandledWithCompletionHandler:^(NSError * _Nullable err) {
         NSLog(@"Send Test Not Handled Command Error: %@", err);
 
-        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 133);
+        XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_INVALID_COMMAND);
         [expectation fulfill];
     }];
 
@@ -18608,7 +18650,7 @@ CHIPDevice * GetConnectedDevice()
                           CHIPTestClusterClusterTestAddArgumentsResponseParams * _Nullable values, NSError * _Nullable err) {
                           NSLog(@"Send failing Test Add Arguments Command Error: %@", err);
 
-                          XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 133);
+                          XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_INVALID_COMMAND);
                           [expectation fulfill];
                       }];
 
@@ -20669,7 +20711,7 @@ CHIPDevice * GetConnectedDevice()
                               completionHandler:^(NSError * _Nullable err) {
                                   NSLog(@"Write attribute OCTET_STRING Error: %@", err);
 
-                                  XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 135);
+                                  XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_CONSTRAINT_ERROR);
                                   [expectation fulfill];
                               }];
 
@@ -20908,7 +20950,7 @@ CHIPDevice * GetConnectedDevice()
                              completionHandler:^(NSError * _Nullable err) {
                                  NSLog(@"Write attribute CHAR_STRING - Value too long Error: %@", err);
 
-                                 XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 135);
+                                 XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_CONSTRAINT_ERROR);
                                  [expectation fulfill];
                              }];
 
@@ -22322,13 +22364,14 @@ CHIPDevice * GetConnectedDevice()
 
     id nullableBitmap8Argument;
     nullableBitmap8Argument = [NSNumber numberWithUnsignedChar:255];
-    [cluster writeAttributeNullableBitmap8WithValue:nullableBitmap8Argument
-                                  completionHandler:^(NSError * _Nullable err) {
-                                      NSLog(@"Write attribute NULLABLE_BITMAP8 Invalid Value Error: %@", err);
+    [cluster
+        writeAttributeNullableBitmap8WithValue:nullableBitmap8Argument
+                             completionHandler:^(NSError * _Nullable err) {
+                                 NSLog(@"Write attribute NULLABLE_BITMAP8 Invalid Value Error: %@", err);
 
-                                      XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 135);
-                                      [expectation fulfill];
-                                  }];
+                                 XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_CONSTRAINT_ERROR);
+                                 [expectation fulfill];
+                             }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -22461,13 +22504,14 @@ CHIPDevice * GetConnectedDevice()
 
     id nullableBitmap16Argument;
     nullableBitmap16Argument = [NSNumber numberWithUnsignedShort:65535U];
-    [cluster writeAttributeNullableBitmap16WithValue:nullableBitmap16Argument
-                                   completionHandler:^(NSError * _Nullable err) {
-                                       NSLog(@"Write attribute NULLABLE_BITMAP16 Invalid Value Error: %@", err);
+    [cluster
+        writeAttributeNullableBitmap16WithValue:nullableBitmap16Argument
+                              completionHandler:^(NSError * _Nullable err) {
+                                  NSLog(@"Write attribute NULLABLE_BITMAP16 Invalid Value Error: %@", err);
 
-                                       XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 135);
-                                       [expectation fulfill];
-                                   }];
+                                  XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_CONSTRAINT_ERROR);
+                                  [expectation fulfill];
+                              }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -22600,13 +22644,14 @@ CHIPDevice * GetConnectedDevice()
 
     id nullableBitmap32Argument;
     nullableBitmap32Argument = [NSNumber numberWithUnsignedInt:4294967295UL];
-    [cluster writeAttributeNullableBitmap32WithValue:nullableBitmap32Argument
-                                   completionHandler:^(NSError * _Nullable err) {
-                                       NSLog(@"Write attribute NULLABLE_BITMAP32 Invalid Value Error: %@", err);
+    [cluster
+        writeAttributeNullableBitmap32WithValue:nullableBitmap32Argument
+                              completionHandler:^(NSError * _Nullable err) {
+                                  NSLog(@"Write attribute NULLABLE_BITMAP32 Invalid Value Error: %@", err);
 
-                                       XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 135);
-                                       [expectation fulfill];
-                                   }];
+                                  XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_CONSTRAINT_ERROR);
+                                  [expectation fulfill];
+                              }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -22739,13 +22784,14 @@ CHIPDevice * GetConnectedDevice()
 
     id nullableBitmap64Argument;
     nullableBitmap64Argument = [NSNumber numberWithUnsignedLongLong:18446744073709551615ULL];
-    [cluster writeAttributeNullableBitmap64WithValue:nullableBitmap64Argument
-                                   completionHandler:^(NSError * _Nullable err) {
-                                       NSLog(@"Write attribute NULLABLE_BITMAP64 Invalid Value Error: %@", err);
+    [cluster
+        writeAttributeNullableBitmap64WithValue:nullableBitmap64Argument
+                              completionHandler:^(NSError * _Nullable err) {
+                                  NSLog(@"Write attribute NULLABLE_BITMAP64 Invalid Value Error: %@", err);
 
-                                       XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 135);
-                                       [expectation fulfill];
-                                   }];
+                                  XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_CONSTRAINT_ERROR);
+                                  [expectation fulfill];
+                              }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -22882,7 +22928,7 @@ CHIPDevice * GetConnectedDevice()
                                 completionHandler:^(NSError * _Nullable err) {
                                     NSLog(@"Write attribute NULLABLE_INT8U Invalid Value Error: %@", err);
 
-                                    XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 135);
+                                    XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_CONSTRAINT_ERROR);
                                     [expectation fulfill];
                                 }];
 
@@ -23017,13 +23063,14 @@ CHIPDevice * GetConnectedDevice()
 
     id nullableInt16uArgument;
     nullableInt16uArgument = [NSNumber numberWithUnsignedShort:65535U];
-    [cluster writeAttributeNullableInt16uWithValue:nullableInt16uArgument
-                                 completionHandler:^(NSError * _Nullable err) {
-                                     NSLog(@"Write attribute NULLABLE_INT16U Invalid Value Error: %@", err);
+    [cluster
+        writeAttributeNullableInt16uWithValue:nullableInt16uArgument
+                            completionHandler:^(NSError * _Nullable err) {
+                                NSLog(@"Write attribute NULLABLE_INT16U Invalid Value Error: %@", err);
 
-                                     XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 135);
-                                     [expectation fulfill];
-                                 }];
+                                XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_CONSTRAINT_ERROR);
+                                [expectation fulfill];
+                            }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -23156,13 +23203,14 @@ CHIPDevice * GetConnectedDevice()
 
     id nullableInt32uArgument;
     nullableInt32uArgument = [NSNumber numberWithUnsignedInt:4294967295UL];
-    [cluster writeAttributeNullableInt32uWithValue:nullableInt32uArgument
-                                 completionHandler:^(NSError * _Nullable err) {
-                                     NSLog(@"Write attribute NULLABLE_INT32U Invalid Value Error: %@", err);
+    [cluster
+        writeAttributeNullableInt32uWithValue:nullableInt32uArgument
+                            completionHandler:^(NSError * _Nullable err) {
+                                NSLog(@"Write attribute NULLABLE_INT32U Invalid Value Error: %@", err);
 
-                                     XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 135);
-                                     [expectation fulfill];
-                                 }];
+                                XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_CONSTRAINT_ERROR);
+                                [expectation fulfill];
+                            }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -23295,13 +23343,14 @@ CHIPDevice * GetConnectedDevice()
 
     id nullableInt64uArgument;
     nullableInt64uArgument = [NSNumber numberWithUnsignedLongLong:18446744073709551615ULL];
-    [cluster writeAttributeNullableInt64uWithValue:nullableInt64uArgument
-                                 completionHandler:^(NSError * _Nullable err) {
-                                     NSLog(@"Write attribute NULLABLE_INT64U Invalid Value Error: %@", err);
+    [cluster
+        writeAttributeNullableInt64uWithValue:nullableInt64uArgument
+                            completionHandler:^(NSError * _Nullable err) {
+                                NSLog(@"Write attribute NULLABLE_INT64U Invalid Value Error: %@", err);
 
-                                     XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 135);
-                                     [expectation fulfill];
-                                 }];
+                                XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_CONSTRAINT_ERROR);
+                                [expectation fulfill];
+                            }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -23438,7 +23487,7 @@ CHIPDevice * GetConnectedDevice()
                                 completionHandler:^(NSError * _Nullable err) {
                                     NSLog(@"Write attribute NULLABLE_INT8S Invalid Value Error: %@", err);
 
-                                    XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 135);
+                                    XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_CONSTRAINT_ERROR);
                                     [expectation fulfill];
                                 }];
 
@@ -23573,13 +23622,14 @@ CHIPDevice * GetConnectedDevice()
 
     id nullableInt16sArgument;
     nullableInt16sArgument = [NSNumber numberWithShort:-32768];
-    [cluster writeAttributeNullableInt16sWithValue:nullableInt16sArgument
-                                 completionHandler:^(NSError * _Nullable err) {
-                                     NSLog(@"Write attribute NULLABLE_INT16S Invalid Value Error: %@", err);
+    [cluster
+        writeAttributeNullableInt16sWithValue:nullableInt16sArgument
+                            completionHandler:^(NSError * _Nullable err) {
+                                NSLog(@"Write attribute NULLABLE_INT16S Invalid Value Error: %@", err);
 
-                                     XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 135);
-                                     [expectation fulfill];
-                                 }];
+                                XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_CONSTRAINT_ERROR);
+                                [expectation fulfill];
+                            }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -23712,13 +23762,14 @@ CHIPDevice * GetConnectedDevice()
 
     id nullableInt32sArgument;
     nullableInt32sArgument = [NSNumber numberWithInt:-2147483648L];
-    [cluster writeAttributeNullableInt32sWithValue:nullableInt32sArgument
-                                 completionHandler:^(NSError * _Nullable err) {
-                                     NSLog(@"Write attribute NULLABLE_INT32S Invalid Value Error: %@", err);
+    [cluster
+        writeAttributeNullableInt32sWithValue:nullableInt32sArgument
+                            completionHandler:^(NSError * _Nullable err) {
+                                NSLog(@"Write attribute NULLABLE_INT32S Invalid Value Error: %@", err);
 
-                                     XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 135);
-                                     [expectation fulfill];
-                                 }];
+                                XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_CONSTRAINT_ERROR);
+                                [expectation fulfill];
+                            }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -23851,13 +23902,14 @@ CHIPDevice * GetConnectedDevice()
 
     id nullableInt64sArgument;
     nullableInt64sArgument = [NSNumber numberWithLongLong:-9223372036854775807LL - 1];
-    [cluster writeAttributeNullableInt64sWithValue:nullableInt64sArgument
-                                 completionHandler:^(NSError * _Nullable err) {
-                                     NSLog(@"Write attribute NULLABLE_INT64S Invalid Value Error: %@", err);
+    [cluster
+        writeAttributeNullableInt64sWithValue:nullableInt64sArgument
+                            completionHandler:^(NSError * _Nullable err) {
+                                NSLog(@"Write attribute NULLABLE_INT64S Invalid Value Error: %@", err);
 
-                                     XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 135);
-                                     [expectation fulfill];
-                                 }];
+                                XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_CONSTRAINT_ERROR);
+                                [expectation fulfill];
+                            }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -23994,7 +24046,7 @@ CHIPDevice * GetConnectedDevice()
                                 completionHandler:^(NSError * _Nullable err) {
                                     NSLog(@"Write attribute NULLABLE_ENUM8 Invalid Value Error: %@", err);
 
-                                    XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 135);
+                                    XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_CONSTRAINT_ERROR);
                                     [expectation fulfill];
                                 }];
 
@@ -24129,13 +24181,14 @@ CHIPDevice * GetConnectedDevice()
 
     id nullableEnum16Argument;
     nullableEnum16Argument = [NSNumber numberWithUnsignedShort:65535U];
-    [cluster writeAttributeNullableEnum16WithValue:nullableEnum16Argument
-                                 completionHandler:^(NSError * _Nullable err) {
-                                     NSLog(@"Write attribute NULLABLE_ENUM16 Invalid Value Error: %@", err);
+    [cluster
+        writeAttributeNullableEnum16WithValue:nullableEnum16Argument
+                            completionHandler:^(NSError * _Nullable err) {
+                                NSLog(@"Write attribute NULLABLE_ENUM16 Invalid Value Error: %@", err);
 
-                                     XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 135);
-                                     [expectation fulfill];
-                                 }];
+                                XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_CONSTRAINT_ERROR);
+                                [expectation fulfill];
+                            }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -28003,7 +28056,7 @@ uint16_t readAttributeVendorIdDefaultValue;
                   completionHandler:^(NSError * _Nullable err) {
                       NSLog(@"Change to Unsupported Mode Error: %@", err);
 
-                      XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], 135);
+                      XCTAssertEqual([CHIPErrorTestUtils errorToZCLErrorCode:err], EMBER_ZCL_STATUS_CONSTRAINT_ERROR);
                       [expectation fulfill];
                   }];
 

--- a/zzz_generated/chip-tool/zap-generated/test/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/test/Commands.h
@@ -270,7 +270,7 @@ private:
 
     void OnFailureResponse_1(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 136));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
         NextTest();
     }
 
@@ -674,7 +674,7 @@ private:
 
     void OnFailureResponse_9(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 136));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
         NextTest();
     }
 
@@ -1133,7 +1133,7 @@ private:
 
     void OnFailureResponse_1(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 136));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
         NextTest();
     }
 
@@ -1313,7 +1313,7 @@ private:
 
     void OnFailureResponse_2(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 136));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
         NextTest();
     }
 
@@ -1413,7 +1413,7 @@ private:
 
     void OnFailureResponse_0(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 136));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
         NextTest();
     }
 
@@ -3443,7 +3443,7 @@ private:
 
     void OnFailureResponse_2(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 136));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
         NextTest();
     }
 
@@ -3522,7 +3522,7 @@ private:
 
     void OnFailureResponse_6(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 136));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
         NextTest();
     }
 
@@ -3601,7 +3601,7 @@ private:
 
     void OnFailureResponse_10(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 136));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
         NextTest();
     }
 
@@ -3680,7 +3680,7 @@ private:
 
     void OnFailureResponse_14(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 136));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
         NextTest();
     }
 
@@ -3872,7 +3872,7 @@ private:
 
     void OnFailureResponse_24(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 136));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
         NextTest();
     }
 
@@ -3969,7 +3969,7 @@ private:
 
     void OnFailureResponse_29(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 136));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
         NextTest();
     }
 
@@ -4047,7 +4047,7 @@ private:
 
     void OnFailureResponse_33(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 136));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
         NextTest();
     }
 
@@ -4125,7 +4125,7 @@ private:
 
     void OnFailureResponse_37(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 136));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
         NextTest();
     }
 
@@ -4203,7 +4203,7 @@ private:
 
     void OnFailureResponse_41(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 136));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
         NextTest();
     }
 
@@ -4281,7 +4281,7 @@ private:
 
     void OnFailureResponse_45(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 136));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
         NextTest();
     }
 
@@ -4360,7 +4360,7 @@ private:
 
     void OnFailureResponse_49(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 136));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
         NextTest();
     }
 
@@ -4439,7 +4439,7 @@ private:
 
     void OnFailureResponse_53(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 136));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
         NextTest();
     }
 
@@ -4518,7 +4518,7 @@ private:
 
     void OnFailureResponse_57(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 136));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
         NextTest();
     }
 
@@ -4577,7 +4577,7 @@ private:
 
     void OnFailureResponse_60(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 136));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
         NextTest();
     }
 
@@ -4712,7 +4712,7 @@ private:
 
     void OnFailureResponse_67(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 136));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
         NextTest();
     }
 
@@ -4772,7 +4772,7 @@ private:
 
     void OnFailureResponse_70(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 136));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
         NextTest();
     }
 
@@ -4852,7 +4852,7 @@ private:
 
     void OnFailureResponse_74(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 136));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
         NextTest();
     }
 
@@ -4912,7 +4912,7 @@ private:
 
     void OnFailureResponse_77(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 136));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
         NextTest();
     }
 
@@ -4972,7 +4972,7 @@ private:
 
     void OnFailureResponse_80(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 136));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
         NextTest();
     }
 
@@ -5051,7 +5051,7 @@ private:
 
     void OnFailureResponse_84(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 136));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
         NextTest();
     }
 
@@ -5111,7 +5111,7 @@ private:
 
     void OnFailureResponse_87(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 136));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
         NextTest();
     }
 
@@ -5190,7 +5190,7 @@ private:
 
     void OnFailureResponse_91(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 136));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
         NextTest();
     }
 
@@ -5250,7 +5250,7 @@ private:
 
     void OnFailureResponse_94(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 136));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
         NextTest();
     }
 
@@ -5329,7 +5329,7 @@ private:
 
     void OnFailureResponse_98(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 136));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
         NextTest();
     }
 
@@ -5389,7 +5389,7 @@ private:
 
     void OnFailureResponse_101(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 136));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
         NextTest();
     }
 
@@ -5468,7 +5468,7 @@ private:
 
     void OnFailureResponse_105(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 136));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
         NextTest();
     }
 
@@ -5528,7 +5528,7 @@ private:
 
     void OnFailureResponse_108(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 136));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
         NextTest();
     }
 
@@ -5607,7 +5607,7 @@ private:
 
     void OnFailureResponse_112(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 136));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
         NextTest();
     }
 
@@ -5667,7 +5667,7 @@ private:
 
     void OnFailureResponse_115(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 136));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
         NextTest();
     }
 
@@ -14043,7 +14043,7 @@ private:
 
     void OnFailureResponse_1(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 136));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
         NextTest();
     }
 
@@ -14143,7 +14143,7 @@ private:
 
     void OnFailureResponse_0(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 136));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
         NextTest();
     }
 
@@ -14375,7 +14375,7 @@ private:
 
     void OnFailureResponse_3(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 136));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
         NextTest();
     }
 
@@ -14396,7 +14396,7 @@ private:
 
     void OnFailureResponse_4(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 136));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
         NextTest();
     }
 
@@ -14695,7 +14695,7 @@ private:
 
     void OnFailureResponse_1(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 136));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
         NextTest();
     }
 
@@ -14795,7 +14795,7 @@ private:
 
     void OnFailureResponse_0(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 136));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
         NextTest();
     }
 
@@ -16176,7 +16176,7 @@ private:
 
     void OnFailureResponse_0(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 136));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
         NextTest();
     }
 
@@ -16893,7 +16893,7 @@ private:
 
     void OnFailureResponse_1(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 136));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
         NextTest();
     }
 
@@ -17103,7 +17103,7 @@ private:
 
     void OnFailureResponse_1(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 136));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
         NextTest();
     }
 
@@ -17163,7 +17163,7 @@ private:
 
     void OnFailureResponse_4(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 136));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
         NextTest();
     }
 
@@ -17224,7 +17224,7 @@ private:
 
     void OnFailureResponse_7(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 136));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
         NextTest();
     }
 
@@ -17524,7 +17524,7 @@ private:
 
     void OnFailureResponse_1(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 136));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
         NextTest();
     }
 
@@ -17583,7 +17583,7 @@ private:
 
     void OnFailureResponse_4(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 136));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
         NextTest();
     }
 
@@ -20085,7 +20085,7 @@ private:
 
     void OnFailureResponse_2(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 136));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
         NextTest();
     }
 
@@ -20309,7 +20309,7 @@ private:
 
     void OnFailureResponse_1(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 136));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
         NextTest();
     }
 
@@ -20368,7 +20368,7 @@ private:
 
     void OnFailureResponse_4(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 136));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
         NextTest();
     }
 
@@ -20427,7 +20427,7 @@ private:
 
     void OnFailureResponse_7(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 136));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
         NextTest();
     }
 
@@ -20527,7 +20527,7 @@ private:
 
     void OnFailureResponse_0(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 136));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
         NextTest();
     }
 
@@ -21164,7 +21164,7 @@ private:
 
     void OnFailureResponse_0(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 136));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
         NextTest();
     }
 
@@ -21521,7 +21521,7 @@ private:
 
     void OnFailureResponse_1(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 136));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
         NextTest();
     }
 
@@ -21816,7 +21816,7 @@ private:
 
     void OnFailureResponse_0(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 136));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
         NextTest();
     }
 
@@ -22782,7 +22782,7 @@ private:
 
     void OnFailureResponse_3(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 136));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
         NextTest();
     }
 
@@ -22862,7 +22862,7 @@ private:
 
     void OnFailureResponse_7(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 136));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
         NextTest();
     }
 
@@ -22942,7 +22942,7 @@ private:
 
     void OnFailureResponse_11(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 136));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
         NextTest();
     }
 
@@ -23022,7 +23022,7 @@ private:
 
     void OnFailureResponse_15(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 136));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
         NextTest();
     }
 
@@ -23763,7 +23763,7 @@ private:
 
     void OnFailureResponse_54(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 136));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
         NextTest();
     }
 
@@ -23822,7 +23822,7 @@ private:
 
     void OnFailureResponse_57(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 136));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
         NextTest();
     }
 
@@ -23862,7 +23862,7 @@ private:
 
     void OnFailureResponse_59(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 136));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
         NextTest();
     }
 
@@ -25501,7 +25501,7 @@ private:
 
     void OnFailureResponse_0(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 136));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
         NextTest();
     }
 
@@ -26512,7 +26512,7 @@ private:
 
     void OnFailureResponse_1(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 136));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
         NextTest();
     }
 
@@ -26701,7 +26701,7 @@ private:
 
     void OnFailureResponse_1(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 136));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
         NextTest();
     }
 
@@ -26762,7 +26762,7 @@ private:
 
     void OnFailureResponse_4(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 136));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
         NextTest();
     }
 
@@ -27606,7 +27606,7 @@ private:
 
     void OnFailureResponse_1(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 136));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
         NextTest();
     }
 
@@ -27667,7 +27667,7 @@ private:
 
     void OnFailureResponse_4(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 136));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
         NextTest();
     }
 
@@ -27728,7 +27728,7 @@ private:
 
     void OnFailureResponse_7(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 136));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
         NextTest();
     }
 
@@ -27789,7 +27789,7 @@ private:
 
     void OnFailureResponse_10(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 136));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
         NextTest();
     }
 
@@ -27907,7 +27907,7 @@ private:
 
     void OnFailureResponse_16(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 136));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
         NextTest();
     }
 
@@ -27969,7 +27969,7 @@ private:
 
     void OnFailureResponse_19(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 136));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
         NextTest();
     }
 
@@ -28031,7 +28031,7 @@ private:
 
     void OnFailureResponse_22(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 136));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
         NextTest();
     }
 
@@ -28093,7 +28093,7 @@ private:
 
     void OnFailureResponse_25(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 136));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
         NextTest();
     }
 
@@ -28154,7 +28154,7 @@ private:
 
     void OnFailureResponse_28(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 136));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
         NextTest();
     }
 
@@ -28215,7 +28215,7 @@ private:
 
     void OnFailureResponse_31(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 136));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
         NextTest();
     }
 
@@ -28276,7 +28276,7 @@ private:
 
     void OnFailureResponse_34(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 136));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
         NextTest();
     }
 
@@ -28337,7 +28337,7 @@ private:
 
     void OnFailureResponse_37(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 136));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
         NextTest();
     }
 
@@ -28398,7 +28398,7 @@ private:
 
     void OnFailureResponse_40(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 136));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
         NextTest();
     }
 
@@ -28459,7 +28459,7 @@ private:
 
     void OnFailureResponse_43(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 136));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
         NextTest();
     }
 
@@ -28520,7 +28520,7 @@ private:
 
     void OnFailureResponse_46(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 136));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
         NextTest();
     }
 
@@ -28581,7 +28581,7 @@ private:
 
     void OnFailureResponse_49(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 136));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
         NextTest();
     }
 
@@ -28642,7 +28642,7 @@ private:
 
     void OnFailureResponse_52(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 136));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_UNSUPPORTED_WRITE));
         NextTest();
     }
 
@@ -34215,7 +34215,7 @@ private:
 
     void OnFailureResponse_1(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 133));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_INVALID_COMMAND));
         NextTest();
     }
 
@@ -34302,7 +34302,7 @@ private:
 
     void OnFailureResponse_4(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 133));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_INVALID_COMMAND));
         NextTest();
     }
 
@@ -35926,7 +35926,7 @@ private:
 
     void OnFailureResponse_93(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 135));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
         NextTest();
     }
 
@@ -36123,7 +36123,7 @@ private:
 
     void OnFailureResponse_103(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 135));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
         NextTest();
     }
 
@@ -37394,7 +37394,7 @@ private:
 
     void OnFailureResponse_152(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 135));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
         NextTest();
     }
 
@@ -37508,7 +37508,7 @@ private:
 
     void OnFailureResponse_158(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 135));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
         NextTest();
     }
 
@@ -37622,7 +37622,7 @@ private:
 
     void OnFailureResponse_164(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 135));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
         NextTest();
     }
 
@@ -37736,7 +37736,7 @@ private:
 
     void OnFailureResponse_170(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 135));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
         NextTest();
     }
 
@@ -37850,7 +37850,7 @@ private:
 
     void OnFailureResponse_176(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 135));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
         NextTest();
     }
 
@@ -37964,7 +37964,7 @@ private:
 
     void OnFailureResponse_182(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 135));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
         NextTest();
     }
 
@@ -38078,7 +38078,7 @@ private:
 
     void OnFailureResponse_188(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 135));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
         NextTest();
     }
 
@@ -38192,7 +38192,7 @@ private:
 
     void OnFailureResponse_194(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 135));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
         NextTest();
     }
 
@@ -38306,7 +38306,7 @@ private:
 
     void OnFailureResponse_200(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 135));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
         NextTest();
     }
 
@@ -38420,7 +38420,7 @@ private:
 
     void OnFailureResponse_206(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 135));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
         NextTest();
     }
 
@@ -38534,7 +38534,7 @@ private:
 
     void OnFailureResponse_212(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 135));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
         NextTest();
     }
 
@@ -38648,7 +38648,7 @@ private:
 
     void OnFailureResponse_218(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 135));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
         NextTest();
     }
 
@@ -38762,7 +38762,7 @@ private:
 
     void OnFailureResponse_224(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 135));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
         NextTest();
     }
 
@@ -38876,7 +38876,7 @@ private:
 
     void OnFailureResponse_230(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 135));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
         NextTest();
     }
 
@@ -44302,7 +44302,7 @@ private:
 
     void OnFailureResponse_7(uint8_t status)
     {
-        VerifyOrReturn(CheckValue("status", status, 135));
+        VerifyOrReturn(CheckValue("status", status, EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
         NextTest();
     }
 


### PR DESCRIPTION
Fixes https://github.com/project-chip/connectedhomeip/issues/12318

#### Problem
Can't write `error: CONSTRAINT_ERROR` in YAML.

#### Change overview
Make it possible to do that.

#### Testing
Manual inspection of generated test code, plus tests pass.