### PR TITLE
[placeholder] Enable SetRegulatoryConfig command

### DIFF
--- a/examples/placeholder/linux/apps/app1/config.zap
+++ b/examples/placeholder/linux/apps/app1/config.zap
@@ -407,6 +407,14 @@
               "outgoing": 0
             },
             {
+              "name": "SetRegulatoryConfig",
+              "code": 2,
+              "mfgCode": null,
+              "source": "client",
+              "incoming": 1,
+              "outgoing": 0
+            },
+            {
               "name": "CommissioningComplete",
               "code": 4,
               "mfgCode": null,
@@ -444,6 +452,14 @@
             {
               "name": "ArmFailSafeResponse",
               "code": 1,
+              "mfgCode": null,
+              "source": "server",
+              "incoming": 0,
+              "outgoing": 1
+            },
+            {
+              "name": "SetRegulatoryConfigResponse",
+              "code": 3,
               "mfgCode": null,
               "source": "server",
               "incoming": 0,

--- a/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
@@ -46,10 +46,12 @@ limitations under the License.
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
+            <include cluster="General Commissioning" client="false" server="true" clientLocked="true" serverLocked="true">
+                <requireCommand>SetRegulatoryConfig</requireCommand>
+            </include>
             <include cluster="Power Source Configuration" client="false" server="false" clientLocked="true" serverLocked="false"></include>
             <include cluster="Time Synchronization" client="false" server="false" clientLocked="true" serverLocked="false"></include>
             <include cluster="Group Key Management" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="General Commissioning" client="false" server="true" clientLocked="true" serverLocked="true"></include>
             <include cluster="Network Commissioning" client="false" server="true" clientLocked="true" serverLocked="true"></include>
             <include cluster="AdministratorCommissioning" client="false" server="true" clientLocked="true" serverLocked="true"></include>
             <include cluster="Operational Credentials" client="false" server="true" clientLocked="true" serverLocked="true"></include>

--- a/zzz_generated/placeholder/app1/zap-generated/IMClusterCommandHandler.cpp
+++ b/zzz_generated/placeholder/app1/zap-generated/IMClusterCommandHandler.cpp
@@ -138,6 +138,15 @@ void DispatchServerCommand(CommandHandler * apCommandObj, const ConcreteCommandP
             }
             break;
         }
+        case Commands::SetRegulatoryConfig::Id: {
+            Commands::SetRegulatoryConfig::DecodableType commandData;
+            TLVError = DataModel::Decode(aDataTlv, commandData);
+            if (TLVError == CHIP_NO_ERROR)
+            {
+                wasHandled = emberAfGeneralCommissioningClusterSetRegulatoryConfigCallback(apCommandObj, aCommandPath, commandData);
+            }
+            break;
+        }
         default: {
             // Unrecognized command ID, error status will apply.
             ReportCommandUnsupported(apCommandObj, aCommandPath);


### PR DESCRIPTION
#### Problem

`chip-tool` can not connect to `examples/placeholder/linux/apps/app1` because of missing support for `SetRegulatoryConfig` command.

#### Change overview
* Enable `SetRegulatoryConfig` into `examples/placeholder/linux/apps/app1/config.zap`
* Update generated code

#### Testing
I have used `chip-tool` locally to commission the simulated node.