### PR TITLE
Remove manufacturer code arrays from endpoint_config.

### DIFF
--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -97,11 +97,6 @@ constexpr const EmberAfAttributeMetadata generatedAttributes[]      = GENERATED_
 constexpr const EmberAfCluster generatedClusters[]                  = GENERATED_CLUSTERS;
 constexpr const EmberAfEndpointType generatedEmberAfEndpointTypes[] = GENERATED_ENDPOINT_TYPES;
 
-constexpr const EmberAfManufacturerCodeEntry clusterManufacturerCodes[]   = GENERATED_CLUSTER_MANUFACTURER_CODES;
-constexpr const uint16_t clusterManufacturerCodeCount                     = GENERATED_CLUSTER_MANUFACTURER_CODE_COUNT;
-constexpr const EmberAfManufacturerCodeEntry attributeManufacturerCodes[] = GENERATED_ATTRIBUTE_MANUFACTURER_CODES;
-constexpr const uint16_t attributeManufacturerCodeCount                   = GENERATED_ATTRIBUTE_MANUFACTURER_CODE_COUNT;
-
 #if !defined(EMBER_SCRIPTED_TEST)
 #define endpointNumber(x) fixedEndpoints[x]
 #define endpointDeviceId(x) fixedDeviceIds[x]
@@ -493,80 +488,32 @@ static EmberAfStatus typeSensitiveMemCopy(ClusterId clusterId, uint8_t * dest, u
     return EMBER_ZCL_STATUS_SUCCESS;
 }
 
-// Returns the manufacturer code or ::EMBER_AF_NULL_MANUFACTURER_CODE if none
-// could be found.
-static uint16_t getManufacturerCode(EmberAfManufacturerCodeEntry * codes, uint16_t codeTableSize, uint16_t tableIndex)
-{
-    uint16_t i;
-    for (i = 0; i < codeTableSize; i++)
-    {
-        if (codes->index == tableIndex)
-        {
-            return codes->manufacturerCode;
-        }
-        codes++;
-    }
-    return EMBER_AF_NULL_MANUFACTURER_CODE;
-}
-
-// This function basically wraps getManufacturerCode with the parameters
-// associating an attributes metadata with its code.
-uint16_t emberAfGetMfgCode(EmberAfAttributeMetadata * metadata)
-{
-    return getManufacturerCode((EmberAfManufacturerCodeEntry *) attributeManufacturerCodes, attributeManufacturerCodeCount,
-                               static_cast<uint16_t>((metadata - generatedAttributes)));
-}
-
-uint16_t emAfGetManufacturerCodeForAttribute(EmberAfCluster * cluster, EmberAfAttributeMetadata * attMetaData)
-{
-    return (emberAfClusterIsManufacturerSpecific(cluster) ? emAfGetManufacturerCodeForCluster(cluster)
-                                                          : emberAfGetMfgCode(attMetaData));
-}
-
-uint16_t emAfGetManufacturerCodeForCluster(EmberAfCluster * cluster)
-{
-    return getManufacturerCode((EmberAfManufacturerCodeEntry *) clusterManufacturerCodes, clusterManufacturerCodeCount,
-                               static_cast<uint16_t>(cluster - generatedClusters));
-}
-
 /**
- * @brief Matches a cluster based on cluster id, direction and manufacturer code.
+ * @brief Matches a cluster based on cluster id and direction.
+ *
  *   This function assumes that the passed cluster's endpoint already
  *   matches the endpoint of the EmberAfAttributeSearchRecord.
  *
- * Cluster's match if:
+ * Clusters match if:
  *   1. Cluster ids match AND
  *   2. Cluster directions match as defined by cluster->mask
- *        and attRecord->clusterMask AND
- *   3. If the clusters are mf specific, their mfg codes match.
+ *        and attRecord->clusterMask
  */
 bool emAfMatchCluster(EmberAfCluster * cluster, EmberAfAttributeSearchRecord * attRecord)
 {
-    return (cluster->clusterId == attRecord->clusterId && cluster->mask & attRecord->clusterMask &&
-            (!emberAfClusterIsManufacturerSpecific(cluster) ||
-             (emAfGetManufacturerCodeForCluster(cluster) == attRecord->manufacturerCode)));
+    return (cluster->clusterId == attRecord->clusterId && cluster->mask & attRecord->clusterMask);
 }
 
 /**
- * @brief Matches an attribute based on attribute id and manufacturer code.
+ * @brief Matches an attribute based on attribute id.
  *   This function assumes that the passed cluster already matches the
- *   clusterId, direction and mf specificity of the passed
- *   EmberAfAttributeSearchRecord.
+ *   clusterId and direction of the passed EmberAfAttributeSearchRecord.
  *
- * Note: If both the attribute and cluster are manufacturer specific,
- *   the cluster's mf code gets precedence.
- *
- * Attributes match if:
- *   1. Att ids match AND
- *      a. cluster IS mf specific OR
- *      b. both stored and saught attributes are NOT mf specific OR
- *      c. stored att IS mf specific AND mfg codes match.
+ * Attributes match if attr ids match.
  */
 bool emAfMatchAttribute(EmberAfCluster * cluster, EmberAfAttributeMetadata * am, EmberAfAttributeSearchRecord * attRecord)
 {
-    return (am->attributeId == attRecord->attributeId &&
-            (emberAfClusterIsManufacturerSpecific(cluster) ||
-             (emAfGetManufacturerCodeForAttribute(cluster, am) == attRecord->manufacturerCode)));
+    return (am->attributeId == attRecord->attributeId);
 }
 
 // When reading non-string attributes, this function returns an error when destination
