### PR TITLE
Removed level control callback in OnOff Cluster

### DIFF
--- a/src/app/clusters/on-off-server/on-off-server.cpp
+++ b/src/app/clusters/on-off-server/on-off-server.cpp
@@ -151,29 +151,11 @@ EmberAfStatus OnOffServer::setOnOffValue(chip::EndpointId endpoint, uint8_t comm
             emberAfOnOffClusterPrintln("ERR: writing on/off %x", status);
             return status;
         }
-
-#ifdef EMBER_AF_PLUGIN_LEVEL_CONTROL
-        // If initiatedByLevelChange is false, then we assume that the level change
-        // ZCL stuff has not happened and we do it here
-        if (!initiatedByLevelChange && emberAfContainsServer(endpoint, LevelControl::Id))
-        {
-            emberAfOnOffClusterLevelControlEffectCallback(endpoint, newValue);
-        }
-#endif // EMBER_AF_PLUGIN_LEVEL_CONTROL
     }
     else // Set Off
     {
         emberAfOnOffClusterPrintln("Off Command - OnTime :  0");
         Attributes::OnTime::Set(endpoint, 0); // Reset onTime
-
-#ifdef EMBER_AF_PLUGIN_LEVEL_CONTROL
-        // If initiatedByLevelChange is false, then we assume that the level change
-        // ZCL stuff has not happened and we do it here
-        if (!initiatedByLevelChange && emberAfContainsServer(endpoint, LevelControl::Id))
-        {
-            emberAfOnOffClusterLevelControlEffectCallback(endpoint, newValue);
-        }
-#endif // EMBER_AF_PLUGIN_LEVEL_CONTROL
 
         // write the new on/off value
         status = Attributes::OnOff::Set(endpoint, newValue);


### PR DESCRIPTION
#### Problem
* Call to level control from OnOff cluster was not spec compliant

#### Change overview
* Removed level control callback in OnOff Cluster 

#### Testing
* Automated tests to validate no regressions were caused
