### PR TITLE
[chip-tool] Use DiscoveredNodeData::LogDetail in DiscoverCommissionab…

### DIFF
--- a/examples/chip-tool/commands/discover/DiscoverCommissionablesCommand.cpp
+++ b/examples/chip-tool/commands/discover/DiscoverCommissionablesCommand.cpp
@@ -30,27 +30,5 @@ CHIP_ERROR DiscoverCommissionablesCommand::RunCommand()
 
 void DiscoverCommissionablesCommand::OnDiscoveredDevice(const chip::Dnssd::DiscoveredNodeData & nodeData)
 {
-    char rotatingId[chip::Dnssd::kMaxRotatingIdLen * 2 + 1] = "";
-    Encoding::BytesToUppercaseHexString(nodeData.rotatingId, nodeData.rotatingIdLen, rotatingId, sizeof(rotatingId));
-
-    ChipLogProgress(Discovery, "Discovered Node: ");
-    ChipLogProgress(Discovery, "\tInstance name:\t\t%s", nodeData.instanceName);
-    ChipLogProgress(Discovery, "\tHost name:\t\t%s", nodeData.hostName);
-    ChipLogProgress(Discovery, "\tPort:\t\t\t%u", nodeData.port);
-    ChipLogProgress(Discovery, "\tLong discriminator:\t%u", nodeData.longDiscriminator);
-    ChipLogProgress(Discovery, "\tVendor ID:\t\t%u", nodeData.vendorId);
-    ChipLogProgress(Discovery, "\tProduct ID:\t\t%u", nodeData.productId);
-    ChipLogProgress(Discovery, "\tCommissioning Mode:\t%u", nodeData.commissioningMode);
-    ChipLogProgress(Discovery, "\tDevice Type:\t\t%u", nodeData.deviceType);
-    ChipLogProgress(Discovery, "\tDevice Name:\t\t%s", nodeData.deviceName);
-    ChipLogProgress(Discovery, "\tRotating Id:\t\t%s", rotatingId);
-    ChipLogProgress(Discovery, "\tPairing Instruction:\t%s", nodeData.pairingInstruction);
-    ChipLogProgress(Discovery, "\tPairing Hint:\t\t%u", nodeData.pairingHint);
-    for (int i = 0; i < nodeData.numIPs; i++)
-    {
-        char buf[chip::Inet::IPAddress::kMaxStringLength];
-        nodeData.ipAddress[i].ToString(buf);
-
-        ChipLogProgress(Discovery, "\tAddress %d:\t\t%s", i, buf);
-    }
+    nodeData.LogDetail();
 }


### PR DESCRIPTION
…lesCommand.cpp

#### Problem

It seems like `DiscoveredNodeData` now has a method to log what it contains directly. It is already used in `DiscoverCommissionersCommand.cpp` but not in `DiscoverCommissionablesCommand.cpp`

#### Change overview
 * Remove hand-crafted code to use `LogDetail`

#### Testing
Locally tested...