### PR TITLE
RPC: Remove chip console build step from linux lighting

### DIFF
--- a/examples/lighting-app/linux/BUILD.gn
+++ b/examples/lighting-app/linux/BUILD.gn
@@ -87,13 +87,6 @@ executable("chip-lighting-app") {
 
 group("linux") {
   deps = [ ":chip-lighting-app" ]
-
-  if (chip_enable_pw_rpc) {
-    deps += [
-      "${chip_root}/examples/common/pigweed/rpc_console/py:chip_rpc.install",
-      "${chip_root}/examples/common/pigweed/rpc_console/py:chip_rpc_wheel",
-    ]
-  }
 }
 
 group("default") {


### PR DESCRIPTION
#### Problem
CI is seeing errors building the python whl for chip console as part of the linux example.

#### Change overview
Remove automatic install of the console for now until we can debug the issue.