@@ -627,8 +574,7 @@ EmberAfStatus emAfReadOrWriteAttribute(EmberAfAttributeSearchRecord * attRecord,
                                     src = buffer;
                                     dst = attributeLocation;
                                     if (!emberAfAttributeWriteAccessCallback(attRecord->endpoint, attRecord->clusterId,
-                                                                             emAfGetManufacturerCodeForAttribute(cluster, am),
-                                                                             am->attributeId))
+                                                                             EMBER_AF_NULL_MANUFACTURER_CODE, am->attributeId))
                                     {
                                         return EMBER_ZCL_STATUS_NOT_AUTHORIZED;
                                     }
@@ -643,8 +589,7 @@ EmberAfStatus emAfReadOrWriteAttribute(EmberAfAttributeSearchRecord * attRecord,
                                     src = attributeLocation;
                                     dst = buffer;
                                     if (!emberAfAttributeReadAccessCallback(attRecord->endpoint, attRecord->clusterId,
-                                                                            emAfGetManufacturerCodeForAttribute(cluster, am),
-                                                                            am->attributeId))
+                                                                            EMBER_AF_NULL_MANUFACTURER_CODE, am->attributeId))
                                     {
                                         return EMBER_ZCL_STATUS_NOT_AUTHORIZED;
                                     }
