### PR TITLE
[Python] TLV schema tag should start from 1

### DIFF
--- a/src/controller/python/chip/ChipReplStartup.py
+++ b/src/controller/python/chip/ChipReplStartup.py
@@ -43,9 +43,19 @@ def ReplInit():
 def matterhelp(classOrObj=None):
     if (classOrObj == None):
         inspect(builtins.devCtrl, methods=True, help=True, private=False)
+        inspect(mattersetlog)
+        inspect(mattersetdebug)
     else:
         inspect(classOrObj, methods=True, help=True, private=False)
 
 
 def mattersetlog(level):
     logging.getLogger().setLevel(level)
+
+
+def mattersetdebug(enableDebugMode: bool = True):
+    ''' Enables debug mode that is utilized by some Matter modules
+        to better facilitate debugging of failures (e.g throwing exceptions instead
+        of returning well-formatted results).
+    '''
+    builtins.enableDebugMode = enableDebugMode

--- a/src/controller/python/chip/ChipStack.py
+++ b/src/controller/python/chip/ChipStack.py
@@ -36,6 +36,7 @@ from threading import Lock, Event, Condition
 from ctypes import *
 from .ChipUtility import ChipUtility
 from .exceptions import *
+import builtins
 
 __all__ = [
     "DeviceStatusStruct",
@@ -160,6 +161,8 @@ _ChipThreadTaskRunnerFunct = CFUNCTYPE(None, py_object)
 @_singleton
 class ChipStack(object):
     def __init__(self, installDefaultLogHandler=True, bluetoothAdapter=0):
+        builtins.enableDebugMode = False
+
         self.networkLock = Lock()
         self.completeEvent = Event()
         self.commissioningCompleteEvent = Event()

--- a/src/controller/python/chip/clusters/Attribute.py
+++ b/src/controller/python/chip/clusters/Attribute.py
@@ -97,6 +97,12 @@ class AttributeReadResult(AttributeStatus):
     Data: Any = None
 
 
+@dataclass
+class ValueDecodeFailure:
+    Value: Any = None
+    Reason: Exception = None
+
+
 _AttributeIndex = {}
 
 
@@ -199,21 +205,24 @@ class AsyncReadTransaction:
             attributeType = _AttributeIndex.get(str(AttributePath(
                 ClusterId=path.ClusterId, AttributeId=path.AttributeId)), None)
             attributeValue = None
+            tlvData = chip.tlv.TLVReader(data).get().get("Any", {})
             if attributeType is None:
-                attributeValue = chip.tlv.TLVReader(data).get().get("Any", {})
+                attributeValue = ValueDecodeFailure(
+                    tlvData, LookupError("attribute schema not found"))
             else:
                 try:
-                    attributeValue = attributeType.FromTLV(data)
-                except:
+                    attributeValue = attributeType(attributeType.FromTLV(data))
+                except Exception as ex:
                     logging.error(
                         f"Error convering TLV to Cluster Object for path: Endpoint = {path.EndpointId}/Cluster = {path.ClusterId}/Attribute = {path.AttributeId}")
                     logging.error(
                         f"Failed Cluster Object: {str(attributeType)}")
-                    raise
+                    attributeValue = ValueDecodeFailure(
+                        tlvData, ex)
 
             with self._resLock:
                 self._res[path] = AttributeReadResult(
-                    Path=path, Status=imStatus, Data=attributeType(attributeValue))
+                    Path=path, Status=imStatus, Data=attributeValue)
                 if self._subscription_handler is not None:
                     self._subscription_handler.OnUpdate(
                         path, attributeType(attributeValue))

--- a/src/controller/python/chip/clusters/Objects.py
+++ b/src/controller/python/chip/clusters/Objects.py
@@ -1563,11 +1563,11 @@ class Scenes(Cluster):
                 return ClusterObjectDescriptor(
                     Fields=[
                         ClusterObjectFieldDescriptor(
-                            Label="clusterId", Tag=0, Type=uint),
+                            Label="clusterId", Tag=1, Type=uint),
                         ClusterObjectFieldDescriptor(
-                            Label="length", Tag=1, Type=uint),
+                            Label="length", Tag=2, Type=uint),
                         ClusterObjectFieldDescriptor(
-                            Label="value", Tag=2, Type=uint),
+                            Label="value", Tag=3, Type=uint),
                     ])
 
             clusterId: 'uint' = None
@@ -3416,13 +3416,13 @@ class PowerProfile(Cluster):
                 return ClusterObjectDescriptor(
                     Fields=[
                         ClusterObjectFieldDescriptor(
-                            Label="powerProfileId", Tag=0, Type=uint),
+                            Label="powerProfileId", Tag=1, Type=uint),
                         ClusterObjectFieldDescriptor(
-                            Label="energyPhaseId", Tag=1, Type=uint),
+                            Label="energyPhaseId", Tag=2, Type=uint),
                         ClusterObjectFieldDescriptor(
-                            Label="powerProfileRemoteControl", Tag=2, Type=bool),
+                            Label="powerProfileRemoteControl", Tag=3, Type=bool),
                         ClusterObjectFieldDescriptor(
-                            Label="powerProfileState", Tag=3, Type=uint),
+                            Label="powerProfileState", Tag=4, Type=uint),
                     ])
 
             powerProfileId: 'uint' = None
@@ -3437,9 +3437,9 @@ class PowerProfile(Cluster):
                 return ClusterObjectDescriptor(
                     Fields=[
                         ClusterObjectFieldDescriptor(
-                            Label="energyPhaseId", Tag=0, Type=uint),
+                            Label="energyPhaseId", Tag=1, Type=uint),
                         ClusterObjectFieldDescriptor(
-                            Label="scheduledTime", Tag=1, Type=uint),
+                            Label="scheduledTime", Tag=2, Type=uint),
                     ])
 
             energyPhaseId: 'uint' = None
