### PR TITLE
[hotfix] fix tv-server build failed issue on arm and added CI for it

### DIFF
--- a/examples/tv-app/android/java/MediaPlaybackManager.cpp
+++ b/examples/tv-app/android/java/MediaPlaybackManager.cpp
@@ -191,7 +191,7 @@ EmberAfMediaPlaybackStatus MediaPlaybackManager::Request(MediaPlaybackRequest me
     CHIP_ERROR err = CHIP_NO_ERROR;
     JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
 
-    ChipLogProgress(Zcl, "MediaPlaybackManager::Request %d-%ld", mediaPlaybackRequest, deltaPositionMilliseconds);
+    ChipLogProgress(Zcl, "MediaPlaybackManager::Request %d-%ld", mediaPlaybackRequest, static_cast<long>(deltaPositionMilliseconds));
     VerifyOrExit(mMediaPlaybackManagerObject != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
     VerifyOrExit(mRequestMethod != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
     VerifyOrExit(env != NULL, err = CHIP_JNI_ERROR_NO_ENV);

--- a/examples/tv-app/android/java/MediaPlaybackManager.cpp
+++ b/examples/tv-app/android/java/MediaPlaybackManager.cpp
@@ -191,7 +191,8 @@ EmberAfMediaPlaybackStatus MediaPlaybackManager::Request(MediaPlaybackRequest me
     CHIP_ERROR err = CHIP_NO_ERROR;
     JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
 
-    ChipLogProgress(Zcl, "MediaPlaybackManager::Request %d-%ld", mediaPlaybackRequest, static_cast<long>(deltaPositionMilliseconds));
+    ChipLogProgress(Zcl, "MediaPlaybackManager::Request %d-%ld", mediaPlaybackRequest,
+                    static_cast<long>(deltaPositionMilliseconds));
     VerifyOrExit(mMediaPlaybackManagerObject != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
     VerifyOrExit(mRequestMethod != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
     VerifyOrExit(env != NULL, err = CHIP_JNI_ERROR_NO_ENV);

--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -199,6 +199,7 @@ def AndroidTargets():
     yield target.Extend('androidstudio-x86-chip-tool', board=AndroidBoard.AndroidStudio_X86, app=AndroidApp.CHIP_TOOL)
     yield target.Extend('androidstudio-x64-chip-tool', board=AndroidBoard.AndroidStudio_X64, app=AndroidApp.CHIP_TOOL)
     yield target.Extend('arm64-chip-tvserver', board=AndroidBoard.ARM64, app=AndroidApp.CHIP_TVServer)
+    yield target.Extend('arm-chip-tvserver', board=AndroidBoard.ARM64, app=AndroidApp.CHIP_TVServer)
 
 
 def MbedTargets():

--- a/scripts/build/testdata/all_targets_except_host.txt
+++ b/scripts/build/testdata/all_targets_except_host.txt
@@ -4,6 +4,7 @@ android-androidstudio-arm64-chip-tool
 android-androidstudio-x64-chip-tool
 android-androidstudio-x86-chip-tool
 android-arm-chip-tool
+android-arm-chip-tvserver
 android-arm64-chip-test
 android-arm64-chip-tool
 android-arm64-chip-tvserver

--- a/scripts/build/testdata/build_all_except_host.txt
+++ b/scripts/build/testdata/build_all_except_host.txt
@@ -70,6 +70,18 @@ python3 build/chip/java/tests/generate_jars_for_test.py
 # Setting up Android deps through Gradle
 python3 third_party/android_deps/set_up_android_deps.py
 
+# Generating android-arm-chip-tvserver
+gn gen --check --fail-on-unused-args {out}/android-arm-chip-tvserver '--args=target_os="android" target_cpu="arm64" android_ndk_root="TEST_ANDROID_NDK_HOME" android_sdk_root="TEST_ANDROID_HOME" chip_config_network_layer_ble=false ' --root={root}/examples/tv-app/android/
+
+# Accepting NDK licenses @ tools
+bash -c 'yes | TEST_ANDROID_HOME/tools/bin/sdkmanager --licenses >/dev/null'
+
+# Generating JARs for Java build rules test
+python3 build/chip/java/tests/generate_jars_for_test.py
+
+# Setting up Android deps through Gradle
+python3 third_party/android_deps/set_up_android_deps.py
+
 # Generating android-arm64-chip-test
 gn gen --check --fail-on-unused-args {out}/android-arm64-chip-test '--args=target_os="android" target_cpu="arm64" android_ndk_root="TEST_ANDROID_NDK_HOME" android_sdk_root="TEST_ANDROID_HOME" '
 
@@ -476,6 +488,29 @@ cp {out}/android-arm-chip-tool/lib/src/platform/android/AndroidPlatform.jar {roo
 
 # Building APP android-arm-chip-tool
 {root}/src/android/CHIPTool/gradlew -p {root}/src/android/CHIPTool -PmatterBuildSrcDir={out}/android-arm-chip-tool -PmatterSdkSourceBuild=false -PbuildDir={out}/android-arm-chip-tool assembleDebug
+
+# Building JNI android-arm-chip-tvserver
+ninja -C {out}/android-arm-chip-tvserver
+
+# Prepare Native libs android-arm-chip-tvserver
+mkdir -p {root}/examples/tv-app/android/App/app/libs/jniLibs/arm64-v8a
+
+cp {out}/android-arm-chip-tvserver/lib/jni/arm64-v8a/libSetupPayloadParser.so {root}/examples/tv-app/android/App/app/libs/jniLibs/arm64-v8a/libSetupPayloadParser.so
+
+cp {out}/android-arm-chip-tvserver/lib/jni/arm64-v8a/libc++_shared.so {root}/examples/tv-app/android/App/app/libs/jniLibs/arm64-v8a/libc++_shared.so
+
+cp {out}/android-arm-chip-tvserver/lib/jni/arm64-v8a/libTvApp.so {root}/examples/tv-app/android/App/app/libs/jniLibs/arm64-v8a/libTvApp.so
+
+cp {out}/android-arm-chip-tvserver/lib/third_party/connectedhomeip/src/setup_payload/java/SetupPayloadParser.jar {root}/examples/tv-app/android/App/app/libs/SetupPayloadParser.jar
+
+cp {out}/android-arm-chip-tvserver/lib/third_party/connectedhomeip/src/platform/android/AndroidPlatform.jar {root}/examples/tv-app/android/App/app/libs/AndroidPlatform.jar
+
+cp {out}/android-arm-chip-tvserver/lib/third_party/connectedhomeip/src/app/server/java/CHIPAppServer.jar {root}/examples/tv-app/android/App/app/libs/CHIPAppServer.jar
+
+cp {out}/android-arm-chip-tvserver/lib/TvApp.jar {root}/examples/tv-app/android/App/app/libs/TvApp.jar
+
+# Building Example android-arm-chip-tvserver
+{root}/examples/tv-app/android/App/gradlew -p {root}/examples/tv-app/android/App/ -PmatterBuildSrcDir={out}/android-arm-chip-tvserver -PmatterSdkSourceBuild=false -PbuildDir={out}/android-arm-chip-tvserver assembleDebug
 
 # Building JNI android-arm64-chip-test
 ninja -C {out}/android-arm64-chip-test

--- a/scripts/build/testdata/glob_star_targets_except_host.txt
+++ b/scripts/build/testdata/glob_star_targets_except_host.txt
@@ -4,6 +4,7 @@ android-androidstudio-arm64-chip-tool
 android-androidstudio-x64-chip-tool
 android-androidstudio-x86-chip-tool
 android-arm-chip-tool
+android-arm-chip-tvserver
 android-arm64-chip-test
 android-arm64-chip-tool
 android-arm64-chip-tvserver


### PR DESCRIPTION
#### Problem
* examples/tv-app/android build failed on the android arm
* No CI for android arm ( only arm64)

#### Change overview
* fix the build error
* added ci

#### Testing
* build_example.py for android
