### PR TITLE
Begin to transition entryType over to type+array=true

### DIFF
--- a/src/app/zap-templates/zcl/data-model/chip/access-control-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/access-control-cluster.xml
@@ -67,13 +67,13 @@ limitations under the License.
       and enforce Access Control for the Node’s endpoints and their associated
       cluster instances.</description>
     <!-- Base data types -->
-    <attribute side="server" code="0x0000" define="ACL" type="ARRAY" entryType="AccessControlEntry" writable="true">
+    <attribute side="server" code="0x0000" define="ACL" type="ARRAY" array="true" entryType="AccessControlEntry" writable="true">
         <description>ACL</description>
         <access op="read" privilege="administer"/>
         <access op="write" privilege="administer"/>        
         <access modifier="fabric-scoped"/>
     </attribute>
-    <attribute side="server" code="0x0001" define="EXTENSION" type="ARRAY" entryType="ExtensionEntry" writable="true">
+    <attribute side="server" code="0x0001" define="EXTENSION" type="ARRAY" array="true" entryType="ExtensionEntry" writable="true">
         <description>Extension</description>
         <access op="read" privilege="administer"/>
         <access op="write" privilege="administer"/>        

--- a/src/app/zap-templates/zcl/data-model/chip/application-launcher-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/application-launcher-cluster.xml
@@ -25,7 +25,7 @@ limitations under the License.
     <server init="false" tick="false">true</server>
     <description>This cluster provides an interface for launching content on a media player device such as a TV or Speaker.</description>
 
-    <attribute side="server" code="0x0000" define="APPLICATION_LAUNCHER_LIST" type="ARRAY" entryType="INT16U" length="254" writable="false" optional="false">application launcher list</attribute>
+    <attribute side="server" code="0x0000" define="APPLICATION_LAUNCHER_LIST" type="ARRAY" array="true" entryType="INT16U" length="254" writable="false" optional="false">application launcher list</attribute>
     <!-- TODO: Convert this to struct once it is supported -->
     <attribute side="server" code="0x0001" define="APPLICATION_LAUNCHER_CURRENT_APP_CATALOG_VENDOR_ID" type="INT8U" min="0x00" max="0xFF" writable="false" default="0x00" optional="true">catalog vendor id</attribute>
     <attribute side="server" code="0x0002" define="APPLICATION_LAUNCHER_CURRENT_APP_APPLICATION_ID" type="INT8U" min="0x00" max="0xFF" writable="false" default="0x00" optional="true">application id</attribute>

--- a/src/app/zap-templates/zcl/data-model/chip/audio-output-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/audio-output-cluster.xml
@@ -25,7 +25,7 @@ limitations under the License.
     <server init="false" tick="false">true</server>
     <!-- TODO: Add feature map once it is supported -->
     <description>This cluster provides an interface for controlling the Output on a media device such as a TV.</description>
-    <attribute side="server" code="0x0000" define="AUDIO_OUTPUT_LIST" type="ARRAY" entryType="AudioOutputInfo" length="254" writable="false" optional="false">audio output list</attribute>
+    <attribute side="server" code="0x0000" define="AUDIO_OUTPUT_LIST" type="ARRAY" array="true" entryType="AudioOutputInfo" length="254" writable="false" optional="false">audio output list</attribute>
     <attribute side="server" code="0x0001" define="AUDIO_OUTPUT_CURRENT_OUTPUT" type="INT8U" min="0x00" max="0xFF" writable="false" default="0x00" optional="true">current audio output</attribute>
 
     <command source="client" code="0x00" name="SelectOutput" optional="false">

--- a/src/app/zap-templates/zcl/data-model/chip/bridged-actions-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/bridged-actions-cluster.xml
@@ -91,8 +91,8 @@ limitations under the License.
     <define>BRIDGED_ACTIONS_CLUSTER</define>
     <description>This cluster provides a standardized way for a Node (typically a Bridge, but could be any Node) to expose action information.</description>
 
-    <attribute side="server" code="0x0000" define="ACTION_LIST" type="ARRAY" entryType="ActionStruct" length="256" writable="false" optional="false">action list</attribute>
-    <attribute side="server" code="0x0001" define="ENDPOINT_LIST" type="ARRAY" entryType="EndpointListStruct" length="256" writable="false" optional="false">endpoint list</attribute>
+    <attribute side="server" code="0x0000" define="ACTION_LIST" type="ARRAY" array="true" entryType="ActionStruct" length="256" writable="false" optional="false">action list</attribute>
+    <attribute side="server" code="0x0001" define="ENDPOINT_LIST" type="ARRAY" array="true" entryType="EndpointListStruct" length="256" writable="false" optional="false">endpoint list</attribute>
     <attribute side="server" code="0x0002" define="SETUP_URL" type="LONG_CHAR_STRING" length="512" writable="false" optional="true">setup url</attribute>
 
     <command source="client" code="0x00" name="InstantAction" optional="true">

