### PR TITLE
Add diagnostic delegate interfaces for event support

### DIFF
--- a/src/app/clusters/general_diagnostics_server/general_diagnostics_server.cpp
+++ b/src/app/clusters/general_diagnostics_server/general_diagnostics_server.cpp
@@ -167,13 +167,13 @@ CHIP_ERROR GeneralDiagosticsAttrAccess::Read(const ConcreteReadAttributePath & a
     return CHIP_NO_ERROR;
 }
 
-class GeneralDiagnosticDelegate : public DeviceLayer::ConnectivityManagerDelegate, public DeviceLayer::DiagnosticsDelegate
+class GeneralDiagnosticsDelegate : public DeviceLayer::ConnectivityManagerDelegate, public DeviceLayer::GeneralDiagnosticsDelegate
 {
 
     // Gets called when any network interface on the Node is updated.
     void OnNetworkInfoChanged() override
     {
-        ChipLogProgress(Zcl, "GeneralDiagnosticDelegate: OnNetworkInfoChanged");
+        ChipLogProgress(Zcl, "GeneralDiagnosticsDelegate: OnNetworkInfoChanged");
 
         for (uint16_t index = 0; index < emberAfEndpointCount(); index++)
         {
@@ -194,7 +194,7 @@ class GeneralDiagnosticDelegate : public DeviceLayer::ConnectivityManagerDelegat
     // Gets called when the device has been rebooted.
     void OnDeviceRebooted() override
     {
-        ChipLogProgress(Zcl, "GeneralDiagnosticDelegate: OnDeviceRebooted");
+        ChipLogProgress(Zcl, "GeneralDiagnosticsDelegate: OnDeviceRebooted");
 
         for (uint16_t index = 0; index < emberAfEndpointCount(); index++)
         {
@@ -217,7 +217,7 @@ class GeneralDiagnosticDelegate : public DeviceLayer::ConnectivityManagerDelegat
     // Get called when the Node detects a hardware fault has been raised.
     void OnHardwareFaultsDetected() override
     {
-        ChipLogProgress(Zcl, "GeneralDiagnosticDelegate: OnHardwareFaultsDetected");
+        ChipLogProgress(Zcl, "GeneralDiagnosticsDelegate: OnHardwareFaultsDetected");
 
         for (uint16_t index = 0; index < emberAfEndpointCount(); index++)
         {
@@ -238,7 +238,7 @@ class GeneralDiagnosticDelegate : public DeviceLayer::ConnectivityManagerDelegat
     // Get called when the Node detects a radio fault has been raised.
     void OnRadioFaultsDetected() override
     {
-        ChipLogProgress(Zcl, "GeneralDiagnosticDelegate: OnHardwareFaultsDetected");
+        ChipLogProgress(Zcl, "GeneralDiagnosticsDelegate: OnHardwareFaultsDetected");
 
         for (uint16_t index = 0; index < emberAfEndpointCount(); index++)
         {
@@ -259,7 +259,7 @@ class GeneralDiagnosticDelegate : public DeviceLayer::ConnectivityManagerDelegat
     // Get called when the Node detects a network fault has been raised.
     void OnNetworkFaultsDetected() override
     {
-        ChipLogProgress(Zcl, "GeneralDiagnosticDelegate: OnHardwareFaultsDetected");
+        ChipLogProgress(Zcl, "GeneralDiagnosticsDelegate: OnHardwareFaultsDetected");
 
         for (uint16_t index = 0; index < emberAfEndpointCount(); index++)
         {
@@ -278,7 +278,7 @@ class GeneralDiagnosticDelegate : public DeviceLayer::ConnectivityManagerDelegat
     }
 };
 
-GeneralDiagnosticDelegate gDiagnosticDelegate;
+GeneralDiagnosticsDelegate gDiagnosticDelegate;
 
 } // anonymous namespace
 
@@ -286,6 +286,6 @@ void MatterGeneralDiagnosticsPluginServerInitCallback()
 {
     registerAttributeAccessOverride(&gAttrAccess);
 
-    GetDiagnosticDataProvider().SetDelegate(&gDiagnosticDelegate);
     ConnectivityMgr().SetDelegate(&gDiagnosticDelegate);
+    GetDiagnosticDataProvider().SetGeneralDiagnosticsDelegate(&gDiagnosticDelegate);
 }

--- a/src/app/clusters/software_diagnostics_server/software_diagnostics_server.cpp
+++ b/src/app/clusters/software_diagnostics_server/software_diagnostics_server.cpp
@@ -33,6 +33,7 @@ using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::SoftwareDiagnostics;
 using namespace chip::app::Clusters::SoftwareDiagnostics::Attributes;
 using chip::DeviceLayer::DiagnosticDataProvider;
+using chip::DeviceLayer::GetDiagnosticDataProvider;
 
 namespace {
 
@@ -122,6 +123,15 @@ CHIP_ERROR SoftwareDiagosticsAttrAccess::ReadThreadMetrics(AttributeValueEncoder
 
     return err;
 }
+
+class SoftwareDiagnosticsDelegate : public DeviceLayer::SoftwareDiagnosticsDelegate
+{
+    // Gets called when a software fault that has taken place on the Node.
+    void OnSoftwareFaultDetected() override { ChipLogProgress(Zcl, "SoftwareDiagnosticsDelegate: OnSoftwareFaultDetected"); }
+};
+
+SoftwareDiagnosticsDelegate gDiagnosticDelegate;
+
 } // anonymous namespace
 
 bool emberAfSoftwareDiagnosticsClusterResetWatermarksCallback(app::CommandHandler * commandObj,
@@ -151,4 +161,5 @@ exit:
 void MatterSoftwareDiagnosticsPluginServerInitCallback()
 {
     registerAttributeAccessOverride(&gAttrAccess);
+    GetDiagnosticDataProvider().SetSoftwareDiagnosticsDelegate(&gDiagnosticDelegate);
 }

--- a/src/app/clusters/wifi_network_diagnostics_server/wifi_network_diagnostics_server.cpp
+++ b/src/app/clusters/wifi_network_diagnostics_server/wifi_network_diagnostics_server.cpp
@@ -33,6 +33,7 @@ using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::WiFiNetworkDiagnostics;
 using namespace chip::app::Clusters::WiFiNetworkDiagnostics::Attributes;
 using chip::DeviceLayer::DiagnosticDataProvider;
+using chip::DeviceLayer::GetDiagnosticDataProvider;
 
 namespace {
 
@@ -144,6 +145,21 @@ CHIP_ERROR WiFiDiagosticsAttrAccess::Read(const ConcreteReadAttributePath & aPat
     }
     return CHIP_NO_ERROR;
 }
+
+class WiFiDiagnosticsDelegate : public DeviceLayer::WiFiDiagnosticsDelegate
+{
+    // Gets called when the Node detects Node’s Wi-Fi connection has been disconnected.
+    void OnDisconnectionDetected() override { ChipLogProgress(Zcl, "WiFiDiagnosticsDelegate: OnDisconnectionDetected"); }
+
+    // Gets called when the Node fails to associate or authenticate an access point.
+    void OnAssociationFailureDetected() override { ChipLogProgress(Zcl, "WiFiDiagnosticsDelegate: OnAssociationFailureDetected"); }
+
+    // Gets when the Node’s connection status to a Wi-Fi network has changed.
+    void OnConnectionStatusChanged() override { ChipLogProgress(Zcl, "WiFiDiagnosticsDelegate: OnConnectionStatusChanged"); }
+};
+
+WiFiDiagnosticsDelegate gDiagnosticDelegate;
+
 } // anonymous namespace
 
 bool emberAfWiFiNetworkDiagnosticsClusterResetCountsCallback(app::CommandHandler * commandObj,
@@ -186,4 +202,5 @@ exit:
 void MatterWiFiNetworkDiagnosticsPluginServerInitCallback()
 {
     registerAttributeAccessOverride(&gAttrAccess);
+    GetDiagnosticDataProvider().SetWiFiDiagnosticsDelegate(&gDiagnosticDelegate);
 }

--- a/src/include/platform/DiagnosticDataProvider.h
+++ b/src/include/platform/DiagnosticDataProvider.h
@@ -50,12 +50,12 @@ struct NetworkInterface : public app::Clusters::GeneralDiagnostics::Structs::Net
 };
 
 /**
- * Defines the delegate class of Platform Manager to notify platform updates.
+ * Defines the General Diagnostics Delegate class to notify platform events.
  */
-class DiagnosticsDelegate
+class GeneralDiagnosticsDelegate
 {
 public:
-    virtual ~DiagnosticsDelegate() {}
+    virtual ~GeneralDiagnosticsDelegate() {}
 
     /**
      * @brief
@@ -83,13 +83,61 @@ public:
 };
 
 /**
+ * Defines the Software Diagnostics Delegate class to notify software events.
+ */
+class SoftwareDiagnosticsDelegate
+{
+public:
+    virtual ~SoftwareDiagnosticsDelegate() {}
+
+    /**
+     * @brief
+     *   Called when a software fault that has taken place on the Node.
+     */
+    virtual void OnSoftwareFaultDetected() {}
+};
+
+/**
+ * Defines the WiFi Diagnostics Delegate class to notify WiFi network events.
+ */
+class WiFiDiagnosticsDelegate
+{
+public:
+    virtual ~WiFiDiagnosticsDelegate() {}
+
+    /**
+     * @brief
+     *   Called when the Node detects Node’s Wi-Fi connection has been disconnected.
+     */
+    virtual void OnDisconnectionDetected() {}
+
+    /**
+     * @brief
+     *   Called when the Node fails to associate or authenticate an access point.
+     */
+    virtual void OnAssociationFailureDetected() {}
+
+    /**
+     * @brief
+     *   Called when the Node’s connection status to a Wi-Fi network has changed.
+     */
+    virtual void OnConnectionStatusChanged() {}
+};
+
+/**
  * Provides access to runtime and build-time configuration information for a chip device.
  */
 class DiagnosticDataProvider
 {
 public:
-    void SetDelegate(DiagnosticsDelegate * delegate) { mDelegate = delegate; }
-    DiagnosticsDelegate * GetDelegate() const { return mDelegate; }
+    void SetGeneralDiagnosticsDelegate(GeneralDiagnosticsDelegate * delegate) { mGeneralDiagnosticsDelegate = delegate; }
+    GeneralDiagnosticsDelegate * GetGeneralDiagnosticsDelegate() const { return mGeneralDiagnosticsDelegate; }
+
+    void SetSoftwareDiagnosticsDelegate(SoftwareDiagnosticsDelegate * delegate) { mSoftwareDiagnosticsDelegate = delegate; }
+    SoftwareDiagnosticsDelegate * GetSoftwareDiagnosticsDelegate() const { return mSoftwareDiagnosticsDelegate; }
+
+    void SetWiFiDiagnosticsDelegate(WiFiDiagnosticsDelegate * delegate) { mWiFiDiagnosticsDelegate = delegate; }
+    WiFiDiagnosticsDelegate * GetWiFiDiagnosticsDelegate() const { return mWiFiDiagnosticsDelegate; }
 
     /**
      * General Diagnostics methods.
@@ -163,7 +211,9 @@ protected:
     virtual ~DiagnosticDataProvider() = default;
 
 private:
-    DiagnosticsDelegate * mDelegate = nullptr;
+    GeneralDiagnosticsDelegate * mGeneralDiagnosticsDelegate   = nullptr;
+    SoftwareDiagnosticsDelegate * mSoftwareDiagnosticsDelegate = nullptr;
+    WiFiDiagnosticsDelegate * mWiFiDiagnosticsDelegate         = nullptr;
 
     // No copy, move or assignment.
     DiagnosticDataProvider(const DiagnosticDataProvider &)  = delete;

--- a/src/platform/Linux/PlatformManagerImpl.cpp
+++ b/src/platform/Linux/PlatformManagerImpl.cpp
@@ -42,6 +42,8 @@
 #include <signal.h>
 #include <unistd.h>
 
+using namespace ::chip::app::Clusters;
+
 namespace chip {
 namespace DeviceLayer {
 
@@ -84,18 +86,26 @@ void SignalHandler(int signum)
         ConfigurationMgr().StoreBootReason(EMBER_ZCL_BOOT_REASON_TYPE_SOFTWARE_UPDATE_COMPLETED);
         err = CHIP_ERROR_REBOOT_SIGNAL_RECEIVED;
         break;
+    case SIGTRAP:
+        PlatformMgrImpl().HandleSoftwareFault(SoftwareDiagnostics::Events::SoftwareFault::kEventId);
+        break;
+    case SIGILL:
+        PlatformMgrImpl().HandleGeneralFault(GeneralDiagnostics::Events::HardwareFaultChange::kEventId);
+        break;
+    case SIGALRM:
+        PlatformMgrImpl().HandleGeneralFault(GeneralDiagnostics::Events::RadioFaultChange::kEventId);
+        break;
+    case SIGVTALRM:
+        PlatformMgrImpl().HandleGeneralFault(GeneralDiagnostics::Events::NetworkFaultChange::kEventId);
+        break;
     default:
         break;
     }
 
-    if (err != CHIP_NO_ERROR)
+    if (err == CHIP_ERROR_REBOOT_SIGNAL_RECEIVED)
     {
         PlatformMgr().Shutdown();
         exit(EXIT_FAILURE);
-    }
-    else
-    {
-        ChipLogDetail(DeviceLayer, "Ignore signal %d", signum);
     }
 }
 
@@ -253,11 +263,44 @@ CHIP_ERROR PlatformManagerImpl::_Shutdown()
 
 void PlatformManagerImpl::HandleDeviceRebooted(intptr_t arg)
 {
-    DiagnosticsDelegate * delegate = GetDiagnosticDataProvider().GetDelegate();
+    GeneralDiagnosticsDelegate * delegate = GetDiagnosticDataProvider().GetGeneralDiagnosticsDelegate();
 
     if (delegate != nullptr)
     {
         delegate->OnDeviceRebooted();
+    }
+}
+
+void PlatformManagerImpl::HandleGeneralFault(uint32_t EventId)
+{
+    GeneralDiagnosticsDelegate * delegate = GetDiagnosticDataProvider().GetGeneralDiagnosticsDelegate();
+
+    if (delegate != nullptr)
+    {
+        switch (EventId)
+        {
+        case GeneralDiagnostics::Events::HardwareFaultChange::kEventId:
+            delegate->OnHardwareFaultsDetected();
+            break;
+        case GeneralDiagnostics::Events::RadioFaultChange::kEventId:
+            delegate->OnRadioFaultsDetected();
+            break;
+        case GeneralDiagnostics::Events::NetworkFaultChange::kEventId:
+            delegate->OnNetworkFaultsDetected();
+            break;
+        default:
+            break;
+        }
+    }
+}
+
+void PlatformManagerImpl::HandleSoftwareFault(uint32_t EventId)
+{
+    SoftwareDiagnosticsDelegate * delegate = GetDiagnosticDataProvider().GetSoftwareDiagnosticsDelegate();
+
+    if (delegate != nullptr)
+    {
+        delegate->OnSoftwareFaultDetected();
     }
 }
 

--- a/src/platform/Linux/PlatformManagerImpl.h
+++ b/src/platform/Linux/PlatformManagerImpl.h
@@ -56,6 +56,9 @@ public:
 
     System::Clock::Timestamp GetStartTime() { return mStartTime; }
 
+    void HandleGeneralFault(uint32_t EventId);
+    void HandleSoftwareFault(uint32_t EventId);
+
 private:
     // ===== Methods that implement the PlatformManager abstract interface.
 


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* We need to have a mechanism to hook IM and SDK platform,this will be used by cluster server to record the event by a Node at the time the event happens.

#### Change overview
Add diagnostic delegate interfaces for event support.

#### Testing
How was this tested? (at least one bullet point required)
* Server side event support is still in progress, there is no good way to test this interface at this moment. Verified from test log and confirm the corresponding delegate API is called on the cluster server when the event diagnostic events occur.
