### PR TITLE
Fix handling of list-typed attributes in Darwin tests.

### DIFF
--- a/.github/workflows/darwin.yaml
+++ b/.github/workflows/darwin.yaml
@@ -114,7 +114,7 @@ jobs:
               run: |
                 mkdir -p /tmp/darwin/framework-tests
                 ../../../out/debug/chip-all-clusters-app > >(tee /tmp/darwin/framework-tests/all-cluster-app.log) 2> >(tee /tmp/darwin/framework-tests/all-cluster-app-err.log >&2) &
-                xcodebuild test -target "CHIP" -scheme "CHIP Framework Tests" -sdk macosx > >(tee /tmp/darwin/framework-tests/darwin-tests.log) 2> >(tee /tmp/darwin/framework-tests/darwin-tests-err.log >&2)
+                xcodebuild test -target "CHIP" -scheme "CHIP Framework Tests" -sdk macosx OTHER_CFLAGS='${inherited} -Werror -Wno-documentation -Wno-conditional-uninitialized -Wno-incomplete-umbrella' > >(tee /tmp/darwin/framework-tests/darwin-tests.log) 2> >(tee /tmp/darwin/framework-tests/darwin-tests-err.log >&2)
               working-directory: src/darwin/Framework
             - name: Uploading log files
               uses: actions/upload-artifact@v2

--- a/src/darwin/Framework/CHIP/templates/helper.js
+++ b/src/darwin/Framework/CHIP/templates/helper.js
@@ -56,6 +56,8 @@ function asTestValue()
     return '[@"Test" dataUsingEncoding:NSUTF8StringEncoding]';
   } else if (StringHelper.isCharString(this.type)) {
     return '@"Test"';
+  } else if (this.isArray) {
+    return '[NSArray array]';
   } else {
     return `@(${this.min || this.max || 0})`;
   }


### PR DESCRIPTION
Two issues here:

1) asTestValue did not handle list attributes properly: it assigned
   @(0) to the NSArray*.

2) This compiled, because we were not enabling -Werror for the build
   of the test harness.

This fixes both issues.  No codegen changes, because we don't actually
have any non-excluded writable list-typed attributes yet.  Which is
good, because they would not have passed CI due to crashing when we
try to treat an NSNumber* as NSArray*.

#### Problem
See above.

#### Change overview
See above.

#### Testing
Ran darwin tests locally and ensured they compile with the warning exclusions I put in.