@@ -3452,17 +3452,17 @@ class PowerProfile(Cluster):
                 return ClusterObjectDescriptor(
                     Fields=[
                         ClusterObjectFieldDescriptor(
-                            Label="energyPhaseId", Tag=0, Type=uint),
+                            Label="energyPhaseId", Tag=1, Type=uint),
                         ClusterObjectFieldDescriptor(
-                            Label="macroPhaseId", Tag=1, Type=uint),
+                            Label="macroPhaseId", Tag=2, Type=uint),
                         ClusterObjectFieldDescriptor(
-                            Label="expectedDuration", Tag=2, Type=uint),
+                            Label="expectedDuration", Tag=3, Type=uint),
                         ClusterObjectFieldDescriptor(
-                            Label="peakPower", Tag=3, Type=uint),
+                            Label="peakPower", Tag=4, Type=uint),
                         ClusterObjectFieldDescriptor(
-                            Label="energy", Tag=4, Type=uint),
+                            Label="energy", Tag=5, Type=uint),
                         ClusterObjectFieldDescriptor(
-                            Label="maxActivationDelay", Tag=5, Type=uint),
+                            Label="maxActivationDelay", Tag=6, Type=uint),
                     ])
 
             energyPhaseId: 'uint' = None
@@ -4276,9 +4276,9 @@ class Descriptor(Cluster):
                 return ClusterObjectDescriptor(
                     Fields=[
                         ClusterObjectFieldDescriptor(
-                            Label="type", Tag=0, Type=uint),
+                            Label="type", Tag=1, Type=uint),
                         ClusterObjectFieldDescriptor(
-                            Label="revision", Tag=1, Type=uint),
+                            Label="revision", Tag=2, Type=uint),
                     ])
 
             type: 'uint' = None
@@ -4645,17 +4645,17 @@ class BridgedActions(Cluster):
                 return ClusterObjectDescriptor(
                     Fields=[
                         ClusterObjectFieldDescriptor(
-                            Label="actionID", Tag=0, Type=uint),
+                            Label="actionID", Tag=1, Type=uint),
                         ClusterObjectFieldDescriptor(
-                            Label="name", Tag=1, Type=str),
+                            Label="name", Tag=2, Type=str),
                         ClusterObjectFieldDescriptor(
-                            Label="type", Tag=2, Type=BridgedActions.Enums.ActionTypeEnum),
+                            Label="type", Tag=3, Type=BridgedActions.Enums.ActionTypeEnum),
                         ClusterObjectFieldDescriptor(
-                            Label="endpointListID", Tag=3, Type=uint),
+                            Label="endpointListID", Tag=4, Type=uint),
                         ClusterObjectFieldDescriptor(
-                            Label="supportedCommands", Tag=4, Type=uint),
+                            Label="supportedCommands", Tag=5, Type=uint),
                         ClusterObjectFieldDescriptor(
-                            Label="status", Tag=5, Type=BridgedActions.Enums.ActionStatusEnum),
+                            Label="status", Tag=6, Type=BridgedActions.Enums.ActionStatusEnum),
                     ])
 
             actionID: 'uint' = None
@@ -4672,13 +4672,13 @@ class BridgedActions(Cluster):
                 return ClusterObjectDescriptor(
                     Fields=[
                         ClusterObjectFieldDescriptor(
-                            Label="endpointListID", Tag=0, Type=uint),
+                            Label="endpointListID", Tag=1, Type=uint),
                         ClusterObjectFieldDescriptor(
-                            Label="name", Tag=1, Type=str),
+                            Label="name", Tag=2, Type=str),
                         ClusterObjectFieldDescriptor(
-                            Label="type", Tag=2, Type=BridgedActions.Enums.EndpointListTypeEnum),
+                            Label="type", Tag=3, Type=BridgedActions.Enums.EndpointListTypeEnum),
                         ClusterObjectFieldDescriptor(
-                            Label="endpoints", Tag=3, Type=typing.List[uint]),
+                            Label="endpoints", Tag=4, Type=typing.List[uint]),
                     ])
 
             endpointListID: 'uint' = None
@@ -6539,7 +6539,7 @@ class GeneralCommissioning(Cluster):
                 return ClusterObjectDescriptor(
                     Fields=[
                         ClusterObjectFieldDescriptor(
-                            Label="failSafeExpiryLengthMs", Tag=0, Type=uint),
+                            Label="failSafeExpiryLengthMs", Tag=1, Type=uint),
                     ])
 
             failSafeExpiryLengthMs: 'uint' = None
@@ -6794,7 +6794,7 @@ class NetworkCommissioning(Cluster):
                 return ClusterObjectDescriptor(
                     Fields=[
                         ClusterObjectFieldDescriptor(
-                            Label="discoveryResponse", Tag=0, Type=bytes),
+                            Label="discoveryResponse", Tag=1, Type=bytes),
                     ])
 
             discoveryResponse: 'bytes' = None
@@ -6806,15 +6806,15 @@ class NetworkCommissioning(Cluster):
                 return ClusterObjectDescriptor(
                     Fields=[
                         ClusterObjectFieldDescriptor(
-                            Label="security", Tag=0, Type=uint),
+                            Label="security", Tag=1, Type=uint),
                         ClusterObjectFieldDescriptor(
-                            Label="ssid", Tag=1, Type=bytes),
+                            Label="ssid", Tag=2, Type=bytes),
                         ClusterObjectFieldDescriptor(
-                            Label="bssid", Tag=2, Type=bytes),
+                            Label="bssid", Tag=3, Type=bytes),
                         ClusterObjectFieldDescriptor(
-                            Label="channel", Tag=3, Type=uint),
+                            Label="channel", Tag=4, Type=uint),
                         ClusterObjectFieldDescriptor(
-                            Label="frequencyBand", Tag=4, Type=uint),
+                            Label="frequencyBand", Tag=5, Type=uint),
                     ])
 
             security: 'uint' = None
@@ -7358,17 +7358,17 @@ class GeneralDiagnostics(Cluster):
                 return ClusterObjectDescriptor(
                     Fields=[
                         ClusterObjectFieldDescriptor(
-                            Label="name", Tag=0, Type=str),
+                            Label="name", Tag=1, Type=str),
                         ClusterObjectFieldDescriptor(
-                            Label="fabricConnected", Tag=1, Type=bool),
+                            Label="fabricConnected", Tag=2, Type=bool),
                         ClusterObjectFieldDescriptor(
-                            Label="offPremiseServicesReachableIPv4", Tag=2, Type=bool),
+                            Label="offPremiseServicesReachableIPv4", Tag=3, Type=bool),
                         ClusterObjectFieldDescriptor(
-                            Label="offPremiseServicesReachableIPv6", Tag=3, Type=bool),
+                            Label="offPremiseServicesReachableIPv6", Tag=4, Type=bool),
                         ClusterObjectFieldDescriptor(
-                            Label="hardwareAddress", Tag=4, Type=bytes),
+                            Label="hardwareAddress", Tag=5, Type=bytes),
                         ClusterObjectFieldDescriptor(
-                            Label="type", Tag=5, Type=GeneralDiagnostics.Enums.InterfaceType),
+                            Label="type", Tag=6, Type=GeneralDiagnostics.Enums.InterfaceType),
                     ])
 
             name: 'str' = None
