### PR TITLE
Go back to using a QR code for test pairing.

### DIFF
--- a/scripts/tests/chiptest/runner.py
+++ b/scripts/tests/chiptest/runner.py
@@ -19,6 +19,7 @@ import sys
 import threading
 import time
 import pty
+import re
 
 from dataclasses import dataclass
 
@@ -48,6 +49,13 @@ class LogPipe(threading.Thread):
 
     def CapturedLogContains(self, txt: str):
         return any(txt in l for l in self.captured_logs)
+
+    def FindLastMatchingLine(self, matcher):
+        for l in reversed(self.captured_logs):
+            match = re.match(matcher, l)
+            if match:
+                return match
+        return None
 
     def fileno(self):
         """Return the write file descriptor of the pipe"""

--- a/scripts/tests/chiptest/test_definition.py
+++ b/scripts/tests/chiptest/test_definition.py
@@ -119,8 +119,11 @@ class TestDefinition:
                 server_is_listening = outpipe.CapturedLogContains(
                     "Server Listening")
             logging.debug('Server is listening. Can proceed.')
+            qrLine = outpipe.FindLastMatchingLine('.*SetupQRCode: *\\[(.*)]')
+            if not qrLine:
+                raise Exception("Unable to find QR code")
 
-            runner.RunSubprocess(tool_cmd + ['pairing', 'onnetwork-long', TEST_NODE_ID, '20202021', discriminator],
+            runner.RunSubprocess(tool_cmd + ['pairing', 'qrcode', TEST_NODE_ID, qrLine.group(1)],
                                  name='PAIR', dependencies=[app_process])
 
             runner.RunSubprocess(tool_cmd + ['tests', self.run_name, TEST_NODE_ID],


### PR DESCRIPTION
Vivien pointed out that there are benefits to exercising the QR code
codepath, since that will likely be the most common commissioning path
in practice.

#### Problem
See above.

#### Change overview
See above.

#### Testing
Ran tests locally, verified we still find the server.