### PR TITLE
Use Pool for mDNS udp endpoint, fix endpoint leak

### DIFF
--- a/src/lib/dnssd/Advertiser_ImplMinimalMdns.cpp
+++ b/src/lib/dnssd/Advertiser_ImplMinimalMdns.cpp
@@ -724,29 +724,30 @@ FullQName AdvertiserMinMdns::GetCommissioningTxtEntries(const CommissionAdvertis
 bool AdvertiserMinMdns::ShouldAdvertiseOn(const chip::Inet::InterfaceId id, const chip::Inet::IPAddress & addr)
 {
     auto & server = GlobalMinimalMdnsServer::Server();
-    for (unsigned i = 0; i < server.GetEndpointCount(); i++)
-    {
-        const ServerBase::EndpointInfo & info = server.GetEndpoints()[i];
 
-        if (info.listen_udp == nullptr)
+    bool result = false;
+
+    server.ForEachEndPoints([&](auto * info) {
+        if (info->mListenUdp == nullptr)
         {
-            continue;
+            return chip::Loop::Continue;
         }
 
-        if (info.interfaceId != id)
+        if (info->mInterfaceId != id)
         {
-            continue;
+            return chip::Loop::Continue;
         }
 
-        if (info.addressType != addr.Type())
+        if (info->mAddressType != addr.Type())
         {
-            continue;
+            return chip::Loop::Continue;
         }
 
-        return true;
-    }
+        result = true;
+        return chip::Loop::Break;
+    });
 
-    return false;
+    return result;
 }
 
 void AdvertiserMinMdns::AdvertiseRecords()

--- a/src/lib/dnssd/minimal_mdns/tests/BUILD.gn
+++ b/src/lib/dnssd/minimal_mdns/tests/BUILD.gn
@@ -38,6 +38,7 @@ chip_test_suite("tests") {
     "${chip_root}/src/lib/core",
     "${chip_root}/src/lib/dnssd",
     "${chip_root}/src/lib/dnssd/minimal_mdns",
+    "${chip_root}/src/transport/raw/tests:helpers",
     "${nlunit_test_root}:nlunit-test",
   ]
 }

--- a/src/lib/dnssd/minimal_mdns/tests/TestAdvertiser.cpp
+++ b/src/lib/dnssd/minimal_mdns/tests/TestAdvertiser.cpp
@@ -30,6 +30,7 @@
 #include <lib/dnssd/minimal_mdns/tests/CheckOnlyServer.h>
 #include <lib/support/UnitTestRegistration.h>
 #include <system/SystemPacketBuffer.h>
+#include <transport/raw/tests/NetworkTestHelpers.h>
 
 #include <nlunit-test.h>
 
@@ -213,7 +214,7 @@ void OperationalAdverts(nlTestSuite * inSuite, void * inContext)
     auto & mdnsAdvertiser = chip::Dnssd::ServiceAdvertiser::Instance();
     NL_TEST_ASSERT(inSuite, mdnsAdvertiser.RemoveServices() == CHIP_NO_ERROR);
 
-    auto & server = reinterpret_cast<CheckOnlyServer &>(GlobalMinimalMdnsServer::Server());
+    auto & server = static_cast<CheckOnlyServer &>(GlobalMinimalMdnsServer::Server());
     server.SetTestSuite(inSuite);
     server.Reset();
 
@@ -341,7 +342,7 @@ void CommissionableAdverts(nlTestSuite * inSuite, void * inContext)
     auto & mdnsAdvertiser = chip::Dnssd::ServiceAdvertiser::Instance();
     NL_TEST_ASSERT(inSuite, mdnsAdvertiser.RemoveServices() == CHIP_NO_ERROR);
 
-    auto & server = reinterpret_cast<CheckOnlyServer &>(GlobalMinimalMdnsServer::Server());
+    auto & server = static_cast<CheckOnlyServer &>(GlobalMinimalMdnsServer::Server());
     server.SetTestSuite(inSuite);
     server.Reset();
 
