### PR TITLE
docker - wget package to 1.20.3-1ubuntu2

### DIFF
--- a/integrations/docker/images/chip-build-k32w/Dockerfile
+++ b/integrations/docker/images/chip-build-k32w/Dockerfile
@@ -4,7 +4,7 @@ FROM connectedhomeip/chip-build:${VERSION} as build
 RUN set -x \
     && apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -fy --no-install-recommends \
-    wget=1.20.3-1ubuntu1 \
+    wget=1.20.3-1ubuntu2 \
     unzip=6.0-25ubuntu1 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/ \

--- a/integrations/docker/images/chip-build-mbed-os/Dockerfile
+++ b/integrations/docker/images/chip-build-mbed-os/Dockerfile
@@ -4,7 +4,7 @@ FROM connectedhomeip/chip-build:${VERSION} as build
 RUN set -x \
     && apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -fy --no-install-recommends \
-    wget=1.20.3-1ubuntu1 \
+    wget=1.20.3-1ubuntu2 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/ \
     && : # last line

--- a/integrations/docker/images/chip-build-telink/Dockerfile
+++ b/integrations/docker/images/chip-build-telink/Dockerfile
@@ -4,7 +4,7 @@ FROM connectedhomeip/chip-build:${VERSION} as build
 RUN set -x \
     && apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -fy --no-install-recommends \
-    wget=1.20.3-1ubuntu1 \
+    wget=1.20.3-1ubuntu2 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/ \
     && : # last line

--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.5.30 Version bump reason: ESP32 update to newest 4.4 commit: ddc44956bf718540d5451e17e1becf6c7dffe5b8
+0.5.31 Version bump reason: Upgrade wget package version to 1.20.3-1ubuntu2


### PR DESCRIPTION
#### Problem
Ubuntu has released a new version for the wget package with affects the building process during the image creation.

#### Change overview
This change upgrades the wget version to the latest one. According to their [change log](https://ubuntu.pkgs.org/20.04/ubuntu-updates-main-amd64/wget_1.20.3-1ubuntu2_amd64.deb.html) this version includes a fix in openSSL

#### Testing
Images were tested locally using the `build.sh` script.