--- a/src/app/zap-templates/zcl/data-model/chip/content-launch-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/content-launch-cluster.xml
@@ -26,8 +26,8 @@ limitations under the License.
     <!-- TODO: Add feature map once it is supported -->
     <description>This cluster provides an interface for launching content on a media player device such as a TV or Speaker.</description>
 
-    <attribute side="server" code="0x0000" define="CONTENT_LAUNCHER_ACCEPTS_HEADER" type="ARRAY" entryType="OCTET_STRING" length="254" writable="false" optional="false">accepts header list</attribute>
-    <attribute side="server" code="0x0001" define="CONTENT_LAUNCHER_SUPPORTED_STREAMING_TYPES" type="ARRAY" entryType="ContentLaunchStreamingType" length="254" writable="false" optional="false">supported streaming types</attribute>
+    <attribute side="server" code="0x0000" define="CONTENT_LAUNCHER_ACCEPTS_HEADER" type="ARRAY" array="true" entryType="OCTET_STRING" length="254" writable="false" optional="false">accepts header list</attribute>
+    <attribute side="server" code="0x0001" define="CONTENT_LAUNCHER_SUPPORTED_STREAMING_TYPES" type="ARRAY" array="true" entryType="ContentLaunchStreamingType" length="254" writable="false" optional="false">supported streaming types</attribute>
 
     <command source="client" code="0x00" name="LaunchContent" optional="false">
       <description>Upon receipt, this SHALL launch the specified content with optional search criteria.</description>

--- a/src/app/zap-templates/zcl/data-model/chip/descriptor-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/descriptor-cluster.xml
@@ -29,9 +29,9 @@ limitations under the License.
     <code>0x001d</code>
     <define>DESCRIPTOR_CLUSTER</define>
     <description>The Descriptor Cluster is meant to replace the support from the Zigbee Device Object (ZDO) for describing a node, its endpoints and clusters.</description>
-    <attribute side="server" code="0x0000" define="DEVICE_LIST" type="ARRAY" entryType="DeviceType" length="254" writable="false" optional="false">device list</attribute>
-    <attribute side="server" code="0x0001" define="SERVER_LIST" type="ARRAY" entryType="CLUSTER_ID" length="254" writable="false" optional="false">server list</attribute>
-    <attribute side="server" code="0x0002" define="CLIENT_LIST" type="ARRAY" entryType="CLUSTER_ID" length="254" writable="false" optional="false">client list</attribute>
-    <attribute side="server" code="0x0003" define="PARTS_LIST" type="ARRAY" entryType="ENDPOINT_NO" length="254" writable="false" optional="false">parts list</attribute>
+    <attribute side="server" code="0x0000" define="DEVICE_LIST" type="ARRAY" array="true" entryType="DeviceType" length="254" writable="false" optional="false">device list</attribute>
+    <attribute side="server" code="0x0001" define="SERVER_LIST" type="ARRAY" array="true" entryType="CLUSTER_ID" length="254" writable="false" optional="false">server list</attribute>
+    <attribute side="server" code="0x0002" define="CLIENT_LIST" type="ARRAY" array="true" entryType="CLUSTER_ID" length="254" writable="false" optional="false">client list</attribute>
+    <attribute side="server" code="0x0003" define="PARTS_LIST" type="ARRAY" array="true" entryType="ENDPOINT_NO" length="254" writable="false" optional="false">parts list</attribute>
   </cluster>
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/fixed-label-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/fixed-label-cluster.xml
@@ -30,6 +30,6 @@ limitations under the License.
     <define>FIXED_LABEL_CLUSTER</define>
     <description>The Fixed Label Cluster provides a feature for the device to tag an endpoint with zero or more read only
 labels.</description>
-    <attribute side="server" code="0x0000" define="LABEL_LIST" type="ARRAY" entryType="LabelStruct" length="254" writable="false" optional="false">label list</attribute>
+    <attribute side="server" code="0x0000" define="LABEL_LIST" type="ARRAY" array="true" entryType="LabelStruct" length="254" writable="false" optional="false">label list</attribute>
   </cluster>
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/general-commissioning-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/general-commissioning-cluster.xml
@@ -40,7 +40,7 @@ limitations under the License.
     <define>GENERAL_COMMISSIONING_CLUSTER</define>
     <description>This cluster is used to set, remove and update fabric information on a commissionee.</description>
     <attribute side="server" code="0x00" define="BREADCRUMB" type="INT64U" writable="true" default="0x0000000000000000" optional="false">Breadcrumb</attribute>