@@ -7622,11 +7622,11 @@ class SoftwareDiagnostics(Cluster):
                 return ClusterObjectDescriptor(
                     Fields=[
                         ClusterObjectFieldDescriptor(
-                            Label="id", Tag=0, Type=uint),
+                            Label="id", Tag=1, Type=uint),
                         ClusterObjectFieldDescriptor(
-                            Label="name", Tag=1, Type=str),
+                            Label="name", Tag=2, Type=str),
                         ClusterObjectFieldDescriptor(
-                            Label="faultRecording", Tag=2, Type=bytes),
+                            Label="faultRecording", Tag=3, Type=bytes),
                     ])
 
             id: 'uint' = None
@@ -7640,15 +7640,15 @@ class SoftwareDiagnostics(Cluster):
                 return ClusterObjectDescriptor(
                     Fields=[
                         ClusterObjectFieldDescriptor(
-                            Label="id", Tag=0, Type=uint),
+                            Label="id", Tag=1, Type=uint),
                         ClusterObjectFieldDescriptor(
-                            Label="name", Tag=1, Type=str),
+                            Label="name", Tag=2, Type=str),
                         ClusterObjectFieldDescriptor(
-                            Label="stackFreeCurrent", Tag=2, Type=uint),
+                            Label="stackFreeCurrent", Tag=3, Type=uint),
                         ClusterObjectFieldDescriptor(
-                            Label="stackFreeMinimum", Tag=3, Type=uint),
+                            Label="stackFreeMinimum", Tag=4, Type=uint),
                         ClusterObjectFieldDescriptor(
-                            Label="stackSize", Tag=4, Type=uint),
+                            Label="stackSize", Tag=5, Type=uint),
                     ])
 
             id: 'uint' = None
@@ -7816,33 +7816,33 @@ class ThreadNetworkDiagnostics(Cluster):
                 return ClusterObjectDescriptor(
                     Fields=[
                         ClusterObjectFieldDescriptor(
-                            Label="extAddress", Tag=0, Type=uint),
+                            Label="extAddress", Tag=1, Type=uint),
                         ClusterObjectFieldDescriptor(
-                            Label="age", Tag=1, Type=uint),
+                            Label="age", Tag=2, Type=uint),
                         ClusterObjectFieldDescriptor(
-                            Label="rloc16", Tag=2, Type=uint),
+                            Label="rloc16", Tag=3, Type=uint),
                         ClusterObjectFieldDescriptor(
-                            Label="linkFrameCounter", Tag=3, Type=uint),
+                            Label="linkFrameCounter", Tag=4, Type=uint),
                         ClusterObjectFieldDescriptor(
-                            Label="mleFrameCounter", Tag=4, Type=uint),
+                            Label="mleFrameCounter", Tag=5, Type=uint),
                         ClusterObjectFieldDescriptor(
-                            Label="lqi", Tag=5, Type=uint),
+                            Label="lqi", Tag=6, Type=uint),
                         ClusterObjectFieldDescriptor(
-                            Label="averageRssi", Tag=6, Type=int),
+                            Label="averageRssi", Tag=7, Type=int),
                         ClusterObjectFieldDescriptor(
-                            Label="lastRssi", Tag=7, Type=int),
+                            Label="lastRssi", Tag=8, Type=int),
                         ClusterObjectFieldDescriptor(
-                            Label="frameErrorRate", Tag=8, Type=uint),
+                            Label="frameErrorRate", Tag=9, Type=uint),
                         ClusterObjectFieldDescriptor(
-                            Label="messageErrorRate", Tag=9, Type=uint),
+                            Label="messageErrorRate", Tag=10, Type=uint),
                         ClusterObjectFieldDescriptor(
-                            Label="rxOnWhenIdle", Tag=10, Type=bool),
+                            Label="rxOnWhenIdle", Tag=11, Type=bool),
                         ClusterObjectFieldDescriptor(
-                            Label="fullThreadDevice", Tag=11, Type=bool),
+                            Label="fullThreadDevice", Tag=12, Type=bool),
                         ClusterObjectFieldDescriptor(
-                            Label="fullNetworkData", Tag=12, Type=bool),
+                            Label="fullNetworkData", Tag=13, Type=bool),
                         ClusterObjectFieldDescriptor(
-                            Label="isChild", Tag=13, Type=bool),
+                            Label="isChild", Tag=14, Type=bool),
                     ])
 
             extAddress: 'uint' = None
@@ -7867,29 +7867,29 @@ class ThreadNetworkDiagnostics(Cluster):
                 return ClusterObjectDescriptor(
                     Fields=[
                         ClusterObjectFieldDescriptor(
-                            Label="activeTimestampPresent", Tag=0, Type=bool),
+                            Label="activeTimestampPresent", Tag=1, Type=bool),
                         ClusterObjectFieldDescriptor(
-                            Label="pendingTimestampPresent", Tag=1, Type=bool),
+                            Label="pendingTimestampPresent", Tag=2, Type=bool),
                         ClusterObjectFieldDescriptor(
-                            Label="masterKeyPresent", Tag=2, Type=bool),
+                            Label="masterKeyPresent", Tag=3, Type=bool),
                         ClusterObjectFieldDescriptor(
-                            Label="networkNamePresent", Tag=3, Type=bool),
+                            Label="networkNamePresent", Tag=4, Type=bool),
                         ClusterObjectFieldDescriptor(
-                            Label="extendedPanIdPresent", Tag=4, Type=bool),
+                            Label="extendedPanIdPresent", Tag=5, Type=bool),
                         ClusterObjectFieldDescriptor(
-                            Label="meshLocalPrefixPresent", Tag=5, Type=bool),
+                            Label="meshLocalPrefixPresent", Tag=6, Type=bool),
                         ClusterObjectFieldDescriptor(
-                            Label="delayPresent", Tag=6, Type=bool),
+                            Label="delayPresent", Tag=7, Type=bool),
                         ClusterObjectFieldDescriptor(
-                            Label="panIdPresent", Tag=7, Type=bool),
+                            Label="panIdPresent", Tag=8, Type=bool),
                         ClusterObjectFieldDescriptor(
-                            Label="channelPresent", Tag=8, Type=bool),
+                            Label="channelPresent", Tag=9, Type=bool),
                         ClusterObjectFieldDescriptor(
-                            Label="pskcPresent", Tag=9, Type=bool),
+                            Label="pskcPresent", Tag=10, Type=bool),
                         ClusterObjectFieldDescriptor(
-                            Label="securityPolicyPresent", Tag=10, Type=bool),
+                            Label="securityPolicyPresent", Tag=11, Type=bool),
                         ClusterObjectFieldDescriptor(
-                            Label="channelMaskPresent", Tag=11, Type=bool),
+                            Label="channelMaskPresent", Tag=12, Type=bool),
                     ])
 
             activeTimestampPresent: 'bool' = None
