### PR TITLE
[EFR32] Fix BRD4170A builds

### DIFF
--- a/examples/platform/efr32/board_config.h
+++ b/examples/platform/efr32/board_config.h
@@ -38,7 +38,6 @@
 #define RADIO_CONFIG_2P4GHZ_OQPSK_SUPPORT 1
 #define RADIO_CONFIG_915MHZ_OQPSK_SUPPORT 0
 
-
 /// The PA(s) is(are) fed from the DCDC
 #if (BRD4166A)
 #define RADIO_CONFIG_PA_USES_DCDC 1

--- a/examples/platform/efr32/board_config.h
+++ b/examples/platform/efr32/board_config.h
@@ -36,13 +36,8 @@
 
 /// Dev board suppports OQPSK modulation in 2.4GHz band.
 #define RADIO_CONFIG_2P4GHZ_OQPSK_SUPPORT 1
-
-/// Dev board doesn't support OQPSK modulation in 915MHz band.
-#if (BRD4170A)
-#define RADIO_CONFIG_915MHZ_OQPSK_SUPPORT 1
-#else
 #define RADIO_CONFIG_915MHZ_OQPSK_SUPPORT 0
-#endif
+
 
 /// The PA(s) is(are) fed from the DCDC
 #if (BRD4166A)


### PR DESCRIPTION
#### Problem
EFR32 examples would not build for BRD4170A.

#### Change overview
Bump ot-efr32 submodule
Disable RADIO_CONFIG_915MHZ_OQPSK_SUPPORT for brd4170A also. Code now validates that only one band is used at a time. We currently run all on 2.4ghz on all supported boards

#### Testing
No behaviour change, Validated that BRD4170a builds and can join the thread network.

