### PR TITLE
Fix two CHIP_ERROR values overlapping.

### DIFF
--- a/src/lib/core/CHIPError.h
+++ b/src/lib/core/CHIPError.h
@@ -2207,15 +2207,6 @@ using CHIP_ERROR = ::chip::ChipError;
  */
 #define CHIP_ERROR_IM_STATUS_CODE_RECEIVED                     CHIP_CORE_ERROR(0xca)
 
-/*
- * @def CHIP_ERROR_ANOTHER_COMMISSIONING_IN_PROGRESS
- *
- * @brief
- *   Indicates that the commissioning window on the device is already open, and another
- *   commissioning is in progress
- */
-#define CHIP_ERROR_ANOTHER_COMMISSIONING_IN_PROGRESS           CHIP_CORE_ERROR(0xcb)
-
 /**
  * @def CHIP_ERROR_IM_MALFORMED_COMMAND_STATUS_IB
  *
@@ -2314,6 +2305,15 @@ using CHIP_ERROR = ::chip::ChipError;
  *   the required elements
  */
 #define CHIP_ERROR_IM_MALFORMED_EVENT_REPORT_IB             CHIP_CORE_ERROR(0xd5)
+
+/*
+ * @def CHIP_ERROR_ANOTHER_COMMISSIONING_IN_PROGRESS
+ *
+ * @brief
+ *   Indicates that the commissioning window on the device is already open, and another
+ *   commissioning is in progress
+ */
+#define CHIP_ERROR_ANOTHER_COMMISSIONING_IN_PROGRESS           CHIP_CORE_ERROR(0xd6)
 
 /**
  *  @}


### PR DESCRIPTION
CHIP_ERROR_ANOTHER_COMMISSIONING_IN_PROGRESS and
CHIP_ERROR_IM_MALFORMED_COMMAND_STATUS_IB have the same value,
probably due to undetected merge conflict.

#### Problem
See above.

#### Change overview
See above.

#### Testing
Run:
```
/out/debug/standalone/chip-tool pairing open-commissioning-window 17 1 500 1000 3840
```
twice.  Before this change I get:
```
[1638815127962] [79120:11404766] CHIP: [-] ../../../examples/chip-tool/third_party/connectedhomeip/src/controller/CHIPDeviceController.cpp:424: CHIP Error 0x000000CB: Malformed Interaction Model Command Status IB at ../../../examples/chip-tool/commands/pa
```
which is very much the wrong error message.  After this change I get:
```
[1638815233427] [79773:11408303] CHIP: [-] ../../../examples/chip-tool/third_party/connectedhomeip/src/controller/CHIPDeviceController.cpp:424: CHIP Error 0x000000D6 at ../../../examples/chip-tool/commands/pairing/OpenCommissioningWindowCommand.cpp:46
```