@@ -653,13 +598,12 @@ EmberAfStatus emAfReadOrWriteAttribute(EmberAfAttributeSearchRecord * attRecord,
                                 // Is the attribute externally stored?
                                 if (am->mask & ATTRIBUTE_MASK_EXTERNAL_STORAGE)
                                 {
-                                    return (write ? emberAfExternalAttributeWriteCallback(
-                                                        attRecord->endpoint, attRecord->clusterId, am,
-                                                        emAfGetManufacturerCodeForAttribute(cluster, am), buffer, index)
-                                                  : emberAfExternalAttributeReadCallback(
-                                                        attRecord->endpoint, attRecord->clusterId, am,
-                                                        emAfGetManufacturerCodeForAttribute(cluster, am), buffer,
-                                                        emberAfAttributeSize(am), index));
+                                    return (write ? emberAfExternalAttributeWriteCallback(attRecord->endpoint, attRecord->clusterId,
+                                                                                          am, EMBER_AF_NULL_MANUFACTURER_CODE,
+                                                                                          buffer, index)
+                                                  : emberAfExternalAttributeReadCallback(attRecord->endpoint, attRecord->clusterId,
+                                                                                         am, EMBER_AF_NULL_MANUFACTURER_CODE,
+                                                                                         buffer, emberAfAttributeSize(am), index));
                                 }
                                 else
                                 {
@@ -719,12 +663,7 @@ EmberAfCluster * emberAfFindClusterInTypeWithMfgCode(EmberAfEndpointType * endpo
         EmberAfCluster * cluster = &(endpointType->cluster[i]);
         if (cluster->clusterId == clusterId &&
             (mask == 0 || (mask == CLUSTER_MASK_CLIENT && emberAfClusterIsClient(cluster)) ||
-             (mask == CLUSTER_MASK_SERVER && emberAfClusterIsServer(cluster))) &&
-            (!emberAfClusterIsManufacturerSpecific(cluster) ||
-             (emAfGetManufacturerCodeForCluster(cluster) == manufacturerCode)
-             // For compatibility with older stack api, we ignore manufacturer code here
-             // if the manufacturerCode == EMBER_AF_NULL_MANUFACTURER_CODE
-             || manufacturerCode == EMBER_AF_NULL_MANUFACTURER_CODE))
+             (mask == CLUSTER_MASK_SERVER && emberAfClusterIsServer(cluster))))
         {
             if (index)
             {
@@ -1279,7 +1218,7 @@ void emAfLoadAttributeDefaults(EndpointId endpoint, bool writeTokens)
                     record.clusterId        = cluster->clusterId;
                     record.clusterMask      = (emberAfAttributeIsClient(am) ? CLUSTER_MASK_CLIENT : CLUSTER_MASK_SERVER);
                     record.attributeId      = am->attributeId;
-                    record.manufacturerCode = emAfGetManufacturerCodeForAttribute(cluster, am);
+                    record.manufacturerCode = EMBER_AF_NULL_MANUFACTURER_CODE;
                     if ((am->mask & ATTRIBUTE_MASK_MIN_MAX) != 0U)
                     {
                         if (emberAfAttributeSize(am) <= 2)

--- a/src/app/util/attribute-storage.h
+++ b/src/app/util/attribute-storage.h
@@ -241,10 +241,6 @@ void emberAfClusterMessageSentWithMfgCodeCallback(const chip::MessageSendDestina
                                                   uint16_t msgLen, uint8_t * message, EmberStatus status,
                                                   uint16_t manufacturerCode);
 
-// Used to retrieve a manufacturer code from an attribute metadata
-uint16_t emAfGetManufacturerCodeForCluster(EmberAfCluster * cluster);
-uint16_t emAfGetManufacturerCodeForAttribute(EmberAfCluster * cluster, EmberAfAttributeMetadata * attMetaData);
-
 // Checks a cluster mask byte against ticks passed bitmask
 // returns true if the mask matches a passed interval
 bool emberAfCheckTick(EmberAfClusterMask mask, uint8_t passedMask);

--- a/src/app/util/attribute-table.cpp
+++ b/src/app/util/attribute-table.cpp
@@ -263,7 +263,6 @@ void emberAfPrintAttributeTable(void)
     decltype(EmberAfEndpointType::clusterCount) clusterIndex;
     uint16_t attributeIndex;
     EmberAfStatus status;
-    uint16_t mfgCode;
     for (endpointIndex = 0; endpointIndex < emberAfEndpointCount(); endpointIndex++)
     {
         EmberAfDefinedEndpoint * ep = &(emAfEndpoints[endpointIndex]);
@@ -286,15 +285,7 @@ void emberAfPrintAttributeTable(void)
                 emberAfAttributesPrint(ChipLogFormatMEI " / %p / " ChipLogFormatMEI " / ", ChipLogValueMEI(cluster->clusterId),
                                        (emberAfAttributeIsClient(metaData) ? "clnt" : "srvr"),
                                        ChipLogValueMEI(metaData->attributeId));
-                mfgCode = emAfGetManufacturerCodeForAttribute(cluster, metaData);
-                if (mfgCode == EMBER_AF_NULL_MANUFACTURER_CODE)
-                {
-                    emberAfAttributesPrint("----");
-                }
-                else
-                {
-                    emberAfAttributesPrint("%2x", mfgCode);
-                }
+                emberAfAttributesPrint("----");
                 emberAfAttributesPrint(" / %x (%x) / %p / %p / ", metaData->attributeType, emberAfAttributeSize(metaData),
                                        (metaData->IsReadOnly() ? "RO" : "RW"),
                                        (emberAfAttributeIsTokenized(metaData)
@@ -303,7 +294,7 @@ void emberAfPrintAttributeTable(void)
                 emberAfAttributesFlush();
                 status = emAfReadAttribute(ep->endpoint, cluster->clusterId, metaData->attributeId,
                                            (emberAfAttributeIsClient(metaData) ? CLUSTER_MASK_CLIENT : CLUSTER_MASK_SERVER),
-                                           mfgCode, data, ATTRIBUTE_LARGEST, NULL);
+                                           EMBER_AF_NULL_MANUFACTURER_CODE, data, ATTRIBUTE_LARGEST, NULL);
                 if (status == EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE)
                 {
                     emberAfAttributesPrintln("Unsupported");
@@ -326,7 +317,7 @@ void emberAfPrintAttributeTable(void)
                     UNUSED_VAR(length);
                     emberAfAttributesPrintBuffer(data, length, true);
                     emberAfAttributesFlush();
-                    emberAfAttributeDecodeAndPrintCluster(cluster->clusterId, mfgCode);
+                    emberAfAttributeDecodeAndPrintCluster(cluster->clusterId, EMBER_AF_NULL_MANUFACTURER_CODE);
                 }
             }
         }

--- a/src/app/zap-templates/templates/app/endpoint_config.zapt
+++ b/src/app/zap-templates/templates/app/endpoint_config.zapt
@@ -81,12 +81,4 @@
 // Array of networks supported on each endpoint
 #define FIXED_NETWORKS {{endpoint_fixed_network_array}}
 
-// This is an array of EmberAfManufacturerCodeEntry structures for clusters.
-#define GENERATED_CLUSTER_MANUFACTURER_CODE_COUNT ({{endpoint_cluster_manufacturer_code_count}})
-#define GENERATED_CLUSTER_MANUFACTURER_CODES {{endpoint_cluster_manufacturer_codes}}
-
-// This is an array of EmberAfManufacturerCodeEntry structures for attributes.
-#define GENERATED_ATTRIBUTE_MANUFACTURER_CODE_COUNT ({{endpoint_attribute_manufacturer_code_count}})
-#define GENERATED_ATTRIBUTE_MANUFACTURER_CODES {{endpoint_attribute_manufacturer_codes}}
-
 {{/endpoint_config}}

--- a/zzz_generated/all-clusters-app/zap-generated/endpoint_config.h
+++ b/zzz_generated/all-clusters-app/zap-generated/endpoint_config.h
@@ -2504,21 +2504,3 @@
     {                                                                                                                              \
         0, 0, 0                                                                                                                    \
     }
-
-// This is an array of EmberAfManufacturerCodeEntry structures for clusters.
-#define GENERATED_CLUSTER_MANUFACTURER_CODE_COUNT (0)
-#define GENERATED_CLUSTER_MANUFACTURER_CODES                                                                                       \
-    {                                                                                                                              \
-        {                                                                                                                          \
-            0x00, 0x00                                                                                                             \
-        }                                                                                                                          \
-    }
-
-// This is an array of EmberAfManufacturerCodeEntry structures for attributes.
-#define GENERATED_ATTRIBUTE_MANUFACTURER_CODE_COUNT (0)
-#define GENERATED_ATTRIBUTE_MANUFACTURER_CODES                                                                                     \
-    {                                                                                                                              \
-        {                                                                                                                          \
-            0x00, 0x00                                                                                                             \
-        }                                                                                                                          \
-    }

--- a/zzz_generated/bridge-app/zap-generated/endpoint_config.h
+++ b/zzz_generated/bridge-app/zap-generated/endpoint_config.h
@@ -937,21 +937,3 @@
     {                                                                                                                              \
         0, 0                                                                                                                       \
     }
-
-// This is an array of EmberAfManufacturerCodeEntry structures for clusters.
-#define GENERATED_CLUSTER_MANUFACTURER_CODE_COUNT (0)
-#define GENERATED_CLUSTER_MANUFACTURER_CODES                                                                                       \
-    {                                                                                                                              \
-        {                                                                                                                          \
-            0x00, 0x00                                                                                                             \
-        }                                                                                                                          \
-    }
-
-// This is an array of EmberAfManufacturerCodeEntry structures for attributes.
-#define GENERATED_ATTRIBUTE_MANUFACTURER_CODE_COUNT (0)
-#define GENERATED_ATTRIBUTE_MANUFACTURER_CODES                                                                                     \
-    {                                                                                                                              \
-        {                                                                                                                          \
-            0x00, 0x00                                                                                                             \
-        }                                                                                                                          \
-    }

--- a/zzz_generated/controller-clusters/zap-generated/endpoint_config.h
+++ b/zzz_generated/controller-clusters/zap-generated/endpoint_config.h
@@ -520,21 +520,3 @@
     {                                                                                                                              \
         0                                                                                                                          \
     }
-
-// This is an array of EmberAfManufacturerCodeEntry structures for clusters.
-#define GENERATED_CLUSTER_MANUFACTURER_CODE_COUNT (0)
-#define GENERATED_CLUSTER_MANUFACTURER_CODES                                                                                       \
-    {                                                                                                                              \
-        {                                                                                                                          \
-            0x00, 0x00                                                                                                             \
-        }                                                                                                                          \
-    }
-
-// This is an array of EmberAfManufacturerCodeEntry structures for attributes.
-#define GENERATED_ATTRIBUTE_MANUFACTURER_CODE_COUNT (0)
-#define GENERATED_ATTRIBUTE_MANUFACTURER_CODES                                                                                     \
-    {                                                                                                                              \
-        {                                                                                                                          \
-            0x00, 0x00                                                                                                             \
-        }                                                                                                                          \
-    }

--- a/zzz_generated/lighting-app/zap-generated/endpoint_config.h
+++ b/zzz_generated/lighting-app/zap-generated/endpoint_config.h
@@ -989,21 +989,3 @@
     {                                                                                                                              \
         0, 0, 0                                                                                                                    \
     }
-
-// This is an array of EmberAfManufacturerCodeEntry structures for clusters.
-#define GENERATED_CLUSTER_MANUFACTURER_CODE_COUNT (0)
-#define GENERATED_CLUSTER_MANUFACTURER_CODES                                                                                       \
-    {                                                                                                                              \
-        {                                                                                                                          \
-            0x00, 0x00                                                                                                             \
-        }                                                                                                                          \
-    }
-
-// This is an array of EmberAfManufacturerCodeEntry structures for attributes.
-#define GENERATED_ATTRIBUTE_MANUFACTURER_CODE_COUNT (0)
-#define GENERATED_ATTRIBUTE_MANUFACTURER_CODES                                                                                     \
-    {                                                                                                                              \
-        {                                                                                                                          \
-            0x00, 0x00                                                                                                             \
-        }                                                                                                                          \
-    }

--- a/zzz_generated/lock-app/zap-generated/endpoint_config.h
+++ b/zzz_generated/lock-app/zap-generated/endpoint_config.h
@@ -851,21 +851,3 @@
     {                                                                                                                              \
         0, 0                                                                                                                       \
     }
-
-// This is an array of EmberAfManufacturerCodeEntry structures for clusters.
-#define GENERATED_CLUSTER_MANUFACTURER_CODE_COUNT (0)
-#define GENERATED_CLUSTER_MANUFACTURER_CODES                                                                                       \
-    {                                                                                                                              \
-        {                                                                                                                          \
-            0x00, 0x00                                                                                                             \
-        }                                                                                                                          \
-    }
-
-// This is an array of EmberAfManufacturerCodeEntry structures for attributes.
-#define GENERATED_ATTRIBUTE_MANUFACTURER_CODE_COUNT (0)
-#define GENERATED_ATTRIBUTE_MANUFACTURER_CODES                                                                                     \
-    {                                                                                                                              \
-        {                                                                                                                          \
-            0x00, 0x00                                                                                                             \
-        }                                                                                                                          \
-    }

--- a/zzz_generated/ota-provider-app/zap-generated/endpoint_config.h
+++ b/zzz_generated/ota-provider-app/zap-generated/endpoint_config.h
@@ -231,21 +231,3 @@
     {                                                                                                                              \
         0                                                                                                                          \
     }
-
-// This is an array of EmberAfManufacturerCodeEntry structures for clusters.
-#define GENERATED_CLUSTER_MANUFACTURER_CODE_COUNT (0)
-#define GENERATED_CLUSTER_MANUFACTURER_CODES                                                                                       \
-    {                                                                                                                              \
-        {                                                                                                                          \
-            0x00, 0x00                                                                                                             \
-        }                                                                                                                          \
-    }
-
-// This is an array of EmberAfManufacturerCodeEntry structures for attributes.
-#define GENERATED_ATTRIBUTE_MANUFACTURER_CODE_COUNT (0)
-#define GENERATED_ATTRIBUTE_MANUFACTURER_CODES                                                                                     \
-    {                                                                                                                              \
-        {                                                                                                                          \
-            0x00, 0x00                                                                                                             \
-        }                                                                                                                          \
-    }

--- a/zzz_generated/ota-requestor-app/zap-generated/endpoint_config.h
+++ b/zzz_generated/ota-requestor-app/zap-generated/endpoint_config.h
@@ -239,21 +239,3 @@
     {                                                                                                                              \
         0                                                                                                                          \
     }
-
-// This is an array of EmberAfManufacturerCodeEntry structures for clusters.
-#define GENERATED_CLUSTER_MANUFACTURER_CODE_COUNT (0)
-#define GENERATED_CLUSTER_MANUFACTURER_CODES                                                                                       \
-    {                                                                                                                              \
-        {                                                                                                                          \
-            0x00, 0x00                                                                                                             \
-        }                                                                                                                          \
-    }
-
-// This is an array of EmberAfManufacturerCodeEntry structures for attributes.
-#define GENERATED_ATTRIBUTE_MANUFACTURER_CODE_COUNT (0)
-#define GENERATED_ATTRIBUTE_MANUFACTURER_CODES                                                                                     \
-    {                                                                                                                              \
-        {                                                                                                                          \
-            0x00, 0x00                                                                                                             \
-        }                                                                                                                          \
-    }

--- a/zzz_generated/placeholder/app1/zap-generated/endpoint_config.h
+++ b/zzz_generated/placeholder/app1/zap-generated/endpoint_config.h
@@ -414,21 +414,3 @@
     {                                                                                                                              \
         0, 0                                                                                                                       \
     }
-
-// This is an array of EmberAfManufacturerCodeEntry structures for clusters.
-#define GENERATED_CLUSTER_MANUFACTURER_CODE_COUNT (0)
-#define GENERATED_CLUSTER_MANUFACTURER_CODES                                                                                       \
-    {                                                                                                                              \
-        {                                                                                                                          \
-            0x00, 0x00                                                                                                             \
-        }                                                                                                                          \
-    }
-
-// This is an array of EmberAfManufacturerCodeEntry structures for attributes.
-#define GENERATED_ATTRIBUTE_MANUFACTURER_CODE_COUNT (0)
-#define GENERATED_ATTRIBUTE_MANUFACTURER_CODES                                                                                     \
-    {                                                                                                                              \
-        {                                                                                                                          \
-            0x00, 0x00                                                                                                             \
-        }                                                                                                                          \
-    }

--- a/zzz_generated/placeholder/app2/zap-generated/endpoint_config.h
+++ b/zzz_generated/placeholder/app2/zap-generated/endpoint_config.h
@@ -393,21 +393,3 @@
     {                                                                                                                              \
         0, 0                                                                                                                       \
     }
-
-// This is an array of EmberAfManufacturerCodeEntry structures for clusters.
-#define GENERATED_CLUSTER_MANUFACTURER_CODE_COUNT (0)
-#define GENERATED_CLUSTER_MANUFACTURER_CODES                                                                                       \
-    {                                                                                                                              \
-        {                                                                                                                          \
-            0x00, 0x00                                                                                                             \
-        }                                                                                                                          \
-    }
-
-// This is an array of EmberAfManufacturerCodeEntry structures for attributes.
-#define GENERATED_ATTRIBUTE_MANUFACTURER_CODE_COUNT (0)
-#define GENERATED_ATTRIBUTE_MANUFACTURER_CODES                                                                                     \
-    {                                                                                                                              \
-        {                                                                                                                          \
-            0x00, 0x00                                                                                                             \
-        }                                                                                                                          \
-    }

--- a/zzz_generated/pump-app/zap-generated/endpoint_config.h
+++ b/zzz_generated/pump-app/zap-generated/endpoint_config.h
@@ -972,21 +972,3 @@
     {                                                                                                                              \
         0, 0                                                                                                                       \
     }
-
-// This is an array of EmberAfManufacturerCodeEntry structures for clusters.
-#define GENERATED_CLUSTER_MANUFACTURER_CODE_COUNT (0)
-#define GENERATED_CLUSTER_MANUFACTURER_CODES                                                                                       \
-    {                                                                                                                              \
-        {                                                                                                                          \
-            0x00, 0x00                                                                                                             \
-        }                                                                                                                          \
-    }
-
-// This is an array of EmberAfManufacturerCodeEntry structures for attributes.
-#define GENERATED_ATTRIBUTE_MANUFACTURER_CODE_COUNT (0)
-#define GENERATED_ATTRIBUTE_MANUFACTURER_CODES                                                                                     \
-    {                                                                                                                              \
-        {                                                                                                                          \
-            0x00, 0x00                                                                                                             \
-        }                                                                                                                          \
-    }

--- a/zzz_generated/pump-controller-app/zap-generated/endpoint_config.h
+++ b/zzz_generated/pump-controller-app/zap-generated/endpoint_config.h
@@ -861,21 +861,3 @@
     {                                                                                                                              \
         0, 0                                                                                                                       \
     }
-
-// This is an array of EmberAfManufacturerCodeEntry structures for clusters.
-#define GENERATED_CLUSTER_MANUFACTURER_CODE_COUNT (0)
-#define GENERATED_CLUSTER_MANUFACTURER_CODES                                                                                       \
-    {                                                                                                                              \
-        {                                                                                                                          \
-            0x00, 0x00                                                                                                             \
-        }                                                                                                                          \
-    }
-
-// This is an array of EmberAfManufacturerCodeEntry structures for attributes.
-#define GENERATED_ATTRIBUTE_MANUFACTURER_CODE_COUNT (0)
-#define GENERATED_ATTRIBUTE_MANUFACTURER_CODES                                                                                     \
-    {                                                                                                                              \
-        {                                                                                                                          \
-            0x00, 0x00                                                                                                             \
-        }                                                                                                                          \
-    }

--- a/zzz_generated/temperature-measurement-app/zap-generated/endpoint_config.h
+++ b/zzz_generated/temperature-measurement-app/zap-generated/endpoint_config.h
@@ -490,21 +490,3 @@
     {                                                                                                                              \
         0, 0                                                                                                                       \
     }
-
-// This is an array of EmberAfManufacturerCodeEntry structures for clusters.
-#define GENERATED_CLUSTER_MANUFACTURER_CODE_COUNT (0)
-#define GENERATED_CLUSTER_MANUFACTURER_CODES                                                                                       \
-    {                                                                                                                              \
-        {                                                                                                                          \
-            0x00, 0x00                                                                                                             \
-        }                                                                                                                          \
-    }
-
-// This is an array of EmberAfManufacturerCodeEntry structures for attributes.
-#define GENERATED_ATTRIBUTE_MANUFACTURER_CODE_COUNT (0)
-#define GENERATED_ATTRIBUTE_MANUFACTURER_CODES                                                                                     \
-    {                                                                                                                              \
-        {                                                                                                                          \
-            0x00, 0x00                                                                                                             \
-        }                                                                                                                          \
-    }

--- a/zzz_generated/thermostat/zap-generated/endpoint_config.h
+++ b/zzz_generated/thermostat/zap-generated/endpoint_config.h
@@ -1075,21 +1075,3 @@
     {                                                                                                                              \
         0, 0                                                                                                                       \
     }
-
-// This is an array of EmberAfManufacturerCodeEntry structures for clusters.
-#define GENERATED_CLUSTER_MANUFACTURER_CODE_COUNT (0)
-#define GENERATED_CLUSTER_MANUFACTURER_CODES                                                                                       \
-    {                                                                                                                              \
-        {                                                                                                                          \
-            0x00, 0x00                                                                                                             \
-        }                                                                                                                          \
-    }
-
-// This is an array of EmberAfManufacturerCodeEntry structures for attributes.
-#define GENERATED_ATTRIBUTE_MANUFACTURER_CODE_COUNT (0)
-#define GENERATED_ATTRIBUTE_MANUFACTURER_CODES                                                                                     \
-    {                                                                                                                              \
-        {                                                                                                                          \
-            0x00, 0x00                                                                                                             \
-        }                                                                                                                          \
-    }

--- a/zzz_generated/tv-app/zap-generated/endpoint_config.h
+++ b/zzz_generated/tv-app/zap-generated/endpoint_config.h
@@ -1621,21 +1621,3 @@
     {                                                                                                                              \
         0, 0, 0, 0, 0, 0                                                                                                           \
     }
-
-// This is an array of EmberAfManufacturerCodeEntry structures for clusters.
-#define GENERATED_CLUSTER_MANUFACTURER_CODE_COUNT (0)
-#define GENERATED_CLUSTER_MANUFACTURER_CODES                                                                                       \
-    {                                                                                                                              \
-        {                                                                                                                          \
-            0x00, 0x00                                                                                                             \
-        }                                                                                                                          \
-    }
-
-// This is an array of EmberAfManufacturerCodeEntry structures for attributes.
-#define GENERATED_ATTRIBUTE_MANUFACTURER_CODE_COUNT (0)
-#define GENERATED_ATTRIBUTE_MANUFACTURER_CODES                                                                                     \
-    {                                                                                                                              \
-        {                                                                                                                          \
-            0x00, 0x00                                                                                                             \
-        }                                                                                                                          \
-    }

--- a/zzz_generated/tv-casting-app/zap-generated/endpoint_config.h
+++ b/zzz_generated/tv-casting-app/zap-generated/endpoint_config.h
@@ -1890,21 +1890,3 @@
     {                                                                                                                              \
         0, 0, 0                                                                                                                    \
     }
-
-// This is an array of EmberAfManufacturerCodeEntry structures for clusters.
-#define GENERATED_CLUSTER_MANUFACTURER_CODE_COUNT (0)
-#define GENERATED_CLUSTER_MANUFACTURER_CODES                                                                                       \
-    {                                                                                                                              \
-        {                                                                                                                          \
-            0x00, 0x00                                                                                                             \
-        }                                                                                                                          \
-    }
-
-// This is an array of EmberAfManufacturerCodeEntry structures for attributes.
-#define GENERATED_ATTRIBUTE_MANUFACTURER_CODE_COUNT (0)
-#define GENERATED_ATTRIBUTE_MANUFACTURER_CODES                                                                                     \
-    {                                                                                                                              \
-        {                                                                                                                          \
-            0x00, 0x00                                                                                                             \
-        }                                                                                                                          \
-    }

--- a/zzz_generated/window-app/zap-generated/endpoint_config.h
+++ b/zzz_generated/window-app/zap-generated/endpoint_config.h
@@ -970,21 +970,3 @@
     {                                                                                                                              \
         0, 0, 0                                                                                                                    \
     }
-
-// This is an array of EmberAfManufacturerCodeEntry structures for clusters.
-#define GENERATED_CLUSTER_MANUFACTURER_CODE_COUNT (0)
-#define GENERATED_CLUSTER_MANUFACTURER_CODES                                                                                       \
-    {                                                                                                                              \
-        {                                                                                                                          \
-            0x00, 0x00                                                                                                             \
-        }                                                                                                                          \
-    }
-
-// This is an array of EmberAfManufacturerCodeEntry structures for attributes.
-#define GENERATED_ATTRIBUTE_MANUFACTURER_CODE_COUNT (0)
-#define GENERATED_ATTRIBUTE_MANUFACTURER_CODES                                                                                     \
-    {                                                                                                                              \
-        {                                                                                                                          \
-            0x00, 0x00                                                                                                             \
-        }                                                                                                                          \
-    }


### PR DESCRIPTION
We're storing the full MEI for cluster and attribute ids, so all this
manufacturer code stuff is dead code.  There's a lot more to remove,
but this is a start.

#### Problem
Various dead code.

#### Change overview
Remove it.

#### Testing
No behavior changes expected.