### PR TITLE
[docker] Enable all docker images in build CI

### DIFF
--- a/.github/workflows/docker_img.yaml
+++ b/.github/workflows/docker_img.yaml
@@ -31,8 +31,24 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                # TODO: Enables "-crosscompile" and "-vscode" images
-                img: ["", "-android", "-cirque", "-doxygen", "-efr32", "-esp32", "-esp32-qemu", "-infineon", "-k32w", "-mbed-os", "-nrf-platform", "-telink", "-tizen"]
+                img:
+                    - ""
+                    - "-ameba"
+                    - "-android"
+                    - "-cirque"
+                    - "-crosscompile"
+                    - "-doxygen"
+                    - "-efr32"
+                    - "-esp32"
+                    - "-esp32-qemu"
+                    - "-infineon"
+                    - "-k32w"
+                    - "-mbed-os"
+                    - "-nrf-platform"
+                    - "-telink"
+                    - "-tizen"
+                    # NOTE: vscode image consumes ~52 GB disk space but GitHub-hosted runners provide ~10 GB free disk space(https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources)
+                    #- "-vscode"
         steps:
             - name: Checkout
               uses: actions/checkout@v2
@@ -43,6 +59,7 @@ jobs:
             - name: Scan for vulnerabilities
               uses: crazy-max/docker-scan-action@master
               with:
-                  image: connectedhomeip/chip-build${{ matrix.img }}:0.5.33
+                  # NOTE: This task validates the images built previously with latest tag
+                  image: connectedhomeip/chip-build${{ matrix.img }}:latest
                   annotations: true
 

--- a/integrations/docker/build.sh
+++ b/integrations/docker/build.sh
@@ -73,6 +73,7 @@ if [[ ${*/--no-cache//} != "${*}" ]]; then
 fi
 
 docker build "${BUILD_ARGS[@]}" --build-arg VERSION="$VERSION" -t "$ORG/$IMAGE:$VERSION" .
+docker image prune --force
 
 [[ ${*/--latest//} != "${*}" ]] && {
     docker tag "$ORG"/"$IMAGE":"$VERSION" "$ORG"/"$IMAGE":latest

--- a/integrations/docker/build.sh
+++ b/integrations/docker/build.sh
@@ -59,6 +59,8 @@ set -ex
 
 [[ -n $VERSION ]] || die "version cannot be empty"
 
+mb_space_before=$(df -m /var/lib/docker/ | awk 'FNR==2{print $3}')
+
 # go find and build any CHIP images this image is "FROM"
 awk -F/ '/^FROM connectedhomeip/ {print $2}' Dockerfile | while read -r dep; do
     dep=${dep%:*}
@@ -87,5 +89,10 @@ docker build "${BUILD_ARGS[@]}" --build-arg VERSION="$VERSION" -t "$ORG/$IMAGE:$
         docker push "$ORG"/"$IMAGE":latest
     }
 }
+
+docker images --filter=reference="$ORG/*"
+df -h /var/lib/docker/
+mb_space_after=$(df -m /var/lib/docker/ | awk 'FNR==2{print $3}')
+printf "%'.f MB total used\n" "$((mb_space_before - mb_space_after))"
 
 exit 0

--- a/integrations/docker/images/build-all.sh
+++ b/integrations/docker/images/build-all.sh
@@ -26,4 +26,3 @@ find "$(git rev-parse --show-toplevel)"/integrations/docker/images/ -name Docker
     ./build.sh "$@"
     popd >/dev/null
 done
-docker image prune --force

--- a/integrations/docker/images/chip-build-crosscompile/Dockerfile
+++ b/integrations/docker/images/chip-build-crosscompile/Dockerfile
@@ -1,14 +1,19 @@
-ARG VERSION=latest
-FROM connectedhomeip/chip-build:${VERSION}
+FROM alpine:3.15 as build
 
-COPY ubuntu-21.04-aarch64-sysroot.tar.xz /opt/ubuntu-21.04-aarch64-sysroot.tar.xz
+RUN apk --no-cache add \
+    bash=5.1.8-r0 \
+    git=2.34.1-r0 \
+    wget=1.21.2-r2
 
+WORKDIR /opt
 # Unpack the sysroot, while also removing some rather large items in it that
 # are generally not required for compilation
 RUN set -x \
-    && cd /opt \
+    && git clone --depth 1 https://chromium.googlesource.com/chromium/tools/depot_tools.git /opt/depot_tools \
+    # TODO: Remove experimental solution to create the sysroot file in cross-compile image
+    && echo 'experimental/matter/sysroot/ubuntu-21.04-aarch64 latest' > ensure_file.txt \
+    && ./depot_tools/cipd ensure -ensure-file ensure_file.txt -root ./ \
     && tar xfvJ ubuntu-21.04-aarch64-sysroot.tar.xz \
-    && rm ubuntu-21.04-aarch64-sysroot.tar.xz \
     && rm -rf /opt/ubuntu-21.04-aarch64-sysroot/usr/lib/firmware \
     && rm -rf /opt/ubuntu-21.04-aarch64-sysroot/usr/lib/git-core \
     && rm -rf /opt/ubuntu-21.04-aarch64-sysroot/usr/lib/modules \
@@ -17,5 +22,8 @@ RUN set -x \
     && rm -rf /opt/ubuntu-21.04-aarch64-sysroot/lib/modules \
     && : # last line
 
+FROM alpine:3.15
+
+COPY --from=build /opt/ubuntu-21.04-aarch64-sysroot/ /opt/ubuntu-21.04-aarch64-sysroot/
 
 ENV SYSROOT_AARCH64=/opt/ubuntu-21.04-aarch64-sysroot

--- a/integrations/docker/images/chip-build-crosscompile/README.md
+++ b/integrations/docker/images/chip-build-crosscompile/README.md
@@ -58,7 +58,7 @@ rebuilding a sysroot. It is located at:
 https://chrome-infra-packages.appspot.com/p/experimental/matter/sysroot/ubuntu-21.04-aarch64/+/
 
 and can be downloaded using the `cipd` script from
-[depot_tools][https://dev.chromium.org/developers/how-tos/depottools]:
+[depot_tools](https://dev.chromium.org/developers/how-tos/depottools):
 
 ```
 echo 'experimental/matter/sysroot/ubuntu-21.04-aarch64 latest' > ensure_file.txt

--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.5.33 Version bump reason: [Ameba] Lwip update
+0.5.34 Version bump reason: Reduce size crosscompile image


### PR DESCRIPTION
#### Problem
* Cross compile image depends on an external tarball.
* New Docker images have been included but not covered in the CI.
* The tag used by the scanner is not verifying the changes in the CI.
* Fixes #10852

#### Change overview
This change includes all the existing Dockerfiles into the Docker build CI workflow as well as the right Docker tag in the Vulnerability Scanner.

It also reduces the size of the crosscompile docker image from 5.22GB to 1.79GB (given that now it uses the alpine as base image instead of chip-base image) as well as includes the instructions to generate Sysroot tarball file.

#### Testing
This was tested locally
