### PR TITLE
Implement run time value to the General diagnostics attributes for EFR32 platform

### DIFF
--- a/src/platform/EFR32/ConfigurationManagerImpl.h
+++ b/src/platform/EFR32/ConfigurationManagerImpl.h
@@ -40,6 +40,12 @@ public:
     // This returns an instance of this class.
     static ConfigurationManagerImpl & GetDefaultInstance();
 
+    uint32_t GetBootReason(void);
+    CHIP_ERROR GetRebootCount(uint32_t & rebootCount);
+    CHIP_ERROR IncreaseBootCount(void);
+    CHIP_ERROR GetTotalOperationalHours(uint32_t & totalOperationalHours);
+    CHIP_ERROR StoreTotalOperationalHours(uint32_t totalOperationalHours);
+
 private:
     // ===== Members that implement the ConfigurationManager public interface.
 
@@ -67,7 +73,7 @@ private:
     void RunConfigUnitTest(void) override;
 
     // ===== Private members reserved for use by this class only.
-
+    uint32_t rebootCause;
     static void DoFactoryReset(intptr_t arg);
 };
 

--- a/src/platform/EFR32/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/EFR32/DiagnosticDataProviderImpl.cpp
@@ -40,6 +40,7 @@ DiagnosticDataProviderImpl & DiagnosticDataProviderImpl::GetDefaultInstance()
     return sInstance;
 }
 
