### PR TITLE
Add IM event urgency option support

### DIFF
--- a/src/app/EventManagement.cpp
+++ b/src/app/EventManagement.cpp
@@ -606,7 +606,11 @@ exit:
                       opts.mTimestamp.mType == Timestamp::Type::kSystem ? "Sys" : "Epoch", ChipLogValueX64(opts.mTimestamp.mValue));
 #endif // CHIP_CONFIG_EVENT_LOGGING_VERBOSE_DEBUG_LOGS
 
-        ScheduleFlushIfNeeded(opts.mUrgent);
+        if (opts.mUrgent == EventOptions::Type::kUrgent)
+        {
+            ConcreteEventPath path(opts.mpEventSchema->mEndpointId, opts.mpEventSchema->mClusterId, opts.mpEventSchema->mEventId);
+            err = InteractionModelEngine::GetInstance()->GetReportingEngine().ScheduleUrgentEventDelivery(path);
+        }
     }
 
     return err;
@@ -849,12 +853,6 @@ CHIP_ERROR EventManagement::EvictEvent(CHIPCircularTLVBuffer & apBuffer, void * 
     // event is not getting dropped. Note how much space it requires, and return.
     ctx->mSpaceNeededForMovedEvent = aReader.GetLengthRead();
     return CHIP_END_OF_TLV;
-}
-
-CHIP_ERROR EventManagement::ScheduleFlushIfNeeded(EventOptions::Type aUrgent)
-{
-    // TODO: Implement ScheduleFlushIfNeeded
-    return CHIP_NO_ERROR;
 }
 
 void EventManagement::SetScheduledEventEndpoint(EventNumber * apEventEndpoints)

--- a/src/app/EventManagement.h
+++ b/src/app/EventManagement.h
@@ -400,39 +400,6 @@ public:
 
     /**
      * @brief
-     *  Schedule a log offload task.
-     *
-     * The function decides whether to schedule a task offload process,
-     * and if so, it schedules the `LoggingFlushHandler` to be run
-     * asynchronously on the Chip thread.
-     *
-     * The decision to schedule a flush is dependent on three factors:
-     *
-     * -- an explicit request to flush the buffer
-     *
-     * -- the state of the event buffer and the amount of data not yet
-     *    synchronized with the event consumers
-     *
-     * -- whether there is an already pending request flush request event.
-     *
-     * The explicit request to schedule a flush is passed via an input
-     * parameter.
-     *
-     * The automatic flush is typically scheduled when the event buffers
-     * contain enough data to merit starting a new offload.  Additional
-     * triggers -- such as minimum and maximum time between offloads --
-     * may also be taken into account depending on the offload strategy.
-     *
-     *
-     * @param aUrgent  indiate whether the flush should be scheduled if it is urgent
-     *
-     * @retval #CHIP_ERROR_INCORRECT_STATE EventManagement module was not initialized fully.
-     * @retval #CHIP_NO_ERROR              On success.
-     */
-    CHIP_ERROR ScheduleFlushIfNeeded(EventOptions::Type aUrgent);
-
-    /**
-     * @brief
      *   Fetch the most recently vended Number for a particular priority level
      *
      * @param aPriority Priority level

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -502,6 +502,11 @@ uint16_t InteractionModelEngine::GetWriteClientArrayIndex(const WriteClient * co
     return static_cast<uint16_t>(apWriteClient - mWriteClients);
 }
 
+uint16_t InteractionModelEngine::GetReadHandlerArrayIndex(const ReadHandler * const apReadHandler) const
+{
+    return static_cast<uint16_t>(apReadHandler - mReadHandlers);
+}
+
 void InteractionModelEngine::ReleaseClusterInfoList(ClusterInfo *& aClusterInfo)
 {
     ClusterInfo * lastClusterInfo = aClusterInfo;

--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -176,6 +176,7 @@ public:
 
     uint16_t GetWriteClientArrayIndex(const WriteClient * const apWriteClient) const;
 
+    uint16_t GetReadHandlerArrayIndex(const ReadHandler * const apReadHandler) const;
     /**
      * The Magic number of this InteractionModelEngine, the magic number is set during Init()
      */

--- a/src/app/ReadHandler.h
+++ b/src/app/ReadHandler.h
@@ -146,6 +146,12 @@ public:
     NodeId GetInitiatorNodeId() const { return mInitiatorNodeId; }
     FabricIndex GetAccessingFabricIndex() const { return mFabricIndex; }
 
+    void UnblockUrgentEventDelivery()
+    {
+        mHoldReport = false;
+        mDirty      = true;
+    }
+
 private:
     friend class TestReadInteraction;
     enum class HandlerState

--- a/src/app/reporting/Engine.cpp
+++ b/src/app/reporting/Engine.cpp
@@ -571,6 +571,23 @@ void Engine::OnReportConfirm()
     ChipLogDetail(DataManagement, "<RE> OnReportConfirm: NumReports = %" PRIu32, mNumReportsInFlight);
 }
 
+CHIP_ERROR Engine::ScheduleUrgentEventDelivery(ConcreteEventPath & aPath)
+{
+    for (auto & handler : InteractionModelEngine::GetInstance()->mReadHandlers)
+    {
+        for (auto clusterInfo = handler.GetEventClusterInfolist(); clusterInfo != nullptr; clusterInfo = clusterInfo->mpNext)
+        {
+            if (clusterInfo->IsEventPathSupersetOf(aPath))
+            {
+                ChipLogProgress(DataManagement, "<RE> Unblock Urgent Event Delivery for readHandler[%d]",
+                                InteractionModelEngine::GetInstance()->GetReadHandlerArrayIndex(&handler));
+                handler.UnblockUrgentEventDelivery();
+            }
+        }
+    }
+    return ScheduleRun();
+}
+
 }; // namespace reporting
 } // namespace app
 } // namespace chip

--- a/src/app/reporting/Engine.h
+++ b/src/app/reporting/Engine.h
@@ -88,6 +88,13 @@ public:
      */
     CHIP_ERROR SetDirty(ClusterInfo & aClusterInfo);
 
+    /**
+     * @brief
+     *  Schedule the urgent event delivery
+     *
+     */
+    CHIP_ERROR ScheduleUrgentEventDelivery(ConcreteEventPath & aPath);
+
 private:
     friend class TestReportingEngine;
     /**


### PR DESCRIPTION
#### Problem
IM Event has urgent option which means event needs to be sent via report immediately, add this support in report engine and event management.
#### Change overview
see above

#### Testing
Update the subscription test to check if the corresponding handler is dirty and report can be sent immediately without block when interested urgent event has been generated.
