### PR TITLE
Send optional MRP parameters in PASE messages

### DIFF
--- a/src/app/server/CommissioningWindowManager.cpp
+++ b/src/app/server/CommissioningWindowManager.cpp
@@ -176,8 +176,9 @@ CHIP_ERROR CommissioningWindowManager::OpenCommissioningWindow()
     if (mUseECM)
     {
         ReturnErrorOnFailure(SetTemporaryDiscriminator(mECMDiscriminator));
-        ReturnErrorOnFailure(mPairingSession.WaitForPairing(mECMPASEVerifier, mECMIterations, ByteSpan(mECMSalt, mECMSaltLength),
-                                                            mECMPasscodeID, keyID, this));
+        ReturnErrorOnFailure(
+            mPairingSession.WaitForPairing(mECMPASEVerifier, mECMIterations, ByteSpan(mECMSalt, mECMSaltLength), mECMPasscodeID,
+                                           keyID, Optional<ReliableMessageProtocolConfig>::Value(gDefaultMRPConfig), this));
 
         // reset all advertising, indicating we are in commissioningMode
         app::DnssdServer::Instance().StartServer(Dnssd::CommissioningMode::kEnabledEnhanced);
@@ -189,7 +190,8 @@ CHIP_ERROR CommissioningWindowManager::OpenCommissioningWindow()
 
         ReturnErrorOnFailure(mPairingSession.WaitForPairing(
             pinCode, kSpake2p_Iteration_Count,
-            ByteSpan(reinterpret_cast<const uint8_t *>(kSpake2pKeyExchangeSalt), strlen(kSpake2pKeyExchangeSalt)), keyID, this));
+            ByteSpan(reinterpret_cast<const uint8_t *>(kSpake2pKeyExchangeSalt), strlen(kSpake2pKeyExchangeSalt)), keyID,
+            Optional<ReliableMessageProtocolConfig>::Value(gDefaultMRPConfig), this));
 
         // reset all advertising, indicating we are in commissioningMode
         app::DnssdServer::Instance().StartServer(Dnssd::CommissioningMode::kEnabledBasic);

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -859,7 +859,8 @@ CHIP_ERROR DeviceCommissioner::EstablishPASEConnection(NodeId remoteDeviceId, Re
     // TODO - Remove use of SetActive/IsActive from CommissioneeDeviceProxy
     device->SetActive(true);
 
-    err = device->GetPairing().Pair(params.GetPeerAddress(), params.GetSetupPINCode(), keyID, exchangeCtxt, this);
+    err = device->GetPairing().Pair(params.GetPeerAddress(), params.GetSetupPINCode(), keyID,
+                                    Optional<ReliableMessageProtocolConfig>::Value(mMRPConfig), exchangeCtxt, this);
     SuccessOrExit(err);
 
     // Immediately persist the updated mNextKeyID value

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -810,6 +810,8 @@ private:
 
     Callback::Callback<OnNOCChainGeneration> mDeviceNOCChainCallback;
     SetUpCodePairer mSetUpCodePairer;
+
+    ReliableMessageProtocolConfig mMRPConfig = gDefaultMRPConfig;
 };
 
 } // namespace Controller

--- a/src/protocols/secure_channel/CASESession.h
+++ b/src/protocols/secure_channel/CASESession.h
@@ -144,10 +144,6 @@ public:
      */
     virtual CHIP_ERROR DeriveSecureSession(CryptoContext & session, CryptoContext::SessionRole role) override;
 
-    const char * GetI2RSessionInfo() const override { return "Sigma I2R Key"; }
-
-    const char * GetR2ISessionInfo() const override { return "Sigma R2I Key"; }
-
     /**
      * @brief Serialize the CASESession to the given cachableSession data structure for secure pairing
      **/

