### PR TITLE
Implement the server side of timed invoke.

### DIFF
--- a/.github/workflows/examples-nrfconnect.yaml
+++ b/.github/workflows/examples-nrfconnect.yaml
@@ -148,6 +148,14 @@ jobs:
               run: |
                   scripts/run_in_build_env.sh "scripts/tests/nrfconnect_native_posix_tests.sh native_posix_64"
 
+            - name: Uploading Failed Test Logs
+              uses: actions/upload-artifact@v2
+              if: ${{ failure() }} && ${{ !env.ACT }}
+              with:
+                  name: test-log
+                  path: |
+                      src/test_driver/nrfconnect/build/Testing/Temporary/LastTest.log
+
             - name: Uploading Size Reports
               uses: actions/upload-artifact@v2
               if: ${{ !env.ACT }}

--- a/examples/all-clusters-app/ameba/chip_main.cmake
+++ b/examples/all-clusters-app/ameba/chip_main.cmake
@@ -23,6 +23,7 @@ list(
     ${chip_dir}/src/app/EventManagement.cpp
     ${chip_dir}/src/app/ReadClient.cpp
     ${chip_dir}/src/app/ReadHandler.cpp
+    ${chip_dir}/src/app/TimedHandler.cpp
     ${chip_dir}/src/app/WriteClient.cpp
     ${chip_dir}/src/app/WriteHandler.cpp
     ${chip_dir}/src/app/util/CHIPDeviceCallbacksMgr.cpp

--- a/examples/lighting-app/ameba/chip_main.cmake
+++ b/examples/lighting-app/ameba/chip_main.cmake
@@ -23,6 +23,7 @@ list(
     ${chip_dir}/src/app/EventManagement.cpp
     ${chip_dir}/src/app/ReadClient.cpp
     ${chip_dir}/src/app/ReadHandler.cpp
+    ${chip_dir}/src/app/TimedHandler.cpp
     ${chip_dir}/src/app/WriteClient.cpp
     ${chip_dir}/src/app/WriteHandler.cpp
     ${chip_dir}/src/app/util/CHIPDeviceCallbacksMgr.cpp

--- a/scripts/tests/nrfconnect_native_posix_tests.sh
+++ b/scripts/tests/nrfconnect_native_posix_tests.sh
@@ -27,4 +27,4 @@ env
 cd "$CHIP_ROOT/src/test_driver/nrfconnect" &&
     west build -b "$BOARD" &&
     cd build &&
-    timeout 5m ctest -V
+    timeout 5m ctest -V --output-on-failure

--- a/src/app/BUILD.gn
+++ b/src/app/BUILD.gn
@@ -120,6 +120,8 @@ static_library("app") {
     "ReadHandler.cpp",
     "StatusResponse.cpp",
     "StatusResponse.h",
+    "TimedHandler.cpp",
+    "TimedHandler.h",
     "WriteClient.cpp",
     "WriteHandler.cpp",
     "decoder.cpp",

--- a/src/app/CommandHandler.h
+++ b/src/app/CommandHandler.h
@@ -128,16 +128,20 @@ public:
      *
      * This function will always call the OnDone function above on the registered callback
      * before returning.
+     *
+     * isTimedInvoke is true if and only if this is part of a Timed Invoke
+     * transaction (i.e. was preceded by a Timed Request).  If we reach here,
+     * the timer verification has already been done.
      */
     CHIP_ERROR OnInvokeCommandRequest(Messaging::ExchangeContext * ec, const PayloadHeader & payloadHeader,
-                                      System::PacketBufferHandle && payload);
+                                      System::PacketBufferHandle && payload, bool isTimedInvoke);
     CHIP_ERROR AddStatus(const ConcreteCommandPath & aCommandPath, const Protocols::InteractionModel::Status aStatus) override;
 
     CHIP_ERROR AddClusterSpecificSuccess(const ConcreteCommandPath & aCommandPath, ClusterStatus aClusterStatus) override;
 
     CHIP_ERROR AddClusterSpecificFailure(const ConcreteCommandPath & aCommandPath, ClusterStatus aClusterStatus) override;
 
-    CHIP_ERROR ProcessInvokeRequest(System::PacketBufferHandle && payload);
+    CHIP_ERROR ProcessInvokeRequest(System::PacketBufferHandle && payload, bool isTimedInvoke);
     CHIP_ERROR PrepareCommand(const CommandPathParams & aCommandPathParams, bool aStartDataStruct = true);
     CHIP_ERROR FinishCommand(bool aStartDataStruct = true);
     CHIP_ERROR PrepareStatus(const CommandPathParams & aCommandPathParams);
@@ -165,6 +169,11 @@ public:
 
         return FinishCommand(/* aEndDataStruct = */ false);
     }
+
+    /**
+     * Check whether the InvokeRequest we are handling is a timed invoke.
+     */
+    bool IsTimedInvoke() const { return mTimedRequest; }
 
 private:
     friend class TestCommandInteraction;

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -95,6 +95,15 @@ void InteractionModelEngine::Shutdown()
         return true;
     });
 
