### PR TITLE
make all gn example builds export the compile commands

### DIFF
--- a/scripts/build/builders/gn.py
+++ b/scripts/build/builders/gn.py
@@ -47,6 +47,7 @@ class GnBuilder(Builder):
         if not os.path.exists(self.output_dir):
             cmd = [
                 'gn', 'gen', '--check', '--fail-on-unused-args',
+                '--export-compile-commands',
                 '--root=%s' % self.root
             ]
 

--- a/scripts/build/testdata/build_all_except_host.txt
+++ b/scripts/build/testdata/build_all_except_host.txt
@@ -125,22 +125,22 @@ gn gen --check --fail-on-unused-args {out}/android-x86-chip-tool '--args=target_
 bash -c 'yes | TEST_ANDROID_HOME/tools/bin/sdkmanager --licenses >/dev/null'
 
 # Generating efr32-brd4161a-light
-gn gen --check --fail-on-unused-args --root={root}/examples/lighting-app/efr32 '--args=efr32_board="BRD4161A"' {out}/efr32-brd4161a-light
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/lighting-app/efr32 '--args=efr32_board="BRD4161A"' {out}/efr32-brd4161a-light
 
 # Generating efr32-brd4161a-light-rpc
-gn gen --check --fail-on-unused-args --root={root}/examples/lighting-app/efr32 '--args=efr32_board="BRD4161A" import("//with_pw_rpc.gni")' {out}/efr32-brd4161a-light-rpc
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/lighting-app/efr32 '--args=efr32_board="BRD4161A" import("//with_pw_rpc.gni")' {out}/efr32-brd4161a-light-rpc
 
 # Generating efr32-brd4161a-lock
-gn gen --check --fail-on-unused-args --root={root}/examples/lock-app/efr32 '--args=efr32_board="BRD4161A"' {out}/efr32-brd4161a-lock
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/lock-app/efr32 '--args=efr32_board="BRD4161A"' {out}/efr32-brd4161a-lock
 
 # Generating efr32-brd4161a-lock-rpc
-gn gen --check --fail-on-unused-args --root={root}/examples/lock-app/efr32 '--args=efr32_board="BRD4161A" import("//with_pw_rpc.gni")' {out}/efr32-brd4161a-lock-rpc
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/lock-app/efr32 '--args=efr32_board="BRD4161A" import("//with_pw_rpc.gni")' {out}/efr32-brd4161a-lock-rpc
 
 # Generating efr32-brd4161a-unit-test
-gn gen --check --fail-on-unused-args --root={root}/src/test_driver/efr32 '--args=efr32_board="BRD4161A"' {out}/efr32-brd4161a-unit-test
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/src/test_driver/efr32 '--args=efr32_board="BRD4161A"' {out}/efr32-brd4161a-unit-test
 
 # Generating efr32-brd4161a-window-covering
-gn gen --check --fail-on-unused-args --root={root}/examples/window-app/efr32 '--args=efr32_board="BRD4161A"' {out}/efr32-brd4161a-window-covering
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/window-app/efr32 '--args=efr32_board="BRD4161A"' {out}/efr32-brd4161a-window-covering
 
 # Generating esp32-c3devkit-all-clusters
 mkdir -p {out}/esp32-c3devkit-all-clusters
@@ -270,13 +270,13 @@ export SDKCONFIG_DEFAULTS={out}/esp32-m5stack-all-clusters-rpc-ipv6only/sdkconfi
 idf.py -C examples/all-clusters-app/esp32 -B {out}/esp32-m5stack-all-clusters-rpc-ipv6only reconfigure'
 
 # Generating infineon-p6-all-clusters
-gn gen --check --fail-on-unused-args --root={root}/examples/all-clusters-app/p6 '--args=p6_board="CY8CKIT-062S2-43012"' {out}/infineon-p6-all-clusters
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/all-clusters-app/p6 '--args=p6_board="CY8CKIT-062S2-43012"' {out}/infineon-p6-all-clusters
 
 # Generating infineon-p6-light
-gn gen --check --fail-on-unused-args --root={root}/examples/lighting-app/p6 '--args=p6_board="CY8CKIT-062S2-43012"' {out}/infineon-p6-light
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/lighting-app/p6 '--args=p6_board="CY8CKIT-062S2-43012"' {out}/infineon-p6-light
 
 # Generating infineon-p6-lock