-    <attribute side="server" code="0x01" define="BASICCOMMISSIONINGINFO_LIST" type="ARRAY" entryType="BasicCommissioningInfoType" length="254" writable="false" optional="false">BasicCommissioningInfoList</attribute>
+    <attribute side="server" code="0x01" define="BASICCOMMISSIONINGINFO_LIST" type="ARRAY" array="true" entryType="BasicCommissioningInfoType" length="254" writable="false" optional="false">BasicCommissioningInfoList</attribute>
     <attribute side="server" code="0x02" define="REGULATORYCONFIG" type="ENUM8" writable="false" optional="true">RegulatoryConfig</attribute>
     <attribute side="server" code="0x03" define="LOCATIONCAPABILITY" type="ENUM8" writable="false" optional="true">LocationCapability</attribute>
     <command source="client" code="0x00" name="ArmFailSafe" optional="false" cli="chip fabric_commissioning armfailsafe">

--- a/src/app/zap-templates/zcl/data-model/chip/general-diagnostics-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/general-diagnostics-cluster.xml
@@ -81,14 +81,14 @@ limitations under the License.
     <code>0x0033</code>
     <define>GENERAL_DIAGNOSTICS_CLUSTER</define>
     <description>The General Diagnostics Cluster, along with other diagnostics clusters, provide a means to acquire standardized diagnostics metrics that MAY be used by a Node to assist a user or Administrative Node in diagnosing potential problems.</description>
-    <attribute side="server" code="0x00" define="NETWORK_INTERFACES" type="ARRAY" entryType="NetworkInterfaceType" length="254" writable="false" optional="false">NetworkInterfaces</attribute>
+    <attribute side="server" code="0x00" define="NETWORK_INTERFACES" type="ARRAY" array="true" entryType="NetworkInterfaceType" length="254" writable="false" optional="false">NetworkInterfaces</attribute>
     <attribute side="server" code="0x01" define="REBOOT_COUNT" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="false">RebootCount</attribute>
     <attribute side="server" code="0x02" define="UPTIME" type="INT64U" min="0x0000000000000000" max="0xFFFFFFFFFFFFFFFF" writable="false" default="0x0000000000000000" optional="true">UpTime</attribute>
     <attribute side="server" code="0x03" define="TOTAL_OPERATIONAL_HOURS" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" default="0x00000000" optional="true">TotalOperationalHours</attribute>
     <attribute side="server" code="0x04" define="BOOT_REASONS" type="ENUM8" writable="false" optional="true">BootReasons</attribute>
-    <attribute side="server" code="0x05" define="ACTIVE_HARDWARE_FAULTS" type="ARRAY" entryType="ENUM8" length="254" writable="false" optional="true">ActiveHardwareFaults</attribute>
-    <attribute side="server" code="0x06" define="ACTIVE_RADIO_FAULTS" type="ARRAY" entryType="ENUM8" length="254" writable="false" optional="true">ActiveRadioFaults</attribute>
-    <attribute side="server" code="0x07" define="ACTIVE_NETWORK_FAULTS" type="ARRAY" entryType="ENUM8" length="254" writable="false" optional="true">ActiveNetworkFaults</attribute>
+    <attribute side="server" code="0x05" define="ACTIVE_HARDWARE_FAULTS" type="ARRAY" array="true" entryType="ENUM8" length="254" writable="false" optional="true">ActiveHardwareFaults</attribute>
+    <attribute side="server" code="0x06" define="ACTIVE_RADIO_FAULTS" type="ARRAY" array="true" entryType="ENUM8" length="254" writable="false" optional="true">ActiveRadioFaults</attribute>
+    <attribute side="server" code="0x07" define="ACTIVE_NETWORK_FAULTS" type="ARRAY" array="true" entryType="ENUM8" length="254" writable="false" optional="true">ActiveNetworkFaults</attribute>
     <event side="server" code="0x00" name="HardwareFaultChange" priority="critical" optional="true">
       <description>Indicate a change in the set of hardware faults currently detected by the Node.</description>
       <field id="0" name="Current" type="HardwareFaultType" array="true"/>

--- a/src/app/zap-templates/zcl/data-model/chip/group-key-mgmt-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/group-key-mgmt-cluster.xml
@@ -45,7 +45,7 @@ limitations under the License.
     <code>0x003F</code>
     <define>GROUP_KEY_MANAGEMENT_CLUSTER</define>
     <description>The Group Key Management Cluster is the mechanism by which group keys are managed.</description>
