### PR TITLE
Adding IsSleepyDevice() and related tests

### DIFF
--- a/src/lib/dnssd/Resolver.h
+++ b/src/lib/dnssd/Resolver.h
@@ -62,6 +62,18 @@ struct ResolvedNodeData
     Optional<System::Clock::Milliseconds32> GetMrpRetryIntervalIdle() const { return mMrpRetryIntervalIdle; }
     Optional<System::Clock::Milliseconds32> GetMrpRetryIntervalActive() const { return mMrpRetryIntervalActive; }
 
+    bool IsDeviceTreatedAsSleepy() const
+    {
+        // If either retry interval (Idle - CRI, Active - CRA) has a value and that value is greater
+        // than the default, then the peer device will be treated as if it is a Sleepy End Device (SED)
+        if ((mMrpRetryIntervalIdle.HasValue() && (mMrpRetryIntervalIdle.Value() > gDefaultMRPConfig.mIdleRetransTimeout)) ||
+            (mMrpRetryIntervalActive.HasValue() && (mMrpRetryIntervalActive.Value() > gDefaultMRPConfig.mActiveRetransTimeout)))
+        {
+            return true;
+        }
+        return false;
+    }
+
     PeerId mPeerId;
     size_t mNumIPs = 0;
     Inet::InterfaceId mInterfaceId;
@@ -133,6 +145,19 @@ struct DiscoveredNodeData
     bool IsValid() const { return !IsHost("") && ipAddress[0] != chip::Inet::IPAddress::Any; }
     Optional<System::Clock::Milliseconds32> GetMrpRetryIntervalIdle() const { return mrpRetryIntervalIdle; }
     Optional<System::Clock::Milliseconds32> GetMrpRetryIntervalActive() const { return mrpRetryIntervalActive; }