@@ -7912,25 +7912,25 @@ class ThreadNetworkDiagnostics(Cluster):
                 return ClusterObjectDescriptor(
                     Fields=[
                         ClusterObjectFieldDescriptor(
-                            Label="extAddress", Tag=0, Type=uint),
+                            Label="extAddress", Tag=1, Type=uint),
                         ClusterObjectFieldDescriptor(
-                            Label="rloc16", Tag=1, Type=uint),
+                            Label="rloc16", Tag=2, Type=uint),
                         ClusterObjectFieldDescriptor(
-                            Label="routerId", Tag=2, Type=uint),
+                            Label="routerId", Tag=3, Type=uint),
                         ClusterObjectFieldDescriptor(
-                            Label="nextHop", Tag=3, Type=uint),
+                            Label="nextHop", Tag=4, Type=uint),
                         ClusterObjectFieldDescriptor(
-                            Label="pathCost", Tag=4, Type=uint),
+                            Label="pathCost", Tag=5, Type=uint),
                         ClusterObjectFieldDescriptor(
-                            Label="LQIIn", Tag=5, Type=uint),
+                            Label="LQIIn", Tag=6, Type=uint),
                         ClusterObjectFieldDescriptor(
-                            Label="LQIOut", Tag=6, Type=uint),
+                            Label="LQIOut", Tag=7, Type=uint),
                         ClusterObjectFieldDescriptor(
-                            Label="age", Tag=7, Type=uint),
+                            Label="age", Tag=8, Type=uint),
                         ClusterObjectFieldDescriptor(
-                            Label="allocated", Tag=8, Type=bool),
+                            Label="allocated", Tag=9, Type=bool),
                         ClusterObjectFieldDescriptor(
-                            Label="linkEstablished", Tag=9, Type=bool),
+                            Label="linkEstablished", Tag=10, Type=bool),
                     ])
 
             extAddress: 'uint' = None
@@ -7951,9 +7951,9 @@ class ThreadNetworkDiagnostics(Cluster):
                 return ClusterObjectDescriptor(
                     Fields=[
                         ClusterObjectFieldDescriptor(
-                            Label="rotationTime", Tag=0, Type=uint),
+                            Label="rotationTime", Tag=1, Type=uint),
                         ClusterObjectFieldDescriptor(
-                            Label="flags", Tag=1, Type=uint),
+                            Label="flags", Tag=2, Type=uint),
                     ])
 
             rotationTime: 'uint' = None
@@ -10265,17 +10265,17 @@ class OperationalCredentials(Cluster):
                 return ClusterObjectDescriptor(
                     Fields=[
                         ClusterObjectFieldDescriptor(
-                            Label="fabricIndex", Tag=0, Type=uint),
+                            Label="fabricIndex", Tag=1, Type=uint),
                         ClusterObjectFieldDescriptor(
-                            Label="rootPublicKey", Tag=1, Type=bytes),
+                            Label="rootPublicKey", Tag=2, Type=bytes),
                         ClusterObjectFieldDescriptor(
-                            Label="vendorId", Tag=2, Type=uint),
+                            Label="vendorId", Tag=3, Type=uint),
                         ClusterObjectFieldDescriptor(
-                            Label="fabricId", Tag=3, Type=uint),
+                            Label="fabricId", Tag=4, Type=uint),
                         ClusterObjectFieldDescriptor(
-                            Label="nodeId", Tag=4, Type=uint),
+                            Label="nodeId", Tag=5, Type=uint),
                         ClusterObjectFieldDescriptor(
-                            Label="label", Tag=5, Type=str),
+                            Label="label", Tag=6, Type=str),
                     ])
 
             fabricIndex: 'uint' = None
@@ -10292,9 +10292,9 @@ class OperationalCredentials(Cluster):
                 return ClusterObjectDescriptor(
                     Fields=[
                         ClusterObjectFieldDescriptor(
-                            Label="fabricIndex", Tag=0, Type=uint),
+                            Label="fabricIndex", Tag=1, Type=uint),
                         ClusterObjectFieldDescriptor(
-                            Label="noc", Tag=1, Type=bytes),
+                            Label="noc", Tag=2, Type=bytes),
                     ])
 
             fabricIndex: 'uint' = None
@@ -10662,9 +10662,9 @@ class FixedLabel(Cluster):
                 return ClusterObjectDescriptor(
                     Fields=[
                         ClusterObjectFieldDescriptor(
-                            Label="label", Tag=0, Type=str),
+                            Label="label", Tag=1, Type=str),
                         ClusterObjectFieldDescriptor(
-                            Label="value", Tag=1, Type=str),
+                            Label="value", Tag=2, Type=str),
                     ])
 
             label: 'str' = None
@@ -10802,11 +10802,11 @@ class ModeSelect(Cluster):
                 return ClusterObjectDescriptor(
                     Fields=[
                         ClusterObjectFieldDescriptor(
-                            Label="label", Tag=0, Type=str),
+                            Label="label", Tag=1, Type=str),
                         ClusterObjectFieldDescriptor(
-                            Label="mode", Tag=1, Type=uint),
+                            Label="mode", Tag=2, Type=uint),
                         ClusterObjectFieldDescriptor(
-                            Label="semanticTag", Tag=2, Type=uint),
+                            Label="semanticTag", Tag=3, Type=uint),
                     ])
 
             label: 'str' = None