+// Software Diagnostics Getters
 /*
  * The following Heap stats are compiled values done by the FreeRTOS Heap4 implementation.
  * See /examples/platform/efr32/heap_4_silabs.c
@@ -73,6 +74,107 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetCurrentHeapHighWatermark(uint64_t & cu
     // Something went wrong, this should not happen
     VerifyOrReturnError(HighestHeapUsageRecorded >= 0, CHIP_ERROR_INVALID_INTEGER_VALUE);
     currentHeapHighWatermark = static_cast<uint64_t>(HighestHeapUsageRecorded);
+
+    return CHIP_NO_ERROR;
+}
+
+// General Diagnostics Getters
+
+CHIP_ERROR DiagnosticDataProviderImpl::GetRebootCount(uint16_t & rebootCount)
+{
+    uint32_t count = 0;
+    CHIP_ERROR err = ConfigurationMgr().GetRebootCount(count);
+
+    if (err == CHIP_NO_ERROR)
+    {
+        VerifyOrReturnError(count <= UINT16_MAX, CHIP_ERROR_INVALID_INTEGER_VALUE);
+        rebootCount = static_cast<uint16_t>(count);
+    }
+
+    return err;
+}
+
+CHIP_ERROR DiagnosticDataProviderImpl::GetBootReason(uint8_t & bootReason)
+{
+    uint32_t reason = 0; 
+    CHIP_ERROR err = ConfigurationMgr().GetBootReason(reason);
+    
+    if (err == CHIP_NO_ERROR)
+    {
+        VerifyOrReturnError(reason <= UINT8_MAX, CHIP_ERROR_INVALID_INTEGER_VALUE);
+        bootReason = static_cast<uint8_t>(reason);
+    }
+
+    return err;
+}
+
+CHIP_ERROR DiagnosticDataProviderImpl::GetUpTime(uint64_t & upTime)
+{
+    System::Clock::Timestamp currentTime = System::SystemClock().GetMonotonicTimestamp();
+    System::Clock::Timestamp startTime   = PlatformMgrImpl().GetStartTime();
+
+    if (currentTime >= startTime)
+    {
+        upTime = std::chrono::duration_cast<System::Clock::Seconds64>(currentTime - startTime).count();
+        return CHIP_NO_ERROR;
+    }
+
+    return CHIP_ERROR_INVALID_TIME;
+}
+
+CHIP_ERROR DiagnosticDataProviderImpl::GetTotalOperationalHours(uint32_t & totalOperationalHours)
+{
+    uint64_t upTime = 0;
+
+    if (GetUpTime(upTime) == CHIP_NO_ERROR)
+    {
+        uint32_t totalHours = 0;
+        if (ConfigurationMgr().GetTotalOperationalHours(totalHours) == CHIP_NO_ERROR)
+        {
+            VerifyOrReturnError(upTime / 3600 <= UINT32_MAX, CHIP_ERROR_INVALID_INTEGER_VALUE);
+            totalOperationalHours = totalHours + static_cast<uint32_t>(upTime / 3600);
+            return CHIP_NO_ERROR;
+        }
+    }
+
+    return CHIP_ERROR_INVALID_TIME;
+}
+
+
+CHIP_ERROR DiagnosticDataProviderImpl::GetActiveHardwareFaults(GeneralFaults<kMaxHardwareFaults> & hardwareFaults)
+{
+#if CHIP_CONFIG_TEST
+    // On Linux Simulation, set following hardware faults statically.
+    ReturnErrorOnFailure(hardwareFaults.add(EMBER_ZCL_HARDWARE_FAULT_TYPE_RADIO));
+    ReturnErrorOnFailure(hardwareFaults.add(EMBER_ZCL_HARDWARE_FAULT_TYPE_SENSOR));
+    ReturnErrorOnFailure(hardwareFaults.add(EMBER_ZCL_HARDWARE_FAULT_TYPE_POWER_SOURCE));
+    ReturnErrorOnFailure(hardwareFaults.add(EMBER_ZCL_HARDWARE_FAULT_TYPE_USER_INTERFACE_FAULT));
+#endif
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR DiagnosticDataProviderImpl::GetActiveRadioFaults(GeneralFaults<kMaxRadioFaults> & radioFaults)
+{
+#if CHIP_CONFIG_TEST
+    // On Linux Simulation, set following radio faults statically.
+    ReturnErrorOnFailure(radioFaults.add(EMBER_ZCL_RADIO_FAULT_TYPE_WI_FI_FAULT));
+    ReturnErrorOnFailure(radioFaults.add(EMBER_ZCL_RADIO_FAULT_TYPE_CELLULAR_FAULT));
+    ReturnErrorOnFailure(radioFaults.add(EMBER_ZCL_RADIO_FAULT_TYPE_THREAD_FAULT));
+    ReturnErrorOnFailure(radioFaults.add(EMBER_ZCL_RADIO_FAULT_TYPE_NFC_FAULT));
+#endif
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR DiagnosticDataProviderImpl::GetActiveNetworkFaults(GeneralFaults<kMaxNetworkFaults> & networkFaults)
+{
+#if CHIP_CONFIG_TEST
+    // On Linux Simulation, set following radio faults statically.
+    ReturnErrorOnFailure(networkFaults.add(EMBER_ZCL_NETWORK_FAULT_TYPE_HARDWARE_FAILURE));
+    ReturnErrorOnFailure(networkFaults.add(EMBER_ZCL_NETWORK_FAULT_TYPE_NETWORK_JAMMED));
+    ReturnErrorOnFailure(networkFaults.add(EMBER_ZCL_NETWORK_FAULT_TYPE_CONNECTION_FAILED));
+#endif
 
     return CHIP_NO_ERROR;
 }

--- a/src/platform/EFR32/DiagnosticDataProviderImpl.h
+++ b/src/platform/EFR32/DiagnosticDataProviderImpl.h
@@ -49,6 +49,8 @@ public:
     CHIP_ERROR GetActiveHardwareFaults(GeneralFaults<kMaxHardwareFaults> & hardwareFaults) override;
     CHIP_ERROR GetActiveRadioFaults(GeneralFaults<kMaxRadioFaults> & radioFaults) override;
     CHIP_ERROR GetActiveNetworkFaults(GeneralFaults<kMaxNetworkFaults> & networkFaults) override;
+    CHIP_ERROR GetNetworkInterfaces(NetworkInterface ** netifpp) override;
+    void ReleaseNetworkInterfaces(NetworkInterface * netifp) override;
 };
 
 } // namespace DeviceLayer

--- a/src/platform/EFR32/DiagnosticDataProviderImpl.h
+++ b/src/platform/EFR32/DiagnosticDataProviderImpl.h
@@ -42,6 +42,13 @@ public:
     CHIP_ERROR GetCurrentHeapFree(uint64_t & currentHeapFree) override;
     CHIP_ERROR GetCurrentHeapUsed(uint64_t & currentHeapUsed) override;
     CHIP_ERROR GetCurrentHeapHighWatermark(uint64_t & currentHeapHighWatermark) override;
+    CHIP_ERROR GetRebootCount(uint16_t & rebootCount) override;
+    CHIP_ERROR GetBootReason(uint8_t & bootReason) override;
+    CHIP_ERROR GetUpTime(uint64_t & upTime) override;
+    CHIP_ERROR GetTotalOperationalHours(uint32_t & totalOperationalHours) override;
+    CHIP_ERROR GetActiveHardwareFaults(GeneralFaults<kMaxHardwareFaults> & hardwareFaults) override;
+    CHIP_ERROR GetActiveRadioFaults(GeneralFaults<kMaxRadioFaults> & radioFaults) override;
+    CHIP_ERROR GetActiveNetworkFaults(GeneralFaults<kMaxNetworkFaults> & networkFaults) override;
 };
 
 } // namespace DeviceLayer

--- a/src/platform/EFR32/EFR32Config.h
+++ b/src/platform/EFR32/EFR32Config.h
@@ -95,8 +95,12 @@ public:
     static constexpr Key kConfigKey_CountryCode        = EFR32ConfigKey(kChipConfig_KeyBase, 0x0A);
     static constexpr Key kConfigKey_Breadcrumb         = EFR32ConfigKey(kChipConfig_KeyBase, 0x0B);
 
-    static constexpr Key kConfigKey_GroupKeyBase = EFR32ConfigKey(kChipConfig_KeyBase, 0x0C);
-    static constexpr Key kConfigKey_GroupKeyMax  = EFR32ConfigKey(kChipConfig_KeyBase, 0x1B); // Allows 16 Group Keys to be created.
+    static constexpr Key kConfigKey_BootCount             = EFR32ConfigKey(kChipCounter_KeyBase, 0x0C);
+    static constexpr Key kConfigKey_TotalOperationalHours = EFR32ConfigKey(kChipCounter_KeyBase, 0x0D);
+
+    static constexpr Key kConfigKey_GroupKeyBase       = EFR32ConfigKey(kChipConfig_KeyBase, 0x0E);
+    static constexpr Key kConfigKey_GroupKeyMax        = EFR32ConfigKey(kChipConfig_KeyBase, 0x1D); // Allows 16 Group Keys to be created.
+
 
     // Set key id limits for each group.
     static constexpr Key kMinConfigKey_ChipFactory = EFR32ConfigKey(kChipFactory_KeyBase, 0x00);

--- a/src/platform/EFR32/EFR32Config.h
+++ b/src/platform/EFR32/EFR32Config.h
@@ -98,9 +98,8 @@ public:
     static constexpr Key kConfigKey_BootCount             = EFR32ConfigKey(kChipCounter_KeyBase, 0x0C);
     static constexpr Key kConfigKey_TotalOperationalHours = EFR32ConfigKey(kChipCounter_KeyBase, 0x0D);
 
-    static constexpr Key kConfigKey_GroupKeyBase       = EFR32ConfigKey(kChipConfig_KeyBase, 0x0E);
-    static constexpr Key kConfigKey_GroupKeyMax        = EFR32ConfigKey(kChipConfig_KeyBase, 0x1D); // Allows 16 Group Keys to be created.
-
+    static constexpr Key kConfigKey_GroupKeyBase = EFR32ConfigKey(kChipConfig_KeyBase, 0x0E);
+    static constexpr Key kConfigKey_GroupKeyMax  = EFR32ConfigKey(kChipConfig_KeyBase, 0x1D); // Allows 16 Group Keys to be created.
 
     // Set key id limits for each group.
     static constexpr Key kMinConfigKey_ChipFactory = EFR32ConfigKey(kChipFactory_KeyBase, 0x00);

--- a/src/platform/EFR32/PlatformManagerImpl.cpp
+++ b/src/platform/EFR32/PlatformManagerImpl.cpp
@@ -60,5 +60,30 @@ exit:
     return err;
 }
 
+CHIP_ERROR PlatformManagerImpl::_Shutdown()
+{
+    uint64_t upTime = 0;
+
+    if (GetDiagnosticDataProvider().GetUpTime(upTime) == CHIP_NO_ERROR)
+    {
+        uint32_t totalOperationalHours = 0;
+
+        if (ConfigurationMgr().GetTotalOperationalHours(totalOperationalHours) == CHIP_NO_ERROR)
+        {
+            ConfigurationMgr().StoreTotalOperationalHours(totalOperationalHours + static_cast<uint32_t>(upTime / 3600));
+        }
+        else
+        {
+            ChipLogError(DeviceLayer, "Failed to get total operational hours of the Node");
+        }
+    }
+    else
+    {
+        ChipLogError(DeviceLayer, "Failed to get current uptime since the Node’s last reboot");
+    }
+
+    return Internal::GenericPlatformManagerImpl_FreeRTOS<PlatformManagerImpl>::_Shutdown();
+}
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/EFR32/PlatformManagerImpl.h
+++ b/src/platform/EFR32/PlatformManagerImpl.h
@@ -53,6 +53,7 @@ private:
     // ===== Methods that implement the PlatformManager abstract interface.
 
     CHIP_ERROR _InitChipStack(void);
+    CHIP_ERROR _Shutdown(void);
 
     // ===== Members for internal use by the following friends.
 
@@ -61,7 +62,7 @@ private:
     friend class Internal::BLEManagerImpl;
 
     System::Clock::Timestamp mStartTime = System::Clock::kZero;
-    
+
     static PlatformManagerImpl sInstance;
 
     using Internal::GenericPlatformManagerImpl_FreeRTOS<PlatformManagerImpl>::PostEventFromISR;

--- a/src/platform/EFR32/PlatformManagerImpl.h
+++ b/src/platform/EFR32/PlatformManagerImpl.h
@@ -47,7 +47,7 @@ class PlatformManagerImpl final : public PlatformManager, public Internal::Gener
 public:
     // ===== Platform-specific members that may be accessed directly by the application.
 
-    /* none so far */
+    System::Clock::Timestamp GetStartTime() { return mStartTime; }
 
 private:
     // ===== Methods that implement the PlatformManager abstract interface.
@@ -60,6 +60,8 @@ private:
     friend PlatformManagerImpl & PlatformMgrImpl(void);
     friend class Internal::BLEManagerImpl;
 
+    System::Clock::Timestamp mStartTime = System::Clock::kZero;
+    
     static PlatformManagerImpl sInstance;
 
     using Internal::GenericPlatformManagerImpl_FreeRTOS<PlatformManagerImpl>::PostEventFromISR;


### PR DESCRIPTION
#### Problem
EFR32 platform do not provide run time value to the General diagnostics attributes.

#### Change overview
Implement the getters and logic in EFR32 DiagnosticDataProviderImpl.cpp and ConfigurationManagerImpl.cpp

#### Testing
Manual testing with chip-tool
./out/standalone/chip-tool generaldiagnostics read  up-time 2145 0
./out/standalone/chip-tool generaldiagnostics read network-interfaces 2145 0
./out/standalone/chip-tool generaldiagnostics read  reboot-count 2145 0
./out/standalone/chip-tool generaldiagnostics read  boot-reasons 2145 0
./out/standalone/chip-tool generaldiagnostics read total-operational-hours 2145 0

