### PR TITLE
[zephyr] Added support for getting GeneralDiagnostics attributes

### DIFF
--- a/config/nrfconnect/app/sample-defaults.conf
+++ b/config/nrfconnect/app/sample-defaults.conf
@@ -25,6 +25,9 @@ CONFIG_ASSERT=y
 CONFIG_HW_STACK_PROTECTION=y
 CONFIG_SHELL=y
 
+# Enable getting reboot reasons information
+CONFIG_HWINFO=y
+
 # Generic networking options
 CONFIG_NETWORKING=y
 CONFIG_NET_SOCKETS=y

--- a/src/app/clusters/general_diagnostics_server/general_diagnostics_server.cpp
+++ b/src/app/clusters/general_diagnostics_server/general_diagnostics_server.cpp
@@ -35,6 +35,13 @@ using chip::DeviceLayer::ConnectivityMgr;
 using chip::DeviceLayer::DiagnosticDataProvider;
 using chip::DeviceLayer::GetDiagnosticDataProvider;
 
+static_assert(sizeof(DiagnosticDataProvider::BootReasonType) == sizeof(EmberAfBootReasonType),
+              "BootReasonType size doesn't match EmberAfBootReasonType size");
+static_assert(static_cast<uint8_t>(DiagnosticDataProvider::BootReasonType::Unspecified) == EMBER_ZCL_BOOT_REASON_TYPE_UNSPECIFIED &&
+                  static_cast<uint8_t>(DiagnosticDataProvider::BootReasonType::SoftwareReset) ==
+                      EMBER_ZCL_BOOT_REASON_TYPE_SOFTWARE_RESET,
+              "BootReasonType and EmberAfBootReasonType values does not match.");
+
 namespace {
 
 class GeneralDiagosticsAttrAccess : public AttributeAccessInterface

--- a/src/include/platform/DiagnosticDataProvider.h
+++ b/src/include/platform/DiagnosticDataProvider.h
@@ -131,6 +131,17 @@ public:
 class DiagnosticDataProvider
 {
 public:
+    enum BootReasonType : uint8_t
+    {
+        Unspecified             = 0,
+        PowerOnReboot           = 1,
+        BrownOutReset           = 2,
+        SoftwareWatchdogReset   = 3,
+        HardwareWatchdogReset   = 4,
+        SoftwareUpdateCompleted = 5,
+        SoftwareReset           = 6,
+    };
+
     void SetGeneralDiagnosticsDelegate(GeneralDiagnosticsDelegate * delegate) { mGeneralDiagnosticsDelegate = delegate; }
     GeneralDiagnosticsDelegate * GetGeneralDiagnosticsDelegate() const { return mGeneralDiagnosticsDelegate; }
 

--- a/src/inet/InetInterface.h
+++ b/src/inet/InetInterface.h
@@ -59,6 +59,18 @@ class IPAddress;
 class IPPrefix;
 
 /**
+ * Data type describing interface type.
+ */
+enum class InterfaceType
+{
+    Unknown  = 0,
+    WiFi     = 1,
+    Ethernet = 2,
+    Cellular = 3,
+    Thread   = 4,
+};
+
+/**
  * Indicator for system network interfaces.
  */
 class InterfaceId
@@ -298,6 +310,22 @@ public:
      *          if not, or if the iterator is positioned beyond the end of the list.
      */
     bool HasBroadcastAddress();
+
+    /**
+     * Get the interface type of the current network interface.
+     *
+     * @param[out]   type       Object to save the interface type.
+     */
+    CHIP_ERROR GetInterfaceType(InterfaceType & type);
+
+    /**
+     * Get the hardware address of the current network interface
+     *
+     * @param[out]   addressBuffer       Region of memory to write the hardware address.
+     * @param[out]   addressSize         Size of the address saved to a buffer.
+     * @param[in]    addressBufferSize   Maximum size of a buffer to save data.
+     */
+    CHIP_ERROR GetHardwareAddress(uint8_t * addressBuffer, uint8_t & addressSize, uint8_t addressBufferSize);
 
 protected:
 #if CHIP_SYSTEM_CONFIG_USE_LWIP

--- a/src/platform/Ameba/ConfigurationManagerImpl.cpp
+++ b/src/platform/Ameba/ConfigurationManagerImpl.cpp
@@ -26,6 +26,7 @@
 
 #include <platform/Ameba/AmebaConfig.h>
 #include <platform/ConfigurationManager.h>
+#include <platform/DiagnosticDataProvider.h>
 #include <platform/internal/GenericConfigurationManagerImpl.cpp>
 #include <support/CodeUtils.h>
 #include <support/logging/CHIPLogging.h>
@@ -79,7 +80,7 @@ CHIP_ERROR ConfigurationManagerImpl::Init()
 
     if (!AmebaConfig::ConfigValueExists(AmebaConfig::kCounterKey_BootReason))
     {
-        err = StoreBootReason(EMBER_ZCL_BOOT_REASON_TYPE_UNSPECIFIED);
+        err = StoreBootReason(DiagnosticDataProvider::BootReasonType::Unspecified);
         SuccessOrExit(err);
     }
 

--- a/src/platform/EFR32/ConfigurationManagerImpl.cpp
+++ b/src/platform/EFR32/ConfigurationManagerImpl.cpp
@@ -27,6 +27,7 @@
 #include <platform/internal/GenericConfigurationManagerImpl.cpp>
 
 #include <platform/ConfigurationManager.h>
+#include <platform/DiagnosticDataProvider.h>
 #include <platform/EFR32/EFR32Config.h>
 
 #include "em_rmu.h"
@@ -106,50 +107,50 @@ uint32_t ConfigurationManagerImpl::GetBootReason(void)
 #if defined(_SILICON_LABS_32B_SERIES_1)
     if (rebootCause & RMU_RSTCAUSE_PORST || rebootCause & RMU_RSTCAUSE_EXTRST) // PowerOn or External pin reset
     {
-        matterBootCause = EMBER_ZCL_BOOT_REASON_TYPE_POWER_ON_REBOOT;
+        matterBootCause = DiagnosticDataProvider::BootReasonType::PowerOnReboot;
     }
     else if (rebootCause & RMU_RSTCAUSE_AVDDBOD || rebootCause & RMU_RSTCAUSE_DVDDBOD || rebootCause & RMU_RSTCAUSE_DECBOD)
     {
-        matterBootCause = EMBER_ZCL_BOOT_REASON_TYPE_BROWN_OUT_RESET;
+        matterBootCause = DiagnosticDataProvider::BootReasonType::BrownOutReset;
     }
     else if (rebootCause & RMU_RSTCAUSE_SYSREQRST)
     {
-        matterBootCause = EMBER_ZCL_BOOT_REASON_TYPE_SOFTWARE_RESET;
+        matterBootCause = DiagnosticDataProvider::BootReasonType::SoftwareReset;
     }
     else if (rebootCause & RMU_RSTCAUSE_WDOGRST)
     {
-        matterBootCause = EMBER_ZCL_BOOT_REASON_TYPE_SOFTWARE_WATCHDOG_RESET;
+        matterBootCause = DiagnosticDataProvider::BootReasonType::SoftwareWatchdogReset;
     }
     else
     {
-        matterBootCause = EMBER_ZCL_BOOT_REASON_TYPE_UNSPECIFIED;
+        matterBootCause = DiagnosticDataProvider::BootReasonType::Unspecified;
     }
     // Not tracked HARDWARE_WATCHDOG_RESET && SOFTWARE_UPDATE_COMPLETED
 #elif defined(_SILICON_LABS_32B_SERIES_2)
     if (rebootCause & EMU_RSTCAUSE_POR || rebootCause & EMU_RSTCAUSE_PIN) // PowerOn or External pin reset
     {
-        matterBootCause = EMBER_ZCL_BOOT_REASON_TYPE_POWER_ON_REBOOT;
+        matterBootCause = DiagnosticDataProvider::BootReasonType::PowerOnReboot;
     }
     else if (rebootCause & EMU_RSTCAUSE_AVDDBOD || rebootCause & EMU_RSTCAUSE_DVDDBOD || rebootCause & EMU_RSTCAUSE_DECBOD ||
              rebootCause & EMU_RSTCAUSE_VREGIN || rebootCause & EMU_RSTCAUSE_IOVDD0BOD || rebootCause & EMU_RSTCAUSE_DVDDLEBOD)
     {
-        matterBootCause = EMBER_ZCL_BOOT_REASON_TYPE_BROWN_OUT_RESET;
+        matterBootCause = DiagnosticDataProvider::BootReasonType::BrownOutReset;
     }
     else if (rebootCause & EMU_RSTCAUSE_SYSREQ)
     {
-        matterBootCause = EMBER_ZCL_BOOT_REASON_TYPE_SOFTWARE_RESET;
+        matterBootCause = DiagnosticDataProvider::BootReasonType::SoftwareReset;
     }
     else if (rebootCause & EMU_RSTCAUSE_WDOG0 || rebootCause & EMU_RSTCAUSE_WDOG1)
     {
-        matterBootCause = EMBER_ZCL_BOOT_REASON_TYPE_SOFTWARE_WATCHDOG_RESET;
+        matterBootCause = DiagnosticDataProvider::BootReasonType::SoftwareWatchdogReset;
     }
     else
     {
-        matterBootCause = EMBER_ZCL_BOOT_REASON_TYPE_UNSPECIFIED;
+        matterBootCause = DiagnosticDataProvider::BootReasonType::Unspecified;
     }
     // Not tracked HARDWARE_WATCHDOG_RESET && SOFTWARE_UPDATE_COMPLETED
 #else
-    matterBootCause = EMBER_ZCL_BOOT_REASON_TYPE_UNSPECIFIED;
+    matterBootCause = DiagnosticDataProvider::BootReasonType::Unspecified;
 #endif
 
     return matterBootCause;

--- a/src/platform/ESP32/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/ESP32/DiagnosticDataProviderImpl.cpp
@@ -167,28 +167,28 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetTotalOperationalHours(uint32_t & total
 
 CHIP_ERROR DiagnosticDataProviderImpl::GetBootReason(uint8_t & bootReason)
 {
-    bootReason = EMBER_ZCL_BOOT_REASON_TYPE_UNSPECIFIED;
+    bootReason = BootReasonType::Unspecified;
     uint8_t reason;
     reason = static_cast<uint8_t>(esp_reset_reason());
     if (reason == ESP_RST_UNKNOWN)
     {
-        bootReason = EMBER_ZCL_BOOT_REASON_TYPE_UNSPECIFIED;
+        bootReason = BootReasonType::Unspecified;
     }
     else if (reason == ESP_RST_POWERON)
     {
-        bootReason = EMBER_ZCL_BOOT_REASON_TYPE_POWER_ON_REBOOT;
+        bootReason = BootReasonType::PowerOnReboot;
     }
     else if (reason == ESP_RST_BROWNOUT)
     {
-        bootReason = EMBER_ZCL_BOOT_REASON_TYPE_BROWN_OUT_RESET;
+        bootReason = BootReasonType::BrownOutReset;
     }
     else if (reason == ESP_RST_SW)
     {
-        bootReason = EMBER_ZCL_BOOT_REASON_TYPE_SOFTWARE_RESET;
+        bootReason = BootReasonType::SoftwareReset;
     }
     else if (reason == ESP_RST_INT_WDT)
     {
-        bootReason = EMBER_ZCL_BOOT_REASON_TYPE_SOFTWARE_WATCHDOG_RESET;
+        bootReason = BootReasonType::SoftwareWatchdogReset;
         /* Reboot can be due to hardware or software watchdog*/
     }
     return CHIP_NO_ERROR;

--- a/src/platform/Linux/ConfigurationManagerImpl.cpp
+++ b/src/platform/Linux/ConfigurationManagerImpl.cpp
@@ -32,6 +32,7 @@
 #include <lib/support/logging/CHIPLogging.h>
 #include <netpacket/packet.h>
 #include <platform/ConfigurationManager.h>
+#include <platform/DiagnosticDataProvider.h>
 #include <platform/Linux/PosixConfig.h>
 #include <platform/internal/GenericConfigurationManagerImpl.cpp>
 
@@ -87,7 +88,7 @@ CHIP_ERROR ConfigurationManagerImpl::Init()
 
     if (!PosixConfig::ConfigValueExists(PosixConfig::kCounterKey_BootReason))
     {
-        err = StoreBootReason(EMBER_ZCL_BOOT_REASON_TYPE_UNSPECIFIED);
+        err = StoreBootReason(DiagnosticDataProvider::BootReasonType::Unspecified);
         SuccessOrExit(err);
     }
 

--- a/src/platform/Linux/PlatformManagerImpl.cpp
+++ b/src/platform/Linux/PlatformManagerImpl.cpp
@@ -63,27 +63,27 @@ void SignalHandler(int signum)
     switch (signum)
     {
     case SIGINT:
-        ConfigurationMgr().StoreBootReason(EMBER_ZCL_BOOT_REASON_TYPE_SOFTWARE_RESET);
+        ConfigurationMgr().StoreBootReason(DiagnosticDataProvider::BootReasonType::SoftwareReset);
         err = CHIP_ERROR_REBOOT_SIGNAL_RECEIVED;
         break;
     case SIGHUP:
-        ConfigurationMgr().StoreBootReason(EMBER_ZCL_BOOT_REASON_TYPE_BROWN_OUT_RESET);
+        ConfigurationMgr().StoreBootReason(DiagnosticDataProvider::BootReasonType::BrownOutReset);
         err = CHIP_ERROR_REBOOT_SIGNAL_RECEIVED;
         break;
     case SIGTERM:
-        ConfigurationMgr().StoreBootReason(EMBER_ZCL_BOOT_REASON_TYPE_POWER_ON_REBOOT);
+        ConfigurationMgr().StoreBootReason(DiagnosticDataProvider::BootReasonType::PowerOnReboot);
         err = CHIP_ERROR_REBOOT_SIGNAL_RECEIVED;
         break;
     case SIGUSR1:
-        ConfigurationMgr().StoreBootReason(EMBER_ZCL_BOOT_REASON_TYPE_HARDWARE_WATCHDOG_RESET);
+        ConfigurationMgr().StoreBootReason(DiagnosticDataProvider::BootReasonType::HardwareWatchdogReset);
         err = CHIP_ERROR_REBOOT_SIGNAL_RECEIVED;
         break;
     case SIGUSR2:
-        ConfigurationMgr().StoreBootReason(EMBER_ZCL_BOOT_REASON_TYPE_SOFTWARE_WATCHDOG_RESET);
+        ConfigurationMgr().StoreBootReason(DiagnosticDataProvider::BootReasonType::SoftwareWatchdogReset);
         err = CHIP_ERROR_REBOOT_SIGNAL_RECEIVED;
         break;
     case SIGTSTP:
-        ConfigurationMgr().StoreBootReason(EMBER_ZCL_BOOT_REASON_TYPE_SOFTWARE_UPDATE_COMPLETED);
+        ConfigurationMgr().StoreBootReason(DiagnosticDataProvider::BootReasonType::SoftwareUpdateCompleted);
         err = CHIP_ERROR_REBOOT_SIGNAL_RECEIVED;
         break;
     case SIGTRAP:

--- a/src/platform/P6/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/P6/DiagnosticDataProviderImpl.cpp
@@ -119,23 +119,23 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetBootReason(uint8_t & bootReason)
     cyhal_reset_reason_t reset_reason = cyhal_system_get_reset_reason();
     if (reset_reason == CYHAL_SYSTEM_RESET_NONE)
     {
-        bootReason = EMBER_ZCL_BOOT_REASON_TYPE_POWER_ON_REBOOT;
+        bootReason = BootReasonType::PowerOnReboot;
     }
     else if (reset_reason == CYHAL_SYSTEM_RESET_WDT)
     {
-        bootReason = EMBER_ZCL_BOOT_REASON_TYPE_SOFTWARE_WATCHDOG_RESET;
+        bootReason = BootReasonType::SoftwareWatchdogReset;
     }
     else if (reset_reason == CYHAL_SYSTEM_RESET_SOFT)
     {
-        bootReason = EMBER_ZCL_BOOT_REASON_TYPE_SOFTWARE_RESET;
+        bootReason = BootReasonType::SoftwareReset;
     }
     else if (reset_reason == CYHAL_SYSTEM_RESET_HIB_WAKEUP)
     {
-        bootReason = EMBER_ZCL_BOOT_REASON_TYPE_HARDWARE_WATCHDOG_RESET;
+        bootReason = BootReasonType::HardwareWatchdogReset;
     }
     else
     {
-        bootReason = EMBER_ZCL_BOOT_REASON_TYPE_UNSPECIFIED;
+        bootReason = BootReasonType::Unspecified;
     }
     return CHIP_NO_ERROR;
 }

--- a/src/platform/Zephyr/ConfigurationManagerImpl.h
+++ b/src/platform/Zephyr/ConfigurationManagerImpl.h
@@ -36,6 +36,8 @@ namespace DeviceLayer {
 class ConfigurationManagerImpl : public Internal::GenericConfigurationManagerImpl<Internal::ZephyrConfig>
 {
 public:
+    CHIP_ERROR GetRebootCount(uint32_t & rebootCount) override;
+    CHIP_ERROR StoreRebootCount(uint32_t rebootCount) override;
     // This returns an instance of this class.
     static ConfigurationManagerImpl & GetDefaultInstance();
 

--- a/src/platform/Zephyr/DiagnosticDataProviderImpl.h
+++ b/src/platform/Zephyr/DiagnosticDataProviderImpl.h
@@ -42,6 +42,11 @@ public:
     CHIP_ERROR GetCurrentHeapFree(uint64_t & currentHeapFree) override;
     CHIP_ERROR GetCurrentHeapUsed(uint64_t & currentHeapUsed) override;
     CHIP_ERROR GetCurrentHeapHighWatermark(uint64_t & currentHeapHighWatermark) override;
+
+    CHIP_ERROR GetRebootCount(uint16_t & rebootCount) override;
+    CHIP_ERROR GetBootReason(uint8_t & bootReason) override;
+    CHIP_ERROR GetNetworkInterfaces(NetworkInterface ** netifpp) override;
+    void ReleaseNetworkInterfaces(NetworkInterface * netifp) override;
 };
 
 } // namespace DeviceLayer

--- a/src/platform/Zephyr/ZephyrConfig.cpp
+++ b/src/platform/Zephyr/ZephyrConfig.cpp
@@ -71,6 +71,11 @@ const ZephyrConfig::Key ZephyrConfig::kConfigKey_FailSafeArmed      = CONFIG_KEY
 const ZephyrConfig::Key ZephyrConfig::kConfigKey_RegulatoryLocation = CONFIG_KEY(NAMESPACE_CONFIG "regulatory-location");
 const ZephyrConfig::Key ZephyrConfig::kConfigKey_CountryCode        = CONFIG_KEY(NAMESPACE_CONFIG "country-code");
 const ZephyrConfig::Key ZephyrConfig::kConfigKey_Breadcrumb         = CONFIG_KEY(NAMESPACE_CONFIG "breadcrumb");
+
+// Keys stored in the counters namespace
+const ZephyrConfig::Key ZephyrConfig::kCounterKey_RebootCount = CONFIG_KEY(NAMESPACE_COUNTERS "reboot-count");
+const ZephyrConfig::Key ZephyrConfig::kCounterKey_BootReason  = CONFIG_KEY(NAMESPACE_COUNTERS "boot-reason");
+
 namespace {
 
 constexpr const char * sAllResettableConfigKeys[] = {

--- a/src/platform/Zephyr/ZephyrConfig.h
+++ b/src/platform/Zephyr/ZephyrConfig.h
@@ -63,6 +63,8 @@ public:
     static const Key kConfigKey_RegulatoryLocation;
     static const Key kConfigKey_CountryCode;
     static const Key kConfigKey_Breadcrumb;
+    static const Key kCounterKey_RebootCount;
+    static const Key kCounterKey_BootReason;
 
     static CHIP_ERROR Init(void);
 


### PR DESCRIPTION
#### Problem
nrfconnect/Zephyr platform doesn't support get methods for `GeneralDiagnostics` attributes

#### Change overview
* Added methods for getting `RebootCount`, `NetworkInterfaces` and `BootReasons`
* Added to the `InterfaceIterator` methods allowing to get interface type and hardware address using Zephyr API
* Added `BootReasonType` to the `DiagnosticDataProvider` to remove dependency between platform and auto-generated code

#### Testing
Tested manually for nrfconnect platform using Python CHIP Controller `zclread GeneralDiagnostics` commands 