@@ -10820,9 +10820,9 @@ class ModeSelect(Cluster):
                 return ClusterObjectDescriptor(
                     Fields=[
                         ClusterObjectFieldDescriptor(
-                            Label="mfgCode", Tag=0, Type=uint),
+                            Label="mfgCode", Tag=1, Type=uint),
                         ClusterObjectFieldDescriptor(
-                            Label="value", Tag=1, Type=uint),
+                            Label="value", Tag=2, Type=uint),
                     ])
 
             mfgCode: 'uint' = None
@@ -21531,9 +21531,9 @@ class IasAce(Cluster):
                 return ClusterObjectDescriptor(
                     Fields=[
                         ClusterObjectFieldDescriptor(
-                            Label="zoneId", Tag=0, Type=uint),
+                            Label="zoneId", Tag=1, Type=uint),
                         ClusterObjectFieldDescriptor(
-                            Label="zoneStatus", Tag=1, Type=uint),
+                            Label="zoneStatus", Tag=2, Type=uint),
                     ])
 
             zoneId: 'uint' = None
@@ -22138,15 +22138,15 @@ class TvChannel(Cluster):
                 return ClusterObjectDescriptor(
                     Fields=[
                         ClusterObjectFieldDescriptor(
-                            Label="majorNumber", Tag=0, Type=uint),
+                            Label="majorNumber", Tag=1, Type=uint),
                         ClusterObjectFieldDescriptor(
-                            Label="minorNumber", Tag=1, Type=uint),
+                            Label="minorNumber", Tag=2, Type=uint),
                         ClusterObjectFieldDescriptor(
-                            Label="name", Tag=2, Type=str),
+                            Label="name", Tag=3, Type=str),
                         ClusterObjectFieldDescriptor(
-                            Label="callSign", Tag=3, Type=str),
+                            Label="callSign", Tag=4, Type=str),
                         ClusterObjectFieldDescriptor(
-                            Label="affiliateCallSign", Tag=4, Type=str),
+                            Label="affiliateCallSign", Tag=5, Type=str),
                     ])
 
             majorNumber: 'uint' = None
@@ -22162,13 +22162,13 @@ class TvChannel(Cluster):
                 return ClusterObjectDescriptor(
                     Fields=[
                         ClusterObjectFieldDescriptor(
-                            Label="operatorName", Tag=0, Type=str),
+                            Label="operatorName", Tag=1, Type=str),
                         ClusterObjectFieldDescriptor(
-                            Label="lineupName", Tag=1, Type=str),
+                            Label="lineupName", Tag=2, Type=str),
                         ClusterObjectFieldDescriptor(
-                            Label="postalCode", Tag=2, Type=str),
+                            Label="postalCode", Tag=3, Type=str),
                         ClusterObjectFieldDescriptor(
-                            Label="lineupInfoType", Tag=3, Type=TvChannel.Enums.TvChannelLineupInfoType),
+                            Label="lineupInfoType", Tag=4, Type=TvChannel.Enums.TvChannelLineupInfoType),
                     ])
 
             operatorName: 'str' = None
@@ -22347,9 +22347,9 @@ class TargetNavigator(Cluster):
                 return ClusterObjectDescriptor(
                     Fields=[
                         ClusterObjectFieldDescriptor(
-                            Label="identifier", Tag=0, Type=uint),
+                            Label="identifier", Tag=1, Type=uint),
                         ClusterObjectFieldDescriptor(
-                            Label="name", Tag=1, Type=str),
+                            Label="name", Tag=2, Type=str),
                     ])
 
             identifier: 'uint' = None
@@ -22487,9 +22487,9 @@ class MediaPlayback(Cluster):
                 return ClusterObjectDescriptor(
                     Fields=[
                         ClusterObjectFieldDescriptor(
-                            Label="updatedAt", Tag=0, Type=uint),
+                            Label="updatedAt", Tag=1, Type=uint),
                         ClusterObjectFieldDescriptor(
-                            Label="position", Tag=1, Type=uint),
+                            Label="position", Tag=2, Type=uint),
                     ])
 
             updatedAt: 'uint' = None
@@ -23005,13 +23005,13 @@ class MediaInput(Cluster):
                 return ClusterObjectDescriptor(
                     Fields=[
                         ClusterObjectFieldDescriptor(
-                            Label="index", Tag=0, Type=uint),
+                            Label="index", Tag=1, Type=uint),
                         ClusterObjectFieldDescriptor(
-                            Label="inputType", Tag=1, Type=MediaInput.Enums.MediaInputType),
+                            Label="inputType", Tag=2, Type=MediaInput.Enums.MediaInputType),
                         ClusterObjectFieldDescriptor(
-                            Label="name", Tag=2, Type=str),
+                            Label="name", Tag=3, Type=str),
                         ClusterObjectFieldDescriptor(
-                            Label="description", Tag=3, Type=str),
+                            Label="description", Tag=4, Type=str),
                     ])
 
             index: 'uint' = None
@@ -23400,9 +23400,9 @@ class ContentLauncher(Cluster):
                 return ClusterObjectDescriptor(
                     Fields=[
                         ClusterObjectFieldDescriptor(
-                            Label="name", Tag=0, Type=str),
+                            Label="name", Tag=1, Type=str),
                         ClusterObjectFieldDescriptor(
-                            Label="value", Tag=1, Type=str),
+                            Label="value", Tag=2, Type=str),
                     ])
 
             name: 'str' = None
@@ -23415,11 +23415,11 @@ class ContentLauncher(Cluster):
                 return ClusterObjectDescriptor(
                     Fields=[
                         ClusterObjectFieldDescriptor(
-                            Label="type", Tag=0, Type=ContentLauncher.Enums.ContentLaunchParameterEnum),
+                            Label="type", Tag=1, Type=ContentLauncher.Enums.ContentLaunchParameterEnum),
                         ClusterObjectFieldDescriptor(
-                            Label="value", Tag=1, Type=str),
+                            Label="value", Tag=2, Type=str),
                         ClusterObjectFieldDescriptor(
-                            Label="externalIDList", Tag=2, Type=typing.List[ContentLauncher.Structs.ContentLaunchAdditionalInfo]),
+                            Label="externalIDList", Tag=3, Type=typing.List[ContentLauncher.Structs.ContentLaunchAdditionalInfo]),
                     ])
 
             type: 'ContentLauncher.Enums.ContentLaunchParameterEnum' = None