-    <attribute side="server" code="0x0000" define="GROUPS" type="ARRAY" entryType="GroupState" length="254" writable="false" optional="false">groups</attribute>
-    <attribute side="server" code="0x0001" define="GROUPKEYS" type="ARRAY" entryType="GroupKey" length="254" writable="false" optional="false">group keys</attribute>
+    <attribute side="server" code="0x0000" define="GROUPS" type="ARRAY" array="true" entryType="GroupState" length="254" writable="false" optional="false">groups</attribute>
+    <attribute side="server" code="0x0001" define="GROUPKEYS" type="ARRAY" array="true" entryType="GroupKey" length="254" writable="false" optional="false">group keys</attribute>
   </cluster>
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/media-input-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/media-input-cluster.xml
@@ -25,7 +25,7 @@ limitations under the License.
     <server init="false" tick="false">true</server>
     <!-- TODO: Add feature map once it is supported -->
     <description>This cluster provides an interface for controlling the Input Selector on a media device such as a TV.</description>
-    <attribute side="server" code="0x0000" define="MEDIA_INPUT_LIST" type="ARRAY" entryType="MediaInputInfo" length="254" writable="false" optional="false">media input list</attribute>
+    <attribute side="server" code="0x0000" define="MEDIA_INPUT_LIST" type="ARRAY" array="true" entryType="MediaInputInfo" length="254" writable="false" optional="false">media input list</attribute>
     <attribute side="server" code="0x0001" define="MEDIA_INPUT_CURRENT_INPUT" type="INT8U" min="0x00" max="0xFF" writable="false" default="0x00" optional="true">current media input</attribute>
 
     <command source="client" code="0x00" name="SelectInput" optional="false">

--- a/src/app/zap-templates/zcl/data-model/chip/mode-select-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/mode-select-cluster.xml
@@ -42,7 +42,7 @@ limitations under the License.
     <description>Attributes and commands for selecting a mode from a list of supported options.</description>
     <!-- Base data types -->
     <attribute side="server" code="0x0000" define="CURRENT_MODE"    type="INT8U"                                            writable="false" optional="false" reportable="true">CurrentMode</attribute>
-    <attribute side="server" code="0x0001" define="SUPPORTED_MODES" type="ARRAY" entryType="ModeOptionStruct" length="255"  writable="false" optional="false">SupportedModes</attribute>
+    <attribute side="server" code="0x0001" define="SUPPORTED_MODES" type="ARRAY" array="true" entryType="ModeOptionStruct" length="255"  writable="false" optional="false">SupportedModes</attribute>
     <attribute side="server" code="0x0002" define="ON_MODE"         type="INT8U"                                            writable="true"  optional="true" default="255">OnMode</attribute>
     <attribute side="server" code="0x0003" define="START_UP_MODE"   type="INT8U"                                            writable="false" optional="false">StartUpMode</attribute>
     <attribute side="server" code="0x0004" define="MODE_DESCRIPTION" type="CHAR_STRING"                                     writable="false" optional="false" length="32">Description</attribute>

--- a/src/app/zap-templates/zcl/data-model/chip/operational-credentials-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/operational-credentials-cluster.xml
@@ -54,11 +54,11 @@ limitations under the License.
     <define>OPERATIONAL_CREDENTIALS_CLUSTER</define>
     <description>This cluster is used to add or remove Operational Credentials on a Commissionee or Node, as well as manage the associated Fabrics.</description>
 
-    <attribute side="server" code="0x0001" define="FABRICS" type="ARRAY" entryType="FabricDescriptor" length="320" writable="false" optional="false">fabrics list</attribute>
+    <attribute side="server" code="0x0001" define="FABRICS" type="ARRAY" array="true" entryType="FabricDescriptor" length="320" writable="false" optional="false">fabrics list</attribute>
     <attribute side="server" code="0x0002" define="SUPPORTED_FABRICS" type="INT8U" writable="false" optional="false">SupportedFabrics</attribute>
     <attribute side="server" code="0x0003" define="COMMISSIONED_FABRICS" type="INT8U" writable="false" optional="false">CommissionedFabrics</attribute>
     <!-- 400 = 400 bytes for root cert -->
-    <attribute side="server" code="0x0004" define="TRUSTED_ROOTS" type="ARRAY" entryType="OCTET_STRING" length="400" writable="false" optional="false">TrustedRootCertificates</attribute>
+    <attribute side="server" code="0x0004" define="TRUSTED_ROOTS" type="ARRAY" array="true" entryType="OCTET_STRING" length="400" writable="false" optional="false">TrustedRootCertificates</attribute>
     <attribute side="server" code="0x0005" define="CURRENT_FABRIC_INDEX" type="fabric_idx" writable="false" optional="false">CurrentFabricIndex</attribute>
 
     <command source="client" code="0x00" name="AttestationRequest" optional="false">

