### PR TITLE
Add a ResolveProxy class to keep track of which controller is issuing…

### DIFF
--- a/src/app/CASESessionManager.cpp
+++ b/src/app/CASESessionManager.cpp
@@ -53,7 +53,7 @@ CHIP_ERROR CASESessionManager::FindOrEstablishSession(NodeId nodeId, Callback::C
         session->OnNodeIdResolved(resolutionData);
     }
 
-    CHIP_ERROR err = session->Connect(onConnection, onFailure);
+    CHIP_ERROR err = session->Connect(onConnection, onFailure, mConfig.dnsResolver);
     if (err != CHIP_NO_ERROR)
     {
         ReleaseSession(session);
@@ -69,8 +69,8 @@ void CASESessionManager::ReleaseSession(NodeId nodeId)
 
 CHIP_ERROR CASESessionManager::ResolveDeviceAddress(NodeId nodeId)
 {
-    return Dnssd::Resolver::Instance().ResolveNodeId(GetFabricInfo()->GetPeerIdForNode(nodeId), Inet::IPAddressType::kAny,
-                                                     Dnssd::Resolver::CacheBypass::On);
+    return mConfig.dnsResolver->ResolveNodeId(GetFabricInfo()->GetPeerIdForNode(nodeId), Inet::IPAddressType::kAny,
+                                              Dnssd::Resolver::CacheBypass::On);
 }
 
 void CASESessionManager::OnNodeIdResolved(const Dnssd::ResolvedNodeData & nodeData)

--- a/src/app/CASESessionManager.h
+++ b/src/app/CASESessionManager.h
@@ -27,7 +27,7 @@
 #include <lib/support/Pool.h>
 #include <transport/SessionDelegate.h>
 
-#include <lib/dnssd/Resolver.h>
+#include <lib/dnssd/ResolverProxy.h>
 
 namespace chip {
 
@@ -36,6 +36,7 @@ struct CASESessionManagerConfig
     DeviceProxyInitParams sessionInitParams;
     Dnssd::DnssdCache<CHIP_CONFIG_MDNS_CACHE_SIZE> * dnsCache = nullptr;
     OperationalDeviceProxyPoolDelegate * devicePool           = nullptr;
+    Dnssd::ResolverProxy * dnsResolver                        = nullptr;
 };
 
 /**

--- a/src/app/OperationalDeviceProxy.cpp
+++ b/src/app/OperationalDeviceProxy.cpp
@@ -43,7 +43,8 @@ using namespace chip::Callback;
 namespace chip {
 
 CHIP_ERROR OperationalDeviceProxy::Connect(Callback::Callback<OnDeviceConnected> * onConnection,
-                                           Callback::Callback<OnDeviceConnectionFailure> * onFailure)
+                                           Callback::Callback<OnDeviceConnectionFailure> * onFailure,
+                                           Dnssd::ResolverProxy * resolver)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
@@ -54,7 +55,8 @@ CHIP_ERROR OperationalDeviceProxy::Connect(Callback::Callback<OnDeviceConnected>
         break;
 
     case State::NeedsAddress:
-        err = Dnssd::Resolver::Instance().ResolveNodeId(mPeerId, chip::Inet::IPAddressType::kAny);
+        VerifyOrReturnError(resolver != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+        err = resolver->ResolveNodeId(mPeerId, chip::Inet::IPAddressType::kAny);
         EnqueueConnectionCallbacks(onConnection, onFailure);
         break;
 

--- a/src/app/OperationalDeviceProxy.h
+++ b/src/app/OperationalDeviceProxy.h
@@ -43,7 +43,7 @@
 #include <transport/raw/MessageHeader.h>
 #include <transport/raw/UDP.h>
 
-#include <lib/dnssd/Resolver.h>
+#include <lib/dnssd/ResolverProxy.h>
 
 namespace chip {
 
@@ -109,9 +109,11 @@ public:
      * session setup fails, `onFailure` will be called.
      *
      * If the session already exists, `onConnection` will be called immediately.
+     * If the resolver is null and the device state is State::NeedsAddress, CHIP_ERROR_INVALID_ARGUMENT will be
+     * returned.
      */
     CHIP_ERROR Connect(Callback::Callback<OnDeviceConnected> * onConnection,
-                       Callback::Callback<OnDeviceConnectionFailure> * onFailure);
+                       Callback::Callback<OnDeviceConnectionFailure> * onFailure, Dnssd::ResolverProxy * resolver);
 
     bool IsConnected() const { return mState == State::SecureConnected; }
 

--- a/src/app/clusters/ota-requestor/OTARequestor.cpp
+++ b/src/app/clusters/ota-requestor/OTARequestor.cpp
@@ -235,6 +235,7 @@ CHIP_ERROR OTARequestor::SetupCASESessionManager(FabricIndex fabricIndex)
             .sessionInitParams = initParams,
             .dnsCache          = nullptr,
             .devicePool        = mServer->GetDevicePool(),
+            .dnsResolver       = nullptr,
         };
 
         mCASESessionManager = Platform::New<CASESessionManager>(sessionManagerConfig);

--- a/src/controller/AbstractDnssdDiscoveryController.cpp
+++ b/src/controller/AbstractDnssdDiscoveryController.cpp
@@ -19,10 +19,6 @@
 // module header, comes first
 #include <controller/AbstractDnssdDiscoveryController.h>
 
-#if CONFIG_DEVICE_LAYER
-#include <platform/CHIPDeviceLayer.h>
-#endif
-
 #include <lib/core/CHIPEncoding.h>
 #include <lib/support/logging/CHIPLogging.h>
 