@@ -23433,17 +23433,17 @@ class ContentLauncher(Cluster):
                 return ClusterObjectDescriptor(
                     Fields=[
                         ClusterObjectFieldDescriptor(
-                            Label="providerName", Tag=0, Type=str),
+                            Label="providerName", Tag=1, Type=str),
                         ClusterObjectFieldDescriptor(
-                            Label="background", Tag=1, Type=uint),
+                            Label="background", Tag=2, Type=uint),
                         ClusterObjectFieldDescriptor(
-                            Label="logo", Tag=2, Type=uint),
+                            Label="logo", Tag=3, Type=uint),
                         ClusterObjectFieldDescriptor(
-                            Label="progressBar", Tag=3, Type=uint),
+                            Label="progressBar", Tag=4, Type=uint),
                         ClusterObjectFieldDescriptor(
-                            Label="splash", Tag=4, Type=uint),
+                            Label="splash", Tag=5, Type=uint),
                         ClusterObjectFieldDescriptor(
-                            Label="waterMark", Tag=5, Type=uint),
+                            Label="waterMark", Tag=6, Type=uint),
                     ])
 
             providerName: 'str' = None
@@ -23460,11 +23460,11 @@ class ContentLauncher(Cluster):
                 return ClusterObjectDescriptor(
                     Fields=[
                         ClusterObjectFieldDescriptor(
-                            Label="width", Tag=0, Type=str),
+                            Label="width", Tag=1, Type=str),
                         ClusterObjectFieldDescriptor(
-                            Label="height", Tag=1, Type=str),
+                            Label="height", Tag=2, Type=str),
                         ClusterObjectFieldDescriptor(
-                            Label="metric", Tag=2, Type=ContentLauncher.Enums.ContentLaunchMetricType),
+                            Label="metric", Tag=3, Type=ContentLauncher.Enums.ContentLaunchMetricType),
                     ])
 
             width: 'str' = None
@@ -23478,11 +23478,11 @@ class ContentLauncher(Cluster):
                 return ClusterObjectDescriptor(
                     Fields=[
                         ClusterObjectFieldDescriptor(
-                            Label="imageUrl", Tag=0, Type=str),
+                            Label="imageUrl", Tag=1, Type=str),
                         ClusterObjectFieldDescriptor(
-                            Label="color", Tag=1, Type=str),
+                            Label="color", Tag=2, Type=str),
                         ClusterObjectFieldDescriptor(
-                            Label="size", Tag=2, Type=uint),
+                            Label="size", Tag=3, Type=uint),
                     ])
 
             imageUrl: 'str' = None
@@ -23653,11 +23653,11 @@ class AudioOutput(Cluster):
                 return ClusterObjectDescriptor(
                     Fields=[
                         ClusterObjectFieldDescriptor(
-                            Label="index", Tag=0, Type=uint),
+                            Label="index", Tag=1, Type=uint),
                         ClusterObjectFieldDescriptor(
-                            Label="outputType", Tag=1, Type=AudioOutput.Enums.AudioOutputType),
+                            Label="outputType", Tag=2, Type=AudioOutput.Enums.AudioOutputType),
                         ClusterObjectFieldDescriptor(
-                            Label="name", Tag=2, Type=str),
+                            Label="name", Tag=3, Type=str),
                     ])
 
             index: 'uint' = None
@@ -23784,9 +23784,9 @@ class ApplicationLauncher(Cluster):
                 return ClusterObjectDescriptor(
                     Fields=[
                         ClusterObjectFieldDescriptor(
-                            Label="catalogVendorId", Tag=0, Type=uint),
+                            Label="catalogVendorId", Tag=1, Type=uint),
                         ClusterObjectFieldDescriptor(
-                            Label="applicationId", Tag=1, Type=str),
+                            Label="applicationId", Tag=2, Type=str),
                     ])
 
             catalogVendorId: 'uint' = None
@@ -24199,21 +24199,21 @@ class TestCluster(Cluster):
                 return ClusterObjectDescriptor(
                     Fields=[
                         ClusterObjectFieldDescriptor(
-                            Label="a", Tag=0, Type=uint),
+                            Label="a", Tag=1, Type=uint),
                         ClusterObjectFieldDescriptor(
-                            Label="b", Tag=1, Type=bool),
+                            Label="b", Tag=2, Type=bool),
                         ClusterObjectFieldDescriptor(
-                            Label="c", Tag=2, Type=TestCluster.Enums.SimpleEnum),
+                            Label="c", Tag=3, Type=TestCluster.Enums.SimpleEnum),
                         ClusterObjectFieldDescriptor(
-                            Label="d", Tag=3, Type=bytes),
+                            Label="d", Tag=4, Type=bytes),
                         ClusterObjectFieldDescriptor(
-                            Label="e", Tag=4, Type=str),
+                            Label="e", Tag=5, Type=str),
                         ClusterObjectFieldDescriptor(
-                            Label="f", Tag=5, Type=uint),
+                            Label="f", Tag=6, Type=uint),
                         ClusterObjectFieldDescriptor(
-                            Label="g", Tag=6, Type=float),
+                            Label="g", Tag=7, Type=float),
                         ClusterObjectFieldDescriptor(
-                            Label="h", Tag=7, Type=float),
+                            Label="h", Tag=8, Type=float),
                     ])
 
             a: 'uint' = None
