### PR TITLE
Bump docker image to  0.5.33 (latest dockerhub version)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,7 +17,7 @@
     "build": {
         "dockerfile": "Dockerfile",
         "args": {
-            "BUILD_VERSION": "0.5.28"
+            "BUILD_VERSION": "0.5.33"
         }
     },
     "remoteUser": "vscode",

--- a/.github/workflows/android.yaml
+++ b/.github/workflows/android.yaml
@@ -34,7 +34,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: connectedhomeip/chip-build-android:0.5.28
+            image: connectedhomeip/chip-build-android:0.5.33
             volumes:
                 - "/tmp/log_output:/tmp/test_logs"
 

--- a/.github/workflows/bloat_check.yaml
+++ b/.github/workflows/bloat_check.yaml
@@ -30,7 +30,7 @@ jobs:
         runs-on: ubuntu-latest
 
         container:
-            image: connectedhomeip/chip-build:0.5.28
+            image: connectedhomeip/chip-build:0.5.33
 
         steps:
             - name: Checkout

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,7 +32,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: connectedhomeip/chip-build:0.5.28
+            image: connectedhomeip/chip-build:0.5.33
             volumes:
                 - "/tmp/log_output:/tmp/test_logs"
             options:
@@ -98,7 +98,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: connectedhomeip/chip-build:0.5.28
+            image: connectedhomeip/chip-build:0.5.33
             volumes:
                 - "/tmp/log_output:/tmp/test_logs"
             options:
@@ -190,7 +190,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: connectedhomeip/chip-build:0.5.28
+            image: connectedhomeip/chip-build:0.5.33
             volumes:
                 - "/tmp/log_output:/tmp/test_logs"
             options:

--- a/.github/workflows/cirque.yaml
+++ b/.github/workflows/cirque.yaml
@@ -29,7 +29,7 @@ jobs:
         timeout-minutes: 60
         
         env:
-            DOCKER_RUN_VERSION: 0.5.28
+            DOCKER_RUN_VERSION: 0.5.33
             GITHUB_CACHE_PATH: /tmp/cirque-cache/
 
         runs-on: ubuntu-latest
@@ -38,7 +38,7 @@ jobs:
 # need to run with privilege, which isn't supported by job.XXX.contaner
 #  https://github.com/actions/container-action/issues/2
 #         container:
-#             image: connectedhomeip/chip-build-cirque:0.5.28
+#             image: connectedhomeip/chip-build-cirque:0.5.33
 #             volumes:
 #                 - "/tmp:/tmp"
 #                 - "/dev/pts:/dev/pts"

--- a/.github/workflows/docker_img.yaml
+++ b/.github/workflows/docker_img.yaml
@@ -43,6 +43,6 @@ jobs:
             - name: Scan for vulnerabilities
               uses: crazy-max/docker-scan-action@master
               with:
-                  image: connectedhomeip/chip-build${{ matrix.img }}:0.5.28
+                  image: connectedhomeip/chip-build${{ matrix.img }}:0.5.33
                   annotations: true
 

--- a/.github/workflows/doxygen.yaml
+++ b/.github/workflows/doxygen.yaml
@@ -30,7 +30,7 @@ jobs:
 
         runs-on: ubuntu-20.04
         container:
-            image: connectedhomeip/chip-build-doxygen:0.5.30
+            image: connectedhomeip/chip-build-doxygen:0.5.33
 
         if: github.actor != 'restyled-io[bot]'
 

--- a/.github/workflows/examples-efr32.yaml
+++ b/.github/workflows/examples-efr32.yaml
@@ -35,7 +35,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: connectedhomeip/chip-build-efr32:0.5.28
+            image: connectedhomeip/chip-build-efr32:0.5.33
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
         steps:

--- a/.github/workflows/examples-esp32.yaml
+++ b/.github/workflows/examples-esp32.yaml
@@ -35,7 +35,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: connectedhomeip/chip-build-esp32:0.5.28
+            image: connectedhomeip/chip-build-esp32:0.5.33
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
 

--- a/.github/workflows/examples-infineon.yaml
+++ b/.github/workflows/examples-infineon.yaml
@@ -32,7 +32,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: connectedhomeip/chip-build-infineon:0.5.28
+            image: connectedhomeip/chip-build-infineon:0.5.33
 
         steps:
             - name: Checkout

--- a/.github/workflows/examples-k32w.yaml
+++ b/.github/workflows/examples-k32w.yaml
@@ -34,7 +34,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: connectedhomeip/chip-build-k32w:0.5.29
+            image: connectedhomeip/chip-build-k32w:0.5.33
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
         steps:

--- a/.github/workflows/examples-linux-standalone.yaml
+++ b/.github/workflows/examples-linux-standalone.yaml
@@ -34,7 +34,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: connectedhomeip/chip-build:0.5.28
+            image: connectedhomeip/chip-build:0.5.33
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
 

--- a/.github/workflows/examples-mbed.yaml
+++ b/.github/workflows/examples-mbed.yaml
@@ -37,7 +37,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: connectedhomeip/chip-build-mbed-os:0.5.28
+            image: connectedhomeip/chip-build-mbed-os:0.5.33
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
 

--- a/.github/workflows/examples-nrfconnect.yaml
+++ b/.github/workflows/examples-nrfconnect.yaml
@@ -34,7 +34,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: connectedhomeip/chip-build-nrf-platform:0.5.28
+            image: connectedhomeip/chip-build-nrf-platform:0.5.33
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
 

