### PR TITLE
Switch SimpleEnum to being an enum class.

### DIFF
--- a/src/app/clusters/test-cluster-server/test-cluster-server.cpp
+++ b/src/app/clusters/test-cluster-server/test-cluster-server.cpp
@@ -87,7 +87,7 @@ uint8_t gListUint8Data[kAttributeListLength];
 OctetStringData gListOctetStringData[kAttributeListLength];
 OctetStringData gListOperationalCert[kAttributeListLength];
 Structs::TestListStructOctet::Type listStructOctetStringData[kAttributeListLength];
-Structs::SimpleStruct::Type gStructAttributeValue = { 0,          false,      SimpleEnum::EMBER_ZCL_SIMPLE_ENUM_VALUE_A,
+Structs::SimpleStruct::Type gStructAttributeValue = { 0,          false,      SimpleEnum::kValueA,
                                                       ByteSpan(), CharSpan(), BitFlags<SimpleBitmap>(),
                                                       0,          0 };
 

--- a/src/app/tests/TestDataModelSerialization.cpp
+++ b/src/app/tests/TestDataModelSerialization.cpp
@@ -178,11 +178,7 @@ void TestDataModelSerialization::TestDataModelSerialization_EncAndDecSimpleStruc
 
         t.a = 20;
         t.b = true;
-#ifdef CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
         t.c = TestCluster::SimpleEnum::kValueA;
-#else  // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
-        t.c = EMBER_ZCL_SIMPLE_ENUM_VALUE_A;
-#endif // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
         t.d = buf;
 
         t.e = Span<char>{ strbuf, strlen(strbuf) };
@@ -211,11 +207,7 @@ void TestDataModelSerialization::TestDataModelSerialization_EncAndDecSimpleStruc
 
         NL_TEST_ASSERT(apSuite, t.a == 20);
         NL_TEST_ASSERT(apSuite, t.b == true);
-#ifdef CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
         NL_TEST_ASSERT(apSuite, t.c == TestCluster::SimpleEnum::kValueA);
-#else  // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
-        NL_TEST_ASSERT(apSuite, t.c == EMBER_ZCL_SIMPLE_ENUM_VALUE_A);
-#endif // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
 
         NL_TEST_ASSERT(apSuite, t.d.size() == 4);
 
@@ -249,11 +241,7 @@ void TestDataModelSerialization::TestDataModelSerialization_EncAndDecNestedStruc
         t.b   = true;
         t.c.a = 11;
         t.c.b = true;
-#ifdef CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
         t.c.c = TestCluster::SimpleEnum::kValueB;
-#else  // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
-        t.c.c = EMBER_ZCL_SIMPLE_ENUM_VALUE_B;
-#endif // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
         t.c.d = buf;
 
         t.c.e = Span<char>{ strbuf, strlen(strbuf) };
@@ -282,11 +270,7 @@ void TestDataModelSerialization::TestDataModelSerialization_EncAndDecNestedStruc
         NL_TEST_ASSERT(apSuite, t.b == true);
         NL_TEST_ASSERT(apSuite, t.c.a == 11);
         NL_TEST_ASSERT(apSuite, t.c.b == true);
-#ifdef CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
         NL_TEST_ASSERT(apSuite, t.c.c == TestCluster::SimpleEnum::kValueB);
-#else  // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
-        NL_TEST_ASSERT(apSuite, t.c.c == EMBER_ZCL_SIMPLE_ENUM_VALUE_B);
-#endif // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
 
         NL_TEST_ASSERT(apSuite, t.c.d.size() == 4);
 
@@ -324,11 +308,7 @@ void TestDataModelSerialization::TestDataModelSerialization_EncAndDecDecodableNe
         t.b   = true;
         t.c.a = 11;
         t.c.b = true;
-#ifdef CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
         t.c.c = TestCluster::SimpleEnum::kValueB;
-#else  // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
-        t.c.c = EMBER_ZCL_SIMPLE_ENUM_VALUE_B;
-#endif // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
         t.c.d = buf;
         t.e   = intBuf;
 
@@ -376,11 +356,7 @@ void TestDataModelSerialization::TestDataModelSerialization_EncAndDecDecodableNe
         NL_TEST_ASSERT(apSuite, t.b == true);
         NL_TEST_ASSERT(apSuite, t.c.a == 11);
         NL_TEST_ASSERT(apSuite, t.c.b == true);
-#ifdef CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
         NL_TEST_ASSERT(apSuite, t.c.c == TestCluster::SimpleEnum::kValueB);
-#else  // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
-        NL_TEST_ASSERT(apSuite, t.c.c == EMBER_ZCL_SIMPLE_ENUM_VALUE_B);
-#endif // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
 
         NL_TEST_ASSERT(apSuite, StringMatches(t.c.e, "chip"));
 
@@ -548,11 +524,7 @@ void TestDataModelSerialization::TestDataModelSerialization_OptionalFields(nlTes
 
         t.a = 20;
         t.b = true;
-#ifdef CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
         t.c = TestCluster::SimpleEnum::kValueA;
-#else  // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
-        t.c = EMBER_ZCL_SIMPLE_ENUM_VALUE_A;
-#endif // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
         t.d = buf;
 
         t.e = Span<char>{ strbuf, strlen(strbuf) };
@@ -592,11 +564,7 @@ void TestDataModelSerialization::TestDataModelSerialization_OptionalFields(nlTes
         NL_TEST_ASSERT(apSuite, t.a == 150);
 
         NL_TEST_ASSERT(apSuite, t.b == true);
-#ifdef CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
         NL_TEST_ASSERT(apSuite, t.c == TestCluster::SimpleEnum::kValueA);
-#else  // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
-        NL_TEST_ASSERT(apSuite, t.c == EMBER_ZCL_SIMPLE_ENUM_VALUE_A);
-#endif // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
 
         NL_TEST_ASSERT(apSuite, t.d.size() == 4);
 
@@ -627,11 +595,7 @@ void TestDataModelSerialization::TestDataModelSerialization_ExtraField(nlTestSui
 
         t.a = 20;
         t.b = true;
-#ifdef CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
         t.c = TestCluster::SimpleEnum::kValueA;
-#else  // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
-        t.c = EMBER_ZCL_SIMPLE_ENUM_VALUE_A;
-#endif // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
         t.d = buf;
 
         t.e = Span<char>{ strbuf, strlen(strbuf) };
@@ -669,11 +633,7 @@ void TestDataModelSerialization::TestDataModelSerialization_ExtraField(nlTestSui
 
         NL_TEST_ASSERT(apSuite, t.a == 20);
         NL_TEST_ASSERT(apSuite, t.b == true);
-#ifdef CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
         NL_TEST_ASSERT(apSuite, t.c == TestCluster::SimpleEnum::kValueA);
-#else  // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
-        NL_TEST_ASSERT(apSuite, t.c == EMBER_ZCL_SIMPLE_ENUM_VALUE_A);
-#endif // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
 
         NL_TEST_ASSERT(apSuite, t.d.size() == 4);
 
@@ -708,11 +668,7 @@ void TestDataModelSerialization::TestDataModelSerialization_InvalidSimpleFieldTy
 
             t.a = 20;
             t.b = true;
-#ifdef CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
             t.c = TestCluster::SimpleEnum::kValueA;
-#else  // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
-            t.c = EMBER_ZCL_SIMPLE_ENUM_VALUE_A;
-#endif // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
             t.d = buf;
 
             t.e = Span<char>{ strbuf, strlen(strbuf) };
@@ -764,11 +720,7 @@ void TestDataModelSerialization::TestDataModelSerialization_InvalidSimpleFieldTy
 
             t.a = 20;
             t.b = true;
-#ifdef CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
             t.c = TestCluster::SimpleEnum::kValueA;
-#else  // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
-            t.c = EMBER_ZCL_SIMPLE_ENUM_VALUE_A;
-#endif // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
             t.d = buf;
 
             t.e = Span<char>{ strbuf, strlen(strbuf) };
@@ -915,20 +867,12 @@ void TestDataModelSerialization::NullablesOptionalsEncodeDecodeCheck(nlTestSuite
     TestCluster::Structs::SimpleStruct::Type myStruct;
     myStruct.a = 17;
     myStruct.b = true;
-#ifdef CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
     myStruct.c = TestCluster::SimpleEnum::kValueB;
-#else  // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
-    myStruct.c = EMBER_ZCL_SIMPLE_ENUM_VALUE_B;
-#endif // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
     myStruct.d = ByteSpan(structBytes);
     myStruct.e = CharSpan(structStr, strlen(structStr));
     myStruct.f = TestCluster::SimpleBitmap(2);
 
-#ifdef CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
     TestCluster::SimpleEnum enumListVals[] = { TestCluster::SimpleEnum::kValueA, TestCluster::SimpleEnum::kValueC };
-#else  // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
-    TestCluster::SimpleEnum enumListVals[] = { EMBER_ZCL_SIMPLE_ENUM_VALUE_A, EMBER_ZCL_SIMPLE_ENUM_VALUE_C };
-#endif // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
     DataModel::List<TestCluster::SimpleEnum> enumList(enumListVals);
 
     // Encode

--- a/src/app/zap-templates/templates/app/helper.js
+++ b/src/app/zap-templates/templates/app/helper.js
@@ -577,7 +577,6 @@ function isWeaklyTypedEnum(label)
     "SaturationStepMode",
     "SecurityType",
     "SetpointAdjustMode",
-    "SimpleEnum",
     "StartUpOnOffValue",
     "StatusCode",
     "StepMode",

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
@@ -28924,9 +28924,6 @@ struct TypeInfo
 } // namespace Attributes
 } // namespace AccountLogin
 namespace TestCluster {
-// Need to convert consumers to using the new enum classes, so we
-// don't just have casts all over.
-#ifdef CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
 // Enum for SimpleEnum
 enum class SimpleEnum : uint8_t
 {
@@ -28935,9 +28932,6 @@ enum class SimpleEnum : uint8_t
     kValueB      = 0x02,
     kValueC      = 0x03,
 };
-#else // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
-using SimpleEnum                      = EmberAfSimpleEnum;
-#endif
 
 // Bitmap for SimpleBitmap
 enum class SimpleBitmap : uint8_t

--- a/zzz_generated/app-common/app-common/zap-generated/enums.h
+++ b/zzz_generated/app-common/app-common/zap-generated/enums.h
@@ -714,15 +714,6 @@ enum EmberAfSetpointAdjustMode : uint8_t
     EMBER_ZCL_SETPOINT_ADJUST_MODE_HEAT_AND_COOL_SETPOINTS = 2,
 };
 
-// Enum for SimpleEnum
-enum EmberAfSimpleEnum : uint8_t
-{
-    EMBER_ZCL_SIMPLE_ENUM_UNSPECIFIED = 0,
-    EMBER_ZCL_SIMPLE_ENUM_VALUE_A     = 1,
-    EMBER_ZCL_SIMPLE_ENUM_VALUE_B     = 2,
-    EMBER_ZCL_SIMPLE_ENUM_VALUE_C     = 3,
-};
-
 // Enum for StartUpOnOffValue
 enum EmberAfStartUpOnOffValue : uint8_t
 {


### PR DESCRIPTION
#### Problem
SimpleEnum is not an enum class.

#### Change overview
Remove it from the "legacy enums that need to not be enum class" list.

#### Testing
Tree compiles.