@@ -24232,29 +24232,29 @@ class TestCluster(Cluster):
                 return ClusterObjectDescriptor(
                     Fields=[
                         ClusterObjectFieldDescriptor(
-                            Label="nullableInt", Tag=0, Type=typing.Union[Nullable, uint]),
+                            Label="nullableInt", Tag=1, Type=typing.Union[Nullable, uint]),
                         ClusterObjectFieldDescriptor(
-                            Label="optionalInt", Tag=1, Type=typing.Optional[uint]),
+                            Label="optionalInt", Tag=2, Type=typing.Optional[uint]),
                         ClusterObjectFieldDescriptor(
-                            Label="nullableOptionalInt", Tag=2, Type=typing.Union[None, Nullable, uint]),
+                            Label="nullableOptionalInt", Tag=3, Type=typing.Union[None, Nullable, uint]),
                         ClusterObjectFieldDescriptor(
-                            Label="nullableString", Tag=3, Type=typing.Union[Nullable, str]),
+                            Label="nullableString", Tag=4, Type=typing.Union[Nullable, str]),
                         ClusterObjectFieldDescriptor(
-                            Label="optionalString", Tag=4, Type=typing.Optional[str]),
+                            Label="optionalString", Tag=5, Type=typing.Optional[str]),
                         ClusterObjectFieldDescriptor(
-                            Label="nullableOptionalString", Tag=5, Type=typing.Union[None, Nullable, str]),
+                            Label="nullableOptionalString", Tag=6, Type=typing.Union[None, Nullable, str]),
                         ClusterObjectFieldDescriptor(
-                            Label="nullableStruct", Tag=6, Type=typing.Union[Nullable, TestCluster.Structs.SimpleStruct]),
+                            Label="nullableStruct", Tag=7, Type=typing.Union[Nullable, TestCluster.Structs.SimpleStruct]),
                         ClusterObjectFieldDescriptor(
-                            Label="optionalStruct", Tag=7, Type=typing.Optional[TestCluster.Structs.SimpleStruct]),
+                            Label="optionalStruct", Tag=8, Type=typing.Optional[TestCluster.Structs.SimpleStruct]),
                         ClusterObjectFieldDescriptor(
-                            Label="nullableOptionalStruct", Tag=8, Type=typing.Union[None, Nullable, TestCluster.Structs.SimpleStruct]),
+                            Label="nullableOptionalStruct", Tag=9, Type=typing.Union[None, Nullable, TestCluster.Structs.SimpleStruct]),
                         ClusterObjectFieldDescriptor(
-                            Label="nullableList", Tag=9, Type=typing.Union[Nullable, typing.List[TestCluster.Enums.SimpleEnum]]),
+                            Label="nullableList", Tag=10, Type=typing.Union[Nullable, typing.List[TestCluster.Enums.SimpleEnum]]),
                         ClusterObjectFieldDescriptor(
-                            Label="optionalList", Tag=10, Type=typing.Optional[typing.List[TestCluster.Enums.SimpleEnum]]),
+                            Label="optionalList", Tag=11, Type=typing.Optional[typing.List[TestCluster.Enums.SimpleEnum]]),
                         ClusterObjectFieldDescriptor(
-                            Label="nullableOptionalList", Tag=11, Type=typing.Union[None, Nullable, typing.List[TestCluster.Enums.SimpleEnum]]),
+                            Label="nullableOptionalList", Tag=12, Type=typing.Union[None, Nullable, typing.List[TestCluster.Enums.SimpleEnum]]),
                     ])
 
             nullableInt: 'typing.Union[Nullable, uint]' = None
@@ -24277,11 +24277,11 @@ class TestCluster(Cluster):
                 return ClusterObjectDescriptor(
                     Fields=[
                         ClusterObjectFieldDescriptor(
-                            Label="a", Tag=0, Type=uint),
+                            Label="a", Tag=1, Type=uint),
                         ClusterObjectFieldDescriptor(
-                            Label="b", Tag=1, Type=bool),
+                            Label="b", Tag=2, Type=bool),
                         ClusterObjectFieldDescriptor(
-                            Label="c", Tag=2, Type=TestCluster.Structs.SimpleStruct),
+                            Label="c", Tag=3, Type=TestCluster.Structs.SimpleStruct),
                     ])
 
             a: 'uint' = None
@@ -24295,19 +24295,19 @@ class TestCluster(Cluster):
                 return ClusterObjectDescriptor(
                     Fields=[
                         ClusterObjectFieldDescriptor(
-                            Label="a", Tag=0, Type=uint),
+                            Label="a", Tag=1, Type=uint),
                         ClusterObjectFieldDescriptor(
-                            Label="b", Tag=1, Type=bool),
+                            Label="b", Tag=2, Type=bool),
                         ClusterObjectFieldDescriptor(
-                            Label="c", Tag=2, Type=TestCluster.Structs.SimpleStruct),
+                            Label="c", Tag=3, Type=TestCluster.Structs.SimpleStruct),
                         ClusterObjectFieldDescriptor(
-                            Label="d", Tag=3, Type=typing.List[TestCluster.Structs.SimpleStruct]),
+                            Label="d", Tag=4, Type=typing.List[TestCluster.Structs.SimpleStruct]),
                         ClusterObjectFieldDescriptor(
-                            Label="e", Tag=4, Type=typing.List[uint]),
+                            Label="e", Tag=5, Type=typing.List[uint]),
                         ClusterObjectFieldDescriptor(
-                            Label="f", Tag=5, Type=typing.List[bytes]),
+                            Label="f", Tag=6, Type=typing.List[bytes]),
                         ClusterObjectFieldDescriptor(
-                            Label="g", Tag=6, Type=typing.List[uint]),
+                            Label="g", Tag=7, Type=typing.List[uint]),
                     ])
 
             a: 'uint' = None
@@ -24325,7 +24325,7 @@ class TestCluster(Cluster):
                 return ClusterObjectDescriptor(
                     Fields=[
                         ClusterObjectFieldDescriptor(
-                            Label="a", Tag=0, Type=typing.List[TestCluster.Structs.NestedStructList]),
+                            Label="a", Tag=1, Type=typing.List[TestCluster.Structs.NestedStructList]),
                     ])
 
             a: 'typing.List[TestCluster.Structs.NestedStructList]' = None
@@ -24337,9 +24337,9 @@ class TestCluster(Cluster):
                 return ClusterObjectDescriptor(
                     Fields=[
                         ClusterObjectFieldDescriptor(
-                            Label="fabricIndex", Tag=0, Type=uint),
+                            Label="fabricIndex", Tag=1, Type=uint),
                         ClusterObjectFieldDescriptor(
-                            Label="operationalCert", Tag=1, Type=bytes),
+                            Label="operationalCert", Tag=2, Type=bytes),
                     ])
 
             fabricIndex: 'uint' = None
@@ -29048,15 +29048,15 @@ class GroupKeyManagement(Cluster):
                 return ClusterObjectDescriptor(
                     Fields=[
                         ClusterObjectFieldDescriptor(
-                            Label="vendorId", Tag=0, Type=uint),
+                            Label="vendorId", Tag=1, Type=uint),
                         ClusterObjectFieldDescriptor(
-                            Label="groupKeyIndex", Tag=1, Type=uint),
+                            Label="groupKeyIndex", Tag=2, Type=uint),
                         ClusterObjectFieldDescriptor(
-                            Label="groupKeyRoot", Tag=2, Type=bytes),
+                            Label="groupKeyRoot", Tag=3, Type=bytes),
                         ClusterObjectFieldDescriptor(
-                            Label="groupKeyEpochStartTime", Tag=3, Type=uint),
+                            Label="groupKeyEpochStartTime", Tag=4, Type=uint),
                         ClusterObjectFieldDescriptor(
-                            Label="groupKeySecurityPolicy", Tag=4, Type=GroupKeyManagement.Enums.GroupKeySecurityPolicy),
+                            Label="groupKeySecurityPolicy", Tag=5, Type=GroupKeyManagement.Enums.GroupKeySecurityPolicy),
                     ])
 
             vendorId: 'uint' = None