-gn gen --check --fail-on-unused-args --root={root}/examples/lock-app/p6 '--args=p6_board="CY8CKIT-062S2-43012"' {out}/infineon-p6-lock
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/lock-app/p6 '--args=p6_board="CY8CKIT-062S2-43012"' {out}/infineon-p6-lock
 
 # Generating config mbed-CY8CPROTO_062_4343W-all-clusters-debug
 mbed-tools configure -t GCC_ARM -m CY8CPROTO_062_4343W -p {root}/examples/all-clusters-app/mbed -o {out}/mbed-CY8CPROTO_062_4343W-all-clusters-debug --mbed-os-path {root}/third_party/mbed-os/repo
@@ -429,7 +429,7 @@ export GNUARMEMB_TOOLCHAIN_PATH="$PW_PIGWEED_CIPD_INSTALL_DIR";
 west build --cmake-only -d {out}/nrf-nrf5340-shell -b nrf5340dk_nrf5340_cpuapp {root}/examples/shell/nrfconnect'
 
 # Generating qpg-qpg6100-lock
-gn gen --check --fail-on-unused-args --root={root}/examples/lock-app/qpg {out}/qpg-qpg6100-lock
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/lock-app/qpg {out}/qpg-qpg6100-lock
 
 # Generating telink-tlsr9518adk80d-light
 bash -c 'export ZEPHYR_BASE="$TELINK_ZEPHYR_BASE"
@@ -439,7 +439,7 @@ source "$ZEPHYR_BASE/zephyr-env.sh";
 west build --cmake-only -d {out}/telink-tlsr9518adk80d-light -b tlsr9518adk80d {root}/examples/lighting-app/telink'
 
 # Generating tizen-arm-light
-gn gen --check --fail-on-unused-args --root={root}/examples/lighting-app/linux '--args=target_os="tizen" target_cpu="arm" sysroot="TEST_TIZEN_HOME"' {out}/tizen-arm-light
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/lighting-app/linux '--args=target_os="tizen" target_cpu="arm" sysroot="TEST_TIZEN_HOME"' {out}/tizen-arm-light
 
 # Building ameba-amebad-all-clusters
 ninja -C {out}/ameba-amebad-all-clusters

--- a/scripts/build/testdata/build_linux_on_x64.txt
+++ b/scripts/build/testdata/build_linux_on_x64.txt
@@ -4,75 +4,75 @@ cd "{root}"
 # Generating linux-arm64-all-clusters
 bash -c '
 PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
- gn gen --check --fail-on-unused-args --root={root}/examples/all-clusters-app/linux '"'"'--args=target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-all-clusters'
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/all-clusters-app/linux '"'"'--args=target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-all-clusters'
 
 # Generating linux-arm64-all-clusters-ipv6only
 bash -c '
 PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
- gn gen --check --fail-on-unused-args --root={root}/examples/all-clusters-app/linux '"'"'--args=chip_inet_config_enable_ipv4=false target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-all-clusters-ipv6only'
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/all-clusters-app/linux '"'"'--args=chip_inet_config_enable_ipv4=false target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-all-clusters-ipv6only'
 
 # Generating linux-arm64-chip-tool
 bash -c '
 PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
- gn gen --check --fail-on-unused-args --root={root}/examples/chip-tool '"'"'--args=target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-chip-tool'
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/chip-tool '"'"'--args=target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-chip-tool'
 
 # Generating linux-arm64-chip-tool-ipv6only
 bash -c '
 PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
- gn gen --check --fail-on-unused-args --root={root}/examples/chip-tool '"'"'--args=chip_inet_config_enable_ipv4=false target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-chip-tool-ipv6only'
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/chip-tool '"'"'--args=chip_inet_config_enable_ipv4=false target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-chip-tool-ipv6only'
 
 # Generating linux-arm64-minmdns
 bash -c '
 PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
- gn gen --check --fail-on-unused-args --root={root}/examples/minimal-mdns '"'"'--args=target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-minmdns'
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/minimal-mdns '"'"'--args=target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-minmdns'
 
 # Generating linux-arm64-minmdns-ipv6only
 bash -c '
 PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
- gn gen --check --fail-on-unused-args --root={root}/examples/minimal-mdns '"'"'--args=chip_inet_config_enable_ipv4=false target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-minmdns-ipv6only'
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/minimal-mdns '"'"'--args=chip_inet_config_enable_ipv4=false target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-minmdns-ipv6only'
 
 # Generating linux-arm64-thermostat
 bash -c '
 PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
