### PR TITLE
Always reply additional data to all queries 

### DIFF
--- a/src/lib/dnssd/minimal_mdns/QueryReplyFilter.h
+++ b/src/lib/dnssd/minimal_mdns/QueryReplyFilter.h
@@ -66,7 +66,7 @@ public:
 private:
     bool AcceptableQueryType(QType qType)
     {
-        if (mSendingAdditionalItems && mQueryData.IsBootAdvertising())
+        if (mSendingAdditionalItems)
         {
             return true;
         }


### PR DESCRIPTION
#### Problem

MinMDNS provides additional records only for ANY queries. 
For example if a PTR query is made, it would not reply with SRV/A/AAAA replies.

RFC 1035 describes the additional records as "the additional records section contains RRs which relate to the query, but are not strictly answers for the question." (i.e. match is not enforced)

We  found that  some legacy MDNS in android code which use 'PTR' queries instead of ANY and refuse to see chip devices without this (they see the PTR reply but without SRV and A/AAAA  it cannot connect even though PTR and SRV are supposed to be optional)

https://datatracker.ietf.org/doc/html/rfc6763#section-12 describes what things `SHOULD` be added to additional records and PTR should also have SRV/A/AAAA (and  SRV should have A/AAAA)

#### Change overview
Enable additional records  regardless of query type (i.e. a PTR query will still receive additional data of different types if required)

#### Testing
Manual minmdns example running.