--- a/src/app/zap-templates/zcl/data-model/chip/power-source-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/power-source-cluster.xml
@@ -41,7 +41,7 @@ limitations under the License.
     <attribute side="server" code="0x0007" define="POWER_SOURCE_WIRED_NOMINAL_VOLTAGE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">WiredNominalVoltage</attribute>
     <attribute side="server" code="0x0008" define="POWER_SOURCE_WIRED_MAXIMUM_CURRENT" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">WiredMaximumCurrent</attribute>
     <attribute side="server" code="0x0009" define="POWER_SOURCE_WIRED_PRESENT" type="BOOLEAN" writable="false" optional="true">WiredPresent</attribute>
-    <attribute side="server" code="0x000A" define="POWER_SOURCE_ACTIVE_WIRED_FAULTS" type="ARRAY" entryType="ENUM8" length="8" writable="false" optional="true">ActiveWiredFaults</attribute>
+    <attribute side="server" code="0x000A" define="POWER_SOURCE_ACTIVE_WIRED_FAULTS" type="ARRAY" array="true" entryType="ENUM8" length="8" writable="false" optional="true">ActiveWiredFaults</attribute>
     <attribute side="server" code="0x000B" define="POWER_SOURCE_BAT_VOLTAGE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">BatteryVoltage</attribute>
     <attribute side="server" code="0x000C" define="POWER_SOURCE_BAT_PERCENT_REMAINING" type="INT8U" min="0x00" max="0xC8" writable="false" optional="true">BatteryPercentRemaining</attribute>
     <attribute side="server" code="0x000D" define="POWER_SOURCE_BAT_TIME_REMAINING" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">BatteryTimeRemaining</attribute>
@@ -49,7 +49,7 @@ limitations under the License.
     <attribute side="server" code="0x000F" define="POWER_SOURCE_BAT_REPLACEMENT_NEEDED" type="BOOLEAN" writable="false" optional="true">BatteryReplacementNeeded</attribute>
     <attribute side="server" code="0x0010" define="POWER_SOURCE_BAT_REPLACEABILITY" type="ENUM8" min="0x00" max="0x03" writable="false" optional="true">BatteryReplaceability</attribute>
     <attribute side="server" code="0x0011" define="POWER_SOURCE_BAT_PRESENT" type="BOOLEAN" writable="false" optional="true">BatteryPresent</attribute>
-    <attribute side="server" code="0x0012" define="POWER_SOURCE_ACTIVE_BAT_FAULTS" type="ARRAY" entryType="ENUM8" length="8" writable="false" optional="true">ActiveBatteryFaults</attribute>
+    <attribute side="server" code="0x0012" define="POWER_SOURCE_ACTIVE_BAT_FAULTS" type="ARRAY" array="true" entryType="ENUM8" length="8" writable="false" optional="true">ActiveBatteryFaults</attribute>
     <attribute side="server" code="0x0013" define="POWER_SOURCE_BAT_REPLACEMENT_DESCRIPTION" type="CHAR_STRING" length="60" writable="false" optional="true">BatteryReplacementDescription</attribute>
     <attribute side="server" code="0x0014" define="POWER_SOURCE_BAT_COMMON_DESIGNATION" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">BatteryCommonDesignation</attribute>
     <attribute side="server" code="0x0015" define="POWER_SOURCE_BAT_ANSI_DESIGNATION" type="CHAR_STRING" length="20" writable="false" optional="true">BatteryANSIDesignation</attribute>
@@ -61,7 +61,7 @@ limitations under the License.
     <attribute side="server" code="0x001B" define="POWER_SOURCE_BAT_TIME_TO_FULL_CHARGE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">BatteryTimeToFullCharge</attribute>
     <attribute side="server" code="0x001C" define="POWER_SOURCE_BAT_FUNCTIONAL_WHILE_CHARGING" type="BOOLEAN" writable="false" optional="true">BatteryFunctionalWhileCharging</attribute>
     <attribute side="server" code="0x001D" define="POWER_SOURCE_BAT_CHARGING_CURRENT" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">BatteryChargingCurrent</attribute>
-    <attribute side="server" code="0x001E" define="POWER_SOURCE_ACTIVE_BAT_CHARGE_FAULTS" type="ARRAY" entryType="ENUM8" length="16" writable="false" optional="true">ActiveBatteryChargeFaults</attribute>
+    <attribute side="server" code="0x001E" define="POWER_SOURCE_ACTIVE_BAT_CHARGE_FAULTS" type="ARRAY" array="true" entryType="ENUM8" length="16" writable="false" optional="true">ActiveBatteryChargeFaults</attribute>
 
     <!-- TODO: Do events work?
     <event code="0x0000" name="WiredFaultChange" priority="info" side="server">