@@ -457,7 +458,7 @@ void CommissionableAndOperationalAdverts(nlTestSuite * inSuite, void * inContext
     auto & mdnsAdvertiser = chip::Dnssd::ServiceAdvertiser::Instance();
     NL_TEST_ASSERT(inSuite, mdnsAdvertiser.RemoveServices() == CHIP_NO_ERROR);
 
-    auto & server = reinterpret_cast<CheckOnlyServer &>(GlobalMinimalMdnsServer::Server());
+    auto & server = static_cast<CheckOnlyServer &>(GlobalMinimalMdnsServer::Server());
     server.SetTestSuite(inSuite);
     server.Reset();
 
@@ -548,12 +549,15 @@ const nlTest sTests[] = {
 int TestAdvertiser(void)
 {
     chip::Platform::MemoryInit();
+    chip::Test::IOContext context;
+    context.Init();
     nlTestSuite theSuite = { "AdvertiserImplMinimal", sTests, nullptr, nullptr };
     CheckOnlyServer server(&theSuite);
     test::ServerSwapper swapper(&server);
     auto & mdnsAdvertiser = chip::Dnssd::ServiceAdvertiser::Instance();
-    mdnsAdvertiser.Init(nullptr);
+    mdnsAdvertiser.Init(&context.GetInetLayer());
     nlTestRunner(&theSuite, &server);
+    server.Shutdown();
     return nlTestRunnerStats(&theSuite);
 }
 

--- a/src/lib/support/PoolWrapper.h
+++ b/src/lib/support/PoolWrapper.h
@@ -33,9 +33,9 @@ public:
 
     virtual ~PoolInterface() {}
 
-    virtual U * CreateObject(ConstructorArguments &&... args)              = 0;
-    virtual void ReleaseObject(U * element)                                = 0;
-    virtual void ResetObject(U * element, ConstructorArguments &&... args) = 0;
+    virtual U * CreateObject(ConstructorArguments... args)              = 0;
+    virtual void ReleaseObject(U * element)                             = 0;
+    virtual void ResetObject(U * element, ConstructorArguments... args) = 0;
 
     template <typename Function>
     Loop ForEachActiveObject(Function && function)
@@ -64,16 +64,13 @@ public:
     PoolProxy() {}
     virtual ~PoolProxy() override {}
 
-    virtual U * CreateObject(ConstructorArguments &&... args) override
-    {
-        return Impl().CreateObject(std::forward<ConstructorArguments>(args)...);
-    }
+    virtual U * CreateObject(ConstructorArguments... args) override { return Impl().CreateObject(std::move(args)...); }
 
     virtual void ReleaseObject(U * element) override { Impl().ReleaseObject(static_cast<T *>(element)); }
 
-    virtual void ResetObject(U * element, ConstructorArguments &&... args) override
+    virtual void ResetObject(U * element, ConstructorArguments... args) override
     {
-        return Impl().ResetObject(static_cast<T *>(element), std::forward<ConstructorArguments>(args)...);
+        return Impl().ResetObject(static_cast<T *>(element), std::move(args)...);
     }
 
 protected:


### PR DESCRIPTION
#### Problem
There are 2 problems:

1. In `ServerBase::Listen` of `src/lib/dnssd/minimal_mdns/Server.cpp`. If `JoinMulticastGroup`, `endpointIndex` won't advance, the `unicast_query_udp` assigned to this slot will be override by next item.
2. `Server` class in `src/lib/dnssd/minimal_mdns/Server.h` is derived from `ServerBase`, when destructing `Server` instance, the `mAllocatedStorage` array is disposed before destructor of `ServerBase` is called, so `~ServerBase` will access already disposed memory.

#### Change overview
Use memory pool to manage objects instead of an array.
Reorder destructor of those objects

#### Testing
Manually tested with unit-tests using x64 linux