### PR TITLE
Added the flexibility to add external/third-party PKIs to the chip-tool

### DIFF
--- a/examples/chip-tool/BUILD.gn
+++ b/examples/chip-tool/BUILD.gn
@@ -25,7 +25,17 @@ declare_args() {
   config_use_separate_eventloop = true
 }
 
-executable("chip-tool") {
+config("config") {
+  include_dirs = [
+    ".",
+    "${chip_root}/zzz_generated/chip-tool",
+    "${chip_root}/src/lib",
+  ]
+
+  defines = [ "CONFIG_USE_SEPARATE_EVENTLOOP=${config_use_separate_eventloop}" ]
+}
+
+static_library("chip-tool-utils") {
   sources = [
     "commands/clusters/ModelCommand.cpp",
     "commands/common/CHIPCommand.cpp",
@@ -33,6 +43,7 @@ executable("chip-tool") {
     "commands/common/Command.cpp",
     "commands/common/CommandInvoker.h",
     "commands/common/Commands.cpp",
+    "commands/common/CredentialIssuerCommands.h",
     "commands/discover/DiscoverCommand.cpp",
     "commands/discover/DiscoverCommissionablesCommand.cpp",
     "commands/discover/DiscoverCommissionersCommand.cpp",
@@ -48,10 +59,7 @@ executable("chip-tool") {
     "commands/payload/SetupPayloadVerhoeff.cpp",
     "commands/tests/TestCommand.cpp",
     "config/PersistentStorage.cpp",
-    "main.cpp",
   ]
-
-  defines = [ "CONFIG_USE_SEPARATE_EVENTLOOP=${config_use_separate_eventloop}" ]
 
   deps = [
     "${chip_root}/src/app/server",
@@ -64,11 +72,31 @@ executable("chip-tool") {
 
   cflags = [ "-Wconversion" ]
 
-  include_dirs = [
-    ".",
-    "${chip_root}/zzz_generated/chip-tool",
+  public_configs = [ ":config" ]
+
+  if (chip_enable_transport_trace) {
+    deps += [ "${chip_root}/examples/common/tracing:trace_handlers" ]
+  }
+
+  output_dir = root_out_dir
+}
+
+executable("chip-tool") {
+  sources = [ "main.cpp" ]
+
+  deps = [
+    ":chip-tool-utils",
+    "${chip_root}/src/app/server",
+    "${chip_root}/src/app/tests/suites/pics",
+    "${chip_root}/src/controller/data_model",
     "${chip_root}/src/lib",
+    "${chip_root}/src/platform",
+    "${chip_root}/third_party/inipp",
   ]
+
+  cflags = [ "-Wconversion" ]
+
+  public_configs = [ ":config" ]
 
   if (chip_enable_transport_trace) {
     deps += [ "${chip_root}/examples/common/tracing:trace_handlers" ]

--- a/examples/chip-tool/commands/common/CHIPCommand.h
+++ b/examples/chip-tool/commands/common/CHIPCommand.h
@@ -18,10 +18,10 @@
 
 #pragma once
 
-#include <controller/ExampleOperationalCredentialsIssuer.h>
-
 #include "../../config/PersistentStorage.h"
 #include "Command.h"
+#include <commands/common/CredentialIssuerCommands.h>
+#include <commands/example/ExampleCredentialIssuerCommands.h>
 
 #pragma once
 
@@ -49,6 +49,11 @@ public:
         AddArgument("trace_file", &mTraceFile);
         AddArgument("trace_log", 0, 1, &mTraceLog);
 #endif // CHIP_CONFIG_TRANSPORT_TRACE_ENABLED
+    }
+
+    CHIPCommand(const char * commandName, CredentialIssuerCommands * credIssuerCmds) : CHIPCommand(commandName)
+    {
+        mCredIssuerCmds = credIssuerCmds;
     }
 
     /////////// Command Interface /////////
@@ -79,7 +84,8 @@ protected:
     PersistentStorage mDefaultStorage;
     PersistentStorage mCommissionerStorage;
     chip::SimpleFabricStorage mFabricStorage;
-    chip::Controller::ExampleOperationalCredentialsIssuer mOpCredsIssuer;
+    ExampleCredentialIssuerCommands mExampleCredentialIssuerCmds;
+    CredentialIssuerCommands * mCredIssuerCmds = &mExampleCredentialIssuerCmds;
 
     std::string GetIdentity();
     void SetIdentity(const char * name);

--- a/examples/chip-tool/commands/common/CredentialIssuerCommands.h
+++ b/examples/chip-tool/commands/common/CredentialIssuerCommands.h
@@ -1,0 +1,73 @@
+/*
+ *   Copyright (c) 2021 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+#pragma once
+
+#include <app/util/basic-types.h>
+#include <controller/CHIPDeviceControllerFactory.h>
+#include <lib/core/CHIPCore.h>
+#include <lib/core/CHIPPersistentStorageDelegate.h>
+
+class CredentialIssuerCommands
+{
+public:
+    virtual ~CredentialIssuerCommands() {}
+
+    /**
+     * @brief
+     *   This function is used to initialize the Credentials Issuer, if needed.
+     *
+     * @param[in] storage A reference to the storage, where the Credentials Issuer can optionally use to access the keypair in
+     *                    storage.
+     *
+     * @return CHIP_ERROR CHIP_NO_ERROR on success, or corresponding error code.
+     */
+    virtual CHIP_ERROR InitializeCredentialsIssuer(chip::PersistentStorageDelegate & storage) = 0;
+
+    /**
+     * @brief
+     *   This function is used to setup Device Attestation Singletons and intialize Setup/Commissioning Parameters with a custom
+     *   Device Attestation Verifier object.
+     *
+     * @param[in] setupParams A reference to the Setup/Commissioning Parameters, to be initialized with custom Device Attestation
+     *                        Verifier.
+     *
+     * @return CHIP_ERROR CHIP_NO_ERROR on success, or corresponding error code.
+     */
+    virtual CHIP_ERROR SetupDeviceAttestation(chip::Controller::SetupParams & setupParams) = 0;
+
+    virtual chip::Controller::OperationalCredentialsDelegate * GetCredentialIssuer() = 0;
+
+    /**
+     * @brief
+     *   This function is used to Generate NOC Chain for the Controller/Commissioner. Parameters follow the example implementation,
+     *   so some parameters may not translate to the real remote Credentials Issuer policy.
+     *
+     * @param[in] nodeId   The desired NodeId for the generated NOC Chain - May be optional/unused in some implementations.
+     * @param[in] fabricId The desired FabricId for the generated NOC Chain - May be optional/unused in some implementations.
+     * @param[in] keypair  The desired Keypair for the generated NOC Chain - May be optional/unused in some implementations.
+     * @param[inout] rcac  Buffer to hold the Root Certificate of the generated NOC Chain.
+     * @param[inout] icac  Buffer to hold the Intermediate Certificate of the generated NOC Chain.
+     * @param[inout] noc   Buffer to hold the Leaf Certificate of the generated NOC Chain.
+     *
+     * @return CHIP_ERROR CHIP_NO_ERROR on success, or corresponding error code.
+     */
+    virtual CHIP_ERROR GenerateControllerNOCChain(chip::NodeId nodeId, chip::FabricId fabricId, chip::Crypto::P256Keypair & keypair,
+                                                  chip::MutableByteSpan & rcac, chip::MutableByteSpan & icac,
+                                                  chip::MutableByteSpan & noc) = 0;
+};

--- a/examples/chip-tool/commands/example/ExampleCredentialIssuerCommands.h
+++ b/examples/chip-tool/commands/example/ExampleCredentialIssuerCommands.h
@@ -1,0 +1,55 @@
+/*
+ *   Copyright (c) 2021 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+#pragma once
+
+#include <commands/common/CredentialIssuerCommands.h>
+#include <controller/ExampleOperationalCredentialsIssuer.h>
+#include <credentials/DeviceAttestationCredsProvider.h>
+#include <credentials/DeviceAttestationVerifier.h>
+#include <credentials/examples/DefaultDeviceAttestationVerifier.h>
+#include <credentials/examples/DeviceAttestationCredsExample.h>
+
+class ExampleCredentialIssuerCommands : public CredentialIssuerCommands
+{
+public:
+    CHIP_ERROR InitializeCredentialsIssuer(chip::PersistentStorageDelegate & storage) override
+    {
+        return mOpCredsIssuer.Initialize(storage);
+    }
+    CHIP_ERROR SetupDeviceAttestation(chip::Controller::SetupParams & setupParams) override
+    {
+        chip::Credentials::SetDeviceAttestationCredentialsProvider(chip::Credentials::Examples::GetExampleDACProvider());
+
+        // TODO: Replace testingRootStore with a AttestationTrustStore that has the necessary official PAA roots available
+        const chip::Credentials::AttestationTrustStore * testingRootStore = chip::Credentials::GetTestAttestationTrustStore();
+        setupParams.deviceAttestationVerifier = chip::Credentials::GetDefaultDACVerifier(testingRootStore);
+
+        return CHIP_NO_ERROR;
+    }
+    chip::Controller::OperationalCredentialsDelegate * GetCredentialIssuer() override { return &mOpCredsIssuer; }
+    CHIP_ERROR GenerateControllerNOCChain(chip::NodeId nodeId, chip::FabricId fabricId, chip::Crypto::P256Keypair & keypair,
+                                          chip::MutableByteSpan & rcac, chip::MutableByteSpan & icac,
+                                          chip::MutableByteSpan & noc) override
+    {
+        return mOpCredsIssuer.GenerateNOCChainAfterValidation(nodeId, fabricId, keypair.Pubkey(), rcac, icac, noc);
+    }
+
+private:
+    chip::Controller::ExampleOperationalCredentialsIssuer mOpCredsIssuer;
+};

--- a/examples/chip-tool/commands/pairing/Commands.h
+++ b/examples/chip-tool/commands/pairing/Commands.h
@@ -23,37 +23,46 @@
 #include "PairingCommand.h"
 
 #include <app/server/Dnssd.h>
+#include <commands/common/CredentialIssuerCommands.h>
 #include <lib/dnssd/Resolver.h>
 
 class Unpair : public PairingCommand
 {
 public:
-    Unpair() : PairingCommand("unpair", PairingMode::None, PairingNetworkType::None) {}
+    Unpair(CredentialIssuerCommands * credsIssuerConfig) :
+        PairingCommand("unpair", PairingMode::None, PairingNetworkType::None, credsIssuerConfig)
+    {}
 };
 
 class PairQRCode : public PairingCommand
 {
 public:
-    PairQRCode() : PairingCommand("qrcode", PairingMode::QRCode, PairingNetworkType::None) {}
+    PairQRCode(CredentialIssuerCommands * credsIssuerConfig) :
+        PairingCommand("qrcode", PairingMode::QRCode, PairingNetworkType::None, credsIssuerConfig)
+    {}
 };
 
 class PairManualCode : public PairingCommand
 {
 public:
-    PairManualCode() : PairingCommand("manualcode", PairingMode::ManualCode, PairingNetworkType::None) {}
+    PairManualCode(CredentialIssuerCommands * credsIssuerConfig) :
+        PairingCommand("manualcode", PairingMode::ManualCode, PairingNetworkType::None, credsIssuerConfig)
+    {}
 };
 
 class PairOnNetwork : public PairingCommand
 {
 public:
-    PairOnNetwork() : PairingCommand("onnetwork", PairingMode::OnNetwork, PairingNetworkType::None) {}
+    PairOnNetwork(CredentialIssuerCommands * credsIssuerConfig) :
+        PairingCommand("onnetwork", PairingMode::OnNetwork, PairingNetworkType::None, credsIssuerConfig)
+    {}
 };
 
 class PairOnNetworkShort : public PairingCommand
 {
 public:
-    PairOnNetworkShort() :
-        PairingCommand("onnetwork-short", PairingMode::OnNetwork, PairingNetworkType::None,
+    PairOnNetworkShort(CredentialIssuerCommands * credsIssuerConfig) :
+        PairingCommand("onnetwork-short", PairingMode::OnNetwork, PairingNetworkType::None, credsIssuerConfig,
                        chip::Dnssd::DiscoveryFilterType::kShortDiscriminator)
     {}
 };
@@ -61,8 +70,8 @@ public:
 class PairOnNetworkLong : public PairingCommand
 {
 public:
-    PairOnNetworkLong() :
-        PairingCommand("onnetwork-long", PairingMode::OnNetwork, PairingNetworkType::None,
+    PairOnNetworkLong(CredentialIssuerCommands * credsIssuerConfig) :
+        PairingCommand("onnetwork-long", PairingMode::OnNetwork, PairingNetworkType::None, credsIssuerConfig,
                        chip::Dnssd::DiscoveryFilterType::kLongDiscriminator)
     {}
 };
@@ -70,8 +79,8 @@ public:
 class PairOnNetworkVendor : public PairingCommand
 {
 public:
-    PairOnNetworkVendor() :
-        PairingCommand("onnetwork-vendor", PairingMode::OnNetwork, PairingNetworkType::None,
+    PairOnNetworkVendor(CredentialIssuerCommands * credsIssuerConfig) :
+        PairingCommand("onnetwork-vendor", PairingMode::OnNetwork, PairingNetworkType::None, credsIssuerConfig,
                        chip::Dnssd::DiscoveryFilterType::kVendorId)
     {}
 };
@@ -79,8 +88,8 @@ public:
 class PairOnNetworkFabric : public PairingCommand
 {
 public:
-    PairOnNetworkFabric() :
-        PairingCommand("onnetwork-fabric", PairingMode::OnNetwork, PairingNetworkType::None,
+    PairOnNetworkFabric(CredentialIssuerCommands * credsIssuerConfig) :
+        PairingCommand("onnetwork-fabric", PairingMode::OnNetwork, PairingNetworkType::None, credsIssuerConfig,
                        chip::Dnssd::DiscoveryFilterType::kCompressedFabricId)
     {}
 };
@@ -88,8 +97,8 @@ public:
 class PairOnNetworkCommissioningMode : public PairingCommand
 {
 public:
-    PairOnNetworkCommissioningMode() :
-        PairingCommand("onnetwork-commissioning-mode", PairingMode::OnNetwork, PairingNetworkType::None,
+    PairOnNetworkCommissioningMode(CredentialIssuerCommands * credsIssuerConfig) :
+        PairingCommand("onnetwork-commissioning-mode", PairingMode::OnNetwork, PairingNetworkType::None, credsIssuerConfig,
                        chip::Dnssd::DiscoveryFilterType::kCommissioningMode)
     {}
 };
@@ -97,8 +106,8 @@ public:
 class PairOnNetworkCommissioner : public PairingCommand
 {
 public:
-    PairOnNetworkCommissioner() :
-        PairingCommand("onnetwork-commissioner", PairingMode::OnNetwork, PairingNetworkType::None,
+    PairOnNetworkCommissioner(CredentialIssuerCommands * credsIssuerConfig) :
+        PairingCommand("onnetwork-commissioner", PairingMode::OnNetwork, PairingNetworkType::None, credsIssuerConfig,
                        chip::Dnssd::DiscoveryFilterType::kCommissioner)
     {}
 };
@@ -106,8 +115,8 @@ public:
 class PairOnNetworkDeviceType : public PairingCommand
 {
 public:
-    PairOnNetworkDeviceType() :
-        PairingCommand("onnetwork-device-type", PairingMode::OnNetwork, PairingNetworkType::None,
+    PairOnNetworkDeviceType(CredentialIssuerCommands * credsIssuerConfig) :
+        PairingCommand("onnetwork-device-type", PairingMode::OnNetwork, PairingNetworkType::None, credsIssuerConfig,
                        chip::Dnssd::DiscoveryFilterType::kDeviceType)
     {}
 };
@@ -115,8 +124,8 @@ public:
 class PairOnNetworkInstanceName : public PairingCommand
 {
 public:
-    PairOnNetworkInstanceName() :
-        PairingCommand("onnetwork-instance-name", PairingMode::OnNetwork, PairingNetworkType::None,
+    PairOnNetworkInstanceName(CredentialIssuerCommands * credsIssuerConfig) :
+        PairingCommand("onnetwork-instance-name", PairingMode::OnNetwork, PairingNetworkType::None, credsIssuerConfig,
                        chip::Dnssd::DiscoveryFilterType::kInstanceName)
     {}
 };
@@ -124,25 +133,33 @@ public:
 class PairBleWiFi : public PairingCommand
 {
 public:
-    PairBleWiFi() : PairingCommand("ble-wifi", PairingMode::Ble, PairingNetworkType::WiFi) {}
+    PairBleWiFi(CredentialIssuerCommands * credsIssuerConfig) :
+        PairingCommand("ble-wifi", PairingMode::Ble, PairingNetworkType::WiFi, credsIssuerConfig)
+    {}
 };
 
 class PairBleThread : public PairingCommand
 {
 public:
-    PairBleThread() : PairingCommand("ble-thread", PairingMode::Ble, PairingNetworkType::Thread) {}
+    PairBleThread(CredentialIssuerCommands * credsIssuerConfig) :
+        PairingCommand("ble-thread", PairingMode::Ble, PairingNetworkType::Thread, credsIssuerConfig)
+    {}
 };
 
 class PairSoftAP : public PairingCommand
 {
 public:
-    PairSoftAP() : PairingCommand("softap", PairingMode::SoftAP, PairingNetworkType::WiFi) {}
+    PairSoftAP(CredentialIssuerCommands * credsIssuerConfig) :
+        PairingCommand("softap", PairingMode::SoftAP, PairingNetworkType::WiFi, credsIssuerConfig)
+    {}
 };
 
 class Ethernet : public PairingCommand
 {
 public:
-    Ethernet() : PairingCommand("ethernet", PairingMode::Ethernet, PairingNetworkType::Ethernet) {}
+    Ethernet(CredentialIssuerCommands * credsIssuerConfig) :
+        PairingCommand("ethernet", PairingMode::Ethernet, PairingNetworkType::Ethernet, credsIssuerConfig)
+    {}
 };
 
 class StartUdcServerCommand : public CHIPCommand
@@ -158,31 +175,31 @@ public:
     }
 };
 
-void registerCommandsPairing(Commands & commands)
+void registerCommandsPairing(Commands & commands, CredentialIssuerCommands * credsIssuerConfig)
 {
     const char * clusterName = "Pairing";
 
     commands_list clusterCommands = {
-        make_unique<Unpair>(),
-        make_unique<PairQRCode>(),
-        make_unique<PairManualCode>(),
-        make_unique<PairBleWiFi>(),
-        make_unique<PairBleThread>(),
-        make_unique<PairSoftAP>(),
-        make_unique<Ethernet>(),
-        make_unique<PairOnNetwork>(),
-        make_unique<PairOnNetworkShort>(),
-        make_unique<PairOnNetworkLong>(),
-        make_unique<PairOnNetworkVendor>(),
-        make_unique<PairOnNetworkCommissioningMode>(),
-        make_unique<PairOnNetworkCommissioner>(),
-        make_unique<PairOnNetworkDeviceType>(),
-        make_unique<PairOnNetworkDeviceType>(),
-        make_unique<PairOnNetworkInstanceName>(),
+        make_unique<Unpair>(credsIssuerConfig),
+        make_unique<PairQRCode>(credsIssuerConfig),
+        make_unique<PairManualCode>(credsIssuerConfig),
+        make_unique<PairBleWiFi>(credsIssuerConfig),
+        make_unique<PairBleThread>(credsIssuerConfig),
+        make_unique<PairSoftAP>(credsIssuerConfig),
+        make_unique<Ethernet>(credsIssuerConfig),
+        make_unique<PairOnNetwork>(credsIssuerConfig),
+        make_unique<PairOnNetworkShort>(credsIssuerConfig),
+        make_unique<PairOnNetworkLong>(credsIssuerConfig),
+        make_unique<PairOnNetworkVendor>(credsIssuerConfig),
+        make_unique<PairOnNetworkCommissioningMode>(credsIssuerConfig),
+        make_unique<PairOnNetworkCommissioner>(credsIssuerConfig),
+        make_unique<PairOnNetworkDeviceType>(credsIssuerConfig),
+        make_unique<PairOnNetworkDeviceType>(credsIssuerConfig),
+        make_unique<PairOnNetworkInstanceName>(credsIssuerConfig),
         // TODO - enable CommissionedListCommand once DNS Cache is implemented
         //        make_unique<CommissionedListCommand>(),
         make_unique<StartUdcServerCommand>(),
-        make_unique<OpenCommissioningWindowCommand>(),
+        make_unique<OpenCommissioningWindowCommand>(credsIssuerConfig),
     };
 
     commands.Register(clusterName, clusterCommands);

--- a/examples/chip-tool/commands/pairing/OpenCommissioningWindowCommand.h
+++ b/examples/chip-tool/commands/pairing/OpenCommissioningWindowCommand.h
@@ -23,8 +23,8 @@
 class OpenCommissioningWindowCommand : public CHIPCommand
 {
 public:
-    OpenCommissioningWindowCommand() :
-        CHIPCommand("open-commissioning-window"), mOnDeviceConnectedCallback(OnDeviceConnectedFn, this),
+    OpenCommissioningWindowCommand(CredentialIssuerCommands * credIssuerCommands) :
+        CHIPCommand("open-commissioning-window", credIssuerCommands), mOnDeviceConnectedCallback(OnDeviceConnectedFn, this),
         mOnDeviceConnectionFailureCallback(OnDeviceConnectionFailureFn, this),
         mOnOpenCommissioningWindowCallback(OnOpenCommissioningWindowResponse, this)
     {

--- a/examples/chip-tool/commands/pairing/PairingCommand.h
+++ b/examples/chip-tool/commands/pairing/PairingCommand.h
@@ -23,6 +23,7 @@
 #include <zap-generated/CHIPClientCallbacks.h>
 #include <zap-generated/CHIPClusters.h>
 
+#include <commands/common/CredentialIssuerCommands.h>
 #include <lib/support/Span.h>
 #include <lib/support/ThreadOperationalDataset.h>
 
@@ -51,8 +52,9 @@ class PairingCommand : public CHIPCommand,
 {
 public:
     PairingCommand(const char * commandName, PairingMode mode, PairingNetworkType networkType,
+                   CredentialIssuerCommands * credIssuerCmds,
                    chip::Dnssd::DiscoveryFilterType filterType = chip::Dnssd::DiscoveryFilterType::kNone) :
-        CHIPCommand(commandName),
+        CHIPCommand(commandName, credIssuerCmds),
         mPairingMode(mode), mNetworkType(networkType),
         mFilterType(filterType), mRemoteAddr{ IPAddress::Any, chip::Inet::InterfaceId::Null() }
     {

--- a/examples/chip-tool/main.cpp
+++ b/examples/chip-tool/main.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "commands/common/Commands.h"
+#include "commands/example/ExampleCredentialIssuerCommands.h"
 
 #include "commands/discover/Commands.h"
 #include "commands/pairing/Commands.h"
@@ -30,10 +31,11 @@
 // ================================================================================
 int main(int argc, char * argv[])
 {
+    ExampleCredentialIssuerCommands credIssuerCommands;
     Commands commands;
     registerCommandsDiscover(commands);
     registerCommandsPayload(commands);
-    registerCommandsPairing(commands);
+    registerCommandsPairing(commands, &credIssuerCommands);
     registerCommandsTests(commands);
     registerClusters(commands);
 

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1239,6 +1239,11 @@ CHIP_ERROR DeviceCommissioner::SendOperationalCertificateSigningRequestCommand(C
     Callback::Cancelable * successCallback = mOpCSRResponseCallback.Cancel();
     Callback::Cancelable * failureCallback = mOnCSRFailureCallback.Cancel();
 
+    uint8_t csrNonceBuf[kOpCSRNonceLength];
+    MutableByteSpan csrNonce(csrNonceBuf);
+    ReturnErrorOnFailure(mOperationalCredentialsDelegate->ObtainCsrNonce(csrNonce));
+    ReturnErrorOnFailure(device->SetCSRNonce(csrNonce));
+
     ReturnErrorOnFailure(cluster.OpCSRRequest(successCallback, failureCallback, device->GetCSRNonce()));
 
     ChipLogDetail(Controller, "Sent OpCSR request, waiting for the CSR");
@@ -1346,7 +1351,7 @@ CHIP_ERROR DeviceCommissioner::ProcessOpCSR(const ByteSpan & NOCSRElements, cons
     FabricInfo * fabric = mSystemState->Fabrics()->FindFabricWithIndex(mFabricIndex);
     mOperationalCredentialsDelegate->SetFabricIdForNextNOCRequest(fabric->GetFabricId());
 
-    return mOperationalCredentialsDelegate->GenerateNOCChain(NOCSRElements, AttestationSignature, ByteSpan(), ByteSpan(),
+    return mOperationalCredentialsDelegate->GenerateNOCChain(NOCSRElements, AttestationSignature, device->GetDAC(), ByteSpan(),
                                                              ByteSpan(), &mDeviceNOCChainCallback);
 }
 

--- a/src/controller/CHIPDeviceControllerFactory.h
+++ b/src/controller/CHIPDeviceControllerFactory.h
@@ -31,6 +31,7 @@
 
 #include <controller/CHIPDeviceController.h>
 #include <controller/CHIPDeviceControllerSystemState.h>
+#include <credentials/DeviceAttestationVerifier.h>
 
 namespace chip {
 
@@ -61,6 +62,8 @@ struct SetupParams
 
     // The Device Pairing Delegated used to initialize a Commissioner
     DevicePairingDelegate * pairingDelegate = nullptr;
+
+    Credentials::DeviceAttestationVerifier * deviceAttestationVerifier = nullptr;
 };
 
 // TODO everything other than the fabric storage here should be removed.

--- a/src/controller/CommissioneeDeviceProxy.h
+++ b/src/controller/CommissioneeDeviceProxy.h
@@ -33,6 +33,7 @@
 #include <app/util/basic-types.h>
 #include <controller-clusters/zap-generated/CHIPClientCallbacks.h>
 #include <controller/CHIPDeviceControllerSystemState.h>
+#include <controller/OperationalCredentialsDelegate.h>
 #include <lib/core/CHIPCallback.h>
 #include <lib/core/CHIPCore.h>
 #include <lib/support/DLLUtil.h>
@@ -54,7 +55,6 @@
 
 namespace chip {
 
-constexpr size_t kOpCSRNonceLength       = 32;
 constexpr size_t kAttestationNonceLength = 32;
 
 using DeviceIPTransportMgr = TransportMgr<Transport::UDP /* IPv6 */
@@ -328,7 +328,7 @@ private:
     FabricIndex mFabricIndex = kUndefinedFabricIndex;
 
     // TODO: Offload Nonces and DAC/PAI into a new struct
-    uint8_t mCSRNonce[kOpCSRNonceLength];
+    uint8_t mCSRNonce[Controller::kOpCSRNonceLength];
     uint8_t mAttestationNonce[kAttestationNonceLength];
 
     uint8_t * mDAC   = nullptr;

--- a/src/controller/OperationalCredentialsDelegate.h
+++ b/src/controller/OperationalCredentialsDelegate.h
@@ -33,6 +33,7 @@ typedef void (*OnNOCChainGeneration)(void * context, CHIP_ERROR status, const By
                                      const ByteSpan & rcac);
 
 constexpr uint32_t kMaxCHIPDERCertLength = 600;
+constexpr size_t kOpCSRNonceLength       = 32;
 
 /// Callbacks for CHIP operational credentials generation
 class DLL_EXPORT OperationalCredentialsDelegate
@@ -76,6 +77,13 @@ public:
      *   fabric ID.
      */
     virtual void SetFabricIdForNextNOCRequest(FabricId fabricId) {}
+
+    virtual CHIP_ERROR ObtainCsrNonce(MutableByteSpan & csrNonce)
+    {
+        VerifyOrReturnError(csrNonce.size() == kOpCSRNonceLength, CHIP_ERROR_INVALID_ARGUMENT);
+        ReturnErrorOnFailure(Crypto::DRBG_get_bytes(csrNonce.data(), csrNonce.size()));
+        return CHIP_NO_ERROR;
+    }
 };
 
 } // namespace Controller


### PR DESCRIPTION
#### Problem
* Example chip-tool currently does not have the flexibility to add external/third-party PKIs

#### Change Overview
* chip-tool now builds the core as a static library (chip-tool-utils)
* Added set of pure virtual methods PKI-related to Commands class
* Added an implementation of Matter’s example PKI
* Added DAC to GenerateNOCChain method call
* Added GenerateNOCSR method to OperationalCredentialsDelegate class so every PKI-vendor can override the nonce generation to follow a custom set of rules. Random example added.

#### Testing
* Matter Unit Tests
* Tested Commissioning flow (chip-tool vs lighting-app)