### PR TITLE
Optimize report delivery timing for subscribe

### DIFF
--- a/src/app/ReadHandler.h
+++ b/src/app/ReadHandler.h
@@ -107,7 +107,7 @@ public:
     CHIP_ERROR SendReportData(System::PacketBufferHandle && aPayload, bool mMoreChunks);
 
     bool IsFree() const { return mState == HandlerState::Uninitialized; }
-    bool IsReportable() const { return mState == HandlerState::GeneratingReports && !mHoldReport; }
+    bool IsReportable() const { return mState == HandlerState::GeneratingReports && !mHoldReport && (mDirty || !mHoldSync); }
     bool IsGeneratingReports() const { return mState == HandlerState::GeneratingReports; }
     bool IsAwaitingReportResponse() const { return mState == HandlerState::AwaitingReportResponse; }
     virtual ~ReadHandler() = default;
@@ -214,6 +214,7 @@ private:
     FabricIndex mFabricIndex                                 = 0;
     AttributePathExpandIterator mAttributePathExpandIterator = AttributePathExpandIterator(nullptr);
     bool mIsFabricFiltered                                   = false;
+    bool mHoldSync                                           = false;
 };
 } // namespace app
 } // namespace chip

--- a/src/app/tests/TestReadInteraction.cpp
+++ b/src/app/tests/TestReadInteraction.cpp
@@ -1106,6 +1106,7 @@ void TestReadInteraction::TestSubscribeRoundtrip(nlTestSuite * apSuite, void * a
 
     // Test empty report
     delegate.mpReadHandler->mHoldReport = false;
+    delegate.mpReadHandler->mHoldSync   = false;
     delegate.mGotReport                 = false;
     delegate.mNumAttributeResponse      = 0;
     engine->GetReportingEngine().Run();


### PR DESCRIPTION
#### Problem
--Between subscribe min and max interval, only send the report when the handler is dirty
--At subscribe max interval, mHoldSync is unset, handler would send the report

#### Change overview
What's in this PR

#### Testing
Existing test covers