--- a/.github/workflows/examples-qpg.yaml
+++ b/.github/workflows/examples-qpg.yaml
@@ -34,7 +34,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: connectedhomeip/chip-build:0.5.28
+            image: connectedhomeip/chip-build:0.5.33
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
         steps:

--- a/.github/workflows/examples-telink.yaml
+++ b/.github/workflows/examples-telink.yaml
@@ -32,7 +32,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: connectedhomeip/chip-build-telink:0.5.28
+            image: connectedhomeip/chip-build-telink:0.5.33
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
 

--- a/.github/workflows/examples-tizen.yaml
+++ b/.github/workflows/examples-tizen.yaml
@@ -28,7 +28,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: connectedhomeip/chip-build-tizen:0.5.28
+            image: connectedhomeip/chip-build-tizen:0.5.33
             options: --user root
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"

--- a/.github/workflows/qemu.yaml
+++ b/.github/workflows/qemu.yaml
@@ -34,7 +34,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: connectedhomeip/chip-build-esp32-qemu:0.5.28
+            image: connectedhomeip/chip-build-esp32-qemu:0.5.33
             volumes:
                 - "/tmp/log_output:/tmp/test_logs"
 

--- a/.github/workflows/release_artifacts.yaml
+++ b/.github/workflows/release_artifacts.yaml
@@ -29,7 +29,7 @@ jobs:
         runs-on: ubuntu-latest
 
         container:
-            image: connectedhomeip/chip-build-esp32:0.5.28
+            image: connectedhomeip/chip-build-esp32:0.5.33
 
         steps:
             - name: Checkout
@@ -70,7 +70,7 @@ jobs:
         runs-on: ubuntu-latest
 
         container:
-            image: connectedhomeip/chip-build-efr32:0.5.28
+            image: connectedhomeip/chip-build-efr32:0.5.33
         steps:
             - name: Checkout
               uses: actions/checkout@v2

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -40,7 +40,7 @@ jobs:
         runs-on: ubuntu-latest
 
         container:
-            image: connectedhomeip/chip-build:0.5.28
+            image: connectedhomeip/chip-build:0.5.33
             options:
                 --privileged --sysctl "net.ipv6.conf.all.disable_ipv6=0
                 net.ipv4.conf.all.forwarding=1 net.ipv6.conf.all.forwarding=1"

--- a/.github/workflows/unit_integration_test.yaml
+++ b/.github/workflows/unit_integration_test.yaml
@@ -37,7 +37,7 @@ jobs:
         runs-on: ubuntu-latest
 
         container:
-            image: connectedhomeip/chip-build:0.5.28
+            image: connectedhomeip/chip-build:0.5.33
             volumes:
                 - "/tmp/log_output:/tmp/test_logs"
             options:

--- a/integrations/cloudbuild/build-all.yaml
+++ b/integrations/cloudbuild/build-all.yaml
@@ -1,5 +1,5 @@
 steps:
-    - name: "connectedhomeip/chip-build-vscode:0.5.28"
+    - name: "connectedhomeip/chip-build-vscode:0.5.33"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:
@@ -12,7 +12,7 @@ steps:
             path: /pwenv
       timeout: 900s
 
-    - name: "connectedhomeip/chip-build-vscode:0.5.28"
+    - name: "connectedhomeip/chip-build-vscode:0.5.33"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:

--- a/integrations/cloudbuild/smoke-test.yaml
+++ b/integrations/cloudbuild/smoke-test.yaml
@@ -1,5 +1,5 @@
 steps:
-    - name: "connectedhomeip/chip-build-vscode:0.5.28"
+    - name: "connectedhomeip/chip-build-vscode:0.5.33"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:
@@ -12,7 +12,7 @@ steps:
             path: /pwenv
       timeout: 900s
 
-    - name: "connectedhomeip/chip-build-vscode:0.5.28"
+    - name: "connectedhomeip/chip-build-vscode:0.5.33"
       id: ESP32
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
@@ -28,7 +28,7 @@ steps:
           - name: pwenv
             path: /pwenv
 
-    - name: "connectedhomeip/chip-build-vscode:0.5.28"
+    - name: "connectedhomeip/chip-build-vscode:0.5.33"
       id: NRFConnect
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
@@ -45,7 +45,7 @@ steps:
           - name: pwenv
             path: /pwenv
 
-    - name: "connectedhomeip/chip-build-vscode:0.5.28"
+    - name: "connectedhomeip/chip-build-vscode:0.5.33"
       id: EFR32
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
@@ -62,7 +62,7 @@ steps:
           - name: pwenv
             path: /pwenv
 
-    - name: "connectedhomeip/chip-build-vscode:0.5.28"
+    - name: "connectedhomeip/chip-build-vscode:0.5.33"
       id: Linux
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
@@ -79,7 +79,7 @@ steps:
           - name: pwenv
             path: /pwenv
 
-    - name: "connectedhomeip/chip-build-vscode:0.5.28"
+    - name: "connectedhomeip/chip-build-vscode:0.5.33"
       id: Android
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv


### PR DESCRIPTION
#### Problem
Docker updated, lots of builds/CI are still using the old version

#### Change overview
Update to 0.5.33

Change was automated:

```
rg 'chip-build.*0\.5\.' --hidden | cut -f1 -d: | uniq | grep -v \.git/ | xargs sd '0.5.\d\d' 0.5.33
```

using ripgrep and https://github.com/chmln/sd

And then manually updated `.devcontainer/devcontainer.json` because the ripgrep search does not find that one.

#### Testing
CI will validate this