### PR TITLE
Reply with additional items on all query types

### DIFF
--- a/src/lib/mdns/minimal/QueryReplyFilter.h
+++ b/src/lib/mdns/minimal/QueryReplyFilter.h
@@ -66,7 +66,7 @@ public:
 private:
     bool AcceptableQueryType(QType qType)
     {
-        if (mSendingAdditionalItems && mQueryData.IsBootAdvertising())
+        if (mSendingAdditionalItems)
         {
             return true;
         }


### PR DESCRIPTION
#### Problem

MinMDNS provides additional records only for ANY queries. 
For example if a PTR query is made, it would not reply with SRV/A/AAAA replies.

RFC 1035 describes the additional records as "the additional records section contains RRs which relate to the query, but are not strictly answers for the question." (i.e. match is not enforced)

#### Change overview
Enable additional records  regardless of query type (i.e. a PTR query will still receive additional data of different types if required)

#### Testing
Manual minmdns example running.
