### PR TITLE
Streamline ObjectPool in System::Timer

### DIFF
--- a/src/credentials/CertificationDeclaration.cpp
+++ b/src/credentials/CertificationDeclaration.cpp
@@ -22,8 +22,9 @@
  *      working with Certification Declaration elements.
  */
 
-#include <inttypes.h>
-#include <stddef.h>
+#include <algorithm>
+#include <cinttypes>
+#include <cstddef>
 
 #include <credentials/CertificationDeclaration.h>
 #include <crypto/CHIPCryptoPAL.h>

--- a/src/inet/InetLayer.cpp
+++ b/src/inet/InetLayer.cpp
@@ -48,7 +48,10 @@ CHIP_ERROR InetLayer::Shutdown()
 {
     VerifyOrReturnError(mLayerState.SetShuttingDown(), CHIP_ERROR_INCORRECT_STATE);
     VerifyOrReturnError(mTCPEndPointManager == nullptr, CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(mUDPEndPointManager != nullptr, CHIP_ERROR_INCORRECT_STATE);
     ReturnErrorOnFailure(mUDPEndPointManager->Shutdown());
+    mUDPEndPointManager = nullptr;
+    mSystemLayer        = nullptr;
     mLayerState.ResetFromShuttingDown(); // Return to uninitialized state to permit re-initialization.
     return CHIP_NO_ERROR;
 }

--- a/src/inet/InetLayer.h
+++ b/src/inet/InetLayer.h
@@ -23,6 +23,7 @@
 #pragma once
 
 #include <lib/support/ObjectLifeCycle.h>
+#include <lib/support/Pool.h>
 #include <platform/LockTracker.h>
 #include <system/SystemLayer.h>
 #include <system/SystemStats.h>

--- a/src/lib/support/TestPersistentStorageDelegate.h
+++ b/src/lib/support/TestPersistentStorageDelegate.h
@@ -23,6 +23,7 @@
 #include <lib/core/CHIPPersistentStorageDelegate.h>
 #include <lib/support/DLLUtil.h>
 #include <map>
+#include <string>
 #include <vector>
 
 namespace chip {

--- a/src/lib/support/Variant.h
+++ b/src/lib/support/Variant.h
@@ -22,6 +22,7 @@
 
 #include <algorithm>
 #include <new>
+#include <tuple>
 #include <type_traits>
 #include <typeinfo>
 #include <utility>

--- a/src/messaging/ExchangeMessageDispatch.cpp
+++ b/src/messaging/ExchangeMessageDispatch.cpp
@@ -28,6 +28,7 @@
 #define __STDC_LIMIT_MACROS
 #endif
 
+#include <errno.h>
 #include <inttypes.h>
 #include <memory>
 

--- a/src/platform/Linux/ConnectivityManagerImpl.h
+++ b/src/platform/Linux/ConnectivityManagerImpl.h
@@ -41,6 +41,8 @@
 #include <platform/Linux/dbus/wpa/DBusWpaBss.h>
 #include <platform/Linux/dbus/wpa/DBusWpaInterface.h>
 #include <platform/Linux/dbus/wpa/DBusWpaNetwork.h>
+
+#include <mutex>
 #endif
 
 namespace chip {

--- a/src/system/SystemConfig.h
+++ b/src/system/SystemConfig.h
@@ -440,20 +440,6 @@ struct LwIPEvent;
 #endif /* CHIP_SYSTEM_CONFIG_NUM_TIMERS */
 
 /**
- *  @def CHIP_SYSTEM_CONFIG_USE_TIMER_POOL
- *
- *  @brief
- *      This defines whether (1) or not (0) the implementation uses the System::Timer pool.
- */
-#ifndef CHIP_SYSTEM_CONFIG_USE_TIMER_POOL
-#if CHIP_SYSTEM_CONFIG_NUM_TIMERS > 0
-#define CHIP_SYSTEM_CONFIG_USE_TIMER_POOL 1
-#else
-#define CHIP_SYSTEM_CONFIG_USE_TIMER_POOL 0
-#endif
-#endif /* CHIP_SYSTEM_CONFIG_USE_TIMER_POOL */
-
-/**
  *  @def CHIP_SYSTEM_CONFIG_PROVIDE_STATISTICS
  *
  *  @brief

--- a/src/system/SystemLayer.h
+++ b/src/system/SystemLayer.h
@@ -37,7 +37,6 @@
 #include <system/SystemClock.h>
 #include <system/SystemError.h>
 #include <system/SystemEvent.h>
-#include <system/SystemTimer.h>
 
 #if CHIP_SYSTEM_CONFIG_USE_SOCKETS
 #include <system/SocketEvents.h>
@@ -46,6 +45,8 @@
 #if CHIP_SYSTEM_CONFIG_USE_DISPATCH
 #include <dispatch/dispatch.h>
 #endif // CHIP_SYSTEM_CONFIG_USE_DISPATCH
+
+#include <utility>
 
 namespace chip {
 namespace System {

--- a/src/system/SystemLayerImplLwIP.h
+++ b/src/system/SystemLayerImplLwIP.h
@@ -24,6 +24,7 @@
 
 #include <lib/support/ObjectLifeCycle.h>
 #include <system/SystemLayer.h>
+#include <system/SystemTimer.h>
 
 namespace chip {
 namespace System {
@@ -51,7 +52,8 @@ private:
 
     CHIP_ERROR StartPlatformTimer(System::Clock::Timeout aDelay);
 
-    Timer::MutexedList mTimerList;
+    TimerPool<TimerList::Node> mTimerPool;
+    TimerList mTimerList;
     bool mHandlingTimerComplete; // true while handling any timer completion
     ObjectLifeCycle mLayerState;
 };

--- a/src/system/SystemLayerImplSelect.cpp
+++ b/src/system/SystemLayerImplSelect.cpp
@@ -46,8 +46,6 @@ CHIP_ERROR LayerImplSelect::Init()
 
     RegisterPOSIXErrorFormatter();
 
-    ReturnErrorOnFailure(mTimerList.Init());
-
     for (auto & w : mSocketWatchPool)
     {
         w.Clear();
@@ -68,21 +66,23 @@ CHIP_ERROR LayerImplSelect::Shutdown()
 {
     VerifyOrReturnError(mLayerState.SetShuttingDown(), CHIP_ERROR_INCORRECT_STATE);
 
-    Timer * timer;
+#if CHIP_SYSTEM_CONFIG_USE_DISPATCH
+    TimerList::Node * timer;
     while ((timer = mTimerList.PopEarliest()) != nullptr)
     {
-        timer->Clear();
-
-#if CHIP_SYSTEM_CONFIG_USE_DISPATCH
         if (timer->mTimerSource != nullptr)
         {
             dispatch_source_cancel(timer->mTimerSource);
             dispatch_release(timer->mTimerSource);
         }
+
+        mTimerPool.Release(timer);
+    }
+#else  // CHIP_SYSTEM_CONFIG_USE_DISPATCH
+    mTimerList.Clear();
+    mTimerPool.ReleaseAll();
 #endif // CHIP_SYSTEM_CONFIG_USE_DISPATCH
 
-        timer->Release();
-    }
     mWakeEvent.Close(*this);
 
     mLayerState.ResetFromShuttingDown(); // Return to uninitialized state to permit re-initialization.
@@ -111,6 +111,7 @@ void LayerImplSelect::Signal()
     CHIP_ERROR status = mWakeEvent.Notify();
     if (status != CHIP_NO_ERROR)
     {
+
         ChipLogError(chipSystemLayer, "System wake event notify failed: %" CHIP_ERROR_FORMAT, status.Format());
     }
 }
@@ -123,7 +124,7 @@ CHIP_ERROR LayerImplSelect::StartTimer(Clock::Timeout delay, TimerCompleteCallba
 
     CancelTimer(onComplete, appState);
 
-    Timer * timer = Timer::New(*this, delay, onComplete, appState);
+    TimerList::Node * timer = mTimerPool.Create(*this, delay, onComplete, appState);
     VerifyOrReturnError(timer != nullptr, CHIP_ERROR_NO_MEMORY);
 
 #if CHIP_SYSTEM_CONFIG_USE_DISPATCH
@@ -164,10 +165,8 @@ void LayerImplSelect::CancelTimer(TimerCompleteCallback onComplete, void * appSt
 {
     VerifyOrReturn(mLayerState.IsInitialized());
 
-    Timer * timer = mTimerList.Remove(onComplete, appState);
+    TimerList::Node * timer = mTimerList.Remove(onComplete, appState);
     VerifyOrReturn(timer != nullptr);
-
-    timer->Clear();
 
 #if CHIP_SYSTEM_CONFIG_USE_DISPATCH
     if (timer->mTimerSource != nullptr)
@@ -177,7 +176,7 @@ void LayerImplSelect::CancelTimer(TimerCompleteCallback onComplete, void * appSt
     }
 #endif
 
-    timer->Release();
+    mTimerPool.Release(timer);
     Signal();
 }
 
@@ -187,7 +186,7 @@ CHIP_ERROR LayerImplSelect::ScheduleWork(TimerCompleteCallback onComplete, void 
 
     CancelTimer(onComplete, appState);
 
-    Timer * timer = Timer::New(*this, Clock::kZero, onComplete, appState);
+    TimerList::Node * timer = mTimerPool.Create(*this, Clock::kZero, onComplete, appState);
     VerifyOrReturnError(timer != nullptr, CHIP_ERROR_NO_MEMORY);
 
 #if CHIP_SYSTEM_CONFIG_USE_DISPATCH
@@ -332,7 +331,7 @@ void LayerImplSelect::PrepareEvents()
     const Clock::Timestamp currentTime = SystemClock().GetMonotonicTimestamp();
     Clock::Timestamp awakenTime        = currentTime + kDefaultMinSleepPeriod;
 
-    Timer * timer = mTimerList.Earliest();
+    TimerList::Node * timer = mTimerList.Earliest();
     if (timer && timer->AwakenTime() < awakenTime)
     {
         awakenTime = timer->AwakenTime();
@@ -386,11 +385,11 @@ void LayerImplSelect::HandleEvents()
 
     // Obtain the list of currently expired timers. Any new timers added by timer callback are NOT handled on this pass,
     // since that could result in infinite handling of new timers blocking any other progress.
-    Timer::List expiredTimers(mTimerList.ExtractEarlier(Clock::Timeout(1) + SystemClock().GetMonotonicTimestamp()));
-    Timer * timer = nullptr;
+    TimerList expiredTimers = mTimerList.ExtractEarlier(Clock::Timeout(1) + SystemClock().GetMonotonicTimestamp());
+    TimerList::Node * timer = nullptr;
     while ((timer = expiredTimers.PopEarliest()) != nullptr)
     {
-        timer->HandleComplete();
+        mTimerPool.Invoke(timer);
     }
 
     for (auto & w : mSocketWatchPool)
@@ -411,10 +410,10 @@ void LayerImplSelect::HandleEvents()
 }
 
 #if CHIP_SYSTEM_CONFIG_USE_DISPATCH
-void LayerImplSelect::HandleTimerComplete(Timer * timer)
+void LayerImplSelect::HandleTimerComplete(TimerList::Node * timer)
 {
     mTimerList.Remove(timer);
-    timer->HandleComplete();
+    mTimerPool.Invoke(timer);
 }
 #endif // CHIP_SYSTEM_CONFIG_USE_DISPATCH
 

--- a/src/system/SystemLayerImplSelect.h
+++ b/src/system/SystemLayerImplSelect.h
@@ -31,6 +31,7 @@
 
 #include <lib/support/ObjectLifeCycle.h>
 #include <system/SystemLayer.h>
+#include <system/SystemTimer.h>
 #include <system/WakeEvent.h>
 
 namespace chip {
@@ -71,7 +72,7 @@ public:
 #if CHIP_SYSTEM_CONFIG_USE_DISPATCH
     void SetDispatchQueue(dispatch_queue_t dispatchQueue) override { mDispatchQueue = dispatchQueue; };
     dispatch_queue_t GetDispatchQueue() override { return mDispatchQueue; };
-    void HandleTimerComplete(Timer * timer);
+    void HandleTimerComplete(TimerList::Node * timer);
 #endif // CHIP_SYSTEM_CONFIG_USE_DISPATCH
 
 protected:
@@ -90,7 +91,8 @@ protected:
     };
     SocketWatch mSocketWatchPool[kSocketWatchMax];
 
-    Timer::MutexedList mTimerList;
+    TimerPool<TimerList::Node> mTimerPool;
+    TimerList mTimerList;
     timeval mNextTimeout;
 
     // Members for select loop


### PR DESCRIPTION
#### Problem

After the unification of the former `system/SystemObject.h`
with `support/Pool.h`, there is an opportunity to simplify
`System::Timer`.

#### Change overview

- Clean up use of `ObjectPool`, with a `TimerPool` wrapper.
- Fix some #includes formerly indirectly included by `SystemTimer.h`

#### Testing

CI; no changes to external functionality.
