### PR TITLE
Avoid IPython v7.30.0 due to bug in 'await'

### DIFF
--- a/src/controller/python/build-chip-wheel.py
+++ b/src/controller/python/build-chip-wheel.py
@@ -116,7 +116,12 @@ try:
     requiredPackages = [
         "coloredlogs",
         'construct',
-        'ipython',
+
+        #
+        # IPython 7.30.0 has a bug which results in the use of await ... failing on some platforms (see https://github.com/ipython/ipython/pull/13269)
+        # For now, let's just avoid that version.
+        #
+        'ipython!=7.30.0',
         'dacite',
         'rich',
         'stringcase',


### PR DESCRIPTION
IPython v7.30.0 introduced a bug that results in the use of 'await ...'
at the shell failing (for more details, see
https://github.com/ipython/ipython/pull/13269#issuecomment-982757299)

For now, let's just avoid that version (it will be fixed in subsequent
versions).