@@ -66,11 +62,6 @@ void AbstractDnssdDiscoveryController::OnNodeDiscoveryComplete(const chip::Dnssd
 
 CHIP_ERROR AbstractDnssdDiscoveryController::SetUpNodeDiscovery()
 {
-#if CONFIG_DEVICE_LAYER
-    ReturnErrorOnFailure(mResolver->Init(&DeviceLayer::InetLayer()));
-#endif
-    mResolver->SetResolverDelegate(this);
-
     auto discoveredNodes = GetDiscoveredNodes();
     for (auto & discoveredNode : discoveredNodes)
     {

--- a/src/controller/AbstractDnssdDiscoveryController.h
+++ b/src/controller/AbstractDnssdDiscoveryController.h
@@ -19,7 +19,7 @@
 #pragma once
 
 #include <controller/DeviceDiscoveryDelegate.h>
-#include <lib/dnssd/Resolver.h>
+#include <lib/dnssd/ResolverProxy.h>
 #include <lib/support/Span.h>
 #include <platform/CHIPDeviceConfig.h>
 
@@ -39,11 +39,7 @@ namespace Controller {
 class DLL_EXPORT AbstractDnssdDiscoveryController : public Dnssd::ResolverDelegate
 {
 public:
-    AbstractDnssdDiscoveryController(chip::Dnssd::Resolver * resolver = &chip::Dnssd::Resolver::Instance())
-    {
-        mResolver = resolver;
-    }
-
+    AbstractDnssdDiscoveryController() {}
     virtual ~AbstractDnssdDiscoveryController() {}
 
     void OnNodeDiscoveryComplete(const chip::Dnssd::DiscoveredNodeData & nodeData) override;
@@ -52,9 +48,9 @@ protected:
     using DiscoveredNodeList = FixedSpan<Dnssd::DiscoveredNodeData, CHIP_DEVICE_CONFIG_MAX_DISCOVERED_NODES>;
     CHIP_ERROR SetUpNodeDiscovery();
     const Dnssd::DiscoveredNodeData * GetDiscoveredNode(int idx);
-    virtual DiscoveredNodeList GetDiscoveredNodes() = 0;
-    chip::Dnssd::Resolver * mResolver;
+    virtual DiscoveredNodeList GetDiscoveredNodes()    = 0;
     DeviceDiscoveryDelegate * mDeviceDiscoveryDelegate = nullptr;
+    Dnssd::ResolverProxy mDNSResolver{ this };
 };
 
 } // namespace Controller

--- a/src/controller/AbstractDnssdDiscoveryController.h
+++ b/src/controller/AbstractDnssdDiscoveryController.h
@@ -50,7 +50,7 @@ protected:
     const Dnssd::DiscoveredNodeData * GetDiscoveredNode(int idx);
     virtual DiscoveredNodeList GetDiscoveredNodes()    = 0;
     DeviceDiscoveryDelegate * mDeviceDiscoveryDelegate = nullptr;
-    Dnssd::ResolverProxy mDNSResolver{ this };
+    Dnssd::ResolverProxy mDNSResolver;
 };
 
 } // namespace Controller

--- a/src/controller/CHIPCommissionableNodeController.cpp
+++ b/src/controller/CHIPCommissionableNodeController.cpp
@@ -19,6 +19,10 @@
 // module header, comes first
 #include <controller/CHIPCommissionableNodeController.h>
 
+#if CONFIG_DEVICE_LAYER
+#include <platform/CHIPDeviceLayer.h>
+#endif
+
 #include <lib/support/CodeUtils.h>
 
 namespace chip {
@@ -27,7 +31,18 @@ namespace Controller {
 CHIP_ERROR CommissionableNodeController::DiscoverCommissioners(Dnssd::DiscoveryFilter discoveryFilter)
 {
     ReturnErrorOnFailure(SetUpNodeDiscovery());
-    return mResolver->FindCommissioners(discoveryFilter);
+
+    if (mResolver == nullptr)
+    {
+        return mDNSResolver.FindCommissioners(discoveryFilter);
+    }
+    else
+    {
+#if CONFIG_DEVICE_LAYER
+        ReturnErrorOnFailure(mResolver->Init(&DeviceLayer::InetLayer()));
+#endif
+        return mResolver->FindCommissioners(discoveryFilter);
+    }
 }
 
 const Dnssd::DiscoveredNodeData * CommissionableNodeController::GetDiscoveredCommissioner(int idx)

--- a/src/controller/CHIPCommissionableNodeController.cpp
+++ b/src/controller/CHIPCommissionableNodeController.cpp
@@ -34,6 +34,10 @@ CHIP_ERROR CommissionableNodeController::DiscoverCommissioners(Dnssd::DiscoveryF
 
     if (mResolver == nullptr)
     {
+#if CONFIG_DEVICE_LAYER
+        ReturnErrorOnFailure(mDNSResolver.Init(&DeviceLayer::InetLayer()));
+#endif
+        mDNSResolver.SetResolverDelegate(this);
         return mDNSResolver.FindCommissioners(discoveryFilter);
     }
     else

--- a/src/controller/CHIPCommissionableNodeController.h
+++ b/src/controller/CHIPCommissionableNodeController.h
@@ -19,7 +19,6 @@
 #pragma once
 
 #include <controller/AbstractDnssdDiscoveryController.h>
-#include <lib/dnssd/Resolver.h>
 #include <lib/support/logging/CHIPLogging.h>
 #include <platform/CHIPDeviceConfig.h>
 
@@ -37,8 +36,7 @@ namespace Controller {
 class DLL_EXPORT CommissionableNodeController : public AbstractDnssdDiscoveryController
 {
 public:
-    CommissionableNodeController(chip::Dnssd::Resolver * resolver = &chip::Dnssd::Resolver::Instance()) :
-        AbstractDnssdDiscoveryController(resolver){};
+    CommissionableNodeController(chip::Dnssd::Resolver * resolver = nullptr) : mResolver(resolver) {}
     virtual ~CommissionableNodeController() {}
 
     CHIP_ERROR DiscoverCommissioners(Dnssd::DiscoveryFilter discoveryFilter = Dnssd::DiscoveryFilter());
@@ -66,6 +64,7 @@ protected:
     DiscoveredNodeList GetDiscoveredNodes() override { return DiscoveredNodeList(mDiscoveredCommissioners); }
 
 private:
+    Dnssd::Resolver * mResolver = nullptr;
     Dnssd::DiscoveredNodeData mDiscoveredCommissioners[CHIP_DEVICE_CONFIG_MAX_DISCOVERED_NODES];
 };
 

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -45,7 +45,6 @@
 
 #include <app/InteractionModelEngine.h>
 #include <app/OperationalDeviceProxy.h>
-#include <app/util/DataModelHandler.h>
 #include <app/util/error-mapping.h>
 #include <credentials/CHIPCert.h>
 #include <credentials/DeviceAttestationCredsProvider.h>
@@ -132,13 +131,10 @@ CHIP_ERROR DeviceController::Init(ControllerInitParams params)
     VerifyOrReturnError(params.systemState->TransportMgr() != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
 
 #if CHIP_DEVICE_CONFIG_ENABLE_DNSSD
-    Dnssd::Resolver::Instance().Init(params.systemState->InetLayer());
-    Dnssd::Resolver::Instance().SetResolverDelegate(this);
+    mDNSResolver.Init();
     RegisterDeviceAddressUpdateDelegate(params.deviceAddressUpdateDelegate);
     RegisterDeviceDiscoveryDelegate(params.deviceDiscoveryDelegate);
 #endif // CHIP_DEVICE_CONFIG_ENABLE_DNSSD
-
-    InitDataModelHandler(params.systemState->ExchangeMgr());
 
     VerifyOrReturnError(params.operationalCredentialsDelegate != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     mOperationalCredentialsDelegate = params.operationalCredentialsDelegate;
@@ -160,6 +156,11 @@ CHIP_ERROR DeviceController::Init(ControllerInitParams params)
         .sessionInitParams = deviceInitParams,
         .dnsCache          = &mDNSCache,
         .devicePool        = &mDevicePool,
+#if CHIP_DEVICE_CONFIG_ENABLE_DNSSD
+        .dnsResolver = &mDNSResolver,
+#else
+        .dnsResolver = nullptr,
+#endif
     };
 
     mCASESessionManager = chip::Platform::New<CASESessionManager>(sessionManagerConfig);
@@ -227,10 +228,6 @@ CHIP_ERROR DeviceController::Shutdown()
 
     mState = State::NotInitialized;
 
-#if CHIP_DEVICE_CONFIG_ENABLE_DNSSD
-    Dnssd::Resolver::Instance().Shutdown();
-#endif // CHIP_DEVICE_CONFIG_ENABLE_DNSSD
-
     mStorageDelegate = nullptr;
 
     mSystemState->Fabrics()->ReleaseFabricIndex(mFabricIndex);
@@ -238,7 +235,7 @@ CHIP_ERROR DeviceController::Shutdown()
     mSystemState = nullptr;
 
 #if CHIP_DEVICE_CONFIG_ENABLE_DNSSD
-    Dnssd::Resolver::Instance().SetResolverDelegate(nullptr);
+    mDNSResolver.Shutdown();
     mDeviceAddressUpdateDelegate = nullptr;
     mDeviceDiscoveryDelegate     = nullptr;
 #endif // CHIP_DEVICE_CONFIG_ENABLE_DNSSD
@@ -1571,7 +1568,7 @@ void DeviceCommissioner::OnSessionEstablishmentTimeoutCallback(System::Layer * a
 CHIP_ERROR DeviceCommissioner::DiscoverCommissionableNodes(Dnssd::DiscoveryFilter filter)
 {
     ReturnErrorOnFailure(SetUpNodeDiscovery());
-    return chip::Dnssd::Resolver::Instance().FindCommissionableNodes(filter);
+    return mDNSResolver.FindCommissionableNodes(filter);
 }
 
 const Dnssd::DiscoveredNodeData * DeviceCommissioner::GetDiscoveredDevice(int idx)
@@ -1837,7 +1834,7 @@ void DeviceCommissioner::AdvanceCommissioningStage(CHIP_ERROR err)
 #if CONFIG_DEVICE_LAYER
         status = DeviceLayer::ConfigurationMgr().GetCountryCode(countryCodeStr, kMaxCountryCodeSize, actualCountryCodeSize);
 #else
-        status            = CHIP_ERROR_NOT_IMPLEMENTED;
+        status = CHIP_ERROR_NOT_IMPLEMENTED;
 #endif
         if (status != CHIP_NO_ERROR)
         {
@@ -1894,7 +1891,7 @@ void DeviceCommissioner::AdvanceCommissioningStage(CHIP_ERROR err)
         RendezvousCleanup(CHIP_NO_ERROR);
 #if CHIP_DEVICE_CONFIG_ENABLE_DNSSD
         ChipLogProgress(Controller, "Finding node on operational network");
-        Dnssd::Resolver::Instance().ResolveNodeId(peerId, Inet::IPAddressType::kAny);
+        mDNSResolver.ResolveNodeId(peerId, Inet::IPAddressType::kAny);
 #endif
     }
     break;

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -131,7 +131,8 @@ CHIP_ERROR DeviceController::Init(ControllerInitParams params)
     VerifyOrReturnError(params.systemState->TransportMgr() != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
 
 #if CHIP_DEVICE_CONFIG_ENABLE_DNSSD
-    mDNSResolver.Init();
+    ReturnErrorOnFailure(mDNSResolver.Init(params.systemState->InetLayer()));
+    mDNSResolver.SetResolverDelegate(this);
     RegisterDeviceAddressUpdateDelegate(params.deviceAddressUpdateDelegate);
     RegisterDeviceDiscoveryDelegate(params.deviceDiscoveryDelegate);
 #endif // CHIP_DEVICE_CONFIG_ENABLE_DNSSD

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -72,6 +72,7 @@
 #include <controller/DeviceAddressUpdateDelegate.h>
 #include <controller/DeviceDiscoveryDelegate.h>
 #include <lib/dnssd/Resolver.h>
+#include <lib/dnssd/ResolverProxy.h>
 #endif
 
 namespace chip {

--- a/src/controller/tests/TestCommissionableNodeController.cpp
+++ b/src/controller/tests/TestCommissionableNodeController.cpp
@@ -180,9 +180,26 @@ const nlTest sTests[] =
 
 } // namespace
 
+int TestCommissionableNodeController_Setup(void * inContext)
+{
+    if (CHIP_NO_ERROR != chip::Platform::MemoryInit())
+    {
+        return FAILURE;
+    }
+
+    return SUCCESS;
+}
+
+int TestCommissionableNodeController_Teardown(void * inContext)
+{
+    chip::Platform::MemoryShutdown();
+    return SUCCESS;
+}
+
 int TestCommissionableNodeController()
 {
-    nlTestSuite theSuite = { "CommissionableNodeController", &sTests[0], NULL, NULL };
+    nlTestSuite theSuite = { "CommissionableNodeController", &sTests[0], TestCommissionableNodeController_Setup,
+                             TestCommissionableNodeController_Teardown };
     nlTestRunner(&theSuite, nullptr);
     return nlTestRunnerStats(&theSuite);
 }

--- a/src/lib/dnssd/Discovery_ImplPlatform.cpp
+++ b/src/lib/dnssd/Discovery_ImplPlatform.cpp
@@ -36,10 +36,94 @@
 namespace chip {
 namespace Dnssd {
 
-DiscoveryImplPlatform DiscoveryImplPlatform::sManager;
+namespace {
+
 #if CHIP_CONFIG_MDNS_CACHE_SIZE > 0
-DnssdCache<CHIP_CONFIG_MDNS_CACHE_SIZE> DiscoveryImplPlatform::sDnssdCache;
+static DnssdCache<CHIP_CONFIG_MDNS_CACHE_SIZE> sDnssdCache;
 #endif
+
+static void HandleNodeResolve(void * context, DnssdService * result, CHIP_ERROR error)
+{
+    VerifyOrReturn(CHIP_NO_ERROR == error);
+
+    DiscoveredNodeData nodeData;
+    Platform::CopyString(nodeData.hostName, result->mHostName);
+    Platform::CopyString(nodeData.instanceName, result->mName);
+
+    if (result->mAddress.HasValue() && nodeData.numIPs < DiscoveredNodeData::kMaxIPAddresses)
+    {
+        nodeData.ipAddress[nodeData.numIPs]   = result->mAddress.Value();
+        nodeData.interfaceId[nodeData.numIPs] = result->mInterface;
+        nodeData.numIPs++;
+    }
+
+    nodeData.port = result->mPort;
+
+    for (size_t i = 0; i < result->mTextEntrySize; ++i)
+    {
+        ByteSpan key(reinterpret_cast<const uint8_t *>(result->mTextEntries[i].mKey), strlen(result->mTextEntries[i].mKey));
+        ByteSpan val(result->mTextEntries[i].mData, result->mTextEntries[i].mDataSize);
+        FillNodeDataFromTxt(key, val, nodeData);
+    }
+
+    ResolverProxy * proxy = static_cast<ResolverProxy *>(context);
+    proxy->OnNodeDiscoveryComplete(nodeData);
+}
+
+static void HandleNodeIdResolve(void * context, DnssdService * result, CHIP_ERROR error)
+{
+    ResolverProxy * proxy = static_cast<ResolverProxy *>(context);
+    VerifyOrReturn(CHIP_NO_ERROR == error, proxy->OnNodeIdResolutionFailed(PeerId(), error));
+    VerifyOrReturn(result != nullptr, proxy->OnNodeIdResolutionFailed(PeerId(), CHIP_ERROR_UNKNOWN_RESOURCE_ID));
+
+    PeerId peerId;
+    VerifyOrReturn(CHIP_NO_ERROR == ExtractIdFromInstanceName(result->mName, &peerId),
+                   proxy->OnNodeIdResolutionFailed(PeerId(), error));
+
+    ResolvedNodeData nodeData;
+    Platform::CopyString(nodeData.mHostName, result->mHostName);
+    nodeData.mInterfaceId = result->mInterface;
+    nodeData.mAddress[0]  = result->mAddress.ValueOr({});
+    nodeData.mPort        = result->mPort;
+    nodeData.mNumIPs      = 1;
+    nodeData.mPeerId      = peerId;
+    // TODO: Use seconds?
+    const System::Clock::Timestamp currentTime = System::SystemClock().GetMonotonicTimestamp();
+
+    nodeData.mExpiryTime = currentTime + System::Clock::Seconds16(result->mTtlSeconds);
+
+    for (size_t i = 0; i < result->mTextEntrySize; ++i)
+    {
+        ByteSpan key(reinterpret_cast<const uint8_t *>(result->mTextEntries[i].mKey), strlen(result->mTextEntries[i].mKey));
+        ByteSpan val(result->mTextEntries[i].mData, result->mTextEntries[i].mDataSize);
+        FillNodeDataFromTxt(key, val, nodeData);
+    }
+
+    nodeData.LogNodeIdResolved();
+#if CHIP_CONFIG_MDNS_CACHE_SIZE > 0
+    LogErrorOnFailure(sDnssdCache.Insert(nodeData));
+#endif
+    proxy->OnNodeIdResolved(nodeData);
+}
+
+static void HandleNodeBrowse(void * context, DnssdService * services, size_t servicesSize, CHIP_ERROR error)
+{
+    for (size_t i = 0; i < servicesSize; ++i)
+    {
+        // For some platforms browsed services are already resolved, so verify if resolve is really needed or call resolve callback
+        if (!services[i].mAddress.HasValue())
+        {
+            ChipDnssdResolve(&services[i], services[i].mInterface, HandleNodeResolve, context);
+        }
+        else
+        {
+            HandleNodeResolve(context, &services[i], error);
+        }
+    }
+}
+} // namespace
+
+DiscoveryImplPlatform DiscoveryImplPlatform::sManager;
 
 DiscoveryImplPlatform::DiscoveryImplPlatform() = default;
 
@@ -460,6 +544,39 @@ CHIP_ERROR DiscoveryImplPlatform::ResolveNodeId(const PeerId & peerId, Inet::IPA
                                                 Resolver::CacheBypass dnssdCacheBypass)
 {
     ReturnErrorOnFailure(InitImpl());
+    return mResolverProxy.ResolveNodeId(peerId, type, dnssdCacheBypass);
+}
+
+CHIP_ERROR DiscoveryImplPlatform::FindCommissionableNodes(DiscoveryFilter filter)
+{
+    ReturnErrorOnFailure(InitImpl());
+    return mResolverProxy.FindCommissionableNodes(filter);
+}
+
+CHIP_ERROR DiscoveryImplPlatform::FindCommissioners(DiscoveryFilter filter)
+{
+    ReturnErrorOnFailure(InitImpl());
+    return mResolverProxy.FindCommissioners(filter);
+}
+
+DiscoveryImplPlatform & DiscoveryImplPlatform::GetInstance()
+{
+    return sManager;
+}
+
+ServiceAdvertiser & chip::Dnssd::ServiceAdvertiser::Instance()
+{
+    return DiscoveryImplPlatform::GetInstance();
+}
+
+Resolver & chip::Dnssd::Resolver::Instance()
+{
+    return DiscoveryImplPlatform::GetInstance();
+}
+
+CHIP_ERROR ResolverProxy::ResolveNodeId(const PeerId & peerId, Inet::IPAddressType type, Resolver::CacheBypass dnssdCacheBypass)
+{
+    ReturnErrorOnFailure(chip::Dnssd::Resolver::Instance().Init(nullptr));
 
 #if CHIP_CONFIG_MDNS_CACHE_SIZE > 0
     if (dnssdCacheBypass == Resolver::CacheBypass::Off)
@@ -483,54 +600,10 @@ CHIP_ERROR DiscoveryImplPlatform::ResolveNodeId(const PeerId & peerId, Inet::IPA
     return ChipDnssdResolve(&service, Inet::InterfaceId::Null(), HandleNodeIdResolve, this);
 }
 
-void DiscoveryImplPlatform::HandleNodeBrowse(void * context, DnssdService * services, size_t servicesSize, CHIP_ERROR error)
+CHIP_ERROR ResolverProxy::FindCommissionableNodes(DiscoveryFilter filter)
 {
-    for (size_t i = 0; i < servicesSize; ++i)
-    {
-        // For some platforms browsed services are already resolved, so verify if resolve is really needed or call resolve callback
-        if (!services[i].mAddress.HasValue())
-        {
-            ChipDnssdResolve(&services[i], services[i].mInterface, HandleNodeResolve, context);
-        }
-        else
-        {
-            HandleNodeResolve(context, &services[i], error);
-        }
-    }
-}
+    ReturnErrorOnFailure(chip::Dnssd::Resolver::Instance().Init(nullptr));
 
-void DiscoveryImplPlatform::HandleNodeResolve(void * context, DnssdService * result, CHIP_ERROR error)
-{
-    if (error != CHIP_NO_ERROR)
-    {
-        return;
-    }
-    DiscoveryImplPlatform * mgr = static_cast<DiscoveryImplPlatform *>(context);
-    DiscoveredNodeData data;
-    Platform::CopyString(data.hostName, result->mHostName);
-    Platform::CopyString(data.instanceName, result->mName);
-
-    if (result->mAddress.HasValue() && data.numIPs < DiscoveredNodeData::kMaxIPAddresses)
-    {
-        data.ipAddress[data.numIPs]   = result->mAddress.Value();
-        data.interfaceId[data.numIPs] = result->mInterface;
-        data.numIPs++;
-    }
-
-    data.port = result->mPort;
-
-    for (size_t i = 0; i < result->mTextEntrySize; ++i)
-    {
-        ByteSpan key(reinterpret_cast<const uint8_t *>(result->mTextEntries[i].mKey), strlen(result->mTextEntries[i].mKey));
-        ByteSpan val(result->mTextEntries[i].mData, result->mTextEntries[i].mDataSize);
-        FillNodeDataFromTxt(key, val, data);
-    }
-    mgr->mResolverDelegate->OnNodeDiscoveryComplete(data);
-}
-
-CHIP_ERROR DiscoveryImplPlatform::FindCommissionableNodes(DiscoveryFilter filter)
-{
-    ReturnErrorOnFailure(InitImpl());
     char serviceName[kMaxCommissionableServiceNameSize];
     ReturnErrorOnFailure(MakeServiceTypeName(serviceName, sizeof(serviceName), filter, DiscoveryType::kCommissionableNode));
 
@@ -538,92 +611,15 @@ CHIP_ERROR DiscoveryImplPlatform::FindCommissionableNodes(DiscoveryFilter filter
                            Inet::InterfaceId::Null(), HandleNodeBrowse, this);
 }
 
-CHIP_ERROR DiscoveryImplPlatform::FindCommissioners(DiscoveryFilter filter)
+CHIP_ERROR ResolverProxy::FindCommissioners(DiscoveryFilter filter)
 {
-    ReturnErrorOnFailure(InitImpl());
+    ReturnErrorOnFailure(chip::Dnssd::Resolver::Instance().Init(nullptr));
+
     char serviceName[kMaxCommissionerServiceNameSize];
     ReturnErrorOnFailure(MakeServiceTypeName(serviceName, sizeof(serviceName), filter, DiscoveryType::kCommissionerNode));
 
     return ChipDnssdBrowse(serviceName, DnssdServiceProtocol::kDnssdProtocolUdp, Inet::IPAddressType::kAny,
                            Inet::InterfaceId::Null(), HandleNodeBrowse, this);
-}
-
-void DiscoveryImplPlatform::HandleNodeIdResolve(void * context, DnssdService * result, CHIP_ERROR error)
-{
-    DiscoveryImplPlatform * mgr = static_cast<DiscoveryImplPlatform *>(context);
-
-    if (mgr->mResolverDelegate == nullptr)
-    {
-        return;
-    }
-
-    if (error != CHIP_NO_ERROR)
-    {
-        ChipLogError(Discovery, "Node ID resolved failed with %s", chip::ErrorStr(error));
-        mgr->mResolverDelegate->OnNodeIdResolutionFailed(PeerId(), error);
-        return;
-    }
-
-    if (result == nullptr)
-    {
-        ChipLogError(Discovery, "Node ID resolve not found");
-        mgr->mResolverDelegate->OnNodeIdResolutionFailed(PeerId(), CHIP_ERROR_UNKNOWN_RESOURCE_ID);
-        return;
-    }
-
-    ResolvedNodeData nodeData;
-
-    error = ExtractIdFromInstanceName(result->mName, &nodeData.mPeerId);
-    if (error != CHIP_NO_ERROR)
-    {
-        ChipLogError(Discovery, "Node ID resolved failed with %s", chip::ErrorStr(error));
-        mgr->mResolverDelegate->OnNodeIdResolutionFailed(PeerId(), error);
-        return;
-    }
-
-    // TODO: Expand the results to include all the addresses.
-    Platform::CopyString(nodeData.mHostName, result->mHostName);
-    nodeData.mInterfaceId = result->mInterface;
-    nodeData.mAddress[0]  = result->mAddress.ValueOr({});
-    nodeData.mPort        = result->mPort;
-    nodeData.mNumIPs      = 1;
-    // TODO: Use seconds?
-    const System::Clock::Timestamp currentTime = System::SystemClock().GetMonotonicTimestamp();
-
-    nodeData.mExpiryTime = currentTime + System::Clock::Seconds16(result->mTtlSeconds);
-
-    for (size_t i = 0; i < result->mTextEntrySize; ++i)
-    {
-        ByteSpan key(reinterpret_cast<const uint8_t *>(result->mTextEntries[i].mKey), strlen(result->mTextEntries[i].mKey));
-        ByteSpan val(result->mTextEntries[i].mData, result->mTextEntries[i].mDataSize);
-        FillNodeDataFromTxt(key, val, nodeData);
-    }
-
-    nodeData.LogNodeIdResolved();
-#if CHIP_CONFIG_MDNS_CACHE_SIZE > 0
-    error = mgr->sDnssdCache.Insert(nodeData);
-
-    if (CHIP_NO_ERROR != error)
-    {
-        ChipLogError(Discovery, "DnssdCache insert failed with %s", chip::ErrorStr(error));
-    }
-#endif
-    mgr->mResolverDelegate->OnNodeIdResolved(nodeData);
-}
-
-DiscoveryImplPlatform & DiscoveryImplPlatform::GetInstance()
-{
-    return sManager;
-}
-
-ServiceAdvertiser & chip::Dnssd::ServiceAdvertiser::Instance()
-{
-    return DiscoveryImplPlatform::GetInstance();
-}
-
-Resolver & chip::Dnssd::Resolver::Instance()
-{
-    return DiscoveryImplPlatform::GetInstance();
 }
 
 } // namespace Dnssd

--- a/src/lib/dnssd/Discovery_ImplPlatform.h
+++ b/src/lib/dnssd/Discovery_ImplPlatform.h
@@ -23,6 +23,7 @@
 #include <lib/dnssd/Advertiser.h>
 #include <lib/dnssd/DnssdCache.h>
 #include <lib/dnssd/Resolver.h>
+#include <lib/dnssd/ResolverProxy.h>
 #include <lib/dnssd/platform/Dnssd.h>
 #include <platform/CHIPDeviceConfig.h>
 
@@ -48,7 +49,7 @@ public:
     CHIP_ERROR GetCommissionableInstanceName(char * instanceName, size_t maxLength) override;
 
     // Members that implement Resolver interface.
-    void SetResolverDelegate(ResolverDelegate * delegate) override { mResolverDelegate = delegate; }
+    void SetResolverDelegate(ResolverDelegate * delegate) override { mResolverProxy.SetResolverDelegate(delegate); }
     CHIP_ERROR ResolveNodeId(const PeerId & peerId, Inet::IPAddressType type, Resolver::CacheBypass dnssdCacheBypass) override;
     CHIP_ERROR FindCommissionableNodes(DiscoveryFilter filter = DiscoveryFilter()) override;
     CHIP_ERROR FindCommissioners(DiscoveryFilter filter = DiscoveryFilter()) override;
@@ -65,11 +66,8 @@ private:
     CHIP_ERROR PublishUnprovisionedDevice(chip::Inet::IPAddressType addressType, chip::Inet::InterfaceId interface);
     CHIP_ERROR PublishProvisionedDevice(chip::Inet::IPAddressType addressType, chip::Inet::InterfaceId interface);
 
-    static void HandleNodeIdResolve(void * context, DnssdService * result, CHIP_ERROR error);
     static void HandleDnssdInit(void * context, CHIP_ERROR initError);
     static void HandleDnssdError(void * context, CHIP_ERROR initError);
-    static void HandleNodeBrowse(void * context, DnssdService * services, size_t servicesSize, CHIP_ERROR error);
-    static void HandleNodeResolve(void * context, DnssdService * result, CHIP_ERROR error);
     static CHIP_ERROR GenerateRotatingDeviceId(char rotatingDeviceIdHexBuffer[], size_t & rotatingDeviceIdHexBufferSize);
 #ifdef DETAIL_LOGGING
     static void PrintEntries(const DnssdService * service);
@@ -83,13 +81,11 @@ private:
     bool mIsCommissionerPublishing       = false;
     uint8_t mCommissionableInstanceName[sizeof(uint64_t)];
 
-    bool mDnssdInitialized               = false;
-    ResolverDelegate * mResolverDelegate = nullptr;
+    bool mDnssdInitialized = false;
+
+    ResolverProxy mResolverProxy;
 
     static DiscoveryImplPlatform sManager;
-#if CHIP_CONFIG_MDNS_CACHE_SIZE > 0
-    static DnssdCache<CHIP_CONFIG_MDNS_CACHE_SIZE> sDnssdCache;
-#endif
 };
 
 } // namespace Dnssd

--- a/src/lib/dnssd/ResolverProxy.h
+++ b/src/lib/dnssd/ResolverProxy.h
@@ -1,0 +1,69 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <lib/dnssd/Resolver.h>
+#include <lib/dnssd/platform/Dnssd.h>
+
+namespace chip {
+namespace Dnssd {
+
+class ResolverProxy : public Resolver, public ResolverDelegate
+{
+public:
+    ResolverProxy() {}
+    ResolverProxy(ResolverDelegate * delegate) : mResolverDelegate(delegate) {}
+
+    // Resolver interface.
+    CHIP_ERROR Init(Inet::InetLayer * = nullptr) override { return CHIP_NO_ERROR; }
+    void Shutdown() override { mResolverDelegate = nullptr; };
+    void SetResolverDelegate(ResolverDelegate * delegate) override { mResolverDelegate = delegate; }
+    CHIP_ERROR ResolveNodeId(const PeerId & peerId, Inet::IPAddressType type,
+                             Resolver::CacheBypass dnssdCacheBypass = CacheBypass::Off) override;
+    CHIP_ERROR FindCommissionableNodes(DiscoveryFilter filter = DiscoveryFilter()) override;
+    CHIP_ERROR FindCommissioners(DiscoveryFilter filter = DiscoveryFilter()) override;
+
+    /// ResolverDelegate interface
+    void OnNodeIdResolved(const ResolvedNodeData & nodeData) override
+    {
+        if (mResolverDelegate != nullptr)
+        {
+            mResolverDelegate->OnNodeIdResolved(nodeData);
+        }
+    }
+    void OnNodeIdResolutionFailed(const PeerId & peerId, CHIP_ERROR error) override
+    {
+        if (mResolverDelegate != nullptr)
+        {
+            mResolverDelegate->OnNodeIdResolutionFailed(peerId, error);
+        }
+    }
+    void OnNodeDiscoveryComplete(const DiscoveredNodeData & nodeData) override
+    {
+        if (mResolverDelegate != nullptr)
+        {
+            mResolverDelegate->OnNodeDiscoveryComplete(nodeData);
+        }
+    }
+
+private:
+    ResolverDelegate * mResolverDelegate = nullptr;
+};
+
+} // namespace Dnssd
+} // namespace chip

--- a/src/lib/dnssd/Resolver_ImplMinimalMdns.cpp
+++ b/src/lib/dnssd/Resolver_ImplMinimalMdns.cpp
@@ -23,6 +23,7 @@
 #include <inet/IPPacketInfo.h>
 #include <lib/core/CHIPConfig.h>
 #include <lib/dnssd/MinimalMdnsServer.h>
+#include <lib/dnssd/ResolverProxy.h>
 #include <lib/dnssd/ServiceNaming.h>
 #include <lib/dnssd/TxtFields.h>
 #include <lib/dnssd/minimal_mdns/ActiveResolveAttempts.h>
@@ -596,6 +597,24 @@ MinMdnsResolver gResolver;
 Resolver & chip::Dnssd::Resolver::Instance()
 {
     return gResolver;
+}
+
+CHIP_ERROR ResolverProxy::ResolveNodeId(const PeerId & peerId, Inet::IPAddressType type, Resolver::CacheBypass dnssdCacheBypass)
+{
+    chip::Dnssd::Resolver::Instance().SetResolverDelegate(this);
+    return chip::Dnssd::Resolver::Instance().ResolveNodeId(peerId, type, dnssdCacheBypass);
+}
+
+CHIP_ERROR ResolverProxy::FindCommissionableNodes(DiscoveryFilter filter)
+{
+    chip::Dnssd::Resolver::Instance().SetResolverDelegate(this);
+    return chip::Dnssd::Resolver::Instance().FindCommissionableNodes(filter);
+}
+
+CHIP_ERROR ResolverProxy::FindCommissioners(DiscoveryFilter filter)
+{
+    chip::Dnssd::Resolver::Instance().SetResolverDelegate(this);
+    return chip::Dnssd::Resolver::Instance().FindCommissioners(filter);
 }
 
 } // namespace Dnssd

--- a/src/lib/dnssd/Resolver_ImplMinimalMdns.cpp
+++ b/src/lib/dnssd/Resolver_ImplMinimalMdns.cpp
@@ -599,21 +599,28 @@ Resolver & chip::Dnssd::Resolver::Instance()
     return gResolver;
 }
 
+// Minimal implementation does not support associating a context to a request (while platforms implementations do). So keep
+// updating the delegate that ends up beeing used by the server by calling 'SetResolverDelegate'.
+// This effectively allow minimal to have multiple controllers issuing requests as long the requests are serialized, but
+// it won't work well if requests are issued in parallel.
 CHIP_ERROR ResolverProxy::ResolveNodeId(const PeerId & peerId, Inet::IPAddressType type, Resolver::CacheBypass dnssdCacheBypass)
 {
-    chip::Dnssd::Resolver::Instance().SetResolverDelegate(this);
+    VerifyOrReturnError(mDelegate != nullptr, CHIP_ERROR_INCORRECT_STATE);
+    chip::Dnssd::Resolver::Instance().SetResolverDelegate(mDelegate);
     return chip::Dnssd::Resolver::Instance().ResolveNodeId(peerId, type, dnssdCacheBypass);
 }
 
 CHIP_ERROR ResolverProxy::FindCommissionableNodes(DiscoveryFilter filter)
 {
-    chip::Dnssd::Resolver::Instance().SetResolverDelegate(this);
+    VerifyOrReturnError(mDelegate != nullptr, CHIP_ERROR_INCORRECT_STATE);
+    chip::Dnssd::Resolver::Instance().SetResolverDelegate(mDelegate);
     return chip::Dnssd::Resolver::Instance().FindCommissionableNodes(filter);
 }
 
 CHIP_ERROR ResolverProxy::FindCommissioners(DiscoveryFilter filter)
 {
-    chip::Dnssd::Resolver::Instance().SetResolverDelegate(this);
+    VerifyOrReturnError(mDelegate != nullptr, CHIP_ERROR_INCORRECT_STATE);
+    chip::Dnssd::Resolver::Instance().SetResolverDelegate(mDelegate);
     return chip::Dnssd::Resolver::Instance().FindCommissioners(filter);
 }
 

--- a/src/lib/shell/commands/Ota.cpp
+++ b/src/lib/shell/commands/Ota.cpp
@@ -22,6 +22,7 @@
 #include <app/server/Server.h>
 #include <lib/core/CHIPCallback.h>
 #include <lib/core/Optional.h>
+#include <lib/dnssd/Resolver.h>
 #include <lib/shell/Commands.h>
 #include <lib/shell/Engine.h>
 #include <lib/shell/commands/Help.h>
@@ -299,7 +300,7 @@ void ConnectDeviceAsync(intptr_t)
     VerifyOrReturn(deviceProxy != nullptr);
 
     deviceProxy->UpdateDeviceData(sOtaContext.providerAddress, deviceProxy->GetMRPConfig());
-    deviceProxy->Connect(&successCallback, &failureCallback);
+    deviceProxy->Connect(&successCallback, &failureCallback, nullptr);
 }
 
 template <OnDeviceConnected OnConnected>


### PR DESCRIPTION
… a dns request

#### Problem
DNS-SD only supports 1 resolver delegate. 

This is a problem for #10089 and for having multiple controller/commissioner objects in a single process.

#### Change overview
 * Add support for multiple delegates

#### Testing
It was tested by locally modifying `chip-tool` by having multiple instances of the `CHIPDeviceController` into the same process.

Fix #11562

This is an other version of ##12261 where the code was updated to have multiple delegates, but here there is a proxy in between the singleton instance of the resolver and the clients. It allows mapping the request directly to the right controller.