### PR TITLE
[OTA] Use CASESessionManager to establish CASE sessions from OTARequestor class

### DIFF
--- a/examples/ota-requestor-app/linux/main.cpp
+++ b/examples/ota-requestor-app/linux/main.cpp
@@ -16,7 +16,8 @@
  *    limitations under the License.
  */
 
-#include <app/OperationalDeviceProxy.h>
+#include <app/CASEClientPool.h>
+#include <app/OperationalDeviceProxyPool.h>
 #include <app/server/Server.h>
 #include <controller/ExampleOperationalCredentialsIssuer.h>
 #include <credentials/examples/DeviceAttestationCredsExample.h>
@@ -30,30 +31,38 @@
 
 using chip::BDXDownloader;
 using chip::ByteSpan;
+using chip::CASEClientPool;
 using chip::CharSpan;
-using chip::DeviceProxy;
 using chip::EndpointId;
 using chip::FabricIndex;
+using chip::GetRequestorInstance;
 using chip::LinuxOTAImageProcessor;
 using chip::NodeId;
 using chip::OnDeviceConnected;
 using chip::OnDeviceConnectionFailure;
+using chip::OperationalDeviceProxyPool;
+using chip::OTADownloader;
 using chip::OTAImageProcessorParams;
+using chip::OTARequestor;
 using chip::PeerId;
 using chip::Server;
 using chip::VendorId;
 using chip::Callback::Callback;
-using chip::Inet::IPAddress;
 using chip::System::Layer;
 using chip::Transport::PeerAddress;
 using namespace chip::ArgParser;
 using namespace chip::Messaging;
 using namespace chip::app::Clusters::OtaSoftwareUpdateProvider::Commands;
 
-OTARequestor requestorCore;
-LinuxOTARequestorDriver requestorUser;
-BDXDownloader downloader;
-LinuxOTAImageProcessor imageProcessor;
+constexpr size_t kMaxActiveCaseClients = 2;
+constexpr size_t kMaxActiveDevices     = 8;
+
+OTARequestor gRequestorCore;
+LinuxOTARequestorDriver gRequestorUser;
+BDXDownloader gDownloader;
+LinuxOTAImageProcessor gImageProcessor;
+CASEClientPool<kMaxActiveCaseClients> gCASEClientPool;
+OperationalDeviceProxyPool<kMaxActiveDevices> gDevicePool;
 
 bool HandleOptions(const char * aProgram, OptionSet * aOptions, int aIdentifier, const char * aName, const char * aValue);
 void OnStartDelayTimerHandler(Layer * systemLayer, void * appState);
@@ -62,10 +71,8 @@ constexpr uint16_t kOptionProviderNodeId      = 'n';
 constexpr uint16_t kOptionProviderFabricIndex = 'f';
 constexpr uint16_t kOptionUdpPort             = 'u';
 constexpr uint16_t kOptionDiscriminator       = 'd';
-constexpr uint16_t kOptionIPAddress           = 'i';
 constexpr uint16_t kOptionDelayQuery          = 'q';
 
-const char * ipAddress          = NULL;
 NodeId providerNodeId           = 0x0;
 FabricIndex providerFabricIndex = 1;
 uint16_t requestorSecurePort    = 0;
@@ -77,8 +84,6 @@ OptionDef cmdLineOptionsDef[] = {
     { "providerFabricIndex", chip::ArgParser::kArgumentRequired, kOptionProviderFabricIndex },
     { "udpPort", chip::ArgParser::kArgumentRequired, kOptionUdpPort },
     { "discriminator", chip::ArgParser::kArgumentRequired, kOptionDiscriminator },
-    // TODO: This can be removed once OperationalDeviceProxy can resolve the IP Address from Node ID
-    { "ipaddress", chip::ArgParser::kArgumentRequired, kOptionIPAddress },
     { "delayQuery", chip::ArgParser::kArgumentRequired, kOptionDelayQuery },
     {},
 };