--- a/src/app/zap-templates/zcl/data-model/chip/power-source-configuration-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/power-source-configuration-cluster.xml
@@ -26,6 +26,6 @@ limitations under the License.
     <client init="false" tick="false">true</client>
     <server init="false" tick="false">true</server>
     <globalAttribute side="either" code="0xFFFD" value="1"/>
-    <attribute side="server" code="0x0000" define="SOURCES" type="ARRAY" entryType="INT8U" length="6" writable="false" optional="false">Sources</attribute>
+    <attribute side="server" code="0x0000" define="SOURCES" type="ARRAY" array="true" entryType="INT8U" length="6" writable="false" optional="false">Sources</attribute>
   </cluster>
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/software-diagnostics-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/software-diagnostics-cluster.xml
@@ -36,7 +36,7 @@ limitations under the License.
     <code>0x0034</code>
     <define>SOFTWARE_DIAGNOSTICS_CLUSTER</define>
     <description>The Software Diagnostics Cluster provides a means to acquire standardized diagnostics metrics that MAY be used by a Node to assist a user or Administrative Node in diagnosing potential problems.</description>
-    <attribute side="server" code="0x00" define="THREAD_METRICS" type="ARRAY" entryType="ThreadMetrics" length="254" writable="false" optional="true">ThreadMetrics</attribute>
+    <attribute side="server" code="0x00" define="THREAD_METRICS" type="ARRAY" array="true" entryType="ThreadMetrics" length="254" writable="false" optional="true">ThreadMetrics</attribute>
     <attribute side="server" code="0x01" define="CURRENT_HEAP_FREE" type="INT64U" min="0x0000000000000000" max="0xFFFFFFFFFFFFFFFF" writable="false" default="0x0000000000000000" optional="true">CurrentHeapFree</attribute>
     <attribute side="server" code="0x02" define="CURRENT_HEAP_USED" type="INT64U" min="0x0000000000000000" max="0xFFFFFFFFFFFFFFFF" writable="false" default="0x0000000000000000" optional="true">CurrentHeapUsed</attribute>
     <attribute side="server" code="0x03" define="CURRENT_HEAP_HIGH_WATERMARK" type="INT64U" min="0x0000000000000000" max="0xFFFFFFFFFFFFFFFF" writable="false" default="0x0000000000000000" optional="false">CurrentHeapHighWatermark</attribute>

--- a/src/app/zap-templates/zcl/data-model/chip/target-navigator-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/target-navigator-cluster.xml
@@ -25,7 +25,7 @@ limitations under the License.
     <server init="false" tick="false">true</server>
     <!-- TODO: Add feature map once it is supported -->
     <description>This cluster provides an interface for UX navigation within a set of targets on a device or endpoint.</description>
-    <attribute side="server" code="0x0000" define="TARGET_NAVIGATOR_LIST" type="ARRAY" entryType="NavigateTargetTargetInfo" length="254" writable="false" optional="false">target navigator list</attribute>
+    <attribute side="server" code="0x0000" define="TARGET_NAVIGATOR_LIST" type="ARRAY" array="true" entryType="NavigateTargetTargetInfo" length="254" writable="false" optional="false">target navigator list</attribute>
     <attribute side="server" code="0x0001" define="TARGET_NAVIGATOR_CURRENT_TARGET" type="INT8U" min="0x00" max="0xFF" writable="false" default="0x00" optional="true">current navigator target</attribute>
 
     <command source="client" code="0x00" name="NavigateTarget" optional="false">

--- a/src/app/zap-templates/zcl/data-model/chip/test-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/test-cluster.xml
@@ -126,9 +126,9 @@ limitations under the License.
     <attribute side="server" code="0x0017" define="FLOAT_SINGLE" type="SINGLE" writable="true" default="0" optional="false">float_single</attribute>
     <attribute side="server" code="0x0018" define="FLOAT_DOUBLE" type="DOUBLE" writable="true" default="0" optional="false">float_double</attribute>
     <attribute side="server" code="0x0019" define="OCTET_STRING" type="OCTET_STRING" length="10" writable="true" optional="false">octet_string</attribute>
