### PR TITLE
RPC: Remove console install from efr lighting

### DIFF
--- a/examples/lighting-app/efr32/BUILD.gn
+++ b/examples/lighting-app/efr32/BUILD.gn
@@ -167,12 +167,6 @@ efr32_executable("lighting_app") {
 
 group("efr32") {
   deps = [ ":lighting_app" ]
-  if (chip_enable_pw_rpc) {
-    deps += [
-      "${chip_root}/examples/common/pigweed/rpc_console/py:chip_rpc.install",
-      "${chip_root}/examples/common/pigweed/rpc_console/py:chip_rpc_wheel",
-    ]
-  }
 }
 
 group("default") {


### PR DESCRIPTION
#### Problem
CI is seeing errors building the python whl for chip console as part of the EFR example.

#### Change overview
Remove automatic install of the console, a similar fix #12494 appears to have fixed the problem for linux.  