@@ -29072,11 +29072,11 @@ class GroupKeyManagement(Cluster):
                 return ClusterObjectDescriptor(
                     Fields=[
                         ClusterObjectFieldDescriptor(
-                            Label="vendorId", Tag=0, Type=uint),
+                            Label="vendorId", Tag=1, Type=uint),
                         ClusterObjectFieldDescriptor(
-                            Label="vendorGroupId", Tag=1, Type=uint),
+                            Label="vendorGroupId", Tag=2, Type=uint),
                         ClusterObjectFieldDescriptor(
-                            Label="groupKeySetIndex", Tag=2, Type=uint),
+                            Label="groupKeySetIndex", Tag=3, Type=uint),
                     ])
 
             vendorId: 'uint' = None

--- a/src/controller/python/templates/python-cluster-Objects-py.zapt
+++ b/src/controller/python/templates/python-cluster-Objects-py.zapt
@@ -42,7 +42,7 @@ class {{asUpperCamelCase name}}(Cluster):
                 return ClusterObjectDescriptor(
                     Fields = [
                         {{#zcl_struct_items}}
-                            ClusterObjectFieldDescriptor(Label="{{ asLowerCamelCase label }}", Tag={{ index }}, Type={{zapTypeToPythonClusterObjectType type ns=(asUpperCamelCase parent.parent.name)}}),
+                            ClusterObjectFieldDescriptor(Label="{{ asLowerCamelCase label }}", Tag={{ fieldIdentifier }}, Type={{zapTypeToPythonClusterObjectType type ns=(asUpperCamelCase parent.parent.name)}}),
                         {{/zcl_struct_items}}
                     ])
 

--- a/src/controller/python/test/test_scripts/cluster_objects.py
+++ b/src/controller/python/test/test_scripts/cluster_objects.py
@@ -34,7 +34,7 @@ def _AssumeDecodeSuccess(values):
         print(f"{k} = {v}")
         if isinstance(v.Data, ValueDecodeFailure):
             raise AssertionError(
-                f"Cannot decode value for path {k}: got {v.Data}")
+                f"Cannot decode value for path {k}, got error: '{str(v.Data.Reason)}', raw TLV data: '{v.Data.TLVValue}'")
 
 
 class ClusterObjectTests:

--- a/src/controller/python/test/test_scripts/cluster_objects.py
+++ b/src/controller/python/test/test_scripts/cluster_objects.py
@@ -18,7 +18,7 @@
 
 import chip.clusters as Clusters
 import logging
-from chip.clusters.Attribute import AttributePath, AttributeReadResult, AttributeStatus
+from chip.clusters.Attribute import AttributePath, AttributeReadResult, AttributeStatus, ValueDecodeFailure
 import chip.interaction_model
 import asyncio
 
@@ -27,6 +27,14 @@ logger.setLevel(logging.INFO)
 
 NODE_ID = 1
 LIGHTING_ENDPOINT_ID = 1
+
+
+def _AssumeDecodeSuccess(values):
+    for k, v in values.items():
+        print(f"{k} = {v}")
+        if isinstance(v.Data, ValueDecodeFailure):
+            raise AssertionError(
+                f"Cannot decode value for path {k}: got {v.Data}")
 
 
 class ClusterObjectTests:
@@ -138,36 +146,37 @@ class ClusterObjectTests:
         if (len(res) != 3):
             raise AssertionError(
                 f"Got back {len(res)} data items instead of 3")
+        _AssumeDecodeSuccess(res)
 
         logger.info("2: Reading Ex Cx A*")
         req = [
             (0, Clusters.Basic),
         ]
-        await devCtrl.ReadAttribute(nodeid=NODE_ID, attributes=req)
+        _AssumeDecodeSuccess(await devCtrl.ReadAttribute(nodeid=NODE_ID, attributes=req))
 
         logger.info("3: Reading E* Cx Ax")
         req = [
             Clusters.Descriptor.Attributes.ServerList
         ]
-        await devCtrl.ReadAttribute(nodeid=NODE_ID, attributes=req)
+        _AssumeDecodeSuccess(await devCtrl.ReadAttribute(nodeid=NODE_ID, attributes=req))
 
         logger.info("4: Reading Ex C* A*")
         req = [
             0
         ]
-        await devCtrl.ReadAttribute(nodeid=NODE_ID, attributes=req)
+        _AssumeDecodeSuccess(await devCtrl.ReadAttribute(nodeid=NODE_ID, attributes=req))
 
         logger.info("5: Reading E* Cx A*")
         req = [
             Clusters.Descriptor
         ]
-        await devCtrl.ReadAttribute(nodeid=NODE_ID, attributes=req)
+        _AssumeDecodeSuccess(await devCtrl.ReadAttribute(nodeid=NODE_ID, attributes=req))
 
         logger.info("6: Reading E* C* A*")
         req = [
             '*'
         ]
-        await devCtrl.ReadAttribute(nodeid=NODE_ID, attributes=req)
+        _AssumeDecodeSuccess(await devCtrl.ReadAttribute(nodeid=NODE_ID, attributes=req))
 
     @classmethod
     async def RunTest(cls, devCtrl):


### PR DESCRIPTION
#### Problem

TLV schema tag should start from 1, and the error is not captured.

#### Change overview

Update codegen, and add tests to verify if we successfully decoded all values.

Create `ValueDecodeFailure` class to wrap the value, since exceptions will be ignored in C callbacks.

Wrap tests by _AssumeDecodeSuccess, users don't have to do this manually, they will see ValueDecodeFailure instead of the attribute describer.

Adds a new global debug mode variable that can be set using `mattersetdebug()` to facilitate debugging of issues (e.g throwing exceptions in the relevant modules instead of returning formatted ValueDecodeFailure objects).

#### Testing

CI with first commit only should fail: https://github.com/erjiaqing/connectedhomeip/actions/runs/1519033903
CI with both commits should success.