-    <attribute side="server" code="0x001A" define="LIST" type="ARRAY" entryType="INT8U" length="10" writable="true" optional="false">list_int8u</attribute>
-    <attribute side="server" code="0x001B" define="LIST_OCTET_STRING" type="ARRAY" entryType="OCTET_STRING" length="254" writable="true" optional="false">list_octet_string</attribute>
-    <attribute side="server" code="0x001C" define="LIST_STRUCT_OCTET_STRING" type="ARRAY" entryType="TestListStructOctet" length="254" writable="true" optional="false">list_struct_octet_string</attribute>
+    <attribute side="server" code="0x001A" define="LIST" type="ARRAY" array="true" entryType="INT8U" length="10" writable="true" optional="false">list_int8u</attribute>
+    <attribute side="server" code="0x001B" define="LIST_OCTET_STRING" type="ARRAY" array="true" entryType="OCTET_STRING" length="254" writable="true" optional="false">list_octet_string</attribute>
+    <attribute side="server" code="0x001C" define="LIST_STRUCT_OCTET_STRING" type="ARRAY" array="true" entryType="TestListStructOctet" length="254" writable="true" optional="false">list_struct_octet_string</attribute>
     <attribute side="server" code="0x001D" define="LONG_OCTET_STRING" type="LONG_OCTET_STRING" length="1000" writable="true" optional="false">long_octet_string</attribute>
     <attribute side="server" code="0x001E" define="CHAR_STRING" type="CHAR_STRING" length="10" writable="true" optional="false">char_string</attribute>
     <attribute side="server" code="0x001F" define="LONG_CHAR_STRING" type="LONG_CHAR_STRING" length="1000" writable="true" optional="false">long_char_string</attribute>
@@ -136,7 +136,7 @@ limitations under the License.
     <attribute side="server" code="0x0021" define="EPOCH_S" type="EPOCH_S" writable="true" optional="false">epoch_s</attribute>
     <attribute side="server" code="0x0022" define="TEST_VENDOR_ID" type="vendor_id"
                writable="true" optional="false" default="0">vendor_id</attribute>
-    <attribute side="server" code="0x0023" define="LIST_OF_STRUCTS_WITH_OPTIONALS" type="ARRAY" entryType="NullablesAndOptionalsStruct"
+    <attribute side="server" code="0x0023" define="LIST_OF_STRUCTS_WITH_OPTIONALS" type="ARRAY" array="true" entryType="NullablesAndOptionalsStruct"
                writable="false" optional="false">list_nullables_and_optionals_struct</attribute>
     <attribute side="server" code="0x0024" define="SIMPLE_ENUM" type="SimpleEnum" writable="true" optional="false">enum_attr</attribute>
     <attribute side="server" code="0x0025" define="STRUCT" type="SimpleStruct" writable="true" optional="false">struct</attribute>

--- a/src/app/zap-templates/zcl/data-model/chip/thread-network-diagnostics-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/thread-network-diagnostics-cluster.xml
@@ -99,8 +99,8 @@ limitations under the License.
     <attribute side="server" code="0x05" define="MESH_LOCAL_PREFIX" type="OCTET_STRING" length="17" writable="false" optional="false">MeshLocalPrefix</attribute>
     <!-- OVERRUN_COUNT Conformance feature [ERRCNT] - for now mandatory -->
     <attribute side="server" code="0x06" define="DIAG_OVERRUN_COUNT" type="INT64U" min="0x0000000000000000" max="0xFFFFFFFFFFFFFFFF" writable="false" default="0x0000000000000000" optional="false">OverrunCount</attribute>
-    <attribute side="server" code="0x07" define="NEIGHBOR_TABLE" type="ARRAY" entryType="NeighborTable" length="254" writable="false" optional="false">NeighborTableList</attribute>
-    <attribute side="server" code="0x08" define="ROUTE_TABLE" type="ARRAY" entryType="RouteTable" length="254" writable="false" optional="false">RouteTableList</attribute>
+    <attribute side="server" code="0x07" define="NEIGHBOR_TABLE" type="ARRAY" array="true" entryType="NeighborTable" length="254" writable="false" optional="false">NeighborTableList</attribute>
+    <attribute side="server" code="0x08" define="ROUTE_TABLE" type="ARRAY" array="true" entryType="RouteTable" length="254" writable="false" optional="false">RouteTableList</attribute>
     <attribute side="server" code="0x09" define="PARTITION_ID" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="false">PartitionId</attribute>
     <attribute side="server" code="0x0A" define="WEIGHTING" type="INT8U" min="0x00" max="0xFF" writable="false" optional="false">weighting</attribute>
     <attribute side="server" code="0x0B" define="DATA_VERSION" type="INT8U" min="0x00" max="0xFF" writable="false" optional="false">DataVersion</attribute>
