### PR TITLE
Fix IPv6 local link address resolve issue with LWIP latest version

### DIFF
--- a/.github/workflows/examples-infineon.yaml
+++ b/.github/workflows/examples-infineon.yaml
@@ -88,3 +88,4 @@ jobs:
                   path: |
                     out/infineon-p6-lock/p6-default-lock-app-sizes.json
                     out/infineon-p6-all-clusters/p6-default-all-clusters-app-sizes.json
+                    out/infineon-p6-light/p6-default-light-app-sizes.json

--- a/examples/lighting-app/p6/README.md
+++ b/examples/lighting-app/p6/README.md
@@ -125,7 +125,7 @@ Once P6 is up and running, we need to set up a device controller on Raspberry Pi
 
 -   Resolve DNS-SD name and update address of the node in the device controller.
 
-         - chip-device-ctrl > resolve 0 1234
+         - chip-device-ctrl > resolve 1234
 
 <a name="Notes"></a>
 
@@ -153,4 +153,4 @@ commands. These power cycle the BlueTooth hardware and disable BR/EDR mode.
     This button is configured with `APP_LIGHT_BUTTON` in `include/AppConfig.h`.
     Press `USER_BTN1` on the board to toggle between Light ON and OFF states.
     Light ON and OFF can be observed with 'LED9' on the board. This LED is
-    configured with `LIGHT_STATE_LED` in `include/AppConfig.h`.
+    configured with `LIGHT_LED` in `include/AppConfig.h`.

--- a/src/inet/IPAddress.cpp
+++ b/src/inet/IPAddress.cpp
@@ -177,7 +177,7 @@ lwip_ip_addr_type IPAddress::ToLwIPAddrType(IPAddressType typ)
 
 ip6_addr_t IPAddress::ToIPv6() const
 {
-    ip6_addr_t ipAddr;
+    ip6_addr_t ipAddr = { 0 };
     static_assert(sizeof(ipAddr.addr) == sizeof(Addr), "ip6_addr_t size mismatch");
     memcpy(&ipAddr.addr, Addr, sizeof(ipAddr.addr));
     return ipAddr;


### PR DESCRIPTION
#### Problem
IPv6 Local link address resolve is failing with LWIP version tag 2.1.2 and above.

**Reason:**
Sigma2 UDP Packet is dropped in nd6_send_ns function as it is comparing zones for these addresses (ip6_addr_netcmp_zone).
IPv6 address is not initialized properly in IPAddress.cpp resulting in random values populated in zone variable.

#### Change overview
- Initialize ipAddr before coping the IPaddress in ToIPv6 function
- Update README for P6
- Add Light app json for artifacts (this is missing in last PR)

#### Testing
Verify Commissioning with P6 using CHIPTOOL
[P6-LOCK_APP_CHIPTOOL_LOG.txt](https://github.com/project-chip/connectedhomeip/files/7631300/P6-LOCK_APP_CHIPTOOL_LOG.txt)

https://github.com/project-chip/connectedhomeip/issues/11998