+
+    bool IsDeviceTreatedAsSleepy() const
+    {
+        // If either retry interval (Idle - CRI, Active - CRA) has a value and that value is greater
+        // than the default, then the peer device will be treated as if it is a Sleepy End Device (SED)
+        if ((mrpRetryIntervalIdle.HasValue() && (mrpRetryIntervalIdle.Value() > gDefaultMRPConfig.mIdleRetransTimeout)) ||
+            (mrpRetryIntervalActive.HasValue() && (mrpRetryIntervalActive.Value() > gDefaultMRPConfig.mActiveRetransTimeout)))
+
+        {
+            return true;
+        }
+        return false;
+    }
 
     void LogDetail() const
     {

--- a/src/lib/dnssd/Resolver.h
+++ b/src/lib/dnssd/Resolver.h
@@ -62,12 +62,13 @@ struct ResolvedNodeData
     Optional<System::Clock::Milliseconds32> GetMrpRetryIntervalIdle() const { return mMrpRetryIntervalIdle; }
     Optional<System::Clock::Milliseconds32> GetMrpRetryIntervalActive() const { return mMrpRetryIntervalActive; }
 
-    bool IsDeviceTreatedAsSleepy() const
+    bool IsDeviceTreatedAsSleepy(const ReliableMessageProtocolConfig * defaultMRPConfig) const
     {
         // If either retry interval (Idle - CRI, Active - CRA) has a value and that value is greater
-        // than the default, then the peer device will be treated as if it is a Sleepy End Device (SED)
-        if ((mMrpRetryIntervalIdle.HasValue() && (mMrpRetryIntervalIdle.Value() > gDefaultMRPConfig.mIdleRetransTimeout)) ||
-            (mMrpRetryIntervalActive.HasValue() && (mMrpRetryIntervalActive.Value() > gDefaultMRPConfig.mActiveRetransTimeout)))
+        // than the value passed to this function, then the peer device will be treated as if it is
+        // a Sleepy End Device (SED)
+        if ((mMrpRetryIntervalIdle.HasValue() && (mMrpRetryIntervalIdle.Value() > defaultMRPConfig->mIdleRetransTimeout)) ||
+            (mMrpRetryIntervalActive.HasValue() && (mMrpRetryIntervalActive.Value() > defaultMRPConfig->mActiveRetransTimeout)))
         {
             return true;
         }
@@ -146,12 +147,13 @@ struct DiscoveredNodeData
     Optional<System::Clock::Milliseconds32> GetMrpRetryIntervalIdle() const { return mrpRetryIntervalIdle; }
     Optional<System::Clock::Milliseconds32> GetMrpRetryIntervalActive() const { return mrpRetryIntervalActive; }
 
-    bool IsDeviceTreatedAsSleepy() const
+    bool IsDeviceTreatedAsSleepy(const ReliableMessageProtocolConfig * defaultMRPConfig) const
     {
         // If either retry interval (Idle - CRI, Active - CRA) has a value and that value is greater
-        // than the default, then the peer device will be treated as if it is a Sleepy End Device (SED)
-        if ((mrpRetryIntervalIdle.HasValue() && (mrpRetryIntervalIdle.Value() > gDefaultMRPConfig.mIdleRetransTimeout)) ||
-            (mrpRetryIntervalActive.HasValue() && (mrpRetryIntervalActive.Value() > gDefaultMRPConfig.mActiveRetransTimeout)))
+        // than the value passed to this function, then the peer device will be treated as if it is
+        // a Sleepy End Device (SED)
+        if ((mrpRetryIntervalIdle.HasValue() && (mrpRetryIntervalIdle.Value() > defaultMRPConfig->mIdleRetransTimeout)) ||
+            (mrpRetryIntervalActive.HasValue() && (mrpRetryIntervalActive.Value() > defaultMRPConfig->mActiveRetransTimeout)))
 
         {
             return true;

--- a/src/lib/dnssd/tests/TestTxtFields.cpp
+++ b/src/lib/dnssd/tests/TestTxtFields.cpp
@@ -30,15 +30,6 @@ using namespace chip;
 using namespace chip::Dnssd;
 using namespace chip::Dnssd::Internal;
 
-namespace chip {
-
-using namespace System::Clock::Literals;
-
-const ReliableMessageProtocolConfig gDefaultMRPConfig(CHIP_CONFIG_MRP_DEFAULT_IDLE_RETRY_INTERVAL,
-                                                      CHIP_CONFIG_MRP_DEFAULT_ACTIVE_RETRY_INTERVAL);
-
-} // namespace chip
-
 namespace {
 
 ByteSpan GetSpan(char * key)
@@ -576,21 +567,23 @@ void TestIsDeviceSleepyIdle(nlTestSuite * inSuite, void * inContext)
     char key[4];
     char val[32];
     NodeData nodeData;
+    const ReliableMessageProtocolConfig defaultMRPConfig(CHIP_CONFIG_MRP_DEFAULT_IDLE_RETRY_INTERVAL,
+                                                         CHIP_CONFIG_MRP_DEFAULT_ACTIVE_RETRY_INTERVAL);
 
     // No key/val set, so the device can't be sleepy
-    NL_TEST_ASSERT(inSuite, !nodeData.IsDeviceTreatedAsSleepy());
+    NL_TEST_ASSERT(inSuite, !nodeData.IsDeviceTreatedAsSleepy(&defaultMRPConfig));
 
     // If the interval is the default value, the device is not sleepy
     sprintf(key, "CRI");
     sprintf(val, "%d", CHIP_CONFIG_MRP_DEFAULT_IDLE_RETRY_INTERVAL.count());
     FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData);
-    NL_TEST_ASSERT(inSuite, !nodeData.IsDeviceTreatedAsSleepy());
+    NL_TEST_ASSERT(inSuite, !nodeData.IsDeviceTreatedAsSleepy(&defaultMRPConfig));
 
     // If the interval is greater than the default value, the device is sleepy
     sprintf(key, "CRI");
     sprintf(val, "%d", CHIP_CONFIG_MRP_DEFAULT_IDLE_RETRY_INTERVAL.count() + 1);
     FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData);
-    NL_TEST_ASSERT(inSuite, nodeData.IsDeviceTreatedAsSleepy());
+    NL_TEST_ASSERT(inSuite, nodeData.IsDeviceTreatedAsSleepy(&defaultMRPConfig));
 }
 
 // Test IsDeviceTreatedAsSleepy() with CRA
@@ -600,21 +593,23 @@ void TestIsDeviceSleepyActive(nlTestSuite * inSuite, void * inContext)
     char key[4];
     char val[32];
     NodeData nodeData;
+    const ReliableMessageProtocolConfig defaultMRPConfig(CHIP_CONFIG_MRP_DEFAULT_IDLE_RETRY_INTERVAL,
+                                                         CHIP_CONFIG_MRP_DEFAULT_ACTIVE_RETRY_INTERVAL);
 
     // No key/val set, so the device can't be sleepy
-    NL_TEST_ASSERT(inSuite, !nodeData.IsDeviceTreatedAsSleepy());
+    NL_TEST_ASSERT(inSuite, !nodeData.IsDeviceTreatedAsSleepy(&defaultMRPConfig));
 
     // If the interval is the default value, the device is not sleepy
     sprintf(key, "CRA");
     sprintf(val, "%d", CHIP_CONFIG_MRP_DEFAULT_ACTIVE_RETRY_INTERVAL.count());
     FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData);
-    NL_TEST_ASSERT(inSuite, !nodeData.IsDeviceTreatedAsSleepy());
+    NL_TEST_ASSERT(inSuite, !nodeData.IsDeviceTreatedAsSleepy(&defaultMRPConfig));
 
     // If the interval is greater than the default value, the device is sleepy
     sprintf(key, "CRA");
     sprintf(val, "%d", CHIP_CONFIG_MRP_DEFAULT_ACTIVE_RETRY_INTERVAL.count() + 1);
     FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData);
-    NL_TEST_ASSERT(inSuite, nodeData.IsDeviceTreatedAsSleepy());
+    NL_TEST_ASSERT(inSuite, nodeData.IsDeviceTreatedAsSleepy(&defaultMRPConfig));
 }
 
 const nlTest sTests[] = {


### PR DESCRIPTION
#### Problem
Need to identify a peer device as a sleepy device
see https://github.com/project-chip/connectedhomeip/issues/11502

#### Change overview
Added functions to identify a peer device as a sleepy device.  Also added related unit tests.

#### Testing
Unit testing was added and is part of this pull request.
