### PR TITLE
Skip the "Set up environment for size reports" step in "act".

### DIFF
--- a/.github/workflows/examples-efr32.yaml
+++ b/.github/workflows/examples-efr32.yaml
@@ -45,6 +45,7 @@ jobs:
                   submodules: true
 
             - name: Set up environment for size reports
+              if: ${{ !env.ACT }}
               env:
                   GH_CONTEXT: ${{ toJson(github) }}
               run: scripts/tools/memory/gh_sizes_environment.py "${GH_CONTEXT}"

--- a/.github/workflows/examples-esp32.yaml
+++ b/.github/workflows/examples-esp32.yaml
@@ -46,6 +46,7 @@ jobs:
                   submodules: true
 
             - name: Set up environment for size reports
+              if: ${{ !env.ACT }}
               env:
                   GH_CONTEXT: ${{ toJson(github) }}
               run: scripts/tools/memory/gh_sizes_environment.py "${GH_CONTEXT}"

--- a/.github/workflows/examples-infineon.yaml
+++ b/.github/workflows/examples-infineon.yaml
@@ -41,6 +41,7 @@ jobs:
                   submodules: true
 
             - name: Set up environment for size reports
+              if: ${{ !env.ACT }}
               env:
                   GH_CONTEXT: ${{ toJson(github) }}
               run: scripts/tools/memory/gh_sizes_environment.py "${GH_CONTEXT}"

--- a/.github/workflows/examples-k32w.yaml
+++ b/.github/workflows/examples-k32w.yaml
@@ -44,6 +44,7 @@ jobs:
                   submodules: true
 
             - name: Set up environment for size reports
+              if: ${{ !env.ACT }}
               env:
                   GH_CONTEXT: ${{ toJson(github) }}
               run: scripts/tools/memory/gh_sizes_environment.py "${GH_CONTEXT}"

--- a/.github/workflows/examples-linux-standalone.yaml
+++ b/.github/workflows/examples-linux-standalone.yaml
@@ -45,6 +45,7 @@ jobs:
                   submodules: true
 
             - name: Set up environment for size reports
+              if: ${{ !env.ACT }}
               env:
                   GH_CONTEXT: ${{ toJson(github) }}
               run: scripts/tools/memory/gh_sizes_environment.py "${GH_CONTEXT}"

--- a/.github/workflows/examples-mbed.yaml
+++ b/.github/workflows/examples-mbed.yaml
@@ -48,6 +48,7 @@ jobs:
                   submodules: true
 
             - name: Set up environment for size reports
+              if: ${{ !env.ACT }}
               env:
                   GH_CONTEXT: ${{ toJson(github) }}
               run: scripts/tools/memory/gh_sizes_environment.py "${GH_CONTEXT}"

--- a/.github/workflows/examples-nrfconnect.yaml
+++ b/.github/workflows/examples-nrfconnect.yaml
@@ -45,6 +45,7 @@ jobs:
                   submodules: true
 
             - name: Set up environment for size reports
+              if: ${{ !env.ACT }}
               env:
                   GH_CONTEXT: ${{ toJson(github) }}
               run: scripts/tools/memory/gh_sizes_environment.py "${GH_CONTEXT}"

--- a/.github/workflows/examples-qpg.yaml
+++ b/.github/workflows/examples-qpg.yaml
@@ -44,6 +44,7 @@ jobs:
                   submodules: true
 
             - name: Set up environment for size reports
+              if: ${{ !env.ACT }}
               env:
                   GH_CONTEXT: ${{ toJson(github) }}
               run: scripts/tools/memory/gh_sizes_environment.py "${GH_CONTEXT}"

--- a/.github/workflows/examples-telink.yaml
+++ b/.github/workflows/examples-telink.yaml
@@ -43,6 +43,7 @@ jobs:
                   submodules: true
 
             - name: Set up environment for size reports
+              if: ${{ !env.ACT }}
               env:
                   GH_CONTEXT: ${{ toJson(github) }}
               run: scripts/tools/memory/gh_sizes_environment.py "${GH_CONTEXT}"

--- a/scripts/tools/memory/gh_sizes_environment.py
+++ b/scripts/tools/memory/gh_sizes_environment.py
@@ -8,6 +8,7 @@ Typically run as:
 
 ```
     - name: Set up environment for size reports
+      if: ${{ !env.ACT }}
       env:
         GH_CONTEXT: ${{ toJson(github) }}
       run: gh_sizes_environment.py "${GH_CONTEXT}"


### PR DESCRIPTION
This step doesn't work in the "act" environment (which makes the whole
CI job fail), and it's not needed anyway since we don't upload size
reports in that environment.

#### Problem
Using "act" to run various jobs fails because the size report preparation step fails.

#### Change overview
Skip this step when doing "act".

#### Testing
Managed to run the nrfconnect CI job locally with this change.