@@ -95,8 +100,6 @@ OptionSet cmdLineOptions = { HandleOptions, cmdLineOptionsDef, "PROGRAM OPTIONS"
                              "  -d/--discriminator <discriminator>\n"
                              "        A 12-bit value used to discern between multiple commissionable CHIP device\n"
                              "        advertisements. If none is specified, default value is 3840.\n"
-                             "  -i/--ipaddress <IP Address>\n"
-                             "        The IP Address of the OTA Provider to connect to. This value must be supplied.\n"
                              "  -q/--delayQuery <Time in seconds>\n"
                              "        From boot up, the amount of time to wait before triggering the QueryImage\n"
                              "        command. If none or zero is supplied, QueryImage will not be triggered.\n" };
@@ -143,10 +146,6 @@ bool HandleOptions(const char * aProgram, OptionSet * aOptions, int aIdentifier,
             PrintArgError("%s: Input ERROR: setupDiscriminator value %s is out of range \n", aProgram, aValue);
             retval = false;
         }
-        break;
-    case kOptionIPAddress:
-        ipAddress = aValue;
-        ChipLogError(SoftwareUpdate, "IP Address = %s", aValue);
         break;
     case kOptionDelayQuery:
         delayQueryTimeInSec = static_cast<uint16_t>(strtol(aValue, NULL, 0));
@@ -201,10 +200,16 @@ int main(int argc, char * argv[])
     SetDeviceAttestationCredentialsProvider(chip::Credentials::Examples::GetExampleDACProvider());
 
     // Initialize and interconnect the Requestor and Image Processor objects -- START
-    SetRequestorInstance(&requestorCore);
+    SetRequestorInstance(&gRequestorCore);
+
+    // Set server instance used for session establishment
+    chip::Server * server = &(chip::Server::GetInstance());
+    server->SetCASEClientPool(&gCASEClientPool);
+    server->SetDevicePool(&gDevicePool);
+    gRequestorCore.SetServerInstance(server);
 
     // Connect the Requestor and Requestor Driver objects
-    requestorCore.SetOtaRequestorDriver(&requestorUser);
+    gRequestorCore.SetOtaRequestorDriver(&gRequestorUser);
 
     // WARNING: this is probably not realistic to know such details of the image or to even have an OTADownloader instantiated at
     // the beginning of program execution. We're using hardcoded values here for now since this is a reference application.
@@ -212,28 +217,20 @@ int main(int argc, char * argv[])
     // TODO: add API for OTARequestor to pass QueryImageResponse info to the application to use for OTADownloader init
     OTAImageProcessorParams ipParams;
     ipParams.imageFile = CharSpan("test.txt");
-    imageProcessor.SetOTAImageProcessorParams(ipParams);
-    imageProcessor.SetOTADownloader(&downloader);
+    gImageProcessor.SetOTAImageProcessorParams(ipParams);
+    gImageProcessor.SetOTADownloader(&gDownloader);
 
     // Connect the Downloader and Image Processor objects
-    downloader.SetImageProcessorDelegate(&imageProcessor);
+    gDownloader.SetImageProcessorDelegate(&gImageProcessor);
 
-    requestorCore.SetBDXDownloader(&downloader);
+    gRequestorCore.SetBDXDownloader(&gDownloader);
     // Initialize and interconnect the Requestor and Image Processor objects -- END
-
-    // Pass the IP Address to the OTARequestor object: Use of explicit IP address is temporary
-    // until the Exchange Layer implements address resolution
-    {
-        IPAddress ipAddr;
-        IPAddress::FromString(ipAddress, ipAddr);
-        requestorCore.SetIpAddress(ipAddr);
-    }
 
     // Test Mode operation: If a delay is provided, QueryImage after the timer expires
     if (delayQueryTimeInSec > 0)
     {
         // In this mode Provider node ID and fabric idx must be supplied explicitly from program args
-        requestorCore.TestModeSetProviderParameters(providerNodeId, providerFabricIndex);
+        gRequestorCore.TestModeSetProviderParameters(providerNodeId, providerFabricIndex);
 
         chip::DeviceLayer::SystemLayer().StartTimer(chip::System::Clock::Milliseconds32(delayQueryTimeInSec * 1000),
                                                     OnStartDelayTimerHandler, nullptr);

--- a/src/app/CASESessionManager.h
+++ b/src/app/CASESessionManager.h
@@ -56,6 +56,9 @@ public:
         VerifyOrDie(params.sessionInitParams.Validate() == CHIP_NO_ERROR);
 
         mConfig = params;
+
+        // TODO: Revisit who should be set as the resolver delegate
+        Dnssd::Resolver::Instance().SetResolverDelegate(this);
     }
 
     virtual ~CASESessionManager() {}