@@ -154,11 +154,11 @@ limitations under the License.
     <attribute side="server" code="0x39" define="PENDING_TIMESTAMP" type="INT64U" min="0x0000000000000000" max="0xFFFFFFFFFFFFFFFF" writable="false" default="0x0000000000000000" optional="true">PendingTimestamp</attribute>
     <attribute side="server" code="0x3A" define="DELAY" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" default="0x0000" optional="true">delay</attribute>
     <!-- SECURITY_POLICY Length = 2 + (arraysize(1) * Size of Struct (4b))-->
-    <attribute side="server" code="0x3B" define="SECURITY_POLICY" type="ARRAY" entryType="SecurityPolicy" length="6" writable="false" optional="false">SecurityPolicy</attribute>
+    <attribute side="server" code="0x3B" define="SECURITY_POLICY" type="ARRAY" array="true" entryType="SecurityPolicy" length="6" writable="false" optional="false">SecurityPolicy</attribute>
     <attribute side="server" code="0x3C" define="DIAG_CHANNEL_MASK" type="OCTET_STRING" length="4" writable="false" optional="false">ChannelMask</attribute>
     <!-- OPERATIONAL_DATASET_COMPONENTS Length = 2 + (arraysize(1) * Size of Struct (12b))-->
-    <attribute side="server" code="0x3D" define="OPERATIONAL_DATASET_COMPONENTS" type="ARRAY" entryType="OperationalDatasetComponents" length="14" writable="false" optional="false">OperationalDatasetComponents</attribute>
-    <attribute side="server" code="0x3E" define="ACTIVE_THREAD_NETWORK_FAULTS" type="ARRAY" entryType="NetworkFault" length="4" writable="false" optional="false">ActiveNetworkFaultsList</attribute>
+    <attribute side="server" code="0x3D" define="OPERATIONAL_DATASET_COMPONENTS" type="ARRAY" array="true" entryType="OperationalDatasetComponents" length="14" writable="false" optional="false">OperationalDatasetComponents</attribute>
+    <attribute side="server" code="0x3E" define="ACTIVE_THREAD_NETWORK_FAULTS" type="ARRAY" array="true" entryType="NetworkFault" length="4" writable="false" optional="false">ActiveNetworkFaultsList</attribute>
     <command source="client" code="0x00" name="ResetCounts" optional="true" cli="chip thread_network_diagnostics resetcounts">
       <description>Reception of this command SHALL reset the OverrunCount attributes to 0</description>
     </command>

--- a/src/app/zap-templates/zcl/data-model/chip/tv-channel-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/tv-channel-cluster.xml
@@ -25,7 +25,7 @@ limitations under the License.
     <server init="false" tick="false">true</server>
     <!-- TODO: Add feature map once it is supported -->
     <description>This cluster provides an interface for controlling the current TV Channel on a device.</description>
-    <attribute side="server" code="0x0000" define="TV_CHANNEL_LIST" type="ARRAY" entryType="TvChannelInfo" length="254" writable="false" optional="false">tv channel list</attribute>
+    <attribute side="server" code="0x0000" define="TV_CHANNEL_LIST" type="ARRAY" array="true" entryType="TvChannelInfo" length="254" writable="false" optional="false">tv channel list</attribute>
     <!-- TODO: Covert this to stuct one it is supported -->
     <attribute side="server" code="0x0001" define="TV_CHANNEL_LINEUP" type="OCTET_STRING" length="32" writable="false" optional="false">tv channel lineup</attribute>
     <!-- TODO: Covert this to stuct one it is supported -->

--- a/src/app/zap-templates/zcl/data-model/chip/user-label-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/user-label-cluster.xml
@@ -29,6 +29,6 @@ limitations under the License.
     <code>0x0041</code>
     <define>USER_LABEL_CLUSTER</define>
     <description>The User Label Cluster provides a feature to tag an endpoint with zero or more labels.</description>
-    <attribute side="server" code="0x0000" define="LABEL_LIST" type="ARRAY" entryType="LabelStruct" length="254" writable="true" optional="false">label list</attribute>
+    <attribute side="server" code="0x0000" define="LABEL_LIST" type="ARRAY" array="true" entryType="LabelStruct" length="254" writable="true" optional="false">label list</attribute>
   </cluster>
 </configurator>


### PR DESCRIPTION
-- does not need regen ---
In the XML typedefs, ARRAY is specified as a type. This is not accurate. The 'type' should be the element of the array. Why? to allow future XML code to typecheck the types.

This is first phase of transitioning entryType to type.

Current
type=ARRAY entryType=struct_name
This change adds...
type=ARRAY entryType=struct_name array=true

Next, modify Zap to key off from array=true instead of type=ARRAY
Adjust Zap to look for type in type='' if entryType missing and array=true

Final phase, remove entryType
type=struct_name array=true
