### PR TITLE
Calls user-supplied function for every endpoint that has correct given server cluster

### DIFF
--- a/src/app/clusters/software_diagnostics_server/software_diagnostics_server.cpp
+++ b/src/app/clusters/software_diagnostics_server/software_diagnostics_server.cpp
@@ -131,7 +131,7 @@ class SoftwareDiagnosticsDelegate : public DeviceLayer::SoftwareDiagnosticsDeleg
     {
         ChipLogProgress(Zcl, "SoftwareDiagnosticsDelegate: OnSoftwareFaultDetected");
 
-        ForAllEndpointsWithServerCluster(GeneralDiagnostics::Id, [](EndpointId endpoint, intptr_t) -> Loop {
+        ForAllEndpointsWithServerCluster(SoftwareDiagnostics::Id, [](EndpointId endpoint, intptr_t) -> Loop {
             // TODO: Log SoftwareFault event and walk them all.
             return Loop::Break;
         });


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* Typo, wrong server cluster is provided to user-supplied function

#### Change overview
Calls user-supplied function for every endpoint that has correct given server cluster

#### Testing
How was this tested? (at least one bullet point required)
* N/A