### PR TITLE
Rename StatusResponse::SendStatusResponse to StatusResponse::Send.

### DIFF
--- a/src/app/CommandHandler.cpp
+++ b/src/app/CommandHandler.cpp
@@ -105,8 +105,8 @@ CHIP_ERROR CommandHandler::ProcessInvokeRequest(System::PacketBufferHandle && pa
     {
         // The message thinks it should be part of a timed interaction but it's
         // not, or vice versa.  Spec says to Respond with UNSUPPORTED_ACCESS.
-        err = StatusResponse::SendStatusResponse(Protocols::InteractionModel::Status::UnsupportedAccess, mpExchangeCtx,
-                                                 /* aExpectResponse = */ false);
+        err = StatusResponse::Send(Protocols::InteractionModel::Status::UnsupportedAccess, mpExchangeCtx,
+                                   /* aExpectResponse = */ false);
 
         // Some unit tests call this function in an abnormal state when we don't
         // even have an exchange.

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -462,7 +462,7 @@ CHIP_ERROR InteractionModelEngine::OnMessageReceived(Messaging::ExchangeContext 
 exit:
     if (status != Protocols::InteractionModel::Status::Success && !apExchangeContext->IsGroupExchangeContext())
     {
-        err = StatusResponse::SendStatusResponse(status, apExchangeContext, false /*aExpectResponse*/);
+        err = StatusResponse::Send(status, apExchangeContext, false /*aExpectResponse*/);
     }
     return err;
 }
@@ -718,7 +718,7 @@ void InteractionModelEngine::OnTimedInvoke(TimedHandler * apTimedHandler, Messag
     OnInvokeCommandRequest(apExchangeContext, aPayloadHeader, std::move(aPayload), /* aIsTimedInvoke = */ true, status);
     if (status != Status::Success)
     {
-        StatusResponse::SendStatusResponse(status, apExchangeContext, /* aExpectResponse = */ false);
+        StatusResponse::Send(status, apExchangeContext, /* aExpectResponse = */ false);
     }
 }
 

--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -410,9 +410,9 @@ exit:
     if (!suppressResponse)
     {
         bool noResponseExpected = IsSubscriptionIdle() && !mPendingMoreChunks;
-        err = StatusResponse::SendStatusResponse(err == CHIP_NO_ERROR ? Protocols::InteractionModel::Status::Success
-                                                                      : Protocols::InteractionModel::Status::InvalidSubscription,
-                                                 mpExchangeCtx, !noResponseExpected);
+        err                     = StatusResponse::Send(err == CHIP_NO_ERROR ? Protocols::InteractionModel::Status::Success
+                                                        : Protocols::InteractionModel::Status::InvalidSubscription,
+                                   mpExchangeCtx, !noResponseExpected);
 
         if (noResponseExpected || (err != CHIP_NO_ERROR))
         {

--- a/src/app/StatusResponse.cpp
+++ b/src/app/StatusResponse.cpp
@@ -21,8 +21,8 @@
 
 namespace chip {
 namespace app {
-CHIP_ERROR StatusResponse::SendStatusResponse(Protocols::InteractionModel::Status aStatus,
-                                              Messaging::ExchangeContext * apExchangeContext, bool aExpectResponse)
+CHIP_ERROR StatusResponse::Send(Protocols::InteractionModel::Status aStatus, Messaging::ExchangeContext * apExchangeContext,
+                                bool aExpectResponse)
 {
     VerifyOrReturnError(apExchangeContext != nullptr, CHIP_ERROR_INCORRECT_STATE);
     System::PacketBufferHandle msgBuf = System::PacketBufferHandle::New(kMaxSecureSduLengthBytes);

--- a/src/app/StatusResponse.h
+++ b/src/app/StatusResponse.h
@@ -30,8 +30,8 @@ static constexpr size_t kMaxSecureSduLengthBytes = 1024;
 class StatusResponse
 {
 public:
-    static CHIP_ERROR SendStatusResponse(Protocols::InteractionModel::Status aStatus,
-                                         Messaging::ExchangeContext * apExchangeContext, bool aExpectResponse);
+    static CHIP_ERROR Send(Protocols::InteractionModel::Status aStatus, Messaging::ExchangeContext * apExchangeContext,
+                           bool aExpectResponse);
     static CHIP_ERROR ProcessStatusResponse(System::PacketBufferHandle && aPayload, StatusIB & aStatus);
 };
 } // namespace app

--- a/src/app/TimedHandler.cpp
+++ b/src/app/TimedHandler.cpp
@@ -53,7 +53,7 @@ CHIP_ERROR TimedHandler::OnMessageReceived(Messaging::ExchangeContext * aExchang
         {
             ChipLogError(DataManagement, "Failed to parse Timed Request action: handler %p exchange " ChipLogFormatExchange, this,
                          ChipLogValueExchange(aExchangeContext));
-            StatusResponse::SendStatusResponse(Status::InvalidAction, aExchangeContext, /* aExpectResponse = */ false);
+            StatusResponse::Send(Status::InvalidAction, aExchangeContext, /* aExpectResponse = */ false);
         }
         return err;
     }
@@ -65,7 +65,7 @@ CHIP_ERROR TimedHandler::OnMessageReceived(Messaging::ExchangeContext * aExchang
             // Time is up.  Spec says to send UNSUPPORTED_ACCESS.
             ChipLogError(DataManagement, "Timeout expired: handler %p exchange " ChipLogFormatExchange, this,
                          ChipLogValueExchange(aExchangeContext));
-            return StatusResponse::SendStatusResponse(Status::UnsupportedAccess, aExchangeContext, /* aExpectResponse = */ false);
+            return StatusResponse::Send(Status::UnsupportedAccess, aExchangeContext, /* aExpectResponse = */ false);
         }
 
         if (aPayloadHeader.HasMessageType(MsgType::InvokeCommandRequest))
@@ -86,7 +86,7 @@ CHIP_ERROR TimedHandler::OnMessageReceived(Messaging::ExchangeContext * aExchang
     ChipLogError(DataManagement, "Unexpected unknown message in tiemd interaction: handler %p exchange " ChipLogFormatExchange,
                  this, ChipLogValueExchange(aExchangeContext));
 
-    return StatusResponse::SendStatusResponse(Status::InvalidAction, aExchangeContext, /* aExpectResponse = */ false);
+    return StatusResponse::Send(Status::InvalidAction, aExchangeContext, /* aExpectResponse = */ false);
 }
 
 void TimedHandler::OnExchangeClosing(Messaging::ExchangeContext *)
@@ -120,7 +120,7 @@ CHIP_ERROR TimedHandler::HandleTimedRequestAction(Messaging::ExchangeContext * a
     // stuck waiting forever if the client never sends another message.
     auto delay = System::Clock::Milliseconds32(timeoutMs);
     aExchangeContext->SetResponseTimeout(delay);
-    ReturnErrorOnFailure(StatusResponse::SendStatusResponse(Status::Success, aExchangeContext, /* aExpectResponse = */ true));
+    ReturnErrorOnFailure(StatusResponse::Send(Status::Success, aExchangeContext, /* aExpectResponse = */ true));
 
     // Now just wait for the client.
     mState     = State::kExpectingFollowingAction;


### PR DESCRIPTION
Shorter, and just as clear.

#### Problem
Existing name is pretty redundant.

#### Change overview
Shorter, but still clear, name.

#### Testing
Tree compiles.