### PR TITLE
Remove weak keyword from OT uart process implemented for efr32 platform

### DIFF
--- a/src/platform/EFR32/ThreadStackManagerImpl.cpp
+++ b/src/platform/EFR32/ThreadStackManagerImpl.cpp
@@ -116,7 +116,7 @@ extern "C" void otPlatFree(void * aPtr)
 #include "uart.h"
 #endif
 
-extern "C" __WEAK otError otPlatUartEnable(void)
+extern "C" otError otPlatUartEnable(void)
 {
 #ifdef PW_RPC_ENABLED
     return OT_ERROR_NOT_IMPLEMENTED;
@@ -126,7 +126,7 @@ extern "C" __WEAK otError otPlatUartEnable(void)
 #endif
 }
 
-extern "C" __WEAK otError otPlatUartSend(const uint8_t * aBuf, uint16_t aBufLength)
+extern "C" otError otPlatUartSend(const uint8_t * aBuf, uint16_t aBufLength)
 {
 #ifdef PW_RPC_ENABLED
     return OT_ERROR_NOT_IMPLEMENTED;
@@ -140,7 +140,7 @@ extern "C" __WEAK otError otPlatUartSend(const uint8_t * aBuf, uint16_t aBufLeng
 #endif
 }
 
-extern "C" __WEAK void efr32UartProcess(void)
+extern "C" void efr32UartProcess(void)
 {
 #if !defined(PW_RPC_ENABLED) && !defined(ENABLE_CHIP_SHELL)
     uint8_t tempBuf[128] = { 0 };


### PR DESCRIPTION
#### Problem
The PR #[12411](https://github.com/project-chip/connectedhomeip/pull/12411) updated ot-efr32 submodule and broke the serial port on efr32 platform

#### Change overview
OT-efr32 submodule update added in some weak empty functions that overwrote the already weak functions implementation that linked ot uart proces to efr32 uart implementation. 

I do not recall why those functions for efr32 needed to be weak in the first place but it isn't the case anymore.

#### Testing
Build and succesfully used thread cli on efr32 platform.
