### PR TITLE
Fix unexpected firmware selection by flashing scripts

### DIFF
--- a/build/toolchain/flashable_executable.gni
+++ b/build/toolchain/flashable_executable.gni
@@ -57,6 +57,7 @@ template("gen_flashing_script") {
                          [
                            "flashing_script_generator",
                            "flashing_script_name",
+                           "flashing_script_inputs",
                            "flashing_options",
                            "deps",
                            "data_deps",
@@ -72,6 +73,7 @@ template("gen_flashing_script") {
     ]
 
     script = flashing_script_generator
+    inputs = flashing_script_inputs
   }
 }
 
@@ -131,6 +133,7 @@ template("flashable_executable") {
 
     gen_flashing_script("$target_name.flashing") {
       flashing_script_generator = invoker.flashing_script_generator
+      flashing_script_inputs = invoker.flashing_script_inputs
       flashing_script_name = "$root_out_dir/${invoker.flashing_script_name}"
       if (defined(invoker.flashing_options)) {
         flashing_options = invoker.flashing_options

--- a/scripts/flashing/efr32_firmware_utils.py
+++ b/scripts/flashing/efr32_firmware_utils.py
@@ -153,8 +153,8 @@ class Flasher(firmware_utils.Flasher):
             if self.erase().err:
                 return self
 
-        application = self.optional_file(self.option.application)
-        if application:
+        if self.option.application:
+            application = self.option.application
             if self.flash(application).err:
                 return self
             if self.option.verify_application:

--- a/scripts/flashing/esp32_firmware_utils.py
+++ b/scripts/flashing/esp32_firmware_utils.py
@@ -73,6 +73,7 @@ operations:
 """
 
 import os
+import pathlib
 import sys
 
 import firmware_utils
@@ -222,7 +223,8 @@ ESP32_OPTIONS = {
             'help': 'Bootloader image',
             'default': None,
             'argparse': {
-                'metavar': 'FILE'
+                'metavar': 'FILE',
+                'type': pathlib.Path,
             },
         },
         'bootloader_offset': {
@@ -237,7 +239,8 @@ ESP32_OPTIONS = {
             'help': 'Partition table image',
             'default': None,
             'argparse': {
-                'metavar': 'FILE'
+                'metavar': 'FILE',
+                'type': pathlib.Path,
             },
         },
         'partition_offset': {
@@ -408,11 +411,11 @@ class Flasher(firmware_utils.Flasher):
             if self.erase().err:
                 return self
 
-        bootloader = self.optional_file(self.option.bootloader)
-        application = self.optional_file(self.option.application)
-        partition = self.optional_file(self.option.partition)
+        if self.option.application:
+            application = self.option.application
+            bootloader = self.option.bootloader
+            partition = self.option.partition
 
-        if bootloader or application or partition:
             # Collect the flashable items.
             flash = []
             if bootloader:

--- a/scripts/flashing/nrfconnect_firmware_utils.py
+++ b/scripts/flashing/nrfconnect_firmware_utils.py
@@ -140,8 +140,8 @@ class Flasher(firmware_utils.Flasher):
             if self.erase().err:
                 return self
 
-        application = self.optional_file(self.option.application)
-        if application:
+        if self.option.application:
+            application = self.option.application
             if self.flash(application).err:
                 return self
             if self.option.verify_application:

--- a/scripts/flashing/p6_firmware_utils.py
+++ b/scripts/flashing/p6_firmware_utils.py
@@ -127,8 +127,8 @@ class Flasher(firmware_utils.Flasher):
             if self.erase().err:
                 return self
 
-        application = self.optional_file(self.option.application)
-        if application:
+        if self.option.application:
+            application = self.option.application
             if self.flash(application).err:
                 return self
             if self.option.verify_application:

--- a/scripts/flashing/qpg_firmware_utils.py
+++ b/scripts/flashing/qpg_firmware_utils.py
@@ -111,8 +111,8 @@ class Flasher(firmware_utils.Flasher):
             if self.erase().err:
                 return self
 
-        application = self.optional_file(self.option.application)
-        if application:
+        if self.option.application:
+            application = self.option.application
             if self.flash(application).err:
                 return self
             if self.option.verify_application:

--- a/third_party/efr32_sdk/efr32_executable.gni
+++ b/third_party/efr32_sdk/efr32_executable.gni
@@ -30,11 +30,12 @@ template("efr32_executable") {
   # or in different containers.
 
   flashing_runtime_target = target_name + ".flashing_runtime"
+  flashing_script_inputs = [
+    "${chip_root}/scripts/flashing/efr32_firmware_utils.py",
+    "${chip_root}/scripts/flashing/firmware_utils.py",
+  ]
   copy(flashing_runtime_target) {
-    sources = [
-      "${chip_root}/scripts/flashing/efr32_firmware_utils.py",
-      "${chip_root}/scripts/flashing/firmware_utils.py",
-    ]
+    sources = flashing_script_inputs
     outputs = [ "${root_out_dir}/{{source_file_part}}" ]
   }
 

--- a/third_party/p6/p6_executable.gni
+++ b/third_party/p6/p6_executable.gni
@@ -31,11 +31,13 @@ template("p6_executable") {
   #or in different containers.
 
   flashing_runtime_target = target_name + ".flashing_runtime"
+  flashing_script_inputs = [
+    "${chip_root}/scripts/flashing/firmware_utils.py",
+    "${chip_root}/scripts/flashing/p6_firmware_utils.py",
+  ]
+
   copy(flashing_runtime_target) {
-    sources = [
-      "${chip_root}/scripts/flashing/firmware_utils.py",
-      "${chip_root}/scripts/flashing/p6_firmware_utils.py",
-    ]
+    sources = flashing_script_inputs
     outputs = [ "${root_out_dir}/{{source_file_part}}" ]
   }
 

--- a/third_party/qpg_sdk/qpg_executable.gni
+++ b/third_party/qpg_sdk/qpg_executable.gni
@@ -30,11 +30,13 @@ template("qpg_executable") {
   # or in different containers.
 
   flashing_runtime_target = target_name + ".flashing_runtime"
+  flashing_script_inputs = [
+    "${chip_root}/scripts/flashing/firmware_utils.py",
+    "${chip_root}/scripts/flashing/qpg_firmware_utils.py",
+  ]
+
   copy(flashing_runtime_target) {
-    sources = [
-      "${chip_root}/scripts/flashing/firmware_utils.py",
-      "${chip_root}/scripts/flashing/qpg_firmware_utils.py",
-    ]
+    sources = flashing_script_inputs
     outputs = [ "${root_out_dir}/{{source_file_part}}" ]
   }
 


### PR DESCRIPTION
### Problem

Currently the flashing scripts will flash a firmware .bin from the
current directory, if it exists with the right filename, and otherwise
finds the firmware in the same directory as the wrapper.

It is confusing that changing directories influences the firmware
selection. Downloading a built firmware archive, unpacking it, and
running the wrapper should always flash the firmware that was unpacked.

#### Change overview

Remove the search logic. Similarly, remove the concept of detection of
"optional" firmware constituents by file presence. The command line
should determine the requisite artifacts; continuing when expected files
are missing is not desirable.

Finally, fix rebuilds of flashing scripts after the python generator's
imports change by adding those to inputs in the build file.

#### Testing

Flashed ESP32, EFR32, nRF Connect via wrapper