--- a/src/app/clusters/ota-requestor/BDXDownloader.h
+++ b/src/app/clusters/ota-requestor/BDXDownloader.h
@@ -33,6 +33,13 @@
 
 namespace chip {
 
+// Constants for BDX URI parsing
+constexpr uint8_t bdxPrefix[]         = { 'b', 'd', 'x', ':', '/', '/' };
+constexpr uint8_t bdxSeparator[]      = { '/' };
+constexpr uint8_t kValidBdxUriMinLen  = 24;
+constexpr uint8_t kNodeIdHexStringLen = 16;
+constexpr size_t kUriMaxLen           = 256;
+
 class BDXDownloader : public chip::OTADownloader
 {
 public:
@@ -64,6 +71,11 @@ public:
     void EndDownload(CHIP_ERROR reason = CHIP_NO_ERROR) override;
     CHIP_ERROR FetchNextData() override;
     // TODO: override SkipData
+
+    /**
+     * Validate the URI and parse the BDX URI for various fields
+     */
+    CHIP_ERROR ParseBdxUri(CharSpan uri, NodeId & nodeId, MutableCharSpan fileDesignator);
 
 private:
     void PollTransferSession();

--- a/src/app/clusters/ota-requestor/ClusterInterface.cpp
+++ b/src/app/clusters/ota-requestor/ClusterInterface.cpp
@@ -28,7 +28,7 @@ bool emberAfOtaSoftwareUpdateRequestorClusterAnnounceOtaProviderCallback(
     const chip::app::Clusters::OtaSoftwareUpdateRequestor::Commands::AnnounceOtaProvider::DecodableType & commandData)
 {
     EmberAfStatus status;
-    OTARequestorInterface * requestor = GetRequestorInstance();
+    chip::OTARequestorInterface * requestor = chip::GetRequestorInstance();
 
     if (requestor != nullptr)
     {

--- a/src/app/clusters/ota-requestor/OTARequestorInterface.h
+++ b/src/app/clusters/ota-requestor/OTARequestorInterface.h
@@ -28,6 +28,8 @@
 
 #pragma once
 
+namespace chip {
+
 // Interface class to connect the OTA Software Update Requestor cluster command processing
 // with the core OTA Requestor logic. The OTARequestor class implements this interface
 class OTARequestorInterface
@@ -56,3 +58,5 @@ void SetRequestorInstance(OTARequestorInterface * instance);
 
 // Get the object implementing OTARequestorInterface
 OTARequestorInterface * GetRequestorInstance();
+
+} // namespace chip

--- a/src/app/server/Server.h
+++ b/src/app/server/Server.h
@@ -17,7 +17,8 @@
 
 #pragma once
 
-#include <app/OperationalDeviceProxy.h>
+#include <app/CASEClientPool.h>
+#include <app/OperationalDeviceProxyPool.h>
 #include <app/server/AppDelegate.h>
 #include <app/server/CommissioningWindowManager.h>
 #include <credentials/FabricTable.h>
@@ -66,6 +67,14 @@ public:
 
     FabricTable & GetFabricTable() { return mFabrics; }
 
+    CASEClientPoolDelegate * GetCASEClientPool() { return mCASEClientPool; }
+
+    void SetCASEClientPool(CASEClientPoolDelegate * clientPool) { mCASEClientPool = clientPool; }
+
+    OperationalDeviceProxyPoolDelegate * GetDevicePool() { return mDevicePool; }
+
+    void SetDevicePool(OperationalDeviceProxyPoolDelegate * devicePool) { mDevicePool = devicePool; }
+
     Messaging::ExchangeManager & GetExchangeManager() { return mExchangeMgr; }
 
     SessionIDAllocator & GetSessionIDAllocator() { return mSessionIDAllocator; }
@@ -73,13 +82,6 @@ public:
     SessionManager & GetSecureSessionManager() { return mSessions; }
 
     TransportMgrBase & GetTransportManager() { return mTransports; }
-
-    chip::OperationalDeviceProxy * GetOperationalDeviceProxy() { return mOperationalDeviceProxy; }
-
-    void SetOperationalDeviceProxy(chip::OperationalDeviceProxy * operationalDeviceProxy)
-    {
-        mOperationalDeviceProxy = operationalDeviceProxy;
-    }
 
 #if CONFIG_NETWORK_LAYER_BLE
     Ble::BleLayer * getBleLayerObject() { return mBleLayer; }
@@ -139,6 +141,8 @@ private:
     ServerTransportMgr mTransports;
     SessionManager mSessions;
     CASEServer mCASEServer;
+    CASEClientPoolDelegate * mCASEClientPool         = nullptr;
+    OperationalDeviceProxyPoolDelegate * mDevicePool = nullptr;
     Messaging::ExchangeManager mExchangeMgr;
     FabricTable mFabrics;
     SessionIDAllocator mSessionIDAllocator;
@@ -156,8 +160,6 @@ private:
     // (https://github.com/project-chip/connectedhomeip/issues/12174)
     TestPersistentStorageDelegate mGroupsStorage;
     Credentials::GroupDataProviderImpl mGroupsProvider;
-
-    chip::OperationalDeviceProxy * mOperationalDeviceProxy = nullptr;
 
     // TODO @ceille: Maybe use OperationalServicePort and CommissionableServicePort
     uint16_t mSecuredServicePort;

--- a/src/lib/core/CHIPError.h
+++ b/src/lib/core/CHIPError.h
@@ -2333,6 +2333,22 @@ using CHIP_ERROR = ::chip::ChipError;
  */
 #define CHIP_ERROR_IM_MALFORMED_DATA_VERSION_FILTER_IB             CHIP_CORE_ERROR(0xd7)
 /**
+ * @def CHIP_ERROR_INVALID_SCHEME_PREFIX
+ *
+ * @brief
+ *   The scheme field contains an invalid prefix
+ */
+#define CHIP_ERROR_INVALID_SCHEME_PREFIX             CHIP_CORE_ERROR(0xd6)
+
+/**
+ * @def CHIP_ERROR_MISSING_URI_SEPARATOR
+ *
+ * @brief
+ *   The URI separator is missing
+ */
+#define CHIP_ERROR_MISSING_URI_SEPARATOR             CHIP_CORE_ERROR(0xd7)
+
+/**
  *  @}
  */
 

--- a/zzz_generated/ota-requestor-app/zap-generated/IMClusterCommandHandler.cpp
+++ b/zzz_generated/ota-requestor-app/zap-generated/IMClusterCommandHandler.cpp
@@ -45,7 +45,9 @@ namespace Basic {
 
 void DispatchServerCommand(CommandHandler * apCommandObj, const ConcreteCommandPath & aCommandPath, TLV::TLVReader & aDataTlv)
 {
-    ReportCommandUnsupported(apCommandObj, aCommandPath);
+    apCommandObj->AddStatus(aCommandPath, Protocols::InteractionModel::Status::UnsupportedCommand);
+    ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI,
+                 ChipLogValueMEI(aCommandPath.mCommandId), ChipLogValueMEI(aCommandPath.mClusterId));
 }
 
 } // namespace Basic


### PR DESCRIPTION
#### Problem
The ota-requestor-app requires the users of this app to pass in the IP address of the provider it wants to query image from. It uses OperationalDeviceProxy object directly and passes the IP address to that object. This should not be needed as IP address should be resolved from a node ID.

Fixes: https://github.com/project-chip/connectedhomeip/issues/11060

#### Change overview
The ota-requestor-app now uses the CASESessionManager to establish a CASE session to the provider.

#### Testing
Manually testing on Linux:

```
./out/debug/chip-ota-provider-app -f test.bin
./out/chip-tool pairing onnetwork 1 20202021
./out/debug/chip-ota-requestor-app -d 30 -u 5550
./out/chip-tool pairing onnetwork-long 2 20202021 30
./out/chip-tool otasoftwareupdaterequestor announce-ota-provider 1 0 0 2 0
```