### PR TITLE
Use MRP parameters provided by CASE/PASE

### DIFF
--- a/src/app/OperationalDeviceProxy.cpp
+++ b/src/app/OperationalDeviceProxy.cpp
@@ -96,6 +96,10 @@ CHIP_ERROR OperationalDeviceProxy::UpdateDeviceData(const Transport::PeerAddress
 
     mMRPConfig = config;
 
+    // Initialize CASE session state with any MRP parameters that DNS-SD has provided.
+    // It can be overridden by CASE session protocol messages that include MRP parameters.
+    mCASESession.SetMRPConfig(mMRPConfig);
+
     if (mState == State::NeedsAddress)
     {
         mState = State::Initialized;
@@ -225,7 +229,6 @@ void OperationalDeviceProxy::OnSessionEstablished()
     VerifyOrReturn(mState != State::Uninitialized,
                    ChipLogError(Controller, "OnSessionEstablished was called while the device was not initialized"));
 
-    // TODO Update the MRP params based on the MRP params extracted from CASE, when this is available.
     CHIP_ERROR err = mInitParams.sessionManager->NewPairing(
         Optional<Transport::PeerAddress>::Value(mDeviceAddress), mPeerId.GetNodeId(), &mCASESession,
         CryptoContext::SessionRole::kInitiator, mInitParams.fabricInfo->GetFabricIndex());

--- a/src/controller/CommissioneeDeviceProxy.cpp
+++ b/src/controller/CommissioneeDeviceProxy.cpp
@@ -121,6 +121,10 @@ CHIP_ERROR CommissioneeDeviceProxy::UpdateDeviceData(const Transport::PeerAddres
 
     mMRPConfig = config;
 
+    // Initialize PASE session state with any MRP parameters that DNS-SD has provided.
+    // It can be overridden by PASE session protocol messages that include MRP parameters.
+    mPairing.SetMRPConfig(mMRPConfig);
+
     ReturnErrorOnFailure(LoadSecureSessionParametersIfNeeded(didLoad));
 
     if (!mSecureSession.HasValue())

--- a/src/transport/PairingSession.h
+++ b/src/transport/PairingSession.h
@@ -92,11 +92,9 @@ public:
      * @brief
      *   Get the value of peer session counter which is synced during session establishment
      */
-    virtual const ReliableMessageProtocolConfig & GetMRPConfig() const
-    {
-        // TODO(#6652): This is a stub implementation, should be replaced by the real one when CASE and PASE is completed
-        return gDefaultMRPConfig;
-    }
+    virtual const ReliableMessageProtocolConfig & GetMRPConfig() const { return mMRPConfig; }
+
+    void SetMRPConfig(const ReliableMessageProtocolConfig & config) { mMRPConfig = config; }
 
     virtual const char * GetI2RSessionInfo() const = 0;
 
@@ -186,6 +184,8 @@ private:
     Transport::PeerAddress mPeerAddress = Transport::PeerAddress::Uninitialized();
 
     Optional<uint16_t> mPeerSessionId;
+
+    ReliableMessageProtocolConfig mMRPConfig = gDefaultMRPConfig;
 };
 
 } // namespace chip


### PR DESCRIPTION
#### Problem
* Fixes #11507
* Fixes #11923
* Fixes #11926
* Fixes #11886
* Fixes #11889

#### Change overview
The MRP parameters can be provided via
1. DNS-SD advertisements
2. CASE/PASE protocol messages

The SessionManager was already using the MRP values contained in CASE/PASE session object. The missing part was setting it to any value that might have been received via DNS-SD resolution.

This PR adds the missing initialization. Also, it adds API that CASE/PASE state machine can call to save the MRP parameters received in the session establishment protocol messages. The work for CASE/PASE message handling is being tracked in individual issues (#9654, #10019)

#### Testing
Tested using chip-tool and all-cluster-app. Tested commissioning flow (for PASE) and tested a few cluster commands for commissioning (for CASE).