--- a/src/protocols/secure_channel/PASESession.cpp
+++ b/src/protocols/secure_channel/PASESession.cpp
@@ -251,7 +251,8 @@ CHIP_ERROR PASESession::SetupSpake2p(uint32_t pbkdf2IterCount, const ByteSpan & 
 }
 
 CHIP_ERROR PASESession::WaitForPairing(uint32_t mySetUpPINCode, uint32_t pbkdf2IterCount, const ByteSpan & salt,
-                                       uint16_t mySessionId, SessionEstablishmentDelegate * delegate)
+                                       uint16_t mySessionId, Optional<ReliableMessageProtocolConfig> mrpConfig,
+                                       SessionEstablishmentDelegate * delegate)
 {
     // Return early on error here, as we have not initalized any state yet
     ReturnErrorCodeIf(salt.empty(), CHIP_ERROR_INVALID_ARGUMENT);
@@ -281,6 +282,7 @@ CHIP_ERROR PASESession::WaitForPairing(uint32_t mySetUpPINCode, uint32_t pbkdf2I
     mNextExpectedMsg = MsgType::PBKDFParamRequest;
     mPairingComplete = false;
     mPasscodeID      = 0;
+    mLocalMRPConfig  = mrpConfig;
 
     ChipLogDetail(SecureChannel, "Waiting for PBKDF param request");
 
@@ -293,9 +295,10 @@ exit:
 }
 
 CHIP_ERROR PASESession::WaitForPairing(const PASEVerifier & verifier, uint32_t pbkdf2IterCount, const ByteSpan & salt,
-                                       uint16_t passcodeID, uint16_t mySessionId, SessionEstablishmentDelegate * delegate)
+                                       uint16_t passcodeID, uint16_t mySessionId, Optional<ReliableMessageProtocolConfig> mrpConfig,
+                                       SessionEstablishmentDelegate * delegate)
 {
-    ReturnErrorOnFailure(WaitForPairing(0, pbkdf2IterCount, salt, mySessionId, delegate));
+    ReturnErrorOnFailure(WaitForPairing(0, pbkdf2IterCount, salt, mySessionId, mrpConfig, delegate));
 
     memmove(&mPASEVerifier, &verifier, sizeof(verifier));
     mComputeVerifier = false;
@@ -305,7 +308,8 @@ CHIP_ERROR PASESession::WaitForPairing(const PASEVerifier & verifier, uint32_t p
 }
 
 CHIP_ERROR PASESession::Pair(const Transport::PeerAddress peerAddress, uint32_t peerSetUpPINCode, uint16_t mySessionId,
-                             Messaging::ExchangeContext * exchangeCtxt, SessionEstablishmentDelegate * delegate)
+                             Optional<ReliableMessageProtocolConfig> mrpConfig, Messaging::ExchangeContext * exchangeCtxt,
+                             SessionEstablishmentDelegate * delegate)
 {
     ReturnErrorCodeIf(exchangeCtxt == nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     CHIP_ERROR err = Init(mySessionId, peerSetUpPINCode, delegate);
@@ -315,6 +319,8 @@ CHIP_ERROR PASESession::Pair(const Transport::PeerAddress peerAddress, uint32_t 
     mExchangeCtxt->SetResponseTimeout(kSpake2p_Response_Timeout);
 
     SetPeerAddress(peerAddress);
+
+    mLocalMRPConfig = mrpConfig;
 
     err = SendPBKDFParamRequest();
     SuccessOrExit(err);
@@ -355,13 +361,14 @@ CHIP_ERROR PASESession::SendPBKDFParamRequest()
 {
     ReturnErrorOnFailure(DRBG_get_bytes(mPBKDFLocalRandomData, sizeof(mPBKDFLocalRandomData)));
 
-    const size_t max_msg_len       = TLV::EstimateStructOverhead(kPBKDFParamRandomNumberSize, // initiatorRandom,
+    const size_t mrpParamsSize = mLocalMRPConfig.HasValue() ? TLV::EstimateStructOverhead(sizeof(uint16_t), sizeof(uint16_t)) : 0;
+    const size_t max_msg_len   = TLV::EstimateStructOverhead(kPBKDFParamRandomNumberSize, // initiatorRandom,
                                                            sizeof(uint16_t),            // initiatorSessionId
                                                            sizeof(uint16_t),            // passcodeId,
-                                                           sizeof(uint8_t)              // hasPBKDFParameters
-                                                           /* TLV::EstimateStructOverhead(sizeof(uint16_t),
-                                                              sizeof(uint16)_t), // initiatorMRPParams */
+                                                           sizeof(uint8_t),             // hasPBKDFParameters
+                                                           mrpParamsSize                // MRP Parameters
     );
+
     System::PacketBufferHandle req = System::PacketBufferHandle::New(max_msg_len);
     VerifyOrReturnError(!req.IsNull(), CHIP_ERROR_NO_MEMORY);
 
@@ -374,9 +381,11 @@ CHIP_ERROR PASESession::SendPBKDFParamRequest()
     ReturnErrorOnFailure(tlvWriter.Put(TLV::ContextTag(2), GetLocalSessionId()));
     ReturnErrorOnFailure(tlvWriter.Put(TLV::ContextTag(3), mPasscodeID));
     ReturnErrorOnFailure(tlvWriter.PutBoolean(TLV::ContextTag(4), mHavePBKDFParameters));
-    // TODO - Add optional MRP parameter support to PASE
-    // When we add MRP params here, adjust the TLV::EstimateStructOverhead call
-    // above accordingly.
+    if (mLocalMRPConfig.HasValue())
+    {
+        ChipLogDetail(SecureChannel, "Including MRP parameters in PBKDF param request");
+        ReturnErrorOnFailure(EncodeMRPParameters(TLV::ContextTag(5), mLocalMRPConfig.Value(), tlvWriter));
+    }
     ReturnErrorOnFailure(tlvWriter.EndContainer(outerContainerType));
     ReturnErrorOnFailure(tlvWriter.Finalize(&req));
 
@@ -433,7 +442,7 @@ CHIP_ERROR PASESession::HandlePBKDFParamRequest(System::PacketBufferHandle && ms
     VerifyOrExit(TLV::TagNumFromTag(tlvReader.GetTag()) == ++decodeTagIdSeq, err = CHIP_ERROR_INVALID_TLV_TAG);
     SuccessOrExit(err = tlvReader.Get(hasPBKDFParameters));
 
-    // TODO - Check if optional MRP parameters were sent. If so, cache them.
+    SuccessOrExit(err = DecodeMRPParametersIfPresent(tlvReader));
 
     err = SendPBKDFParamResponse(ByteSpan(initiatorRandom), hasPBKDFParameters);
     SuccessOrExit(err);
@@ -453,14 +462,15 @@ CHIP_ERROR PASESession::SendPBKDFParamResponse(ByteSpan initiatorRandom, bool in
 {
     ReturnErrorOnFailure(DRBG_get_bytes(mPBKDFLocalRandomData, sizeof(mPBKDFLocalRandomData)));
 
+    const size_t mrpParamsSize = mLocalMRPConfig.HasValue() ? TLV::EstimateStructOverhead(sizeof(uint16_t), sizeof(uint16_t)) : 0;
     const size_t max_msg_len =
-        TLV::EstimateStructOverhead(kPBKDFParamRandomNumberSize,                               // initiatorRandom
-                                    kPBKDFParamRandomNumberSize,                               // responderRandom
-                                    sizeof(uint16_t),                                          // responderSessionId
-                                    TLV::EstimateStructOverhead(sizeof(uint32_t), mSaltLength) // pbkdf_parameters
-                                    /* TLV::EstimateStructOverhead(sizeof(uint16_t),
-                                        sizeof(uint16)_t), // responderMRPParams */
+        TLV::EstimateStructOverhead(kPBKDFParamRandomNumberSize,                                // initiatorRandom
+                                    kPBKDFParamRandomNumberSize,                                // responderRandom
+                                    sizeof(uint16_t),                                           // responderSessionId
+                                    TLV::EstimateStructOverhead(sizeof(uint32_t), mSaltLength), // pbkdf_parameters
+                                    mrpParamsSize                                               // MRP Parameters
         );
+
     System::PacketBufferHandle resp = System::PacketBufferHandle::New(max_msg_len);
     VerifyOrReturnError(!resp.IsNull(), CHIP_ERROR_NO_MEMORY);
 
@@ -483,8 +493,11 @@ CHIP_ERROR PASESession::SendPBKDFParamResponse(ByteSpan initiatorRandom, bool in
         ReturnErrorOnFailure(tlvWriter.EndContainer(pbkdfParamContainer));
     }
 
-    // When we add MRP params here, adjust the TLV::EstimateStructOverhead call
-    // above accordingly.
+    if (mLocalMRPConfig.HasValue())
+    {
+        ChipLogDetail(SecureChannel, "Including MRP parameters in PBKDF param response");
+        ReturnErrorOnFailure(EncodeMRPParameters(TLV::ContextTag(5), mLocalMRPConfig.Value(), tlvWriter));
+    }
 
     ReturnErrorOnFailure(tlvWriter.EndContainer(outerContainerType));
     ReturnErrorOnFailure(tlvWriter.Finalize(&resp));
@@ -549,6 +562,8 @@ CHIP_ERROR PASESession::HandlePBKDFParamResponse(System::PacketBufferHandle && m
 
     if (mHavePBKDFParameters)
     {
+        SuccessOrExit(err = DecodeMRPParametersIfPresent(tlvReader));
+
         // TODO - Add a unit test that exercises mHavePBKDFParameters path
         err = SetupSpake2p(mIterationCount, ByteSpan(mSalt, mSaltLength));
         SuccessOrExit(err);
@@ -567,6 +582,10 @@ CHIP_ERROR PASESession::HandlePBKDFParamResponse(System::PacketBufferHandle && m
         VerifyOrExit(TLV::TagNumFromTag(tlvReader.GetTag()) == ++decodeTagIdSeq, err = CHIP_ERROR_INVALID_TLV_TAG);
         saltLength = tlvReader.GetLength();
         SuccessOrExit(err = tlvReader.GetDataPtr(salt));
+
+        SuccessOrExit(err = tlvReader.ExitContainer(containerType));
+
+        SuccessOrExit(err = DecodeMRPParametersIfPresent(tlvReader));
 
         err = SetupSpake2p(iterCount, ByteSpan(salt, saltLength));
         SuccessOrExit(err);

--- a/src/protocols/secure_channel/PASESession.h
+++ b/src/protocols/secure_channel/PASESession.h
@@ -172,10 +172,6 @@ public:
      */
     CHIP_ERROR DeriveSecureSession(CryptoContext & session, CryptoContext::SessionRole role) override;
 
-    const char * GetI2RSessionInfo() const override { return kSpake2pI2RSessionInfo; }
-
-    const char * GetR2ISessionInfo() const override { return kSpake2pR2ISessionInfo; }
-
     /** @brief Serialize the Pairing Session to a string.
      *
      * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
@@ -372,10 +368,6 @@ public:
         memcpy(serializable.mKe, kTestSecret, secretLen);
         return CHIP_NO_ERROR;
     }
-
-    const char * GetI2RSessionInfo() const override { return "i2r"; }
-
-    const char * GetR2ISessionInfo() const override { return "r2i"; }
 
 private:
     const char * kTestSecret = CHIP_CONFIG_TEST_SHARED_SECRET_VALUE;

--- a/src/protocols/secure_channel/PASESession.h
+++ b/src/protocols/secure_channel/PASESession.h
@@ -107,7 +107,7 @@ public:
      * @return CHIP_ERROR     The result of initialization
      */
     CHIP_ERROR WaitForPairing(uint32_t mySetUpPINCode, uint32_t pbkdf2IterCount, const ByteSpan & salt, uint16_t mySessionId,
-                              SessionEstablishmentDelegate * delegate);
+                              Optional<ReliableMessageProtocolConfig> mrpConfig, SessionEstablishmentDelegate * delegate);
 
     /**
      * @brief
@@ -123,7 +123,8 @@ public:
      * @return CHIP_ERROR     The result of initialization
      */
     CHIP_ERROR WaitForPairing(const PASEVerifier & verifier, uint32_t pbkdf2IterCount, const ByteSpan & salt, uint16_t passcodeID,
-                              uint16_t mySessionId, SessionEstablishmentDelegate * delegate);
+                              uint16_t mySessionId, Optional<ReliableMessageProtocolConfig> mrpConfig,
+                              SessionEstablishmentDelegate * delegate);
 
     /**
      * @brief
@@ -141,7 +142,8 @@ public:
      * @return CHIP_ERROR      The result of initialization
      */
     CHIP_ERROR Pair(const Transport::PeerAddress peerAddress, uint32_t peerSetUpPINCode, uint16_t mySessionId,
-                    Messaging::ExchangeContext * exchangeCtxt, SessionEstablishmentDelegate * delegate);
+                    Optional<ReliableMessageProtocolConfig> mrpConfig, Messaging::ExchangeContext * exchangeCtxt,
+                    SessionEstablishmentDelegate * delegate);
 
     /**
      * @brief
@@ -303,6 +305,8 @@ private:
     Messaging::ExchangeContext * mExchangeCtxt = nullptr;
 
     SessionEstablishmentExchangeDispatch mMessageDispatch;
+
+    Optional<ReliableMessageProtocolConfig> mLocalMRPConfig;
 
     struct Spake2pErrorMsg
     {

--- a/src/transport/BUILD.gn
+++ b/src/transport/BUILD.gn
@@ -25,6 +25,7 @@ static_library("transport") {
     "MessageCounter.cpp",
     "MessageCounter.h",
     "MessageCounterManagerInterface.h",
+    "PairingSession.cpp",
     "PeerMessageCounter.h",
     "SecureMessageCodec.cpp",
     "SecureMessageCodec.h",

--- a/src/transport/PairingSession.cpp
+++ b/src/transport/PairingSession.cpp
@@ -1,0 +1,88 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file defines a common interface to access various types of secure
+ *      pairing sessions (e.g. PASE, CASE)
+ *
+ */
+
+#include <transport/PairingSession.h>
+
+#include <lib/core/CHIPTLVTypes.h>
+#include <lib/support/SafeInt.h>
+
+namespace chip {
+
+CHIP_ERROR PairingSession::EncodeMRPParameters(TLV::Tag tag, const ReliableMessageProtocolConfig & mrpConfig,
+                                               System::PacketBufferTLVWriter & tlvWriter)
+{
+    VerifyOrReturnError(CanCastTo<uint16_t>(mrpConfig.mIdleRetransTimeout.count()), CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(CanCastTo<uint16_t>(mrpConfig.mActiveRetransTimeout.count()), CHIP_ERROR_INVALID_ARGUMENT);
+
+    TLV::TLVType mrpParamsContainer;
+    ReturnErrorOnFailure(tlvWriter.StartContainer(tag, TLV::kTLVType_Structure, mrpParamsContainer));
+    ReturnErrorOnFailure(tlvWriter.Put(TLV::ContextTag(1), static_cast<uint16_t>(mrpConfig.mIdleRetransTimeout.count())));
+    ReturnErrorOnFailure(tlvWriter.Put(TLV::ContextTag(2), static_cast<uint16_t>(mrpConfig.mActiveRetransTimeout.count())));
+    return tlvWriter.EndContainer(mrpParamsContainer);
+}
+
+CHIP_ERROR PairingSession::DecodeMRPParametersIfPresent(System::PacketBufferTLVReader & tlvReader)
+{
+    // The MRP parameters are optional.
+    CHIP_ERROR err = tlvReader.Next();
+    if (err == CHIP_END_OF_TLV)
+    {
+        return CHIP_NO_ERROR;
+    }
+    ReturnErrorOnFailure(err);
+
+    TLV::TLVType containerType = TLV::kTLVType_Structure;
+    ReturnErrorOnFailure(tlvReader.EnterContainer(containerType));
+
+    uint16_t tlvElementValue = 0;
+
+    ReturnErrorOnFailure(tlvReader.Next());
+
+    ChipLogDetail(SecureChannel, "Found MRP parameters in the message");
+
+    // Both TLV elements in the strucutre are optional. If the first element is present, process it and move
+    // the TLV reader to the next element.
+    if (TLV::TagNumFromTag(tlvReader.GetTag()) == 1)
+    {
+        ReturnErrorOnFailure(tlvReader.Get(tlvElementValue));
+        mMRPConfig.mIdleRetransTimeout = System::Clock::Milliseconds32(tlvElementValue);
+
+        // The next element is optional. If it's not present, return CHIP_NO_ERROR.
+        err = tlvReader.Next();
+        if (err == CHIP_END_OF_TLV)
+        {
+            return CHIP_NO_ERROR;
+        }
+        ReturnErrorOnFailure(err);
+    }
+
+    VerifyOrReturnError(TLV::TagNumFromTag(tlvReader.GetTag()) == 2, CHIP_ERROR_INVALID_TLV_TAG);
+    ReturnErrorOnFailure(tlvReader.Get(tlvElementValue));
+    mMRPConfig.mActiveRetransTimeout = System::Clock::Milliseconds32(tlvElementValue);
+
+    return tlvReader.ExitContainer(containerType);
+}
+
+} // namespace chip

--- a/src/transport/PairingSession.cpp
+++ b/src/transport/PairingSession.cpp
@@ -24,7 +24,7 @@
 namespace chip {
 
 CHIP_ERROR PairingSession::EncodeMRPParameters(TLV::Tag tag, const ReliableMessageProtocolConfig & mrpConfig,
-                                               System::PacketBufferTLVWriter & tlvWriter)
+                                               TLV::TLVWriter & tlvWriter)
 {
     VerifyOrReturnError(CanCastTo<uint16_t>(mrpConfig.mIdleRetransTimeout.count()), CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(CanCastTo<uint16_t>(mrpConfig.mActiveRetransTimeout.count()), CHIP_ERROR_INVALID_ARGUMENT);
@@ -36,7 +36,7 @@ CHIP_ERROR PairingSession::EncodeMRPParameters(TLV::Tag tag, const ReliableMessa
     return tlvWriter.EndContainer(mrpParamsContainer);
 }
 
-CHIP_ERROR PairingSession::DecodeMRPParametersIfPresent(System::PacketBufferTLVReader & tlvReader)
+CHIP_ERROR PairingSession::DecodeMRPParametersIfPresent(TLV::ContiguousBufferTLVReader & tlvReader)
 {
     // The MRP parameters are optional.
     CHIP_ERROR err = tlvReader.Next();

--- a/src/transport/PairingSession.cpp
+++ b/src/transport/PairingSession.cpp
@@ -16,13 +16,6 @@
  *    limitations under the License.
  */
 
-/**
- *    @file
- *      This file defines a common interface to access various types of secure
- *      pairing sessions (e.g. PASE, CASE)
- *
- */
-
 #include <transport/PairingSession.h>
 
 #include <lib/core/CHIPTLVTypes.h>

--- a/src/transport/PairingSession.h
+++ b/src/transport/PairingSession.h
@@ -29,6 +29,7 @@
 #include <messaging/ExchangeContext.h>
 #include <protocols/secure_channel/Constants.h>
 #include <protocols/secure_channel/StatusReport.h>
+#include <system/TLVPacketBufferBackingStore.h>
 #include <transport/CryptoContext.h>
 #include <transport/SecureSession.h>
 
@@ -158,6 +159,11 @@ protected:
 
         return err;
     }
+
+    static CHIP_ERROR EncodeMRPParameters(TLV::Tag tag, const ReliableMessageProtocolConfig & mrpConfig,
+                                          System::PacketBufferTLVWriter & tlvWriter);
+
+    CHIP_ERROR DecodeMRPParametersIfPresent(System::PacketBufferTLVReader & tlvReader);
 
     // TODO: remove Clear, we should create a new instance instead reset the old instance.
     void Clear()

--- a/src/transport/PairingSession.h
+++ b/src/transport/PairingSession.h
@@ -97,9 +97,11 @@ public:
 
     void SetMRPConfig(const ReliableMessageProtocolConfig & config) { mMRPConfig = config; }
 
-    virtual const char * GetI2RSessionInfo() const = 0;
-
-    virtual const char * GetR2ISessionInfo() const = 0;
+    /**
+     * Encode the provided MRP parameters using the provided TLV tag.
+     */
+    static CHIP_ERROR EncodeMRPParameters(TLV::Tag tag, const ReliableMessageProtocolConfig & mrpConfig,
+                                          System::PacketBufferTLVWriter & tlvWriter);
 
 protected:
     void SetSecureSessionType(Transport::SecureSession::Type secureSessionType) { mSecureSessionType = secureSessionType; }
@@ -160,9 +162,16 @@ protected:
         return err;
     }
 
-    static CHIP_ERROR EncodeMRPParameters(TLV::Tag tag, const ReliableMessageProtocolConfig & mrpConfig,
-                                          System::PacketBufferTLVWriter & tlvWriter);
-
+    /**
+     * Try to decode the next element (pointed by the TLV reader) as MRP parameters.
+     * If the MRP parameters are found, mMRPConfig is updated with the devoded values.
+     *
+     * MRP parameters are optional. So, if the TLV reader is not pointing to the MRP parameters,
+     * the function is a noop.
+     *
+     * If the parameters are present, but TLV reader fails to correctly parse it, the function will
+     * return the corresponding error.
+     */
     CHIP_ERROR DecodeMRPParametersIfPresent(System::PacketBufferTLVReader & tlvReader);
 
     // TODO: remove Clear, we should create a new instance instead reset the old instance.

--- a/src/transport/PairingSession.h
+++ b/src/transport/PairingSession.h
@@ -26,10 +26,10 @@
 #pragma once
 
 #include <lib/core/CHIPError.h>
+#include <lib/core/CHIPTLV.h>
 #include <messaging/ExchangeContext.h>
 #include <protocols/secure_channel/Constants.h>
 #include <protocols/secure_channel/StatusReport.h>
-#include <system/TLVPacketBufferBackingStore.h>
 #include <transport/CryptoContext.h>
 #include <transport/SecureSession.h>
 
@@ -101,7 +101,7 @@ public:
      * Encode the provided MRP parameters using the provided TLV tag.
      */
     static CHIP_ERROR EncodeMRPParameters(TLV::Tag tag, const ReliableMessageProtocolConfig & mrpConfig,
-                                          System::PacketBufferTLVWriter & tlvWriter);
+                                          TLV::TLVWriter & tlvWriter);
 
 protected:
     void SetSecureSessionType(Transport::SecureSession::Type secureSessionType) { mSecureSessionType = secureSessionType; }
@@ -172,7 +172,7 @@ protected:
      * If the parameters are present, but TLV reader fails to correctly parse it, the function will
      * return the corresponding error.
      */
-    CHIP_ERROR DecodeMRPParametersIfPresent(System::PacketBufferTLVReader & tlvReader);
+    CHIP_ERROR DecodeMRPParametersIfPresent(TLV::ContiguousBufferTLVReader & tlvReader);
 
     // TODO: remove Clear, we should create a new instance instead reset the old instance.
     void Clear()

--- a/src/transport/tests/BUILD.gn
+++ b/src/transport/tests/BUILD.gn
@@ -23,6 +23,7 @@ chip_test_suite("tests") {
   output_name = "libTransportLayerTests"
 
   test_sources = [
+    "TestPairingSession.cpp",
     "TestPeerConnections.cpp",
     "TestSecureSession.cpp",
     "TestSessionHandle.cpp",

--- a/src/transport/tests/TestPairingSession.cpp
+++ b/src/transport/tests/TestPairingSession.cpp
@@ -31,8 +31,8 @@
 #include <transport/PairingSession.h>
 
 #include <lib/support/UnitTestRegistration.h>
-#include <system/SystemClock.h>
 #include <stdarg.h>
+#include <system/SystemClock.h>
 
 using namespace chip;
 using namespace chip::System::Clock;
@@ -40,10 +40,7 @@ using namespace chip::System::Clock;
 class TestPairingSession : public PairingSession
 {
 public:
-    CHIP_ERROR DeriveSecureSession(CryptoContext & session, CryptoContext::SessionRole role) override
-    {
-        return CHIP_NO_ERROR;
-    }
+    CHIP_ERROR DeriveSecureSession(CryptoContext & session, CryptoContext::SessionRole role) override { return CHIP_NO_ERROR; }
 
     CHIP_ERROR DecodeMRPParametersIfPresent(System::PacketBufferTLVReader & tlvReader)
     {
@@ -64,7 +61,7 @@ void PairingSessionEncodeDecodeMRPParams(nlTestSuite * inSuite, void * inContext
     TLV::TLVType outerContainerType = TLV::kTLVType_NotSpecified;
     NL_TEST_ASSERT(inSuite, writer.StartContainer(TLV::AnonymousTag, TLV::kTLVType_Structure, outerContainerType) == CHIP_NO_ERROR);
 
-    CHIP_ERROR err =  PairingSession::EncodeMRPParameters(TLV::ContextTag(1), config, writer);
+    CHIP_ERROR err = PairingSession::EncodeMRPParameters(TLV::ContextTag(1), config, writer);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     NL_TEST_ASSERT(inSuite, writer.EndContainer(outerContainerType) == CHIP_NO_ERROR);

--- a/src/transport/tests/TestPairingSession.cpp
+++ b/src/transport/tests/TestPairingSession.cpp
@@ -157,7 +157,7 @@ static nlTestSuite sSuite =
 /**
  *  Main
  */
-int TestPairingSession()
+int TestPairingSessionInit()
 {
     // Run test suit against one context
     nlTestRunner(&sSuite, nullptr);
@@ -165,4 +165,4 @@ int TestPairingSession()
     return (nlTestRunnerStats(&sSuite));
 }
 
-CHIP_REGISTER_TEST_SUITE(TestPairingSession)
+CHIP_REGISTER_TEST_SUITE(TestPairingSessionInit)

--- a/src/transport/tests/TestPairingSession.cpp
+++ b/src/transport/tests/TestPairingSession.cpp
@@ -33,6 +33,7 @@
 #include <lib/support/UnitTestRegistration.h>
 #include <stdarg.h>
 #include <system/SystemClock.h>
+#include <system/TLVPacketBufferBackingStore.h>
 
 using namespace chip;
 using namespace chip::System::Clock;

--- a/src/transport/tests/TestPairingSession.cpp
+++ b/src/transport/tests/TestPairingSession.cpp
@@ -1,0 +1,168 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file implements unit tests for the CryptoContext implementation.
+ */
+
+#include <errno.h>
+#include <nlunit-test.h>
+
+#include <lib/core/CHIPCore.h>
+#include <lib/support/CodeUtils.h>
+
+#include <messaging/ReliableMessageProtocolConfig.h>
+#include <transport/PairingSession.h>
+
+#include <lib/support/UnitTestRegistration.h>
+#include <system/SystemClock.h>
+#include <stdarg.h>
+
+using namespace chip;
+using namespace chip::System::Clock;
+
+class TestPairingSession : public PairingSession
+{
+public:
+    CHIP_ERROR DeriveSecureSession(CryptoContext & session, CryptoContext::SessionRole role) override
+    {
+        return CHIP_NO_ERROR;
+    }
+
+    CHIP_ERROR DecodeMRPParametersIfPresent(System::PacketBufferTLVReader & tlvReader)
+    {
+        return PairingSession::DecodeMRPParametersIfPresent(tlvReader);
+    }
+};
+
+void PairingSessionEncodeDecodeMRPParams(nlTestSuite * inSuite, void * inContext)
+{
+    TestPairingSession session;
+
+    ReliableMessageProtocolConfig config(Milliseconds32(100), Milliseconds32(200));
+
+    System::PacketBufferHandle buf = System::PacketBufferHandle::New(64, 0);
+    System::PacketBufferTLVWriter writer;
+    writer.Init(buf.Retain());
+
+    TLV::TLVType outerContainerType = TLV::kTLVType_NotSpecified;
+    NL_TEST_ASSERT(inSuite, writer.StartContainer(TLV::AnonymousTag, TLV::kTLVType_Structure, outerContainerType) == CHIP_NO_ERROR);
+
+    CHIP_ERROR err =  PairingSession::EncodeMRPParameters(TLV::ContextTag(1), config, writer);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    NL_TEST_ASSERT(inSuite, writer.EndContainer(outerContainerType) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, writer.Finalize(&buf) == CHIP_NO_ERROR);
+
+    System::PacketBufferTLVReader reader;
+    TLV::TLVType containerType = TLV::kTLVType_Structure;
+
+    reader.Init(std::move(buf));
+    NL_TEST_ASSERT(inSuite, reader.Next(containerType, TLV::AnonymousTag) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, reader.EnterContainer(containerType) == CHIP_NO_ERROR);
+
+    err = session.DecodeMRPParametersIfPresent(reader);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    NL_TEST_ASSERT(inSuite, session.GetMRPConfig().mIdleRetransTimeout == config.mIdleRetransTimeout);
+    NL_TEST_ASSERT(inSuite, session.GetMRPConfig().mActiveRetransTimeout == config.mActiveRetransTimeout);
+}
+
+void PairingSessionTryDecodeMissingMRPParams(nlTestSuite * inSuite, void * inContext)
+{
+    TestPairingSession session;
+
+    System::PacketBufferHandle buf = System::PacketBufferHandle::New(64, 0);
+    System::PacketBufferTLVWriter writer;
+    writer.Init(buf.Retain());
+
+    TLV::TLVType outerContainerType = TLV::kTLVType_NotSpecified;
+    NL_TEST_ASSERT(inSuite, writer.StartContainer(TLV::AnonymousTag, TLV::kTLVType_Structure, outerContainerType) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, writer.EndContainer(outerContainerType) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, writer.Finalize(&buf) == CHIP_NO_ERROR);
+
+    System::PacketBufferTLVReader reader;
+    TLV::TLVType containerType = TLV::kTLVType_Structure;
+
+    reader.Init(std::move(buf));
+    NL_TEST_ASSERT(inSuite, reader.Next(containerType, TLV::AnonymousTag) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, reader.EnterContainer(containerType) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, session.DecodeMRPParametersIfPresent(reader) == CHIP_NO_ERROR);
+
+    NL_TEST_ASSERT(inSuite, session.GetMRPConfig().mIdleRetransTimeout == gDefaultMRPConfig.mIdleRetransTimeout);
+    NL_TEST_ASSERT(inSuite, session.GetMRPConfig().mActiveRetransTimeout == gDefaultMRPConfig.mActiveRetransTimeout);
+}
+
+// Test Suite
+
+/**
+ *  Test Suite that lists all the test functions.
+ */
+// clang-format off
+static const nlTest sTests[] =
+{
+    NL_TEST_DEF("Encode and Decode MRP params", PairingSessionEncodeDecodeMRPParams),
+    NL_TEST_DEF("Decode missing MRP params", PairingSessionTryDecodeMissingMRPParams),
+
+    NL_TEST_SENTINEL()
+};
+// clang-format on
+
+/**
+ *  Set up the test suite.
+ */
+int TestPairingSession_Setup(void * inContext)
+{
+    CHIP_ERROR error = chip::Platform::MemoryInit();
+    if (error != CHIP_NO_ERROR)
+        return FAILURE;
+    return SUCCESS;
+}
+
+/**
+ *  Tear down the test suite.
+ */
+int TestPairingSession_Teardown(void * inContext)
+{
+    chip::Platform::MemoryShutdown();
+    return SUCCESS;
+}
+
+// clang-format off
+static nlTestSuite sSuite =
+{
+    "Test-CHIP-PairingSession",
+    &sTests[0],
+    TestPairingSession_Setup,
+    TestPairingSession_Teardown
+};
+// clang-format on
+
+/**
+ *  Main
+ */
+int TestPairingSession()
+{
+    // Run test suit against one context
+    nlTestRunner(&sSuite, nullptr);
+
+    return (nlTestRunnerStats(&sSuite));
+}
+
+CHIP_REGISTER_TEST_SUITE(TestPairingSession)


### PR DESCRIPTION
#### Problem
* Fixes #9654 

#### Change overview
Include MRP parameters in PBKDF param request and response messages.
Add unit tests in TestPASESession to check that the parameters are received correctly.

#### Testing
Added three new unit tests to `TestPASESession`
