### PR TITLE
Updated Google Vendor Identifier

### DIFF
--- a/src/lib/core/CHIPVendorIdentifiers.hpp
+++ b/src/lib/core/CHIPVendorIdentifiers.hpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2020-2021 Project CHIP Authors
  *    Copyright (c) 2014-2017 Nest Labs, Inc.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -33,12 +33,16 @@ namespace chip {
 //
 // CHIP Vendor Identifiers (16 bits max)
 //
-
+// These values are under administration by Connectivity Standards Alliance (CSA).
+// For new value allocation make a formal request to CSA.
+// The database of currently allocated identifiers can be found in this document:
+// https://groups.csa-iot.org/wg/members-all/document/10905
+//
 // As per specifications (section 2.5.2 Vendor Identifier)
 enum VendorId : uint16_t
 {
     Common       = 0x0000u,
-    GoogleNest   = 0x235Au,
+    Google       = 0x6006u,
     TestVendor1  = 0xFFF1u,
     TestVendor2  = 0xFFF2u,
     TestVendor3  = 0xFFF3u,


### PR DESCRIPTION
Updated Google VendorId to match the value allocated by CSA:
https://groups.csa-iot.org/wg/members-all/document/10905