### PR TITLE
[Android] Fix accidental Verify condition when throwing exception

### DIFF
--- a/src/controller/java/AndroidClusterExceptions.cpp
+++ b/src/controller/java/AndroidClusterExceptions.cpp
@@ -71,7 +71,7 @@ CHIP_ERROR AndroidClusterExceptions::CreateIllegalStateException(JNIEnv * env, c
 void AndroidClusterExceptions::ReturnIllegalStateException(JNIEnv * env, jobject callback, const char message[],
                                                            ChipError errorCode)
 {
-    VerifyOrReturn(callback == nullptr, ChipLogDetail(Zcl, "Callback is null in ReturnIllegalStateException(), exiting early"));
+    VerifyOrReturn(callback != nullptr, ChipLogDetail(Zcl, "Callback is null in ReturnIllegalStateException(), exiting early"));
 
     CHIP_ERROR err = CHIP_NO_ERROR;
     jmethodID method;


### PR DESCRIPTION
#### Problem
* Verifying callback == nullptr instead of callback != nullptr.

#### Change overview
* Use !=.

#### Testing
* Manually called ReturnIllegalStateException, verified that exception was thrown iff callback exists.