- gn gen --check --fail-on-unused-args --root={root}/examples/thermostat/linux '"'"'--args=target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-thermostat'
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/thermostat/linux '"'"'--args=target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-thermostat'
 
 # Generating linux-arm64-thermostat-ipv6only
 bash -c '
 PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
- gn gen --check --fail-on-unused-args --root={root}/examples/thermostat/linux '"'"'--args=chip_inet_config_enable_ipv4=false target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-thermostat-ipv6only'
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/thermostat/linux '"'"'--args=chip_inet_config_enable_ipv4=false target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-thermostat-ipv6only'
 
 # Generating linux-x64-all-clusters
-gn gen --check --fail-on-unused-args --root={root}/examples/all-clusters-app/linux {out}/linux-x64-all-clusters
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/all-clusters-app/linux {out}/linux-x64-all-clusters
 
 # Generating linux-x64-all-clusters-ipv6only
-gn gen --check --fail-on-unused-args --root={root}/examples/all-clusters-app/linux --args=chip_inet_config_enable_ipv4=false {out}/linux-x64-all-clusters-ipv6only
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/all-clusters-app/linux --args=chip_inet_config_enable_ipv4=false {out}/linux-x64-all-clusters-ipv6only
 
 # Generating linux-x64-chip-tool
-gn gen --check --fail-on-unused-args --root={root}/examples/chip-tool {out}/linux-x64-chip-tool
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/chip-tool {out}/linux-x64-chip-tool
 
 # Generating linux-x64-chip-tool-ipv6only
-gn gen --check --fail-on-unused-args --root={root}/examples/chip-tool --args=chip_inet_config_enable_ipv4=false {out}/linux-x64-chip-tool-ipv6only
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/chip-tool --args=chip_inet_config_enable_ipv4=false {out}/linux-x64-chip-tool-ipv6only
 
 # Generating linux-x64-minmdns
-gn gen --check --fail-on-unused-args --root={root}/examples/minimal-mdns {out}/linux-x64-minmdns
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/minimal-mdns {out}/linux-x64-minmdns
 
 # Generating linux-x64-minmdns-ipv6only
-gn gen --check --fail-on-unused-args --root={root}/examples/minimal-mdns --args=chip_inet_config_enable_ipv4=false {out}/linux-x64-minmdns-ipv6only
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/minimal-mdns --args=chip_inet_config_enable_ipv4=false {out}/linux-x64-minmdns-ipv6only
 
 # Generating linux-x64-rpc-console
-gn gen --check --fail-on-unused-args --root={root}/examples/common/pigweed/rpc_console {out}/linux-x64-rpc-console
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/common/pigweed/rpc_console {out}/linux-x64-rpc-console
 
 # Generating linux-x64-thermostat
-gn gen --check --fail-on-unused-args --root={root}/examples/thermostat/linux {out}/linux-x64-thermostat
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/thermostat/linux {out}/linux-x64-thermostat
 
 # Generating linux-x64-thermostat-ipv6only
-gn gen --check --fail-on-unused-args --root={root}/examples/thermostat/linux --args=chip_inet_config_enable_ipv4=false {out}/linux-x64-thermostat-ipv6only
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/thermostat/linux --args=chip_inet_config_enable_ipv4=false {out}/linux-x64-thermostat-ipv6only
 
 # Generating linux-x64-tv-app
-gn gen --check --fail-on-unused-args --root={root}/examples/tv-app/linux {out}/linux-x64-tv-app
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/tv-app/linux {out}/linux-x64-tv-app
 
 # Generating linux-x64-tv-app-ipv6only
-gn gen --check --fail-on-unused-args --root={root}/examples/tv-app/linux --args=chip_inet_config_enable_ipv4=false {out}/linux-x64-tv-app-ipv6only
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/tv-app/linux --args=chip_inet_config_enable_ipv4=false {out}/linux-x64-tv-app-ipv6only
 
 # Building linux-arm64-all-clusters
 ninja -C {out}/linux-arm64-all-clusters


### PR DESCRIPTION
#### Problem
compile_commands.json is really helpful for IDEs/autocomplete.  

#### Change overview
Make build_examples.py generate this file automatically, since there seems to be little downside (some extra storage and time, but likely  minimal) and great benefit (ide autocomplete).

#### Testing
Unit tests  validate this
Ran a build and found compile_commands.json exists in the output directory.