+    mTimedHandlers.ForEachActiveObject([this](TimedHandler * obj) -> bool {
+        // This calls back into us and deallocates |obj|.  As above, this is not
+        // really guaranteed, and we should do something better here (like
+        // ignoring the calls to OnTimedInteractionFailed and then doing a
+        // DeallocateAll.
+        mpExchangeMgr->CloseAllContextsForDelegate(obj);
+        return true;
+    });
+
     for (auto & readClient : mReadClients)
     {
         if (!readClient.IsFree())
@@ -277,7 +286,7 @@ void InteractionModelEngine::OnDone(CommandHandler & apCommandObj)
 
 CHIP_ERROR InteractionModelEngine::OnInvokeCommandRequest(Messaging::ExchangeContext * apExchangeContext,
                                                           const PayloadHeader & aPayloadHeader,
-                                                          System::PacketBufferHandle && aPayload,
+                                                          System::PacketBufferHandle && aPayload, bool aIsTimedInvoke,
                                                           Protocols::InteractionModel::Status & aStatus)
 {
     CommandHandler * commandHandler = mCommandHandlerObjs.CreateObject(this);
@@ -287,7 +296,8 @@ CHIP_ERROR InteractionModelEngine::OnInvokeCommandRequest(Messaging::ExchangeCon
         aStatus = Protocols::InteractionModel::Status::Busy;
         return CHIP_ERROR_NO_MEMORY;
     }
-    ReturnErrorOnFailure(commandHandler->OnInvokeCommandRequest(apExchangeContext, aPayloadHeader, std::move(aPayload)));
+    ReturnErrorOnFailure(
+        commandHandler->OnInvokeCommandRequest(apExchangeContext, aPayloadHeader, std::move(aPayload), aIsTimedInvoke));
     aStatus = Protocols::InteractionModel::Status::Success;
     return CHIP_NO_ERROR;
 }
@@ -360,6 +370,25 @@ CHIP_ERROR InteractionModelEngine::OnWriteRequest(Messaging::ExchangeContext * a
     return CHIP_NO_ERROR;
 }
 
+CHIP_ERROR InteractionModelEngine::OnTimedRequest(Messaging::ExchangeContext * apExchangeContext,
+                                                  const PayloadHeader & aPayloadHeader, System::PacketBufferHandle && aPayload,
+                                                  Protocols::InteractionModel::Status & aStatus)
+{
+    TimedHandler * handler = mTimedHandlers.CreateObject();
+    if (handler == nullptr)
+    {
+        ChipLogProgress(InteractionModel, "no resource for Timed interaction");
+        aStatus = Protocols::InteractionModel::Status::Busy;
+        return CHIP_ERROR_NO_MEMORY;
+    }
+
+    // The timed handler takes over handling of this exchange and will do its
+    // own status reporting as needed.
+    aStatus = Protocols::InteractionModel::Status::Success;
+    apExchangeContext->SetDelegate(handler);
+    return handler->OnMessageReceived(apExchangeContext, aPayloadHeader, std::move(aPayload));
+}
+
 CHIP_ERROR InteractionModelEngine::OnUnsolicitedReportData(Messaging::ExchangeContext * apExchangeContext,
                                                            const PayloadHeader & aPayloadHeader,
                                                            System::PacketBufferHandle && aPayload)
@@ -392,12 +421,15 @@ CHIP_ERROR InteractionModelEngine::OnUnsolicitedReportData(Messaging::ExchangeCo
 CHIP_ERROR InteractionModelEngine::OnMessageReceived(Messaging::ExchangeContext * apExchangeContext,
                                                      const PayloadHeader & aPayloadHeader, System::PacketBufferHandle && aPayload)
 {
+    using namespace Protocols::InteractionModel;
+
     CHIP_ERROR err                             = CHIP_NO_ERROR;
     Protocols::InteractionModel::Status status = Protocols::InteractionModel::Status::Failure;
 
     if (aPayloadHeader.HasMessageType(Protocols::InteractionModel::MsgType::InvokeCommandRequest))
     {
-        SuccessOrExit(OnInvokeCommandRequest(apExchangeContext, aPayloadHeader, std::move(aPayload), status));
+        SuccessOrExit(
+            OnInvokeCommandRequest(apExchangeContext, aPayloadHeader, std::move(aPayload), /* aIsTimedInvoke = */ false, status));
     }
     else if (aPayloadHeader.HasMessageType(Protocols::InteractionModel::MsgType::ReadRequest))
     {
@@ -417,6 +449,10 @@ CHIP_ERROR InteractionModelEngine::OnMessageReceived(Messaging::ExchangeContext 
     {
         ReturnErrorOnFailure(OnUnsolicitedReportData(apExchangeContext, aPayloadHeader, std::move(aPayload)));
         status = Protocols::InteractionModel::Status::Success;
+    }
+    else if (aPayloadHeader.HasMessageType(MsgType::TimedRequest))
+    {
+        SuccessOrExit(OnTimedRequest(apExchangeContext, aPayloadHeader, std::move(aPayload), status));
     }
     else
     {
@@ -550,6 +586,9 @@ void InteractionModelEngine::DispatchCommand(CommandHandler & apCommandObj, cons
 
     if (handler)
     {
+        // TODO: Figure out who is responsible for handling checking
+        // apCommandObj->IsTimedInvoke() for commands that require a timed
+        // invoke and have a CommandHandlerInterface handling them.
         CommandHandlerInterface::HandlerContext context(apCommandObj, aCommandPath, apPayload);
         handler->InvokeCommand(context);
 
@@ -655,6 +694,32 @@ CommandHandlerInterface * InteractionModelEngine::FindCommandHandler(EndpointId 
     }
 
     return nullptr;
+}
+
+void InteractionModelEngine::OnTimedInteractionFailed(TimedHandler * apTimedHandler)
+{
+    mTimedHandlers.Deallocate(apTimedHandler);
+}
+
+void InteractionModelEngine::OnTimedInvoke(TimedHandler * apTimedHandler, Messaging::ExchangeContext * apExchangeContext,
+                                           const PayloadHeader & aPayloadHeader, System::PacketBufferHandle && aPayload)
+{
+    using namespace Protocols::InteractionModel;
+
+    // Reset the ourselves as the exchange delegate for now, to match what we'd
+    // do with an initial unsolicited invoke.
+    apExchangeContext->SetDelegate(this);
+    mTimedHandlers.Deallocate(apTimedHandler);
+
+    VerifyOrDie(aPayloadHeader.HasMessageType(MsgType::InvokeCommandRequest));
+    VerifyOrDie(!apExchangeContext->IsGroupExchangeContext());
+
+    Status status = Status::Failure;
+    OnInvokeCommandRequest(apExchangeContext, aPayloadHeader, std::move(aPayload), /* aIsTimedInvoke = */ true, status);
+    if (status != Status::Success)
+    {
+        StatusResponse::SendStatusResponse(status, apExchangeContext, /* aExpectResponse = */ false);
+    }
 }
 
 } // namespace app

--- a/src/app/MessageDef/InvokeRequestMessage.cpp
+++ b/src/app/MessageDef/InvokeRequestMessage.cpp
@@ -119,7 +119,7 @@ CHIP_ERROR InvokeRequestMessage::Parser::GetSuppressResponse(bool * const apSupp
 
 CHIP_ERROR InvokeRequestMessage::Parser::GetTimedRequest(bool * const apTimedRequest) const
 {
-    return GetSimpleValue(to_underlying(Tag::kSuppressResponse), TLV::kTLVType_Boolean, apTimedRequest);
+    return GetSimpleValue(to_underlying(Tag::kTimedRequest), TLV::kTLVType_Boolean, apTimedRequest);
 }
 
 CHIP_ERROR InvokeRequestMessage::Parser::GetInvokeRequests(InvokeRequests::Parser * const apInvokeRequests) const

--- a/src/app/TimedHandler.cpp
+++ b/src/app/TimedHandler.cpp
@@ -1,0 +1,132 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "TimedHandler.h"
+#include <app/InteractionModelEngine.h>
+#include <app/MessageDef/TimedRequestMessage.h>
+#include <app/StatusResponse.h>
+#include <lib/core/CHIPTLV.h>
+#include <lib/support/logging/CHIPLogging.h>
+#include <system/SystemClock.h>
+#include <system/TLVPacketBufferBackingStore.h>
+
+namespace chip {
+namespace app {
+
+CHIP_ERROR TimedHandler::OnMessageReceived(Messaging::ExchangeContext * aExchangeContext, const PayloadHeader & aPayloadHeader,
+                                           System::PacketBufferHandle && aPayload)
+{
+    using namespace Protocols::InteractionModel;
+
+    if (aExchangeContext->IsGroupExchangeContext())
+    {
+        // Timed interactions are always supposed to be unicast.  Nothing else
+        // to do here; exchange will close and we'll free ourselves.
+        ChipLogError(DataManagement, "Dropping Timed Request on group exchange " ChipLogFormatExchange,
+                     ChipLogValueExchange(aExchangeContext));
+        return CHIP_NO_ERROR;
+    }
+
+    if (mState == State::kExpectingTimedAction)
+    {
+        // We were just created; our caller should have done this only if it's
+        // dealing with a Timed Request message.
+        VerifyOrDie(aPayloadHeader.HasMessageType(MsgType::TimedRequest));
+        mState         = State::kReceivedTimedAction;
+        CHIP_ERROR err = HandleTimedRequestAction(aExchangeContext, aPayloadHeader, std::move(aPayload));
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogError(DataManagement, "Failed to parse Timed Request action: handler %p exchange " ChipLogFormatExchange, this,
+                         ChipLogValueExchange(aExchangeContext));
+            StatusResponse::SendStatusResponse(Status::InvalidAction, aExchangeContext, /* aExpectResponse = */ false);
+        }
+        return err;
+    }
+
+    if (mState == State::kExpectingFollowingAction)
+    {
+        if (System::SystemClock().GetMonotonicTimestamp() > mTimeLimit)
+        {
+            // Time is up.  Spec says to send UNSUPPORTED_ACCESS.
+            ChipLogError(DataManagement, "Timeout expired: handler %p exchange " ChipLogFormatExchange, this,
+                         ChipLogValueExchange(aExchangeContext));
+            return StatusResponse::SendStatusResponse(Status::UnsupportedAccess, aExchangeContext, /* aExpectResponse = */ false);
+        }
+
+        if (aPayloadHeader.HasMessageType(MsgType::InvokeCommandRequest))
+        {
+            auto * imEngine = InteractionModelEngine::GetInstance();
+            aExchangeContext->SetDelegate(imEngine);
+            ChipLogDetail(DataManagement, "Handing timed invoke to IM engine: handler %p exchange " ChipLogFormatExchange, this,
+                          ChipLogValueExchange(aExchangeContext));
+            imEngine->OnTimedInvoke(this, aExchangeContext, aPayloadHeader, std::move(aPayload));
+            return CHIP_NO_ERROR;
+        }
+
+        // TODO: Add handling of MsgType::WriteRequest here.
+    }
+
+    // Not an expected message.  Send an error response.  The exchange will
+    // close when we return.
+    ChipLogError(DataManagement, "Unexpected unknown message in tiemd interaction: handler %p exchange " ChipLogFormatExchange,
+                 this, ChipLogValueExchange(aExchangeContext));
+
+    return StatusResponse::SendStatusResponse(Status::InvalidAction, aExchangeContext, /* aExpectResponse = */ false);
+}
+
+void TimedHandler::OnExchangeClosing(Messaging::ExchangeContext *)
+{
+    InteractionModelEngine::GetInstance()->OnTimedInteractionFailed(this);
+}
+
+CHIP_ERROR TimedHandler::HandleTimedRequestAction(Messaging::ExchangeContext * aExchangeContext,
+                                                  const PayloadHeader & aPayloadHeader, System::PacketBufferHandle && aPayload)
+{
+    using namespace Protocols::InteractionModel;
+
+    System::PacketBufferTLVReader reader;
+    reader.Init(std::move(aPayload));
+
+    reader.Next();
+
+    TimedRequestMessage::Parser parser;
+    ReturnErrorOnFailure(parser.Init(reader));
+
+#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
+    ReturnErrorOnFailure(parser.CheckSchemaValidity());
+#endif
+
+    uint16_t timeoutMs;
+    ReturnErrorOnFailure(parser.GetTimeoutMs(&timeoutMs));
+
+    ChipLogDetail(DataManagement, "Got Timed Request with timeout %" PRIu16 ": handler %p exchange " ChipLogFormatExchange,
+                  timeoutMs, this, ChipLogValueExchange(aExchangeContext));
+    // Tell the exchange to close after the timeout passes, so we don't get
+    // stuck waiting forever if the client never sends another message.
+    auto delay = System::Clock::Milliseconds32(timeoutMs);
+    aExchangeContext->SetResponseTimeout(delay);
+    ReturnErrorOnFailure(StatusResponse::SendStatusResponse(Status::Success, aExchangeContext, /* aExpectResponse = */ true));
+
+    // Now just wait for the client.
+    mState     = State::kExpectingFollowingAction;
+    mTimeLimit = System::SystemClock().GetMonotonicTimestamp() + delay;
+    return CHIP_NO_ERROR;
+}
+
+} // namespace app
+} // namespace chip

--- a/src/app/TimedHandler.h
+++ b/src/app/TimedHandler.h
@@ -1,0 +1,99 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      Definition of a handler for timed interactions.
+ *
+ */
+
+#pragma once
+
+#include <messaging/ExchangeContext.h>
+#include <messaging/ExchangeDelegate.h>
+#include <system/SystemClock.h>
+#include <system/SystemLayer.h>
+#include <system/SystemPacketBuffer.h>
+#include <transport/raw/MessageHeader.h>
+
+/**
+ * A TimedHandler handles a Timed Request action and then waits for a
+ * subsequent Invoke or Write action and hands those on to
+ * InteractionModelEngine if they arrive soon enough.
+ *
+ * Lifetime handling:
+ *
+ * A TimedHandler is initially allocated when the Timed Request is received and
+ * becomes the delegate for that exchange.  After that it remains alive until
+ * either the exchange is closed or the interaction is handed on to the
+ * InteractionModelEngine.
+ */
+
+namespace chip {
+namespace app {
+
+class TimedHandler : public Messaging::ExchangeDelegate
+{
+public:
+    TimedHandler() {}
+    virtual ~TimedHandler() {}
+
+    // ExchangeDelegate implementation.
+    CHIP_ERROR OnMessageReceived(Messaging::ExchangeContext * aExchangeContext, const PayloadHeader & aPayloadHeader,
+                                 System::PacketBufferHandle && aPayload) override;
+
+private:
+    // ExchangeDelegate implementation.
+    void OnResponseTimeout(Messaging::ExchangeContext *) override
+    { /* We just want to allow the exchange to close */
+    }
+    void OnExchangeClosing(Messaging::ExchangeContext * aExchangeContext) override;
+
+    void CancelTimer();
+
+    /**
+     * Handler for the Timed Request action.  This returns success if the Timed
+     * Request action is parsed successfully and the success Status Response
+     * action is sent, failure otherwise.
+     */
+    CHIP_ERROR HandleTimedRequestAction(Messaging::ExchangeContext * aExchangeContext, const PayloadHeader & aPayloadHeader,
+                                        System::PacketBufferHandle && aPayload);
+
+    enum class State : uint8_t
+    {
+        kExpectingTimedAction,     // Initial state: expecting a timed action.
+        kReceivedTimedAction,      // Have received the timed action.  This can
+                                   // be a terminal state if the action ends up
+                                   // malformed.
+        kExpectingFollowingAction, // Expecting write or invoke.
+    };
+
+    // Because we have a vtable pointer and mTimeLimit needs to be 8-byte
+    // aligned on ARM, putting mState first here means we fit in 16 bytes on
+    // 32-bit ARM, whereas if we put it second we'd be 24 bytes.
+    // On platforms where either vtable pointers are 8 bytes or 64-bit ints can
+    // be 4-byte-aligned the ordering here does not matter.
+    State mState = State::kExpectingTimedAction;
+    // We keep track of the time limit for message reception, in case our
+    // exchange's "response expected" timer gets delayed and does not fire when
+    // the time runs out.
+    System::Clock::Timestamp mTimeLimit;
+};
+
+} // namespace app
+} // namespace chip

--- a/src/app/WriteHandler.h
+++ b/src/app/WriteHandler.h
@@ -86,6 +86,11 @@ public:
 
     FabricIndex GetAccessingFabricIndex() const;
 
+    /**
+     * Check whether the WriteRequest we are handling is a timed write.
+     */
+    bool IsTimedWrite() const { return mIsTimedRequest; }
+
 private:
     enum class State
     {

--- a/src/app/tests/AppTestContext.cpp
+++ b/src/app/tests/AppTestContext.cpp
@@ -36,6 +36,7 @@ CHIP_ERROR AppContext::Init()
 
 CHIP_ERROR AppContext::Shutdown()
 {
+    chip::app::InteractionModelEngine::GetInstance()->Shutdown();
     ReturnErrorOnFailure(MessagingContext::Shutdown());
     ReturnErrorOnFailure(mIOContext.Shutdown());
     chip::Platform::MemoryShutdown();

--- a/src/app/tests/BUILD.gn
+++ b/src/app/tests/BUILD.gn
@@ -57,6 +57,7 @@ chip_test_suite("tests") {
     "TestReadInteraction.cpp",
     "TestReportingEngine.cpp",
     "TestStatusResponseMessage.cpp",
+    "TestTimedHandler.cpp",
     "TestWriteInteraction.cpp",
   ]
 

--- a/src/app/tests/TestTimedHandler.cpp
+++ b/src/app/tests/TestTimedHandler.cpp
@@ -1,0 +1,240 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <app/InteractionModelEngine.h>
+#include <app/MessageDef/TimedRequestMessage.h>
+#include <app/StatusResponse.h>
+#include <app/tests/AppTestContext.h>
+#include <lib/core/CHIPCore.h>
+#include <lib/core/CHIPTLV.h>
+#include <lib/support/UnitTestRegistration.h>
+#include <lib/support/UnitTestUtils.h>
+#include <protocols/interaction_model/Constants.h>
+#include <system/TLVPacketBufferBackingStore.h>
+#include <transport/SessionManager.h>
+
+#include <nlunit-test.h>
+
+using TestContext = chip::Test::AppContext;
+
+namespace chip {
+namespace app {
+
+using namespace Messaging;
+using namespace Protocols::InteractionModel;
+
+class TestTimedHandler
+{
+public:
+    static void TestInvokeFastEnough(nlTestSuite * aSuite, void * aContext);
+    static void TestInvokeTooSlow(nlTestSuite * aSuite, void * aContext);
+
+    static void TestInvokeNeverComes(nlTestSuite * aSuite, void * aContext);
+
+private:
+    static void GenerateTimedRequest(nlTestSuite * aSuite, uint16_t aTimeoutValue, System::PacketBufferHandle & aPayload);
+};
+
+namespace {
+
+class TestExchangeDelegate : public Messaging::ExchangeDelegate
+{
+    CHIP_ERROR OnMessageReceived(Messaging::ExchangeContext * aExchangeContext, const PayloadHeader & aPayloadHeader,
+                                 System::PacketBufferHandle && aPayload) override
+    {
+        mNewMessageReceived   = true;
+        mLastMessageWasStatus = aPayloadHeader.HasMessageType(MsgType::StatusResponse);
+        if (mLastMessageWasStatus)
+        {
+            mStatus.mStatus = Status::Failure;
+            StatusResponse::ProcessStatusResponse(std::move(aPayload), mStatus);
+        }
+        if (mKeepExchangeOpen)
+        {
+            aExchangeContext->WillSendMessage();
+        }
+        return CHIP_NO_ERROR;
+    }
+
+    void OnResponseTimeout(Messaging::ExchangeContext *) override {}
+
+public:
+    bool mKeepExchangeOpen     = false;
+    bool mNewMessageReceived   = false;
+    bool mLastMessageWasStatus = false;
+    StatusIB mStatus;
+};
+
+} // anonymous namespace
+
+void TestTimedHandler::GenerateTimedRequest(nlTestSuite * aSuite, uint16_t aTimeoutValue, System::PacketBufferHandle & aPayload)
+{
+    aPayload = System::PacketBufferHandle::New(System::PacketBuffer::kMaxSize);
+    NL_TEST_ASSERT(aSuite, !aPayload.IsNull());
+
+    System::PacketBufferTLVWriter writer;
+    writer.Init(std::move(aPayload));
+
+    TimedRequestMessage::Builder builder;
+    CHIP_ERROR err = builder.Init(&writer);
+    NL_TEST_ASSERT(aSuite, err == CHIP_NO_ERROR);
+
+    builder.TimeoutMs(aTimeoutValue);
+    NL_TEST_ASSERT(aSuite, builder.GetError() == CHIP_NO_ERROR);
+
+    err = writer.Finalize(&aPayload);
+    NL_TEST_ASSERT(aSuite, err == CHIP_NO_ERROR);
+}
+
+void TestTimedHandler::TestInvokeFastEnough(nlTestSuite * aSuite, void * aContext)
+{
+    TestContext & ctx = *static_cast<TestContext *>(aContext);
+
+    System::PacketBufferHandle payload;
+    GenerateTimedRequest(aSuite, 50, payload);
+
+    TestExchangeDelegate delegate;
+    ExchangeContext * exchange = ctx.NewExchangeToAlice(&delegate);
+    NL_TEST_ASSERT(aSuite, exchange != nullptr);
+
+    NL_TEST_ASSERT(aSuite, !delegate.mNewMessageReceived);
+
+    delegate.mKeepExchangeOpen = true;
+
+    CHIP_ERROR err = exchange->SendMessage(MsgType::TimedRequest, std::move(payload), SendMessageFlags::kExpectResponse);
+    NL_TEST_ASSERT(aSuite, err == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(aSuite, delegate.mNewMessageReceived);
+    NL_TEST_ASSERT(aSuite, delegate.mLastMessageWasStatus);
+    NL_TEST_ASSERT(aSuite, delegate.mStatus.mStatus == Status::Success);
+
+    // Send an empty payload, which will error out but not with the
+    // UNSUPPORTED_ACCESS status we expect if we miss our timeout.
+    payload = MessagePacketBuffer::New(0);
+    NL_TEST_ASSERT(aSuite, !payload.IsNull());
+
+    delegate.mKeepExchangeOpen   = false;
+    delegate.mNewMessageReceived = false;
+
+    err = exchange->SendMessage(MsgType::InvokeCommandRequest, std::move(payload));
+    NL_TEST_ASSERT(aSuite, err == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(aSuite, delegate.mNewMessageReceived);
+    NL_TEST_ASSERT(aSuite, delegate.mLastMessageWasStatus);
+    NL_TEST_ASSERT(aSuite, delegate.mStatus.mStatus != Status::UnsupportedAccess);
+}
+
+void TestTimedHandler::TestInvokeTooSlow(nlTestSuite * aSuite, void * aContext)
+{
+    TestContext & ctx = *static_cast<TestContext *>(aContext);
+
+    System::PacketBufferHandle payload;
+    GenerateTimedRequest(aSuite, 50, payload);
+
+    TestExchangeDelegate delegate;
+    ExchangeContext * exchange = ctx.NewExchangeToAlice(&delegate);
+    NL_TEST_ASSERT(aSuite, exchange != nullptr);
+
+    NL_TEST_ASSERT(aSuite, !delegate.mNewMessageReceived);
+
+    delegate.mKeepExchangeOpen = true;
+
+    CHIP_ERROR err = exchange->SendMessage(MsgType::TimedRequest, std::move(payload), SendMessageFlags::kExpectResponse);
+    NL_TEST_ASSERT(aSuite, err == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(aSuite, delegate.mNewMessageReceived);
+    NL_TEST_ASSERT(aSuite, delegate.mLastMessageWasStatus);
+    NL_TEST_ASSERT(aSuite, delegate.mStatus.mStatus == Status::Success);
+
+    // Sleep for > 50ms so we miss our time window.
+    chip::test_utils::SleepMillis(75);
+
+    // Send an empty payload, which will error out but not with the
+    // UNSUPPORTED_ACCESS status we expect if we miss our timeout.
+    payload = MessagePacketBuffer::New(0);
+    NL_TEST_ASSERT(aSuite, !payload.IsNull());
+
+    delegate.mKeepExchangeOpen   = false;
+    delegate.mNewMessageReceived = false;
+
+    err = exchange->SendMessage(MsgType::InvokeCommandRequest, std::move(payload));
+    NL_TEST_ASSERT(aSuite, err == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(aSuite, delegate.mNewMessageReceived);
+    NL_TEST_ASSERT(aSuite, delegate.mLastMessageWasStatus);
+    NL_TEST_ASSERT(aSuite, delegate.mStatus.mStatus == Status::UnsupportedAccess);
+}
+
+void TestTimedHandler::TestInvokeNeverComes(nlTestSuite * aSuite, void * aContext)
+{
+    TestContext & ctx = *static_cast<TestContext *>(aContext);
+
+    System::PacketBufferHandle payload;
+    GenerateTimedRequest(aSuite, 50, payload);
+
+    TestExchangeDelegate delegate;
+    ExchangeContext * exchange = ctx.NewExchangeToAlice(&delegate);
+    NL_TEST_ASSERT(aSuite, exchange != nullptr);
+
+    NL_TEST_ASSERT(aSuite, !delegate.mNewMessageReceived);
+
+    CHIP_ERROR err = exchange->SendMessage(MsgType::TimedRequest, std::move(payload), SendMessageFlags::kExpectResponse);
+    NL_TEST_ASSERT(aSuite, err == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(aSuite, delegate.mNewMessageReceived);
+    NL_TEST_ASSERT(aSuite, delegate.mLastMessageWasStatus);
+    NL_TEST_ASSERT(aSuite, delegate.mStatus.mStatus == Status::Success);
+
+    // Do nothing else; exchange on the server remains open.  We are testing to
+    // see whether shutdown cleans it up properly.
+}
+
+} // namespace app
+} // namespace chip
+
+namespace {
+
+/**
+ *   Test Suite. It lists all the test functions.
+ */
+
+// clang-format off
+const nlTest sTests[] =
+{
+        NL_TEST_DEF("TimedHandlerTestInvokeFastEnough", chip::app::TestTimedHandler::TestInvokeFastEnough),
+        NL_TEST_DEF("TimedHandlerTestInvokeTooSlow", chip::app::TestTimedHandler::TestInvokeTooSlow),
+        NL_TEST_DEF("TimedHandlerTestInvokeNeverComes", chip::app::TestTimedHandler::TestInvokeNeverComes),
+        NL_TEST_SENTINEL()
+};
+// clang-format on
+
+// clang-format off
+nlTestSuite sSuite =
+{
+    "TestTimedHandler",
+    &sTests[0],
+    TestContext::Initialize,
+    TestContext::Finalize
+};
+// clang-format on
+
+} // namespace
+
+int TestTimedHandler()
+{
+    TestContext gContext;
+    nlTestRunner(&sSuite, &gContext);
+    return (nlTestRunnerStats(&sSuite));
+}
+
+CHIP_REGISTER_TEST_SUITE(TestTimedHandler)

--- a/src/app/util/ember-compatibility-functions.cpp
+++ b/src/app/util/ember-compatibility-functions.cpp
@@ -702,6 +702,11 @@ CHIP_ERROR WriteSingleClusterData(ClusterInfo & aClusterInfo, TLV::TLVReader & a
         return apWriteHandler->AddStatus(attributePathParams, Protocols::InteractionModel::Status::UnsupportedWrite);
     }
 
+    if (attributeMetadata->MustUseTimedWrite() && !apWriteHandler->IsTimedWrite())
+    {
+        return apWriteHandler->AddStatus(attributePathParams, Protocols::InteractionModel::Status::NeedsTimedInteraction);
+    }
+
     AttributeAccessInterface * attrOverride = findAttributeAccessOverride(aClusterInfo.mEndpointId, aClusterInfo.mClusterId);
     if (attrOverride != nullptr)
     {

--- a/src/app/zap-templates/partials/im_command_handler_cluster_commands.zapt
+++ b/src/app/zap-templates/partials/im_command_handler_cluster_commands.zapt
@@ -1,4 +1,10 @@
 {{#if (isServer parent.side)}}
+{{#if mustUseTimedInvoke}}
+if (!apCommandObj->IsTimedInvoke()) {
+  apCommandObj->AddStatus(aCommandPath, Protocols::InteractionModel::Status::NeedsTimedInteraction);
+  return;
+}
+{{/if}}
 Commands::{{asUpperCamelCase name}}::DecodableType commandData;
 TLVError = DataModel::Decode(aDataTlv, commandData);
 if (TLVError == CHIP_NO_ERROR) {

--- a/src/lib/core/CHIPConfig.h
+++ b/src/lib/core/CHIPConfig.h
@@ -2427,6 +2427,7 @@ extern const char CHIP_NON_PRODUCTION_MARKER[];
  *      * #CHIP_IM_SERVER_MAX_NUM_PATH_GROUPS
  *      * #CHIP_IM_MAX_NUM_WRITE_HANDLER
  *      * #CHIP_IM_MAX_NUM_WRITE_CLIENT
+ *      * #CHIP_IM_MAX_NUM_TIMED_HANDLER
  *
  *  @{
  */
@@ -2492,6 +2493,16 @@ extern const char CHIP_NON_PRODUCTION_MARKER[];
  */
 #ifndef CHIP_IM_MAX_NUM_WRITE_CLIENT
 #define CHIP_IM_MAX_NUM_WRITE_CLIENT 4
+#endif
+
+/**
+ * @def CHIP_IM_MAX_NUM_TIMED_HANDLER
+ *
+ * @brief Defines the maximum number of TimedHandler, limits the number of
+ *        active timed interactions waiting for the Invoke or Write.
+ */
+#ifndef CHIP_IM_MAX_NUM_TIMED_HANDLER
+#define CHIP_IM_MAX_NUM_TIMED_HANDLER 8
 #endif
 
 /**

--- a/src/messaging/ExchangeMgr.cpp
+++ b/src/messaging/ExchangeMgr.cpp
@@ -223,6 +223,9 @@ void ExchangeManager::OnMessageReceived(const PacketHeader & packetHeader, const
                     ec->SetMsgRcvdFromPeer(true);
                 }
 
+                ChipLogDetail(ExchangeManager, "Found matching exchange: " ChipLogFormatExchange ", Delegate: 0x%p",
+                              ChipLogValueExchange(ec), ec->GetDelegate());
+
                 // Matched ExchangeContext; send to message handler.
                 ec->HandleMessage(packetHeader.GetMessageCounter(), payloadHeader, source, msgFlags, std::move(msgBuf));
                 found = true;

--- a/zzz_generated/all-clusters-app/zap-generated/IMClusterCommandHandler.cpp
+++ b/zzz_generated/all-clusters-app/zap-generated/IMClusterCommandHandler.cpp
@@ -1758,6 +1758,11 @@ void DispatchServerCommand(CommandHandler * apCommandObj, const ConcreteCommandP
             break;
         }
         case Commands::TimedInvokeRequest::Id: {
+            if (!apCommandObj->IsTimedInvoke())
+            {
+                apCommandObj->AddStatus(aCommandPath, Protocols::InteractionModel::Status::NeedsTimedInteraction);
+                return;
+            }
             Commands::TimedInvokeRequest::DecodableType commandData;
             TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)


### PR DESCRIPTION
#### Problem
No implementation of timed invoke yet.

#### Change overview
This implements the server side of timed invoke.  Client side will be a separate PR.  Server side of timed write will also be a separate PR.

#### Testing
New unit tests added.  Other tests will need to wait on client-side support, though once #12380 lands I will at least be able to add a test that that an untimed invoke of a command that requires timed invoke fails.