### PR TITLE
Disable detail logging on K32W platform for now.

### DIFF
--- a/src/platform/nxp/k32w/k32w0/args.gni
+++ b/src/platform/nxp/k32w/k32w0/args.gni
@@ -28,6 +28,8 @@ chip_build_tests = false
 
 chip_mdns = "platform"
 
+chip_detail_logging = false
+
 mbedtls_target = "${chip_root}/third_party/nxp/k32w0_sdk:mbedtls"
 openthread_external_mbedtls = mbedtls_target
 


### PR DESCRIPTION
We're not fitting in flash.  This is a workaround to make CI green,
but we need to find some flash savings somewhere better

#### Problem
Can't link, not enough flash.

#### Change overview
Disable detail logging for now as a way to save some flash.

#### Testing
Ran via "act -j k32w" locally and verified that the job fails without this change, passes with.