### PR TITLE
Use a random discriminator for test runs.

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -90,7 +90,7 @@ jobs:
                   "./scripts/tests/run_test_suite.py \
                      --chip-tool ./out/debug/standalone/chip-tool \
                      run \
-                     --iterations 2 \
+                     --iterations 1 \
                      --all-clusters-app ./out/debug/standalone/chip-all-clusters-app \
                      --tv-app ./out/debug/standalone/chip-tv-app \
                   "
@@ -180,7 +180,7 @@ jobs:
                      --chip-tool ./out/debug/standalone/chip-tool \
                      --target-skip-glob 'TV_*' \
                      run \
-                     --iterations 2 \
+                     --iterations 1 \
                      --all-clusters-app ./out/debug/standalone/chip-all-clusters-app \
                      --tv-app ./out/debug/standalone/chip-tv-app \
                   "

--- a/examples/platform/linux/Options.cpp
+++ b/examples/platform/linux/Options.cpp
@@ -174,9 +174,20 @@ bool HandleOption(const char * aProgram, OptionSet * aOptions, int aIdentifier, 
         LinuxDeviceOptions::GetInstance().payload.rendezvousInformation.SetRaw(static_cast<uint8_t>(atoi(aValue)));
         break;
 
-    case kDeviceOption_Discriminator:
-        LinuxDeviceOptions::GetInstance().payload.discriminator = static_cast<uint16_t>(atoi(aValue));
+    case kDeviceOption_Discriminator: {
+        uint16_t value = static_cast<uint16_t>(atoi(aValue));
+        if (value >= 4096)
+        {
+            PrintArgError("%s: invalid value specified for discriminator: %s\n", aProgram, aValue);
+            retval = false;
+        }
+        else
+        {
+            LinuxDeviceOptions::GetInstance().payload.discriminator = value;
+            DeviceLayer::ConfigurationMgr().StoreSetupDiscriminator(value);
+        }
         break;
+    }
 
     case kDeviceOption_Passcode:
         LinuxDeviceOptions::GetInstance().payload.setUpPINCode = static_cast<uint32_t>(atoi(aValue));

--- a/scripts/tests/chiptest/test_definition.py
+++ b/scripts/tests/chiptest/test_definition.py
@@ -22,6 +22,7 @@ import threading
 
 from enum import Enum, auto
 from dataclasses import dataclass
+from random import randrange
 
 TEST_NODE_ID = '0x12344321'
 
@@ -101,9 +102,11 @@ class TestDefinition:
             if os.path.exists('/tmp/chip_tool_config.ini'):
                 os.unlink('/tmp/chip_tool_config.ini')
 
-            logging.debug('Executing application under test.')
+            discriminator = str(randrange(1, 4096))
+            logging.debug(
+                'Executing application under test with discriminator %s.' % discriminator)
             app_process, outpipe, errpipe = runner.RunSubprocess(
-                app_cmd, name='APP ', wait=False)
+                app_cmd + ['--discriminator', discriminator], name='APP ', wait=False)
 
             logging.debug('Waiting for server to listen.')
             start_time = time.time()
@@ -117,7 +120,7 @@ class TestDefinition:
                     "Server Listening")
             logging.debug('Server is listening. Can proceed.')
 
-            runner.RunSubprocess(tool_cmd + ['pairing', 'qrcode', TEST_NODE_ID, 'MT:D8XA0CQM00KA0648G00'],
+            runner.RunSubprocess(tool_cmd + ['pairing', 'onnetwork-long', TEST_NODE_ID, '20202021', discriminator],
                                  name='PAIR', dependencies=[app_process])
 
             runner.RunSubprocess(tool_cmd + ['tests', self.run_name, TEST_NODE_ID],


### PR DESCRIPTION
If we're getting cross-talk, maybe this will help.

#### Problem
All of our test instances use the same onboarding info, so if we are in fact getting cross-talk the chip-tool of one test can end up talking to the all-clusters-app of a different test.

#### Change overview
Try using a randomly generated discriminator to work around that potential problem.

The switch from qrcode to onnetwork-long is to avoid needing to parse the QR code out from the all-clusters-app log, since it would no longer be constant.

#### Testing
Ran test locally and things worked.